### PR TITLE
add an assert for a debug feature to avoid wasted time

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6890,6 +6890,11 @@ impl AccountsDb {
 
         stats.oldest_root = storages.range().start;
 
+        assert!(
+            !(config.store_detailed_debug_info_on_failure && config.use_write_cache),
+            "cannot accurately capture all data for debugging if accounts cache is being used"
+        );
+
         self.mark_old_slots_as_dirty(storages, Some(config.epoch_schedule.slots_per_epoch));
 
         let (num_hash_scan_passes, bins_per_pass) = Self::bins_per_pass(self.num_hash_scan_passes);


### PR DESCRIPTION
#### Problem

The debug feature to capture contents of a hash calc for later debugging is not compatible with using the write cache for hash calculation. So, assert if that combination is requested. Note that this should not happen unless a custom build is used with hardcoding for whether to capture the failing hash contents. But, when this does happen, a long time can be wasted figuring out that this was an invalid request. Now, this will immediately fail.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
