### PR TITLE
Update `solana deploy` subcommand to warn non-upgradable

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -137,7 +137,7 @@ impl ProgramSubCommands for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("deploy")
-                        .about("Deploy a program")
+                        .about("Deploy an upgradeable program")
                         .arg(
                             Arg::with_name("program_location")
                                 .index(1)
@@ -403,7 +403,7 @@ impl ProgramSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("Deploy a program")
+                .about("Deploy a non-upgradeable program. Use `solana program deploy` instead to deploy upgradeable programs")
                 .setting(AppSettings::Hidden)
                 .arg(
                     Arg::with_name("program_location")


### PR DESCRIPTION
#### Problem
`solana deploy --help` made no mention of deploy being non-upgradeable and the preferred operation is `solana program deploy`

#### Summary of Changes
Updated the subcommand 'about' text to give more information

Fixes #27228
