### PR TITLE
Verifying snapshot bank must always specify the snapshot slot

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7124,19 +7124,19 @@ impl Bank {
         &self,
         test_hash_calculation: bool,
         accounts_db_skip_shrink: bool,
-        last_full_snapshot_slot: Option<Slot>,
+        last_full_snapshot_slot: Slot,
     ) -> bool {
         let mut clean_time = Measure::start("clean");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("cleaning..");
-            self.clean_accounts(true, true, last_full_snapshot_slot);
+            self.clean_accounts(true, true, Some(last_full_snapshot_slot));
         }
         clean_time.stop();
 
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("shrinking..");
-            self.shrink_all_slots(true, last_full_snapshot_slot);
+            self.shrink_all_slots(true, Some(last_full_snapshot_slot));
         }
         shrink_all_slots_time.stop();
 
@@ -11631,11 +11631,11 @@ pub(crate) mod tests {
         .unwrap();
         bank.freeze();
         bank.update_accounts_hash();
-        assert!(bank.verify_snapshot_bank(true, false, None));
+        assert!(bank.verify_snapshot_bank(true, false, bank.slot()));
 
         // tamper the bank after freeze!
         bank.increment_signature_count(1);
-        assert!(!bank.verify_snapshot_bank(true, false, None));
+        assert!(!bank.verify_snapshot_bank(true, false, bank.slot()));
     }
 
     // Test that two bank forks with the same accounts should not hash to the same value.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -949,7 +949,7 @@ pub fn bank_from_snapshot_archives(
     if !bank.verify_snapshot_bank(
         test_hash_calculation,
         accounts_db_skip_shrink || !full_snapshot_archive_info.is_remote(),
-        Some(full_snapshot_archive_info.slot()),
+        full_snapshot_archive_info.slot(),
     ) && limit_load_slot_count_from_snapshot.is_none()
     {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());


### PR DESCRIPTION
#### Problem

By definition, if we're verifying the bank from a snapshot, then there will be a slot for that snapshot/bank. When calling `verify_snapshot_bank()`, we currently do not enforce that, which could result in unintended misuse/bugs.

#### Summary of Changes

Change `last_full_snapshot_slot` param's type in `Bank::verify_snapshot_bank()` to `Slot`.