### PR TITLE
Add a SanitizedMessage type that caches writable accounts indexes

### DIFF
--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -228,7 +228,7 @@ pub(crate) mod tests {
             clock::Slot,
             hash::Hash,
             instruction::CompiledInstruction,
-            message::{Message, MessageHeader, SanitizedMessage},
+            message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
             nonce::{self, state::DurableNonce},
             nonce_account,
             pubkey::Pubkey,
@@ -372,7 +372,7 @@ pub(crate) mod tests {
             durable_nonce_fee: Some(DurableNonceFee::from(
                 &NonceFull::from_partial(
                     rollback_partial,
-                    &SanitizedMessage::Legacy(message),
+                    &SanitizedMessage::Legacy(LegacyMessage::new(message)),
                     &[(pubkey, nonce_account)],
                     &rent_debits,
                 )

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -270,20 +270,21 @@ mod tests {
             AccountMeta::new_readonly(readonly_pubkey, false),
         ];
 
-        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
-            1,
-            0,
-            2,
-            account_keys.clone(),
-            Hash::default(),
-            AccountKeys::new(&account_keys, None).compile_instructions(&[
-                Instruction::new_with_bincode(
-                    mock_system_program_id,
-                    &MockSystemInstruction::Correct,
-                    account_metas.clone(),
-                ),
-            ]),
-        )));
+        let message =
+            SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
+                1,
+                0,
+                2,
+                account_keys.clone(),
+                Hash::default(),
+                AccountKeys::new(&account_keys, None).compile_instructions(&[
+                    Instruction::new_with_bincode(
+                        mock_system_program_id,
+                        &MockSystemInstruction::Correct,
+                        account_metas.clone(),
+                    ),
+                ]),
+            )));
         let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
@@ -320,20 +321,21 @@ mod tests {
             0
         );
 
-        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
-            1,
-            0,
-            2,
-            account_keys.clone(),
-            Hash::default(),
-            AccountKeys::new(&account_keys, None).compile_instructions(&[
-                Instruction::new_with_bincode(
-                    mock_system_program_id,
-                    &MockSystemInstruction::TransferLamports { lamports: 50 },
-                    account_metas.clone(),
-                ),
-            ]),
-        )));
+        let message =
+            SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
+                1,
+                0,
+                2,
+                account_keys.clone(),
+                Hash::default(),
+                AccountKeys::new(&account_keys, None).compile_instructions(&[
+                    Instruction::new_with_bincode(
+                        mock_system_program_id,
+                        &MockSystemInstruction::TransferLamports { lamports: 50 },
+                        account_metas.clone(),
+                    ),
+                ]),
+            )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -359,20 +361,21 @@ mod tests {
             ))
         );
 
-        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
-            1,
-            0,
-            2,
-            account_keys.clone(),
-            Hash::default(),
-            AccountKeys::new(&account_keys, None).compile_instructions(&[
-                Instruction::new_with_bincode(
-                    mock_system_program_id,
-                    &MockSystemInstruction::ChangeData { data: 50 },
-                    account_metas,
-                ),
-            ]),
-        )));
+        let message =
+            SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
+                1,
+                0,
+                2,
+                account_keys.clone(),
+                Hash::default(),
+                AccountKeys::new(&account_keys, None).compile_instructions(&[
+                    Instruction::new_with_bincode(
+                        mock_system_program_id,
+                        &MockSystemInstruction::ChangeData { data: 50 },
+                        account_metas,
+                    ),
+                ]),
+            )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -179,7 +179,7 @@ mod tests {
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             instruction::{AccountMeta, Instruction, InstructionError},
-            message::{AccountKeys, Message},
+            message::{AccountKeys, LegacyMessage, Message},
             native_loader::{self, create_loadable_account_for_test},
             pubkey::Pubkey,
             secp256k1_instruction::new_secp256k1_instruction,
@@ -270,7 +270,7 @@ mod tests {
             AccountMeta::new_readonly(readonly_pubkey, false),
         ];
 
-        let message = SanitizedMessage::Legacy(Message::new_with_compiled_instructions(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
             1,
             0,
             2,
@@ -283,7 +283,7 @@ mod tests {
                     account_metas.clone(),
                 ),
             ]),
-        ));
+        )));
         let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
@@ -320,7 +320,7 @@ mod tests {
             0
         );
 
-        let message = SanitizedMessage::Legacy(Message::new_with_compiled_instructions(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
             1,
             0,
             2,
@@ -333,7 +333,7 @@ mod tests {
                     account_metas.clone(),
                 ),
             ]),
-        ));
+        )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -359,7 +359,7 @@ mod tests {
             ))
         );
 
-        let message = SanitizedMessage::Legacy(Message::new_with_compiled_instructions(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new_with_compiled_instructions(
             1,
             0,
             2,
@@ -372,7 +372,7 @@ mod tests {
                     account_metas,
                 ),
             ]),
-        ));
+        )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -501,14 +501,14 @@ mod tests {
         ];
 
         // Try to borrow mut the same account
-        let message = SanitizedMessage::Legacy(Message::new(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new(
             &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::BorrowFail,
                 account_metas.clone(),
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
-        ));
+        )));
         let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
@@ -536,14 +536,14 @@ mod tests {
         );
 
         // Try to borrow mut the same account in a safe way
