### PR TITLE
Rename lowest_purge_slot to oldest_available_slot and correct code comments

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -23,7 +23,7 @@ pub enum PurgeType {
 
 impl Blockstore {
     /// Performs cleanup based on the specified deletion range.  After this
-    /// function call, entries within \[`from_slot`, `to_slot`\] will become
+    /// function call, entries within \[`from_slot`, `to_slot`) will become
     /// unavailable to the reader immediately, while its disk space occupied
     /// by the deletion entries are reclaimed later via RocksDB's background
     /// compaction.


### PR DESCRIPTION
#### Problem
`lowest_purge_slot` is a variable that remembers the cleanup progress.
However, `lowest_purge_slot` itself is actually still available as RocksDB's
DeleteRange applies to [from, to) instead of [from, to].

#### Summary of Changes
This PR renames `lowest_purge_slot` to `oldest_available_slot`
and corrects comment blocks to clarify the purge range.

