### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,31 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 See [Adding to this Changelog](#adding-to-this-changelog) section below for details on how to add notes to this file
 
 ## [Unreleased master - edge]
 ### Changes
-- 
+-
 ### Upgrade Notes
 #### Minor version upgrade
-- 
+-
 
 ## [Unreleased v1.11 - beta]
 ### Changes
 - Added a change log!
 ### Upgrade Notes
 #### Patch upgrade
-- 
+-
 #### Minor version upgrade
-- 
+-
 
 ## [Unreleased v1.10 - stable]
 ### Changes
 -
 ### Upgrade Notes
 #### Patch upgrade
-- 
+-
 
 ## [1.11.4] - 2022-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and follows a [Backwards Compatability Policy]
 
 ## Adding to this Changelog
 ### Audience
-* Entries in this log are intended to be easily understood by core contributors,
+* Entries in this log are intended to be easily understood by contributors,
 consensus validator operators, rpc operators, and dapp developers.
 
 ### Noteworthy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and follows a [Backwards Compatability Policy]
 (https://docs.solana.com/developing/backwards-compatibility)
 
-Release branches have their own copy of this changelog:
+Release channels have their own copy of this changelog:
+* [edge - v1.17](#edge-channel)
 * [beta - v1.16](https://github.com/solana-labs/solana/blob/v1.16/CHANGELOG.md)
 * [stable - v1.14](https://github.com/solana-labs/solana/blob/v1.14/CHANGELOG.md)
 
+<a name="edge-channel"></a>
 ## [1.17.0] - Unreleased
 * Changes
   * Added a changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,43 +5,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and follows a [Backwards Compatability Policy](https://docs.solana.com/developing/backwards-compatibility)
 
 ## Adding to this Changelog
+### Audience
 * Entries in this log are intended to be easily understood by consensus validators, rpc operators, and dapp developers.
-* Add notes to the [Unreleased] section that corresponds with the branch you're updating.
-    * Add a description of your change to the Changes section
-    * If your change is likely to require operators to update their configs add to the Upgrade Notes
-        * If you backport your change to the previous release branch or you're updating the stable branch, add note to the "patch" section
-        * If you don't backport, add node to the "minor version" section (these notes will be carried forward for releases on this branch until the previous branch is no longer supported)
+
+### Noteworthy
+* Changes that relate to a SIMD, or add a feature gate should add an entry to this log. Other changes that are relevant to consensus validators, rpc operators, and dapp developers should add an entry at the discretion of authors and reviewers.
+
+### Instructions
+* Update this log with the same commit that implements the change. If the change is spread over several commits update this log with the commit that makes the feature code complete.
+* Add notes to the [Unreleased] section in each branch that you merge to
+  * Add a description of your change to the Changes section
+  * If your change is likely to require operators to update their configs add to the Upgrade Notes
 
 ## How To Maintain This Changelog
-* When the version is bumped:
-    * Patch
-        * Date and tag the [Unreleased] section with the new release including a link to the release page
-        * Create new [Unreleased] section and copy the minor upgrade notes into it
-    * Minor
-        * Advance the version numbers in the [Unreleased sections]
+* When a release is tagged and the version is bumped:
+  * Date and tag the [Unreleased] section with the new release including a link to the release page
+  * Create new [Unreleased] section
 
 ## Unreleased
-### [master - edge]
-* Changes
-* Upgrade Notes
-    * Minor version upgrade
--
-
-### [v1.16 - beta]
 * Changes
   * Added a change log!
 * Upgrade Notes
-  * Patch upgrade
-  * Minor version upgrade
-
-### [v1.14 - stable]
-* Changes
-* Upgrade Notes
-  * Patch upgrade
 
 ## Released
-### 2022-07-23 - [1.11.4] 
-
-### 2022-07-26 - [1.10.33]
-- Fix bug to enable support for token-2022 accounts in preTokenBalances/postTokenBalances
-- Add Display implementations for various zk-token-sdk Pod structs
+### 2023-05-31 - [1.16.0](https://github.com/solana-labs/solana/releases/tag/v1.16.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,35 +6,45 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and follows a [Backwards Compatability Policy]
 (https://docs.solana.com/developing/backwards-compatibility)
 
-## Adding to this Changelog
-### Audience
-* Entries in this log are intended to be easily understood by core contributors, consensus validator operators, rpc operators, and dapp developers.
-
-### Noteworthy
-* Changes that relate to a SIMD, or add a feature gate should add an entry to
-this log. Other changes that are relevant to the aforementioned audiences should
-add an entry at the discretion of authors and reviewers.
-
-### Instructions
-* Update this log in the same pull request that implements the change. If the
-change is spread over several pull requests update this log in the one that
-makes the feature code complete.
-* Add notes to the [Unreleased] section in each branch that you merge to.
-  * Add a description of your change to the Changes section
-  * If your change is likely to require operators to update their configs add to
-  the Upgrade Notes
-* If you add entries on multiple branches please use the same wording if
-possible. This simplifies the process of diffing between versions of the log.
-
-## How To Maintain This Changelog
-* When a release is tagged and the version is bumped:
-  * Move that release's notes to the Released section
-  * Add a new section to Unreleased for the next anticipated release.
-
 ## Unreleased
+### [1.17.0]
 * Changes
   * Added a changelog!
 * Upgrade Notes
 
 ## Released
 ### 2023-05-31 - [1.16.0](https://github.com/solana-labs/solana/releases/tag/v1.16.0)
+
+## Adding to this Changelog
+### Audience
+* Entries in this log are intended to be easily understood by core contributors,
+consensus validator operators, rpc operators, and dapp developers.
+
+### Noteworthy
+* A change is noteworthy if it:
+  * Adds a feature gate, or
+  * Implements a SIMD, or
+  * Modifies API or ABI, or
+  * Changes normal validator / rpc run configurations, or
+  * Changes command line arguments, or
+  * Fixes a bug that has received public attention, or
+  * Significantly improves performance, or
+  * Is authored by an external contributor.
+
+### Instructions
+* Update this log in the same pull request that implements the change. If the
+change is spread over several pull requests update this log in the one that
+makes the feature code complete.
+* Add notes to the [Unreleased] section in each branch that you merge to.
+  * Add a description of your change to the Changes section.
+  * Add Upgrade Notes if the change is likely to require:
+    * validator or rpc operators to update their configs, or
+    * dapp developers to make changes.
+* Link to any relevant feature gate issues or SIMDs.
+* If you add entries on multiple branches use the same wording if possible.
+This simplifies the process of diffing between versions of the log.
+
+## Maintaining This Changelog
+* When a release is tagged and the version is bumped:
+  * Move that release's notes to the Released section.
+  * Add a new section to Unreleased for the next anticipated release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ this log. Other changes that are relevant to the aforementioned audiences should
 add an entry at the discretion of authors and reviewers.
 
 ### Instructions
-* Update this log with the same commit that implements the change. If the change
-is spread over several commits update this log with the commit that makes the
-feature code complete.
+* Update this log in the same pull request that implements the change. If the
+change is spread over several pull requests update this log in the one that
+makes the feature code complete.
 * Add notes to the [Unreleased] section in each branch that you merge to.
   * Add a description of your change to the Changes section
   * If your change is likely to require operators to update their configs add to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,9 @@ possible. This simplifies the process of diffing between versions of the log.
 
 ## How To Maintain This Changelog
 * When a release is tagged and the version is bumped:
-  * Date and tag the [Unreleased] section with the new release including a link
-  to the release page
-  * Create new [Unreleased] section
-change
+  * Move that release's notes to the Released section
+  * Add a new section to Unreleased for the next anticipated release.
+
 ## Unreleased
 * Changes
   * Added a changelog!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ consensus validator operators, rpc operators, and dapp developers.
 * A change is noteworthy if it:
   * Adds a feature gate, or
   * Implements a SIMD, or
-  * Modifies API or ABI, or
+  * Modifies a public API, or
   * Changes normal validator / rpc run configurations, or
   * Changes command line arguments, or
   * Fixes a bug that has received public attention, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and follows a [Backwards Compatability Policy]
 
 ## Adding to this Changelog
 ### Audience
-* Entries in this log are intended to be easily understood by consensus
-validators, rpc operators, and dapp developers.
+* Entries in this log are intended to be easily understood by core contributors, consensus validator operators, rpc operators, and dapp developers.
 
 ### Noteworthy
 * Changes that relate to a SIMD, or add a feature gate should add an entry to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 Please follow the [guidance](#adding-to-this-changelog) at the bottom of this file when making changes
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-and follows a [Backwards Compatability Policy]
-(https://docs.solana.com/developing/backwards-compatibility)
+and follows a [Backwards Compatability Policy](https://docs.solana.com/developing/backwards-compatibility)
 
 Release channels have their own copy of this changelog:
 * [edge - v1.17](#edge-channel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and follows a [Backwards Compatability Policy]
 (https://docs.solana.com/developing/backwards-compatibility)
 
-## Unreleased
-### [1.17.0]
-* Changes
-  * Added a changelog!
-* Upgrade Notes
+Release branches have their own copy of this changelog:
+* [beta - v1.16](https://github.com/solana-labs/solana/blob/v1.16/CHANGELOG.md)
+* [stable - v1.14](https://github.com/solana-labs/solana/blob/v1.14/CHANGELOG.md)
 
-## Released
-### 2023-05-31 - [1.16.0](https://github.com/solana-labs/solana/releases/tag/v1.16.0)
+## [1.17.0] - Unreleased
+* Changes
+  * Added a changelog.
+* Upgrade Notes
 
 ## Adding to this Changelog
 ### Audience
@@ -40,12 +40,21 @@ makes the feature code complete.
   * Add a description of your change to the Changes section.
   * Add Upgrade Notes if the change is likely to require:
     * validator or rpc operators to update their configs, or
-    * dapp developers to make changes.
+    * dapp or client developers to make changes.
 * Link to any relevant feature gate issues or SIMDs.
 * If you add entries on multiple branches use the same wording if possible.
 This simplifies the process of diffing between versions of the log.
 
 ## Maintaining This Changelog
-* When a release is tagged and the version is bumped:
-  * Move that release's notes to the Released section.
-  * Add a new section to Unreleased for the next anticipated release.
+### When creating a new release branch:
+* Commit to master updating the changelog:
+  * Remove `Unreleased` annotation from vx.y.0 section.
+  * Create new section: `vx.y+1.0 - Unreleased`
+* Create vx.y branch starting at that commit
+* Tag that commit as vx.y.0
+
+### When creating a new patch release:
+* Commit to the release branch updating the changelog:
+  * Remove `Unreleased` annotation from `vx.y.z` section
+  * Add a new section at the top for `vx.y.z+1 - Unreleased`
+* Tag that new commit as the new release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ makes the feature code complete.
   * Add a description of your change to the Changes section
   * If your change is likely to require operators to update their configs add to
   the Upgrade Notes
-* If you add entries on multiple branches please use the same wording if
-possible. This simplifies the process of diffing between versions of the log.
 
 ## How To Maintain This Changelog
 * When a release is tagged and the version is bumped:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
+See [Adding to this Changelog](#adding-to-this-changelog) section below for details on how to add notes to this file
+
+## [Unreleased master - edge]
+### Changes
+- 
+### Upgrade Notes
+#### Minor version upgrade
+- 
+
+## [Unreleased v1.11 - beta]
+### Changes
+- Added a change log!
+### Upgrade Notes
+#### Patch upgrade
+- 
+#### Minor version upgrade
+- 
+
+## [Unreleased v1.10 - stable]
+### Changes
+-
+### Upgrade Notes
+#### Patch upgrade
+- 
+
+## [1.11.4] - 2022-07-23
+
+## [1.10.33] - 2022-07-26
+- Fix bug to enable support for token-2022 accounts in preTokenBalances/postTokenBalances
+- Add Display implementations for various zk-token-sdk Pod structs
+
+## Adding to this Changelog
+* Entries in this log are intended to be easily understood by users.
+* Add notes to the [Unreleased] section that corresponds with the branch you're updating.
+    * Add a description of your change to the Changes section
+    * If your change is likely to require validators to update their configs add to the Upgrade Notes
+        * If you backport your change to the previous release branch or you're updating the stable branch, add note to the "patch" section
+        * If you don't backport, add node to the "minor version" section (these notes will be carried forward for releases on this branch until the previous branch is no longer supported)
+
+## How To Maintain This Changelog
+* When the version is bumped:
+    * Patch
+        * Tag and date the [Unreleased] section with the new release including a link to the release page
+        * Create new [Unreleased] section and copy the minor upgrade notes into it
+    * Minor
+        * Advance the version numbers in the [Unreleased sections]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,35 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and follows a [Backwards Compatability Policy](https://docs.solana.com/developing/backwards-compatibility)
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+and follows a [Backwards Compatability Policy]
+(https://docs.solana.com/developing/backwards-compatibility)
 
 ## Adding to this Changelog
 ### Audience
-* Entries in this log are intended to be easily understood by consensus validators, rpc operators, and dapp developers.
+* Entries in this log are intended to be easily understood by consensus
+validators, rpc operators, and dapp developers.
 
 ### Noteworthy
-* Changes that relate to a SIMD, or add a feature gate should add an entry to this log. Other changes that are relevant to the aforementioned audiences should add an entry at the discretion of authors and reviewers.
+* Changes that relate to a SIMD, or add a feature gate should add an entry to
+this log. Other changes that are relevant to the aforementioned audiences should
+add an entry at the discretion of authors and reviewers.
 
 ### Instructions
-* Update this log with the same commit that implements the change. If the change is spread over several commits update this log with the commit that makes the feature code complete.
+* Update this log with the same commit that implements the change. If the change
+is spread over several commits update this log with the commit that makes the
+feature code complete.
 * Add notes to the [Unreleased] section in each branch that you merge to.
   * Add a description of your change to the Changes section
-  * If your change is likely to require operators to update their configs add to the Upgrade Notes
-* If you add entries on multiple branches please use the same wording if possible. This simplifies the process of diffing between versions of the log. 
+  * If your change is likely to require operators to update their configs add to
+  the Upgrade Notes
+* If you add entries on multiple branches please use the same wording if
+possible. This simplifies the process of diffing between versions of the log.
 
 ## How To Maintain This Changelog
 * When a release is tagged and the version is bumped:
-  * Date and tag the [Unreleased] section with the new release including a link to the release page
+  * Date and tag the [Unreleased] section with the new release including a link
+  to the release page
   * Create new [Unreleased] section
 change
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Instructions
 * Update this log with the same commit that implements the change. If the change is spread over several commits update this log with the commit that makes the feature code complete.
-* Add notes to the [Unreleased] section in each branch that you merge to
+* Add notes to the [Unreleased] section in each branch that you merge to.
   * Add a description of your change to the Changes section
   * If your change is likely to require operators to update their configs add to the Upgrade Notes
+* If you add entries on multiple branches please use the same wording if possible. This simplifies the process of diffing between versions of the log. 
 
 ## How To Maintain This Changelog
 * When a release is tagged and the version is bumped:
   * Date and tag the [Unreleased] section with the new release including a link to the release page
   * Create new [Unreleased] section
-
+change
 ## Unreleased
 * Changes
-  * Added a change log!
+  * Added a changelog!
 * Upgrade Notes
 
 ## Released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,51 +1,47 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-See [Adding to this Changelog](#adding-to-this-changelog) section below for details on how to add notes to this file
-
-## [Unreleased master - edge]
-### Changes
--
-### Upgrade Notes
-#### Minor version upgrade
--
-
-## [Unreleased v1.11 - beta]
-### Changes
-- Added a change log!
-### Upgrade Notes
-#### Patch upgrade
--
-#### Minor version upgrade
--
-
-## [Unreleased v1.10 - stable]
-### Changes
--
-### Upgrade Notes
-#### Patch upgrade
--
-
-## [1.11.4] - 2022-07-23
-
-## [1.10.33] - 2022-07-26
-- Fix bug to enable support for token-2022 accounts in preTokenBalances/postTokenBalances
-- Add Display implementations for various zk-token-sdk Pod structs
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and follows a [Backwards Compatability Policy](https://docs.solana.com/developing/backwards-compatibility)
 
 ## Adding to this Changelog
-* Entries in this log are intended to be easily understood by users.
+* Entries in this log are intended to be easily understood by consensus validators, rpc operators, and dapp developers.
 * Add notes to the [Unreleased] section that corresponds with the branch you're updating.
     * Add a description of your change to the Changes section
-    * If your change is likely to require validators to update their configs add to the Upgrade Notes
+    * If your change is likely to require operators to update their configs add to the Upgrade Notes
         * If you backport your change to the previous release branch or you're updating the stable branch, add note to the "patch" section
         * If you don't backport, add node to the "minor version" section (these notes will be carried forward for releases on this branch until the previous branch is no longer supported)
 
 ## How To Maintain This Changelog
 * When the version is bumped:
     * Patch
-        * Tag and date the [Unreleased] section with the new release including a link to the release page
+        * Date and tag the [Unreleased] section with the new release including a link to the release page
         * Create new [Unreleased] section and copy the minor upgrade notes into it
     * Minor
         * Advance the version numbers in the [Unreleased sections]
+
+## Unreleased
+### [master - edge]
+* Changes
+* Upgrade Notes
+    * Minor version upgrade
+-
+
+### [v1.16 - beta]
+* Changes
+  * Added a change log!
+* Upgrade Notes
+  * Patch upgrade
+  * Minor version upgrade
+
+### [v1.14 - stable]
+* Changes
+* Upgrade Notes
+  * Patch upgrade
+
+## Released
+### 2022-07-23 - [1.11.4] 
+
+### 2022-07-26 - [1.10.33]
+- Fix bug to enable support for token-2022 accounts in preTokenBalances/postTokenBalances
+- Add Display implementations for various zk-token-sdk Pod structs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+Please follow the [guidance](#adding-to-this-changelog) at the bottom of this file when making changes
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and follows a [Backwards Compatability Policy]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Entries in this log are intended to be easily understood by consensus validators, rpc operators, and dapp developers.
 
 ### Noteworthy
-* Changes that relate to a SIMD, or add a feature gate should add an entry to this log. Other changes that are relevant to consensus validators, rpc operators, and dapp developers should add an entry at the discretion of authors and reviewers.
+* Changes that relate to a SIMD, or add a feature gate should add an entry to this log. Other changes that are relevant to the aforementioned audiences should add an entry at the discretion of authors and reviewers.
 
 ### Instructions
 * Update this log with the same commit that implements the change. If the change is spread over several commits update this log with the commit that makes the feature code complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ makes the feature code complete.
   * Add a description of your change to the Changes section
   * If your change is likely to require operators to update their configs add to
   the Upgrade Notes
+* If you add entries on multiple branches please use the same wording if
+possible. This simplifies the process of diffing between versions of the log.
 
 ## How To Maintain This Changelog
 * When a release is tagged and the version is bumped:


### PR DESCRIPTION
#### Problem
* Release notes are written from commit messages which are usually not written for end users.
* We don't track upgrade notes which causes confusion when config changes are required.

#### Summary of Changes
* Add a change log to facilitate writing and tracking release notes.
