### PR TITLE
Handle VoteStateUpdates for outdated roots bigger than slots in existing VoteState

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -198,12 +198,12 @@ fn check_update_vote_state_slots_are_valid(
             let mut prev_slot = Slot::MAX;
             let current_root = vote_state_update.root;
             for lockout in vote_state.votes.iter().rev() {
-                let is_bigger_than_root = current_root
+                let is_slot_bigger_than_root = current_root
                     .map(|current_root| lockout.slot > current_root)
                     .unwrap_or(true);
                 // Ensure we're iterating from biggest to smallest vote in the
                 // current vote state
-                assert!(lockout.slot < prev_slot && is_bigger_than_root);
+                assert!(lockout.slot < prev_slot && is_slot_bigger_than_root);
                 if lockout.slot <= new_proposed_root {
                     vote_state_update.root = Some(lockout.slot);
                     break;
@@ -214,7 +214,7 @@ fn check_update_vote_state_slots_are_valid(
     }
 
     // Index into the new proposed vote state's slots, starting with the root if it exists then
-    // we use this mutable root to fold checking the root slot into this the below loop
+    // we use this mutable root to fold checking the root slot into the below loop
     // for performance
     let mut root_to_check = vote_state_update.root;
     let mut vote_state_update_index = 0;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -510,6 +510,10 @@ pub mod stop_sibling_instruction_search_at_parent {
     solana_sdk::declare_id!("EYVpEP7uzH1CoXzbD6PubGhYmnxRXPeq3PPsm1ba3gpo");
 }
 
+pub mod vote_state_update_root_fix {
+    solana_sdk::declare_id!("G74BkWBzmsByZ1kxHy44H3wjwp5hp7JbrGRuDpco22tY");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -632,6 +636,7 @@ lazy_static! {
         (disable_cpi_setting_executable_and_rent_epoch::id(), "disable setting is_executable and_rent_epoch in CPI #26987"),
         (relax_authority_signer_check_for_lookup_table_creation::id(), "relax authority signer check for lookup table creation #27205"),
         (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
+        (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/27361

#### Summary of Changes
Set root to largest slot in VoteState less than the proposed root

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
