### PR TITLE
only READ BankIncrementalSnapshotPersistence in 1.11

### DIFF
--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -210,7 +210,7 @@ impl<'a> TypeContext<'a> for Context {
             // we can grab it on restart.
             // TODO: if we do a snapshot version bump, consider moving this out.
             lamports_per_signature,
-            None::<BankIncrementalSnapshotPersistence>,
+            // None::<BankIncrementalSnapshotPersistence>, this will be saved starting in 1.12
         )
             .serialize(serializer)
     }
@@ -339,7 +339,7 @@ impl<'a> TypeContext<'a> for Context {
         stream_reader: &mut BufReader<R>,
         stream_writer: &mut BufWriter<W>,
         accounts_hash: &Hash,
-        incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
+        _incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     ) -> std::result::Result<(), Box<bincode::ErrorKind>>
     where
         R: Read,
@@ -394,7 +394,7 @@ impl<'a> TypeContext<'a> for Context {
                 bank,
                 accounts_db_fields,
                 lamports_per_signature,
-                incremental_snapshot_persistence,
+                // incremental_snapshot_persistence, this will be saved starting in 1.12
             ),
         )
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -190,9 +190,12 @@ fn test_bank_serialize_style(
     serde_style: SerdeStyle,
     reserialize_accounts_hash: bool,
     update_accounts_hash: bool,
-    incremental_snapshot_persistence: bool,
+    _incremental_snapshot_persistence: bool,
 ) {
     solana_logger::setup();
+
+    // in 1.11, don't test incremental snapshot persistence because we are not writing it - only reading it and ignoring it
+    let incremental_snapshot_persistence = false;
     let (genesis_config, _) = create_genesis_config(500);
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
@@ -581,7 +584,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "5py4Wkuj5fV2sLyA1MrPg4pGNwMEaygQLnpLyY8MMLGC")]
+    #[frozen_abi(digest = "9vGBt7YfymKUTPWLHVVpQbDtPD7dFDwXRMFkCzwujNqJ")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem

See #27212
If we save these new fields in 1.11, then 1.10 will be unable to load snapshots created in 1.11

#### Summary of Changes

In 1.11, just READ the new fields, but do not write them.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
