### PR TITLE
chore: upload test results to buildkite and datadog

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -20,6 +20,12 @@ else
     SUCCESS=false
   fi
 
+  if [[ "$BUILDKITE_BRANCH" == 'master' && -f "results.json" ]]; then
+    awk '/{ "type": .* }/' results.json > sanitized-results.json
+    cargo2junit > results.xml < sanitized-results.json
+    datadog-ci junit upload --service solana results.xml
+  fi
+
   point_tags="pipeline=$BUILDKITE_PIPELINE_SLUG,job=$CI_LABEL,pr=$PR,success=$SUCCESS"
   point_tags="${point_tags// /\\ }"  # Escape spaces
 

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -21,7 +21,13 @@ else
   fi
 
   if [[ "$BUILDKITE_BRANCH" == 'master' && -f "results.json" ]]; then
+    # prepare result file
     awk '/{ "type": .* }/' results.json > sanitized-results.json
+
+    # upload to buildkite
+    buildkite-test-collector < sanitized-results.json
+
+    # upload to datadog
     cargo2junit > results.xml < sanitized-results.json
     datadog-ci junit upload --service solana results.xml
   fi

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -127,7 +127,8 @@ test-stable-perf)
   fi
 
   _ "$cargo" stable build --bins ${V:+--verbose}
-  _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
+  _ "$cargo" stable test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   _ "$cargo" stable run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
   ;;
 test-local-cluster)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,6 +12,12 @@ annotate() {
   }
 }
 
+exit_if_error() {
+   if [[ "$1" -ne 0 ]]; then
+    exit "$1"
+  fi
+}
+
 # Run the appropriate test based on entrypoint
 testName=$(basename "$0" .sh)
 
@@ -35,7 +41,8 @@ JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 echo "Executing $testName"
 case $testName in
 test-stable)
-  _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+  _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   ;;
 test-stable-bpf)
   # Clear the C dependency files, if dependency moves these files are not regenerated

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -151,7 +151,8 @@ test-local-cluster-slow-1)
   ;;
 test-local-cluster-slow-2)
   _ "$cargo" stable build --release --bins ${V:+--verbose}
-  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
+  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   exit 0
   ;;
 test-wasm)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -139,7 +139,8 @@ test-local-cluster)
   ;;
 test-local-cluster-flakey)
   _ "$cargo" stable build --release --bins ${V:+--verbose}
-  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
+  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   exit 0
   ;;
 test-local-cluster-slow-1)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -66,7 +66,8 @@ test-stable-bpf)
   _ make -C programs/bpf/c tests
   _ "$cargo" stable test \
     --manifest-path programs/bpf/Cargo.toml \
-    --no-default-features --features=bpf_c,bpf_rust -- --nocapture
+    --no-default-features --features=bpf_c,bpf_rust -- -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
 
   # BPF Rust program unit tests
   for bpf_test in programs/bpf/rust/*; do
@@ -102,7 +103,8 @@ test-stable-bpf)
   _ "$cargo" stable test \
     --manifest-path programs/bpf/Cargo.toml \
     --no-default-features --features=bpf_c,bpf_rust assert_instruction_count \
-    -- --nocapture &> "${bpf_target_path}"/deploy/instuction_counts.txt
+    -- -Z unstable-options --format json --report-time |& tee results.json
+  awk '!/{ "type": .* }/' results.json > "${bpf_target_path}"/deploy/instuction_counts.txt
 
   bpf_dump_archive="bpf-dumps.tar.bz2"
   rm -f "$bpf_dump_archive"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -169,7 +169,8 @@ test-wasm)
   exit 0
   ;;
 test-docs)
-  _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+  _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   exit 0
   ;;
 *)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -133,7 +133,8 @@ test-stable-perf)
   ;;
 test-local-cluster)
   _ "$cargo" stable build --release --bins ${V:+--verbose}
-  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
+  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   exit 0
   ;;
 test-local-cluster-flakey)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -145,7 +145,8 @@ test-local-cluster-flakey)
   ;;
 test-local-cluster-slow-1)
   _ "$cargo" stable build --release --bins ${V:+--verbose}
-  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
+  _ "$cargo" stable test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
+  exit_if_error "${PIPESTATUS[0]}"
   exit 0
   ;;
 test-local-cluster-slow-2)


### PR DESCRIPTION
#### Problem

We don't have an efficient way to detect flaky tests. I uploaded test results to buildkite and datadog. Let them generate an analysis for us.

#### Summary of Changes

exported test result in this PR

- stable
- doctest
- stable-bpf
- stable-perf
- local-cluster
- local-cluster-flakey
- local-cluster-slow-1
- local-cluster-slow-2

will export in next PR

- coverage

will ignore

- sanity
- shellcheck
- checks
- downstream-projects
- wasm
- bench