### PR TITLE
Reduce quic multi write test packets count

### DIFF
--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -93,7 +93,7 @@ mod tests {
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;
-        let num_expected_packets: usize = 3072;
+        let num_expected_packets: usize = 3000;
         let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch_async(packets).is_ok());
@@ -138,7 +138,7 @@ mod tests {
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;
-        let num_expected_packets: usize = 3072;
+        let num_expected_packets: usize = 3000;
         let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch(&packets).await.is_ok());

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -93,7 +93,7 @@ mod tests {
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;
-        let num_expected_packets: usize = 4000;
+        let num_expected_packets: usize = 3072;
         let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch_async(packets).is_ok());
@@ -138,7 +138,7 @@ mod tests {
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;
-        let num_expected_packets: usize = 4000;
+        let num_expected_packets: usize = 3072;
         let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch(&packets).await.is_ok());


### PR DESCRIPTION
#### Problem

The tests test_quic_client_multiple_writes fails sporadically because all 4000 packets might not be sent all in the allotted time.
The issue is likely more easily showing up since the receive_window change when we reduce the receive_window for non-staked nodes.

#### Summary of Changes
Reduce the count to 3000
