### PR TITLE
Fix startup panic if removing accounts directory fails

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2076,7 +2076,12 @@ fn move_and_async_delete_path(path: impl AsRef<Path> + Copy) {
             "Path renaming failed: {}.  Falling back to rm_dir in sync mode",
             err.to_string()
         );
-        std::fs::remove_dir_all(&path).unwrap();
+        if let Err(e) = std::fs::remove_dir_all(&path) {
+            warn!(
+                "encountered error removing accounts path: {:?}: {}",
+                path.as_ref(), e
+            );
+        }
         return;
     }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2094,36 +2094,34 @@ fn move_and_async_delete_path(path: impl AsRef<Path> + Copy) {
 /// delete the contents of that directory.
 fn delete_contents_of_path(path: impl AsRef<Path> + Copy) {
     if let Ok(dir_entries) = std::fs::read_dir(&path) {
-        for dir_entry in dir_entries {
-            if let Ok(entry) = dir_entry {
-                let sub_path = entry.path();
-                let metadata = match entry.metadata() {
-                    Ok(metadata) => metadata,
-                    Err(err) => {
-                        warn!(
-                            "Failed to get metadata for {}. Error: {}",
-                            sub_path.display(),
-                            err.to_string()
-                        );
-                        break;
-                    }
-                };
-                if metadata.is_dir() {
-                    if let Err(err) = std::fs::remove_dir_all(&sub_path) {
-                        warn!(
-                            "Failed to remove sub directory {}.  Error: {}",
-                            sub_path.display(),
-                            err.to_string()
-                        );
-                    }
-                } else {
-                    if let Err(err) = std::fs::remove_file(&sub_path) {
-                        warn!(
-                            "Failed to remove file {}.  Error: {}",
-                            sub_path.display(),
-                            err.to_string()
-                        );
-                    }
+        for entry in dir_entries.flatten() {
+            let sub_path = entry.path();
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(err) => {
+                    warn!(
+                        "Failed to get metadata for {}. Error: {}",
+                        sub_path.display(),
+                        err.to_string()
+                    );
+                    break;
+                }
+            };
+            if metadata.is_dir() {
+                if let Err(err) = std::fs::remove_dir_all(&sub_path) {
+                    warn!(
+                        "Failed to remove sub directory {}.  Error: {}",
+                        sub_path.display(),
+                        err.to_string()
+                    );
+                }
+            } else if metadata.is_file() {
+                if let Err(err) = std::fs::remove_file(&sub_path) {
+                    warn!(
+                        "Failed to remove file {}.  Error: {}",
+                        sub_path.display(),
+                        err.to_string()
+                    );
                 }
             }
         }


### PR DESCRIPTION
#### Problem
If the validator does not have permission to delete the directory passed with the `--accounts` arg the validator will panic on startup.

#### Summary of Changes
Catch error and log warning.

I'm starting this on mce2 at the moment. It's past the warning and looks good but I'll wait for it to catch up to be sure.

Fixes #27350