### PR TITLE
Fix test_accounts_data_size_and_resize_transactions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19305,7 +19305,10 @@ pub(crate) mod tests {
         {
             let account_pubkey = Pubkey::new_unique();
             let account_balance = LAMPORTS_PER_SOL;
-            let account_size = rng.gen_range(1, MAX_PERMITTED_DATA_LENGTH) as usize;
+            let account_size = rng.gen_range(
+                1,
+                MAX_PERMITTED_DATA_LENGTH as usize - MAX_PERMITTED_DATA_INCREASE,
+            );
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);
             bank.store_account(&account_pubkey, &account_data);


### PR DESCRIPTION
#### Problem

The bank test, `test_accounts_data_size_and_resize_transactions`, sometimes fails if the random numbers used to create the account and grow the account are too large. If the starting account size is very large, and the resize amount is also large, then the resize transaction will fail due to the new account size being greater than the max allowed size.

It likely happened here:
https://buildkite.com/solana-labs/solana/builds/79623#01829209-7fdb-4941-a2ab-7abb8a52a23e


#### Summary of Changes

Limit the random number generator's range such that the resize will always be a valid amount.