### PR TITLE
Assign custom names to the Rayon global thread pool

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -425,6 +425,14 @@ impl Validator {
             info!("entrypoint: {:?}", cluster_entrypoint);
         }
 
+        if rayon::ThreadPoolBuilder::new()
+            .thread_name(|ix| format!("solRayonGlob{:02}", ix))
+            .build_global()
+            .is_err()
+        {
+            warn!("Rayon global thread pool already initialized");
+        }
+
         if solana_perf::perf_libs::api().is_some() {
             info!("Initializing sigverify, this could take a while...");
         } else {


### PR DESCRIPTION
Threads in the global Rayon pool are now named, `solRayonGlob{:02}` instead of the less useful default name of `solana-validato`.