### PR TITLE
Check overflow on vote tx compaction boundary

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -70,7 +70,7 @@ use {
         timing::timestamp,
         transaction::Transaction,
     },
-    solana_vote_program::vote_state::{CompactVoteStateUpdate, VoteTransaction},
+    solana_vote_program::vote_state::VoteTransaction,
     std::{
         collections::{HashMap, HashSet},
         result,
@@ -2012,7 +2012,13 @@ impl ReplayStage {
             .is_active(&feature_set::compact_vote_state_updates::id());
         let vote = match (should_compact, vote) {
             (true, VoteTransaction::VoteStateUpdate(vote_state_update)) => {
-                VoteTransaction::from(CompactVoteStateUpdate::from(vote_state_update))
+                if let Some(compact_vote_state_update) = vote_state_update.compact() {
+                    VoteTransaction::from(compact_vote_state_update)
+                } else {
+                    // Compaction failed
+                    warn!("Compaction failed when generating vote tx for vote account {}. Unable to vote", vote_account_pubkey);
+                    return None;
+                }
             }
             (_, vote) => vote,
         };

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -3,11 +3,7 @@
 use {
     crate::vote_state,
     log::*,
-    solana_program::vote::{
-        instruction::VoteInstruction,
-        program::id,
-        state::{VoteAuthorize, VoteStateUpdate},
-    },
+    solana_program::vote::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     solana_program_runtime::{
         invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
     },
@@ -186,11 +182,12 @@ pub fn process_instruction(
                 let sysvar_cache = invoke_context.get_sysvar_cache();
                 let slot_hashes = sysvar_cache.get_slot_hashes()?;
                 let clock = sysvar_cache.get_clock()?;
+                let vote_state_update = compact_vote_state_update.uncompact()?;
                 vote_state::process_vote_state_update(
                     &mut me,
                     slot_hashes.slot_hashes(),
                     &clock,
-                    VoteStateUpdate::from(compact_vote_state_update),
+                    vote_state_update,
                     &signers,
                     &invoke_context.feature_set,
                 )

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -2631,13 +2631,13 @@ mod tests {
         vote_state_update.hash = Hash::new_unique();
         vote_state_update.root = Some(1);
 
-        let compact_vote_state_update = CompactVoteStateUpdate::from(vote_state_update.clone());
+        let compact_vote_state_update = vote_state_update.clone().compact().unwrap();
 
         assert_eq!(vote_state_update.slots(), compact_vote_state_update.slots());
         assert_eq!(vote_state_update.hash, compact_vote_state_update.hash);
         assert_eq!(vote_state_update.root, compact_vote_state_update.root());
 
-        let vote_state_update_new = VoteStateUpdate::from(compact_vote_state_update);
+        let vote_state_update_new = compact_vote_state_update.uncompact().unwrap();
         assert_eq!(vote_state_update, vote_state_update_new);
     }
 
@@ -2651,11 +2651,11 @@ mod tests {
             (u64::pow(2, 28), 17),
             (u64::pow(2, 28) + u64::pow(2, 16), 1),
         ]);
-        let compact_vote_state_update = CompactVoteStateUpdate::from(vote_state_update.clone());
+        let compact_vote_state_update = vote_state_update.clone().compact().unwrap();
 
         assert_eq!(vote_state_update.slots(), compact_vote_state_update.slots());
 
-        let vote_state_update_new = VoteStateUpdate::from(compact_vote_state_update);
+        let vote_state_update_new = compact_vote_state_update.uncompact().unwrap();
         assert_eq!(vote_state_update, vote_state_update_new);
     }
 
@@ -2671,11 +2671,11 @@ mod tests {
             (two_31 + two_15 + 1, 6),
             (two_31 + two_15 + 1 + 64, 1),
         ]);
-        let compact_vote_state_update = CompactVoteStateUpdate::from(vote_state_update.clone());
+        let compact_vote_state_update = vote_state_update.clone().compact().unwrap();
 
         assert_eq!(vote_state_update.slots(), compact_vote_state_update.slots());
 
-        let vote_state_update_new = VoteStateUpdate::from(compact_vote_state_update);
+        let vote_state_update_new = compact_vote_state_update.uncompact().unwrap();
         assert_eq!(vote_state_update, vote_state_update_new);
     }
 
