### PR TITLE
ledger-tool: fix double-readlock in main

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3832,6 +3832,14 @@ fn main() {
                                         }
 
                                         for point_detail in point_details {
+                                            let (cluster_rewards, cluster_points) =
+                                                last_point_value
+                                                    .read()
+                                                    .unwrap()
+                                                    .clone()
+                                                    .map_or((None, None), |pv| {
+                                                        (Some(pv.rewards), Some(pv.points))
+                                                    });
                                             let record = InflationRecord {
                                                 cluster_type: format!(
                                                     "{:?}",
@@ -3898,20 +3906,8 @@ fn main() {
                                                 commission: format_or_na(
                                                     detail.map(|d| d.commission),
                                                 ),
-                                                cluster_rewards: format_or_na(
-                                                    last_point_value
-                                                        .read()
-                                                        .unwrap()
-                                                        .clone()
-                                                        .map(|pv| pv.rewards),
-                                                ),
-                                                cluster_points: format_or_na(
-                                                    last_point_value
-                                                        .read()
-                                                        .unwrap()
-                                                        .clone()
-                                                        .map(|pv| pv.points),
-                                                ),
+                                                cluster_rewards: format_or_na(cluster_rewards),
+                                                cluster_points: format_or_na(cluster_points),
                                                 old_capitalization: base_bank.capitalization(),
                                                 new_capitalization: warped_bank.capitalization(),
                                             };


### PR DESCRIPTION
#### Problem

There is a possible deadlock caused by double readlock in fn `ledger-tool/src/main.rs`.

`last_point_value: Arc<RwLock<Option<PointValue>>>`

The first readlock is on L3737 and the second on L3744

https://github.com/solana-labs/solana/blob/e4a7d01e10e7f0dea2254025d76897ff008f3118/ledger-tool/src/main.rs#L3734-L3747

For more details on this kind of deadlock, see
https://www.reddit.com/r/rust/comments/urnqz8/different_behaviors_of_recursive_read_locks_in/

#### Summary of Changes

Call read lock once. If the returned `Option<PointValue>` is Some, then map it to pair (Some(rewards), Some(points)); othewise, map it to (None, None).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
