### PR TITLE
Make `solana-ledger-tool` run AccountsBackgroundService

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -116,9 +116,6 @@ use {
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 
-/// maximum drop bank signal queue length
-const MAX_DROP_BANK_SIGNAL_QUEUE_SIZE: usize = 10_000;
-
 pub struct ValidatorConfig {
     pub halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,
@@ -1468,22 +1465,8 @@ fn load_blockstore(
     // drop behavior can be safely synchronized with any other ongoing accounts activity like
     // cache flush, clean, shrink, as long as the same thread performing those activities also
     // is processing the dropped banks from the `pruned_banks_receiver` channel.
-
-    // There should only be one bank, the root bank in BankForks. Thus all banks added to
-    // BankForks from now on will be descended from the root bank and thus will inherit
-    // the bank drop callback.
-    assert_eq!(bank_forks.read().unwrap().banks().len(), 1);
-    let (pruned_banks_sender, pruned_banks_receiver) = bounded(MAX_DROP_BANK_SIGNAL_QUEUE_SIZE);
-    {
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        root_bank.set_callback(Some(Box::new(
-            root_bank
-                .rc
-                .accounts
-                .accounts_db
-                .create_drop_bank_callback(pruned_banks_sender),
-        )));
-    }
+    let pruned_banks_receiver =
+        AccountsBackgroundService::setup_bank_drop_callback(bank_forks.clone());
 
     {
         let hard_forks: Vec<_> = bank_forks

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -9,6 +9,7 @@ use {
     },
     log::*,
     solana_runtime::{
+        accounts_background_service::AbsRequestSender,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank_forks::BankForks,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
@@ -68,7 +69,7 @@ pub fn load(
         &process_options,
         transaction_status_sender,
         cache_block_meta_sender,
-        &solana_runtime::accounts_background_service::AbsRequestSender::default(),
+        &AbsRequestSender::default(),
     )
     .map(|_| (bank_forks, leader_schedule_cache, starting_snapshot_hashes))
 }


### PR DESCRIPTION
#### Problem
Prior to this change, long running commands like `solana-ledger-tool
verify` would OOM due to AccountsDb cleanup not happening.

#### Summary of Changes
Make `solana-ledger-tool` enable `AccountsBackgroundService`.

Credit to @mvines for doing most of the actual work in https://github.com/solana-labs/solana/pull/26349.

#### Testing
I had previously been encountering an OOM after ~5k slots of processing on mnb with `solana-ledger-tool` on a ledger I had assembled for testing something else. With this change, I successfully processed the ~10k slots I had been hoping to without issue.

As an interesting perf datapoint, here is processing comparison between `master` and `v1.10.32`; the memory stats are taken from last print out immediately before last frozen bank:
```
# v1.10.32
datapoint: memory-stats total=269843996672i
  swap_total=1996796i
  free_percent=5.375635007967986
  used_bytes=83485450240i
  avail_percent=69.06158696519826
  buffers_percent=0.08825304210472022
  cached_percent=62.40292294391176
  swap_free_percent=98.64843479253764
...
ledger processed in 42 minutes, 27 seconds, 918 ms, 89 µs and 490 ns. root slot is 144172963, 34 banks: ...

# master
datapoint: memory-stats total=269843996672i
  swap_total=2044719104i
  free_percent=14.293261788173817
  used_bytes=19493175296i
  avail_percent=92.77613156623444
  buffers_percent=0.14457524377472322
  cached_percent=77.14281880468457
  swap_free_percent=98.49078223313748
...
ledger processed in 33 minutes, 3 seconds, 914 ms, 915 µs and 405 ns. root slot is 144172963, 34 banks: 1...
```


Fixes #26895 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
