### PR TITLE
delay trying to flush cached upserts until far future

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -232,16 +232,16 @@ pub struct AccountMapEntryMeta {
 }
 
 impl AccountMapEntryMeta {
-    pub fn new_dirty<T: IndexValue>(storage: &Arc<BucketMapHolder<T>>) -> Self {
+    pub fn new_dirty<T: IndexValue>(storage: &Arc<BucketMapHolder<T>>, is_cached: bool) -> Self {
         AccountMapEntryMeta {
             dirty: AtomicBool::new(true),
-            age: AtomicU8::new(storage.future_age_to_flush()),
+            age: AtomicU8::new(storage.future_age_to_flush(is_cached)),
         }
     }
     pub fn new_clean<T: IndexValue>(storage: &Arc<BucketMapHolder<T>>) -> Self {
         AccountMapEntryMeta {
             dirty: AtomicBool::new(false),
-            age: AtomicU8::new(storage.future_age_to_flush()),
+            age: AtomicU8::new(storage.future_age_to_flush(false)),
         }
     }
 }
@@ -414,7 +414,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
     ) -> AccountMapEntry<T> {
         let is_cached = account_info.is_cached();
         let ref_count = if is_cached { 0 } else { 1 };
-        let meta = AccountMapEntryMeta::new_dirty(storage);
+        let meta = AccountMapEntryMeta::new_dirty(storage, is_cached);
         Arc::new(AccountMapEntryInner::new(
             vec![(slot, account_info)],
             ref_count,

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -266,6 +266,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     fn get_only_in_mem<RT>(
         &self,
         pubkey: &K,
+        update_age: bool,
         callback: impl for<'a> FnOnce(Option<&'a AccountMapEntry<T>>) -> RT,
     ) -> RT {
         let mut found = true;
@@ -276,7 +277,9 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
             m.stop();
 
             callback(if let Some(entry) = result {
-                self.set_age_to_future(entry);
+                if update_age {
+                    self.set_age_to_future(entry, false);
+                }
                 Some(entry)
             } else {
                 drop(map);
@@ -302,8 +305,10 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         self.get_internal(pubkey, |entry| (true, entry.map(Arc::clone)))
     }
 
-    fn set_age_to_future(&self, entry: &AccountMapEntry<T>) {
-        entry.set_age(self.storage.future_age_to_flush());
+    /// set age of 'entry' to the future
+    /// if 'is_cached', age will be set farther
+    fn set_age_to_future(&self, entry: &AccountMapEntry<T>, is_cached: bool) {
+        entry.set_age(self.storage.future_age_to_flush(is_cached));
     }
 
     /// lookup 'pubkey' in index (in_mem or disk).
@@ -314,7 +319,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         // return true if item should be added to in_mem cache
         callback: impl for<'a> FnOnce(Option<&AccountMapEntry<T>>) -> (bool, RT),
     ) -> RT {
-        self.get_only_in_mem(pubkey, |entry| {
+        self.get_only_in_mem(pubkey, true, |entry| {
             if let Some(entry) = entry {
                 callback(Some(entry)).1
             } else {
@@ -448,16 +453,12 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     ) {
         let mut updated_in_mem = true;
         // try to get it just from memory first using only a read lock
-        self.get_only_in_mem(pubkey, |entry| {
+        self.get_only_in_mem(pubkey, false, |entry| {
             if let Some(entry) = entry {
-                Self::lock_and_update_slot_list(
-                    entry,
-                    new_value.into(),
-                    other_slot,
-                    reclaims,
-                    reclaim,
-                );
-                // age is incremented by caller
+                let new_value: (Slot, T) = new_value.into();
+                let upsert_cached = new_value.1.is_cached();
+                Self::lock_and_update_slot_list(entry, new_value, other_slot, reclaims, reclaim);
+                self.set_age_to_future(entry, upsert_cached);
             } else {
                 let mut m = Measure::start("entry");
                 let mut map = self.map_internal.write().unwrap();
@@ -466,15 +467,13 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 let found = matches!(entry, Entry::Occupied(_));
                 match entry {
                     Entry::Occupied(mut occupied) => {
+                        let new_value: (Slot, T) = new_value.into();
+                        let upsert_cached = new_value.1.is_cached();
                         let current = occupied.get_mut();
                         Self::lock_and_update_slot_list(
-                            current,
-                            new_value.into(),
-                            other_slot,
-                            reclaims,
-                            reclaim,
+                            current, new_value, other_slot, reclaims, reclaim,
                         );
-                        self.set_age_to_future(current);
+                        self.set_age_to_future(current, upsert_cached);
                     }
                     Entry::Vacant(vacant) => {
                         // not in cache, look on disk
@@ -483,14 +482,17 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         // go to in-mem cache first
                         let disk_entry = self.load_account_entry_from_disk(vacant.key());
                         let new_value = if let Some(disk_entry) = disk_entry {
+                            let new_value: (Slot, T) = new_value.into();
+                            let upsert_cached = new_value.1.is_cached();
                             // on disk, so merge new_value with what was on disk
                             Self::lock_and_update_slot_list(
                                 &disk_entry,
-                                new_value.into(),
+                                new_value,
                                 other_slot,
                                 reclaims,
                                 reclaim,
                             );
+                            self.set_age_to_future(&disk_entry, upsert_cached);
                             disk_entry
                         } else {
                             // not on disk, so insert new thing
@@ -501,7 +503,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         vacant.insert(new_value);
                         self.stats().inc_mem_count(self.bin);
                     }
-                }
+                };
 
                 drop(map);
                 self.update_entry_stats(m, found);
@@ -872,7 +874,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         if let Some(disk) = self.bucket.as_ref() {
             let mut map = self.map_internal.write().unwrap();
             let items = disk.items_in_range(range); // map's lock has to be held while we are getting items from disk
-            let future_age = self.storage.future_age_to_flush();
+            let future_age = self.storage.future_age_to_flush(false);
             for item in items {
                 let entry = map.entry(item.pubkey);
                 match entry {
@@ -1235,7 +1237,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
 
         let stop_evictions_changes_at_start = self.get_stop_evictions_changes();
-        let next_age_on_failure = self.storage.future_age_to_flush();
+        let next_age_on_failure = self.storage.future_age_to_flush(false);
         if self.get_stop_evictions() {
             // ranges were changed
             self.move_ages_to_future(next_age_on_failure, current_age, &evictions);


### PR DESCRIPTION
#### Problem

In mem acct idx holds items in memory for at most 255 'ages'. An age is 400ms, so correlates to slot time.
We hold in-mem anything with a slot list len > 1 or with a cached item.
Bg threads have to go through all in-mem entries to figure out what to throw out. Items that are put into memory with cached items especially are unlikely to be flushed for approximately 100 slots into the future. This means the bg threads will continually check to see if they can be thrown out yet, only to find out 'no' and punting them 5 more slots into the future. When the write cache is flushed, the index is updated with non-cache append vec ids and eviction is scheduled for the normal 5 slots in the future.

It is better to have a mechanism where if we know a cached item is being added, we set the age to try eviction far into the future so that we don't waste time checking the item over and over.

#### Summary of Changes

Set the age to flush for cached items far into the 'age' future. Which is a max of 255 since age is a u8.

Worst case, we will hold updated entries in the cache for 250 slots past what we do today. The cache will begin more aggressively flushing once it gets too large.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
