### PR TITLE
(Ledger-Tool) Add command --purge-older-slots

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -136,12 +136,11 @@ impl Blockstore {
         }
     }
 
-    pub(crate) fn run_purge(
-        &self,
-        from_slot: Slot,
-        to_slot: Slot,
-        purge_type: PurgeType,
-    ) -> Result<bool> {
+    /// Purge any slots within the specified slot range for all slot-based columns.
+    ///
+    /// Note that `from_slot` is 0, any sst-file with a slot-range completely older
+    /// than `to_slot` will be deleted immediately.
+    pub fn run_purge(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) -> Result<bool> {
         self.run_purge_with_stats(from_slot, to_slot, purge_type, &mut PurgeStats::default())
     }
 


### PR DESCRIPTION
#### Problem
The current ledger tool does not have a subcommand to purge older slots.
Example use cases of this subcommand include:
* Deleting slots older than the slot-range of a corrupted sst file in order to quickly restart the validator.
* Freeing up ledger disk space.

#### Summary of Changes
This PR adds --purge-older-slots to the ledger tool that allows users to
delete slots that are older than or equal to the specified slot.

This PR depends on #26651 and is related to #26790.