### PR TITLE
feat: add VersionedMessage.deserializeMessageVersion utility function

### DIFF
--- a/web3.js/test/message-tests/versioned.test.ts
+++ b/web3.js/test/message-tests/versioned.test.ts
@@ -1,0 +1,28 @@
+import {expect} from 'chai';
+
+import {VersionedMessage} from '../../src/message';
+
+describe('VersionedMessage', () => {
+  it('deserializeMessageVersion', () => {
+    const bufferWithLegacyPrefix = new Uint8Array([1]);
+    expect(
+      VersionedMessage.deserializeMessageVersion(bufferWithLegacyPrefix),
+    ).to.eq('legacy');
+
+    for (const version of [0, 1, 127]) {
+      const bufferWithVersionPrefix = new Uint8Array([(1 << 7) + version]);
+      expect(
+        VersionedMessage.deserializeMessageVersion(bufferWithVersionPrefix),
+      ).to.eq(version);
+    }
+  });
+
+  it('deserialize failure', () => {
+    const bufferWithV1Prefix = new Uint8Array([(1 << 7) + 1]);
+    expect(() => {
+      VersionedMessage.deserialize(bufferWithV1Prefix);
+    }).to.throw(
+      'Transaction message version 1 deserialization is not supported',
+    );
+  });
+});


### PR DESCRIPTION
#### Problem
Lack of utility function to check the version of a serialized message without fully deserializing the message

#### Summary of Changes
- Added `VersionedMessage.deserializeMessageVersion`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
