### PR TITLE
Add get_account_with_commitment to BenchTpsClient

### DIFF
--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -83,6 +83,13 @@ pub trait BenchTpsClient {
 
     /// Returns all information associated with the account of the provided pubkey
     fn get_account(&self, pubkey: &Pubkey) -> Result<Account>;
+
+    /// Returns all information associated with the account of the provided pubkey, using explicit commitment
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Account>;
 }
 
 mod bank_client;

--- a/bench-tps/src/bench_tps_client/bank_client.rs
+++ b/bench-tps/src/bench_tps_client/bank_client.rs
@@ -93,4 +93,18 @@ impl BenchTpsClient for BankClient {
                 })
             })
     }
+
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Account> {
+        SyncClient::get_account_with_commitment(self, pubkey, commitment_config)
+            .map_err(|err| err.into())
+            .and_then(|account| {
+                account.ok_or_else(|| {
+                    BenchTpsError::Custom(format!("AccountNotFound: pubkey={}", pubkey))
+                })
+            })
+    }
 }

--- a/bench-tps/src/bench_tps_client/thin_client.rs
+++ b/bench-tps/src/bench_tps_client/thin_client.rs
@@ -1,5 +1,5 @@
 use {
-    crate::bench_tps_client::{BenchTpsClient, Result},
+    crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_client::thin_client::ThinClient,
     solana_sdk::{
         account::Account,
@@ -89,5 +89,19 @@ impl BenchTpsClient for ThinClient {
         self.rpc_client()
             .get_account(pubkey)
             .map_err(|err| err.into())
+    }
+
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Account> {
+        SyncClient::get_account_with_commitment(self, pubkey, commitment_config)
+            .map_err(|err| err.into())
+            .and_then(|account| {
+                account.ok_or_else(|| {
+                    BenchTpsError::Custom(format!("AccountNotFound: pubkey={}", pubkey))
+                })
+            })
     }
 }

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -1,5 +1,5 @@
 use {
-    crate::bench_tps_client::{BenchTpsClient, Result},
+    crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_client::tpu_client::TpuClient,
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
@@ -101,5 +101,21 @@ impl BenchTpsClient for TpuClient {
         self.rpc_client()
             .get_account(pubkey)
             .map_err(|err| err.into())
+    }
+
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Account> {
+        self.rpc_client()
+            .get_account_with_commitment(pubkey, commitment_config)
+            .map(|res| res.value)
+            .map_err(|err| err.into())
+            .and_then(|account| {
+                account.ok_or_else(|| {
+                    BenchTpsError::Custom(format!("AccountNotFound: pubkey={}", pubkey))
+                })
+            })
     }
 }


### PR DESCRIPTION
#### Problem

Add method `get_account_with_commitment` (`get_account` already exists).
Version of the method with explicit commitment is used for consistency with the codebase of bench-tps.
RpcClient and TpuClient are using default commitment level `CommitmentConfig::confirmed()`, for ThinClient it is not explicitly specified.

It is used in the next https://github.com/solana-labs/solana/pull/27151 to get durable nonce from account data (https://github.com/solana-labs/solana/pull/27151/commits/4feeb4afdbc826a0ce9238e0afe763e1312f99b5).

For simplicity, this wrapper`BenchTpsClient::get_account_with_commitment`  returns `Result<Account>` instead of `Result<Option<Account>>` like in the underlying implementation.
