### PR TITLE
add use_durable_nonce option

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -11,6 +11,7 @@ use {
     solana_metrics::{self, datapoint_info},
     solana_sdk::{
         clock::{DEFAULT_MS_PER_SLOT, DEFAULT_S_PER_SLOT, MAX_PROCESSING_AGE},
+        commitment_config::CommitmentConfig,
         compute_budget::ComputeBudgetInstruction,
         hash::Hash,
         instruction::{AccountMeta, Instruction},
@@ -544,7 +545,9 @@ fn get_nonce_blockhash<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
     nonce_account_pubkey: Pubkey,
 ) -> Hash {
     loop {
-        match client.get_account(&nonce_account_pubkey) {
+        match client
+            .get_account_with_commitment(&nonce_account_pubkey, CommitmentConfig::processed())
+        {
             Ok(nonce_account) => match nonce_utils::data_from_account(&nonce_account) {
                 Ok(nonce_data) => return nonce_data.blockhash(),
                 Err(err) => {

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -313,6 +313,11 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .takes_value(false)
                 .help("Sets random compute-unit-price in range [0..100] to transfer transactions"),
         )
+        .arg(
+            Arg::with_name("use_durable_nonce")
+                .long("use-durable-nonce")
+                .help("Use durable transaction nonce instead of recent blockhash"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -445,6 +450,10 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
 
     if matches.is_present("use_randomized_compute_unit_price") {
         args.use_randomized_compute_unit_price = true;
+    }
+
+    if matches.is_present("use_durable_nonce") {
+        args.use_durable_nonce = true;
     }
 
     args

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -109,6 +109,7 @@ pub fn generate_durable_nonce_accounts<T: 'static + BenchTpsClient + Send + Sync
     let (mut nonce_keypairs, _extra) = generate_keypairs(seed_keypair, count as u64);
     nonce_keypairs.truncate(count);
 
+    info!("Creating {} nonce accounts...", count);
     let to_fund: Vec<NonceCreateSigners> = authority_keypairs
         .iter()
         .zip(nonce_keypairs.iter())


### PR DESCRIPTION
#### Problem

Final PR in the [chain of PRs](https://github.com/solana-labs/solana/issues/25759) adding durable nonce transactions to bench-tps.

~Requires https://github.com/solana-labs/solana/pull/27176~
Requires https://github.com/solana-labs/solana/pull/27379

#### Summary of Changes

* Introduce `--use-durable-nonce` option to cli
* Request durable nonce in a loop

## UPD:

TPS is now ~5k

Some plots with running with this option:
<img width="1153" alt="Screenshot 2022-08-26 at 17 07 14" src="https://user-images.githubusercontent.com/687962/186936144-23d00a50-b277-4ea0-b1ff-ae6f4d716309.png">

The bottom plot is for data shreds: at the beggining there are many data shreds because we create nonce durable accounts. During transactions execution this metric is lower.


If we zoom into the transaction phase, we observe that the tps is spiky:
<img width="707" alt="Screenshot 2022-08-26 at 17 10 47" src="https://user-images.githubusercontent.com/687962/186936639-0658906b-92de-483c-bdfa-37d3a93c6513.png">

It happens because it takes time to request blockhashes before executing transactions
