### PR TITLE
Fixed a cargo warning on specifing quinn dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,13 +3574,13 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.8.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "quinn-udp 0.1.3",
  "rustls 0.20.6",
  "thiserror",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.8.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "bytes",
  "fxhash",
@@ -3646,11 +3646,11 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.1.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "futures-util",
  "libc",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "socket2",
  "tokio",
  "tracing",
@@ -6341,8 +6341,8 @@ dependencies = [
  "pem",
  "percentage",
  "pkcs8",
- "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3285,13 +3285,13 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.8.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "quinn-udp 0.1.3",
  "rustls 0.20.6",
  "thiserror",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.8.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "bytes",
  "fxhash",
@@ -3357,11 +3357,11 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.1.3"
-source = "git+https://github.com/quinn-rs/quinn.git?branch=0.8.x#37c19743cc881cf71369946d572849d5d2ffc3fd"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd#37c19743cc881cf71369946d572849d5d2ffc3fd"
 dependencies = [
  "futures-util",
  "libc",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "socket2",
  "tokio",
  "tracing",
@@ -5680,8 +5680,8 @@ dependencies = [
  "pem",
  "percentage",
  "pkcs8",
- "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
- "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?branch=0.8.x)",
+ "quinn 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
+ "quinn-proto 0.8.3 (git+https://github.com/quinn-rs/quinn.git?rev=37c19743cc881cf71369946d572849d5d2ffc3fd)",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -21,8 +21,8 @@ nix = "0.24.2"
 pem = "1.0.2"
 percentage = "0.1.0"
 pkcs8 = { version = "0.8.0", features = ["alloc"] }
-quinn = {git = "https://github.com/quinn-rs/quinn.git", branch = "0.8.x", commit = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
-quinn-proto = {git = "https://github.com/quinn-rs/quinn.git", branch = "0.8.x", commit = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
+quinn = {git = "https://github.com/quinn-rs/quinn.git", rev = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
+quinn-proto = {git = "https://github.com/quinn-rs/quinn.git", rev = "37c19743cc881cf71369946d572849d5d2ffc3fd"}
 
 rand = "0.7.0"
 rcgen = "0.9.2"


### PR DESCRIPTION
#### Problem

Warning during build:

warning: /Users/lijunwang/sol2/solana2/streamer/Cargo.toml: unused manifest key: dependencies.quinn-proto.commit
warning: /Users/lijunwang/sol2/solana2/streamer/Cargo.toml: unused manifest key: dependencies.quinn.commit

#### Summary of Changes

Use "rev" only in git dependency.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
