### PR TITLE
Add use-quic flag to allow for using quic in program deploy

### DIFF
--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -85,6 +85,12 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .help("Show additional information"),
         )
         .arg(
+            Arg::with_name("use_quic")
+                .long("use-quic")
+                .global(true)
+                .help("Use QUIC when sending transactions."),
+        )
+        .arg(
             Arg::with_name("no_address_labels")
                 .long("no-address-labels")
                 .global(true)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -503,6 +503,7 @@ pub struct CliConfig<'a> {
     pub send_transaction_config: RpcSendTransactionConfig,
     pub confirm_transaction_initial_timeout: Duration,
     pub address_labels: HashMap<String, String>,
+    pub use_quic: bool,
 }
 
 impl CliConfig<'_> {
@@ -550,6 +551,7 @@ impl Default for CliConfig<'_> {
                 u64::from_str(DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS).unwrap(),
             ),
             address_labels: HashMap::new(),
+            use_quic: false,
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -202,6 +202,8 @@ pub fn parse_args<'a>(
         config.address_labels
     };
 
+    let use_quic = matches.is_present("use_quic");
+
     Ok((
         CliConfig {
             command,
@@ -220,6 +222,7 @@ pub fn parse_args<'a>(
             },
             confirm_transaction_initial_timeout,
             address_labels,
+            use_quic,
         },
         signers,
     ))

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2224,7 +2224,11 @@ fn send_deploy_messages(
     if let Some(write_messages) = write_messages {
         if let Some(write_signer) = write_signer {
             trace!("Writing program data");
-            let connection_cache = Arc::new(ConnectionCache::default());
+            let connection_cache = if config.use_quic {
+                Arc::new(ConnectionCache::new(1))
+            } else {
+                Arc::new(ConnectionCache::with_udp(1))
+            };
             let tpu_client = TpuClient::new_with_connection_cache(
                 rpc_client.clone(),
                 &config.websocket_url,


### PR DESCRIPTION
#### Problem

Program deploy uses UDP transaction send and has no QUIC path.

#### Summary of Changes

Add --use-quic flag so that `solana program deploy` can use QUIC to send transactions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
