### PR TITLE
Fix broken macro doc links

### DIFF
--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -48,6 +48,9 @@ pub const NON_DUP_MARKER: u8 = u8::MAX;
 /// It also sets up a [global allocator] and [panic handler], using the
 /// [`custom_heap_default`] and [`custom_panic_default`] macros.
 ///
+/// [`custom_heap_default`]: crate::custom_heap_default
+/// [`custom_panic_default`]: crate::custom_panic_default
+///
 /// [global allocator]: https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html
 /// [panic handler]: https://doc.rust-lang.org/nomicon/panic-handler.html
 ///

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -7,7 +7,7 @@
 //! The most common way to emit logs is through the [`msg!`] macro, which logs
 //! simple strings, as well as [formatted strings][fs].
 //!
-//! [`msg!`]: msg
+//! [`msg!`]: crate::msg!
 //! [fs]: https://doc.rust-lang.org/std/fmt/
 //!
 //! Logs can be viewed in multiple ways:

--- a/sdk/program/src/program.rs
+++ b/sdk/program/src/program.rs
@@ -24,6 +24,8 @@ use crate::{
 /// program, and provided by _its_ caller. The same is true of the program ID of
 /// the called program.
 ///
+/// [entrypoint!]: crate::entrypoint!
+///
 /// The `Instruction` is usually built from within the calling program, but may
 /// be deserialized from an external source.
 ///


### PR DESCRIPTION
#### Problem

Rust 1.63 appears to fixed some bugs in macro doc link resolution. This makes these links work again.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
