### PR TITLE
[docs] Terminology PDA - replace owner by authority

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -229,7 +229,7 @@ The executable code that interprets the [instructions](#instruction) sent inside
 
 ## program derived account (PDA)
 
-An account whose owner is a program and thus is not controlled by a private key like other accounts.
+An account whose signing authority is a program and thus is not controlled by a private key like other accounts.
 
 ## program id
 


### PR DESCRIPTION
#### Problem
Terminology about PDA confuses owner and authority.

#### Summary of Changes
Replaced "An account whose owner is a program" by "An account whose **signing authority** is a program"
