### PR TITLE
Relax authority signer check for lookup table creation

### DIFF
--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -3,8 +3,8 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     solana_address_lookup_table_program::{
         instruction::{
-            close_lookup_table, create_lookup_table, deactivate_lookup_table, extend_lookup_table,
-            freeze_lookup_table,
+            close_lookup_table, create_lookup_table, create_lookup_table_signed,
+            deactivate_lookup_table, extend_lookup_table, freeze_lookup_table,
         },
         state::AddressLookupTable,
     },
@@ -542,12 +542,11 @@ fn process_create_lookup_table(
     })?;
 
     let payer_address = payer_signer.pubkey();
-    let (create_lookup_table_ix, lookup_table_address) = create_lookup_table(
-        authority_address,
-        payer_address,
-        clock.slot,
-        authority_signer.is_some(),
-    );
+    let (create_lookup_table_ix, lookup_table_address) = if authority_signer.is_some() {
+        create_lookup_table_signed(authority_address, payer_address, clock.slot)
+    } else {
+        create_lookup_table(authority_address, payer_address, clock.slot)
+    };
 
     let blockhash = rpc_client.get_latest_blockhash()?;
     let mut tx = Transaction::new_unsigned(Message::new(

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -531,7 +531,7 @@ fn process_create_lookup_table(
     let authority_address = authority_signer.pubkey();
     let payer_address = payer_signer.pubkey();
     let (create_lookup_table_ix, lookup_table_address) =
-        create_lookup_table(authority_address, payer_address, clock.slot);
+        create_lookup_table(authority_address, payer_address, clock.slot, true);
 
     let blockhash = rpc_client.get_latest_blockhash()?;
     let mut tx = Transaction::new_unsigned(Message::new(

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -71,15 +71,20 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_PUBKEY")
                                 .takes_value(true)
                                 .validator(is_pubkey)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority address [default: the default configured keypair]. \
+                                    WARNING: Cannot be used for creating a lookup table for a cluster running v1.11
+                                    or earlier which requires the authority to sign for lookup table creation.",
+                                )
                         )
                         .arg(
                             Arg::with_name("authority_signer")
                                 .long("authority-signer")
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
+                                .conflicts_with("authority")
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help("Lookup table authority keypair [default: the default configured keypair].")
                         )
                         .arg(
                             Arg::with_name("payer")

--- a/cli/tests/address_lookup_table.rs
+++ b/cli/tests/address_lookup_table.rs
@@ -42,7 +42,8 @@ fn test_cli_create_extend_and_freeze_address_lookup_table() {
     // Create lookup table
     config.command =
         CliCommand::AddressLookupTable(AddressLookupTableCliCommand::CreateLookupTable {
-            authority_signer_index: 0,
+            authority_pubkey: keypair.pubkey(),
+            authority_signer_index: None,
             payer_signer_index: 0,
         });
     let response: CliAddressLookupTableCreated =
@@ -156,7 +157,8 @@ fn test_cli_create_and_deactivate_address_lookup_table() {
     // Create lookup table
     config.command =
         CliCommand::AddressLookupTable(AddressLookupTableCliCommand::CreateLookupTable {
-            authority_signer_index: 0,
+            authority_pubkey: keypair.pubkey(),
+            authority_signer_index: Some(0),
             payer_signer_index: 0,
         });
     let response: CliAddressLookupTableCreated =

--- a/programs/address-lookup-table-tests/tests/create_lookup_table_ix.rs
+++ b/programs/address-lookup-table-tests/tests/create_lookup_table_ix.rs
@@ -4,19 +4,28 @@ use {
     solana_address_lookup_table_program::{
         id,
         instruction::create_lookup_table,
+        processor::process_instruction,
         state::{AddressLookupTable, LOOKUP_TABLE_META_SIZE},
     },
     solana_program_test::*,
     solana_sdk::{
-        clock::Slot, instruction::InstructionError, pubkey::Pubkey, rent::Rent, signature::Signer,
-        signer::keypair::Keypair, transaction::Transaction,
+        clock::Slot, feature_set, instruction::InstructionError, pubkey::Pubkey, rent::Rent,
+        signature::Signer, signer::keypair::Keypair, transaction::Transaction,
     },
 };
 
 mod common;
 
+pub async fn setup_test_context_without_authority_feature() -> ProgramTestContext {
+    let mut program_test = ProgramTest::new("", id(), Some(process_instruction));
+    program_test.deactivate_feature(
+        feature_set::relax_authority_signer_check_for_lookup_table_creation::id(),
+    );
+    program_test.start_with_context().await
+}
+
 #[tokio::test]
-async fn test_create_lookup_table() {
+async fn test_create_lookup_table_idempotent() {
     let mut context = setup_test_context().await;
 
     let test_recent_slot = 123;
@@ -25,17 +34,16 @@ async fn test_create_lookup_table() {
     let client = &mut context.banks_client;
     let payer = &context.payer;
     let recent_blockhash = context.last_blockhash;
-    let authority_keypair = Keypair::new();
-    let authority_address = authority_keypair.pubkey();
+    let authority_address = Pubkey::new_unique();
     let (create_lookup_table_ix, lookup_table_address) =
-        create_lookup_table(authority_address, payer.pubkey(), test_recent_slot);
+        create_lookup_table(authority_address, payer.pubkey(), test_recent_slot, false);
 
     // First create should succeed
     {
         let transaction = Transaction::new_signed_with_payer(
             &[create_lookup_table_ix.clone()],
             Some(&payer.pubkey()),
-            &[payer, &authority_keypair],
+            &[payer],
             recent_blockhash,
         );
 
@@ -45,7 +53,7 @@ async fn test_create_lookup_table() {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(lookup_table_account.owner, crate::id());
+        assert_eq!(lookup_table_account.owner, id());
         assert_eq!(lookup_table_account.data.len(), LOOKUP_TABLE_META_SIZE);
         assert_eq!(
             lookup_table_account.lamports,
@@ -58,6 +66,47 @@ async fn test_create_lookup_table() {
         assert_eq!(lookup_table.meta.last_extended_slot_start_index, 0);
         assert_eq!(lookup_table.addresses.len(), 0);
     }
+
+    // Second create should succeed too
+    {
+        let recent_blockhash = client
+            .get_new_latest_blockhash(&recent_blockhash)
+            .await
+            .unwrap();
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_lookup_table_ix],
+            Some(&payer.pubkey()),
+            &[payer],
+            recent_blockhash,
+        );
+
+        assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    }
+}
+
+#[tokio::test]
+async fn test_create_lookup_table_not_idempotent() {
+    let mut context = setup_test_context_without_authority_feature().await;
+
+    let test_recent_slot = 123;
+    overwrite_slot_hashes_with_slots(&mut context, &[test_recent_slot]);
+
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+    let authority_keypair = Keypair::new();
+    let authority_address = authority_keypair.pubkey();
+    let (create_lookup_table_ix, ..) =
+        create_lookup_table(authority_address, payer.pubkey(), test_recent_slot, true);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[create_lookup_table_ix.clone()],
+        Some(&payer.pubkey()),
+        &[payer, &authority_keypair],
+        recent_blockhash,
+    );
+
+    assert_matches!(client.process_transaction(transaction).await, Ok(()));
 
     // Second create should fail
     {
@@ -87,7 +136,7 @@ async fn test_create_lookup_table_use_payer_as_authority() {
     let recent_blockhash = context.last_blockhash;
     let authority_address = payer.pubkey();
     let transaction = Transaction::new_signed_with_payer(
-        &[create_lookup_table(authority_address, payer.pubkey(), test_recent_slot).0],
+        &[create_lookup_table(authority_address, payer.pubkey(), test_recent_slot, false).0],
         Some(&payer.pubkey()),
         &[payer],
         recent_blockhash,
@@ -97,14 +146,15 @@ async fn test_create_lookup_table_use_payer_as_authority() {
 }
 
 #[tokio::test]
-async fn test_create_lookup_table_without_signer() {
-    let mut context = setup_test_context().await;
+async fn test_create_lookup_table_missing_signer() {
+    let mut context = setup_test_context_without_authority_feature().await;
     let unsigned_authority_address = Pubkey::new_unique();
 
     let mut ix = create_lookup_table(
         unsigned_authority_address,
         context.payer.pubkey(),
         Slot::MAX,
+        true,
     )
     .0;
     ix.accounts[1].is_signer = false;
@@ -122,15 +172,14 @@ async fn test_create_lookup_table_without_signer() {
 async fn test_create_lookup_table_not_recent_slot() {
     let mut context = setup_test_context().await;
     let payer = &context.payer;
-    let authority_keypair = Keypair::new();
-    let authority_address = authority_keypair.pubkey();
+    let authority_address = Pubkey::new_unique();
 
-    let ix = create_lookup_table(authority_address, payer.pubkey(), Slot::MAX).0;
+    let ix = create_lookup_table(authority_address, payer.pubkey(), Slot::MAX, false).0;
 
     assert_ix_error(
         &mut context,
         ix,
-        Some(&authority_keypair),
+        None,
         InstructionError::InvalidInstructionData,
     )
     .await;
@@ -142,17 +191,10 @@ async fn test_create_lookup_table_pda_mismatch() {
     let test_recent_slot = 123;
     overwrite_slot_hashes_with_slots(&mut context, &[test_recent_slot]);
     let payer = &context.payer;
-    let authority_keypair = Keypair::new();
-    let authority_address = authority_keypair.pubkey();
+    let authority_address = Pubkey::new_unique();
 
-    let mut ix = create_lookup_table(authority_address, payer.pubkey(), test_recent_slot).0;
+    let mut ix = create_lookup_table(authority_address, payer.pubkey(), test_recent_slot, false).0;
     ix.accounts[0].pubkey = Pubkey::new_unique();
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority_keypair),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    assert_ix_error(&mut context, ix, None, InstructionError::InvalidArgument).await;
 }

--- a/programs/address-lookup-table/src/instruction.rs
+++ b/programs/address-lookup-table/src/instruction.rs
@@ -80,7 +80,39 @@ pub fn derive_lookup_table_address(
 
 /// Constructs an instruction to create a table account and returns
 /// the instruction and the table account's derived address.
+///
+/// # Note
+///
+/// This instruction requires the authority to be a signer but
+/// in v1.12 the address lookup table program will no longer require
+/// the authority to sign the transaction.
+pub fn create_lookup_table_signed(
+    authority_address: Pubkey,
+    payer_address: Pubkey,
+    recent_slot: Slot,
+) -> (Instruction, Pubkey) {
+    create_lookup_table_common(authority_address, payer_address, recent_slot, true)
+}
+
+/// Constructs an instruction to create a table account and returns
+/// the instruction and the table account's derived address.
+///
+/// # Note
+///
+/// This instruction doesn't require the authority to be a signer but
+/// until v1.12 the address lookup table program still requires the
+/// authority to sign the transaction.
 pub fn create_lookup_table(
+    authority_address: Pubkey,
+    payer_address: Pubkey,
+    recent_slot: Slot,
+) -> (Instruction, Pubkey) {
+    create_lookup_table_common(authority_address, payer_address, recent_slot, false)
+}
+
+/// Constructs an instruction to create a table account and returns
+/// the instruction and the table account's derived address.
+fn create_lookup_table_common(
     authority_address: Pubkey,
     payer_address: Pubkey,
     recent_slot: Slot,

--- a/programs/address-lookup-table/src/instruction.rs
+++ b/programs/address-lookup-table/src/instruction.rs
@@ -84,6 +84,7 @@ pub fn create_lookup_table(
     authority_address: Pubkey,
     payer_address: Pubkey,
     recent_slot: Slot,
+    authority_is_signer: bool,
 ) -> (Instruction, Pubkey) {
     let (lookup_table_address, bump_seed) =
         derive_lookup_table_address(&authority_address, recent_slot);
@@ -95,7 +96,7 @@ pub fn create_lookup_table(
         },
         vec![
             AccountMeta::new(lookup_table_address, false),
-            AccountMeta::new_readonly(authority_address, true),
+            AccountMeta::new_readonly(authority_address, authority_is_signer),
             AccountMeta::new(payer_address, true),
             AccountMeta::new_readonly(system_program::id(), false),
         ],

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -502,6 +502,10 @@ pub mod disable_cpi_setting_executable_and_rent_epoch {
     solana_sdk::declare_id!("B9cdB55u4jQsDNsdTK525yE9dmSc5Ga7YBaBrDFvEhM9");
 }
 
+pub mod relax_authority_signer_check_for_lookup_table_creation {
+    solana_sdk::declare_id!("FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -622,6 +626,7 @@ lazy_static! {
         (check_ping_ancestor_requests::id(), "ancestor hash repair socket ping/pong support #26963"),
         (incremental_snapshot_only_incremental_hash_calculation::id(), "only hash accounts in incremental snapshot during incremental snapshot creation #26799"),
         (disable_cpi_setting_executable_and_rent_epoch::id(), "disable setting is_executable and_rent_epoch in CPI #26987"),
+        (relax_authority_signer_check_for_lookup_table_creation::id(), "relax authority signer check for lookup table creation #27205"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Since lookup tables are derived from a recent slot, it's difficult to time a transaction that creates an address lookup table account controlled by a multisig or governance program. This is due to the create lookup table instruction requiring the authority to be a signer.

#### Summary of Changes
- Allow address lookup tables to be created for an authority without requiring the signer to sign
- Make lookup table creation idempotent so that lookup table creation can't be failed from front-running

Feature Gate Issue: https://github.com/solana-labs/solana/issues/27205
