### PR TITLE
replay: signal exit when main loop breaks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -910,7 +910,10 @@ impl ReplayStage {
                         let result = ledger_signal_receiver.recv_timeout(timer);
                         match result {
                             Err(RecvTimeoutError::Timeout) => (),
-                            Err(_) => break,
+                            Err(err) => {
+                                error!("exiting! ledger_signal_receiver error: {}", err);
+                                break;
+                            }
                             Ok(_) => trace!("blockstore signal"),
                         };
                     }
@@ -937,6 +940,10 @@ impl ReplayStage {
                         retransmit_not_propagated_time.as_us(),
                     );
                 }
+
+                // signal app exit in case we've broken the loop by means other
+                // than having observed an exit signal
+                exit.store(true, Ordering::Relaxed);
             })
             .unwrap();
 


### PR DESCRIPTION
#### Problem

we don't signal app exit when the replay stage loop breaks for reasons other than having observed an app exit signal. namely, [when the final blockstore signal sender is dropped](https://github.com/solana-labs/solana/blob/2da93bd45a840ce66294ddf5decdf94c17bfbef3/core/src/replay_stage.rs#L913).  this can leave any service threads not in the magic web of channels running and the appearance of a running validator to the naive observer

#### Summary of Changes

unconditionally signal app exit upon leaving the replay stage main loop

calling in the old farts for review on this one since it's been around since 2019
