### PR TITLE
adjusts max coding shreds per slot

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -49,6 +49,8 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
+#[cfg(test)]
+pub(crate) use shred_code::MAX_CODE_SHREDS_PER_SLOT;
 pub(crate) use shred_data::ShredData;
 pub use {
     self::stats::{ProcessShredsStats, ShredFetchStats},

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -325,7 +325,7 @@ impl ShredCode {
 mod test {
     use {
         super::*,
-        crate::shred::{ShredType, MAX_DATA_SHREDS_PER_SLOT},
+        crate::shred::{shred_code::MAX_CODE_SHREDS_PER_SLOT, ShredType, MAX_DATA_SHREDS_PER_SLOT},
         matches::assert_matches,
     };
 
@@ -433,10 +433,10 @@ mod test {
         }
         {
             let mut shred = shred.clone();
-            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32;
+            shred.common_header.index = MAX_CODE_SHREDS_PER_SLOT as u32;
             assert_matches!(
                 shred.sanitize(),
-                Err(Error::InvalidShredIndex(ShredType::Code, 32768))
+                Err(Error::InvalidShredIndex(ShredType::Code, 557_056))
             );
         }
         // pos >= num_coding is invalid.
@@ -454,7 +454,7 @@ mod test {
         {
             let mut shred = shred.clone();
             shred.common_header.fec_set_index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
-            shred.coding_header.num_data_shreds = 2;
+            shred.coding_header.num_data_shreds = 3;
             shred.coding_header.num_coding_shreds = 4;
             shred.coding_header.position = 1;
             shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
@@ -463,6 +463,7 @@ mod test {
                 Err(Error::InvalidErasureShardIndex { .. })
             );
 
+            shred.coding_header.num_data_shreds = 2;
             shred.coding_header.num_coding_shreds = 2000;
             assert_matches!(shred.sanitize(), Err(Error::InvalidNumCodingShreds(2000)));
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -10,7 +10,9 @@ use {
     static_assertions::const_assert_eq,
 };
 
-pub(super) const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
+// See ERASURE_BATCH_SIZE.
+const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768 * 17);
+pub(crate) const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT * 17;
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -378,9 +378,12 @@ fn get_fec_set_offsets(
 mod tests {
     use {
         super::*,
-        crate::shred::{
-            self, max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred,
-            ShredType,
+        crate::{
+            blockstore::MAX_DATA_SHREDS_PER_SLOT,
+            shred::{
+                self, max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred,
+                ShredType, MAX_CODE_SHREDS_PER_SLOT,
+            },
         },
         bincode::serialized_size,
         matches::assert_matches,
@@ -1103,6 +1106,19 @@ mod tests {
                 |((offset, chunk_size), (next_offset, _chunk_size))| offset + chunk_size
                     == *next_offset
             ));
+        }
+    }
+
+    #[test]
+    fn test_max_shreds_per_slot() {
+        for num_data_shreds in 0..128 {
+            let num_coding_shreds = get_erasure_batch_size(num_data_shreds)
+                .checked_sub(num_data_shreds)
+                .unwrap();
+            assert!(
+                MAX_DATA_SHREDS_PER_SLOT * num_coding_shreds
+                    <= MAX_CODE_SHREDS_PER_SLOT * num_data_shreds
+            );
         }
     }
 }


### PR DESCRIPTION

#### Problem
As a consequence of removing buffering when generating coding shreds:
https://github.com/solana-labs/solana/pull/25807
more coding shreds are generated than data shreds, and so
`MAX_CODE_SHREDS_PER_SLOT` needs to be adjusted accordingly.


#### Summary of Changes
Updated values based on `ERASURE_BATCH_SIZE`.