### PR TITLE
Setter for node_version property

### DIFF
--- a/client/src/nonblocking/pubsub_client.rs
+++ b/client/src/nonblocking/pubsub_client.rs
@@ -118,6 +118,12 @@ impl PubsubClient {
         self.ws.await.unwrap() // WS future should not be cancelled or panicked
     }
 
+    pub async fn set_node_version(&self, version: semver::Version) -> Result<(), ()> {
+        let mut w_node_version = self.node_version.write().await;
+        *w_node_version = Some(version);
+        Ok(())
+    }
+
     async fn get_node_version(&self) -> PubsubClientResult<semver::Version> {
         let r_node_version = self.node_version.read().await;
         if let Some(version) = &*r_node_version {

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -508,6 +508,12 @@ impl RpcClient {
         self.sender.url()
     }
 
+    pub async fn set_node_version(&self, version: semver::Version) -> Result<(), ()> {
+        let mut w_node_version = self.node_version.write().await;
+        *w_node_version = Some(version);
+        Ok(())
+    }
+
     async fn get_node_version(&self) -> Result<semver::Version, RpcError> {
         let r_node_version = self.node_version.read().await;
         if let Some(version) = &*r_node_version {


### PR DESCRIPTION
#### Problem

The RPC method `getVersion` is called everytime when you are calling some methods, which can be an issue when the number of RPC calls is limited with some services (ChainStack, QuickNode ...)


#### Summary of Changes
Add a setter in order to force the RPC version and avoid a call to the `get_version` method