### PR TITLE
calculate cache hash path for store_detailed_debug_info_on_failure

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6560,7 +6560,7 @@ impl AccountsDb {
                             amod.hash(&mut hasher);
                         }
                     }
-                    if load_from_cache && eligible_for_caching {
+                    if load_from_cache {
                         // we have a hash value for all the storages in this slot
                         // so, build a file name:
                         let hash = hasher.finish();
@@ -6569,14 +6569,15 @@ impl AccountsDb {
                             start, end_exclusive, bin_range.start, bin_range.end, hash
                         );
                         let mut retval = scanner.get_accum();
-                        if cache_hash_data
-                            .load(
-                                &Path::new(&file_name),
-                                &mut retval,
-                                start_bin_index,
-                                bin_calculator,
-                            )
-                            .is_ok()
+                        if eligible_for_caching
+                            && cache_hash_data
+                                .load(
+                                    &Path::new(&file_name),
+                                    &mut retval,
+                                    start_bin_index,
+                                    bin_calculator,
+                                )
+                                .is_ok()
                         {
                             return retval;
                         }


### PR DESCRIPTION
#### Problem

This causes all slots (including start..first_boundary and last_full_slot_end..max_slot to be included when we dump the debug hash info on mismatch.
Without this, we fail to save some pubkeys that were used to calculate the full hash, if they were in slots at the oldest or newest uneven chunks of the last 432k slots.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
