### PR TITLE
Refactor: Flattens `TransactionContext::instruction_trace`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -325,7 +325,7 @@ impl<'a> InvokeContext<'a> {
                 .get_instruction_context_stack_height())
                 .any(|level| {
                     self.transaction_context
-                        .get_instruction_context_at(level)
+                        .get_instruction_context_at_nesting_level(level)
                         .and_then(|instruction_context| {
                             instruction_context
                                 .try_borrow_last_program_account(self.transaction_context)

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -497,21 +497,20 @@ mod tests {
                 &program_indices,
             )
             .instruction_accounts;
-
-            let transaction_context =
-                TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
             let instruction_data = vec![];
-            let instruction_context = InstructionContext::new(
-                0,
-                0,
-                &program_indices,
-                &instruction_accounts,
-                &instruction_data,
-            );
+
+            let mut transaction_context =
+                TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
+            transaction_context
+                .push(&program_indices, &instruction_accounts, &instruction_data)
+                .unwrap();
+            let instruction_context = transaction_context
+                .get_instruction_context_at_index_in_trace(0)
+                .unwrap();
 
             let serialization_result = serialize_parameters(
                 &transaction_context,
-                &instruction_context,
+                instruction_context,
                 should_cap_ix_accounts,
             );
             assert_eq!(

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1712,25 +1712,34 @@ declare_syscall!(
         // Reverse iterate through the instruction trace,
         // ignoring anything except instructions on the same level
         let stack_height = invoke_context.get_stack_height();
-        let instruction_trace = invoke_context.transaction_context.get_instruction_trace();
-        let mut current_index = 0;
-        let mut instruction_context = None;
-        for current_instruction_context in instruction_trace.iter().rev() {
-            if current_instruction_context.get_stack_height() == TRANSACTION_LEVEL_STACK_HEIGHT
+        let instruction_trace_length = invoke_context
+            .transaction_context
+            .get_instruction_trace_length();
+        let mut reverse_index_at_stack_height = 0;
+        let mut found_instruction_context = None;
+        for index_in_trace in (0..instruction_trace_length).rev() {
+            let instruction_context = question_mark!(
+                invoke_context
+                    .transaction_context
+                    .get_instruction_context_at_index_in_trace(index_in_trace)
+                    .map_err(SyscallError::InstructionError),
+                result
+            );
+            if instruction_context.get_stack_height() == TRANSACTION_LEVEL_STACK_HEIGHT
                 && stack_height > TRANSACTION_LEVEL_STACK_HEIGHT
             {
                 break;
             }
-            if current_instruction_context.get_stack_height() == stack_height {
-                if index.saturating_add(1) == current_index {
-                    instruction_context = Some(current_instruction_context);
+            if instruction_context.get_stack_height() == stack_height {
+                if index.saturating_add(1) == reverse_index_at_stack_height {
+                    found_instruction_context = Some(instruction_context);
                     break;
                 }
-                current_index = current_index.saturating_add(1);
+                reverse_index_at_stack_height = reverse_index_at_stack_height.saturating_add(1);
             }
         }
 
-        if let Some(instruction_context) = instruction_context {
+        if let Some(instruction_context) = found_instruction_context {
             let ProcessedSiblingInstruction {
                 data_len,
                 accounts_len,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1714,15 +1714,21 @@ declare_syscall!(
         let stack_height = invoke_context.get_stack_height();
         let instruction_trace = invoke_context.transaction_context.get_instruction_trace();
         let mut current_index = 0;
-        let instruction_context = instruction_trace.iter().rev().find(|instruction_context| {
-            if instruction_context.get_stack_height() == stack_height {
+        let mut instruction_context = None;
+        for current_instruction_context in instruction_trace.iter().rev() {
+            if current_instruction_context.get_stack_height() == TRANSACTION_LEVEL_STACK_HEIGHT
+                && stack_height > TRANSACTION_LEVEL_STACK_HEIGHT
+            {
+                break;
+            }
+            if current_instruction_context.get_stack_height() == stack_height {
                 if index.saturating_add(1) == current_index {
-                    return true;
+                    instruction_context = Some(current_instruction_context);
+                    break;
                 }
                 current_index = current_index.saturating_add(1);
             }
-            false
-        });
+        }
 
         if let Some(instruction_context) = instruction_context {
             let ProcessedSiblingInstruction {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -766,14 +766,14 @@ pub fn inner_instructions_list_from_instruction_trace(
     transaction_context: &TransactionContext,
 ) -> InnerInstructionsList {
     debug_assert!(transaction_context
-        .get_instruction_context_at_index(0)
+        .get_instruction_context_at_index_in_trace(0)
         .map(|instruction_context| instruction_context.get_stack_height()
             == TRANSACTION_LEVEL_STACK_HEIGHT)
         .unwrap_or(true));
     let mut outer_instructions = Vec::new();
     for index_in_trace in 0..transaction_context.get_instruction_trace_length() {
         if let Ok(instruction_context) =
-            transaction_context.get_instruction_context_at_index(index_in_trace)
+            transaction_context.get_instruction_context_at_index_in_trace(index_in_trace)
         {
             if instruction_context.get_stack_height() == TRANSACTION_LEVEL_STACK_HEIGHT {
                 outer_instructions.push(Vec::new());

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -680,6 +680,6 @@ mod tests {
                 InstructionError::Custom(0xbabb1e)
             ))
         );
-        assert_eq!(transaction_context.get_instruction_trace().len(), 2);
+        assert_eq!(transaction_context.get_instruction_trace_length(), 2);
     }
 }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -211,13 +211,13 @@ impl TransactionContext {
                 return Err(InstructionError::UnbalancedInstruction);
             }
         }
-        let instruction_context = InstructionContext {
-            nesting_level: self.instruction_stack.len(),
-            instruction_accounts_lamport_sum: callee_instruction_accounts_lamport_sum,
-            program_accounts: program_accounts.to_vec(),
-            instruction_accounts: instruction_accounts.to_vec(),
-            instruction_data: instruction_data.to_vec(),
-        };
+        let instruction_context = InstructionContext::new(
+            self.instruction_stack.len(),
+            callee_instruction_accounts_lamport_sum,
+            program_accounts.to_vec(),
+            instruction_accounts.to_vec(),
+            instruction_data.to_vec(),
+        );
         let index_in_trace = self.instruction_trace.len();
         self.instruction_trace.push(instruction_context);
         if self.instruction_stack.len() >= self.instruction_context_capacity {
@@ -335,19 +335,19 @@ pub struct InstructionContext {
 
 impl InstructionContext {
     /// New
-    pub fn new(
+    fn new(
         nesting_level: usize,
         instruction_accounts_lamport_sum: u128,
-        program_accounts: &[usize],
-        instruction_accounts: &[InstructionAccount],
-        instruction_data: &[u8],
+        program_accounts: Vec<usize>,
+        instruction_accounts: Vec<InstructionAccount>,
+        instruction_data: Vec<u8>,
     ) -> Self {
         InstructionContext {
             nesting_level,
             instruction_accounts_lamport_sum,
-            program_accounts: program_accounts.to_vec(),
-            instruction_accounts: instruction_accounts.to_vec(),
-            instruction_data: instruction_data.to_vec(),
+            program_accounts,
+            instruction_accounts,
+            instruction_data,
         }
     }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -138,19 +138,19 @@ impl TransactionContext {
     }
 
     /// Gets an InstructionContext by its nesting level in the stack
-    pub fn get_instruction_context_at(
+    pub fn get_instruction_context_at_nesting_level(
         &self,
-        level: usize,
+        nesting_level: usize,
     ) -> Result<&InstructionContext, InstructionError> {
         let index_in_trace = *self
             .instruction_stack
-            .get(level)
+            .get(nesting_level)
             .ok_or(InstructionError::CallDepth)?;
         let instruction_context = self
             .instruction_trace
             .get(index_in_trace)
             .ok_or(InstructionError::CallDepth)?;
-        debug_assert_eq!(instruction_context.nesting_level, level);
+        debug_assert_eq!(instruction_context.nesting_level, nesting_level);
         Ok(instruction_context)
     }
 
@@ -171,7 +171,7 @@ impl TransactionContext {
             .get_instruction_context_stack_height()
             .checked_sub(1)
             .ok_or(InstructionError::CallDepth)?;
-        self.get_instruction_context_at(level)
+        self.get_instruction_context_at_nesting_level(level)
     }
 
     /// Pushes a new InstructionContext


### PR DESCRIPTION
#### Problem
ABIv2 will need a consecutive memory layout to map the `instruction_trace` into the VM address space. Also, putting everything in a single allocation would reduce the multi threading overhead of memory management dramatically.

#### Summary of Changes
The `instruction_trace` is flattened from a `Vec<Vec<InstructionContext>>` into a `Vec<InstructionContext>`. The outer `Vec` represented the transaction level instructions and the inner `Vec` the CPI instructions, the `instruction_stack` had the index into the outer `Vec` as the first entry and indices into the inner `Vec` for every following entry.

Now, both levels are collapsed into one homogeneous `instruction_trace` and `instruction_stack`. No information is lost by removing the partitioning of the outer `Vec`, because `InstructionContext` has a `nesting_level` property which can be used to partition by transaction level instructions while iterating.

Not just is the `instruction_trace` flattened, its interface is made structure independent as well. So, instead of returning a slice to the `instruction_trace` from which you then pick the instruction context or iterate over, we now provide a method to access a single entry by `index_in_trace` additionally to `get_instruction_context_at_nesting_level`.

- Renames `get_instruction_context_at()` => `get_instruction_context_at_nesting_level()`.
- Replaces `TransactionContext::get_instruction_trace()` by `TransactionContext::get_instruction_trace_length()` and `TransactionContext::get_instruction_context_at_index()`.
- `TransactionContext::instruction_accounts_lamport_sum()` now takes an iterator instead of a slice.
- Removes `instruction_trace` from `ExecutionRecord`.