### PR TITLE
clean feature: `request_units_deprecated`

### DIFF
--- a/core/src/transaction_priority_details.rs
+++ b/core/src/transaction_priority_details.rs
@@ -24,7 +24,6 @@ pub trait GetTransactionPriorityDetails {
             .process_instructions(
                 instructions,
                 true, // use default units per instruction
-                true, // don't reject txs that use set compute unit price ix
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3798,7 +3798,6 @@ fn test_program_fees() {
         congestion_multiplier,
         &fee_structure,
         true,
-        true,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3819,7 +3818,6 @@ fn test_program_fees() {
         &sanitized_message,
         congestion_multiplier,
         &fee_structure,
-        true,
         true,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -34,9 +34,7 @@ use {
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot, INITIAL_RENT_EPOCH},
-        feature_set::{
-            self, add_set_compute_unit_price_ix, use_default_units_in_fee_calculation, FeatureSet,
-        },
+        feature_set::{self, use_default_units_in_fee_calculation, FeatureSet},
         fee::FeeStructure,
         genesis_config::ClusterType,
         hash::Hash,
@@ -554,7 +552,6 @@ impl Accounts {
                             tx.message(),
                             lamports_per_signature,
                             fee_structure,
-                            feature_set.is_active(&add_set_compute_unit_price_ix::id()),
                             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                         )
                     } else {
@@ -1673,7 +1670,6 @@ mod tests {
             &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
             lamports_per_signature,
             &FeeStructure::default(),
-            true,
             true,
         );
         assert_eq!(fee, lamports_per_signature);


### PR DESCRIPTION
#### Problem
`request_units_deprecated ` is now activated on all clusters and the feature gate code can be removed

#### Summary of Changes
Removed usages of `request_units_deprecated `

Closes https://github.com/solana-labs/solana/issues/25050
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
