### PR TITLE
Fix rust flags handling in cargo-build-sbf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,8 +3314,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
 dependencies = [
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -4821,6 +4839,7 @@ dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
  "log",
+ "predicates",
  "regex",
  "serial_test",
  "solana-download-utils",

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -22,6 +22,7 @@ tar = "0.4.38"
 
 [dev-dependencies]
 assert_cmd = "*"
+predicates = "2.0"
 serial_test = "*"
 
 [features]

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -564,25 +564,6 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
 
-    let rustflags = env::var("RUSTFLAGS").ok();
-    let mut rustflags = Cow::Borrowed(rustflags.as_deref().unwrap_or_default());
-    if config.remap_cwd {
-        rustflags = Cow::Owned(format!("{} -Zremap-cwd-prefix=", &rustflags));
-    }
-    if config.debug {
-        // Replace with -Zsplit-debuginfo=packed when stabilized.
-        rustflags = Cow::Owned(format!("{} -g", &rustflags));
-    }
-    if let Cow::Owned(flags) = rustflags {
-        env::set_var("RUSTFLAGS", &flags);
-    }
-    if config.verbose {
-        debug!(
-            "RUSTFLAGS=\"{}\"",
-            env::var("RUSTFLAGS").ok().unwrap_or_default()
-        );
-    }
-
     // RUSTC variable overrides cargo +<toolchain> mechanism of
     // selecting the rust compiler and makes cargo run a rust compiler
     // other than the one linked in BPF toolchain. We have to prevent
@@ -593,15 +574,40 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
         );
         env::remove_var("RUSTC")
     }
-
-    let mut target_rustflags = env::var("CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS")
-        .ok()
-        .unwrap_or_default();
+    let cargo_target = if config.arch == "bpf" {
+        "CARGO_TARGET_BPFEL_UNKNOWN_UNKNOWN_RUSTFLAGS"
+    } else {
+        "CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS"
+    };
+    let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
+    if env::var("RUSTFLAGS").is_ok() {
+        warn!(
+            "Removed RUSTFLAGS from cargo environment, because it overrides {}.",
+            cargo_target,
+        );
+        env::remove_var("RUSTFLAGS")
+    }
+    let target_rustflags = env::var(cargo_target).ok();
+    let mut target_rustflags = Cow::Borrowed(target_rustflags.as_deref().unwrap_or_default());
+    target_rustflags = Cow::Owned(format!("{} {}", &rustflags, &target_rustflags));
+    if config.remap_cwd {
+        target_rustflags = Cow::Owned(format!("{} -Zremap-cwd-prefix=", &target_rustflags));
+    }
+    if config.debug {
+        // Replace with -Zsplit-debuginfo=packed when stabilized.
+        target_rustflags = Cow::Owned(format!("{} -g", &target_rustflags));
+    }
     if config.arch == "sbfv2" {
-        target_rustflags = format!("{} {}", "-C target_cpu=sbfv2", target_rustflags);
-        env::set_var(
-            "CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS",
-            &target_rustflags,
+        target_rustflags = Cow::Owned(format!("{} -C target_cpu=sbfv2", &target_rustflags));
+    }
+    if let Cow::Owned(flags) = target_rustflags {
+        env::set_var(cargo_target, &flags);
+    }
+    if config.verbose {
+        debug!(
+            "{}=\"{}\"",
+            cargo_target,
+            env::var(cargo_target).ok().unwrap_or_default(),
         );
     }
 


### PR DESCRIPTION
#### Problem

cargo-build-sbf uses `CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS` env variable to pass solana specific command line options to rust compiler. However, it also sets `RUSTFLAGS` environment variable which overrides the former variable.

#### Summary of Changes

- Make cargo-build-sbf use `CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS` exclusively to pass rust compiler options.
- Add an integration test that validates that `--arch sbfv2` option indeed forces cargo-build-sbf to build SBFv2 binaries.

Fixes #26971
