### PR TITLE
Specify rust version in the toolchain file

### DIFF
--- a/cargo
+++ b/cargo
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-# TODO(klykov): this file is depricated and will be deleted. It is left to split changes on the scripts and github workflow sides (see PR#27018)
+
+echo "Notice: please run `cargo` directly. This cargo wrapper script will be removed in the future"
+
+# The code below will be simplified to `exec cargo "$@"` after github workflow changes, see #29105
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 

--- a/cargo
+++ b/cargo
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# TODO(klykov): this file is depricated and will be deleted. It is left to split changes on the scripts and github workflow sides (see PR#27018)
+# shellcheck source=ci/rust-version.sh
+here=$(dirname "$0")
+
+toolchain=
+case "$1" in
+  stable)
+    source "${here}"/ci/rust-version.sh stable
+    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
+    toolchain="$rust_stable"
+    shift
+    ;;
+  nightly)
+    source "${here}"/ci/rust-version.sh nightly
+    # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
+    toolchain="$rust_nightly"
+    shift
+    ;;
+  *)
+    source "${here}"/ci/rust-version.sh stable
+    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
+    toolchain="$rust_stable"
+    ;;
+esac
+
+set -x
+exec cargo "+${toolchain}" "${@}"

--- a/cargo-build-bpf
+++ b/cargo-build-bpf
@@ -11,9 +11,9 @@ done
 
 set -ex
 if [[ ! -f "$here"/sdk/bpf/syscalls.txt ]]; then
-  "$here"/cargo build --manifest-path "$here"/programs/bpf_loader/gen-syscall-list/Cargo.toml
+  cargo build --manifest-path "$here"/programs/bpf_loader/gen-syscall-list/Cargo.toml
 fi
 if [[ ! -f "$here"/target/debug/cargo-build-sbf ]]; then
-    "$here"/cargo build --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml
+    cargo build --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml
 fi
-exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-build-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"
+exec cargo run --manifest-path "$here"/sdk/cargo-build-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"

--- a/cargo-build-sbf
+++ b/cargo-build-sbf
@@ -11,6 +11,6 @@ done
 
 set -ex
 if [[ ! -f "$here"/sdk/sbf/syscalls.txt ]]; then
-  "$here"/cargo build --manifest-path "$here"/programs/bpf_loader/gen-syscall-list/Cargo.toml
+  cargo build --manifest-path "$here"/programs/bpf_loader/gen-syscall-list/Cargo.toml
 fi
-exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"
+exec cargo run --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"

--- a/cargo-nightly
+++ b/cargo-nightly
@@ -18,9 +18,9 @@ case "$1" in
     shift
     ;;
   *)
-    source "${here}"/ci/rust-version.sh stable
-    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
-    toolchain="$rust_stable"
+    source "${here}"/ci/rust-version.sh nightly
+    # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
+    toolchain="$rust_nightly"
     ;;
 esac
 

--- a/cargo-nightly
+++ b/cargo-nightly
@@ -3,26 +3,6 @@
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 
-toolchain=
-case "$1" in
-  stable)
-    source "${here}"/ci/rust-version.sh stable
-    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
-    toolchain="$rust_stable"
-    shift
-    ;;
-  nightly)
-    source "${here}"/ci/rust-version.sh nightly
-    # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
-    toolchain="$rust_nightly"
-    shift
-    ;;
-  *)
-    source "${here}"/ci/rust-version.sh nightly
-    # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
-    toolchain="$rust_nightly"
-    ;;
-esac
-
+source "${here}"/ci/rust-version.sh nightly
 set -x
-exec cargo "+${toolchain}" "${@}"
+exec cargo "+${rust_nightly}" "${@}"

--- a/cargo-test-bpf
+++ b/cargo-test-bpf
@@ -12,9 +12,9 @@ done
 export CARGO_BUILD_BPF="$here"/cargo-build-bpf
 set -x
 if [[ ! -f "$here"/target/debug/cargo-build-sbf ]]; then
