### PR TITLE
Enable QUIC client by default. Add arg to disable QUIC client.

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -214,10 +214,10 @@ fn main() {
                 .help("Number of threads to use in the banking stage"),
         )
         .arg(
-            Arg::new("tpu_use_quic")
-                .long("tpu-use-quic")
+            Arg::new("tpu_disable_quic")
+                .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Forward messages to TPU using QUIC"),
+                .help("Disable forwarding messages to TPU using QUIC"),
         )
         .get_matches();
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -290,10 +290,10 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .help("Submit transactions with a TpuClient")
         )
         .arg(
-            Arg::with_name("tpu_use_quic")
-                .long("tpu-use-quic")
+            Arg::with_name("tpu_disable_quic")
+                .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Submit transactions via QUIC; only affects ThinClient (default) \
+                .help("Do not submit transactions via QUIC; only affects ThinClient (default) \
                     or TpuClient sends"),
         )
         .arg(
@@ -348,8 +348,8 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         args.external_client_type = ExternalClientType::RpcClient;
     }
 
-    if matches.is_present("tpu_use_quic") {
-        args.use_quic = true;
+    if matches.is_present("tpu_disable_quic") {
+        args.use_quic = false;
     }
 
     if let Some(v) = matches.value_of("tpu_connection_pool_size") {

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -32,7 +32,7 @@ static MAX_CONNECTIONS: usize = 1024;
 
 /// Used to decide whether the TPU and underlying connection cache should use
 /// QUIC connections.
-pub const DEFAULT_TPU_USE_QUIC: bool = false;
+pub const DEFAULT_TPU_USE_QUIC: bool = true;
 
 /// Default TPU connection pool size per remote address
 pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -683,7 +683,11 @@ mod tests {
         // be lazy and not connect until first use or handle connection errors somehow
         // (without crashing, as would be required in a real practical validator)
         let connection_cache = ConnectionCache::default();
-        let port_offset = if connection_cache.use_quic() { QUIC_PORT_OFFSET } else { 0 };
+        let port_offset = if connection_cache.use_quic() {
+            QUIC_PORT_OFFSET
+        } else {
+            0
+        };
         let addrs = (0..MAX_CONNECTIONS)
             .into_iter()
             .map(|_| {
@@ -696,7 +700,10 @@ mod tests {
             let map = connection_cache.map.read().unwrap();
             assert!(map.len() == MAX_CONNECTIONS);
             addrs.iter().for_each(|a| {
-                let port = a.port().checked_add(port_offset).unwrap_or_else(|| a.port());
+                let port = a
+                    .port()
+                    .checked_add(port_offset)
+                    .unwrap_or_else(|| a.port());
                 let addr = &SocketAddr::new(a.ip(), port);
 
                 let conn = &map.get(addr).expect("Address not found").connections[0];
@@ -708,7 +715,10 @@ mod tests {
         let addr = &get_addr(&mut rng);
         connection_cache.get_connection(&addr);
 
-        let port = addr.port().checked_add(port_offset).unwrap_or_else(|| addr.port());
+        let port = addr
+            .port()
+            .checked_add(port_offset)
+            .unwrap_or_else(|| addr.port());
         let addr_with_quic_port = SocketAddr::new(addr.ip(), port);
         let map = connection_cache.map.read().unwrap();
         assert!(map.len() == MAX_CONNECTIONS);

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -713,7 +713,7 @@ mod tests {
         }
 
         let addr = &get_addr(&mut rng);
-        connection_cache.get_connection(&addr);
+        connection_cache.get_connection(addr);
 
         let port = addr
             .port()

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -683,6 +683,7 @@ mod tests {
         // be lazy and not connect until first use or handle connection errors somehow
         // (without crashing, as would be required in a real practical validator)
         let connection_cache = ConnectionCache::default();
+        let port_offset = if connection_cache.use_quic() { QUIC_PORT_OFFSET } else { 0 };
         let addrs = (0..MAX_CONNECTIONS)
             .into_iter()
             .map(|_| {
@@ -695,18 +696,23 @@ mod tests {
             let map = connection_cache.map.read().unwrap();
             assert!(map.len() == MAX_CONNECTIONS);
             addrs.iter().for_each(|a| {
-                let conn = &map.get(a).expect("Address not found").connections[0];
-                let conn = conn.new_blocking_connection(*a, connection_cache.stats.clone());
-                assert!(a.ip() == conn.tpu_addr().ip());
+                let port = a.port().checked_add(port_offset).unwrap_or_else(|| a.port());
+                let addr = &SocketAddr::new(a.ip(), port);
+
+                let conn = &map.get(addr).expect("Address not found").connections[0];
+                let conn = conn.new_blocking_connection(*addr, connection_cache.stats.clone());
+                assert!(addr.ip() == conn.tpu_addr().ip());
             });
         }
 
-        let addr = get_addr(&mut rng);
+        let addr = &get_addr(&mut rng);
         connection_cache.get_connection(&addr);
 
+        let port = addr.port().checked_add(port_offset).unwrap_or_else(|| addr.port());
+        let addr_with_quic_port = SocketAddr::new(addr.ip(), port);
         let map = connection_cache.map.read().unwrap();
         assert!(map.len() == MAX_CONNECTIONS);
-        let _conn = map.get(&addr).expect("Address not found");
+        let _conn = map.get(&addr_with_quic_port).expect("Address not found");
     }
 
     #[test]

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -248,7 +248,6 @@ mod tests {
             "--valid-signatures",
             "--num-signatures",
             "8",
-            "--tpu-use-quic",
             "--send-batch-size",
             "1",
         ])

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -61,7 +61,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --tpu-use-quic ]]; then
+    elif [[ $1 = --tpu-disable-quic ]]; then
       args+=("$1")
       shift
     elif [[ $1 = --rpc-send-batch-ms ]]; then

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1205,10 +1205,10 @@ pub fn main() {
                 .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
         )
         .arg(
-            Arg::with_name("tpu_use_quic")
-                .long("tpu-use-quic")
+            Arg::with_name("tpu_disable_quic")
+                .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Use QUIC to send transactions."),
+                .help("Do not use QUIC to send transactions."),
         )
         .arg(
             Arg::with_name("disable_quic_servers")
@@ -2309,7 +2309,7 @@ pub fn main() {
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
-    let tpu_use_quic = matches.is_present("tpu_use_quic");
+    let tpu_use_quic = !matches.is_present("tpu_disable_quic");
     let enable_quic_servers = !matches.is_present("disable_quic_servers");
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1206,11 +1206,11 @@ pub fn main() {
         )
         .arg(
             Arg::with_name("tpu_use_quic")
-            .long("tpu-use-quic")
-            .takes_value(false)
-            .hidden(true)
-            .conflicts_with("tpu_disable_quic")
-            .help("Use QUIC to send transactions."),
+                .long("tpu-use-quic")
+                .takes_value(false)
+                .hidden(true)
+                .conflicts_with("tpu_disable_quic")
+                .help("Use QUIC to send transactions."),
         )
         .arg(
             Arg::with_name("tpu_disable_quic")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1205,6 +1205,14 @@ pub fn main() {
                 .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
         )
         .arg(
+            Arg::with_name("tpu_use_quic")
+            .long("tpu-use-quic")
+            .takes_value(false)
+            .hidden(true)
+            .conflicts_with("tpu_disable_quic")
+            .help("Use QUIC to send transactions."),
+        )
+        .arg(
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)


### PR DESCRIPTION
#### Problem
* As of v1.10.32 the validator listens for QUIC connections by default
* The validator can forward transactions via quic if run with `--tpu-use-quic`, but doesn't by default

#### Summary of Changes
* Switch the default client behavior to use QUIC
* Add argument to disable the quic client
