### PR TITLE
sdk: Fix args after "--" in build-bpf and test-bpf

### DIFF
--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -26,8 +26,9 @@ fn main() {
             args.remove(0);
         }
     }
-    args.push("--arch".to_string());
-    args.push("bpf".to_string());
+    let index = args.iter().position(|x| x == "--").unwrap_or(args.len());
+    args.insert(index, "bpf".to_string());
+    args.insert(index, "--arch".to_string());
     print!("cargo-build-bpf child: {}", program.display());
     for a in &args {
         print!(" {}", a);

--- a/sdk/cargo-test-bpf/src/main.rs
+++ b/sdk/cargo-test-bpf/src/main.rs
@@ -32,8 +32,9 @@ fn main() {
             args.remove(0);
         }
     }
-    args.push("--arch".to_string());
-    args.push("bpf".to_string());
+    let index = args.iter().position(|x| x == "--").unwrap_or(args.len());
+    args.insert(index, "bpf".to_string());
+    args.insert(index, "--arch".to_string());
     print!("cargo-test-bpf child: {}", program.display());
     for a in &args {
         print!(" {}", a);


### PR DESCRIPTION
#### Problem

If you run `cargo build-bpf <args> -- <extra_args>`, the `--arch bpf` bit is added at the end, rather than before the `--`, which breaks builds.

#### Summary of Changes

Put `--arch bpf` before `--`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

cc @2501babe 