### PR TITLE
Fix local-cluster for QUIC more

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -43,7 +43,7 @@ use {
     },
 };
 
-fn get_client_facing_addr(contact_info: &ContactInfo) -> (SocketAddr, SocketAddr) {
+pub fn get_client_facing_addr(contact_info: &ContactInfo) -> (SocketAddr, SocketAddr) {
     let (rpc, mut tpu) = contact_info.client_facing_addr();
     // QUIC certificate authentication requires the IP Address to match. ContactInfo might have
     // 0.0.0.0 as the IP instead of 127.0.0.1.

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -424,7 +424,7 @@ impl LocalCluster {
         mut voting_keypair: Option<Arc<Keypair>>,
         socket_addr_space: SocketAddrSpace,
     ) -> Pubkey {
-        let (rpc, tpu) = self.entry_point_info.client_facing_addr();
+        let (rpc, tpu) = cluster_tests::get_client_facing_addr(&self.entry_point_info);
         let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
 
         // Must have enough tokens to fund vote account and set delegate
@@ -510,7 +510,7 @@ impl LocalCluster {
     }
 
     pub fn transfer(&self, source_keypair: &Keypair, dest_pubkey: &Pubkey, lamports: u64) -> u64 {
-        let (rpc, tpu) = self.entry_point_info.client_facing_addr();
+        let (rpc, tpu) = cluster_tests::get_client_facing_addr(&self.entry_point_info);
         let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
         Self::transfer_with_client(&client, source_keypair, dest_pubkey, lamports)
     }
@@ -757,7 +757,7 @@ impl Cluster for LocalCluster {
 
     fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient> {
         self.validators.get(pubkey).map(|f| {
-            let (rpc, tpu) = f.info.contact_info.client_facing_addr();
+            let (rpc, tpu) = cluster_tests::get_client_facing_addr(&f.info.contact_info);
             ThinClient::new(rpc, tpu, self.connection_cache.clone())
         })
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -191,7 +191,7 @@ fn test_local_cluster_signature_subscribe() {
         .unwrap();
     let non_bootstrap_info = cluster.get_contact_info(&non_bootstrap_id).unwrap();
 
-    let (rpc, tpu) = non_bootstrap_info.client_facing_addr();
+    let (rpc, tpu) = cluster_tests::get_client_facing_addr(non_bootstrap_info);
     let tx_client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
 
     let (blockhash, _) = tx_client
@@ -418,7 +418,7 @@ fn test_mainnet_beta_cluster_type() {
     .unwrap();
     assert_eq!(cluster_nodes.len(), 1);
 
-    let (rpc, tpu) = cluster.entry_point_info.client_facing_addr();
+    let (rpc, tpu) = cluster_tests::get_client_facing_addr(&cluster.entry_point_info);
     let client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
 
     // Programs that are available at epoch 0


### PR DESCRIPTION
#### Problem
Some local cluster tests are still failing when QUIC is enabled.

#### Summary of Changes
Following #27071, changes server addresses to 127.0.0.1

I don't think this fixes all the problems, but it allows some tests that were failing in current iteration of  #26927 to succeed (eg. `test_spend_and_verify_all_nodes_2`, `test_spend_and_verify_all_nodes_3`) cc @willhickey 
