### PR TITLE
slots_per_epoch shouldn't be optional

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6648,20 +6648,18 @@ impl AccountsDb {
     }
 
     /// storages are sorted by slot and have range info.
-    /// if we know slots_per_epoch, then add all stores older than slots_per_epoch to dirty_stores so clean visits these slots
-    fn mark_old_slots_as_dirty(&self, storages: &SortedStorages, slots_per_epoch: Option<Slot>) {
-        if let Some(slots_per_epoch) = slots_per_epoch {
-            let max = storages.max_slot_inclusive();
-            let acceptable_straggler_slot_count = 100; // do nothing special for these old stores which will likely get cleaned up shortly
-            let sub = slots_per_epoch + acceptable_straggler_slot_count;
-            let in_epoch_range_start = max.saturating_sub(sub);
-            for (slot, storages) in storages.iter_range(..in_epoch_range_start) {
-                if let Some(storages) = storages {
-                    storages.iter().for_each(|store| {
-                        self.dirty_stores
-                            .insert((slot, store.append_vec_id()), store.clone());
-                    });
-                }
+    /// add all stores older than slots_per_epoch to dirty_stores so clean visits these slots
+    fn mark_old_slots_as_dirty(&self, storages: &SortedStorages, slots_per_epoch: Slot) {
+        let max = storages.max_slot_inclusive();
+        let acceptable_straggler_slot_count = 100; // do nothing special for these old stores which will likely get cleaned up shortly
+        let sub = slots_per_epoch + acceptable_straggler_slot_count;
+        let in_epoch_range_start = max.saturating_sub(sub);
+        for (slot, storages) in storages.iter_range(..in_epoch_range_start) {
+            if let Some(storages) = storages {
+                storages.iter().for_each(|store| {
+                    self.dirty_stores
+                        .insert((slot, store.append_vec_id()), store.clone());
+                });
             }
         }
     }
@@ -6900,7 +6898,7 @@ impl AccountsDb {
             "cannot accurately capture all data for debugging if accounts cache is being used"
         );
 
-        self.mark_old_slots_as_dirty(storages, Some(config.epoch_schedule.slots_per_epoch));
+        self.mark_old_slots_as_dirty(storages, config.epoch_schedule.slots_per_epoch);
 
         let (num_hash_scan_passes, bins_per_pass) = Self::bins_per_pass(self.num_hash_scan_passes);
         let use_bg_thread_pool = config.use_bg_thread_pool;


### PR DESCRIPTION
#### Problem
`mark_old_slots_as_dirty` never had a None `slots_per_epoch` passed to it

#### Summary of Changes
Make `slots_per_epoch` a required parameter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
