### PR TITLE
Call AccountsDb::clean_accounts() directly, inside Bank::verify_snapshot_bank()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7159,7 +7159,10 @@ impl Bank {
         let mut clean_time = Measure::start("clean");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("cleaning..");
-            self._clean_accounts(true, true, Some(last_full_snapshot_slot));
+            self.rc
+                .accounts
+                .accounts_db
+                .clean_accounts(None, true, Some(last_full_snapshot_slot));
         }
         clean_time.stop();
 


### PR DESCRIPTION
#### Problem

On startup from a snapshot, the bank is verified after deserialization. In that fn, `Bank::verify_snapshot_bank()`, it calls `clean` and `shrink`. However, `clean` and `shrink` specify different `max_clean_root`s. These should be the same.

Since were at startup, there's no outstanding scans that could occur, and no reason why we cannot clean all slots. We do need to make sure 0-lamport accounts are still kept around for slots past the last full snapshot, and that behavior has not changed.

See https://github.com/solana-labs/solana/pull/27200 for full context


#### Summary of Changes

In `Bank::verify_snapshot_bank()`, call `AccountsDb::clean_accounts()` directly, and set `max_clean_roots` to `None`.