### PR TITLE
Featurize spinner in rpc-client and tpu-client

### DIFF
--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -24,7 +24,7 @@ solana-poh = { path = "../poh", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -18,7 +18,7 @@ solana-client = { path = "../client", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 tarpc = { version = "0.29.0", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -28,14 +28,14 @@ solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-metrics = { path = "../metrics", version = "=1.12.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
 solana-thin-client = { path = "../thin-client", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-version = { path = "../version", version = "=1.12.0" }
 thiserror = "1.0"
 

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -22,7 +22,7 @@ solana-perf = { path = "../perf", version = "=1.12.0" }
 solana-pubsub-client = { path = "../pubsub-client", version = "=1.12.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,7 +56,7 @@ solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 solana-version = { path = "../version", version = "=1.12.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -26,10 +26,10 @@ solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
 solana-perf = { path = "../perf", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -43,7 +43,7 @@ solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
 solana-thin-client = { path = "../thin-client", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-version = { path = "../version", version = "=1.12.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 thiserror = "1.0"

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -29,7 +29,7 @@ serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
 solana-config-program = { path = "../programs/config", version = "=1.12.0" }
 solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-version = { path = "../version", version = "=1.12.0" }
 tar = "0.4.38"

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -22,14 +22,14 @@ solana-entry = { path = "../entry", version = "=1.12.0" }
 solana-gossip = { path = "../gossip", version = "=1.12.0" }
 solana-ledger = { path = "../ledger", version = "=1.12.0" }
 solana-pubsub-client = { path = "../pubsub-client", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
 solana-thin-client = { path = "../thin-client", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 tempfile = "3.3.0"
 

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 clap = "2.33.0"
 solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0"
 

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1.57"
 base64 = "0.13.0"
 bincode = "1.3.3"
 bs58 = "0.4.0"
-indicatif = "0.17.0"
+indicatif = { version = "0.17.0", optional = true }
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.13"
@@ -35,6 +35,12 @@ crossbeam-channel = "0.5"
 futures = "0.3"
 jsonrpc-core = "18.0.0"
 jsonrpc-http-server = "18.0.0"
+
+[features]
+default = ["spinner"]
+# Support rpc-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = ["dep:indicatif"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -12,13 +12,14 @@ use solana_rpc_client_api::deprecated_config::{
     RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
     RpcGetConfirmedSignaturesForAddress2Config,
 };
+#[cfg(feature = "spinner")]
+use {crate::spinner, solana_sdk::clock::MAX_HASH_AGE_IN_SECONDS, std::cmp::min};
 use {
     crate::{
         http_sender::HttpSender,
         mock_sender::MockSender,
         rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClientConfig},
         rpc_sender::*,
-        spinner,
     },
     bincode::serialize,
     log::*,
@@ -38,7 +39,7 @@ use {
     },
     solana_sdk::{
         account::Account,
-        clock::{Epoch, Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT, MAX_HASH_AGE_IN_SECONDS},
+        clock::{Epoch, Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT},
         commitment_config::{CommitmentConfig, CommitmentLevel},
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
@@ -55,7 +56,6 @@ use {
     },
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
     std::{
-        cmp::min,
         net::SocketAddr,
         str::FromStr,
         time::{Duration, Instant},
@@ -278,10 +278,10 @@ impl RpcClient {
     /// The URL is an HTTP URL, usually for port 8899, as in
     /// "http://localhost:8899".
     ///
-    /// The `confirm_transaction_initial_timeout` argument specifies, when
+    /// The `confirm_transaction_initial_timeout` argument specifies the amount of
+    /// time to allow for the server to initially process a transaction, when
     /// confirming a transaction via one of the `_with_spinner` methods, like
-    /// [`RpcClient::send_and_confirm_transaction_with_spinner`], the amount of
-    /// time to allow for the server to initially process a transaction. In
+    /// [`RpcClient::send_and_confirm_transaction_with_spinner`]. In
     /// other words, setting `confirm_transaction_initial_timeout` to > 0 allows
     /// `RpcClient` to wait for confirmation of a transaction that the server
     /// has not "seen" yet.
@@ -708,6 +708,7 @@ impl RpcClient {
         .into())
     }
 
+    #[cfg(feature = "spinner")]
     pub async fn send_and_confirm_transaction_with_spinner(
         &self,
         transaction: &Transaction,
@@ -719,6 +720,7 @@ impl RpcClient {
         .await
     }
 
+    #[cfg(feature = "spinner")]
     pub async fn send_and_confirm_transaction_with_spinner_and_commitment(
         &self,
         transaction: &Transaction,
@@ -735,6 +737,7 @@ impl RpcClient {
         .await
     }
 
+    #[cfg(feature = "spinner")]
     pub async fn send_and_confirm_transaction_with_spinner_and_config(
         &self,
         transaction: &Transaction,
@@ -1124,6 +1127,7 @@ impl RpcClient {
         })
     }
 
+    #[cfg(feature = "spinner")]
     pub async fn confirm_transaction_with_spinner(
         &self,
         signature: &Signature,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -308,10 +308,10 @@ impl RpcClient {
     /// The URL is an HTTP URL, usually for port 8899, as in
     /// "http://localhost:8899".
     ///
-    /// The `confirm_transaction_initial_timeout` argument specifies, when
+    /// The `confirm_transaction_initial_timeout` argument specifies the amount of
+    /// time to allow for the server to initially process a transaction, when
     /// confirming a transaction via one of the `_with_spinner` methods, like
-    /// [`RpcClient::send_and_confirm_transaction_with_spinner`], the amount of
-    /// time to allow for the server to initially process a transaction. In
+    /// [`RpcClient::send_and_confirm_transaction_with_spinner`]. In
     /// other words, setting `confirm_transaction_initial_timeout` to > 0 allows
     /// `RpcClient` to wait for confirmation of a transaction that the server
     /// has not "seen" yet.
@@ -631,6 +631,7 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).send_and_confirm_transaction(transaction))
     }
 
+    #[cfg(feature = "spinner")]
     pub fn send_and_confirm_transaction_with_spinner(
         &self,
         transaction: &Transaction,
@@ -640,6 +641,7 @@ impl RpcClient {
         )
     }
 
+    #[cfg(feature = "spinner")]
     pub fn send_and_confirm_transaction_with_spinner_and_commitment(
         &self,
         transaction: &Transaction,
@@ -651,6 +653,7 @@ impl RpcClient {
         )
     }
 
+    #[cfg(feature = "spinner")]
     pub fn send_and_confirm_transaction_with_spinner_and_config(
         &self,
         transaction: &Transaction,
@@ -949,6 +952,7 @@ impl RpcClient {
         )
     }
 
+    #[cfg(feature = "spinner")]
     pub fn confirm_transaction_with_spinner(
         &self,
         signature: &Signature,

--- a/rpc-client/src/spinner.rs
+++ b/rpc-client/src/spinner.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "spinner")]
 //! Spinner creator
 
 use {

--- a/rpc-client/src/spinner.rs
+++ b/rpc-client/src/spinner.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "spinner")]
-//! Spinner creator
+//! Spinner creator.
+//! This module is wrapped by the `spinner` feature, which is on by default.
+//! It can be disabled and the dependency on `indicatif` avoided by running
+//! with `default-features = false`
 
 use {
     indicatif::{ProgressBar, ProgressStyle},

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -22,12 +22,12 @@ serde_json = "1.0.83"
 solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
 solana-pubsub-client = { path = "../pubsub-client", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
 solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 tokio = { version = "~1.14.1", features = ["full"] }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -46,7 +46,7 @@ solana-send-transaction-service = { path = "../send-transaction-service", versio
 solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 solana-version = { path = "../version", version = "=1.12.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -16,7 +16,7 @@ solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-metrics = { path = "../metrics", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.12.0" }

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -25,11 +25,11 @@ solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
 solana-program-test = { path = "../program-test", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/thin-client/Cargo.toml
+++ b/thin-client/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 [dependencies]
 bincode = "1.3.3"
 log = "0.4.17"
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 
 [dev-dependencies]
 rayon = "1.5.3"

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -17,7 +17,7 @@ enum_dispatch = "0.3.8"
 futures = "0.3"
 futures-util = "0.3.21"
 indexmap = "1.9.1"
-indicatif = "0.17.0"
+indicatif = { version = "0.17.0", optional = true }
 itertools = "0.10.2"
 lazy_static = "1.4.0"
 log = "0.4.17"
@@ -31,7 +31,7 @@ solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-metrics = { path = "../metrics", version = "=1.12.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
 solana-pubsub-client = { path = "../pubsub-client", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
@@ -43,6 +43,12 @@ crossbeam-channel = "0.5"
 rand_chacha = "0.2.2"
 solana-logger = { path = "../logger", version = "=1.12.0" }
 solana-perf = { path = "../perf", version = "=1.12.0" }
+
+[features]
+default = ["spinner"]
+# Support tpu-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = ["dep:indicatif", "solana-rpc-client/spinner"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -1,32 +1,33 @@
+#[cfg(feature = "spinner")]
+use {
+    crate::tpu_client::{SEND_TRANSACTION_INTERVAL, TRANSACTION_RESEND_INTERVAL},
+    indicatif::ProgressBar,
+    solana_rpc_client::spinner,
+    solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
+    solana_sdk::{message::Message, signers::Signers, transaction::TransactionError},
+};
 use {
     crate::{
         connection_cache::ConnectionCache,
         nonblocking::tpu_connection::TpuConnection,
-        tpu_client::{
-            RecentLeaderSlots, TpuClientConfig, MAX_FANOUT_SLOTS, SEND_TRANSACTION_INTERVAL,
-            TRANSACTION_RESEND_INTERVAL,
-        },
+        tpu_client::{RecentLeaderSlots, TpuClientConfig, MAX_FANOUT_SLOTS},
     },
     bincode::serialize,
     futures_util::{future::join_all, stream::StreamExt},
-    indicatif::ProgressBar,
     log::*,
     solana_pubsub_client::nonblocking::pubsub_client::{PubsubClient, PubsubClientError},
-    solana_rpc_client::{nonblocking::rpc_client::RpcClient, spinner},
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
         client_error::{Error as ClientError, Result as ClientResult},
-        request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
         response::{RpcContactInfo, SlotUpdate},
     },
     solana_sdk::{
         clock::Slot,
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
-        message::Message,
         pubkey::Pubkey,
         signature::SignerError,
-        signers::Signers,
-        transaction::{Transaction, TransactionError},
+        transaction::Transaction,
         transport::{Result as TransportResult, TransportError},
     },
     std::{
@@ -326,6 +327,7 @@ impl TpuClient {
         })
     }
 
+    #[cfg(feature = "spinner")]
     pub async fn send_and_confirm_messages_with_spinner<T: Signers>(
         &self,
         messages: &[Message],
@@ -667,6 +669,7 @@ async fn maybe_fetch_cache_info(
     }
 }
 
+#[cfg(feature = "spinner")]
 fn set_message_for_confirmed_transactions(
     progress_bar: &ProgressBar,
     confirmed_transactions: u32,

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -5,18 +5,16 @@ use {
         nonblocking::tpu_client::TpuClient as NonblockingTpuClient,
     },
     solana_rpc_client::rpc_client::RpcClient,
-    solana_sdk::{
-        clock::Slot,
-        message::Message,
-        signers::Signers,
-        transaction::{Transaction, TransactionError},
-        transport::Result as TransportResult,
-    },
+    solana_sdk::{clock::Slot, transaction::Transaction, transport::Result as TransportResult},
     std::{
         collections::VecDeque,
         net::UdpSocket,
         sync::{Arc, RwLock},
     },
+};
+#[cfg(feature = "spinner")]
+use {
+    solana_sdk::{message::Message, signers::Signers, transaction::TransactionError},
     tokio::time::Duration,
 };
 
@@ -29,8 +27,10 @@ pub const DEFAULT_FANOUT_SLOTS: u64 = 12;
 pub const MAX_FANOUT_SLOTS: u64 = 100;
 
 /// Send at ~100 TPS
+#[cfg(feature = "spinner")]
 pub(crate) const SEND_TRANSACTION_INTERVAL: Duration = Duration::from_millis(10);
 /// Retry batch send after 4 seconds
+#[cfg(feature = "spinner")]
 pub(crate) const TRANSACTION_RESEND_INTERVAL: Duration = Duration::from_secs(4);
 
 /// Config params for `TpuClient`
@@ -124,6 +124,7 @@ impl TpuClient {
         })
     }
 
+    #[cfg(feature = "spinner")]
     pub fn send_and_confirm_messages_with_spinner<T: Signers>(
         &self,
         messages: &[Message],

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -23,7 +23,7 @@ solana-gossip = { path = "../gossip", version = "=1.12.0" }
 solana-logger = { path = "../logger", version = "=1.12.0" }
 solana-measure = { path = "../measure", version = "=1.12.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -45,7 +45,7 @@ solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
 solana-perf = { path = "../perf", version = "=1.12.0" }
 solana-poh = { path = "../poh", version = "=1.12.0" }
 solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-runtime = { path = "../runtime", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
@@ -53,7 +53,7 @@ solana-send-transaction-service = { path = "../send-transaction-service", versio
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
 solana-streamer = { path = "../streamer", version = "=1.12.0" }
 solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
-solana-tpu-client = { path = "../tpu-client", version = "=1.12.0" }
+solana-tpu-client = { path = "../tpu-client", version = "=1.12.0", default-features = false }
 solana-version = { path = "../version", version = "=1.12.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 symlink = "0.1.0"

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -19,7 +19,7 @@ solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
 solana-logger = { path = "../logger", version = "=1.12.0" }
 solana-metrics = { path = "../metrics", version = "=1.12.0" }
 solana-notifier = { path = "../notifier", version = "=1.12.0" }
-solana-rpc-client = { path = "../rpc-client", version = "=1.12.0" }
+solana-rpc-client = { path = "../rpc-client", version = "=1.12.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.12.0" }
 solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana-version = { path = "../version", version = "=1.12.0" }


### PR DESCRIPTION
#### Problem
As per https://github.com/solana-labs/solana/pull/27246#discussion_r953005270, the client progress bars pull in dependencies that are only useful when building a command-line tool.

#### Summary of Changes
Wrap `spinner` module and client methods that use it in a `spinner` feature in rpc-client and tpu-client
This is currently an "opt-out" feature (on by default); I went back and forth on this, but landed on this direction because I was worried that docs.rs wouldn't display the docs for the feature-wrapped apis if spinner was off by default


Toward #27352
