### PR TITLE
Unpin tokio for non-rpc crates

### DIFF
--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -19,7 +19,7 @@ solana-runtime = { path = "../runtime", version = "=1.11.6" }
 solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.6" }
 tarpc = { version = "0.29.0", features = ["full"] }
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 tokio-stream = "0.1"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -51,7 +51,7 @@ solana-version = { path = "../version", version = "=1.11.6" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.6" }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.9"
 tokio-tungstenite = { version = "0.17.1", features = ["rustls-tls-webpki-roots"] }
 tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -25,7 +25,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-version = { path = "../version", version = "=1.11.6" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -36,7 +36,7 @@ solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.6" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.6" }
 solana-version = { path = "../version", version = "=1.11.6" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.6" }
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { package = "tikv-jemallocator", version = "0.4.1", features = ["unprefixed_malloc_on_supported_platforms"] }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -53,7 +53,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.11.6" }
 static_assertions = "1.1.0"
 tempfile = "3.3.0"
 thiserror = "1.0"
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 trees = "0.4.2"
 

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -22,7 +22,7 @@ socket2 = "0.4.4"
 solana-logger = { path = "../logger", version = "=1.11.6" }
 solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-version = { path = "../version", version = "=1.11.6" }
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 url = "2.2.2"
 
 [lib]

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -24,4 +24,4 @@ solana-runtime = { path = "../runtime", version = "=1.11.6" }
 solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.6" }
 thiserror = "1.0"
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -32,7 +32,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.11.6" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.6" }
 thiserror = "1.0"
-tokio = "~1.14.1"
+tokio = "1"
 tonic = { version = "0.8.0", features = ["tls", "transport"] }
 zstd = "0.11.2"
 

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -29,7 +29,7 @@ solana-metrics = { path = "../metrics", version = "=1.11.6" }
 solana-perf = { path = "../perf", version = "=1.11.6" }
 solana-sdk = { path = "../sdk", version = "=1.11.6" }
 thiserror = "1.0"
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 x509-parser = "0.14.0"
 
 [dev-dependencies]

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -28,7 +28,7 @@ solana-rpc = { path = "../rpc", version = "=1.11.6" }
 solana-runtime = { path = "../runtime", version = "=1.11.6" }
 solana-sdk = { path = "../sdk", version = "=1.11.6" }
 solana-streamer = { path = "../streamer", version = "=1.11.6" }
-tokio = { version = "~1.14.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/25028 pinned tokio across all solana crates. However, in actuality only solana-rpc needs to be pinned to avoid the RPC stalls, and the pin is causing problems for downstream users of solana client crates.

#### Summary of Changes
Unpin tokio everywhere except solana-rpc
