### PR TITLE
tracer-packet-stats reporting should not reset id

### DIFF
--- a/core/src/tracer_packet_stats.rs
+++ b/core/src/tracer_packet_stats.rs
@@ -199,7 +199,8 @@ impl TracerPacketStats {
                     )
                 );
 
-                *self = Self::default();
+                let id = self.id;
+                *self = Self::new(id);
                 self.last_report = timestamp();
             }
         }


### PR DESCRIPTION
#### Problem
report is reseting the id to 0, so we lose that info after the first report

#### Summary of Changes
Get the current id, and call new instead of setting to default

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
