### PR TITLE
(Ledger Tool) Add fully-compact-target under the copy command

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -24,7 +24,7 @@ use {
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
         blockstore::{create_new_ledger, Blockstore, PurgeType},
-        blockstore_db::{self, Database},
+        blockstore_db::{self, columns as cf, Column, ColumnName, Database},
         blockstore_options::{
             AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
             ShredStorageType,
@@ -823,6 +823,80 @@ fn open_blockstore(
             exit(1);
         }
     }
+}
+
+fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
+    match column_name {
+        cf::SlotMeta::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
+        cf::Orphans::NAME => Some(cf::Orphans::slot(cf::Orphans::index(key))),
+        cf::DeadSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
+        cf::DuplicateSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
+        cf::ErasureMeta::NAME => Some(cf::ErasureMeta::slot(cf::ErasureMeta::index(key))),
+        cf::BankHash::NAME => Some(cf::BankHash::slot(cf::BankHash::index(key))),
+        cf::Root::NAME => Some(cf::Root::slot(cf::Root::index(key))),
+        cf::Index::NAME => Some(cf::Index::slot(cf::Index::index(key))),
+        cf::ShredData::NAME => Some(cf::ShredData::slot(cf::ShredData::index(key))),
+        cf::ShredCode::NAME => Some(cf::ShredCode::slot(cf::ShredCode::index(key))),
+        cf::TransactionStatus::NAME => Some(cf::TransactionStatus::slot(
+            cf::TransactionStatus::index(key),
+        )),
+        cf::AddressSignatures::NAME => Some(cf::AddressSignatures::slot(
+            cf::AddressSignatures::index(key),
+        )),
+        cf::TransactionMemos::NAME => None, // does not implement slot()
+        cf::TransactionStatusIndex::NAME => None, // does not implement slot()
+        cf::Rewards::NAME => Some(cf::Rewards::slot(cf::Rewards::index(key))),
+        cf::Blocktime::NAME => Some(cf::Blocktime::slot(cf::Blocktime::index(key))),
+        cf::PerfSamples::NAME => Some(cf::PerfSamples::slot(cf::PerfSamples::index(key))),
+        cf::BlockHeight::NAME => Some(cf::BlockHeight::slot(cf::BlockHeight::index(key))),
+        cf::ProgramCosts::NAME => None, // does not implement slot()
+        cf::OptimisticSlots::NAME => {
+            Some(cf::OptimisticSlots::slot(cf::OptimisticSlots::index(key)))
+        }
+        &_ => None,
+    }
+}
+
+fn print_blockstore_file_info(
+    blockstore: &Blockstore,
+    file_name: &Option<String>,
+) -> Result<(), String> {
+    match blockstore.live_files_metadata() {
+        Ok(live_files) => {
+            // All files under live_files_metadata are prefixed with "/".
+            let sst_file_name = file_name.as_ref().map(|name| format!("/{}", name));
+            for file in live_files {
+                if sst_file_name.is_none() || file.name.eq(sst_file_name.as_ref().unwrap()) {
+                    println!(
+                        "[{}] cf_name: {}, level: {}, start_slot: {:?}, end_slot: {:?}, size: {}, num_entries: {}",
+                        file.name,
+                        file.column_family_name,
+                        file.level,
+                        raw_key_to_slot(&file.start_key.unwrap(), &file.column_family_name),
+                        raw_key_to_slot(&file.end_key.unwrap(), &file.column_family_name),
+                        file.size,
+                        file.num_entries,
+                    );
+                    if sst_file_name.is_some() {
+                        return Ok(());
+                    }
+                }
+            }
+            if sst_file_name.is_some() {
+                return Err(format!(
+                    "Failed to find or load the metadata of the specified file {:?}",
+                    file_name
+                ));
+            }
+        }
+        Err(err) => {
+            return Err(format!(
+                "Unable to identify slot range of the specified file {:?}: {:?}",
+                file_name, err
+            ));
+        }
+    }
+    Ok(())
 }
 
 // This function is duplicated in validator/src/main.rs...
