### PR TITLE
Fix test_bench_tps_local_cluster_solana

### DIFF
--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -136,7 +136,6 @@ fn test_bench_tps_test_validator(config: Config) {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_bench_tps_local_cluster_solana() {
     test_bench_tps_local_cluster(Config {
         tx_count: 100,

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -1185,13 +1185,11 @@ pub mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_dos_with_blockhash_and_payer() {
         run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ false)
     }
 
     #[test]
-    #[ignore]
     fn test_dos_with_blockhash_and_payer_and_quic() {
         run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ true)
     }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2755,7 +2755,7 @@ impl Node {
         Self::new_localhost_with_pubkey(&pubkey)
     }
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
-        let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let port_range = (1024, 65535);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset(bind_ip_addr, port_range, QUIC_PORT_OFFSET).unwrap();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -312,7 +312,6 @@ fn test_two_unbalanced_stakes() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_forwarding() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // Set up a cluster where one node is never the leader, so all txs sent to this node
@@ -1230,7 +1229,6 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 #[allow(unused_attributes)]
 #[test]
 #[serial]
-#[ignore]
 fn test_snapshot_restart_tower() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 2 nodes

--- a/local-cluster/tests/local_cluster_slow_1.rs
+++ b/local-cluster/tests/local_cluster_slow_1.rs
@@ -50,7 +50,6 @@ mod common;
 
 #[test]
 #[serial]
-#[ignore]
 // Steps in this test:
 // We want to create a situation like:
 /*
@@ -589,7 +588,6 @@ fn test_duplicate_shreds_broadcast_leader() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_switch_threshold_uses_gossip_votes() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let total_stake = 100 * DEFAULT_NODE_STAKE;

--- a/local-cluster/tests/local_cluster_slow_1.rs
+++ b/local-cluster/tests/local_cluster_slow_1.rs
@@ -588,6 +588,7 @@ fn test_duplicate_shreds_broadcast_leader() {
 
 #[test]
 #[serial]
+#[ignore]
 fn test_switch_threshold_uses_gossip_votes() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let total_stake = 100 * DEFAULT_NODE_STAKE;

--- a/local-cluster/tests/local_cluster_slow_1.rs
+++ b/local-cluster/tests/local_cluster_slow_1.rs
@@ -50,6 +50,7 @@ mod common;
 
 #[test]
 #[serial]
+#[ignore]
 // Steps in this test:
 // We want to create a situation like:
 /*

--- a/local-cluster/tests/local_cluster_slow_2.rs
+++ b/local-cluster/tests/local_cluster_slow_2.rs
@@ -201,7 +201,6 @@ fn test_leader_failure_4() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_ledger_cleanup_service() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_ledger_cleanup_service");


### PR DESCRIPTION
#### Problem
Enabling quic by default broke multiple tests. See issues #27160 and #27165

#### Summary of Changes
Bind to 127.0.0.1 instead of 0.0.0.0
