### PR TITLE
add get_multiple_accounts to BenchTpsClient

### DIFF
--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -90,6 +90,8 @@ pub trait BenchTpsClient {
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> Result<Account>;
+
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>>;
 }
 
 mod bank_client;

--- a/bench-tps/src/bench_tps_client/bank_client.rs
+++ b/bench-tps/src/bench_tps_client/bank_client.rs
@@ -107,4 +107,8 @@ impl BenchTpsClient for BankClient {
                 })
             })
     }
+
+    fn get_multiple_accounts(&self, _pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        unimplemented!("BankClient doesn't support get_multiple_accounts");
+    }
 }

--- a/bench-tps/src/bench_tps_client/rpc_client.rs
+++ b/bench-tps/src/bench_tps_client/rpc_client.rs
@@ -99,4 +99,8 @@ impl BenchTpsClient for RpcClient {
                 })
             })
     }
+
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        RpcClient::get_multiple_accounts(self, pubkeys).map_err(|err| err.into())
+    }
 }

--- a/bench-tps/src/bench_tps_client/thin_client.rs
+++ b/bench-tps/src/bench_tps_client/thin_client.rs
@@ -104,4 +104,10 @@ impl BenchTpsClient for ThinClient {
                 })
             })
     }
+
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        self.rpc_client()
+            .get_multiple_accounts(pubkeys)
+            .map_err(|err| err.into())
+    }
 }

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -118,4 +118,10 @@ impl BenchTpsClient for TpuClient {
                 })
             })
     }
+
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        self.rpc_client()
+            .get_multiple_accounts(pubkeys)
+            .map_err(|err| err.into())
+    }
 }


### PR DESCRIPTION
#### Problem

It turned out that requesting durable nonce blockhashes one by one is too expensive. 
By requesting 100 of them (maximum possible), tps is x3 higher.

These changes will be used for https://github.com/solana-labs/solana/pull/27151
In particular, at this line: https://github.com/solana-labs/solana/blob/19de07a98633fd21e9a6ca100a2a0f1bd3f15c7b/bench-tps/src/bench.rs#L549

#### Summary of Changes

* add `get_multiple_accounts` to BenchTpsClient`
* note, that this method is not implemented for `BankClient` because neither `SyncClient` nor `AsyncClient` doesn't have it
