### PR TITLE
accounts: Don't collect rent on newly created accounts

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1289,7 +1289,9 @@ impl Accounts {
                     );
 
                     if execution_status.is_ok() || is_nonce_account || is_fee_payer {
-                        if account.rent_epoch() == INITIAL_RENT_EPOCH {
+                        if !preserve_rent_epoch_for_rent_exempt_accounts
+                            && account.rent_epoch() == INITIAL_RENT_EPOCH
+                        {
                             let rent = rent_collector
                                 .collect_from_created_account(
                                     address,


### PR DESCRIPTION
#### Problem

This is a doozy for a one-line change.

With  #26479 activated, the rent epoch of accounts is no longer updated. If you start a new cluster (or test validator) with this enabled, there may be some accounts with `rent_epoch = 0`.

When one of those accounts is closed, the runtime thinks it's a new account since its rent epoch is 0, tries to collect rent on it, and cleans up the account in the process.

This is normally OK, but if the account in question is a stake account, the stakes cache will go out of sync and eventually crash the bank during epoch rollover on this assertion: https://github.com/solana-labs/solana/blob/422cff69fdc6e9268020dd52db842c6a0b64a4cd/runtime/src/bank.rs#L2704

#### Summary of Changes

Very simply, don't collect rent on newly created accounts if the feature flag from #26479 is enabled.  Since newly created accounts cannot be rent-paying, this rent collection never happened anyway.  The rent collector code can be cleaned up once the feature is removed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
