### PR TITLE
Remove `fn slot_deltas()` from StatusCache

### DIFF
--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -28,24 +28,10 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
             status_cache.insert(&blockhash, &sig, 0, Ok(()));
         }
     }
+    assert!(status_cache.roots().contains(&0));
     bencher.iter(|| {
-        let _ = serialize(&status_cache.slot_deltas(&[0])).unwrap();
+        let _ = serialize(&status_cache.root_slot_deltas()).unwrap();
     });
-}
-
-#[bench]
-fn bench_status_cache_slot_deltas(bencher: &mut Bencher) {
-    let mut status_cache = BankStatusCache::default();
-
-    // fill the status cache
-    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
-    for slot in &slots {
-        for _ in 0..5 {
-            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
-        }
-    }
-
-    bencher.iter(|| test::black_box(status_cache.slot_deltas(&slots)));
 }
 
 #[bench]
@@ -62,16 +48,4 @@ fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     }
 
     bencher.iter(|| test::black_box(status_cache.root_slot_deltas()));
-}
-
-/// Benchmark the worst-case time getting slot deltas where every slot requested is not in the
-/// status cache
-#[bench]
-fn bench_status_cache_slot_deltas_empty(bencher: &mut Bencher) {
-    let status_cache = BankStatusCache::default();
-
-    // *do not* fill the status cache
-    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
-
-    bencher.iter(|| test::black_box(status_cache.slot_deltas(&slots)));
 }


### PR DESCRIPTION
#### Problem

The `slot_deltas()` and `root_slot_deltas()` functions have different behavior w.r.t. not-found slots. They probably shouldn't.

Please see https://github.com/solana-labs/solana/pull/26170#discussion_r938054799 for more context.


#### Summary of Changes

Remove `fn slot_deltas()`


### OLD SUMMARY BELOW

#### Summary of Changes

Add a new private function that wraps the impl of both `slot_deltas()` and `root_slot_deltas()`. Now both have the same behavior (to create a unique entry per missing slot, instead of sharing a single 'empty').

Some benchmarks:

before:

```text
test bench_status_cache_root_slot_deltas  ... bench:       7,712 ns/iter (+/- 388)
test bench_status_cache_slot_deltas       ... bench:       8,826 ns/iter (+/- 1,448)
test bench_status_cache_slot_deltas_empty ... bench:       5,441 ns/iter (+/- 318)
```

after:

```text
test bench_status_cache_root_slot_deltas  ... bench:       7,596 ns/iter (+/- 344)
test bench_status_cache_slot_deltas       ... bench:       8,582 ns/iter (+/- 539)
test bench_status_cache_slot_deltas_empty ... bench:      27,687 ns/iter (+/- 2,144)
```

The only change is that 'empty'/missing slots are now more expensive, since a new `Status` is created for each one. In practice I cannot imagine that roots have zero transactions, therefore this pathological case should never occur.