### PR TITLE
store hash calc failures in a separate folder by slot

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6861,12 +6861,17 @@ impl AccountsDb {
 
     /// normal code path returns the common cache path
     /// when called after a failure has been detected, redirect the cache storage to a separate folder for debugging later
-    fn get_cache_hash_data(&self, config: &CalcAccountsHashConfig<'_>) -> CacheHashData {
+    fn get_cache_hash_data(
+        &self,
+        config: &CalcAccountsHashConfig<'_>,
+        slot: Slot,
+    ) -> CacheHashData {
         if !config.store_detailed_debug_info_on_failure {
             CacheHashData::new(&self.accounts_hash_cache_path)
         } else {
             // this path executes when we are failing with a hash mismatch
             let mut new = self.accounts_hash_cache_path.clone();
+            new.push(format!("{}", slot));
             new.push("failed_calculate_accounts_hash_cache");
             let _ = std::fs::remove_dir_all(&new);
             CacheHashData::new(&new)
@@ -6893,7 +6898,7 @@ impl AccountsDb {
             let mut previous_pass = PreviousPass::default();
             let mut final_result = (Hash::default(), 0);
 
-            let cache_hash_data = self.get_cache_hash_data(config);
+            let cache_hash_data = self.get_cache_hash_data(config, storages.max_slot_inclusive());
 
             for pass in 0..num_hash_scan_passes {
                 let bounds = Range {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6871,7 +6871,7 @@ impl AccountsDb {
         } else {
             // this path executes when we are failing with a hash mismatch
             let mut new = self.accounts_hash_cache_path.clone();
-            new.push(format!("{}", slot));
+            new.push(slot.to_string());
             new.push("failed_calculate_accounts_hash_cache");
             let _ = std::fs::remove_dir_all(&new);
             CacheHashData::new(&new)


### PR DESCRIPTION
#### Problem
When a validator fails due to a cap mismatch, it restarts. it often then gets another snapshot. It can then fail again on a different slot.

#### Summary of Changes
Keep track of failures per slot. Note this has the downside that it can use up all disk capacity, but that is only in the case that it repeatedly encounters hash calc cap mismatches, which should be exceedingly rare in practice.
This allows the original failure to be debugged.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
