### PR TITLE
Fix windows release builds

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -50,6 +50,7 @@ jobs:
           choco install openssl
           export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
           choco install protoc
+          export PROTOC="C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe"
           source /tmp/env.sh
           echo "::set-output name=tag::$CI_TAG"
           eval "$(ci/channel-info.sh)"

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -12,5 +12,9 @@ version = "1.12.0"
 [workspace]
 
 [dependencies]
-protobuf-src = "1.0.5"
 tonic-build = "0.8.0"
+
+# windows users should install the protobuf compiler manually and set the PROTOC
+# envar to point to the installed binary
+[target."cfg(not(windows))".dependencies]
+protobuf-src = "1.0.5"

--- a/storage-bigtable/build-proto/src/main.rs
+++ b/storage-bigtable/build-proto/src/main.rs
@@ -1,6 +1,7 @@
 fn main() -> Result<(), std::io::Error> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
+        #[cfg(not(windows))]
         std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
     }
 

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -29,5 +29,9 @@ name = "solana_storage_proto"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-protobuf-src = "1.0.5"
 tonic-build = "0.8.0"
+
+# windows users should install the protobuf compiler manually and set the PROTOC
+# envar to point to the installed binary
+[target."cfg(not(windows))".build-dependencies]
+protobuf-src = "1.0.5"

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -1,6 +1,7 @@
 fn main() -> Result<(), std::io::Error> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
+        #[cfg(not(windows))]
         std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
     }
 


### PR DESCRIPTION
#### Problem
 #26854 broke windows release builds do to the requirement of a C compiler

#### Summary of Changes
On windows machines, use installed protoc, instead of trying to build vendored package

Here is an example successful build: https://github.com/solana-labs/solana/runs/7721331802?check_suite_focus=true
[from this branch](https://github.com/solana-labs/solana/pull/26981), hacked up to run the CI job on a PR and only build the `solana-storage-proto` crate

Adding protoc to $PATH instead of setting the envar should also work, if you prefer that approach @yihau .
