### PR TITLE
add subcommand to set randomized compute-unit-price to transactions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,6 +4721,7 @@ dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
  "log",
+ "rand 0.7.3",
  "rayon",
  "serde_json",
  "serde_yaml",

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 clap = "2.33.1"
 crossbeam-channel = "0.5"
 log = "0.4.17"
+rand = "0.7.0"
 rayon = "1.5.3"
 serde_json = "1.0.83"
 serde_yaml = "0.8.26"

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -54,6 +54,7 @@ pub struct Config {
     pub external_client_type: ExternalClientType,
     pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
+    pub use_randomized_compute_unit_price: bool,
 }
 
 impl Default for Config {
@@ -81,6 +82,7 @@ impl Default for Config {
             external_client_type: ExternalClientType::default(),
             use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            use_randomized_compute_unit_price: false,
         }
     }
 }
@@ -303,6 +305,12 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .help("Controls the connection pool size per remote address; only affects ThinClient (default) \
                     or TpuClient sends"),
         )
+        .arg(
+            Arg::with_name("use_randomized_compute_unit_price")
+                .long("use-randomized-compute-unit-price")
+                .takes_value(false)
+                .help("Sets random compute-unit-price in range [0..100] to transfer transactions"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -431,6 +439,10 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
             .to_string()
             .parse()
             .expect("can't parse target slots per epoch");
+    }
+
+    if matches.is_present("use_randomized_compute_unit_price") {
+        args.use_randomized_compute_unit_price = true;
     }
 
     args

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -4,7 +4,7 @@ use {
     clap::value_t,
     log::*,
     solana_bench_tps::{
-        bench::do_bench_tps,
+        bench::{do_bench_tps, max_lamporots_for_prioritization},
         bench_tps_client::BenchTpsClient,
         cli::{self, ExternalClientType},
         keypairs::get_keypairs,
@@ -153,6 +153,7 @@ fn main() {
         external_client_type,
         use_quic,
         tpu_connection_pool_size,
+        use_randomized_compute_unit_price,
         ..
     } = &cli_config;
 
@@ -161,8 +162,11 @@ fn main() {
         info!("Generating {} keypairs", keypair_count);
         let (keypairs, _) = generate_keypairs(id, keypair_count as u64);
         let num_accounts = keypairs.len() as u64;
-        let max_fee =
-            FeeRateGovernor::new(*target_lamports_per_signature, 0).max_lamports_per_signature;
+        let max_fee = FeeRateGovernor::new(*target_lamports_per_signature, 0)
+            .max_lamports_per_signature
+            .saturating_add(max_lamporots_for_prioritization(
+                *use_randomized_compute_unit_price,
+            ));
         let num_lamports_per_account = (num_accounts - 1 + NUM_SIGNATURES_FOR_TXS * max_fee)
             / num_accounts
             + num_lamports_per_account;


### PR DESCRIPTION
#### Problem
bench-tps should have option to send transactions with different compute-unit-price in order to test fee market functions. 

#### Summary of Changes
- Add option to enable sending transactions with randomized compute-unit-price (in range of 0..100).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
