### PR TITLE
zk-token-sdk: remove non-constant time assign for fee_proof transcript

### DIFF
--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -40,6 +40,9 @@ impl FeeSigmaProof {
     /// Creates a fee sigma proof assuming that the committed fee is greater than the maximum fee
     /// bound.
     ///
+    /// Note: the proof is generated twice via `create_proof_fee_above_max` and
+    /// `create_proof_fee_below_max` to enforce constant time execution.
+    ///
     /// * `(fee_amount, fee_commitment, fee_opening)` - The amount, Pedersen commitment, and
     /// opening of the transfer fee
     /// * `(delta_fee, delta_commitment, delta_opening)` - The amount, Pedersen commitment, and
@@ -76,24 +79,29 @@ impl FeeSigmaProof {
 
         let below_max = u64::ct_gt(&max_fee, &fee_amount);
 
-        // conditionally assign transcript; transcript is not conditionally selectable
-        if bool::from(below_max) {
-            *transcript = transcript_fee_below_max;
-        } else {
-            *transcript = transcript_fee_above_max;
-        }
+        // choose one of `proof_fee_above_max` or `proof_fee_below_max` according to whether the
+        // fee amount surpasses max fee
+        let fee_max_proof = FeeMaxProof::conditional_select(
+            &proof_fee_above_max.fee_max_proof,
+            &proof_fee_below_max.fee_max_proof,
+            below_max,
+        );
+
+        let fee_equality_proof = FeeEqualityProof::conditional_select(
+            &proof_fee_above_max.fee_equality_proof,
+            &proof_fee_below_max.fee_equality_proof,
+            below_max,
+        );
+
+        transcript.append_point(b"Y_max_proof", &fee_max_proof.Y_max_proof);
+        transcript.append_point(b"Y_delta", &fee_equality_proof.Y_delta);
+        transcript.append_point(b"Y_claimed", &fee_equality_proof.Y_claimed);
+        transcript.challenge_scalar(b"c");
+        transcript.challenge_scalar(b"w");
 
         Self {
-            fee_max_proof: FeeMaxProof::conditional_select(
-                &proof_fee_above_max.fee_max_proof,
-                &proof_fee_below_max.fee_max_proof,
-                below_max,
-            ),
-            fee_equality_proof: FeeEqualityProof::conditional_select(
-                &proof_fee_above_max.fee_equality_proof,
-                &proof_fee_below_max.fee_equality_proof,
-                below_max,
-            ),
+            fee_max_proof,
+            fee_equality_proof,
         }
     }
 


### PR DESCRIPTION
#### Problem
The transcript that is used in sigma proofs is not constant-time conditionally selectable. This results in the fee sigma proof generation to execute in non-constant time.

#### Summary of Changes
Remove transcript from being assigned conditionally by hashing proof values into the transcript twice. This allows proof generation to run in constant time at a small cost of a few additional hashes.