### PR TITLE
Allow Ctrl-C when querying balances

### DIFF
--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         Command::Balances(mut args) => {
             spl_token::update_decimals(&client, &mut args.spl_token_args)?;
-            commands::process_balances(&client, &args)?;
+            commands::process_balances(&client, &args, exit)?;
         }
         Command::TransactionLog(args) => {
             commands::process_transaction_log(&args)?;


### PR DESCRIPTION
#### Problem

`solana-tokens` installs a handler for Ctrl-C so that the db is cleaned up nicely. However, querying balances does not check the `exit` flag, so it will not terminate early gracefully.

This is an issue with a lot of accounts (like when doing a feature proposal for 3100+ validators).

#### Summary of Changes

Pass the `exit` flag when querying balances.