### PR TITLE
Avoid account copy by taking writable accounts from the readonly cache

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -285,10 +285,11 @@ impl Accounts {
                         {
                             (account_override.clone(), 0)
                         } else {
+                            let is_writable = message.is_writable(i);
                             self.accounts_db
-                                .load_with_fixed_root(ancestors, key, true)
+                                .load_with_fixed_root(ancestors, key, is_writable)
                                 .map(|(mut account, _)| {
-                                    if message.is_writable(i) {
+                                    if is_writable {
                                         let rent_due = rent_collector
                                             .collect_from_existing_account(
                                                 key,


### PR DESCRIPTION
#### Problem

If an account stored in the readonly cache needs to be written to during a transaction, a copy is required since the cache holds a strong refcount to the account data.

#### Summary of Changes

Opportunistically take the account from the readonly cache instead of copying. If the transaction that writes to the account ends up being discarded, the next time the account is accessed it will be retrieved again from disk and reinserted in the cache.