### PR TITLE
Revert "serialize incremental_snapshot_hash (backport #26839)"

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -190,7 +190,6 @@ impl AccountsHashVerifier {
             accounts_package.snapshot_links.path(),
             accounts_package.slot,
             &accounts_hash,
-            None,
         );
         datapoint_info!(
             "accounts_hash_verifier",

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -257,7 +257,6 @@ fn run_bank_forks_snapshot_n<F>(
         accounts_package.snapshot_links.path(),
         accounts_package.slot,
         &last_bank.get_accounts_hash(),
-        None,
     );
     let snapshot_package = SnapshotPackage::new(accounts_package, last_bank.get_accounts_hash());
     snapshot_utils::archive_snapshot_package(
@@ -493,7 +492,6 @@ fn test_concurrent_snapshot_packaging(
                 accounts_package.snapshot_links.path(),
                 accounts_package.slot,
                 &Hash::default(),
-                None,
             );
             let snapshot_package = SnapshotPackage::new(accounts_package, Hash::default());
             pending_snapshot_package
@@ -537,7 +535,6 @@ fn test_concurrent_snapshot_packaging(
         saved_snapshots_dir.path(),
         saved_slot,
         &Hash::default(),
-        None,
     );
 
     snapshot_utils::verify_snapshot_archive(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -236,25 +236,6 @@ impl RentDebit {
     }
 }
 
-/// Incremental snapshots only calculate their accounts hash based on the account changes WITHIN the incremental slot range.
-/// So, we need to keep track of the full snapshot expected accounts hash results.
-/// We also need to keep track of the hash and capitalization specific to the incremental snapshot slot range.
-/// The capitalization we calculate for the incremental slot will NOT be consistent with the bank's capitalization.
-/// It is not feasible to calculate a capitalization delta that is correct given just incremental slots account data and the full snapshot's capitalization.
-#[derive(Serialize, Deserialize, AbiExample, Clone, Debug, Default, PartialEq, Eq)]
-pub struct BankIncrementalSnapshotPersistence {
-    /// slot of full snapshot
-    pub full_slot: Slot,
-    /// accounts hash from the full snapshot
-    pub full_hash: Hash,
-    /// capitalization from the full snapshot
-    pub full_capitalization: u64,
-    /// hash of the accounts in the incremental snapshot slot range, including zero-lamport accounts
-    pub incremental_hash: Hash,
-    /// capitalization of the accounts in the incremental snapshot slot range
-    pub incremental_capitalization: u64,
-}
-
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RentDebits(HashMap<Pubkey, RentDebit>);
 impl RentDebits {
@@ -995,7 +976,6 @@ pub struct BankFieldsToDeserialize {
     pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
-    pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
 }
 
 // Bank's common fields shared by all supported snapshot versions for serialization.
@@ -1103,7 +1083,6 @@ impl PartialEq for Bank {
             accounts_data_size_delta_on_chain: _,
             accounts_data_size_delta_off_chain: _,
             fee_structure: _,
-            incremental_snapshot_persistence: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this ParitalEq is accordingly updated.
@@ -1356,8 +1335,6 @@ pub struct Bank {
 
     /// Transaction fee structure
     pub fee_structure: FeeStructure,
-
-    pub incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
 }
 
 struct VoteWithStakeDelegations {
@@ -1486,7 +1463,6 @@ impl Bank {
 
     fn default_with_accounts(accounts: Accounts) -> Self {
         let mut bank = Self {
-            incremental_snapshot_persistence: None,
             rewrites_skipped_this_slot: Rewrites::default(),
             rc: BankRc::new(accounts, Slot::default()),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
@@ -1794,7 +1770,6 @@ impl Bank {
 
         let accounts_data_size_initial = parent.load_accounts_data_size();
         let mut new = Bank {
-            incremental_snapshot_persistence: None,
             rewrites_skipped_this_slot: Rewrites::default(),
             rc,
             status_cache,
@@ -2155,7 +2130,6 @@ impl Bank {
         }
         let feature_set = new();
         let mut bank = Self {
-            incremental_snapshot_persistence: fields.incremental_snapshot_persistence,
             rewrites_skipped_this_slot: Rewrites::default(),
             rc: bank_rc,
             status_cache: new(),

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -96,7 +96,6 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             stakes: dvb.stakes,
             epoch_stakes: dvb.epoch_stakes,
             is_delta: dvb.is_delta,
-            incremental_snapshot_persistence: None,
         }
     }
 }
@@ -210,7 +209,6 @@ impl<'a> TypeContext<'a> for Context {
             // we can grab it on restart.
             // TODO: if we do a snapshot version bump, consider moving this out.
             lamports_per_signature,
-            None::<BankIncrementalSnapshotPersistence>,
         )
             .serialize(serializer)
     }
@@ -316,10 +314,6 @@ impl<'a> TypeContext<'a> for Context {
         bank_fields.fee_rate_governor = bank_fields
             .fee_rate_governor
             .clone_with_lamports_per_signature(lamports_per_signature);
-
-        let incremental_snapshot_persistence = ignore_eof_error(deserialize_from(stream))?;
-        bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
-
         Ok((bank_fields, accounts_db_fields))
     }
 
@@ -333,13 +327,12 @@ impl<'a> TypeContext<'a> for Context {
     }
 
     /// deserialize the bank from 'stream_reader'
-    /// modify the accounts_hash and incremental_snapshot_persistence
+    /// modify the accounts_hash
     /// reserialize the bank to 'stream_writer'
     fn reserialize_bank_fields_with_hash<R, W>(
         stream_reader: &mut BufReader<R>,
         stream_writer: &mut BufWriter<W>,
         accounts_hash: &Hash,
-        incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     ) -> std::result::Result<(), Box<bincode::ErrorKind>>
     where
         R: Read,
@@ -352,7 +345,6 @@ impl<'a> TypeContext<'a> for Context {
         let blockhash_queue = RwLock::new(rhs.blockhash_queue.clone());
         let hard_forks = RwLock::new(rhs.hard_forks.clone());
         let lamports_per_signature = rhs.fee_rate_governor.lamports_per_signature;
-
         let bank = SerializableVersionedBank {
             blockhash_queue: &blockhash_queue,
             ancestors: &rhs.ancestors,
@@ -390,12 +382,7 @@ impl<'a> TypeContext<'a> for Context {
 
         bincode::serialize_into(
             stream_writer,
-            &(
-                bank,
-                accounts_db_fields,
-                lamports_per_signature,
-                incremental_snapshot_persistence,
-            ),
+            &(bank, accounts_db_fields, lamports_per_signature),
         )
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2038,7 +2038,6 @@ pub fn package_and_archive_full_snapshot(
         accounts_package.snapshot_links.path(),
         accounts_package.slot,
         &bank.get_accounts_hash(),
-        None,
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());
@@ -2091,7 +2090,6 @@ pub fn package_and_archive_incremental_snapshot(
         accounts_package.snapshot_links.path(),
         accounts_package.slot,
         &bank.get_accounts_hash(),
-        None,
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());


### PR DESCRIPTION
Reverts solana-labs/solana#27212

We may need to revert this. We may only want to READ the new fields out here and not write them. Otherwise, snapshots generated by 1.11 will fail with 1.10...