### PR TITLE
Attempt to skip redundant startup account verification

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -853,12 +853,8 @@ pub fn process_blockstore_from_root(
     // We might be promptly restarted after bad capitalization was detected while creating newer snapshot.
     // In that case, we're most likely restored from the last good snapshot and replayed up to this root.
     // So again check here for the bad capitalization to avoid to continue until the next snapshot creation.
-    if !bank_forks
-        .read()
-        .unwrap()
-        .root_bank()
-        .calculate_and_verify_capitalization(debug_verify)
-    {
+    let bank = bank_forks.read().unwrap().root_bank();
+    if start_slot != bank.slot() && !bank.calculate_and_verify_capitalization(debug_verify) {
         return Err(
             BlockstoreProcessorError::RootBankWithMismatchedCapitalization(
                 bank_forks.read().unwrap().root(),


### PR DESCRIPTION
#### Problem
We potentially run accounts hash/capitalization verification from two places at almost the same time, which seems wasteful and appears to slow down startup by ~30 seconds (Takes ~2 minutes on current master and ~1.5 minutes after this change). Here is the call stack for each:
![image](https://user-images.githubusercontent.com/44715351/183482525-c518c7ea-2459-475e-80a4-efa84ebd92a8.png)

#### Summary of Changes
Wait for any existing verifications to complete. Only check capitalization from `process_blockstore_from_root` in the event we loaded frozen bank forks