### PR TITLE
Bump spl-token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6685,11 +6685,12 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc67166ef99d10c18cb5e9c208901e6d8255c6513bb1f877977eba48e6cc4fb"
+checksum = "32d05653bed5932064a287340dbc8a3cb298ee717e5c7ec3353d7cdb9f8fb7e1"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.81"
 solana-config-program = { path = "../programs/config", version = "=1.11.5" }
 solana-sdk = { path = "../sdk", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
-spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.11.2"

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -26,7 +26,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.5" }
 solana-streamer = { path = "../streamer", version = "=1.11.5" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.5" }
 solana-version = { path = "../version", version = "=1.11.5" }
-spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-core = { path = "../core", version = "=1.11.5" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5875,11 +5875,12 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc67166ef99d10c18cb5e9c208901e6d8255c6513bb1f877977eba48e6cc4fb"
+checksum = "32d05653bed5932064a287340dbc8a3cb298ee717e5c7ec3353d7cdb9f8fb7e1"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -49,7 +49,7 @@ solana-streamer = { path = "../streamer", version = "=1.11.5" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.5" }
 solana-version = { path = "../version", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
-spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -28,7 +28,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.5" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.5" }
 solana-version = { path = "../version", version = "=1.11.5" }
 spl-associated-token-account = { version = "=1.0.5" }
-spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
 tempfile = "3.3.0"
 thiserror = "1.0"
 

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -28,7 +28,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
 spl-associated-token-account = { version = "=1.0.5", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
-spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/26899 bumped spl-token on v1.10

#### Summary of Changes
While v1.11.4 rpc instruction parsing is safe from the token unpack bug, due to its dependency on spl-token-2022, bump spl-token for consistency.