-    "$here"/cargo build --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml
+    cargo build --manifest-path "$here"/sdk/cargo-build-sbf/Cargo.toml
 fi
 if [[ ! -f "$here"/target/debug/cargo-test-sbf ]]; then
-    "$here"/cargo build --manifest-path "$here"/sdk/cargo-test-sbf/Cargo.toml
+    cargo build --manifest-path "$here"/sdk/cargo-test-sbf/Cargo.toml
 fi
-exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-test-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"
+exec cargo run --manifest-path "$here"/sdk/cargo-test-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"

--- a/cargo-test-sbf
+++ b/cargo-test-sbf
@@ -11,4 +11,4 @@ done
 
 export CARGO_BUILD_SBF="$here"/cargo-build-sbf
 set -x
-exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-test-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"
+exec cargo run --manifest-path "$here"/sdk/cargo-test-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -13,4 +13,4 @@ cargo_audit_ignores=(
   # Blocked on chrono updating `time` to >= 0.2.23
   --ignore RUSTSEC-2020-0071
 )
-scripts/cargo-for-all-lock-files.sh stable audit "${cargo_audit_ignores[@]}"
+scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}"

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -14,10 +14,9 @@ import sys;
 
 real_file = os.path.realpath(__file__)
 ci_path = os.path.dirname(real_file)
-src_root = os.path.dirname(ci_path)
 
 def load_metadata():
-    cmd = f'{src_root}/cargo metadata --no-deps --format-version=1'
+    cmd = f'cargo metadata --no-deps --format-version=1'
     return json.loads(subprocess.Popen(
         cmd, shell=True, stdout=subprocess.PIPE).communicate()[0])
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -4,8 +4,6 @@ cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
 source ci/rust-version.sh stable
 
