### PR TITLE
bpf-loader: make syscalls pub

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1,16 +1,16 @@
+pub use self::{
+    cpi::{SyscallInvokeSignedC, SyscallInvokeSignedRust},
+    logging::{
+        SyscallLog, SyscallLogBpfComputeUnits, SyscallLogData, SyscallLogPubkey, SyscallLogU64,
+    },
+    mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
+    sysvar::{
+        SyscallGetClockSysvar, SyscallGetEpochScheduleSysvar, SyscallGetFeesSysvar,
+        SyscallGetRentSysvar,
+    },
+};
 #[allow(deprecated)]
 use {
-    self::{
-        cpi::{SyscallInvokeSignedC, SyscallInvokeSignedRust},
-        logging::{
-            SyscallLog, SyscallLogBpfComputeUnits, SyscallLogData, SyscallLogPubkey, SyscallLogU64,
-        },
-        mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
-        sysvar::{
-            SyscallGetClockSysvar, SyscallGetEpochScheduleSysvar, SyscallGetFeesSysvar,
-            SyscallGetRentSysvar,
-        },
-    },
     crate::{allocator_bump::BpfAllocator, BpfError},
     solana_program_runtime::{
         ic_logger_msg, ic_msg,


### PR DESCRIPTION
#### Problem

PR #26637 refactored syscalls into modules. This downgraded the visibility of these syscalls from public to private (default-visibility). 

Out-of-tree apps using syscalls are stuck with Solana ~v1.11.2 for now and can't upgrade to v1.11.5.
This seems like an inadvertent change since it's a breaking change but it went into a patch release.

#### Summary of Changes

Make syscalls pub again!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
