### PR TITLE
Remove `total_data_size` and `data_size_changed` from `ExecuteDetailsTimings`

### DIFF
--- a/program-runtime/src/pre_account.rs
+++ b/program-runtime/src/pre_account.rs
@@ -120,7 +120,6 @@ impl PreAccount {
 
         if outermost_call {
             timings.total_account_count = timings.total_account_count.saturating_add(1);
-            timings.total_data_size = timings.total_data_size.saturating_add(post.data().len());
             if owner_changed
                 || lamports_changed
                 || data_len_changed
@@ -129,8 +128,6 @@ impl PreAccount {
                 || self.changed
             {
                 timings.changed_account_count = timings.changed_account_count.saturating_add(1);
-                timings.data_size_changed =
-                    timings.data_size_changed.saturating_add(post.data().len());
             }
         }
 

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -191,16 +191,6 @@ eager_macro_rules! { $eager_1
                 i64
             ),
             (
-                "execute_details_total_data_size",
-                $self.details.total_data_size,
-                i64
-            ),
-            (
-                "execute_details_data_size_changed",
-                $self.details.data_size_changed,
-                i64
-            ),
-            (
                 "execute_details_create_executor_register_syscalls_us",
                 $self
                     .details
@@ -409,8 +399,6 @@ pub struct ExecuteDetailsTimings {
     pub get_or_create_executor_us: u64,
     pub changed_account_count: u64,
     pub total_account_count: u64,
-    pub total_data_size: usize,
-    pub data_size_changed: usize,
     pub create_executor_register_syscalls_us: u64,
     pub create_executor_load_elf_us: u64,
     pub create_executor_verify_code_us: u64,
@@ -430,8 +418,6 @@ impl ExecuteDetailsTimings {
         );
         saturating_add_assign!(self.changed_account_count, other.changed_account_count);
         saturating_add_assign!(self.total_account_count, other.total_account_count);
-        saturating_add_assign!(self.total_data_size, other.total_data_size);
-        saturating_add_assign!(self.data_size_changed, other.data_size_changed);
         saturating_add_assign!(
             self.create_executor_register_syscalls_us,
             other.create_executor_register_syscalls_us
@@ -547,15 +533,12 @@ mod tests {
         let mut other_execute_details_timings =
             construct_execute_timings_with_program(&program_id, us, compute_units_consumed);
         let account_count = 1;
-        let data_size_changed = 1;
         other_execute_details_timings.serialize_us = us;
         other_execute_details_timings.create_vm_us = us;
         other_execute_details_timings.execute_us = us;
         other_execute_details_timings.deserialize_us = us;
         other_execute_details_timings.changed_account_count = account_count;
         other_execute_details_timings.total_account_count = account_count;
-        other_execute_details_timings.total_data_size = data_size_changed;
-        other_execute_details_timings.data_size_changed = data_size_changed;
 
         // Accumulate the other instance into the current instance
         execute_details_timings.accumulate(&other_execute_details_timings);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4458,7 +4458,10 @@ impl Bank {
             total_size_of_all_accounts,
             total_size_of_touched_accounts,
             accounts_resize_delta,
-        } = transaction_context.into();
+        } = ExecutionRecord::from_transaction_context(
+            transaction_context,
+            tx.message().account_keys().len(),
+        );
         loaded_transaction.accounts = accounts;
         if self
             .feature_set

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4454,9 +4454,7 @@ impl Bank {
         let ExecutionRecord {
             accounts,
             mut return_data,
-            changed_account_count,
-            total_size_of_all_accounts,
-            total_size_of_touched_accounts,
+            touched_account_count,
             accounts_resize_delta,
         } = transaction_context.into();
         loaded_transaction.accounts = accounts;
@@ -4468,15 +4466,7 @@ impl Bank {
                 timings.details.total_account_count,
                 loaded_transaction.accounts.len() as u64
             );
-            saturating_add_assign!(timings.details.changed_account_count, changed_account_count);
-            saturating_add_assign!(
-                timings.details.total_data_size,
-                total_size_of_all_accounts as usize
-            );
-            saturating_add_assign!(
-                timings.details.data_size_changed,
-                total_size_of_touched_accounts as usize
-            );
+            saturating_add_assign!(timings.details.changed_account_count, touched_account_count);
             accounts_data_len_delta = status.as_ref().map_or(0, |_| accounts_resize_delta);
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4458,10 +4458,7 @@ impl Bank {
             total_size_of_all_accounts,
             total_size_of_touched_accounts,
             accounts_resize_delta,
-        } = ExecutionRecord::from_transaction_context(
-            transaction_context,
-            tx.message().account_keys().len(),
-        );
+        } = transaction_context.into();
         loaded_transaction.accounts = accounts;
         if self
             .feature_set

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -897,9 +897,12 @@ pub struct ExecutionRecord {
     pub accounts_resize_delta: i64,
 }
 
-/// Used by the bank in the runtime to write back the processed accounts and recorded instructions
-impl From<TransactionContext> for ExecutionRecord {
-    fn from(context: TransactionContext) -> Self {
+impl ExecutionRecord {
+    /// Used by the bank in the runtime to write back the processed accounts and recorded instructions
+    pub fn from_transaction_context(
+        context: TransactionContext,
+        number_of_message_accounts: usize,
+    ) -> Self {
         let mut changed_account_count = 0u64;
         let mut total_size_of_all_accounts = 0u64;
         let mut total_size_of_touched_accounts = 0u64;
@@ -907,7 +910,11 @@ impl From<TransactionContext> for ExecutionRecord {
             .account_touched_flags
             .try_borrow()
             .expect("borrowing transaction_context.account_touched_flags failed");
-        for (index_in_transaction, was_touched) in account_touched_flags.iter().enumerate() {
+        for (index_in_transaction, was_touched) in account_touched_flags
+            .iter()
+            .take(number_of_message_accounts)
+            .enumerate()
+        {
             let account_data_size = context
                 .get_account_at_index(index_in_transaction)
                 .expect("index_in_transaction out of bounds")

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -897,12 +897,9 @@ pub struct ExecutionRecord {
     pub accounts_resize_delta: i64,
 }
 
-impl ExecutionRecord {
-    /// Used by the bank in the runtime to write back the processed accounts and recorded instructions
-    pub fn from_transaction_context(
-        context: TransactionContext,
-        number_of_message_accounts: usize,
-    ) -> Self {
+/// Used by the bank in the runtime to write back the processed accounts and recorded instructions
+impl From<TransactionContext> for ExecutionRecord {
+    fn from(context: TransactionContext) -> Self {
         let mut changed_account_count = 0u64;
         let mut total_size_of_all_accounts = 0u64;
         let mut total_size_of_touched_accounts = 0u64;
@@ -910,11 +907,7 @@ impl ExecutionRecord {
             .account_touched_flags
             .try_borrow()
             .expect("borrowing transaction_context.account_touched_flags failed");
-        for (index_in_transaction, was_touched) in account_touched_flags
-            .iter()
-            .take(number_of_message_accounts)
-            .enumerate()
-        {
+        for (index_in_transaction, was_touched) in account_touched_flags.iter().enumerate() {
             let account_data_size = context
                 .get_account_at_index(index_in_transaction)
                 .expect("index_in_transaction out of bounds")


### PR DESCRIPTION
#### Problem
See #26990

#### Summary of Changes
Removes `total_data_size` and `data_size_changed` from `ExecuteDetailsTimings`.

Fixes #26990