@@ -1948,6 +2022,19 @@ fn main() {
                     .multiple(true)
                     .takes_value(true)
                     .help("Slots that their blocks are computed for cost, default to all slots in ledger"),
+            )
+        )
+        .subcommand(
+            SubCommand::with_name("print-file-info")
+            .about("Print the metadata of the specified ledger-store file. \
+                    If no file name is specified, it will print the metadata of all ledger files.")
+            .arg(
+                Arg::with_name("file_name")
+                    .long("file-name")
+                    .takes_value(true)
+                    .value_name("SST_FILE_NAME")
+                    .help("The ledger file name (e.g. 011080.sst.) \
+                           If no file name is specified, it will print the metadata of all ledger files.")
             )
         )
         .get_matches();
@@ -3931,6 +4018,21 @@ fn main() {
                     if let Err(err) = compute_slot_cost(&blockstore, slot) {
                         eprintln!("{}", err);
                     }
+                }
+            }
+            ("print-file-info", Some(arg_matches)) => {
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
+                let mut sst_file_name = None;
+                if arg_matches.is_present("file_name") {
+                    sst_file_name = Some(value_t_or_exit!(arg_matches, "file_name", String));
+                }
+                if let Err(err) = print_blockstore_file_info(&blockstore, &sst_file_name) {
+                    eprintln!("{}", err);
                 }
             }
             ("", _) => {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1421,6 +1421,12 @@ fn main() {
                     .takes_value(true)
                     .help("Target db"),
             )
+            .arg(
+                Arg::with_name("fully_compact_target")
+                    .long("fully-compact-target")
+                    .help("Fully compact the target db. The resulting db will have \
+                           one sst file per column family."),
+            )
         )
         .subcommand(
             SubCommand::with_name("slot")
@@ -2120,6 +2126,9 @@ fn main() {
                             warn!("error inserting shreds for slot {}", slot);
                         }
                     }
