### PR TITLE
add program account to bpf loader close instruction parser

### DIFF
--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -146,7 +146,12 @@ pub fn parse_bpf_upgradeable_loader(
                 info: json!({
                     "account": account_keys[instruction.accounts[0] as usize].to_string(),
                     "recipient": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "authority": account_keys[instruction.accounts[2] as usize].to_string()
+                    "authority": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "programAccount": if instruction.accounts.len() > 3 {
+                        Some(account_keys[instruction.accounts[3] as usize].to_string())
+                    } else {
+                        None
+                    }
                 }),
             })
         }
@@ -606,7 +611,7 @@ mod test {
     }
 
     #[test]
-    fn test_parse_bpf_upgradeable_loader_close_ix() {
+    fn test_parse_bpf_upgradeable_loader_close_buffer_ix() {
         let close_address = Pubkey::new_unique();
         let recipient_address = Pubkey::new_unique();
         let authority_address = Pubkey::new_unique();
@@ -625,6 +630,7 @@ mod test {
                     "account": close_address.to_string(),
                     "recipient": recipient_address.to_string(),
                     "authority": authority_address.to_string(),
+                    "programAccount": Value::Null
                 }),
             }
         );
@@ -634,6 +640,50 @@ mod test {
         )
         .is_err());
         let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_bpf_upgradeable_loader_close_program_ix() {
+        let close_address = Pubkey::new_unique();
+        let recipient_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+        let program_address = Pubkey::new_unique();
+        let instruction = bpf_loader_upgradeable::close_any(
+            &close_address,
+            &recipient_address,
+            Some(&authority_address),
+            Some(&program_address),
+        );
+        let mut message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_bpf_upgradeable_loader(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "close".to_string(),
+                info: json!({
+                    "account": close_address.to_string(),
+                    "recipient": recipient_address.to_string(),
+                    "authority": authority_address.to_string(),
+                    "programAccount": program_address.to_string()
+                }),
+            }
+        );
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..1], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_bpf_upgradeable_loader(
             &message.instructions[0],


### PR DESCRIPTION
#### Problem

The close instruction of the `bpf_loader` program can either be called to close a buffer account or a program data account.
Currently, the bpf loader parser parse the closure of a buffer account properly but is missing an account regarding closure of a program account.
This PR add parsing for the program account.
