### PR TITLE
eliminate unnecessary ZERO_RAW_LAMPORTS_SENTINEL

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1820,14 +1820,7 @@ impl<'a, T: Fn(Slot) -> Option<Slot> + Sync + Send + Clone> AppendVecScan for Sc
         // when we are scanning with bin ranges, we don't need to use exact bin numbers. Subtract to make first bin we care about at index 0.
         self.pubkey_to_bin_index -= self.bin_range.start;
 
-        let raw_lamports = loaded_account.lamports();
-        let zero_raw_lamports = raw_lamports == 0;
-        let balance = if zero_raw_lamports {
-            crate::accounts_hash::ZERO_RAW_LAMPORTS_SENTINEL
-        } else {
-            raw_lamports
-        };
-
+        let balance = loaded_account.lamports();
         let loaded_hash = loaded_account.loaded_hash();
         let new_hash = ExpectedRentCollection::maybe_rehash_skipped_rewrite(
             loaded_account,

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -18,7 +18,6 @@ use {
         },
     },
 };
-pub const ZERO_RAW_LAMPORTS_SENTINEL: u64 = std::u64::MAX;
 pub const MERKLE_FANOUT: usize = 16;
 
 #[derive(Default, Debug)]
@@ -844,7 +843,7 @@ impl AccountsHash {
             );
 
             // add lamports, get hash as long as the lamports are > 0
-            if item.lamports != ZERO_RAW_LAMPORTS_SENTINEL
+            if item.lamports != 0
                 && (!filler_accounts_enabled || !self.is_filler_account(&item.pubkey))
             {
                 overall_sum = Self::checked_cast_for_capitalization(
@@ -1042,7 +1041,7 @@ pub mod tests {
         // 2nd key - zero lamports, so will be removed
         let key = Pubkey::new(&[12u8; 32]);
         let hash = Hash::new(&[2u8; 32]);
-        let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+        let val = CalculateHashIntermediate::new(hash, 0, key);
         account_maps.push(val);
 
         let accounts_hash = AccountsHash::default();
@@ -1116,7 +1115,7 @@ pub mod tests {
             // 2nd key - zero lamports, so will be removed
             let key = Pubkey::new(&[12u8; 32]);
             let hash = Hash::new(&[2u8; 32]);
-            let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+            let val = CalculateHashIntermediate::new(hash, 0, key);
             account_maps.push(val);
 
             let mut previous_pass = PreviousPass::default();
@@ -1395,10 +1394,13 @@ pub mod tests {
 
     #[test]
     fn test_accountsdb_de_dup_accounts_zero_chunks() {
-        let vec = [vec![vec![CalculateHashIntermediate::default()]]];
+        let vec = [vec![vec![CalculateHashIntermediate {
+            lamports: 1,
+            ..CalculateHashIntermediate::default()
+        }]]];
         let (hashes, lamports, _) = AccountsHash::default().de_dup_accounts_in_parallel(&vec, 0);
         assert_eq!(vec![&Hash::default()], hashes);
-        assert_eq!(lamports, 0);
+        assert_eq!(lamports, 1);
     }
 
     #[test]
@@ -1653,7 +1655,7 @@ pub mod tests {
         assert_eq!(result, (vec![&val.hash], val.lamports as u64, 1));
 
         // zero original lamports, higher version
-        let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+        let val = CalculateHashIntermediate::new(hash, 0, key);
         account_maps.push(val); // has to be after previous entry since account_maps are in slot order
 
         let vecs = vec![vec![account_maps.to_vec()]];


### PR DESCRIPTION
#### Problem

An old feature modified some sysvar lamport values from 1 to 0 for the purposes of hash calc. This causes us to need to distinguish between ACTUALLY 0 lamport accounts and those that had become 0 during hash calculation. This feature code has since been removed and we no longer modify lamport values for hash calculation. So, the very convenient '0' value can be used for zero lamport accounts. This removes an unnecessary concept.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
