### PR TITLE
chore: annotate more types as deprecated

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -874,6 +874,8 @@ export type TransactionResponse = {
 
 /**
  * A confirmed transaction on the ledger
+ *
+ * @deprecated Deprecated since Solana v1.8.0.
  */
 export type ConfirmedTransaction = {
   /** The slot during which the transaction was processed */
@@ -1003,7 +1005,9 @@ export type BlockResponse = {
 };
 
 /**
- * A ConfirmedBlock on the ledger
+ * A confirmed block on the ledger
+ *
+ * @deprecated Deprecated since Solana v1.8.0.
  */
 export type ConfirmedBlock = {
   /** Blockhash of this block */

--- a/web3.js/src/fee-calculator.ts
+++ b/web3.js/src/fee-calculator.ts
@@ -9,6 +9,8 @@ export const FeeCalculatorLayout = BufferLayout.nu64('lamportsPerSignature');
 
 /**
  * Calculator for transaction fees.
+ *
+ * @deprecated Deprecated since Solana v1.8.0.
  */
 export interface FeeCalculator {
   /** Cost in lamports to validate a signature. */


### PR DESCRIPTION
#### Problem
Some types are only used by deprecated methods but aren't annotated as deprecated yet

#### Summary of Changes
annotate more types as deprecated

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
