### PR TITLE
--halt-at-slot-store-hash-raw-data works for root bank

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1533,23 +1533,32 @@ fn load_frozen_forks(
             )?;
 
             if slot >= halt_at_slot {
-                bank.force_flush_accounts_cache();
-                let can_cached_slot_be_unflushed = true;
-                // note that this slot may not be a root
-                let _ = bank.verify_bank_hash(VerifyBankHash {
-                    test_hash_calculation: false,
-                    can_cached_slot_be_unflushed,
-                    ignore_mismatch: true,
-                    require_rooted_bank: false,
-                    run_in_background: false,
-                    store_hash_raw_data_for_debug: on_halt_store_hash_raw_data_for_debug,
-                });
+                run_final_hash_calc(&bank, on_halt_store_hash_raw_data_for_debug);
                 break;
             }
         }
+    } else if on_halt_store_hash_raw_data_for_debug {
+        run_final_hash_calc(
+            &bank_forks.read().unwrap().root_bank(),
+            on_halt_store_hash_raw_data_for_debug,
+        );
     }
 
     Ok(())
+}
+
+fn run_final_hash_calc(bank: &Bank, on_halt_store_hash_raw_data_for_debug: bool) {
+    bank.force_flush_accounts_cache();
+    let can_cached_slot_be_unflushed = true;
+    // note that this slot may not be a root
+    let _ = bank.verify_bank_hash(VerifyBankHash {
+        test_hash_calculation: false,
+        can_cached_slot_be_unflushed,
+        ignore_mismatch: true,
+        require_rooted_bank: false,
+        run_in_background: false,
+        store_hash_raw_data_for_debug: on_halt_store_hash_raw_data_for_debug,
+    });
 }
 
 // `roots` is sorted largest to smallest by root slot


### PR DESCRIPTION
#### Problem

When using ledger-tool to dump debug info for the accounts hash calculation, the option doesn't work if the snapshot is AT the slot that we want to halt at.

#### Summary of Changes

Run the post-hash code if the cli option is specified to dump the debug data.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
