### PR TITLE
zk-token-sdk:add length checks

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -18,7 +18,6 @@ use {
         discrete_log::DiscreteLog,
         pedersen::{Pedersen, PedersenCommitment, PedersenOpening, G, H},
     },
-    arrayref::{array_ref, array_refs},
     core::ops::{Add, Mul, Sub},
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
@@ -195,8 +194,12 @@ impl ElGamalKeypair {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != 64 {
+            return None;
+        }
+
         Some(Self {
-            public: ElGamalPubkey::from_bytes(bytes[..32].try_into().ok()?)?,
+            public: ElGamalPubkey::from_bytes(&bytes[..32])?,
             secret: ElGamalSecretKey::from_bytes(bytes[32..].try_into().ok()?)?,
         })
     }
@@ -276,7 +279,11 @@ impl ElGamalPubkey {
         self.0.compress().to_bytes()
     }
 
-    pub fn from_bytes(bytes: &[u8; 32]) -> Option<ElGamalPubkey> {
+    pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalPubkey> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
         Some(ElGamalPubkey(
             CompressedRistretto::from_slice(bytes).decompress()?,
         ))
@@ -375,8 +382,11 @@ impl ElGamalSecretKey {
         self.0.to_bytes()
     }
 
-    pub fn from_bytes(bytes: [u8; 32]) -> Option<ElGamalSecretKey> {
-        Scalar::from_canonical_bytes(bytes).map(ElGamalSecretKey)
+    pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalSecretKey> {
+        match bytes.try_into() {
+            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(ElGamalSecretKey),
+            _ => None,
+        }
     }
 }
 
@@ -431,15 +441,13 @@ impl ElGamalCiphertext {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalCiphertext> {
-        let bytes = array_ref![bytes, 0, 64];
-        let (commitment, handle) = array_refs![bytes, 32, 32];
-
-        let commitment = CompressedRistretto::from_slice(commitment).decompress()?;
-        let handle = CompressedRistretto::from_slice(handle).decompress()?;
+        if bytes.len() != 64 {
+            return None;
+        }
 
         Some(ElGamalCiphertext {
-            commitment: PedersenCommitment(commitment),
-            handle: DecryptHandle(handle),
+            commitment: PedersenCommitment::from_bytes(&bytes[..32])?,
+            handle: DecryptHandle::from_bytes(&bytes[32..])?,
         })
     }
 
@@ -549,6 +557,10 @@ impl DecryptHandle {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Option<DecryptHandle> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
         Some(DecryptHandle(
             CompressedRistretto::from_slice(bytes).decompress()?,
         ))

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -176,6 +176,10 @@ impl PedersenCommitment {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Option<PedersenCommitment> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
         Some(PedersenCommitment(
             CompressedRistretto::from_slice(bytes).decompress()?,
         ))

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -205,6 +205,10 @@ impl CtxtCommEqualityProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, EqualityProofError> {
+        if bytes.len() != 192 {
+            return Err(EqualityProofError::Format);
+        }
+
         let bytes = array_ref![bytes, 0, 192];
         let (Y_0, Y_1, Y_2, z_s, z_x, z_r) = array_refs![bytes, 32, 32, 32, 32, 32, 32];
 
@@ -424,6 +428,10 @@ impl CtxtCtxtEqualityProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, EqualityProofError> {
+        if bytes.len() != 224 {
+            return Err(EqualityProofError::Format);
+        }
+
         let bytes = array_ref![bytes, 0, 224];
         let (Y_0, Y_1, Y_2, Y_3, z_s, z_x, z_r) = array_refs![bytes, 32, 32, 32, 32, 32, 32, 32];
 

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -352,6 +352,10 @@ impl FeeSigmaProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, FeeSigmaProofError> {
+        if bytes.len() != 256 {
+            return Err(FeeSigmaProofError::Format);
+        }
+
         let bytes = array_ref![bytes, 0, 256];
         let (Y_max_proof, z_max_proof, c_max_proof, Y_delta, Y_claimed, z_x, z_delta, z_claimed) =
             array_refs![bytes, 32, 32, 32, 32, 32, 32, 32, 32];

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -193,6 +193,10 @@ impl ValidityProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidityProofError> {
+        if bytes.len() != 160 {
+            return Err(ValidityProofError::Format);
+        }
+
         let bytes = array_ref![bytes, 0, 160];
         let (Y_0, Y_1, Y_2, z_r, z_x) = array_refs![bytes, 32, 32, 32, 32, 32];
 

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -152,6 +152,10 @@ impl ZeroBalanceProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ZeroBalanceProofError> {
+        if bytes.len() != 96 {
+            return Err(ZeroBalanceProofError::Format);
+        }
+
         let bytes = array_ref![bytes, 0, 96];
         let (Y_P, Y_D, z) = array_refs![bytes, 32, 32, 32];
 


### PR DESCRIPTION
#### Problem
Currently, the decoding of some of the cryptographic objects in the zk-token-sdk could panic when the supplied byte slice is of different size.

#### Summary of Changes
Add length checks on slices during decoding of cryptographic objects.