### PR TITLE
remove redundant call that bumps age to future

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -315,7 +315,6 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     ) -> RT {
         self.get_only_in_mem(pubkey, |entry| {
             if let Some(entry) = entry {
-                entry.set_age(self.storage.future_age_to_flush());
                 callback(Some(entry)).1
             } else {
                 // not in cache, look on disk


### PR DESCRIPTION
#### Problem

Caller already sets the age to the future.

https://github.com/solana-labs/solana/blob/7720b48aa67450485d6dc1e7a3db216b34a3bfe9/runtime/src/in_mem_accounts_index.rs#L281-L284

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
