### PR TITLE
sha256 compression syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5803,6 +5803,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
+ "generic-array 0.14.5",
  "getrandom 0.2.3",
  "itertools",
  "js-sys",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4449,6 +4449,8 @@ version = "1.11.6"
 dependencies = [
  "blake3",
  "solana-program 1.11.6",
+ "generic-array 0.14.5",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -5149,6 +5151,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
+ "generic-array 0.14.5",
  "getrandom 0.2.4",
  "itertools",
  "js-sys",

--- a/programs/bpf/rust/sha/Cargo.toml
+++ b/programs/bpf/rust/sha/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2021"
 [dependencies]
 blake3 = "1.0.0"
 solana-program = { path = "../../../../sdk/program", version = "=1.11.6" }
+generic-array = "0.14.5"
+sha2 = "0.10.2"
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sha/src/lib.rs
+++ b/programs/bpf/rust/sha/src/lib.rs
@@ -28,6 +28,37 @@ fn test_blake3_hasher() {
     assert_eq!(hashv(vals).0, *hash.as_bytes());
 }
 
+fn test_sha256_compression() {
+    use solana_program::hash::{compress, H256_256, Hasher};
+    use generic_array::{GenericArray, typenum::U64};
+
+    let vals = &["Gaggablaghblagh!".as_ref(), "flurbos".as_ref()];
+    let mut hasher = Hasher::default();
+    hasher.hashv(vals);
+    let left = hasher.result();
+
+    let vals = &["wubbbawubbadubdub!".as_ref(), "dinglebop".as_ref()];
+    let mut hasher = Hasher::default();
+    hasher.hashv(vals);
+    let right = hasher.result();
+
+    let mut block = [0u8; 64];
+    (&mut block[..32]).copy_from_slice(&left.to_bytes());
+    (&mut block[32..]).copy_from_slice(&right.to_bytes());
+    let compressed = compress(&[block]);
+
+    let mut state = H256_256;
+    let block_arr = GenericArray::<u8, U64>::from(block);
+    sha2::compress256(&mut state, &[block_arr]);
+
+    let mut compressed_correct = [0u8; 32];
+    for (chunk, v) in compressed_correct.chunks_exact_mut(4).zip(state.iter()) {
+        chunk.copy_from_slice(&v.to_be_bytes());
+    }
+
+    assert_eq!(compressed.to_bytes(), compressed_correct);
+}
+
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("sha");

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -39,7 +39,7 @@ use {
             limit_secp256k1_recovery_id, prevent_calling_precompiles_as_programs,
             syscall_saturated_math,
         },
-        hash::{Hasher, HASH_BYTES, compress},
+        hash::{compress, Hasher, HASH_BYTES},
         instruction::{
             AccountMeta, Instruction, InstructionError, ProcessedSiblingInstruction,
             TRANSACTION_LEVEL_STACK_HEIGHT,
@@ -953,7 +953,7 @@ declare_syscall!(
                 .consume(compute_budget.sha256_base_cost),
             result
         );
-        
+
         let hash_result = question_mark!(
             translate_slice_mut::<u8>(
                 memory_mapping,
@@ -994,7 +994,6 @@ declare_syscall!(
         *result = Ok(0);
     }
 );
-
 
 declare_syscall!(
     // Keccak256

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -29,7 +29,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
-sha2 = "0.10.0"
+sha2 = { version = "0.10.0", features = ["compress"] }
+generic-array = "0.14.5"
 sha3 = "0.10.0"
 solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.6" }
 solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.11.6" }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -6,8 +6,8 @@
 use {
     crate::{sanitize::Sanitize, wasm_bindgen},
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    sha2::{Digest, Sha256, compress256},
-    generic_array::{GenericArray, typenum::U64},
+    generic_array::{typenum::U64, GenericArray},
+    sha2::{compress256, Digest, Sha256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
@@ -20,8 +20,7 @@ const MAX_BASE58_LEN: usize = 44;
 /// Initial Value for SHA256 State
 /// copied from https://github.com/RustCrypto/hashes/blob/457061f19b3538651aa7ef208ce6b04bfba65e61/sha2/src/consts.rs#L84
 pub const H256_256: [u32; 8] = [
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
 ];
 
 /// A hash; the 32-byte output of a hashing algorithm.
@@ -221,9 +220,9 @@ pub fn compress(blocks: &[[u8; 64]]) -> Hash {
     {
         unsafe {
             crate::syscalls::sol_sha256_compress(
-                blocks as * const _ as * const u8,
+                blocks as *const _ as *const u8,
                 blocks.len() as u64,
-                &mut res as &mut _ as *mut u8
+                &mut res as &mut _ as *mut u8,
             );
         }
         Hash::new_from_array(res)

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -189,7 +189,7 @@ pub fn extend_and_hash(id: &Hash, val: &[u8]) -> Hash {
     hash(&hash_data)
 }
 
-/// Execute the comepression function used internally by sha256 over 512-bit blocks, without the padding step.
+/// Execute the compression function used internally by sha256 over 512-bit blocks, without the padding step.
 /// This is not the same thing as the sha256 hash - chances are you want to use the `Hasher` instead.
 /// IMPORTANT: The padding step of SHA256 is included in the standard for a reason - only use this if you know what you're doing.
 pub fn compress(blocks: &[[u8; 64]]) -> Hash {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -43,6 +43,7 @@ define_syscall!(fn sol_log_pubkey(pubkey_addr: *const u8));
 define_syscall!(fn sol_create_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8) -> u64);
 define_syscall!(fn sol_try_find_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8, bump_seed_addr: *const u8) -> u64);
 define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_sha256_compress(block: *const u8, num_blocks: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_secp256k1_recover(hash: *const u8, recovery_id: u64, signature: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);


### PR DESCRIPTION
#### Problem

We're building a ZK execution layer with the candyland team, which requires updating their merkle tree in a ZK circuit. When building a merkle tree, the hash inputs are always fixed-sized, so we don't need the padding step for sha256. This PR adds a syscall for the "compression function" used internally by sha256, which leads to significantly smaller ZK circuits.

Spoke with @jackcmay about it in discord. Related to #26934.

#### Summary of Changes

- Added a syscall `sol_sha256_compress` that performs this operation over a variable number of blocks, charging the same compute budget as `sol_sha256`.
