### PR TITLE
Set receive_window per quic connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,8 +3573,26 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn-udp 0.1.0",
+ "rustls 0.20.6",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.8.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-udp 0.1.3",
  "rustls 0.20.6",
  "thiserror",
  "tokio",
@@ -3603,6 +3621,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-proto"
+version = "0.8.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand 0.8.5",
+ "ring",
+ "rustls 0.20.6",
+ "rustls-native-certs",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "quinn-udp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,7 +3648,20 @@ dependencies = [
  "futures-util",
  "libc",
  "mio",
- "quinn-proto",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "futures-util",
+ "libc",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "socket2",
  "tokio",
  "tracing",
@@ -4959,8 +5009,8 @@ dependencies = [
  "jsonrpc-http-server",
  "lazy_static",
  "log",
- "quinn",
- "quinn-proto",
+ "quinn 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
@@ -6308,7 +6358,7 @@ dependencies = [
  "pem",
  "percentage",
  "pkcs8",
- "quinn",
+ "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,6 +6359,7 @@ dependencies = [
  "percentage",
  "pkcs8",
  "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5636,6 +5636,7 @@ dependencies = [
  "percentage",
  "pkcs8",
  "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3229,8 +3229,26 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn-udp 0.1.1",
+ "rustls 0.20.6",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.8.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-udp 0.1.3",
  "rustls 0.20.6",
  "thiserror",
  "tokio",
@@ -3259,6 +3277,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-proto"
+version = "0.8.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand 0.8.5",
+ "ring",
+ "rustls 0.20.6",
+ "rustls-native-certs",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "quinn-udp"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,7 +3304,20 @@ dependencies = [
  "futures-util",
  "libc",
  "mio",
- "quinn-proto",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.3"
+source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+dependencies = [
+ "futures-util",
+ "libc",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "socket2",
  "tokio",
  "tracing",
@@ -4605,8 +4655,8 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "quinn",
- "quinn-proto",
+ "quinn 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn-proto 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
@@ -5585,7 +5635,7 @@ dependencies = [
  "pem",
  "percentage",
  "pkcs8",
- "quinn",
+ "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -17,7 +17,7 @@ pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS: u64 = 60_000;
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
 pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 1;
 
-/// The receive window for QUIC connection from minum staked nodes is
+/// The receive window for QUIC connection from minimum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
 pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 2;
 

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -12,3 +12,15 @@ pub const QUIC_KEEP_ALIVE_MS: u64 = 1_000;
 // applications. Different applications vary, but most seem to
 // be in the 30-60 second range
 pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS: u64 = 60_000;
+
+/// The receive window for QUIC connection from unstaked nodes is
+/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: f64 = 1.;
+
+/// The receive window for QUIC connection from minum staked nodes is
+/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: f64 = 1.2;
+
+/// The receive window for QUIC connection from maximum staked nodes is
+/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: f64 = 10.;

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -19,7 +19,7 @@ pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: f64 = 1.;
 
 /// The receive window for QUIC connection from minum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: f64 = 1.2;
+pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: f64 = 2.;
 
 /// The receive window for QUIC connection from maximum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -15,12 +15,12 @@ pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS: u64 = 60_000;
 
 /// The receive window for QUIC connection from unstaked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: f64 = 1.;
+pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 1;
 
 /// The receive window for QUIC connection from minum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: f64 = 2.;
+pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 2;
 
 /// The receive window for QUIC connection from maximum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: f64 = 10.;
+pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 10;

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -22,6 +22,7 @@ pem = "1.0.2"
 percentage = "0.1.0"
 pkcs8 = { version = "0.8.0", features = ["alloc"] }
 quinn = {git = "https://github.com/quinn-rs/quinn.git", branch = "0.8.x", commit = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
+quinn-proto = {git = "https://github.com/quinn-rs/quinn.git", branch = "0.8.x", commit = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
 
 rand = "0.7.0"
 rcgen = "0.9.2"

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -21,7 +21,8 @@ nix = "0.24.2"
 pem = "1.0.2"
 percentage = "0.1.0"
 pkcs8 = { version = "0.8.0", features = ["alloc"] }
-quinn = "0.8.3"
+quinn = {git = "https://github.com/quinn-rs/quinn.git", branch = "0.8.x", commit = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
+
 rand = "0.7.0"
 rcgen = "0.9.2"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -337,8 +337,8 @@ fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, 
     let min_ratio = QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO;
     if max_stake > min_stake {
         let a = (max_ratio - min_ratio) / (max_stake - min_stake) as f64;
-        let b: f64 = max_ratio - ((max_stake as f64) * a);
-        (a as f64 * stake as f64) + b
+        let b = max_ratio - ((max_stake as f64) * a);
+        (a * stake as f64) + b
     } else {
         QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO
     }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1603,7 +1603,8 @@ pub mod test {
 
         let ratio =
             compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake / 2);
-        let average_ratio = (QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO + QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO) / 2;
+        let average_ratio =
+            (QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO + QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO) / 2;
         assert_eq!(ratio, average_ratio);
 
         max_stake = 10000;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -18,8 +18,9 @@ use {
         packet::{Packet, PACKET_DATA_SIZE},
         pubkey::Pubkey,
         quic::{
-            QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-            QUIC_MIN_STAKED_CONCURRENT_STREAMS,
+            QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS, QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO,
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
+            QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO, QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
         },
         signature::Keypair,
         timing,
@@ -142,7 +143,7 @@ fn prune_unstaked_connection_table(
 fn get_connection_stake(
     connection: &Connection,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-) -> Option<(Pubkey, u64, u64)> {
+) -> Option<(Pubkey, u64, u64, u64, u64)> {
     connection
         .peer_identity()
         .and_then(|der_cert_any| der_cert_any.downcast::<Vec<rustls::Certificate>>().ok())
@@ -152,10 +153,12 @@ fn get_connection_stake(
 
                 let staked_nodes = staked_nodes.read().unwrap();
                 let total_stake = staked_nodes.total_stake;
+                let max_stake = staked_nodes.max_stake;
+                let min_stake = staked_nodes.min_stake;
                 staked_nodes
                     .pubkey_stake_map
                     .get(&pubkey)
-                    .map(|stake| (pubkey, *stake, total_stake))
+                    .map(|stake| (pubkey, *stake, total_stake, max_stake, min_stake))
             })
         })
 }
@@ -198,6 +201,8 @@ struct NewConnectionHandlerParams {
     total_stake: u64,
     max_connections_per_peer: usize,
     stats: Arc<StreamStats>,
+    max_stake: u64,
+    min_stake: u64,
 }
 
 impl NewConnectionHandlerParams {
@@ -213,6 +218,8 @@ impl NewConnectionHandlerParams {
             total_stake: 0,
             max_connections_per_peer,
             stats,
+            max_stake: 0,
+            min_stake: 0,
         }
     }
 }
@@ -235,7 +242,14 @@ fn handle_and_cache_new_connection(
         params.total_stake,
     ) as u64)
     {
+        let receive_window = compute_recieve_window(
+            params.max_stake,
+            params.min_stake,
+            connection_table_l.peer_type,
+            params.stake,
+        );
         connection.set_max_concurrent_uni_streams(max_uni_streams);
+        connection.set_receive_window(receive_window);
         debug!(
             "Peer type: {:?}, stake {}, total stake {}, max streams {}",
             connection_table_l.peer_type,
@@ -305,6 +319,46 @@ fn prune_unstaked_connections_and_add_new_connection(
     }
 }
 
+/// Calculate the ratio for per connection receive window from a staked peer
+fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, stake: u64) -> f64 {
+    // Testing shows the maximum througput from a connection is achieved at receive_window =
+    // PACKET_DATA_SIZE * 10. Beyond that, there is not much gain. We linearly map the
+    // stake to the ratio range from QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO to
+    // QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO. Where the linear algebra of finding the ratio 'r'
+    // for stake 's' is,
+    // r(s) = a * s + b. Given the max_stake, min_stake, max_ratio, min_ratio, we can find
+    // a and b.
+
+    let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
+    let min_ratio = QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO;
+    if max_stake > min_stake {
+        let a = (max_ratio - min_ratio) / (max_stake - min_stake) as f64;
+        let b: f64 = max_ratio - ((max_stake as f64) * a);
+        (a as f64 * stake as f64) + b
+    } else {
+        QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO
+    }
+}
+
+fn compute_recieve_window(
+    max_stake: u64,
+    min_stake: u64,
+    peer_type: ConnectionPeerType,
+    peer_stake: u64,
+) -> VarInt {
+    match peer_type {
+        ConnectionPeerType::Unstaked => {
+            VarInt::from_u64((PACKET_DATA_SIZE as f64 * QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO) as u64)
+                .unwrap()
+        }
+        ConnectionPeerType::Staked => {
+            let ratio =
+                compute_receive_window_ratio_for_staked_node(max_stake, min_stake, peer_stake);
+            VarInt::from_u64((PACKET_DATA_SIZE as f64 * ratio) as u64).unwrap()
+        }
+    }
+}
+
 async fn setup_connection(
     connecting: Connecting,
     unstaked_connection_table: Arc<Mutex<ConnectionTable>>,
@@ -333,13 +387,17 @@ async fn setup_connection(
                         max_connections_per_peer,
                         stats.clone(),
                     ),
-                    |(pubkey, stake, total_stake)| NewConnectionHandlerParams {
-                        packet_sender,
-                        remote_pubkey: Some(pubkey),
-                        stake,
-                        total_stake,
-                        max_connections_per_peer,
-                        stats: stats.clone(),
+                    |(pubkey, stake, total_stake, max_stake, min_stake)| {
+                        NewConnectionHandlerParams {
+                            packet_sender,
+                            remote_pubkey: Some(pubkey),
+                            stake,
+                            total_stake,
+                            max_connections_per_peer,
+                            stats: stats.clone(),
+                            max_stake,
+                            min_stake,
+                        }
                     },
                 );
 
@@ -1475,6 +1533,7 @@ pub mod test {
     }
 
     #[test]
+
     fn test_max_allowed_uni_streams() {
         assert_eq!(
             compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 0, 0),
@@ -1524,5 +1583,35 @@ pub mod test {
             compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 0, 10000),
             QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
         );
+    }
+
+    #[test]
+    fn test_cacluate_receive_window_ratio_for_staked_node() {
+        let mut max_stake = 10000;
+        let mut min_stake = 0;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, min_stake);
+        let ratio = format!("{:.2}", ratio);
+        let min_ratio = format!("{:.2}", QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO);
+        assert_eq!(ratio, min_ratio);
+
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        let ratio = format!("{:.2}", ratio);
+        let max_ratio = format!("{:.2}", QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO);
+        assert_eq!(ratio, max_ratio);
+
+        let ratio =
+            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake / 2);
+        let ratio = format!("{:.2}", ratio);
+        let average_ratio = format!(
+            "{:.2}",
+            (QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO + QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO) / 2.
+        );
+        assert_eq!(ratio, average_ratio);
+
+        max_stake = 10000;
+        min_stake = 10000;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        let ratio = format!("{:.2}", ratio);
+        assert_eq!(ratio, max_ratio);
     }
 }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -329,6 +329,10 @@ fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, 
     // r(s) = a * s + b. Given the max_stake, min_stake, max_ratio, min_ratio, we can find
     // a and b.
 
+    if stake > max_stake {
+        return QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
+    }
+
     let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
     let min_ratio = QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO;
     if max_stake > min_stake {
@@ -1611,6 +1615,19 @@ pub mod test {
         max_stake = 10000;
         min_stake = 10000;
         let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        let ratio = format!("{:.2}", ratio);
+        assert_eq!(ratio, max_ratio);
+
+        max_stake = 0;
+        min_stake = 0;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        let ratio = format!("{:.2}", ratio);
+        assert_eq!(ratio, max_ratio);
+
+        max_stake = 1000;
+        min_stake = 10;
+        let ratio =
+            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake + 10);
         let ratio = format!("{:.2}", ratio);
         assert_eq!(ratio, max_ratio);
     }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -28,6 +28,8 @@ use {
 #[derive(Default)]
 pub struct StakedNodes {
     pub total_stake: u64,
+    pub max_stake: u64,
+    pub min_stake: u64,
     pub ip_stake_map: HashMap<IpAddr, u64>,
     pub pubkey_stake_map: HashMap<Pubkey, u64>,
 }


### PR DESCRIPTION
#### Problem
Differentiate the staked and non-staked connections and set different receive_window. Testing has show that with everything equal, by tweaking the receive window alone, the receive_window is impacting the chunks_received only below about 10 * PACKET_DATA_SIZE. Beyond that -- it is not making much difference. 


#### Summary of Changes
This change sets the receive_window for non-staked node to 1 * PACKET_DATA_SIZE, and maps the staked nodes's connection's receive_window between 1.2 * PACKET_DATA_SIZE to  10 * PACKET_DATA_SIZE based on the stakes.

The changes is based on Quinn library change to support per connection receive_window tweak at the server side. https://github.com/quinn-rs/quinn/pull/1393

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
