### PR TITLE
Make CommitmentLevel constructors const

### DIFF
--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -60,19 +60,19 @@ impl CommitmentConfig {
         }
     }
 
-    pub fn finalized() -> Self {
+    pub const fn finalized() -> Self {
         Self {
             commitment: CommitmentLevel::Finalized,
         }
     }
 
-    pub fn confirmed() -> Self {
+    pub const fn confirmed() -> Self {
         Self {
             commitment: CommitmentLevel::Confirmed,
         }
     }
 
-    pub fn processed() -> Self {
+    pub const fn processed() -> Self {
         Self {
             commitment: CommitmentLevel::Processed,
         }


### PR DESCRIPTION
#### Problem
The `CommitmentConfig` constructors cannot be used in const contexts. This isn't a big problem because `CommitmentConfigs`'s only field is public, so sdk users can just use e.g. `CommitmentConfig{commitment: CommitmentLevel::Finalized}` instead of `CommitmentConfig::finalized()`, but using the latter would be a bit more convenient and there aren't any obvious-to-me reasons not to make the functions `const`.

#### Summary of Changes
Make the constructors `const`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
