### PR TITLE
Rename to `MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA`

### DIFF
--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -63,5 +63,6 @@ pub const MAX_WRITABLE_ACCOUNT_UNITS: u64 = MAX_BLOCK_REPLAY_TIME_US * COMPUTE_U
 /// sets at ~75% of MAX_BLOCK_UNITS to leave room for non-vote transactions
 pub const MAX_VOTE_UNITS: u64 = (MAX_BLOCK_UNITS as f64 * 0.75_f64) as u64;
 
-/// max length of account data in a block (bytes)
-pub const MAX_ACCOUNT_DATA_BLOCK_LEN: u64 = 100_000_000;
+/// The maximum allowed size, in bytes, that accounts data can grow, per block.
+/// This can also be thought of as the maximum size of new allocations per block.
+pub const MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA: u64 = 100_000_000;

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -218,7 +218,7 @@ impl CostTracker {
             }
         }
 
-        if account_data_size > MAX_ACCOUNT_DATA_BLOCK_LEN {
+        if account_data_size > MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
         }
 
@@ -618,8 +618,8 @@ mod tests {
         let second_account = Keypair::new();
         let (_tx1, mut tx_cost1) = build_simple_transaction(&mint_keypair, &start_hash);
         let (_tx2, mut tx_cost2) = build_simple_transaction(&second_account, &start_hash);
-        tx_cost1.account_data_size = MAX_ACCOUNT_DATA_BLOCK_LEN;
-        tx_cost2.account_data_size = MAX_ACCOUNT_DATA_BLOCK_LEN + 1;
+        tx_cost1.account_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
+        tx_cost2.account_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA + 1;
         let cost1 = tx_cost1.sum();
         let cost2 = tx_cost2.sum();
 


### PR DESCRIPTION
#### Problem

`MAX_ACCOUNT_DATA_BLOCK_LEN` is not a clear name.

Original comment/request: https://github.com/solana-labs/solana/pull/26744#discussion_r941295237


#### Summary of Changes

Rename to `MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA`.