### PR TITLE
snapshots: serialize version file first

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -345,10 +345,12 @@ pub fn archive_snapshot_package(
 
         let do_archive_files = |encoder: &mut dyn Write| -> Result<()> {
             let mut archive = tar::Builder::new(encoder);
+            // Serialize the version and snapshots files before accounts so we can quickly determine the version
+            // and other bank fields. This is necessary if we want to interleave unpacking with reconstruction
+            archive.append_path_with_name(staging_dir.as_ref().join("version"), "version")?;
             for dir in ["snapshots", "accounts"] {
                 archive.append_dir_all(dir, staging_dir.as_ref().join(dir))?;
             }
-            archive.append_path_with_name(staging_dir.as_ref().join("version"), "version")?;
             archive.into_inner()?;
             Ok(())
         };


### PR DESCRIPTION
#### Problem
Similar to #25889, we should also serialize the version file so we can unpack and reconstruct in parallel.
Necessary to make #26590 more robust and switch on version.

#### Summary of Changes
Serialize the version file first so we can check the version and switch to the correct deserialization method while we unpack.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
