### PR TITLE
Bench tps add nonce flag

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -55,6 +55,7 @@ pub struct Config {
     pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
     pub use_randomized_compute_unit_price: bool,
+    pub use_durable_nonce: bool,
 }
 
 impl Default for Config {
@@ -83,6 +84,7 @@ impl Default for Config {
             use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             use_randomized_compute_unit_price: false,
+            use_durable_nonce: false,
         }
     }
 }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -8,7 +8,7 @@ use {
         bench_tps_client::BenchTpsClient,
         cli::{self, ExternalClientType},
         keypairs::get_keypairs,
-        send_batch::generate_keypairs,
+        send_batch::{generate_durable_nonce_accounts, generate_keypairs},
     },
     solana_client::{
         connection_cache::ConnectionCache,
@@ -154,6 +154,7 @@ fn main() {
         use_quic,
         tpu_connection_pool_size,
         use_randomized_compute_unit_price,
+        use_durable_nonce,
         ..
     } = &cli_config;
 
@@ -230,5 +231,11 @@ fn main() {
         client_ids_and_stake_file,
         *read_from_client_file,
     );
-    do_bench_tps(client, cli_config, keypairs);
+
+    let nonce_keypairs = if *use_durable_nonce {
+        Some(generate_durable_nonce_accounts(client.clone(), &keypairs))
+    } else {
+        None
+    };
+    do_bench_tps(client, cli_config, keypairs, nonce_keypairs);
 }

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -76,7 +76,7 @@ fn test_bench_tps_local_cluster(config: Config) {
     )
     .unwrap();
 
-    let _total = do_bench_tps(client, config, keypairs);
+    let _total = do_bench_tps(client, config, keypairs, None);
 
     #[cfg(not(debug_assertions))]
     assert!(_total > 100);
@@ -121,7 +121,7 @@ fn test_bench_tps_test_validator(config: Config) {
     )
     .unwrap();
 
-    let _total = do_bench_tps(client, config, keypairs);
+    let _total = do_bench_tps(client, config, keypairs, None);
 
     #[cfg(not(debug_assertions))]
     assert!(_total > 100);


### PR DESCRIPTION
#### Problem

Part of [chain of PRs](https://github.com/solana-labs/solana/issues/25759) to add durable nonce to the bench-tps tool.
This one introduces flag `use_durable_nonce` which allows to turn on this mode manually (cli option in the next PR).
It also introduce optional creation of blockhash thread (since for durable nonce we don't need blockhashes).

