### PR TITLE
enable accounts hash caching if store_detailed_debug_info_on_failure

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6496,7 +6496,8 @@ impl AccountsDb {
                     return scanner.scanning_complete();
                 }
 
-                let should_cache_hash_data = CalcAccountsHashConfig::get_should_cache_hash_data();
+                let should_cache_hash_data = CalcAccountsHashConfig::get_should_cache_hash_data()
+                    || config.store_detailed_debug_info_on_failure;
 
                 // if we're using the write cache, then we can't rely on cached append vecs since the append vecs may not include every account
                 // Single cached slots get cached and full chunks get cached.


### PR DESCRIPTION
#### Problem

if caching was disabled, `--halt-at-slot-store-hash-raw-data` debug feature wasn't working

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
