### PR TITLE
zk-token-sdk: calculate transfer fee without conditional branch

### DIFF
--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -697,18 +697,20 @@ impl FeeParameters {
 #[cfg(not(target_os = "solana"))]
 fn calculate_fee(transfer_amount: u64, fee_rate_basis_points: u16) -> Option<(u64, u64)> {
     let numerator = (transfer_amount as u128).checked_mul(fee_rate_basis_points as u128)?;
-    let mut fee = numerator.checked_div(ONE_IN_BASIS_POINTS)?;
-    let mut delta_fee = 0_u128;
 
-    let remainder = numerator.checked_rem(ONE_IN_BASIS_POINTS)?;
-    if remainder > 0 {
-        fee = fee.checked_add(1)?;
+    // Warning: Division may involve CPU opcodes that have variable execution times. This
+    // non-constant-time execution of the fee calculation can theoretically reveal information
+    // about the transfer amount. For transfers that invole extremely sensitive data, additional
+    // care should be put into how the fees are calculated.
+    let fee = numerator
+        .checked_add(ONE_IN_BASIS_POINTS)?
+        .checked_sub(1)?
+        .checked_div(ONE_IN_BASIS_POINTS)?;
 
-        let scaled_fee = fee.checked_mul(ONE_IN_BASIS_POINTS)?;
-        delta_fee = scaled_fee.checked_sub(numerator)?;
-    }
+    let delta_fee = fee
+        .checked_mul(ONE_IN_BASIS_POINTS)?
+        .checked_sub(numerator)?;
 
-    let fee = u64::try_from(fee).ok()?;
     Some((fee as u64, delta_fee as u64))
 }
 


### PR DESCRIPTION
#### Problem
The fee calculation when producing zk-proofs for the fees involve conditional branches, which results in non-constant-time execution. This could theoretically reveal information about the transfer amount.

#### Summary of Changes
Instead of dividing and checking whether remainder is zero, add by (dividend-1) and then divide. This results in a simpler round-up division without conditional branches.

The `checked_div` operation may still be implemented as non-constant-time ops by the rust compiler. Making the fee calculation completely constant-time will require a new division implementation. Since timing attacks are generally theoretical vulnerabilities, we opt to still use `checked_div` and then provide sufficient warning on non-constant-time execution for fee calculation.