-cargo="cargo"
-
 # shellcheck disable=SC2086
 is_crate_version_uploaded() {
   name=$1
@@ -68,11 +66,11 @@ for Cargo_toml in $Cargo_tomls; do
       (
         set -x
         rm -rf crate-test
-        "$cargo" stable init crate-test
+        cargo init crate-test
         cd crate-test/
         echo "${crate_name} = \"=${expectedCrateVersion}\"" >> Cargo.toml
         echo "[workspace]" >> Cargo.toml
-        "$cargo" stable check
+        cargo check
       ) && really_uploaded=1
       if ((really_uploaded)); then
         break;

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
 source ci/rust-version.sh stable
 
-cargo="$(readlink -f ./cargo)"
+cargo="cargo"
 
 # shellcheck disable=SC2086
 is_crate_version_uploaded() {

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -10,7 +10,7 @@ if [[ -n $APPVEYOR ]]; then
 
   appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   export USERPROFILE="D:\\"
-  ./rustup-init -yv --default-toolchain $rust_stable --default-host x86_64-pc-windows-msvc
+  ./rustup-init -yv --default-toolchain "$rust_stable" --default-host x86_64-pc-windows-msvc
   export PATH="$PATH:/d/.cargo/bin"
   rustc -vV
   cargo -vV

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -20,6 +20,8 @@ if [[ -n $RUST_STABLE_VERSION ]]; then
 else
   # read rust version from rust-toolchain.toml file
   base="$(dirname "${BASH_SOURCE[0]}")"
+  # pacify shellcheck: cannot follow dynamic path
+  # shellcheck disable=SC1090,SC1091
   source "$base/../scripts/read-cargo-variable.sh"
   stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -19,8 +19,9 @@ if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
   # read rust version from rust-toolchain.toml file
-  source "./scripts/read-cargo-variable.sh"
-  stable_version=$(readCargoVariable channel "./rust-toolchain.toml")
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  source "$base/../scripts/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -19,9 +19,8 @@ if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
   # read rust version from rust-toolchain.toml file
-  base="$(dirname "${BASH_SOURCE[0]}")"
-  source "$base/../scripts/read-cargo-variable.sh"
-  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
+  source "./scripts/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "./rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,10 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.65.0
+  # read rust version from rust-toolchain.toml file
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  source "$base/../scripts/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -7,7 +7,7 @@ source ci/upload-ci-artifact.sh
 
 eval "$(ci/channel-info.sh)"
 
-cargo="$(readlink -f "./cargo")"
+cargoNightly="$(readlink -f "./cargo-nightly")"
 
 set -o pipefail
 export RUST_BACKTRACE=1

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -24,7 +24,7 @@ BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
 # solana-keygen required when building C programs
-_ "$cargo" build --manifest-path=keygen/Cargo.toml
+_ cargo build --manifest-path=keygen/Cargo.toml
 export PATH="$PWD/target/debug":$PATH
 
 # Clear the C dependency files, if dependency moves these files are not regenerated
@@ -32,43 +32,43 @@ test -d target/debug/sbf && find target/debug/sbf -name '*.d' -delete
 test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
 
 # Ensure all dependencies are built
-_ "$cargo" nightly build --release
+_ "$cargoNightly" build --release
 
 # Remove "BENCH_FILE", if it exists so that the following commands can append
 rm -f "$BENCH_FILE"
 
 # Run sdk benches
-_ "$cargo" nightly bench --manifest-path sdk/Cargo.toml ${V:+--verbose} \
+_ "$cargoNightly" bench --manifest-path sdk/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run runtime benches
-_ "$cargo" nightly bench --manifest-path runtime/Cargo.toml ${V:+--verbose} \
+_ "$cargoNightly" bench --manifest-path runtime/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run gossip benches
-_ "$cargo" nightly bench --manifest-path gossip/Cargo.toml ${V:+--verbose} \
+_ "$cargoNightly" bench --manifest-path gossip/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run poh benches
-_ "$cargo" nightly bench --manifest-path poh/Cargo.toml ${V:+--verbose} \
+_ "$cargoNightly" bench --manifest-path poh/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run core benches
-_ "$cargo" nightly bench --manifest-path core/Cargo.toml ${V:+--verbose} \
+_ "$cargoNightly" bench --manifest-path core/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run sbf benches
-_ "$cargo" nightly bench --manifest-path programs/sbf/Cargo.toml ${V:+--verbose} --features=sbf_c \
+_ "$cargoNightly" bench --manifest-path programs/sbf/Cargo.toml ${V:+--verbose} --features=sbf_c \
   -- -Z unstable-options --format=json --nocapture | tee -a "$BENCH_FILE"
 
 # Run banking/accounts bench. Doesn't require nightly, but use since it is already built.
-_ "$cargo" nightly run --release --manifest-path banking-bench/Cargo.toml ${V:+--verbose} | tee -a "$BENCH_FILE"
-_ "$cargo" nightly run --release --manifest-path accounts-bench/Cargo.toml ${V:+--verbose} -- --num_accounts 10000 --num_slots 4 | tee -a "$BENCH_FILE"
+_ "$cargoNightly" run --release --manifest-path banking-bench/Cargo.toml ${V:+--verbose} | tee -a "$BENCH_FILE"
+_ "$cargoNightly" run --release --manifest-path accounts-bench/Cargo.toml ${V:+--verbose} -- --num_accounts 10000 --num_slots 4 | tee -a "$BENCH_FILE"
 
 # `solana-upload-perf` disabled as it can take over 30 minutes to complete for some
 # reason
 exit 0
-_ "$cargo" nightly run --release --package solana-upload-perf \
+_ "$cargoNightly" run --release --package solana-upload-perf \
   -- "$BENCH_FILE" "$TARGET_BRANCH" "$UPLOAD_METRICS" | tee "$BENCH_ARTIFACT"
 
 upload-ci-artifact "$BENCH_FILE"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -8,7 +8,7 @@ source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
 eval "$(ci/channel-info.sh)"
-cargo="$(readlink -f "./cargo")"
+cargoNightly="$(readlink -f "./cargo-nightly")"
 
 scripts/increment-cargo-version.sh check
 
@@ -33,14 +33,14 @@ echo --- build environment
   rustup run "$rust_stable" rustc --version --verbose
   rustup run "$rust_nightly" rustc --version --verbose
 
-  "$cargo" stable --version --verbose
-  "$cargo" nightly --version --verbose
+  cargo stable --version --verbose
+  "$cargoNightly" --version --verbose
 
-  "$cargo" stable clippy --version --verbose
-  "$cargo" nightly clippy --version --verbose
+  cargo stable clippy --version --verbose
+  "$cargoNightly" nightly clippy --version --verbose
 
   # audit is done only with "$cargo stable"
-  "$cargo" stable audit --version
+  cargo stable audit --version
 
   grcov --version
 )

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -37,7 +37,7 @@ echo --- build environment
   "$cargoNightly" --version --verbose
 
   cargo stable clippy --version --verbose
-  "$cargoNightly" nightly clippy --version --verbose
+  "$cargoNightly" clippy --version --verbose
 
   # audit is done only with "$cargo stable"
   cargo stable audit --version

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -2,6 +2,8 @@
 set -e
 cd "$(dirname "$0")/.."
 
+cargo="$(readlink -f "./cargo")"
+
 source ci/_
 
 annotate() {
@@ -60,10 +62,10 @@ echo "Executing $testName"
 case $testName in
 test-stable)
   if need_to_generate_test_result; then
-    _ cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo  test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+    _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   fi
   ;;
 test-stable-sbf)
