### PR TITLE
Refactor: `InstructionContext::configure()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -349,7 +349,9 @@ impl<'a> InvokeContext<'a> {
 
         self.syscall_context.push(None);
         self.transaction_context
-            .push(program_indices, instruction_accounts, instruction_data)
+            .get_next_instruction_context()?
+            .configure(program_indices, instruction_accounts, instruction_data);
+        self.transaction_context.push()
     }
 
     /// Pop a stack frame from the invocation stack

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -106,8 +106,10 @@ fn create_inputs() -> TransactionContext {
         TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .push(&[0], &instruction_accounts, &instruction_data)
-        .unwrap();
+        .get_next_instruction_context()
+        .unwrap()
+        .configure(&[0], &instruction_accounts, &instruction_data);
+    transaction_context.push().unwrap();
     transaction_context
 }
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -502,8 +502,10 @@ mod tests {
             let mut transaction_context =
                 TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
             transaction_context
-                .push(&program_indices, &instruction_accounts, &instruction_data)
-                .unwrap();
+                .get_next_instruction_context()
+                .unwrap()
+                .configure(&program_indices, &instruction_accounts, &instruction_data);
+            transaction_context.push().unwrap();
             let instruction_context = transaction_context
                 .get_instruction_context_at_index_in_trace(0)
                 .unwrap();

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -649,12 +649,15 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
-            .push(
-                &preparation.instruction_accounts,
+            .transaction_context
+            .get_next_instruction_context()
+            .unwrap()
+            .configure(
                 &program_indices,
+                &preparation.instruction_accounts,
                 &instruction_data,
-            )
-            .unwrap();
+            );
+        invoke_context.push().unwrap();
         let instruction_context = invoke_context
             .transaction_context
             .get_current_instruction_context()

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3253,8 +3253,10 @@ mod tests {
                     is_writable: false,
                 }];
                 transaction_context
-                    .push(&[0], &instruction_accounts, &[index_in_trace as u8])
-                    .unwrap();
+                    .get_next_instruction_context()
+                    .unwrap()
+                    .configure(&[0], &instruction_accounts, &[index_in_trace as u8]);
+                transaction_context.push().unwrap();
             }
         }
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2023,7 +2023,12 @@ mod tests {
             let mut $transaction_context =
                 TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
             let mut $invoke_context = InvokeContext::new_mock(&mut $transaction_context, &[]);
-            $invoke_context.push(&[], &[0, 1], &[]).unwrap();
+            $invoke_context
+                .transaction_context
+                .get_next_instruction_context()
+                .unwrap()
+                .configure(&[0, 1], &[], &[]);
+            $invoke_context.push().unwrap();
         };
     }
 
@@ -3397,9 +3402,11 @@ mod tests {
         ];
         let mut transaction_context =
             TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context
-            .push(
+        transaction_context
+            .get_next_instruction_context()
+            .unwrap()
+            .configure(
+                &[0, 1],
                 &[
                     InstructionAccount {
                         index_in_transaction: 2,
@@ -3416,10 +3423,10 @@ mod tests {
                         is_writable: true,
                     },
                 ],
-                &[0, 1],
                 &[],
-            )
-            .unwrap();
+            );
+        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+        invoke_context.push().unwrap();
 
         let keys = [loader_key];
         let updates_list = [

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -115,8 +115,11 @@ fn bench_process_vote_instruction(
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
-            .push(&instruction_accounts, &[0], &instruction_data)
-            .unwrap();
+            .transaction_context
+            .get_next_instruction_context()
+            .unwrap()
+            .configure(&[0], &instruction_accounts, &instruction_data);
+        invoke_context.push().unwrap();
         assert!(
             solana_vote_program::vote_processor::process_instruction(1, &mut invoke_context)
                 .is_ok()

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -224,12 +224,15 @@ native machine code before execting it in the virtual machine.",
     );
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     invoke_context
-        .push(
-            &preparation.instruction_accounts,
+        .transaction_context
+        .get_next_instruction_context()
+        .unwrap()
+        .configure(
             &program_indices,
+            &preparation.instruction_accounts,
             &instruction_data,
-        )
-        .unwrap();
+        );
+    invoke_context.push().unwrap();
     let (mut parameter_bytes, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,
         invoke_context

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -18849,8 +18849,10 @@ pub(crate) mod tests {
             }
             if stack_height > transaction_context.get_instruction_context_stack_height() {
                 transaction_context
-                    .push(&[], &[], &[index_in_trace as u8])
-                    .unwrap();
+                    .get_next_instruction_context()
+                    .unwrap()
+                    .configure(&[], &[], &[index_in_trace as u8]);
+                transaction_context.push().unwrap();
             }
         }
         let inner_instructions =

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -288,8 +288,11 @@ mod test {
     macro_rules! push_instruction_context {
         ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
-                .push(&$instruction_accounts, &[2], &[])
-                .unwrap();
+                .transaction_context
+                .get_next_instruction_context()
+                .unwrap()
+                .configure(&[2], &$instruction_accounts, &[]);
+            $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context
                 .get_current_instruction_context()

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -428,13 +428,13 @@ impl InstructionContext {
     #[cfg(not(target_os = "solana"))]
     pub fn configure(
         &mut self,
-        program_accounts: Vec<usize>,
-        instruction_accounts: Vec<InstructionAccount>,
-        instruction_data: Vec<u8>,
+        program_accounts: &[usize],
+        instruction_accounts: &[InstructionAccount],
+        instruction_data: &[u8],
     ) {
-        self.program_accounts = program_accounts;
-        self.instruction_accounts = instruction_accounts;
-        self.instruction_data = instruction_data;
+        self.program_accounts = program_accounts.to_vec();
+        self.instruction_accounts = instruction_accounts.to_vec();
+        self.instruction_data = instruction_data.to_vec();
     }
 
     /// How many Instructions were on the stack after this one was pushed

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -544,15 +544,12 @@ impl InstructionContext {
         &'a self,
         transaction_context: &'b TransactionContext,
     ) -> Result<&'b Pubkey, InstructionError> {
-        let result = self
-            .get_index_of_program_account_in_transaction(
-                self.program_accounts.len().saturating_sub(1),
-            )
-            .and_then(|index_in_transaction| {
-                transaction_context.get_key_of_account_at_index(index_in_transaction)
-            });
-        debug_assert!(result.is_ok());
-        result
+        self.get_index_of_program_account_in_transaction(
+            self.program_accounts.len().saturating_sub(1),
+        )
+        .and_then(|index_in_transaction| {
+            transaction_context.get_key_of_account_at_index(index_in_transaction)
+        })
     }
 
     fn try_borrow_account<'a, 'b: 'a>(

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -202,9 +202,10 @@ impl TransactionContext {
         self.account_keys.iter().rposition(|key| key == pubkey)
     }
 
-    /// Returns instruction trace length
+    /// Returns the instruction trace length.
     ///
-    /// Not counting the empty `InstructionContext` at the end.
+    /// Not counting the last empty InstructionContext which is always pre-reserved for the next instruction.
+    /// See also `get_next_instruction_context()`.
     pub fn get_instruction_trace_length(&self) -> usize {
         self.instruction_trace.len().saturating_sub(1)
     }
@@ -253,7 +254,9 @@ impl TransactionContext {
         self.get_instruction_context_at_nesting_level(level)
     }
 
-    /// Returns the InstructionContext to configure for the next invocation
+    /// Returns the InstructionContext to configure for the next invocation.
+    ///
+    /// The last InstructionContext is always empty and pre-reserved for the next instruction.
     pub fn get_next_instruction_context(
         &mut self,
     ) -> Result<&mut InstructionContext, InstructionError> {


### PR DESCRIPTION
#### Problem
Preparation for ABIv2 so that SBF programs can write into the last `InstructionContext` of the `TransactionContext::transaction_trace` directly. This way the CPI syscall of ABIv2 does not need to copy any `Instruction` data (see https://github.com/solana-labs/solana/issues/27384).

#### Summary of Changes
- Replaces `InstructionContext::new()` by `InstructionContext::configure()`.
- Adds `TransactionContext::get_next_instruction_context()`.
- Hoists `InstructionContext::configure()` from `TransactionContext::push()` and `InvokeContext::push()` into `InvokeContext::process_instruction()`.
- Switches back to using references as parameters for `InstructionContext::configure()`.