### PR TITLE
Reduce severity level of log in replay

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2602,7 +2602,8 @@ impl ReplayStage {
         let num_active_banks = active_bank_slots.len();
         trace!(
             "{} active bank(s) to replay: {:?}",
-            num_active_banks, active_bank_slots
+            num_active_banks,
+            active_bank_slots
         );
         if num_active_banks > 0 {
             let replay_result_vec = if num_active_banks > 1 {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2600,7 +2600,7 @@ impl ReplayStage {
     ) -> bool {
         let active_bank_slots = bank_forks.read().unwrap().active_bank_slots();
         let num_active_banks = active_bank_slots.len();
-        warn!(
+        trace!(
             "{} active bank(s) to replay: {:?}",
             num_active_banks, active_bank_slots
         );


### PR DESCRIPTION
#### Problem
Spamming warn log with messages like:
`405344:[2022-08-02T18:06:32.918756200Z WARN  solana_core::replay_stage] 1 active bank(s) to replay: [144228509]`

#### Summary of Changes
Reduce log severity to trace
