### PR TITLE
To allow cache and share transaction's account locks

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -595,9 +595,17 @@ fn process_entries_with_callback(
                     (starting_index..starting_index.saturating_add(transactions.len())).collect()
                 };
 
+                let tx_account_locks_results: Vec<Result<_>> = transactions
+                    .iter()
+                    .map(|tx| tx.get_account_locks(bank.get_transaction_account_lock_limit()))
+                    .collect();
+
                 loop {
                     // try to lock the accounts
-                    let batch = bank.prepare_sanitized_batch(transactions);
+                    let batch = bank.prepare_sanitized_batch_with_account_locks(
+                        transactions,
+                        &tx_account_locks_results,
+                    );
                     let first_lock_err = first_err(batch.lock_results());
 
                     // if locking worked

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -139,8 +139,9 @@ use {
         sysvar::{self, Sysvar, SysvarId},
         timing::years_as_slots,
         transaction::{
-            MessageHash, Result, SanitizedTransaction, Transaction, TransactionError,
-            TransactionVerificationMode, VersionedTransaction, MAX_TX_ACCOUNT_LOCKS,
+            MessageHash, Result, SanitizedTransaction, Transaction, TransactionAccountLocks,
+            TransactionError, TransactionVerificationMode, VersionedTransaction,
+            MAX_TX_ACCOUNT_LOCKS,
         },
         transaction_context::{
             ExecutionRecord, InstructionTrace, TransactionAccount, TransactionContext,
@@ -3942,6 +3943,20 @@ impl Bank {
             .rc
             .accounts
             .lock_accounts(txs.iter(), tx_account_lock_limit);
+        TransactionBatch::new(lock_results, self, Cow::Borrowed(txs))
+    }
+
+    /// Prepare a locked transaction batch from a list of sanitized transactions and their account
+    /// locks
+    pub fn prepare_sanitized_batch_with_account_locks<'a, 'b>(
+        &'a self,
+        txs: &'b [SanitizedTransaction],
+        tx_account_locks_results: &[Result<TransactionAccountLocks>],
+    ) -> TransactionBatch<'a, 'b> {
+        let lock_results = self
+            .rc
+            .accounts
+            .lock_these_accounts(tx_account_locks_results);
         TransactionBatch::new(lock_results, self, Cow::Borrowed(txs))
     }
 


### PR DESCRIPTION
#### Problem
Transactions `get_account_locks` are called during `bank` prepares transactions for execution, and at several additional points where cost/fee are measured. `get_account_locks()` isn't cheap, I timed it to be ~250ns per call, it'd be 1.25ms for 5k transactions. Avoid calling it multiple times for same transaction would be good for perf. 

Added bonus is instead of passing transactions to cost & fee related functions, we can just pass ref of accounts. 

#### Summary of Changes
- Add `bank.prepare_sanitized_batch_with_account_locks()` to locks account with shared account_locks_results.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
