### PR TITLE
Call `AccountsDb::shrink_all_slots()` directly

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7162,7 +7162,10 @@ impl Bank {
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("shrinking..");
-            self.shrink_all_slots(true, Some(last_full_snapshot_slot));
+            self.rc
+                .accounts
+                .accounts_db
+                .shrink_all_slots(true, Some(last_full_snapshot_slot));
         }
         shrink_all_slots_time.stop();
 
@@ -7456,13 +7459,6 @@ impl Bank {
             is_startup,
             last_full_snapshot_slot,
         );
-    }
-
-    pub fn shrink_all_slots(&self, is_startup: bool, last_full_snapshot_slot: Option<Slot>) {
-        self.rc
-            .accounts
-            .accounts_db
-            .shrink_all_slots(is_startup, last_full_snapshot_slot);
     }
 
     pub fn print_accounts_stats(&self) {


### PR DESCRIPTION
#### Problem

`Bank` has its own (`pub`) wrapper fn for `AccountsDb::shrink_all_slots()`. It (1) passes everything directly to AccountsDb, and (2) is only called in one place. No need to inadvertently expose this fn by wrapping it and making it public.

#### Summary of Changes

Remove `Bank::shrink_all_slots()` and call AccountsDb directly.