### PR TITLE
Watchtower improvements

### DIFF
--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -60,6 +60,7 @@ impl HttpSender {
             reqwest::Client::builder()
                 .default_headers(default_headers)
                 .timeout(timeout)
+                .pool_idle_timeout(timeout)
                 .build()
                 .expect("build rpc client"),
         );


### PR DESCRIPTION
#### Problem

There are two problems with current `solana-watchtower`:

1. It is not always possible to tell to which cluster certain error message belongs if two `solana-watchtower` processes (one for the Testnet and one for the Mainnet) send notifications into the same one channel.
2. `Error: rpc-error: error sending request for url (https://api.testnet.solana.com/): connection closed before message completed` every two minutes. This problem seems to be rare and depends on ISP. Quick search on Discord shows that I am not the only one affected: 
![image](https://user-images.githubusercontent.com/18099621/186822048-b7a9a66c-b99c-44ee-b4eb-9b617139ec4d.png)

#### Summary of Changes

* `Add watchtower option to add custom string into notifications` addresses first problem.
* `Add a builder for an HttpSender to support more client options` makes HTTP RPC client more configurable, with a possibility to add more configuration options in future.
* `Add watchtower option to specify RPC timeout` makes HTTP RPC timeout adjustable for `solana-watchtower`. This does not fix anything for me, but I decided to keep it as `solana` CLI has `--rpc-timeout` option too.
* `Allow reducing HTTP's pool idle timeout in watchtower` addresses second problem. As an alternative solution I also tried to enable TCP keeplive, without any success.