### PR TITLE
add ed25519_program to built-in instruction cost list

### DIFF
--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -3,7 +3,8 @@
 use {
     lazy_static::lazy_static,
     solana_sdk::{
-        feature, incinerator, native_loader, pubkey::Pubkey, secp256k1_program, system_program,
+        ed25519_program, feature, incinerator, native_loader, pubkey::Pubkey, secp256k1_program,
+        system_program,
     },
     std::collections::HashMap,
 };
@@ -40,6 +41,7 @@ lazy_static! {
         (solana_vote_program::id(), COMPUTE_UNIT_TO_US_RATIO * 70),
         // secp256k1 is executed in banking stage, it should cost similar to sigverify
         (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
+        (ed25519_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
     ]
     .iter()

--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -39,7 +39,6 @@ lazy_static! {
         (solana_sdk::stake::program::id(), COMPUTE_UNIT_TO_US_RATIO * 25),
         (solana_config_program::id(), COMPUTE_UNIT_TO_US_RATIO * 15),
         (solana_vote_program::id(), COMPUTE_UNIT_TO_US_RATIO * 70),
-        // secp256k1 is executed in banking stage, it should cost similar to sigverify
         (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (ed25519_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),


### PR DESCRIPTION
#### Problem
`ed25519_program` is missing from built-in instructions cost table

#### Summary of Changes
add it

follow-up to: #21995