### PR TITLE
[docs] added commitment page

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,5 +1,5 @@
 module.exports = {
-  introdutionSidebar: [
+  introductionSidebar: [
     {
       type: "category",
       collapsed: false,
@@ -234,6 +234,7 @@ module.exports = {
         "cluster/fork-generation",
         "cluster/managing-forks",
         "cluster/turbine-block-propagation",
+        "cluster/commitments",
         "cluster/vote-signing",
         "cluster/stake-delegation-and-rewards",
       ],

--- a/docs/src/cluster/commitments.md
+++ b/docs/src/cluster/commitments.md
@@ -1,0 +1,21 @@
+---
+title: Commitment Status
+description: "Processed, confirmed, and finalized. Learn the differences between the different commitment statuses on the Solana blockchain."
+keywords: processed, confirmed, finalized, stake level, block, blockhash,
+---
+
+The [commitment](./../terminology.md#commitment) metric gives clients a standard measure of the network confirmation for the block. Clients can then use this information to derive their own measures of commitment.
+
+There are three specific commitment statuses:
+
+- Processed
+- Confirmed
+- Finalized
+
+| Property                              | Processed | Confirmed | Finalized |
+| ------------------------------------- | --------- | --------- | --------- |
+| Received block                        | X         | X         | X         |
+| Block on majority fork                | X         | X         | X         |
+| Block contains target tx              | X         | X         | X         |
+| 66%+ stake voted on block             | -         | X         | X         |
+| 31+ confirmed blocks built atop block | -         | -         | X         |

--- a/docs/src/implemented-proposals/commitment.md
+++ b/docs/src/implemented-proposals/commitment.md
@@ -4,7 +4,7 @@ title: Commitment
 
 The commitment metric aims to give clients a measure of the network confirmation
 and stake levels on a particular block. Clients can then use this information to
-derive their own measures of commitment.
+derive their own [measures of commitment](../cluster/commitments.md).
 
 # Calculation RPC
 
@@ -40,7 +40,7 @@ This computation is performed on a votable candidate bank `b` as follows.
    }
 ```
 
-where `f` is some accumulation function that modifies the `Stake` entry
+Where `f` is some accumulation function that modifies the `Stake` entry
 for slot `a` with some data derivable from vote `v` and `vote_account`
 (stake, lockout, etc.). Note here that the `ancestors` here only includes
 slots that are present in the current status cache. Signatures for banks earlier

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -54,6 +54,10 @@ The Solana program that owns and loads [BPF](developing/on-chain-programs/overvi
 
 A computer program that accesses the Solana server network [cluster](#cluster).
 
+## commitment
+
+A measure of the network confirmation for the [block](#block).
+
 ## cluster
 
 A set of [validators](#validator) maintaining a single [ledger](#ledger).
@@ -72,7 +76,7 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 
 ## confirmed block
 
-A [block](#block) that has received a [supermajority](#supermajority) of [ledger votes](#ledger-vote).
+A [block](#block) that has received a [super majority](#supermajority) of [ledger votes](#ledger-vote).
 
 ## control plane
 
@@ -100,7 +104,7 @@ An off-chain service that acts as a custodian for a user's private key. It typic
 
 ## entry
 
-An entry on the [ledger](#ledger) either a [tick](#tick) or a [transactions entry](#transactions-entry).
+An entry on the [ledger](#ledger) either a [tick](#tick) or a [transaction's entry](#transactions-entry).
 
 ## entry id
 


### PR DESCRIPTION
#### Problem
Very little information on the commitment statuses

#### Summary of Changes
- added a commitment doc (with the summary table from trent [here](https://solana.stackexchange.com/questions/1760/commitment-processed-vs-confirmed-vs-finalized/2199#2199))
- added this new page the the "architecture/consensus" sidebar area
- added commitment to the terminology page
- minor typo fixes


#### Screenshot of new page and sidebar link:

![Screenshot from 2022-08-19 14-17-03](https://user-images.githubusercontent.com/75431177/185682281-52203700-5d62-4695-9666-c633593c3e4b.png)

