### PR TITLE
feat: remove maxSupportedTransactionVersion config from getTransaction

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -529,6 +529,14 @@ export type GetSlotLeaderConfig = {
 export type GetTransactionConfig = {
   /** The level of finality desired */
   commitment?: Finality;
+};
+
+/**
+ * Configuration object for changing `getParsedTransaction` query behavior
+ */
+export type GetParsedTransactionConfig = {
+  /** The level of finality desired */
+  commitment?: Finality;
   /** The max transaction version to return in responses. If the requested transaction is a higher version, an error will be returned */
   maxSupportedTransactionVersion?: number;
 };
@@ -3747,7 +3755,7 @@ export class Connection {
    */
   async getParsedTransaction(
     signature: TransactionSignature,
-    commitmentOrConfig?: GetTransactionConfig | Finality,
+    commitmentOrConfig?: GetParsedTransactionConfig | Finality,
   ): Promise<ParsedConfirmedTransaction | null> {
     const {commitment, config} =
       extractCommitmentFromConfig(commitmentOrConfig);


### PR DESCRIPTION
#### Problem
There's no backwards compatible way to support versioned transactions with the `Connection.getTransaction` method so it shouldn't allow fetching versioned transactions. This is because the `Connection.getTransaction` method returns a response that uses the `Message` class which can't be repurposed with support for expanded account keys from address lookup tables without breaking assumptions that clients make about message account keys.

#### Summary of Changes
- Separate the config structs for `getParsedTransaction` and `getTransaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