@@ -2685,11 +2685,42 @@ mod tests {
         let two_31 = u64::pow(2, 31);
         let mut vote_state_update = VoteStateUpdate::from(vec![(two_58, 31), (two_58 + two_31, 1)]);
         vote_state_update.root = Some(two_31);
-        let compact_vote_state_update = CompactVoteStateUpdate::from(vote_state_update.clone());
+        let compact_vote_state_update = vote_state_update.clone().compact().unwrap();
 
         assert_eq!(vote_state_update.slots(), compact_vote_state_update.slots());
 
-        let vote_state_update_new = VoteStateUpdate::from(compact_vote_state_update);
+        let vote_state_update_new = compact_vote_state_update.uncompact().unwrap();
         assert_eq!(vote_state_update, vote_state_update_new);
+    }
+
+    #[test]
+    fn test_compact_vote_state_update_overflow() {
+        let compact_vote_state_update = CompactVoteStateUpdate {
+            root: u64::MAX - 1,
+            root_to_first_vote_offset: 10,
+            lockouts_32: vec![],
+            lockouts_16: vec![],
+            lockouts_8: vec![CompactLockout::new(10)],
+            hash: Hash::new_unique(),
+            timestamp: None,
+        };
+        assert_eq!(
+            Err(InstructionError::ArithmeticOverflow),
+            compact_vote_state_update.uncompact()
+        );
+
+        let compact_vote_state_update = CompactVoteStateUpdate {
+            root: u64::MAX - u32::MAX as u64,
+            root_to_first_vote_offset: 10,
+            lockouts_32: vec![CompactLockout::new(u32::MAX)],
+            lockouts_16: vec![],
+            lockouts_8: vec![CompactLockout::new(10)],
+            hash: Hash::new_unique(),
+            timestamp: None,
+        };
+        assert_eq!(
+            Err(InstructionError::ArithmeticOverflow),
+            compact_vote_state_update.uncompact()
+        );
     }
 }

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
 //! Vote state
 
 #[cfg(test)]
@@ -76,6 +75,7 @@ impl Lockout {
     // The last slot at which a vote is still locked out. Validators should not
     // vote on a slot in another fork which is less than or equal to this slot
     // to avoid having their stake slashed.
+    #[allow(clippy::integer_arithmetic)]
     pub fn last_locked_out_slot(&self) -> Slot {
         self.slot + self.lockout()
     }
@@ -399,6 +399,7 @@ pub struct CircBuf<I> {
 }
 
 impl<I: Default + Copy> Default for CircBuf<I> {
+    #[allow(clippy::integer_arithmetic)]
     fn default() -> Self {
         Self {
             buf: [I::default(); MAX_ITEMS],
@@ -409,6 +410,7 @@ impl<I: Default + Copy> Default for CircBuf<I> {
 }
 
 impl<I> CircBuf<I> {
+    #[allow(clippy::integer_arithmetic)]
     pub fn append(&mut self, item: I) {
         // remember prior delegate and when we switched, to support later slashing
         self.idx += 1;
@@ -518,6 +520,7 @@ impl VoteState {
     ///
     ///  if commission calculation is 100% one way or other,
     ///   indicate with false for was_split
+    #[allow(clippy::integer_arithmetic)]
     pub fn commission_split(&self, on: u64) -> (u64, u64, bool) {
         match self.commission.min(100) {
             0 => (0, on, false),
@@ -585,6 +588,7 @@ impl VoteState {
     }
 
     /// increment credits, record credits for last epoch if new epoch
+    #[allow(clippy::integer_arithmetic)]
     pub fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
         // increment credits, record by epoch
 
@@ -612,6 +616,7 @@ impl VoteState {
         self.epoch_credits.last_mut().unwrap().1 += credits;
     }
 
+    #[allow(clippy::integer_arithmetic)]
     pub fn nth_recent_vote(&self, position: usize) -> Option<&Lockout> {
         if position < self.votes.len() {
             let pos = self.votes.len() - 1 - position;
@@ -747,6 +752,7 @@ impl VoteState {
         }
     }
 
+    #[allow(clippy::integer_arithmetic)]
     pub fn double_lockouts(&mut self) {
         let stack_depth = self.votes.len();
         for (i, v) in self.votes.iter_mut().enumerate() {
@@ -774,6 +780,7 @@ impl VoteState {
         Ok(())
     }
 
+    #[allow(clippy::integer_arithmetic)]
     pub fn is_correct_size_and_initialized(data: &[u8]) -> bool {
         const VERSION_OFFSET: usize = 4;
         data.len() == VoteState::size_of()


### PR DESCRIPTION

#### Problem
When converting between `VoteStateUpdate` and `CompactVoteStateUpdate` we perform unchecked arithmetic which could cause overflow and liveness issues in debug builds. 

#### Summary of Changes
Check overflow 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
