### PR TITLE
Fix the boundary inconsistency between delete_file_in_range and delete_range

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2059,8 +2059,8 @@ impl Blockstore {
         )
     }
 
-    /// Toggles the active primary index between `0` and `1`, and clears the stored max-slot of the
-    /// frozen index in preparation for pruning.
+    /// Toggles the active primary index between `0` and `1`, and clears the
+    /// stored max-slot of the frozen index in preparation for pruning.
     fn toggle_transaction_status_index(
         &self,
         batch: &mut WriteBatch,


### PR DESCRIPTION
#### Problem
RocksDB's delete_range applies to [from, to) while delete_file_in_range
applies to [from, to] by default, and the rust-rocksdb api does not include
the option to make delete_file_in_range apply to [from, to).  Such inconsistency
might cause `blockstore::run_purge` to produce an inconsistent result as it
invokes both delete_range and delete_file_in_range.

rocksdb::DeleteRange
https://github.com/facebook/rocksdb/blob/91166012c848f720f0208e91d766810d4f7e8cf9/include/rocksdb/db.h#L463-L479
rocksdb::DeleteFilesInRange
https://github.com/facebook/rocksdb/blob/91166012c848f720f0208e91d766810d4f7e8cf9/include/rocksdb/convenience.h#L496-L503

and rocksdb's c api hides the `include_end` default param, defaulting to `= true`....
https://github.com/facebook/rocksdb/blob/91166012c848f720f0208e91d766810d4f7e8cf9/db/c.cc#L5236-L5259


#### Summary of Changes
This PR makes all our purge / delete related functions to be inclusive
on both starting and ending slots.


