### PR TITLE
Bumps solana_rbpf to v0.2.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6672,9 +6672,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a28c5dfe7e8af38daa39d6561c8e8b9ed7a2f900951ebe7362ad6348d36c73"
+checksum = "fe055100805e9069715acf73529ec563ad987a4d042da9defe9b7554560f2df4"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 solana-version = { path = "../version", version = "=1.12.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
-solana_rbpf = "=0.2.31"
+solana_rbpf = "=0.2.32"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5942,9 +5942,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a28c5dfe7e8af38daa39d6561c8e8b9ed7a2f900951ebe7362ad6348d36c73"
+checksum = "fe055100805e9069715acf73529ec563ad987a4d042da9defe9b7554560f2df4"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -38,7 +38,7 @@ solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
 solana-runtime = { path = "../../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=1.12.0" }
-solana_rbpf = "=0.2.31"
+solana_rbpf = "=0.2.32"
 
 [dev-dependencies]
 solana-ledger = { path = "../../ledger", version = "=1.12.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.12.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
 solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.12.0" }
-solana_rbpf = "=0.2.31"
+solana_rbpf = "=0.2.32"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/allocator_bump.rs
+++ b/programs/bpf_loader/src/allocator_bump.rs
@@ -2,21 +2,21 @@
 
 use {
     solana_program_runtime::invoke_context::{Alloc, AllocErr},
-    solana_rbpf::aligned_memory::AlignedMemory,
+    solana_rbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     std::alloc::Layout,
 };
 
 #[derive(Debug)]
 pub struct BpfAllocator {
     #[allow(dead_code)]
-    heap: AlignedMemory,
+    heap: AlignedMemory<HOST_ALIGN>,
     start: u64,
     len: u64,
     pos: u64,
 }
 
 impl BpfAllocator {
-    pub fn new(heap: AlignedMemory, virtual_address: u64) -> Self {
+    pub fn new(heap: AlignedMemory<HOST_ALIGN>, virtual_address: u64) -> Self {
         let len = heap.len() as u64;
         Self {
             heap,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_rbpf::{
         aligned_memory::AlignedMemory,
-        ebpf,
+        ebpf::{self, HOST_ALIGN},
         error::EbpfError,
         memory_region::{AccessType, MemoryMapping},
         question_mark,
@@ -362,7 +362,7 @@ pub fn register_syscalls(
 pub fn bind_syscall_context_objects<'a, 'b>(
     vm: &mut EbpfVm<'a, RequisiteVerifier, BpfError, crate::ThisInstructionMeter>,
     invoke_context: &'a mut InvokeContext<'b>,
-    heap: AlignedMemory,
+    heap: AlignedMemory<HOST_ALIGN>,
     orig_account_lengths: Vec<usize>,
 ) -> Result<(), EbpfError<BpfError>> {
     let check_aligned = bpf_loader_deprecated::id()
@@ -2488,7 +2488,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::<HOST_ALIGN>::zero_filled(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
@@ -2530,7 +2530,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::<HOST_ALIGN>::zero_filled(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
@@ -2571,7 +2571,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::<HOST_ALIGN>::zero_filled(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
@@ -2613,7 +2613,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::<HOST_ALIGN>::zero_filled(100);
             let config = Config::default();
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.
 solana-logger = { path = "../logger", version = "=1.12.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana_rbpf = "=0.2.31"
+solana_rbpf = "=0.2.32"


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.32](https://github.com/solana-labs/rbpf/releases/tag/v0.2.32) was released.

#### Summary of Changes
- `AlignedMemory` now takes the alignment as a const generic instead of a constructor parameter.
- `AlignedMemory::new` => `AlignedMemory::with_capacity`
- `AlignedMemory::new_with_size` => `AlignedMemory::zero_filled`
- `AlignedMemory::resize` => `AlignedMemory::fill_write`
- Removed `disable_unresolved_symbols_at_runtime` and `disable_deprecated_load_instructions` from `vm::Config`
- Added `new_elf_parser` and `reject_rodata_stack_overlap` to `vm::Config`