### PR TITLE
Flaky Unit Test test_rpc_subscriptions

### DIFF
--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -402,7 +402,7 @@ fn test_rpc_subscriptions() {
         }
     }
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(10);
     let mut account_notifications = transactions.len();
     while account_notifications > 0 {
         let timeout = deadline.saturating_duration_since(Instant::now());


### PR DESCRIPTION
#### Problem
`test_rpc_subscriptions` is timing out somewhat frequently. Here are two examples where unrelated changes failed in CI:
```
thread 'test_rpc_subscriptions' panicked at 'recv_timeout, 4/1000 accounts remaining', rpc-test/tests/rpc.rs:415:17
thread 'test_rpc_subscriptions' panicked at 'recv_timeout, 30/1000 accounts remaining', rpc-test/tests/rpc.rs:415:17
```
In both cases we were very close to completing all of the accounts.

#### Summary of Changes
Increase timeout from 5 seconds to 10 seconds
