### PR TITLE
fix version of spl-token to prevent conflict

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -51,7 +51,7 @@ solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.6" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.11.6" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.6" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.6" }
-spl-token = { version = "=3.3.1", features = ["no-entrypoint"] }
+spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
 tempfile = "3.3.0"


### PR DESCRIPTION
#### Problem

master cannot be build due to version conflict
```
cargo build
    Updating crates.io index
error: failed to select a version for `spl-token`.
    ... required by package `solana-ledger v1.11.6 (edger)`
    ... which satisfies path dependency `solana-ledger` (locked to 1.11.6) of package `solana-gossip v1.11.6 (gossip)`
    ... which satisfies path dependency `solana-gossip` (locked to 1.11.6) of package `solana-accounts-cluster-bench v1.11.6 (accounts-cluster-bench)`
versions that meet the requirements `=3.3.1` are: 3.3.1

all possible versions conflict with previously selected packages.

  previously selected package `spl-token v3.5.0`
    ... which satisfies dependency `spl-token = "=3.5.0"` of package `solana-account-decoder v1.11.6 (/account-decoder)`
    ... which satisfies path dependency `solana-account-decoder` (locked to 1.11.6) of package `solana-accounts-cluster-bench v1.11.6 (accounts-cluster-bench)`

failed to select a version for `spl-token` which could resolve this conflict
```

#### Summary of Changes

Update spl-token version (3.3.1) for ledger to prevent conflict with version used in accounts-decoder (3.5.0)
