### PR TITLE
Retype program of ParsedInstruction

### DIFF
--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -168,7 +168,7 @@ mod test {
         assert_eq!(
             parse(&MEMO_V1_PROGRAM_ID, &memo_instruction, &no_keys).unwrap(),
             ParsedInstruction {
-                program: "spl-memo".to_string(),
+                program: ParsableProgram::SplMemo,
                 program_id: MEMO_V1_PROGRAM_ID.to_string(),
                 parsed: json!("🦖"),
             }
@@ -176,7 +176,7 @@ mod test {
         assert_eq!(
             parse(&MEMO_V3_PROGRAM_ID, &memo_instruction, &no_keys).unwrap(),
             ParsedInstruction {
-                program: "spl-memo".to_string(),
+                program: ParsableProgram::SplMemo,
                 program_id: MEMO_V3_PROGRAM_ID.to_string(),
                 parsed: json!("🦖"),
             }

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -8,7 +8,6 @@ use {
         parse_token::parse_token,
         parse_vote::parse_vote,
     },
-    inflector::Inflector,
     serde_json::Value,
     solana_account_decoder::parse_token::spl_token_ids,
     solana_sdk::{
@@ -72,7 +71,7 @@ pub enum ParseInstructionError {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedInstruction {
-    pub program: String,
+    pub program: ParsableProgram,
     pub program_id: String,
     pub parsed: Value,
 }
@@ -86,7 +85,7 @@ pub struct ParsedInstructionEnum {
     pub info: Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum ParsableProgram {
     SplAssociatedTokenAccount,
@@ -124,7 +123,7 @@ pub fn parse(
         ParsableProgram::Vote => serde_json::to_value(parse_vote(instruction, account_keys)?)?,
     };
     Ok(ParsedInstruction {
-        program: format!("{:?}", program_name).to_kebab_case(),
+        program: *program_name,
         program_id: program_id.to_string(),
         parsed: parsed_json,
     })


### PR DESCRIPTION
#### Problem
The property `program` of struct `ParsedInstruction` is wrongly type and not restrictive during a match on the value

#### Summary of Changes
Retype property `program` of struct `ParsedInstruction` by the correct enum