@@ -72,10 +74,10 @@ test-stable-sbf)
   test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
 
   # rustfilt required for dumping SBF assembly listings
-  cargo install rustfilt
+  "$cargo" install rustfilt
 
   # solana-keygen required when building C programs
-  _ cargo build --manifest-path=keygen/Cargo.toml
+  _ "$cargo" build --manifest-path=keygen/Cargo.toml
 
   export PATH="$PWD/target/debug":$PATH
   cargo_build_sbf="$(realpath ./cargo-build-sbf)"
@@ -87,12 +89,12 @@ test-stable-sbf)
   # SBF C program system tests
   _ make -C programs/sbf/c tests
   if need_to_generate_test_result; then
-    _ cargo  test \
+    _ "$cargo" stable test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test \
+    _ "$cargo" stable test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust -- --nocapture
   fi
@@ -100,7 +102,7 @@ test-stable-sbf)
   # SBF Rust program unit tests
   for sbf_test in programs/sbf/rust/*; do
     if pushd "$sbf_test"; then
-      cargo test
+      "$cargo" test
       "$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
       "$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
       popd
@@ -129,13 +131,13 @@ test-stable-sbf)
   # SBF program instruction count assertion
   sbf_target_path=programs/sbf/target
   if need_to_generate_test_result; then
-    _ cargo test \
+    _ "$cargo" stable test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
       -- -Z unstable-options --format json --report-time |& tee results.json
     awk '!/{ "type": .* }/' results.json >"${sbf_target_path}"/deploy/instuction_counts.txt
   else
-    _ cargo test \
+    _ "$cargo" stable test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
       -- --nocapture &> "${sbf_target_path}"/deploy/instuction_counts.txt
@@ -163,52 +165,52 @@ test-stable-perf)
     export SOLANA_CUDA=1
   fi
 
-  _ cargo build --bins ${V:+--verbose}
+  _ "$cargo" stable build --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
+    _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
   fi
-  _ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
+  _ "$cargo" stable run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
   ;;
 test-local-cluster)
-  _ cargo build --release --bins ${V:+--verbose}
+  _ "$cargo" stable build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-flakey)
-  _ cargo build --release --bins ${V:+--verbose}
+  _ "$cargo" stable build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-slow-1)
-  _ cargo build --release --bins ${V:+--verbose}
+  _ "$cargo" stable build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-slow-2)
-  _ cargo build --release --bins ${V:+--verbose}
+  _ "$cargo" stable build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
+    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
@@ -227,10 +229,10 @@ test-wasm)
   ;;
 test-docs)
   if need_to_generate_test_result; then
-    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit "${PIPESTATUS[0]}"
   else
-    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+    _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
     exit 0
   fi
   ;;

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -2,8 +2,6 @@
 set -e
 cd "$(dirname "$0")/.."
 
-cargo="cargo"
-
 source ci/_
 
 annotate() {
@@ -62,10 +60,10 @@ echo "Executing $testName"
 case $testName in
 test-stable)
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+    _ cargo  test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   fi
   ;;
 test-stable-sbf)
@@ -74,10 +72,10 @@ test-stable-sbf)
   test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
 
   # rustfilt required for dumping SBF assembly listings
-  "$cargo" install rustfilt
+  cargo install rustfilt
 
   # solana-keygen required when building C programs
-  _ "$cargo" build --manifest-path=keygen/Cargo.toml
+  _ cargo build --manifest-path=keygen/Cargo.toml
 
   export PATH="$PWD/target/debug":$PATH
   cargo_build_sbf="$(realpath ./cargo-build-sbf)"
@@ -89,12 +87,12 @@ test-stable-sbf)
   # SBF C program system tests
   _ make -C programs/sbf/c tests
   if need_to_generate_test_result; then
-    _ "$cargo" stable test \
+    _ cargo  test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test \
+    _ cargo test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust -- --nocapture
   fi
@@ -102,7 +100,7 @@ test-stable-sbf)
   # SBF Rust program unit tests
   for sbf_test in programs/sbf/rust/*; do
     if pushd "$sbf_test"; then
-      "$cargo" test
+      cargo test
       "$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
       "$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
       popd
@@ -131,13 +129,13 @@ test-stable-sbf)
   # SBF program instruction count assertion
   sbf_target_path=programs/sbf/target
   if need_to_generate_test_result; then
-    _ "$cargo" stable test \
+    _ cargo test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
       -- -Z unstable-options --format json --report-time |& tee results.json
     awk '!/{ "type": .* }/' results.json >"${sbf_target_path}"/deploy/instuction_counts.txt
   else
-    _ "$cargo" stable test \
+    _ cargo test \
       --manifest-path programs/sbf/Cargo.toml \
       --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
       -- --nocapture &> "${sbf_target_path}"/deploy/instuction_counts.txt
@@ -165,52 +163,52 @@ test-stable-perf)
     export SOLANA_CUDA=1
   fi
 
-  _ "$cargo" stable build --bins ${V:+--verbose}
+  _ cargo build --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
+    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
   fi
-  _ "$cargo" stable run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
+  _ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
   ;;
 test-local-cluster)
-  _ "$cargo" stable build --release --bins ${V:+--verbose}
+  _ cargo build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
+    _ cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-flakey)
-  _ "$cargo" stable build --release --bins ${V:+--verbose}
+  _ cargo build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
+    _ cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-slow-1)
-  _ "$cargo" stable build --release --bins ${V:+--verbose}
+  _ cargo build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
+    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
 test-local-cluster-slow-2)
-  _ "$cargo" stable build --release --bins ${V:+--verbose}
+  _ cargo build --release --bins ${V:+--verbose}
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
     exit_if_error "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
+    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
   fi
   exit 0
   ;;
@@ -229,10 +227,10 @@ test-wasm)
   ;;
 test-docs)
   if need_to_generate_test_result; then
-    _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
     exit "${PIPESTATUS[0]}"
   else
-    _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
     exit 0
   fi
   ;;

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 
-cargo="$(readlink -f "./cargo")"
+cargo="cargo"
 
 source ci/_
 

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -2,7 +2,6 @@
 set -e
 
 cd "$(dirname "$0")"
-cargo=../cargo
 
 # shellcheck source=ci/rust-version.sh
 source ../ci/rust-version.sh stable
@@ -12,7 +11,7 @@ source ../ci/rust-version.sh stable
 # pre-build with output enabled to appease Travis CI's hang check
 "$cargo" build -p solana-cli
 
-usage=$("$cargo" stable -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
+usage=$(cargo -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
 
 out=${1:-src/cli/usage.md}
 
@@ -40,6 +39,6 @@ in_subcommands=0
 while read -r subcommand rest; do
   [[ $subcommand == "SUBCOMMANDS:" ]] && in_subcommands=1 && continue
   if ((in_subcommands)); then
-      section "$("$cargo" stable -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$out"
+      section "$(cargo -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$out"
   fi
 done <<<"$usage">>"$out"

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -9,7 +9,7 @@ source ../ci/rust-version.sh stable
 : "${rust_stable:=}" # Pacify shellcheck
 
 # pre-build with output enabled to appease Travis CI's hang check
-"$cargo" build -p solana-cli
+cargo build -p solana-cli
 
 usage=$(cargo -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.65.0"

--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -43,6 +43,8 @@ anchor() {
   set -x
   rm -rf anchor
   git clone https://github.com/coral-xyz/anchor.git
+  # copy toolchain file to use solana's rust version
+  cp "$solana_dir"/rust-toolchain.toml anchor/
   cd anchor
 
   update_solana_dependencies . "$solana_ver"
@@ -62,6 +64,8 @@ mango() {
     set -x
     rm -rf mango-v3
     git clone https://github.com/blockworks-foundation/mango-v3
+    # copy toolchain file to use solana's rust version
+    cp "$solana_dir"/rust-toolchain.toml mango-v3/
     cd mango-v3
 
     update_solana_dependencies . "$solana_ver"
@@ -81,6 +85,8 @@ metaplex() {
     set -x
     rm -rf metaplex-program-library
     git clone https://github.com/metaplex-foundation/metaplex-program-library
+    # copy toolchain file to use solana's rust version
+    cp "$solana_dir"/rust-toolchain.toml metaplex-program-library/
     cd metaplex-program-library
 
     update_solana_dependencies . "$solana_ver"

--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -11,7 +11,6 @@ source scripts/read-cargo-variable.sh
 
 solana_ver=$(readCargoVariable version sdk/Cargo.toml)
 solana_dir=$PWD
-cargo="$solana_dir"/cargo
 cargo_build_sbf="$solana_dir"/cargo-build-sbf
 cargo_test_sbf="$solana_dir"/cargo-test-sbf
 
@@ -49,8 +48,8 @@ anchor() {
   update_solana_dependencies . "$solana_ver"
   patch_crates_io_solana Cargo.toml "$solana_dir"
 
-  $cargo build
-  $cargo test
+  cargo build
+  cargo test
 
   anchor_dir=$PWD
   anchor_ver=$(readCargoVariable version "$anchor_dir"/lang/Cargo.toml)
@@ -70,8 +69,8 @@ mango() {
     patch_crates_io_solana Cargo.toml "$solana_dir"
     patch_crates_io_anchor Cargo.toml "$anchor_dir"
 
-    $cargo build
-    $cargo test
+    cargo build
+    cargo test
     $cargo_build_sbf
     $cargo_test_sbf
   )
@@ -89,8 +88,8 @@ metaplex() {
     patch_crates_io_solana Cargo.toml "$solana_dir"
     patch_crates_io_anchor Cargo.toml "$anchor_dir"
 
-    $cargo build
-    $cargo test
+    cargo build
+    cargo test
     $cargo_build_sbf
     $cargo_test_sbf
   )

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -23,6 +23,8 @@ example_helloworld() {
     set -x
     rm -rf example-helloworld
     git clone https://github.com/solana-labs/example-helloworld.git
+    # copy toolchain file to use solana's rust version
+    cp "$solana_dir"/rust-toolchain.toml example-helloworld/
     cd example-helloworld
 
     update_solana_dependencies src/program-rust "$solana_ver"
@@ -56,6 +58,8 @@ spl() {
     set -x
     rm -rf spl
     git clone https://github.com/solana-labs/solana-program-library.git spl
+    # copy toolchain file to use solana's rust version
+    cp "$solana_dir"/rust-toolchain.toml spl/
     cd spl
 
     project_used_solana_version=$(sed -nE 's/solana-sdk = \"[>=<~]*(.*)\"/\1/p' <"token/program/Cargo.toml")
@@ -84,6 +88,8 @@ openbook_dex() {
     set -x
     rm -rf openbook-dex
     git clone https://github.com/openbook-dex/program.git openbook-dex
+    # copy toolchain file to use solana's rust version
+    cp "$solana_dir"/rust-toolchain.toml openbook-dex/
     cd openbook-dex
 
     update_solana_dependencies . "$solana_ver"

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -12,7 +12,6 @@ source scripts/read-cargo-variable.sh
 
 solana_ver=$(readCargoVariable version sdk/Cargo.toml)
 solana_dir=$PWD
-cargo="$solana_dir"/cargo
 cargo_build_sbf="$solana_dir"/cargo-build-sbf
 cargo_test_sbf="$solana_dir"/cargo-test-sbf
 
@@ -75,8 +74,8 @@ spl() {
     # TODO better: `build.rs` for spl-token-cli doesn't seem to properly build
     # the required programs to run the tests, so instead we run the tests
     # after we know programs have been built
-    $cargo build
-    $cargo test
+    cargo build
+    cargo test
   )
 }
 
@@ -101,12 +100,12 @@ exclude = [
     "permissioned",
 ]
 EOF
-    $cargo build
+    cargo build
 
     $cargo_build_sbf \
       --manifest-path dex/Cargo.toml --no-default-features --features program
 
-    $cargo test \
+    cargo test \
       --manifest-path dex/Cargo.toml --no-default-features --features program
   )
 }

--- a/scripts/cargo-fmt.sh
+++ b/scripts/cargo-fmt.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")"
+cargoNightly="$(readlink -f "${here}/../cargo-nightly")"
 
-if [[ -z $cargo ]]; then
+if [[ -z $cargoNightly ]]; then
   >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
   to gnu readlink with 'brew install coreutils' and then symlink greadlink as
   /usr/local/bin/readlink."
@@ -12,9 +12,9 @@ fi
 
 set -ex
 
-"$cargo" nightly fmt --all
-(cd programs/sbf && "$cargo" nightly fmt --all)
-(cd sdk/cargo-build-sbf/tests/crates/fail && "$cargo" nightly fmt --all)
-(cd sdk/cargo-build-sbf/tests/crates/noop && "$cargo" nightly fmt --all)
-(cd storage-bigtable/build-proto && "$cargo" nightly fmt --all)
-(cd web3.js/test/fixtures/noop-program && "$cargo" nightly fmt --all)
+"$cargoNightly" fmt --all
+(cd programs/sbf && "$cargoNightly" fmt --all)
+(cd sdk/cargo-build-sbf/tests/crates/fail && "$cargoNightly" fmt --all)
+(cd sdk/cargo-build-sbf/tests/crates/noop && "$cargoNightly" fmt --all)
+(cd storage-bigtable/build-proto && "$cargoNightly" fmt --all)
+(cd web3.js/test/fixtures/noop-program && "$cargoNightly" fmt --all)

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -44,7 +44,7 @@ for lock_file in $files; do
     echo "--- [$lock_file]: cargo " "${shifted_args[@]}" "$@"
   fi
 
-  if (set -x && cd "$(dirname "$lock_file")" && "$cargo" "${shifted_args[@]}" "$@"); then
+  if (set -x && cd "$(dirname "$lock_file")" && cargo "${shifted_args[@]}" "$@"); then
     # noop
     true
   else

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-here="$(dirname "$0")"
 cargo="cargo"
 
 if [[ -z $cargo ]]; then

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")"
+cargo="cargo"
 
 if [[ -z $cargo ]]; then
   >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if command -v cargo &> /dev/null ; then
+if ! command -v cargo &> /dev/null ; then
   >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
   to gnu readlink with 'brew install coreutils' and then symlink greadlink as
   /usr/local/bin/readlink."

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-cargo="cargo"
-
-if [[ -z $cargo ]]; then
+if command -v cargo &> /dev/null ; then
   >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
   to gnu readlink with 'brew install coreutils' and then symlink greadlink as
   /usr/local/bin/readlink."

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -16,8 +16,6 @@ if [[ $OSTYPE == darwin* ]]; then
   fi
 fi
 
-cargo="cargo"
-
 set -e
 
 usage() {
@@ -138,12 +136,12 @@ mkdir -p "$installDir/bin"
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
+  cargo $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
+    cargo $maybeRustVersion install --locked spl-token-cli --root "$installDir"
   fi
 )
 
@@ -157,9 +155,9 @@ fi
 
 if [[ -z "$validatorOnly" ]]; then
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion build --manifest-path programs/bpf_loader/gen-syscall-list/Cargo.toml
+  cargo $maybeRustVersion build --manifest-path programs/bpf_loader/gen-syscall-list/Cargo.toml
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion run --bin gen-headers
+  cargo $maybeRustVersion run --bin gen-headers
   mkdir -p "$installDir"/bin/sdk/sbf
   cp -a sdk/sbf/* "$installDir"/bin/sdk/sbf
 fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -2,7 +2,6 @@
 #
 # |cargo install| of the top-level crate will not install binaries for
 # other workspace crates or native program crates.
-here="$(dirname "$0")"
 readlink_cmd="readlink"
 echo "OSTYPE IS: $OSTYPE"
 if [[ $OSTYPE == darwin* ]]; then

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -17,7 +17,7 @@ if [[ $OSTYPE == darwin* ]]; then
   fi
 fi
 
-cargo="$("${readlink_cmd}" -f "${here}/../cargo")"
+cargo="cargo"
 
 set -e
 

--- a/scripts/coverage-in-disk.sh
+++ b/scripts/coverage-in-disk.sh
@@ -21,7 +21,7 @@ set -e
 cd "$(dirname "$0")/.."
 source ci/_
 
-cargo="$(readlink -f "./cargo")"
+cargoNightly="$(readlink -f "./cargo-nightly")"
 
 : "${CI_COMMIT:=local}"
 reportName="lcov-${CI_COMMIT:0:9}"
@@ -79,8 +79,8 @@ fi
 NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 
-RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
+RUST_LOG=solana=trace _ "$cargoNightly" test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
+if RUST_LOG=solana=trace _ "$cargoNightly" test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
   test_status=0
 else
   test_status=$?

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -21,7 +21,7 @@ set -e
 cd "$(dirname "$0")/.."
 source ci/_
 
-cargo="$(readlink -f "./cargo")"
+cargoNightly="$(readlink -f "./cargo-nightly")"
 
 : "${CI_COMMIT:=local}"
 reportName="lcov-${CI_COMMIT:0:9}"
@@ -78,8 +78,8 @@ fi
 NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 
-RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" -- --nocapture 2> >(tee target/cov/coverage-stderr.log >&2); then
+RUST_LOG=solana=trace _ "$cargoNightly" test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
+if RUST_LOG=solana=trace _ "$cargoNightly" test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" -- --nocapture 2> >(tee target/cov/coverage-stderr.log >&2); then
   test_status=0
 else
   test_status=$?


### PR DESCRIPTION
#### Problem

Explicitly specify rust version in the toolchain file.
For details, see https://github.com/solana-labs/solana/issues/25603

As the result, we will have two places where the rust version is specified -- toml file and installation CI script https://github.com/solana-labs/solana/blob/24634b6e255118a7d340f20ca41442795fbe4a6b/ci/rust-version.sh#L21

#### Summary of Changes
