### PR TITLE
Account files remove

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -457,7 +457,7 @@ impl Validator {
         info!("Cleaning accounts paths..");
         *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
         let mut start = Measure::start("clean_accounts_paths");
-        cleanup_accounts_paths(&config);
+        cleanup_accounts_paths(config);
         start.stop();
         info!("done. {}", start);
 
@@ -2061,7 +2061,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 /// If the process is killed and the deleting process is not done,
 /// the leftover path will be deleted in the next process life, so
 /// there is no file space leaking.
-fn move_and_async_delete_path(path: &std::path::Path) {
+fn move_and_async_delete_path(path: &Path) {
     let mut del_path_str = OsString::from(path);
     del_path_str.push("_deleted");
     let path_delete = PathBuf::from(del_path_str);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -456,14 +456,7 @@ impl Validator {
         info!("Cleaning accounts paths..");
         *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
         let mut start = Measure::start("clean_accounts_paths");
-        for accounts_path in &config.account_paths {
-            cleanup_accounts_path(accounts_path);
-        }
-        if let Some(ref shrink_paths) = config.account_shrink_paths {
-            for accounts_path in shrink_paths {
-                cleanup_accounts_path(accounts_path);
-            }
-        }
+        cleanup_accounts_paths(&config);
         start.stop();
         info!("done. {}", start);
 
@@ -2068,6 +2061,17 @@ fn cleanup_accounts_path(account_path: &std::path::Path) {
             "encountered error removing accounts path: {:?}: {}",
             account_path, e
         );
+    }
+}
+
+fn cleanup_accounts_paths(config: &ValidatorConfig) {
+    for accounts_path in &config.account_paths {
+        cleanup_accounts_path(accounts_path);
+    }
+    if let Some(ref shrink_paths) = config.account_shrink_paths {
+        for accounts_path in shrink_paths {
+            cleanup_accounts_path(accounts_path);
+        }
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2071,6 +2071,11 @@ fn move_and_async_delete_path(path: &Path) {
         std::fs::remove_dir_all(&path_delete).unwrap();
     }
 
+    if !path.exists() {
+        info!("move_and_async_delete_path: path {path:?} does not exist");
+        return;
+    }
+
     std::fs::rename(&path, &path_delete).unwrap();
 
     Builder::new()


### PR DESCRIPTION
#### Problem
The validator logs show that clean_accounts_paths takes too long time.  This moves files deleting work to an async background task, unblocking validator new() to move forward without waiting for the deletion to be done.

INFO  solana_core::validator] done. clean_accounts_paths took 14.5s

#### Summary of Changes
Rename the files first, which should take much less time than deleting them.
Call an async task to remove the files in async context, let the validator init to go forward without blocking on it.

Before the validator process starts, there is 105GB files in the directory, which would take 14s before the change. 
sol@dev-server-da11:~$ du /mnt/nvme1n1/ledger/accounts
98832856        /mnt/nvme1n1/ledger/accounts/accounts
105338348       /mnt/nvme1n1/ledger/accounts

With the change, there is no more 14s waiting.
1984890 [2022-08-17T21:22:08.428526819Z INFO  solana_core::validator] Cleaning accounts paths..
1984891 [2022-08-17T21:22:08.428580241Z INFO  solana_core::validator] done. clean_accounts_paths took 43us

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
