### PR TITLE
Switch concurrent replay from feature to param

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -84,6 +84,7 @@ pub struct TvuConfig {
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
     pub wait_for_vote_to_start_leader: bool,
+    pub replay_slots_concurrently: bool,
 }
 
 impl Tvu {
@@ -237,6 +238,7 @@ impl Tvu {
             ancestor_hashes_replay_update_sender,
             tower_storage: tower_storage.clone(),
             wait_to_vote_slot,
+            replay_slots_concurrently: tvu_config.replay_slots_concurrently,
         };
 
         let (voting_sender, voting_receiver) = unbounded();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -175,6 +175,7 @@ pub struct ValidatorConfig {
     pub wait_to_vote_slot: Option<Slot>,
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
+    pub replay_slots_concurrently: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -238,6 +239,7 @@ impl Default for ValidatorConfig {
             wait_to_vote_slot: None,
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
+            replay_slots_concurrently: false,
         }
     }
 }
@@ -982,6 +984,7 @@ impl Validator {
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
                 wait_for_vote_to_start_leader,
+                replay_slots_concurrently: config.replay_slots_concurrently,
             },
             &max_slots,
             &cost_model,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -65,6 +65,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wait_to_vote_slot: config.wait_to_vote_slot,
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
+        replay_slots_concurrently: config.replay_slots_concurrently,
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7523,11 +7523,6 @@ impl Bank {
             .is_active(&feature_set::preserve_rent_epoch_for_rent_exempt_accounts::id())
     }
 
-    pub fn concurrent_replay_of_forks(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::concurrent_replay_of_forks::id())
-    }
-
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {
         self.cost_tracker.read()
     }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -486,10 +486,6 @@ pub mod sign_repair_requests {
     solana_sdk::declare_id!("sigrs6u1EWeHuoKFkY8RR7qcSsPmrAeBBPESyf5pnYe");
 }
 
-pub mod concurrent_replay_of_forks {
-    solana_sdk::declare_id!("9F2Dcu8xkBPKxiiy65XKPZYdCG3VZDpjDTuSmeYLozJe");
-}
-
 pub mod check_ping_ancestor_requests {
     solana_sdk::declare_id!("AXLB87anNaUQtqBSsxkm4gvNzYY985aLtNtpJC94uWLJ");
 }
@@ -630,7 +626,6 @@ lazy_static! {
         (use_default_units_in_fee_calculation::id(), "use default units per instruction in fee calculation #26785"),
         (compact_vote_state_updates::id(), "Compact vote state updates to lower block size"),
         (sign_repair_requests::id(), "sign repair requests #26834"),
-        (concurrent_replay_of_forks::id(), "Allow slots from different forks to be replayed concurrently #26465"),
         (check_ping_ancestor_requests::id(), "ancestor hash repair socket ping/pong support #26963"),
         (incremental_snapshot_only_incremental_hash_calculation::id(), "only hash accounts in incremental snapshot during incremental snapshot creation #26799"),
         (disable_cpi_setting_executable_and_rent_epoch::id(), "disable setting is_executable and_rent_epoch in CPI #26987"),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1819,6 +1819,11 @@ pub fn main() {
                 .value_name("BYTES")
                 .help("Maximum number of bytes written to the program log before truncation")
         )
+        .arg(
+            Arg::with_name("replay_slots_concurrently")
+                .long("replay-slots-concurrently")
+                .help("Allow concurrent replay of slots on different forks")
+        )
         .after_help("The default subcommand is run")
         .subcommand(
             SubCommand::with_name("exit")
@@ -1992,11 +1997,6 @@ pub fn main() {
                 Arg::with_name("skip_new_snapshot_check")
                     .long("skip-new-snapshot-check")
                     .help("Skip check for a new snapshot")
-            )
-            .arg(
-                Arg::with_name("replay_slots_concurrently")
-                    .long("replay-slots-concurrently")
-                    .help("Allow concurrent replay of slots on different forks.")
             )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1993,6 +1993,11 @@ pub fn main() {
                     .long("skip-new-snapshot-check")
                     .help("Skip check for a new snapshot")
             )
+            .arg(
+                Arg::with_name("replay_slots_concurrently")
+                    .long("replay-slots-concurrently")
+                    .help("Allow concurrent replay of slots on different forks.")
+            )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")
         )
@@ -2759,6 +2764,7 @@ pub fn main() {
             ..RuntimeConfig::default()
         },
         staked_nodes_overrides: staked_nodes_overrides.clone(),
+        replay_slots_concurrently: matches.is_present("replay_slots_concurrently"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
Concurrent slot replay has been merged but is currently not active and controlled by a feature switch. Feature switch is unnecessary in this case, and parameter would allow some set of validators to opt in to testing this capability.

#### Summary of Changes
Add `replay_slots_concurrently` parameter to enable replaying of slots from different forks concurrently during replay stage.
