### PR TITLE
slots_connected: check if the range is connected (>= ending_slot)

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -955,9 +955,9 @@ fn load_bank_forks(
     };
 
     if let Some(halt_slot) = process_options.halt_at_slot {
-        // Check if we have the slot data necessary to replay from starting_slot to halt_slot.
+        // Check if we have the slot data necessary to replay from starting_slot to >= halt_slot.
         //  - This will not catch the case when loading from genesis without a full slot 0.
-        if !blockstore.slots_connected(starting_slot, halt_slot) {
+        if !blockstore.slot_range_connected(starting_slot, halt_slot) {
             eprintln!(
                 "Unable to load bank forks at slot {} due to disconnected blocks.",
                 halt_slot,


### PR DESCRIPTION
#### Problem
`slots_connected` was returning false if we did not have *exactly* the `ending_slot`. This is more restrictive than necessary for ledger-tool modes that are not `create-snapshot`.

#### Summary of Changes
* `slots_connected` => `slot_range_connected`
* returns true if we can get past the `ending_slot` (ie there is a path from `starting_slot` to some slot >= `ending_slot`)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
