### PR TITLE
remove old bank hashes with ancient shrink

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4045,6 +4045,7 @@ impl AccountsDb {
             dropped_roots.iter().for_each(|slot| {
                 self.accounts_index
                     .clean_dead_slot(*slot, &mut AccountsIndexRootsStats::default());
+                self.bank_hashes.write().unwrap().remove(slot);
             });
         }
 


### PR DESCRIPTION
#### Problem

ancient shrink combines parts of shrink and clean.
When a slot gets old, we remove its alive contents and put it into an ancient append vec in a prior slot. When we remove all storages from a slot, the slot is now not useful. Clean removes dead slots in a similar way. When it does so, the mechanism to get rid of a bank hash entry for that slot runs. This same mechanism needs to run when we combine an old slot's data into an ancient append vec.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
