### PR TITLE
Add a measure_block macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,6 +5642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-measure-block"
+version = "1.12.0"
+dependencies = [
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "solana-measure",
+]
+
+[[package]]
 name = "solana-merkle-root-bench"
 version = "1.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "log-analyzer",
     "logger",
     "measure",
+    "measure-block",
     "merkle-root-bench",
     "merkle-tree",
     "metrics",

--- a/measure-block/Cargo.toml
+++ b/measure-block/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-measure-block"
+description = "Blockchain, Rebuilt for Scale"
+version = "1.12.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-measure-block"
+readme = "../README.md"
+repository = "https://github.com/solana-labs/solana"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+proc_macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+solana-measure = { path = "../measure", version = "=1.12.0" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/measure-block/src/lib.rs
+++ b/measure-block/src/lib.rs
@@ -1,0 +1,56 @@
+use {proc_macro::TokenStream, quote::quote};
+
+/// Wraps a block of code in Measure::start and stop without changing how
+/// the code needs to be written.
+///
+/// # Arguments
+///
+/// * `measure_name` - The name of the measure struct for the block
+/// * `block` - The block of code you want to measure
+///
+/// # Example
+///
+/// ```
+/// use solana_measure_block::measure_block;
+/// use solana_measure::measure::Measure;
+/// measure_block!(my_measure,
+///     let x = 5;
+/// );
+///
+/// // can access assigned variables outside the macro call
+/// assert_eq!(x, 5);
+/// // a new measure is created with the name given to the `measure_block!` macro
+/// let my_time_us = my_measure.as_us();
+/// ```
+#[proc_macro]
+pub fn measure_block(input: TokenStream) -> TokenStream {
+    // Convert input int proc_macro2 format
+    let input = proc_macro2::TokenStream::from(input);
+
+    // Make sure input is in the expected format
+    let mut token_trees = input.into_iter();
+    let measure_name_tt = token_trees.next().expect("missing 'measure_name'");
+    let comma_tt = token_trees
+        .next()
+        .expect("expected comma between 'measure_name' and 'block'");
+    if let proc_macro2::TokenTree::Punct(punct) = comma_tt {
+        assert!(punct.as_char() == ',');
+    } else {
+        panic!("incorrect input format: missing code block");
+    }
+
+    let measure_name = if let proc_macro2::TokenTree::Ident(measure_name) = measure_name_tt {
+        measure_name
+    } else {
+        panic!("incorrect input: missing measure_name")
+    };
+
+    let measure_name_str = measure_name.to_string();
+
+    let expanded = quote! {
+        let mut #measure_name = Measure::start(&#measure_name_str);
+        #(#token_trees)*
+        #measure_name.stop();
+    };
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
#### Problem
The existing measure! macro can change the way we write our code, and is not always easy to use when we want access to several variables assigned in the block being measured.

#### Summary of Changes
Added a new procedural macro `measure_block!` which inserts a measure::start and stop call around a block of code. All variables assigned inside the block are still accessible outside.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
