### PR TITLE
zk-token-sdk: constant time equality check for elgamal and aes key derivation

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -16,6 +16,7 @@ use {
         signer::{Signer, SignerError},
     },
     std::{convert::TryInto, fmt},
+    subtle::ConstantTimeEq,
     zeroize::Zeroize,
 };
 
@@ -71,7 +72,7 @@ impl AeKey {
 
         // Some `Signer` implementations return the default signature, which is not suitable for
         // use as key material
-        if signature == Signature::default() {
+        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
             Err(SignerError::Custom("Rejecting default signature".into()))
         } else {
             Ok(AeKey(signature.as_ref()[..16].try_into().unwrap()))

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -166,7 +166,7 @@ impl ElGamalKeypair {
 
         // Some `Signer` implementations return the default signature, which is not suitable for
         // use as key material
-        if signature == Signature::default() {
+        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
             return Err(SignerError::Custom("Rejecting default signature".into()));
         }
 


### PR DESCRIPTION
#### Problem
Authenticated encryption and ElGamal secret key can be derived from the signing key for easier key management. Currently, the key derivation function runs in non-constant-time since it uses the vanilla bit-wise equality check.

#### Summary of Changes
Use the constant time equality provided by the `subtle` crate for key derivation.