### PR TITLE
RPC: Add ability to get information about all available snapshots on the cluster

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -376,6 +376,8 @@ impl RpcSender for MockSender {
                 version: Some("1.0.0 c375ce1f".to_string()),
                 feature_set: None,
                 shred_version: None,
+                full_snapshots: None,
+                incremental_snapshots: None,
             }])?,
             "getBlock" => serde_json::to_value(EncodedConfirmedBlock {
                 previous_blockhash: "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B".to_string(),

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -330,3 +330,9 @@ pub struct RpcContextConfig {
     pub commitment: Option<CommitmentConfig>,
     pub min_context_slot: Option<Slot>,
 }
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcGetClusterNodesConfig {
+    pub with_snapshots: bool,
+}

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -285,6 +285,10 @@ pub struct RpcContactInfo {
     pub feature_set: Option<u32>,
     /// Shred version
     pub shred_version: Option<u16>,
+    /// Full snapshots
+    pub full_snapshots: Option<Vec<(Slot, String)>>,
+    /// Incremental snapshots
+    pub incremental_snapshots: Option<Vec<(Slot, Slot, String)>>,
 }
 
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -878,7 +878,8 @@ Returns information about all the nodes participating in the cluster
 
 #### Parameters:
 
-None
+- `<object>` - (optional) Configuration object containing the following fields:
+  - `withSnapshots: <bool>` - if true add snapshot information to return in response (default: false)
 
 #### Results:
 
@@ -891,6 +892,8 @@ The result field will be an array of JSON objects, each with the following sub f
 - `version: <string | null>` - The software version of the node, or `null` if the version information is not available
 - `featureSet: <u32 | null >` - The unique identifier of the node's feature set
 - `shredVersion: <u16 | null>` - The shred version the node has been configured to use
+- `fullSnapshots: <array | null>` - Full snapshots available on the node, as an array of arrays containing: `[slot: <u64>, hash: <string>]`
+- `incrementalSnapshots: <array | null>` - Incremental snapshots available on the node, as an array of arrays containing: `[baseSlot: <u64>, slot: <u64>, hash: <string>]`
 
 #### Example:
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5091,6 +5091,8 @@ pub mod tests {
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
             "version": null,
             "featureSet": null,
+            "fullSnapshots": null,
+            "incrementalSnapshots": null,
         }]);
         assert_eq!(result, expected);
     }


### PR DESCRIPTION
#### Problem

There is no simple way to get information about available snapshots on the cluster.

#### Summary of Changes

Add optional param `withSnapshots` to `getClusterNodes` rpc request.

**Request**:

`curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getClusterNodes", "params":[{"withSnapshots":true}]}'`

**Result (`| jq '.'`)**:
```
{
  "jsonrpc": "2.0",
  "result": [
    {
      "featureSet": 3605932003,
      "fullSnapshots": [
        [
          144515460,
          "EQcYuGoyMbKAxNVEW5pCSPQwybwdNYtVEcJ4vHD66sMD"
        ]
      ],
      "gossip": "135.181.60.221:8000",
      "incrementalSnapshots": [
        [
          144515460,
          144537749,
          "CNULcPDhJdayFX1kxQB7hnTtoZU3zmBtpYtmPtMSPg1p"
        ]
      ],
      "pubkey": "111AA9fqgNXBnzzV4Ef1CpNZbWqFvzKoT9vyYqDHSkF",
      "rpc": null,
      "shredVersion": 33548,
      "tpu": "135.181.60.221:8003",
      "version": "1.12.0"
    },
    {
      "featureSet": 3605932003,
      "fullSnapshots": [
        [
          144476180,
          "AFeNP6yMqZFac1LzfP1SVrBGSZdhugHxigjYqibUvEPK"
        ],
        [
          144515460,
          "EQcYuGoyMbKAxNVEW5pCSPQwybwdNYtVEcJ4vHD66sMD"
        ]
      ],
      "gossip": "144.76.60.22:8000",
      "incrementalSnapshots": [
        [
          144515460,
          144533663,
          "3J95De9FtFtS3cgE7K83uFzEn9XAuNKHtF2YTFUoKRzR"
        ],
        [
          144515460,
          144535162,
          "Fa9PvgA2hTMKEaGikzZHQhuBsdFpeSMNnvDZ7zYYykGv"
        ],
        [
          144515460,
          144537446,
          "3Thsk76kYvDGiWXMhVmbN7kqxgUqi4CfderaJUD4Jvtn"
        ],
        [
          144515460,
          144538245,
          "CeHwyC4QtJDeki3f2Bc5Pm14pgE5gFBHJ4ttd7TX74Me"
        ]
      ],
      "pubkey": "52GEvaeCcEyAUKrfoPcey6vdyw6th588nYPuCkn3Kxes",
      "rpc": "144.76.60.22:8899",
      "shredVersion": 33548,
      "tpu": "144.76.60.22:8003",
      "version": "1.11.5"
    },
...
```
