### PR TITLE
Move pruned_banks_receiver into PrunedBanksRequestHandler

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -67,8 +67,8 @@ use {
     },
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
-            SnapshotRequestHandler,
+            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
+            PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
         accounts_index::AccountSecondaryIndexes,
@@ -640,13 +640,16 @@ impl Validator {
                 config.snapshot_config.clone(),
             );
 
+            let pruned_banks_request_handler = PrunedBanksRequestHandler {
+                pruned_banks_receiver,
+            };
             let last_full_snapshot_slot = starting_snapshot_hashes.map(|x| x.full.hash.0);
             let accounts_background_service = AccountsBackgroundService::new(
                 bank_forks.clone(),
                 &exit,
-                AbsRequestHandler {
+                AbsRequestHandlers {
                     snapshot_request_handler,
-                    pruned_banks_receiver,
+                    pruned_banks_request_handler,
                 },
                 config.accounts_db_caching_enabled,
                 config.accounts_db_test_hash_calculation,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -13,7 +13,8 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
+            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
+            PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         accounts_db::{self, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         accounts_index::AccountSecondaryIndexes,
@@ -929,9 +930,12 @@ fn test_snapshots_with_background_services(
         snapshot_request_receiver,
         pending_accounts_package: Arc::clone(&pending_accounts_package),
     });
-    let abs_request_handler = AbsRequestHandler {
-        snapshot_request_handler,
+    let pruned_banks_request_handler = PrunedBanksRequestHandler {
         pruned_banks_receiver,
+    };
+    let abs_request_handler = AbsRequestHandlers {
+        snapshot_request_handler,
+        pruned_banks_request_handler,
     };
 
     let exit = Arc::new(AtomicBool::new(false));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -37,7 +37,8 @@ use {
     solana_measure::{measure, measure::Measure},
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandler, AbsRequestSender, AccountsBackgroundService,
+            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
+            PrunedBanksRequestHandler,
         },
         accounts_db::{AccountsDbConfig, FillerAccountsConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanConfig},
@@ -1030,9 +1031,12 @@ fn load_bank_forks(
 
     let pruned_banks_receiver =
         AccountsBackgroundService::setup_bank_drop_callback(bank_forks.clone());
-    let abs_request_handler = AbsRequestHandler {
-        snapshot_request_handler: None,
+    let pruned_banks_request_handler = PrunedBanksRequestHandler {
         pruned_banks_receiver,
+    };
+    let abs_request_handler = AbsRequestHandlers {
+        snapshot_request_handler: None,
+        pruned_banks_request_handler,
     };
     let exit = Arc::new(AtomicBool::new(false));
     let accounts_background_service = AccountsBackgroundService::new(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7997,7 +7997,7 @@ pub(crate) mod tests {
     use {
         super::*,
         crate::{
-            accounts_background_service::{AbsRequestHandler, SendDroppedBankCallback},
+            accounts_background_service::{PrunedBanksRequestHandler, SendDroppedBankCallback},
             accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
             accounts_index::{AccountIndex, AccountSecondaryIndexes, ScanError, ITER_BATCH_SIZE},
             ancestors::Ancestors,
@@ -16126,8 +16126,7 @@ pub(crate) mod tests {
     fn test_store_scan_consistency_unrooted() {
         for accounts_db_caching_enabled in &[false, true] {
             let (pruned_banks_sender, pruned_banks_receiver) = unbounded();
-            let abs_request_handler = AbsRequestHandler {
-                snapshot_request_handler: None,
+            let pruned_banks_request_handler = PrunedBanksRequestHandler {
                 pruned_banks_receiver,
             };
             test_store_scan_consistency(
@@ -16211,7 +16210,7 @@ pub(crate) mod tests {
                         current_major_fork_bank.clean_accounts_for_tests();
                         // Move purge here so that Bank::drop()->purge_slots() doesn't race
                         // with clean. Simulates the call from AccountsBackgroundService
-                        abs_request_handler.handle_pruned_banks(&current_major_fork_bank, true);
+                        pruned_banks_request_handler.handle_request(&current_major_fork_bank, true);
                     }
                 },
                 Some(Box::new(SendDroppedBankCallback::new(


### PR DESCRIPTION
#### Problem

While working on the implementation for [Epoch Accounts Hash](https://github.com/orgs/solana-labs/projects/9), I ran into an issue while adding support in ABS: adding fields to `AbsRequestHandler` would require rework to some tests to pass in new fields.

The tests in ABS for pruned banks requests don't actually need the full `AbsRequestHandler`, since they are only exercising the drop-banks code. This isn't a big deal currently, since the snapshot request handler is an `Option`, so defaulting it to `None` is both simple and correct. As I add a non-`Option` field to `AbsRequestHandler`, this is different. Instead of plumbing new code into the test, pull out the pruned banks receiver into its own request handler, `PrunedBanksRequestHandler`, that can be tested directly.

#### Summary of Changes

Move `pruned_banks_receiver` into `PrunedBanksRequestHandler` and call tests on it directly, instead of testing it through `AbsRequestHandler`.

(Also rename `AbsRequestHandler` to `AbsRequestHandlers` (with the `s`).)