### PR TITLE
ignore clippy derive_partial_eq_without_eq in prost generated code

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -16,6 +16,7 @@ use {
     tonic::{codegen::InterceptedService, transport::ClientTlsConfig, Request, Status},
 };
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod google {
     mod rpc {
         include!(concat!(

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -25,6 +25,7 @@ use {
     },
 };
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod generated {
     include!(concat!(
         env!("OUT_DIR"),
@@ -32,6 +33,7 @@ pub mod generated {
     ));
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod tx_by_addr {
     include!(concat!(
         env!("OUT_DIR"),


### PR DESCRIPTION
#### Problem
Clippy warnings are annoying after #27303 

#### Summary of Changes
Ignore the warning, as per reccomended from a prost maintainer: https://github.com/tokio-rs/prost/issues/661

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
