### PR TITLE
Share Ancestors API get with contains_key

### DIFF
--- a/runtime/src/ancestors.rs
+++ b/runtime/src/ancestors.rs
@@ -65,10 +65,6 @@ impl Ancestors {
         self.ancestors.get_all()
     }
 
-    pub fn get(&self, slot: &Slot) -> bool {
-        self.ancestors.contains(slot)
-    }
-
     pub fn remove(&mut self, slot: &Slot) {
         self.ancestors.remove(slot);
     }
@@ -182,10 +178,10 @@ pub mod tests {
             let key = item.0;
             min = std::cmp::min(min, *key);
             max = std::cmp::max(max, *key);
-            assert!(ancestors.get(key));
+            assert!(ancestors.contains_key(key));
         }
         for slot in min - 1..max + 2 {
-            assert_eq!(ancestors.get(&slot), hashset.contains(&slot));
+            assert_eq!(ancestors.contains_key(&slot), hashset.contains(&slot));
         }
     }
 

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -137,7 +137,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         if let Some(stored_forks) = keymap.get(key_slice) {
             let res = stored_forks
                 .iter()
-                .find(|(f, _)| ancestors.get(f) || self.roots.get(f).is_some())
+                .find(|(f, _)| ancestors.contains_key(f) || self.roots.get(f).is_some())
                 .cloned();
             if res.is_some() {
                 return res;


### PR DESCRIPTION
#### Problem

On Ancestors, the `get` and `contains_key` APIs are exactly the same, which cause confusion. 


#### Summary of Changes

Remove `get` API and replace with `contains_key`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
