### PR TITLE
Temporarily disable spl from downstream-projects CI

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -98,5 +98,5 @@ EOF
 }
 
 _ example_helloworld
-_ spl
+# _ spl
 _ serum_dex


### PR DESCRIPTION
#### Problem
Disable steps that fail due to being unable to find eligible rocksdb package due to being locked to older rust version:
```
error: failed to select a version for the requirement `librocksdb-sys = "^0.8.0"`
--
  | candidate versions found which didn't match: 6.20.3, 6.17.3, 6.11.4, ...
  | location searched: crates.io index
  | required by package `rocksdb v0.19.0`
  | ... which satisfies dependency `rocksdb = "^0.19.0"`
```
#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