-        let message = SanitizedMessage::Legacy(Message::new(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new(
             &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::MultiBorrowMut,
                 account_metas.clone(),
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
-        ));
+        )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -564,7 +564,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Do work on the same transaction account but at different instruction accounts
-        let message = SanitizedMessage::Legacy(Message::new(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new(
             &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::DoWork {
@@ -574,7 +574,7 @@ mod tests {
                 account_metas,
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
-        ));
+        )));
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -644,7 +644,7 @@ mod tests {
         let mut transaction_context =
             TransactionContext::new(accounts, Some(Rent::default()), 1, 2);
 
-        let message = SanitizedMessage::Legacy(Message::new(
+        let message = SanitizedMessage::Legacy(LegacyMessage::new(Message::new(
             &[
                 new_secp256k1_instruction(
                     &libsecp256k1::SecretKey::random(&mut rand::thread_rng()),
@@ -653,7 +653,7 @@ mod tests {
                 Instruction::new_with_bytes(mock_program_id, &[], vec![]),
             ],
             None,
-        ));
+        )));
         let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -14,6 +14,9 @@ pub struct LoadedMessage<'a> {
     pub message: Cow<'a, v0::Message>,
     /// Addresses loaded with on-chain address lookup tables
     pub loaded_addresses: Cow<'a, LoadedAddresses>,
+    /// List of boolean with same length as account_keys(), each boolean value indicates if
+    /// corresponding account key is writable or not.
+    pub is_writable_account_cache: Vec<bool>,
 }
 
 /// Collection of addresses loaded from on-chain lookup tables, split
@@ -53,17 +56,36 @@ impl LoadedAddresses {
 
 impl<'a> LoadedMessage<'a> {
     pub fn new(message: v0::Message, loaded_addresses: LoadedAddresses) -> Self {
-        Self {
+        let mut loaded_message = Self {
             message: Cow::Owned(message),
             loaded_addresses: Cow::Owned(loaded_addresses),
-        }
+            is_writable_account_cache: Vec::default(),
+        };
+        loaded_message.set_is_writable_account_cache();
+        loaded_message
     }
 
     pub fn new_borrowed(message: &'a v0::Message, loaded_addresses: &'a LoadedAddresses) -> Self {
-        Self {
+        let mut loaded_message = Self {
             message: Cow::Borrowed(message),
             loaded_addresses: Cow::Borrowed(loaded_addresses),
-        }
+            is_writable_account_cache: Vec::default(),
+        };
+        loaded_message.set_is_writable_account_cache();
+        loaded_message
+    }
+
+    fn set_is_writable_account_cache(&mut self) {
+        let is_writable_account_cache = self
+            .account_keys()
+            .iter()
+            .enumerate()
+            .map(|(i, _key)| self.is_writable_internal(i))
+            .collect::<Vec<_>>();
+        let _ = std::mem::replace(
+            &mut self.is_writable_account_cache,
+            is_writable_account_cache,
+        );
     }
 
     /// Returns the full list of static and dynamic account keys that are loaded for this message.
@@ -105,13 +127,20 @@ impl<'a> LoadedMessage<'a> {
     }
 
     /// Returns true if the account at the specified index was loaded as writable
-    pub fn is_writable(&self, key_index: usize) -> bool {
+    fn is_writable_internal(&self, key_index: usize) -> bool {
         if self.is_writable_index(key_index) {
             if let Some(key) = self.account_keys().get(key_index) {
                 return !(is_builtin_key_or_sysvar(key) || self.demote_program_id(key_index));
             }
         }
         false
+    }
+
+    pub fn is_writable(&self, key_index: usize) -> bool {
+        *self
+            .is_writable_account_cache
+            .get(key_index)
+            .unwrap_or(&false)
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -204,6 +204,7 @@ impl SanitizedTransaction {
                 signatures,
                 message: VersionedMessage::Legacy(message.clone()),
             },
+            SanitizedMessage::SanitizedWithWritableAccountsIndexCache {sanitized_message, writable_accounts_cache: _} => todo!(),
         }
     }
 
@@ -249,6 +250,7 @@ impl SanitizedTransaction {
         match &self.message {
             SanitizedMessage::Legacy(_) => LoadedAddresses::default(),
             SanitizedMessage::V0(message) => LoadedAddresses::clone(&message.loaded_addresses),
+            SanitizedMessage::SanitizedWithWritableAccountsIndexCache {sanitized_message, writable_accounts_cache: _} => todo!(),
         }
     }
 
@@ -262,6 +264,7 @@ impl SanitizedTransaction {
         match &self.message {
             SanitizedMessage::Legacy(message) => message.serialize(),
             SanitizedMessage::V0(loaded_msg) => loaded_msg.message.serialize(),
+            SanitizedMessage::SanitizedWithWritableAccountsIndexCache {sanitized_message, writable_accounts_cache: _} => todo!(),
         }
     }
 


### PR DESCRIPTION
#### Problem
Would be good if `SanitizedMessage` can cache writable accounts for reusing, cause repeatedly calling `is_writable()` can be costly.

#### Summary of Changes
- Add `is_writable_account_cache: Vec<usize>` to `SanitizedMessage` variants. 
- Call `is_writable()` once during construction to populate `is_writable_account_cache: Vec<usize>`
- Add test

#### Fixes
Comments from #27263 , 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
