### PR TITLE
renames size_of_erasure_encoded_slice to ShredCode::capacity

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -68,7 +68,7 @@ use {
         clock::Slot,
         hash::{hashv, Hash},
         pubkey::Pubkey,
-        signature::{Keypair, Signature, Signer},
+        signature::{Keypair, Signature, Signer, SIGNATURE_BYTES},
     },
     static_assertions::const_assert_eq,
     std::fmt::Debug,
@@ -92,7 +92,7 @@ pub const SIZE_OF_NONCE: usize = 4;
 const SIZE_OF_COMMON_SHRED_HEADER: usize = 83;
 const SIZE_OF_DATA_SHRED_HEADERS: usize = 88;
 const SIZE_OF_CODING_SHRED_HEADERS: usize = 89;
-const SIZE_OF_SIGNATURE: usize = 64;
+const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 const SIZE_OF_SHRED_VARIANT: usize = 1;
 const SIZE_OF_SHRED_SLOT: usize = 8;
 const SIZE_OF_SHRED_INDEX: usize = 4;


### PR DESCRIPTION
#### Problem
Maintain symmetry between code and data shreds:
* `ShredData::capacity` -> data buffer capacity
* `ShredCode::capacity` -> erasure code capacity


#### Summary of Changes
renames `size_of_erasure_encoded_slice` to `ShredCode::capacity`.
