### PR TITLE
ledger-tool: support Geyser accounts updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5500,6 +5500,7 @@ dependencies = [
  "solana-cli-output",
  "solana-core",
  "solana-entry",
+ "solana-geyser-plugin-manager",
  "solana-ledger",
  "solana-logger 1.12.0",
  "solana-measure",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -26,6 +26,7 @@ solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
 solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
 solana-core = { path = "../core", version = "=1.12.0" }
 solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.12.0" }
 solana-ledger = { path = "../ledger", version = "=1.12.0" }
 solana-logger = { path = "../logger", version = "=1.12.0" }
 solana-measure = { path = "../measure", version = "=1.12.0" }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -6,6 +6,7 @@ use {
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
     },
+    crossbeam_channel::unbounded,
     dashmap::DashMap,
     itertools::Itertools,
     log::*,
@@ -20,6 +21,7 @@ use {
     },
     solana_core::system_monitor_service::SystemMonitorService,
     solana_entry::entry::Entry,
+    solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
@@ -39,6 +41,7 @@ use {
         },
         accounts_db::{AccountsDbConfig, FillerAccountsConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanConfig},
+        accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank::{Bank, RewardCalculationEvent},
         bank_forks::BankForks,
         cost_model::CostModel,
@@ -926,6 +929,25 @@ fn load_bank_forks(
         vec![non_primary_accounts_path]
     };
 
+    let mut accounts_update_notifier = Option::<AccountsUpdateNotifier>::default();
+    if arg_matches.is_present("geyser_plugin_config") {
+        let geyser_config_files = values_t_or_exit!(arg_matches, "geyser_plugin_config", String)
+            .into_iter()
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+
+        let (confirmed_bank_sender, confirmed_bank_receiver) = unbounded();
+        drop(confirmed_bank_sender);
+        let geyser_service =
+            GeyserPluginService::new(confirmed_bank_receiver, &geyser_config_files).unwrap_or_else(
+                |err| {
+                    eprintln!("Failed to setup Geyser service: {:?}", err);
+                    exit(1);
+                },
+            );
+        accounts_update_notifier = geyser_service.get_accounts_update_notifier();
+    }
+
     let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) =
         bank_forks_utils::load_bank_forks(
             genesis_config,
@@ -935,7 +957,7 @@ fn load_bank_forks(
             snapshot_config.as_ref(),
             &process_options,
             None,
-            None,
+            accounts_update_notifier,
         );
 
     let pruned_banks_receiver =
@@ -1275,6 +1297,13 @@ fn main() {
     .default_value(default_max_incremental_snapshot_archives_to_retain)
     .help("The maximum number of incremental snapshot archives to hold on to when purging older snapshots.");
 
+    let geyser_plugin_args = Arg::with_name("geyser_plugin_config")
+        .long("geyser-plugin-config")
+        .value_name("FILE")
+        .takes_value(true)
+        .multiple(true)
+        .help("Specify the configuration file for the Geyser plugin.");
+
     let rent = Rent::default();
     let default_bootstrap_validator_lamports = &sol_to_lamports(500.0)
         .max(VoteState::get_rent_exempt_reserve(&rent))
@@ -1559,6 +1588,7 @@ fn main() {
             .arg(&allow_dead_slots_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
             .arg(&debug_key_arg)
+            .arg(&geyser_plugin_args)
             .arg(
                 Arg::with_name("skip_poh_verify")
                     .long("skip-poh-verify")
@@ -1613,6 +1643,7 @@ fn main() {
             .arg(&snapshot_version_arg)
             .arg(&maximum_full_snapshot_archives_to_retain)
             .arg(&maximum_incremental_snapshot_archives_to_retain)
+            .arg(&geyser_plugin_args)
             .arg(
                 Arg::with_name("snapshot_slot")
                     .index(1)
@@ -1785,6 +1816,7 @@ fn main() {
             .arg(&account_paths_arg)
             .arg(&halt_at_slot_arg)
             .arg(&hard_forks_arg)
+            .arg(&geyser_plugin_args)
             .arg(
                 Arg::with_name("include_sysvars")
                     .long("include-sysvars")
@@ -1811,6 +1843,7 @@ fn main() {
             .arg(&halt_at_slot_arg)
             .arg(&hard_forks_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(&geyser_plugin_args)
             .arg(
                 Arg::with_name("warp_epoch")
                     .required(false)


### PR DESCRIPTION
#### Problem

See #26886 

Support Geyser plugins in `solana-ledger-tool verify`

#### Summary of Changes

Adds `--geyser-plugin-config` flag to ledger-tool.

Only supports account updates for now.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
