### PR TITLE
Add `Signers` impls for `Arc<dyn Signer>`

### DIFF
--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -1,9 +1,11 @@
 #![cfg(feature = "full")]
 
-use std::sync::Arc;
-use crate::{
-    pubkey::Pubkey,
-    signature::{Signature, Signer, SignerError},
+use {
+    crate::{
+        pubkey::Pubkey,
+        signature::{Signature, Signer, SignerError},
+    },
+    std::sync::Arc,
 };
 
 /// Convenience trait for working with mixed collections of `Signer`s

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "full")]
+
+use std::sync::Arc;
 use crate::{
     pubkey::Pubkey,
     signature::{Signature, Signer, SignerError},
@@ -56,6 +58,14 @@ impl Signers for [Box<dyn Signer>] {
 }
 
 impl Signers for Vec<Box<dyn Signer>> {
+    default_keypairs_impl!();
+}
+
+impl Signers for [Arc<dyn Signer>] {
+    default_keypairs_impl!();
+}
+
+impl Signers for Vec<Arc<dyn Signer>> {
     default_keypairs_impl!();
 }
 


### PR DESCRIPTION
@joncinque

#### Problem
Sometimes a `Signer` need to be cloned as a trait object to avoid (attempted) rereads of the source data, like in https://github.com/solana-labs/solana-program-library/issues/2668 where data is provided via STDIN. A `Box` holding a trait object can't be cloned in this way, but using another pointer type which allows cloning trait objects like `Arc` requires `Signers` impls for `Vec<Arc<dyn Signer>>` and `[Arc<dyn Signer>>]`.

#### Summary of Changes
Add `Signers` impls for `Vec<Arc<dyn Signer>>` and `[Arc<dyn Signer>>]`

See https://github.com/solana-labs/solana-program-library/pull/3290#discussion_r929262764