### PR TITLE
correct double negation

### DIFF
--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -142,9 +142,9 @@ pub enum TransactionError {
     #[error("Transaction contains a duplicate instruction ({0}) that is not allowed")]
     DuplicateInstruction(u8),
 
-    /// Transaction results in an account without insufficient funds for rent
+    /// Transaction results in an account with insufficient funds for rent
     #[error(
-        "Transaction results in an account ({account_index}) without insufficient funds for rent"
+        "Transaction results in an account ({account_index}) with insufficient funds for rent"
     )]
     InsufficientFundsForRent { account_index: u8 },
 }


### PR DESCRIPTION
Problem

I ran into this problem today where I developed on Solana and did not provide sufficient funds:
<img width="949" alt="Screenshot 2022-08-18 at 21 05 14" src="https://user-images.githubusercontent.com/42893075/185474602-5e6a95fe-464b-47d1-b8c6-fdaad5f6ad87.png">

Now I'm pretty sure that is a case of double negation and *should* say 

"results in an account *with* insufficient funds for rent"

So i corrected that in this repo where it appeared