+                }
+                if arg_matches.is_present("fully_compact_target") {
+                    target.fully_compact_all_columns();
                 }
             }
             ("genesis", Some(arg_matches)) => {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -420,6 +420,38 @@ impl Blockstore {
         self.no_compaction = no_compaction;
     }
 
+    /// Fully compact all the ledger columns.  The resulting Blockstore
+    /// will contain one sst file for each column family.
+    ///
+    /// Note that depending on the size of the blockstore, the entire
+    /// background compaction might take a long time to finish and will
+    /// temporarily require more disk space.
+    ///
+    /// In usual cases, you might only want to do this when you're switching
+    /// between different compaction styles or try to create a single
+    /// sst file from a healthy blockstore to replace a corrupted sst file.
+    pub fn fully_compact_all_columns(&self) {
+        self.meta_cf.fully_compact();
+        self.dead_slots_cf.fully_compact();
+        self.duplicate_slots_cf.fully_compact();
+        self.erasure_meta_cf.fully_compact();
+        self.orphans_cf.fully_compact();
+        self.index_cf.fully_compact();
+        self.data_shred_cf.fully_compact();
+        self.code_shred_cf.fully_compact();
+        self.transaction_status_cf.fully_compact();
+        self.address_signatures_cf.fully_compact();
+        self.transaction_memos_cf.fully_compact();
+        self.transaction_status_index_cf.fully_compact();
+        self.rewards_cf.fully_compact();
+        self.blocktime_cf.fully_compact();
+        self.perf_samples_cf.fully_compact();
+        self.block_height_cf.fully_compact();
+        self.program_costs_cf.fully_compact();
+        self.bank_hash_cf.fully_compact();
+        self.optimistic_slots_cf.fully_compact();
+    }
+
     /// Deletes the blockstore at the specified path.
     ///
     /// Note that if the `ledger_path` has multiple rocksdb instances, this

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -30,7 +30,7 @@ use {
         iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
         ThreadPool,
     },
-    rocksdb::DBRawIterator,
+    rocksdb::{DBRawIterator, LiveFile},
     solana_entry::entry::{create_ticks, Entry},
     solana_measure::measure::Measure,
     solana_metrics::{
@@ -498,6 +498,10 @@ impl Blockstore {
 
         let orphans_iter = self.orphans_iterator(root + 1).unwrap();
         root_forks.chain(orphans_iter.flat_map(move |orphan| NextSlotsIterator::new(orphan, self)))
+    }
+
+    pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
+        self.db.live_files_metadata()
     }
 
     pub fn slot_data_iterator(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -19,8 +19,8 @@ use {
         self,
         compaction_filter::CompactionFilter,
         compaction_filter_factory::{CompactionFilterContext, CompactionFilterFactory},
-        properties as RocksProperties, ColumnFamily, ColumnFamilyDescriptor, CompactionDecision,
-        DBCompactionStyle, DBIterator, DBRawIterator, FifoCompactOptions,
+        properties as RocksProperties, ColumnFamily, ColumnFamilyDescriptor, CompactOptions,
+        CompactionDecision, DBCompactionStyle, DBIterator, DBRawIterator, FifoCompactOptions,
         IteratorMode as RocksIteratorMode, LiveFile, Options, WriteBatch as RWriteBatch, DB,
     },
     serde::{de::DeserializeOwned, Serialize},
@@ -1210,6 +1210,20 @@ where
         let to = Some(C::key(C::as_index(to)));
         self.backend.db.compact_range_cf(cf, from, to);
         Ok(true)
+    }
+
+    /// Compact the entire column family into one single file.
+    pub fn fully_compact(&self) {
+        let mut compact_options = CompactOptions::default();
+        compact_options.set_target_level(0);
+        compact_options.set_change_level(true);
+
+        self.backend.db.compact_range_cf_opt(
+            self.handle(),
+            None::<&str>,
+            None::<&str>,
+            &compact_options,
+        );
     }
 
     #[inline]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -21,7 +21,7 @@ use {
         compaction_filter_factory::{CompactionFilterContext, CompactionFilterFactory},
         properties as RocksProperties, ColumnFamily, ColumnFamilyDescriptor, CompactionDecision,
         DBCompactionStyle, DBIterator, DBRawIterator, FifoCompactOptions,
-        IteratorMode as RocksIteratorMode, Options, WriteBatch as RWriteBatch, DB,
+        IteratorMode as RocksIteratorMode, LiveFile, Options, WriteBatch as RWriteBatch, DB,
     },
     serde::{de::DeserializeOwned, Serialize},
     solana_runtime::hardened_unpack::UnpackError,
@@ -513,6 +513,13 @@ impl Rocks {
         match self.db.property_int_value_cf(cf, name) {
             Ok(Some(value)) => Ok(value.try_into().unwrap()),
             Ok(None) => Ok(0),
+            Err(e) => Err(BlockstoreError::RocksDb(e)),
+        }
+    }
+
+    fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
+        match self.db.live_files() {
+            Ok(live_files) => Ok(live_files),
             Err(e) => Err(BlockstoreError::RocksDb(e)),
         }
     }
@@ -1123,6 +1130,10 @@ impl Database {
 
     pub fn set_oldest_slot(&self, oldest_slot: Slot) {
         self.backend.oldest_slot.set(oldest_slot);
+    }
+
+    pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
+        self.backend.live_files_metadata()
     }
 }
 


### PR DESCRIPTION
#### Problem
#26813 describes possible ways to recover a corrupted sst file.
One necessary step is to support full compaction that makes the resulting
database have one file for each column family. 

#### Summary of Changes
This PR adds `--fully-compact-target` under the copy command of the
ledger tool.  If this option is specified, each column family of the target
database will be compacted into one sst file.

This PR depends on #26790