### PR TITLE
mark repair ping packets for discard only after successful signature verification

### DIFF
--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -1277,7 +1277,7 @@ mod tests {
             456, // index
             111, // parent_offset
             &data_buf,
-            ShredFlags::empty(), //ShredFlags::LAST_SHRED_IN_SLOT,
+            ShredFlags::empty(),
             222, // reference_tick
             333, // version
             444, // fec_set_index


### PR DESCRIPTION
#### Problem

Repair socket handling processes both ping responses and shred packets. A shred packet with size equal to a ping response can be discarded by ping processing.

#### Summary of Changes

When attempting to process ping responses only discard packets which have successfully passed signature verification.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
