### PR TITLE
wait for bg hash calc to complete before 'calculate_capitalization'

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -795,6 +795,9 @@ impl Accounts {
         let use_index = false;
         let is_startup = true;
         self.accounts_db
+            .verify_accounts_hash_in_bg
+            .wait_for_complete();
+        self.accounts_db
             .update_accounts_hash_with_index_option(
                 use_index,
                 debug_verify,


### PR DESCRIPTION
#### Problem

under certain startup conditions, 2 hash calcs could run in parallel.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
