### PR TITLE
Update BigTable apis to respect a limit of zero

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -404,7 +404,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
     ///
     /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
     /// continue until the `rows_limit` is reached or the end of the table, whichever comes first.
-    /// If `rows_limit` is zero, the listing will continue until the end of the table.
+    /// If `rows_limit` is zero, this method will return an empty array.
     pub async fn get_row_keys(
         &mut self,
         table_name: &str,
@@ -412,6 +412,9 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         end_at: Option<RowKey>,
         rows_limit: i64,
     ) -> Result<Vec<RowKey>> {
+        if rows_limit == 0 {
+            return Ok(vec![]);
+        }
         self.refresh_access_token().await;
         let response = self
             .client
@@ -466,7 +469,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
     ///
     /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
     /// continue until the `rows_limit` is reached or the end of the table, whichever comes first.
-    /// If `rows_limit` is zero, the listing will continue until the end of the table.
+    /// If `rows_limit` is zero, this method will return an empty array.
     pub async fn get_row_data(
         &mut self,
         table_name: &str,
@@ -474,8 +477,10 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         end_at: Option<RowKey>,
         rows_limit: i64,
     ) -> Result<Vec<(RowKey, RowData)>> {
+        if rows_limit == 0 {
+            return Ok(vec![]);
+        }
         self.refresh_access_token().await;
-
         let response = self
             .client
             .read_rows(ReadRowsRequest {
@@ -516,7 +521,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
             .read_rows(ReadRowsRequest {
                 table_name: format!("{}{}", self.table_prefix, table_name),
                 app_profile_id: self.app_profile_id.clone(),
-                rows_limit: 0, // return all keys
+                rows_limit: 0, // return all existing rows
                 rows: Some(RowSet {
                     row_keys: row_keys
                         .iter()

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -460,8 +460,7 @@ impl LedgerStorage {
     /// Fetch the next slots after the provided slot that contains a block
     ///
     /// start_slot: slot to start the search from (inclusive)
-    /// limit: stop after this many slots have been found; if limit==0, all records in the table
-    /// after start_slot will be read
+    /// limit: stop after this many slots have been found
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
         debug!(
             "LedgerStorage::get_confirmed_blocks request received: {:?} {:?}",


### PR DESCRIPTION
#### Problem
`BigTable::get_row_*` apis unexpected return data when a limit of zero is passed.

#### Summary of Changes
Update two apis to respect the zero limit
