### PR TITLE
remove storages that only contain empty

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4046,6 +4046,16 @@ impl AccountsDb {
                 self.accounts_index
                     .clean_dead_slot(*slot, &mut AccountsIndexRootsStats::default());
                 self.bank_hashes.write().unwrap().remove(slot);
+                // all storages have been removed from here and recycled or dropped
+                assert!(self
+                    .storage
+                    .map
+                    .remove(slot)
+                    .unwrap()
+                    .1
+                    .read()
+                    .unwrap()
+                    .is_empty());
             });
         }
 


### PR DESCRIPTION
#### Problem
ancient shrink combines parts of shrink and clean.
When a slot gets old, we remove its alive contents and put it into an ancient append vec in a prior slot. When we remove all storages from a slot, the slot is now not useful. Clean removes dead slots in a similar way. When it does so, the removal of the hashmap entry from that slot to a now empty set of storages runs. This same mechanism needs to run when we combine an old slot's data into an ancient append vec.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
