### PR TITLE
feat(web3.js): add buffer-layout for stake account

### DIFF
--- a/web3.js/src/index.ts
+++ b/web3.js/src/index.ts
@@ -12,6 +12,7 @@ export * from './message';
 export * from './nonce-account';
 export * from './programs';
 export * from './publickey';
+export * from './stake-account';
 export * from './transaction';
 export * from './validator-info';
 export * from './vote-account';

--- a/web3.js/src/stake-account.ts
+++ b/web3.js/src/stake-account.ts
@@ -1,0 +1,134 @@
+import * as BufferLayout from '@solana/buffer-layout';
+
+import * as Layout from './layout';
+
+/** Define who is authorized to change a stake */
+export type AuthorizedRaw = Readonly<{
+  staker: Uint8Array;
+  withdrawer: Uint8Array;
+}>;
+
+export type LockupRaw = Readonly<{
+  /** custodian can update the lockup while in force */
+  custodian: Uint8Array;
+  epoch: number;
+  unixTimestamp: number;
+}>;
+
+/** Stake State  When Statetype is INITIALIZED */
+export type Meta = Readonly<{
+  rentExemptReserve: number;
+  authorized: AuthorizedRaw;
+  lockup: LockupRaw;
+}>;
+
+export type Delegation = Readonly<{
+  /** to whom the stake is delegated */
+  voterPubkey: Uint8Array;
+  /** activated stake amount, set at delegate() time */
+  stake: number;
+  /** epoch at which this stake was activated, std::Epoch::MAX if is a bootstrap stake */
+  activationEpoch: number;
+  /** epoch the stake was deactivated, std::Epoch::MAX if not deactivated */
+  deactivationEpoch: number;
+  /** how much stake we can activate per-epoch as a fraction of currently effective stake */
+  warmupCooldownRate: number;
+}>;
+
+export type Stake = Readonly<{
+  delegation: Delegation;
+  /** credits observed is credits from vote account state when delegated or redeemed */
+  creditsObserved: number;
+}>;
+
+export type StakeAndMeta = Readonly<{
+  /** Stake State  When Statetype is STAKE */
+  meta: Meta;
+  stake: Stake;
+}>;
+
+export enum StakeStateType {
+  /** Stake State Types */
+  UNINITIALIZED = 0,
+  INITIALIZED = 1,
+  STAKE = 2,
+  REWARDS_POOL = 3,
+}
+
+export type StakeAccountData = {
+  stateType: StakeStateType;
+  /** Stake State */
+  state?: StakeAndMeta | Meta;
+};
+
+/**
+ * See https://github.com/solana-labs/solana/blob/f7c6901191cb3eac8c876362c19159a9d8feec95/sdk/program/src/stake/state.rs#L21
+ *
+ * @internal
+ */
+
+export function stakeAccountLayout(
+  buffer: Buffer | number,
+): BufferLayout.Layout<StakeAccountData> {
+  let type;
+  if (typeof buffer === 'number') {
+    type = buffer;
+  } else {
+    const layout = BufferLayout.struct<StakeAccountData>([
+      BufferLayout.u32('stateType'),
+    ]);
+    const decodedData = layout.decode(buffer);
+    type = decodedData.stateType;
+  }
+  switch (type) {
+    case StakeStateType.INITIALIZED:
+      return BufferLayout.struct<StakeAccountData>([
+        BufferLayout.u32('stateType'),
+        BufferLayout.struct<Meta>(
+          [
+            BufferLayout.nu64('rentExemptReserve'),
+            Layout.lockup(),
+            Layout.authorized(),
+          ],
+          'state',
+        ),
+      ]);
+    case StakeStateType.STAKE:
+      return BufferLayout.struct<StakeAccountData>([
+        BufferLayout.u32('stateType'),
+        BufferLayout.struct<StakeAndMeta>(
+          [
+            BufferLayout.struct<Meta>(
+              [
+                BufferLayout.nu64('rentExemptReserve'),
+                Layout.lockup(),
+                Layout.authorized(),
+              ],
+              'meta',
+            ),
+            BufferLayout.struct<Stake>(
+              [
+                BufferLayout.struct<Delegation>(
+                  [
+                    Layout.publicKey('voterPubkey'),
+                    BufferLayout.nu64('stake'),
+                    BufferLayout.nu64('activationEpoch'),
+                    BufferLayout.nu64('deactivationEpoch'),
+                    BufferLayout.f64('warmupCooldownRate'),
+                  ],
+                  'delegation',
+                ),
+                BufferLayout.nu64('creditsObserved'),
+              ],
+              'stake',
+            ),
+          ],
+          'state',
+        ),
+      ]);
+    default:
+      return BufferLayout.struct<StakeAccountData>([
+        BufferLayout.u32('stateType'),
+      ]);
+  }
+}

