### PR TITLE
Add more sysvar API docs

### DIFF
--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -44,15 +44,15 @@ fn id_to_tokens(
     tokens: &mut proc_macro2::TokenStream,
 ) {
     tokens.extend(quote! {
-        /// The static program ID
+        /// The static program ID.
         pub static ID: #pubkey_type = #id;
 
-        /// Confirms that a given pubkey is equivalent to the program ID
+        /// Returns `true` if given pubkey is the program ID.
         pub fn check_id(id: &#pubkey_type) -> bool {
             id == &ID
         }
 
-        /// Returns the program ID
+        /// Returns the program ID.
         pub fn id() -> #pubkey_type {
             ID
         }
@@ -71,16 +71,16 @@ fn deprecated_id_to_tokens(
     tokens: &mut proc_macro2::TokenStream,
 ) {
     tokens.extend(quote! {
-        /// The static program ID
+        /// The static program ID.
         pub static ID: #pubkey_type = #id;
 
-        /// Confirms that a given pubkey is equivalent to the program ID
+        /// Returns `true` if given pubkey is the program ID.
         #[deprecated()]
         pub fn check_id(id: &#pubkey_type) -> bool {
             id == &ID
         }
 
-        /// Returns the program ID
+        /// Returns the program ID.
         #[deprecated()]
         pub fn id() -> #pubkey_type {
             ID

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -39,7 +39,7 @@ pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 #[cfg(test)]
 static_assertions::const_assert_eq!(SLOT_MS, 400);
 
-/// The duration of a slot (400 milliseconds).
+/// The expected duration of a slot (400 milliseconds).
 pub const SLOT_MS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SECOND;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -11,7 +11,7 @@
 //! time for the network to produce slots. Note though that this method suffers
 //! a variable amount of drift, as the network does not produce slots at exactly
 //! the target rate, and the greater number of slots being calculated for, the
-//! greater the drift. Epochs can not be used this way as they contain variable
+//! greater the drift. Epochs cannot be used this way as they contain variable
 //! numbers of slots.
 //!
 //! The network's current view of the real-world time can always be accessed via

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -1,6 +1,6 @@
 //! Information about the network's clock, ticks, slots, etc.
 //!
-//! Time in Solana is marked primily by _slots_, which occur approximately every
+//! Time in Solana is marked primarily by _slots_, which occur approximately every
 //! 400 milliseconds, and are numbered sequentially. For every slot a leader is
 //! chosen from the validator set, and that leader is expected to produce a new
 //! block, though sometimes leaders may fail to do so. Blocks can be identified

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -149,7 +149,7 @@ pub struct Clock {
     pub slot: Slot,
     /// The timestamp of the first `Slot` in this `Epoch`.
     pub epoch_start_timestamp: UnixTimestamp,
-    /// The bank `Epoch`.
+    /// The current `Epoch`.
     pub epoch: Epoch,
     /// The future `Epoch` for which the leader schedule has
     /// most recently been calculated.

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -145,7 +145,7 @@ pub type UnixTimestamp = i64;
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub struct Clock {
-    /// The current network/bank `Slot`.
+    /// The current `Slot`.
     pub slot: Slot,
     /// The timestamp of the first `Slot` in this `Epoch`.
     pub epoch_start_timestamp: UnixTimestamp,

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -80,8 +80,8 @@ static_assertions::const_assert_eq!(DEFAULT_MS_PER_SLOT, 400);
 pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 pub const DEFAULT_S_PER_SLOT: f64 = DEFAULT_TICKS_PER_SLOT as f64 / DEFAULT_TICKS_PER_SECOND as f64;
 
-/// The time window of recent block hash values that the bank will track the
-/// signatures of over.
+/// The time window of recent block hash values over which the bank will track
+/// signatures.
 ///
 /// Once the bank discards a block hash, it will reject any transactions that
 /// use that `recent_blockhash` in a transaction. Lowering this value reduces

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -85,7 +85,7 @@ pub const DEFAULT_S_PER_SLOT: f64 = DEFAULT_TICKS_PER_SLOT as f64 / DEFAULT_TICK
 ///
 /// Once the bank discards a block hash, it will reject any transactions that
 /// use that `recent_blockhash` in a transaction. Lowering this value reduces
-/// memory consumption, but requires clients to update its `recent_blockhash`
+/// memory consumption, but requires a client to update its `recent_blockhash`
 /// more frequently. Raising the value lengthens the time a client must wait to
 /// be certain a missing transaction will not be processed by the network.
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -1,7 +1,7 @@
 //! Information about the network's clock, ticks, slots, etc.
 //!
 //! Time in Solana is marked primarily by _slots_, which occur approximately every
-//! 400 milliseconds, and are numbered sequentially. For every slot a leader is
+//! 400 milliseconds, and are numbered sequentially. For every slot, a leader is
 //! chosen from the validator set, and that leader is expected to produce a new
 //! block, though sometimes leaders may fail to do so. Blocks can be identified
 //! by their slot number, and some slots do not contain a block.

--- a/sdk/program/src/epoch_schedule.rs
+++ b/sdk/program/src/epoch_schedule.rs
@@ -18,9 +18,6 @@ use {
 };
 
 /// The default number of slots before an epoch starts to calculate the leader schedule.
-///
-/// The default is an entire epoch, i.e. leader schedule for epoch X is calculated at
-/// the beginning of epoch X - 1.
 pub const DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET: u64 = DEFAULT_SLOTS_PER_EPOCH;
 
 /// The maximum number of slots before an epoch starts to calculate the leader schedule.

--- a/sdk/program/src/epoch_schedule.rs
+++ b/sdk/program/src/epoch_schedule.rs
@@ -2,7 +2,7 @@
 //!
 //! Epochs mark a period of time composed of _slots_, for which a particular
 //! [leader schedule][ls] is in effect. The epoch schedule determines the length
-//! of epochs, and the timing of the next leader schedule selection.
+//! of epochs, and the timing of the next leader-schedule selection.
 //!
 //! [ls]: https://docs.solana.com/cluster/leader-rotation#leader-schedule-rotation
 //!

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -116,6 +116,10 @@ pub mod solana_sdk {
         address_lookup_table_account, hash, instruction, keccak, message, nonce,
         pubkey::{self, Pubkey},
         system_instruction, system_program,
+        sysvar::{
+            self,
+            clock::{self, Clock},
+        },
     };
 
     pub mod account {

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -28,7 +28,7 @@
 //! [serialization]: #serialization
 //! [np]: #native-programs
 //! [cpi]: #cross-program-instruction-execution
-//! [sysvar]: #sysvars
+//! [sysvar]: crate::sysvar
 //!
 //! Idiomatic examples of `solana-program` usage can be found in
 //! [the Solana Program Library][spl].
@@ -466,89 +466,6 @@
 //!   - Invokable by programs? yes
 //!
 //! [lut]: https://docs.solana.com/proposals/transactions-v2
-//!
-//! # Sysvars
-//!
-//! Sysvars are special accounts that contain dynamically-updated data about
-//! the network cluster, the blockchain history, and the executing transaction.
-//!
-//! The program IDs for sysvars are defined in the [`sysvar`] module, and simple
-//! sysvars implement the [`Sysvar::get`] method, which loads a sysvar directly
-//! from the runtime, as in this example that logs the `clock` sysvar:
-//!
-//! [`Sysvar::get`]: sysvar::Sysvar::get
-//!
-//! ```
-//! use solana_program::{
-//!     account_info::AccountInfo,
-//!     clock,
-//!     entrypoint::ProgramResult,
-//!     msg,
-//!     pubkey::Pubkey,
-//!     sysvar::Sysvar,
-//! };
-//!
-//! fn process_instruction(
-//!     program_id: &Pubkey,
-//!     accounts: &[AccountInfo],
-//!     instruction_data: &[u8],
-//! ) -> ProgramResult {
-//!     let clock = clock::Clock::get()?;
-//!     msg!("clock: {:#?}", clock);
-//!     Ok(())
-//! }
-//! ```
-//!
-//! Since Solana sysvars are accounts, if the `AccountInfo` is provided to the
-//! program, then the program can deserialize the sysvar with
-//! [`Sysvar::from_account_info`] to access its data, as in this example that
-//! again logs the [`clock`][clk] sysvar.
-//!
-//! [`Sysvar::from_account_info`]: sysvar::Sysvar::from_account_info
-//! [clk]: sysvar::clock
-//!
-//! ```
-//! use solana_program::{
-//!     account_info::{next_account_info, AccountInfo},
-//!     clock,
-//!     entrypoint::ProgramResult,
-//!     msg,
-//!     pubkey::Pubkey,
-//!     sysvar::Sysvar,
-//! };
-//!
-//! fn process_instruction(
-//!     program_id: &Pubkey,
-//!     accounts: &[AccountInfo],
-//!     instruction_data: &[u8],
-//! ) -> ProgramResult {
-//!     let account_info_iter = &mut accounts.iter();
-//!     let clock_account = next_account_info(account_info_iter)?;
-//!     let clock = clock::Clock::from_account_info(&clock_account)?;
-//!     msg!("clock: {:#?}", clock);
-//!     Ok(())
-//! }
-//! ```
-//!
-//! When possible, programs should prefer to call `Sysvar::get` instead of
-//! deserializing with `Sysvar::from_account_info`, as the latter imposes extra
-//! overhead of deserialization while also requiring the sysvar account address
-//! be passed to the program, wasting the limited space available to
-//! transactions. Deserializing sysvars that can instead be retrieved with
-//! `Sysvar::get` should be only be considered for compatibility with older
-//! programs that pass around sysvar accounts.
-//!
-//! Some sysvars are too large to deserialize within a program, and
-//! `Sysvar::from_account_info` returns an error. Some sysvars are too large
-//! to deserialize within a program, and attempting to will exhaust the
-//! program's compute budget. Some sysvars do not implement `Sysvar::get` and
-//! return an error. Some sysvars have custom deserializers that do not
-//! implement the `Sysvar` trait. These cases are documented in the modules for
-//! individual sysvars.
-//!
-//! For more details see the Solana [documentation on sysvars][sysvardoc].
-//!
-//! [sysvardoc]: https://docs.solana.com/developing/runtime-facilities/sysvars
 
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -48,9 +48,8 @@ pub const DEFAULT_BURN_PERCENT: u8 = 50;
 
 /// Account storage overhead for calculation of base rent.
 ///
-/// This is an approximate constant number of bytes required to store an account
-/// of any size. It is added to an accounts data length when calculating
-/// [`Rent::minimum_balance`].
+/// This is the number of bytes required to store an account with no data. It is
+/// added to an accounts data length when calculating [`Rent::minimum_balance`].
 pub const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;
 
 impl Default for Rent {

--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -4,7 +4,7 @@
 //!
 //! The sysvar ID is declared in [`sysvar::slot_hashes`].
 //!
-//! [`sysvar::slot_hashes`]: crate::slot_hashes
+//! [`sysvar::slot_hashes`]: crate::sysvar::slot_hashes
 
 pub use crate::clock::Slot;
 use {

--- a/sdk/program/src/slot_history.rs
+++ b/sdk/program/src/slot_history.rs
@@ -4,12 +4,13 @@
 //!
 //! The sysvar ID is declared in [`sysvar::slot_history`].
 //!
-//! [`sysvar::slot_history`]: crate::slot_history
+//! [`sysvar::slot_history`]: crate::sysvar::slot_history
 
 #![allow(clippy::integer_arithmetic)]
 pub use crate::clock::Slot;
 use bv::{BitVec, BitsMut};
 
+/// A bitvector indicating which slots are present in the past epoch.
 #[repr(C)]
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SlotHistory {

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -1,5 +1,132 @@
-//! This account contains the clock slot, epoch, and leader_schedule_epoch
+//! Information about the network’s clock, ticks, slots, etc.
 //!
+//! The _clock sysvar_ provides access to the [`Clock`] type, which includes the
+//! current slot, the current epoch, and the approximate real-world time of the
+//! slot.
+//!
+//! [`Clock`] implements [`Sysvar::get`] and can be loaded efficiently without
+//! passing the sysvar account ID to the program.
+//!
+//! See also the Solana [documentation on the clock sysvar][sdoc].
+//!
+//! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#clock
+//!
+//! # Examples
+//!
+//! Accessing via on-chain program directly:
+//!
+//! ```no_run
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::clock::{self, Clock},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!
+//!     let clock = Clock::get()?;
+//!     msg!("clock: {:#?}", clock);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = Clock::id();
+//! # let l = &mut 1169280;
+//! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via on-chain program's account parameters:
+//!
+//! ```
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::clock::{self, Clock},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!     let account_info_iter = &mut accounts.iter();
+//!     let clock_account_info = next_account_info(account_info_iter)?;
+//!
+//!     assert!(clock::check_id(clock_account_info.key));
+//!
+//!     let clock = Clock::from_account_info(clock_account_info)?;
+//!     msg!("clock: {:#?}", clock);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = Clock::id();
+//! # let l = &mut 1169280;
+//! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::clock::{self, Clock};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_clock(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(clock::ID, Account {
+//! #       lamports: 1169280,
+//! #       data: vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0],
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! #   });
+//! #
+//!     let clock = client.get_account(&clock::ID)?;
+//!     let data: Clock = bincode::deserialize(&clock.data)?;
+//!     println!("clock account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_clock(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 pub use crate::clock::Clock;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -116,7 +116,6 @@
 //! #
 //!     let clock = client.get_account(&clock::ID)?;
 //!     let data: Clock = bincode::deserialize(&clock.data)?;
-//!     println!("clock account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -1,5 +1,131 @@
-//! This account contains the current cluster rent
+//! Information about epoch duration.
 //!
+//! The _epoch schedule_ sysvar provides access to the [`EpochSchedule`] type,
+//! which includes the number of slots per epoch, timing of leader schedule
+//! selection, and information about epoch warm-up time.
+//!
+//! [`EpochSchedule`] implements [`Sysvar::get`] and can be loaded efficiently without
+//! passing the sysvar account ID to the program.
+//!
+//! See also the Solana [documentation on the epoch schedule sysvar][sdoc].
+//!
+//! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#epochschedule
+//!
+//! # Examples
+//!
+//! Accessing via on-chain program directly:
+//!
+//! ```no_run
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::epoch_schedule::{self, EpochSchedule},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!
+//!     let epoch_schedule = EpochSchedule::get()?;
+//!     msg!("epoch_schedule: {:#?}", epoch_schedule);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = EpochSchedule::id();
+//! # let l = &mut 1120560;
+//! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via on-chain program's account parameters:
+//!
+//! ```
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::epoch_schedule::{self, EpochSchedule},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!     let account_info_iter = &mut accounts.iter();
+//!     let epoch_schedule_account_info = next_account_info(account_info_iter)?;
+//!
+//!     assert!(epoch_schedule::check_id(epoch_schedule_account_info.key));
+//!
+//!     let epoch_schedule = EpochSchedule::from_account_info(epoch_schedule_account_info)?;
+//!     msg!("epoch_schedule: {:#?}", epoch_schedule);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = EpochSchedule::id();
+//! # let l = &mut 1120560;
+//! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::epoch_schedule::{self, EpochSchedule};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_epoch_schedule(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(epoch_schedule::ID, Account {
+//! #       lamports: 1120560,
+//! #       data: vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! # });
+//! #
+//!     let epoch_schedule = client.get_account(&epoch_schedule::ID)?;
+//!     let data: EpochSchedule = bincode::deserialize(&epoch_schedule.data)?;
+//!     println!("epoch_schedule account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_epoch_schedule(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
 pub use crate::epoch_schedule::EpochSchedule;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -116,7 +116,6 @@
 //! #
 //!     let epoch_schedule = client.get_account(&epoch_schedule::ID)?;
 //!     let data: EpochSchedule = bincode::deserialize(&epoch_schedule.data)?;
-//!     println!("epoch_schedule account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -1,5 +1,23 @@
-//! This account contains the current cluster fees
+//! Current cluster fees.
 //!
+//! The _fees sysvar_ provides access to the [`Fees`] type, which contains the
+//! current [`FeeCalculator`].
+//!
+//! [`Fees`] implements [`Sysvar::get`] and can be loaded efficiently without
+//! passing the sysvar account ID to the program.
+//!
+//! This sysvar is deprecated and will not be available in the future.
+//! Transaction fees should be determined with the [`getFeeForMessage`] RPC
+//! method. For additional context see the [Comprehensive Compute Fees
+//! proposal][ccf].
+//!
+//! [`getFeeForMessage`]: https://docs.solana.com/developing/clients/jsonrpc-api#getfeeformessage
+//! [ccf]: https://docs.solana.com/proposals/comprehensive-compute-fees
+//!
+//! See also the Solana [documentation on the fees sysvar][sdoc].
+//!
+//! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#fees
+
 #![allow(deprecated)]
 
 use {
@@ -12,6 +30,7 @@ use {
 
 crate::declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
 
+/// Transaction fees.
 #[deprecated(
     since = "1.9.0",
     note = "Please do not use, will no longer be available in the future"

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -67,12 +67,11 @@
 //! programs that pass around sysvar accounts.
 //!
 //! Some sysvars are too large to deserialize within a program, and
-//! `Sysvar::from_account_info` returns an error, or the serialization attempt 
-//! will exhaust the program's compute budget. 
-//! Some sysvars do not implement `Sysvar::get` and
-//! return an error. Some sysvars have custom deserializers that do not
-//! implement the `Sysvar` trait. These cases are documented in the modules for
-//! individual sysvars.
+//! `Sysvar::from_account_info` returns an error, or the serialization attempt
+//! will exhaust the program's compute budget. Some sysvars do not implement
+//! `Sysvar::get` and return an error. Some sysvars have custom deserializers
+//! that do not implement the `Sysvar` trait. These cases are documented in the
+//! modules for individual sysvars.
 //!
 //! All sysvar accounts are owned by the account identified by [`sysvar::ID`].
 //!

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -67,9 +67,9 @@
 //! programs that pass around sysvar accounts.
 //!
 //! Some sysvars are too large to deserialize within a program, and
-//! `Sysvar::from_account_info` returns an error. Some sysvars are too large
-//! to deserialize within a program, and attempting to will exhaust the
-//! program's compute budget. Some sysvars do not implement `Sysvar::get` and
+//! `Sysvar::from_account_info` returns an error, or the serialization attempt 
+//! will exhaust the program's compute budget. 
+//! Some sysvars do not implement `Sysvar::get` and
 //! return an error. Some sysvars have custom deserializers that do not
 //! implement the `Sysvar` trait. These cases are documented in the modules for
 //! individual sysvars.

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -1,4 +1,4 @@
-//! Information about the network’s clock, ticks, slots, etc.
+//! Information about recent blocks and their fee calculators.
 //!
 //! The _recent blockhashes sysvar_ provides access to the [`RecentBlockhashes`],
 //! which contains recent blockhahes and their [`FeeCalculator`]s.

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -1,3 +1,21 @@
+//! Information about the network’s clock, ticks, slots, etc.
+//!
+//! The _recent blockhashes sysvar_ provides access to the [`RecentBlockhashes`],
+//! which contains recent blockhahes and their [`FeeCalculator`]s.
+//!
+//! [`RecentBlockhashes`] does not implement [`Sysvar::get`].
+//!
+//! This sysvar is deprecated and should not be used. Transaction fees should be
+//! determined with the [`getFeeForMessage`] RPC method. For additional context
+//! see the [Comprehensive Compute Fees proposal][ccf].
+//!
+//! [`getFeeForMessage`]: https://docs.solana.com/developing/clients/jsonrpc-api#getfeeformessage
+//! [ccf]: https://docs.solana.com/proposals/comprehensive-compute-fees
+//!
+//! See also the Solana [documentation on the recent blockhashes sysvar][sdoc].
+//!
+//! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#recentblockhashes
+
 #![allow(deprecated)]
 #![allow(clippy::integer_arithmetic)]
 use {

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -1,5 +1,132 @@
-//! This account contains the current cluster rent
+//! Configuration for network [rent].
 //!
+//! [rent]: https://docs.solana.com/implemented-proposals/rent
+//!
+//! The _rent sysvar_ provides access to the [`Rent`] type, which defines
+//! storage rent fees.
+//!
+//! [`Rent`] implements [`Sysvar::get`] and can be loaded efficiently without
+//! passing the sysvar account ID to the program.
+//!
+//! See also the Solana [documentation on the rent sysvar][sdoc].
+//!
+//! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#rent
+//!
+//! # Examples
+//!
+//! Accessing via on-chain program directly:
+//!
+//! ```no_run
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::rent::{self, Rent},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!
+//!     let rent = Rent::get()?;
+//!     msg!("rent: {:#?}", rent);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = Rent::id();
+//! # let l = &mut 1009200;
+//! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via on-chain program's parameters:
+//!
+//! ```
+//! # use solana_program::{
+//! #    account_info::{AccountInfo, next_account_info},
+//! #    entrypoint::ProgramResult,
+//! #    msg,
+//! #    pubkey::Pubkey,
+//! #    sysvar::rent::{self, Rent},
+//! #    sysvar::Sysvar,
+//! # };
+//! # use solana_program::program_error::ProgramError;
+//! #
+//! fn process_instruction(
+//!     program_id: &Pubkey,
+//!     accounts: &[AccountInfo],
+//!     instruction_data: &[u8],
+//! ) -> ProgramResult {
+//!     let account_info_iter = &mut accounts.iter();
+//!     let rent_account_info = next_account_info(account_info_iter)?;
+//!
+//!     assert!(rent::check_id(rent_account_info.key));
+//!
+//!     let rent = Rent::from_account_info(rent_account_info)?;
+//!     msg!("rent: {:#?}", rent);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # use solana_program::sysvar::SysvarId;
+//! # let p = Rent::id();
+//! # let l = &mut 1009200;
+//! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];
+//! # let a = AccountInfo::new(&p, false, false, l, d, &p, false, 0);
+//! # let accounts = &[a.clone(), a];
+//! # process_instruction(
+//! #     &Pubkey::new_unique(),
+//! #     accounts,
+//! #     &[],
+//! # )?;
+//! # Ok::<(), ProgramError>(())
+//! ```
+//!
+//! Accessing via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::rent::{self, Rent};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_rent(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(rent::ID, Account {
+//! #       lamports: 1009200,
+//! #       data: vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100],
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! # });
+//! #
+//!     let rent = client.get_account(&rent::ID)?;
+//!     let data: Rent = bincode::deserialize(&rent.data)?;
+//!     println!("rent account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_rent(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
 pub use crate::rent::Rent;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -117,7 +117,6 @@
 //! #
 //!     let rent = client.get_account(&rent::ID)?;
 //!     let data: Rent = bincode::deserialize(&rent.data)?;
-//!     println!("rent account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/rewards.rs
+++ b/sdk/program/src/sysvar/rewards.rs
@@ -1,5 +1,5 @@
-//! DEPRECATED: This sysvar can be removed once the pico-inflation feature is enabled
-//!
+//! This sysvar is deprecated and unused.
+
 use crate::sysvar::Sysvar;
 
 crate::declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -35,7 +35,6 @@
 //! #
 //!     let slot_hashes = client.get_account(&slot_hashes::ID)?;
 //!     let data: SlotHashes = bincode::deserialize(&slot_hashes.data)?;
-//!     println!("slot_hashes account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -1,7 +1,51 @@
-//! named accounts for synthesized data accounts for bank state, etc.
+//! The most recent hashes of a slot's parent banks.
 //!
-//! this account carries the Bank's most recent bank hashes for some N parents
+//! The _slot hashes sysvar_ provides access to the [`SlotHashes`] type.
 //!
+//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always returns
+//! [`ProgramError::UnsupportedSysvar`] because this sysvar account is too large
+//! to process on-chain. Thus this sysvar cannot be accessed on chain, though
+//! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and
+//! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
+//! off-chain through RPC.
+//!
+//! [`SysvarId::id`]: crate::sysvar::SysvarId::id
+//! [`SysvarId::check_id`]: crate::sysvar::SysvarId::check_id
+//!
+//! # Examples
+//!
+//! Calling via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::slot_hashes::{self, SlotHashes};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_slot_hashes(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(slot_hashes::ID, Account {
+//! #       lamports: 1009200,
+//! #       data: vec![1, 0, 0, 0, 0, 0, 0, 0, 86, 190, 235, 7, 0, 0, 0, 0, 133, 242, 94, 158, 223, 253, 207, 184, 227, 194, 235, 27, 176, 98, 73, 3, 175, 201, 224, 111, 21, 65, 73, 27, 137, 73, 229, 19, 255, 192, 193, 126],
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! # });
+//! #
+//!     let slot_hashes = client.get_account(&slot_hashes::ID)?;
+//!     let data: SlotHashes = bincode::deserialize(&slot_hashes.data)?;
+//!     println!("slot_hashes account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_slot_hashes(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 pub use crate::slot_hashes::SlotHashes;
 use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::Sysvar};
 

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -2,7 +2,7 @@
 //!
 //! The _slot hashes sysvar_ provides access to the [`SlotHashes`] type.
 //!
-//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always returns
+//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always return
 //! [`ProgramError::UnsupportedSysvar`] because this sysvar account is too large
 //! to process on-chain. Thus this sysvar cannot be accessed on chain, though
 //! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -1,8 +1,53 @@
-//! named accounts for synthesized data accounts for bank state, etc.
+//! Access to slots present over the last epoch.
 //!
-//! this account carries a bitvector of slots present over the past
-//! epoch
+//! The _slot history sysvar_ provides access to the [`SlotHistory`] type.
 //!
+//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always returns
+//! [`ProgramError::UnsupportedSysvar`] because this sysvar account is too large
+//! to process on-chain. Thus this sysvar cannot be accessed on chain, though
+//! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and
+//! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
+//! off-chain through RPC.
+//!
+//! [`SysvarId::id`]: crate::sysvar::SysvarId::id
+//! [`SysvarId::check_id`]: crate::sysvar::SysvarId::check_id
+//!
+//! # Examples
+//!
+//! Calling via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::slot_history::{self, SlotHistory};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_slot_history(client: &RpcClient) -> Result<()> {
+//! #   let slot_history = SlotHistory::default();
+//! #   let data: Vec<u8> = bincode::serialize(&slot_history)?;
+//! #   client.set_get_account_response(slot_history::ID, Account {
+//! #       lamports: 913326000,
+//! #       data,
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! #   });
+//! #
+//!     let slot_history = client.get_account(&slot_history::ID)?;
+//!     let data: SlotHistory = bincode::deserialize(&slot_history.data)?;
+//!     println!("slot_history account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_slot_history(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 use crate::sysvar::Sysvar;
 pub use crate::{
     account_info::AccountInfo, program_error::ProgramError, slot_history::SlotHistory,

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -1,4 +1,4 @@
-//! Access to slots present over the last epoch.
+//! A bitvector of slots present over the last epoch.
 //!
 //! The _slot history sysvar_ provides access to the [`SlotHistory`] type.
 //!

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -2,7 +2,7 @@
 //!
 //! The _slot history sysvar_ provides access to the [`SlotHistory`] type.
 //!
-//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always returns
+//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always return
 //! [`ProgramError::UnsupportedSysvar`] because this sysvar account is too large
 //! to process on-chain. Thus this sysvar cannot be accessed on chain, though
 //! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -37,7 +37,6 @@
 //! #
 //!     let slot_history = client.get_account(&slot_history::ID)?;
 //!     let data: SlotHistory = bincode::deserialize(&slot_history.data)?;
-//!     println!("slot_history account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -35,7 +35,6 @@
 //! #
 //!     let stake_history = client.get_account(&stake_history::ID)?;
 //!     let data: StakeHistory = bincode::deserialize(&stake_history.data)?;
-//!     println!("stake_history account data: {:#?}", data);
 //!
 //!     Ok(())
 //! }

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -1,7 +1,51 @@
-//! named accounts for synthesized data accounts for bank state, etc.
+//! History of stake activations and de-activations.
 //!
-//! this account carries history about stake activations and de-activations
+//! The _stake history sysvar_ provides access to the [`StakeHistory`] type.
 //!
+//! The [`Sysvar::get`] method always returns
+//! [`ProgramError::UnsupportedSysvar`], and in practice the data size of this
+//! sysvar is too large to process on chain. One can still use the
+//! [`SysvarId::id`], [`SysvarId::check_id`] and [`Sysvar::size_of`] methods in
+//! an on-chain program, and it can be accessed off-chain through RPC.
+//!
+//! [`ProgramError::UnsupportedSysvar`]: crate::program_error::ProgramError::UnsupportedSysvar
+//! [`SysvarId::id`]: crate::sysvar::SysvarId::id
+//! [`SysvarId::check_id`]: crate::sysvar::SysvarId::check_id
+//!
+//! # Examples
+//!
+//! Calling via the RPC client:
+//!
+//! ```
+//! # use solana_program::example_mocks::solana_sdk;
+//! # use solana_program::example_mocks::solana_client;
+//! # use solana_sdk::account::Account;
+//! # use solana_client::rpc_client::RpcClient;
+//! # use solana_sdk::sysvar::stake_history::{self, StakeHistory};
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_stake_history(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(stake_history::ID, Account {
+//! #       lamports: 114979200,
+//! #       data: vec![0, 0, 0, 0, 0, 0, 0, 0],
+//! #       owner: solana_sdk::system_program::ID,
+//! #       executable: false,
+//! #       rent_epoch: 307,
+//! #   });
+//! #
+//!     let stake_history = client.get_account(&stake_history::ID)?;
+//!     let data: StakeHistory = bincode::deserialize(&stake_history.data)?;
+//!     println!("stake_history account data: {:#?}", data);
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_stake_history(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 pub use crate::stake_history::StakeHistory;
 use crate::sysvar::Sysvar;
 


### PR DESCRIPTION
#### Problem

More docs needed.

#### Summary of Changes

This adds documentation to the sysvar module and its submodules, to the data types and supporting functions associated with each sysvar. It moves the crate-level sysvar docs into the sysvar module.

