### PR TITLE
Parse address-lookup-table instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6461,6 +6461,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-address-lookup-table-program",
  "solana-measure",
  "solana-metrics",
  "solana-sdk 1.12.0",

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -214,7 +214,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.12.0 |   |
+| Address Lookup | v1.12.0 | v1.12.0 |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-address-lookup-table-program",
  "solana-measure",
  "solana-metrics",
  "solana-sdk 1.12.0",

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0.143"
 serde_derive = "1.0.103"
 serde_json = "1.0.83"
 solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
 solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-metrics = { path = "../metrics", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -34,6 +34,7 @@ extern crate serde_derive;
 
 pub mod extract_memos;
 pub mod parse_accounts;
+pub mod parse_address_lookup_table;
 pub mod parse_associated_token;
 pub mod parse_bpf_loader;
 pub mod parse_instruction;

--- a/transaction-status/src/parse_address_lookup_table.rs
+++ b/transaction-status/src/parse_address_lookup_table.rs
@@ -36,7 +36,7 @@ pub fn parse_address_lookup_table(
                 info: json!({
                     "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
                     "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "source": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "payerAccount": account_keys[instruction.accounts[2] as usize].to_string(),
                     "systemProgram": account_keys[instruction.accounts[3] as usize].to_string(),
                     "recentSlot": recent_slot,
                     "bumpSeed": bump_seed,
@@ -67,7 +67,7 @@ pub fn parse_address_lookup_table(
             let map = value.as_object_mut().unwrap();
             if instruction.accounts.len() >= 4 {
                 map.insert(
-                    "source".to_string(),
+                    "payerAccount".to_string(),
                     json!(account_keys[instruction.accounts[2] as usize].to_string()),
                 );
                 map.insert(
@@ -97,7 +97,7 @@ pub fn parse_address_lookup_table(
                 info: json!({
                     "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
                     "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "recipient": account_keys[instruction.accounts[2] as usize].to_string(),
                 }),
             })
         }
@@ -141,7 +141,7 @@ mod test {
                 info: json!({
                     "lookupTableAccount": lookup_table_pubkey.to_string(),
                     "lookupTableAuthority": authority.to_string(),
-                    "source": from_pubkey.to_string(),
+                    "payerAccount": from_pubkey.to_string(),
                     "systemProgram": system_program::id().to_string(),
                     "recentSlot": slot,
                     "bumpSeed": 254,
@@ -258,7 +258,7 @@ mod test {
                 info: json!({
                     "lookupTableAccount": lookup_table_pubkey.to_string(),
                     "lookupTableAuthority": authority.to_string(),
-                    "source": from_pubkey.to_string(),
+                    "payerAccount": from_pubkey.to_string(),
                     "systemProgram": system_program::id().to_string(),
                     "newAddresses": [
                         address0.to_string(),
@@ -338,7 +338,7 @@ mod test {
                 info: json!({
                     "lookupTableAccount": lookup_table_pubkey.to_string(),
                     "lookupTableAuthority": authority.to_string(),
-                    "destination": recipient.to_string(),
+                    "recipient": recipient.to_string(),
                 }),
             }
         );

--- a/transaction-status/src/parse_address_lookup_table.rs
+++ b/transaction-status/src/parse_address_lookup_table.rs
@@ -1,0 +1,268 @@
+use {
+    crate::parse_instruction::{
+        check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
+    },
+    bincode::deserialize,
+    serde_json::json,
+    solana_address_lookup_table_program::instruction::ProgramInstruction,
+    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys},
+};
+
+pub fn parse_address_lookup_table(
+    instruction: &CompiledInstruction,
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    let address_lookup_table_instruction: ProgramInstruction = deserialize(&instruction.data)
+        .map_err(|_| {
+            ParseInstructionError::InstructionNotParsable(ParsableProgram::AddressLookupTable)
+        })?;
+    match instruction.accounts.iter().max() {
+        Some(index) if (*index as usize) < account_keys.len() => {}
+        _ => {
+            // Runtime should prevent this from ever happening
+            return Err(ParseInstructionError::InstructionKeyMismatch(
+                ParsableProgram::AddressLookupTable,
+            ));
+        }
+    }
+    match address_lookup_table_instruction {
+        ProgramInstruction::CreateLookupTable {
+            recent_slot,
+            bump_seed,
+        } => {
+            check_num_address_lookup_table_accounts(&instruction.accounts, 4)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "createLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "source": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "systemProgram": account_keys[instruction.accounts[3] as usize].to_string(),
+                    "recentSlot": recent_slot,
+                    "bumpSeed": bump_seed,
+                }),
+            })
+        }
+        ProgramInstruction::FreezeLookupTable => {
+            check_num_address_lookup_table_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "freezeLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                }),
+            })
+        }
+        ProgramInstruction::ExtendLookupTable { new_addresses } => {
+            check_num_address_lookup_table_accounts(&instruction.accounts, 2)?;
+            let mut value = json!({
+                "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                "newAddresses": new_addresses,
+            });
+            let map = value.as_object_mut().unwrap();
+            if instruction.accounts.len() >= 4 {
+                map.insert(
+                    "source".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "systemProgram".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "freezeLookupTable".to_string(),
+                info: value,
+            })
+        }
+        ProgramInstruction::DeactivateLookupTable => {
+            check_num_address_lookup_table_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "deactivateLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                }),
+            })
+        }
+        ProgramInstruction::CloseLookupTable => {
+            check_num_address_lookup_table_accounts(&instruction.accounts, 3)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "closeLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "lookupTableAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "destination": account_keys[instruction.accounts[2] as usize].to_string(),
+                }),
+            })
+        }
+    }
+}
+
+fn check_num_address_lookup_table_accounts(
+    accounts: &[u8],
+    num: usize,
+) -> Result<(), ParseInstructionError> {
+    check_num_accounts(accounts, num, ParsableProgram::AddressLookupTable)
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        solana_address_lookup_table_program::instruction,
+        solana_sdk::{message::Message, pubkey::Pubkey, system_program},
+        std::str::FromStr,
+    };
+
+    #[test]
+    fn test_parse_create_address_lookup_table_ix() {
+        let from_pubkey = Pubkey::new_unique();
+        // use explicit key to have predicatble bump_seed
+        let authority = Pubkey::from_str("HkxY6vXdrKzoCQLmdJ3cYo9534FdZQxzBNWTyrJzzqJM").unwrap();
+        let slot = 42;
+
+        let (instruction, lookup_table_pubkey) =
+            instruction::create_lookup_table(authority, from_pubkey, slot);
+        let mut message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_address_lookup_table(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "createLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": lookup_table_pubkey.to_string(),
+                    "lookupTableAuthority": authority.to_string(),
+                    "source": from_pubkey.to_string(),
+                    "systemProgram": system_program::id().to_string(),
+                    "recentSlot": slot,
+                    "bumpSeed": 254,
+                }),
+            }
+        );
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..3], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_freeze_lookup_table_ix() {
+        let lookup_table_pubkey = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let instruction = instruction::freeze_lookup_table(lookup_table_pubkey, authority);
+        let mut message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_address_lookup_table(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "freezeLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": lookup_table_pubkey.to_string(),
+                    "lookupTableAuthority": authority.to_string(),
+                }),
+            }
+        );
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..1], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_deactivate_lookup_table_ix() {
+        let lookup_table_pubkey = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let instruction = instruction::deactivate_lookup_table(lookup_table_pubkey, authority);
+        let mut message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_address_lookup_table(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "deactivateLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": lookup_table_pubkey.to_string(),
+                    "lookupTableAuthority": authority.to_string(),
+                }),
+            }
+        );
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..1], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_close_lookup_table_ix() {
+        let lookup_table_pubkey = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let instruction =
+            instruction::close_lookup_table(lookup_table_pubkey, authority, recipient);
+        let mut message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_address_lookup_table(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "closeLookupTable".to_string(),
+                info: json!({
+                    "lookupTableAccount": lookup_table_pubkey.to_string(),
+                    "lookupTableAuthority": authority.to_string(),
+                    "destination": recipient.to_string(),
+                }),
+            }
+        );
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..2], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_address_lookup_table(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
#### Problem
RPC nodes parse address-lookup-table accounts, but not instructions

#### Summary of Changes
Add parser for address-lookup-table instructions

https://github.com/solana-labs/solana/pull/27268 needs updating