--- a/web3.js/test/stake-account.test.ts
+++ b/web3.js/test/stake-account.test.ts
@@ -1,0 +1,85 @@
+import {expect} from 'chai';
+
+import {
+  Keypair,
+  StakeAccountData,
+  stakeAccountLayout,
+  StakeStateType,
+} from '../src';
+import {toBuffer} from '../src/utils/to-buffer';
+
+describe('Stake Account', () => {
+  it('stake account layout', () => {
+    // Layout when StakeState is Stake
+    const ExpectedDataStake: StakeAccountData = {
+      stateType: StakeStateType.STAKE,
+      state: {
+        meta: {
+          rentExemptReserve: 1,
+          lockup: {
+            epoch: 32,
+            unixTimestamp: 2,
+            custodian: toBuffer(Keypair.generate().publicKey.toBuffer()),
+          },
+          authorized: {
+            staker: toBuffer(Keypair.generate().publicKey.toBuffer()),
+            withdrawer: toBuffer(Keypair.generate().publicKey.toBuffer()),
+          },
+        },
+        stake: {
+          delegation: {
+            voterPubkey: toBuffer(Keypair.generate().publicKey.toBuffer()),
+            stake: 0,
+            activationEpoch: 1,
+            deactivationEpoch: 1,
+            warmupCooldownRate: 1.2,
+          },
+          creditsObserved: 1,
+        },
+      },
+    };
+
+    let encodeLayout = stakeAccountLayout(StakeStateType.STAKE);
+    let encodedData = Buffer.alloc(encodeLayout.span);
+    encodeLayout.encode(ExpectedDataStake, encodedData);
+    let decodedLayout = stakeAccountLayout(encodedData);
+    let decodedData = decodedLayout.decode(encodedData);
+    expect(decodedData).to.deep.equal(ExpectedDataStake);
+
+    // Layout when StakeState is INITIALIZED
+
+    const ExpectedDataInitialized: StakeAccountData = {
+      stateType: StakeStateType.INITIALIZED,
+      state: {
+        rentExemptReserve: 1,
+        lockup: {
+          unixTimestamp: 2,
+          epoch: 32,
+          custodian: toBuffer(Keypair.generate().publicKey.toBuffer()),
+        },
+        authorized: {
+          staker: toBuffer(Keypair.generate().publicKey.toBuffer()),
+          withdrawer: toBuffer(Keypair.generate().publicKey.toBuffer()),
+        },
+      },
+    };
+    encodeLayout = stakeAccountLayout(StakeStateType.INITIALIZED);
+    encodedData = Buffer.alloc(encodeLayout.span);
+    encodeLayout.encode(ExpectedDataInitialized, encodedData);
+    decodedLayout = stakeAccountLayout(encodedData);
+    decodedData = decodedLayout.decode(encodedData);
+    expect(decodedData).to.deep.equal(ExpectedDataInitialized);
+
+    // Layout when StakeState is UNINITIALIZED
+
+    const ExpectedDataUninitialized: StakeAccountData = {
+      stateType: StakeStateType.UNINITIALIZED,
+    };
+    encodeLayout = stakeAccountLayout(StakeStateType.UNINITIALIZED);
+    encodedData = Buffer.alloc(encodeLayout.span);
+    encodeLayout.encode(ExpectedDataUninitialized, encodedData);
+    decodedLayout = stakeAccountLayout(encodedData);
+    decodedData = decodedLayout.decode(encodedData);
+    expect(decodedData).to.deep.equal(ExpectedDataUninitialized);
+  });
+});


### PR DESCRIPTION
This PR adds :-
1). Buffer Layout for stake account in web3.js
2). Tests for Layout for different stake states
