### PR TITLE
chore: only buildkite pipelines use sccache in docker-run.sh

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -45,14 +45,16 @@ if [[ -n $CI ]]; then
   # Share the real ~/.cargo between docker containers in CI for speed
   ARGS+=(--volume "$HOME:/home")
 
-  # sccache
-  ARGS+=(
-    --env "RUSTC_WRAPPER=/home/.cargo/bin/sccache"
-    --env AWS_ACCESS_KEY_ID
-    --env AWS_SECRET_ACCESS_KEY
-    --env SCCACHE_BUCKET
-    --env SCCACHE_REGION
-  )
+  if [[ -n $BUILDKITE ]]; then
+    # sccache
+    ARGS+=(
+      --env "RUSTC_WRAPPER=/home/.cargo/bin/sccache"
+      --env AWS_ACCESS_KEY_ID
+      --env AWS_SECRET_ACCESS_KEY
+      --env SCCACHE_BUCKET
+      --env SCCACHE_REGION
+    )
+  fi
 else
   # Avoid sharing ~/.cargo when building locally to avoid a mixed macOS/Linux
   # ~/.cargo


### PR DESCRIPTION
#### Problem

I broke docs pipeline due to sccache

https://github.com/solana-labs/solana/runs/7883281080?check_suite_focus=true

#### Summary of Changes

only buildkite ci use sccache when exec docker-run
