### PR TITLE
rpc-sts: respect app exit in tx receiver thread

### DIFF
--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -414,7 +414,11 @@ impl SendTransactionService {
             .spawn(move || loop {
                 let recv_timeout_ms = config.batch_send_rate_ms;
                 let stats = &stats_report.stats;
-                match receiver.recv_timeout(Duration::from_millis(recv_timeout_ms)) {
+                let recv_result = receiver.recv_timeout(Duration::from_millis(recv_timeout_ms));
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                match recv_result {
                     Err(RecvTimeoutError::Disconnected) => {
                         info!("Terminating send-transaction-service.");
                         exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

RPC STS ignores app exit, zombieing the process in some fatal error cases

#### Summary of Changes

check exit signal in tx receiver thread loop
