### PR TITLE
Add off-chain messages support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6243,6 +6243,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
+ "num_enum",
  "pbkdf2 0.11.0",
  "qstring",
  "rand 0.7.3",

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -279,6 +279,14 @@ impl WalletSubCommands for App<'_, '_> {
             SubCommand::with_name("sign-offchain-message")
                 .about("Sign off-chain message")
                 .arg(
+                    Arg::with_name("message")
+                        .index(1)
+                        .takes_value(true)
+                        .value_name("STRING")
+                        .required(true)
+                        .help("The message text to be signed")
+                )
+                .arg(
                     Arg::with_name("version")
                         .long("version")
                         .takes_value(true)
@@ -290,33 +298,14 @@ impl WalletSubCommands for App<'_, '_> {
                             Ok(_) => { Ok(()) }
                         })
                         .help("The off-chain message version")
-                )
-                .arg(
-                    Arg::with_name("message")
-                        .takes_value(true)
-                        .value_name("STRING")
-                        .required(true)
-                        .help("The message text to be signed")
                 )
         )
         .subcommand(
             SubCommand::with_name("verify-offchain-signature")
                 .about("Verify off-chain message signature")
                 .arg(
-                    Arg::with_name("version")
-                        .long("version")
-                        .takes_value(true)
-                        .value_name("VERSION")
-                        .required(false)
-                        .default_value("0")
-                        .validator(|p| match p.parse::<u8>() {
-                            Err(_) => Err(String::from("Must be unsigned integer")),
-                            Ok(_) => { Ok(()) }
-                        })
-                        .help("The off-chain message version")
-                )
-                .arg(
                     Arg::with_name("message")
+                        .index(1)
                         .takes_value(true)
                         .value_name("STRING")
                         .required(true)
@@ -324,10 +313,24 @@ impl WalletSubCommands for App<'_, '_> {
                 )
                 .arg(
                     Arg::with_name("signature")
+                        .index(2)
                         .value_name("SIGNATURE")
                         .takes_value(true)
                         .required(true)
                         .help("The message signature to verify")
+                )
+                .arg(
+                    Arg::with_name("version")
+                        .long("version")
+                        .takes_value(true)
+                        .value_name("VERSION")
+                        .required(false)
+                        .default_value("0")
+                        .validator(|p| match p.parse::<u8>() {
+                            Err(_) => Err(String::from("Must be unsigned integer")),
+                            Ok(_) => { Ok(()) }
+                        })
+                        .help("The off-chain message version")
                 )
                 .arg(
                     pubkey!(Arg::with_name("signer")
@@ -515,7 +518,7 @@ pub fn parse_sign_offchain_message(
     default_signer: &DefaultSigner,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let version: u8 = value_of(matches, "version").unwrap_or(0);
+    let version: u8 = value_of(matches, "version").unwrap();
     let message_text: String = value_of(matches, "message")
         .ok_or_else(|| CliError::BadParameter("MESSAGE".to_string()))?;
     let message = OffchainMessage::new(version, message_text.as_bytes())
@@ -532,7 +535,7 @@ pub fn parse_verify_offchain_signature(
     default_signer: &DefaultSigner,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let version: u8 = value_of(matches, "version").unwrap_or(0);
+    let version: u8 = value_of(matches, "version").unwrap();
     let message_text: String = value_of(matches, "message")
         .ok_or_else(|| CliError::BadParameter("MESSAGE".to_string()))?;
     let message = OffchainMessage::new(version, message_text.as_bytes())

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -33,6 +33,7 @@ use {
     solana_sdk::{
         commitment_config::CommitmentConfig,
         message::Message,
+        offchain_message::OffchainMessage,
         pubkey::Pubkey,
         signature::Signature,
         stake,
@@ -274,6 +275,68 @@ impl WalletSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
                 .arg(compute_unit_price_arg()),
         )
+        .subcommand(
+            SubCommand::with_name("sign-offchain-message")
+                .about("Sign off-chain message")
+                .arg(
+                    Arg::with_name("version")
+                        .long("version")
+                        .takes_value(true)
+                        .value_name("VERSION")
+                        .required(false)
+                        .default_value("0")
+                        .validator(|p| match p.parse::<u8>() {
+                            Err(_) => Err(String::from("Must be unsigned integer")),
+                            Ok(_) => { Ok(()) }
+                        })
+                        .help("The off-chain message version")
+                )
+                .arg(
+                    Arg::with_name("message")
+                        .takes_value(true)
+                        .value_name("STRING")
+                        .required(true)
+                        .help("The message text to be signed")
+                )
+        )
+        .subcommand(
+            SubCommand::with_name("verify-offchain-signature")
+                .about("Verify off-chain message signature")
+                .arg(
+                    Arg::with_name("version")
+                        .long("version")
+                        .takes_value(true)
+                        .value_name("VERSION")
+                        .required(false)
+                        .default_value("0")
+                        .validator(|p| match p.parse::<u8>() {
+                            Err(_) => Err(String::from("Must be unsigned integer")),
+                            Ok(_) => { Ok(()) }
+                        })
+                        .help("The off-chain message version")
+                )
+                .arg(
+                    Arg::with_name("message")
+                        .takes_value(true)
+                        .value_name("STRING")
+                        .required(true)
+                        .help("The text of the original message")
+                )
+                .arg(
+                    Arg::with_name("signature")
+                        .value_name("SIGNATURE")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The message signature to verify")
+                )
+                .arg(
+                    pubkey!(Arg::with_name("signer")
+                        .long("signer")
+                        .value_name("PUBKEY")
+                        .required(false),
+                        "The pubkey of the message signer (if different from config default)")
+                )
+        )
     }
 }
 
@@ -444,6 +507,54 @@ pub fn parse_transfer(
             compute_unit_price,
         },
         signers: signer_info.signers,
+    })
+}
+
+pub fn parse_sign_offchain_message(
+    matches: &ArgMatches<'_>,
+    default_signer: &DefaultSigner,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
+    let version: u8 = value_of(matches, "version").unwrap_or(0);
+    let message_text: String = value_of(matches, "message")
+        .ok_or_else(|| CliError::BadParameter("MESSAGE".to_string()))?;
+    let message = OffchainMessage::new(version, message_text.as_bytes())
+        .map_err(|_| CliError::BadParameter("VERSION or MESSAGE".to_string()))?;
+
+    Ok(CliCommandInfo {
+        command: CliCommand::SignOffchainMessage { message },
+        signers: vec![default_signer.signer_from_path(matches, wallet_manager)?],
+    })
+}
+
+pub fn parse_verify_offchain_signature(
+    matches: &ArgMatches<'_>,
+    default_signer: &DefaultSigner,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
+    let version: u8 = value_of(matches, "version").unwrap_or(0);
+    let message_text: String = value_of(matches, "message")
+        .ok_or_else(|| CliError::BadParameter("MESSAGE".to_string()))?;
+    let message = OffchainMessage::new(version, message_text.as_bytes())
+        .map_err(|_| CliError::BadParameter("VERSION or MESSAGE".to_string()))?;
+
+    let signer_pubkey = pubkey_of_signer(matches, "signer", wallet_manager)?;
+    let signers = if signer_pubkey.is_some() {
+        vec![]
+    } else {
+        vec![default_signer.signer_from_path(matches, wallet_manager)?]
+    };
+
+    let signature = value_of(matches, "signature")
+        .ok_or_else(|| CliError::BadParameter("SIGNATURE".to_string()))?;
+
+    Ok(CliCommandInfo {
+        command: CliCommand::VerifyOffchainSignature {
+            signer_pubkey,
+            signature,
+            message,
+        },
+        signers,
     })
 }
 
@@ -777,5 +888,31 @@ pub fn process_transfer(
             rpc_client.send_and_confirm_transaction_with_spinner(&tx)
         };
         log_instruction_custom_error::<SystemError>(result, config)
+    }
+}
+
+pub fn process_sign_offchain_message(
+    config: &CliConfig,
+    message: &OffchainMessage,
+) -> ProcessResult {
+    Ok(message.sign(config.signers[0])?.to_string())
+}
+
+pub fn process_verify_offchain_signature(
+    config: &CliConfig,
+    signer_pubkey: &Option<Pubkey>,
+    signature: &Signature,
+    message: &OffchainMessage,
+) -> ProcessResult {
+    let signer = if let Some(pubkey) = signer_pubkey {
+        *pubkey
+    } else {
+        config.signers[0].pubkey()
+    };
+
+    if message.verify(&signer, signature)? {
+        Ok("Signature is valid".to_string())
+    } else {
+        Err(CliError::InvalidSignature.into())
     }
 }

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -339,6 +339,7 @@ module.exports = {
     "offline-signing",
     "offline-signing/durable-nonce",
     "cli/usage",
+    "cli/sign-offchain-message",
   ],
   architectureSidebar: [
     {

--- a/docs/src/cli/sign-offchain-message.md
+++ b/docs/src/cli/sign-offchain-message.md
@@ -2,7 +2,9 @@
 title: Off-Chain Message Signing
 ---
 
-Off-chain message signing is a method of signing non-transaction messages with a Solana wallet. This feature can be used to authenticate users or provide proof of wallet ownership.
+Off-chain message signing is a method of signing non-transaction messages with
+a Solana wallet. This feature can be used to authenticate users or provide
+proof of wallet ownership.
 
 ## Sign Off-Chain Message
 
@@ -12,22 +14,27 @@ To sign an arbitrary off-chain message, run the following command:
 solana sign-offchain-message <MESSAGE>
 ```
 
-The message will be encoded and signed with CLI's default private key and signature printed to the output. If you want to sign it with another key, just use the `-k/--keypair` option:
+The message will be encoded and signed with CLI's default private key and
+signature printed to the output. If you want to sign it with another key, just
+use the `-k/--keypair` option:
 
 ```bash
 solana sign-offchain-message -k <KEYPAIR> <MESSAGE>
 ```
 
-By default, version 0 messages are constructed (and the only supported at this moment). When other versions become available, you can override default value with `--version` option:
+By default, the messages constructed are version 0, the only version currently
+supported. When other versions become available, you can override the default
+value with the `--version` option:
 
 ```bash
 solana sign-offchain-message -k <KEYPAIR> --version <VERSION> <MESSAGE>
 ```
 
-The message format is determined automatically based on the version and text of the message.
+The message format is determined automatically based on the version and text
+of the message.
 
-Version `0` headers specify three message formats allowing for trade-offs between
-compatibility and composition of messages:
+Version `0` headers specify three message formats allowing for trade-offs
+between compatibility and composition of messages:
 
 | ID  |      Encoding       | Maximum Length | Hardware Wallet Support |
 | :-: | :-----------------: | :------------: | :---------------------: |
@@ -38,19 +45,26 @@ compatibility and composition of messages:
 \* Those characters for which [`isprint(3)`](https://linux.die.net/man/3/isprint)
 returns true. That is, `0x20..=0x7e`.
 
-Formats `0` and `1` are motivated by hardware wallet support where both RAM to store the payload and font character support are limited.
+Formats `0` and `1` are motivated by hardware wallet support where both RAM to
+store the payload and font character support are limited.
 
-To sign an off-chain message with Ledger, ensure your Ledger is running latest firmware and Solana Ledger App version 1.3.0 or later. After Ledger is unlocked and Solana Ledger App is open, run:
+To sign an off-chain message with Ledger, ensure your Ledger is running latest
+firmware and Solana Ledger App version 1.3.0 or later. After Ledger is
+unlocked and Solana Ledger App is open, run:
 
 ```bash
 solana sign-offchain-message -k usb://ledger <MESSAGE>
 ```
 
-For more information on how to setup and work with the ledger device see this [link](../wallet-guide/hardware-wallets/ledger.md).
+For more information on how to setup and work with the ledger device see this
+[link](../wallet-guide/hardware-wallets/ledger.md).
 
-Please note that UTF-8 encoded messages require `Allow blind sign` option enabled in Solana Ledger App. Also, due to the lack of UTF-8 support in Ledger devices, only the hash of the message will be displayed in such cases.
+Please note that UTF-8 encoded messages require `Allow blind sign` option
+enabled in Solana Ledger App. Also, due to the lack of UTF-8 support in Ledger
+devices, only the hash of the message will be displayed in such cases.
 
-If `Display mode` is set to `Expert`, Ledger will display technical information about the message to be signed.
+If `Display mode` is set to `Expert`, Ledger will display technical
+information about the message to be signed.
 
 ## Verify Off-Chain Message Signature
 
@@ -60,13 +74,15 @@ To verify the off-chain message signature, run the following command:
 solana verify-offchain-signature <MESSAGE> <SIGNATURE>
 ```
 
-The public key of the default CLI signer will be used. You can specify another key with the `--signer` option:
+The public key of the default CLI signer will be used. You can specify another
+key with the `--signer` option:
 
 ```bash
 solana verify-offchain-signature --signer <PUBKEY> <MESSAGE> <SIGNATURE>
 ```
 
-If the signed message has a version different from the default, you need to specify the matching version explicitly:
+If the signed message has a version different from the default, you need to
+specify the matching version explicitly:
 
 ```bash
 solana verify-offchain-signature --version <VERSION> <MESSAGE> <SIGNATURE>
@@ -74,4 +90,9 @@ solana verify-offchain-signature --version <VERSION> <MESSAGE> <SIGNATURE>
 
 ## Protocol Specification
 
-To ensure that off-chain messages are not valid transactions, they are encoded with a fixed prefix: `\xffsolana offchain`, where first byte is chosen such that it is implicitly illegal as the first byte in a transaction `MessageHeader` today. More details about the payload format and other considerations are available in the [proposal](https://github.com/solana-labs/solana/blob/e80f67dd58b7fa3901168055211f346164efa43a/docs/src/proposals/off-chain-message-signing.md).
+To ensure that off-chain messages are not valid transactions, they are encoded
+with a fixed prefix: `\xffsolana offchain`, where first byte is chosen such
+that it is implicitly illegal as the first byte in a transaction
+`MessageHeader` today. More details about the payload format and other
+considerations are available in the
+[proposal](https://github.com/solana-labs/solana/blob/e80f67dd58b7fa3901168055211f346164efa43a/docs/src/proposals/off-chain-message-signing.md).

--- a/docs/src/cli/sign-offchain-message.md
+++ b/docs/src/cli/sign-offchain-message.md
@@ -1,0 +1,75 @@
+---
+title: Off-Chain Message Signing
+---
+
+Off-chain message signing is a method of signing non-transaction messages with a Solana wallet. This feature can be used to authenticate users or provide proof of wallet ownership.
+
+## Sign Off-Chain Message
+
+To sign an arbitrary off-chain message, run the following command:
+
+```bash
+solana sign-offchain-message <MESSAGE>
+```
+
+The message will be encoded and signed with CLI's default private key and signature printed to the output. If you want to sign it with another key, just use the `-k/--keypair` option:
+
+```bash
+solana sign-offchain-message -k <KEYPAIR> <MESSAGE>
+```
+
+By default, version 0 messages are constructed. You can override this with `--version` option:
+
+```bash
+solana sign-offchain-message -k <KEYPAIR> --version <VERSION> <MESSAGE>
+```
+
+The message format is determined automatically based on the version and text of the message.
+
+Version `0` headers specify three message formats allowing for trade-offs between
+compatibility and composition of messages:
+
+| ID  |      Encoding       | Maximum Length | Hardware Wallet Support |
+| :-: | :-----------------: | :------------: | :---------------------: |
+|  0  | Restricted ASCII \* |      1212      |           Yes           |
+|  1  |        UTF-8        |      1212      |     Blind sign only     |
+|  2  |        UTF-8        |     65515      |           No            |
+
+\* Those characters for which [`isprint(3)`](https://linux.die.net/man/3/isprint)
+returns true. That is, `0x20..=0x7e`.
+
+Formats `0` and `1` are motivated by hardware wallet support where both RAM to store the payload and font character support are limited.
+
+To sign an off-chain message with Ledger, ensure your Ledger is running firmware with SE version 1.0.3 or later and Solana Ledger App version 1.3.0 or later. After Ledger is unlocked and Solana Ledger App is open, run:
+
+```bash
+solana sign-offchain-message -k usb://ledger <MESSAGE>
+```
+
+Please note that UTF-8 encoded messages require `Allow blind sign` option enabled in Solana Ledger App. Also, due to the lack of UTF-8 support in Ledger devices, only the hash of the message will be displayed in such cases.
+
+If `Display mode` is set to `Expert`, Ledger will display technical information about the message to be signed.
+
+## Verify Off-Chain Message Signature
+
+To verify the off-chain message signature, run the following command:
+
+```bash
+solana verify-offchain-signature <MESSAGE> <SIGNATURE>
+```
+
+The public key of the default CLI signer will be used. You can specify another key with the `--signer` option:
+
+```bash
+solana verify-offchain-signature --signer <PUBKEY> <MESSAGE> <SIGNATURE>
+```
+
+If the signed message has a version different from the default, you need to specify the matching version explicitly:
+
+```bash
+solana verify-offchain-signature --version <VERSION> <MESSAGE> <SIGNATURE>
+```
+
+## Protocol Specification
+
+To ensure that off-chain messages are not valid transactions, they are encoded with a fixed prefix: `\xffsolana offchain`, where first byte is chosen such that it is implicitly illegal as the first byte in a transaction `MessageHeader` today. More details about the payload format and other considerations are available in the [proposal](https://github.com/solana-labs/solana/blob/e80f67dd58b7fa3901168055211f346164efa43a/docs/src/proposals/off-chain-message-signing.md).

--- a/docs/src/cli/sign-offchain-message.md
+++ b/docs/src/cli/sign-offchain-message.md
@@ -18,7 +18,7 @@ The message will be encoded and signed with CLI's default private key and signat
 solana sign-offchain-message -k <KEYPAIR> <MESSAGE>
 ```
 
-By default, version 0 messages are constructed. You can override this with `--version` option:
+By default, version 0 messages are constructed (and the only supported at this moment). When other versions become available, you can override default value with `--version` option:
 
 ```bash
 solana sign-offchain-message -k <KEYPAIR> --version <VERSION> <MESSAGE>
@@ -40,11 +40,13 @@ returns true. That is, `0x20..=0x7e`.
 
 Formats `0` and `1` are motivated by hardware wallet support where both RAM to store the payload and font character support are limited.
 
-To sign an off-chain message with Ledger, ensure your Ledger is running firmware with SE version 1.0.3 or later and Solana Ledger App version 1.3.0 or later. After Ledger is unlocked and Solana Ledger App is open, run:
+To sign an off-chain message with Ledger, ensure your Ledger is running latest firmware and Solana Ledger App version 1.3.0 or later. After Ledger is unlocked and Solana Ledger App is open, run:
 
 ```bash
 solana sign-offchain-message -k usb://ledger <MESSAGE>
 ```
+
+For more information on how to setup and work with the ledger device see this [link](../wallet-guide/hardware-wallets/ledger.md).
 
 Please note that UTF-8 encoded messages require `Allow blind sign` option enabled in Solana Ledger App. Also, due to the lack of UTF-8 support in Ledger devices, only the hash of the message will be displayed in such cases.
 

--- a/docs/src/wallet-guide/hardware-wallets/ledger.md
+++ b/docs/src/wallet-guide/hardware-wallets/ledger.md
@@ -2,7 +2,7 @@
 title: Ledger Nano
 ---
 
-This page describes how to use a Ledger Nano S or Nano X to interact with Solana
+This page describes how to use a Ledger Nano S, Nano S Plus, or Nano X to interact with Solana
 using the command line tools.
 
 ## Before You Begin

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5572,6 +5572,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
+ "num_enum",
  "pbkdf2 0.11.0",
  "qstring",
  "rand 0.7.3",

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -67,6 +67,7 @@ mod commands {
     pub const GET_APP_CONFIGURATION: u8 = 0x04;
     pub const GET_PUBKEY: u8 = 0x05;
     pub const SIGN_MESSAGE: u8 = 0x06;
+    pub const SIGN_OFFCHAIN_MESSAGE: u8 = 0x07;
 }
 
 enum ConfigurationVersion {
@@ -430,6 +431,11 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         derivation_path: &DerivationPath,
         data: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
+        if !data.is_empty() && data[0] == 0xff {
+            // on-chain message doesn't start with 0xff, it either starts with
+            // 0x80 (MESSAGE_VERSION_PREFIX) or number of signatures
+            return self.sign_offchain_message(derivation_path, data);
+        }
         let mut payload = if self.outdated_app() {
             extend_and_serialize(derivation_path)
         } else {
@@ -498,10 +504,55 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
             chunks.last_mut().unwrap().0 &= !P2_MORE;
 
             for (p2, payload) in chunks {
-                result = self.send_apdu(commands::SIGN_MESSAGE, p1, p2, &payload)?;
+                result = self.send_apdu(
+                    if self.outdated_app() {
+                        commands::DEPRECATED_SIGN_MESSAGE
+                    } else {
+                        commands::SIGN_MESSAGE
+                    },
+                    p1,
+                    p2,
+                    &payload,
+                )?;
             }
         }
 
+        if result.len() != 64 {
+            return Err(RemoteWalletError::Protocol(
+                "Signature packet size mismatch",
+            ));
+        }
+        Ok(Signature::new(&result))
+    }
+
+    fn sign_offchain_message(
+        &self,
+        derivation_path: &DerivationPath,
+        message: &[u8],
+    ) -> Result<Signature, RemoteWalletError> {
+        if message.len()
+            > solana_sdk::offchain_message::v0::OffchainMessage::MAX_LEN_LEDGER
+                + solana_sdk::offchain_message::v0::OffchainMessage::HEADER_LEN
+        {
+            return Err(RemoteWalletError::InvalidInput(
+                "Off-chain message to sign is too long".to_string(),
+            ));
+        }
+
+        let mut data = extend_and_serialize_multiple(&[derivation_path]);
+        data.extend_from_slice(message);
+
+        let p1 = P1_CONFIRM;
+        let mut p2 = 0;
+        let mut payload = data.as_slice();
+        while payload.len() > MAX_CHUNK_SIZE {
+            let chunk = &payload[..MAX_CHUNK_SIZE];
+            self.send_apdu(commands::SIGN_OFFCHAIN_MESSAGE, p1, p2 | P2_MORE, chunk)?;
+            payload = &payload[MAX_CHUNK_SIZE..];
+            p2 |= P2_EXTEND;
+        }
+
+        let result = self.send_apdu(commands::SIGN_OFFCHAIN_MESSAGE, p1, p2, payload)?;
         if result.len() != 64 {
             return Err(RemoteWalletError::Protocol(
                 "Signature packet size mismatch",

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -431,9 +431,11 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         derivation_path: &DerivationPath,
         data: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
+        // If the first byte of the data is 0xff then it is an off-chain message
+        // because it starts with the Domain Specifier b"\xffsolana offchain".
+        // On-chain messages, in contrast, start with either 0x80 (MESSAGE_VERSION_PREFIX)
+        // or the number of signatures (0x00 - 0x13).
         if !data.is_empty() && data[0] == 0xff {
-            // on-chain message doesn't start with 0xff, it either starts with
-            // 0x80 (MESSAGE_VERSION_PREFIX) or number of signatures
             return self.sign_offchain_message(derivation_path, data);
         }
         let mut payload = if self.outdated_app() {

--- a/remote-wallet/src/ledger_error.rs
+++ b/remote-wallet/src/ledger_error.rs
@@ -71,6 +71,15 @@ pub enum LedgerError {
     #[error("Ledger received invalid Solana message")]
     SolanaInvalidMessage = 0x6a80,
 
+    #[error("Ledger received message with invalid header")]
+    SolanaInvalidMessageHeader = 0x6a81,
+
+    #[error("Ledger received message in invalid format")]
+    SolanaInvalidMessageFormat = 0x6a82,
+
+    #[error("Ledger received message with invalid size")]
+    SolanaInvalidMessageSize = 0x6a83,
+
     #[error("Solana summary finalization failed on Ledger device")]
     SolanaSummaryFinalizeFailed = 0x6f00,
 

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -236,6 +236,15 @@ pub trait RemoteWallet<T> {
     ) -> Result<Signature, RemoteWalletError> {
         unimplemented!();
     }
+
+    /// Sign off-chain message with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
+    fn sign_offchain_message(
+        &self,
+        derivation_path: &DerivationPath,
+        message: &[u8],
+    ) -> Result<Signature, RemoteWalletError> {
+        unimplemented!();
+    }
 }
 
 /// `RemoteWallet` device

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -60,6 +60,7 @@ log = "0.4.17"
 memmap2 = { version = "0.5.3", optional = true }
 num-derive = "0.3"
 num-traits = "0.2"
+num_enum = "0.5.7"
 pbkdf2 = { version = "0.11.0", default-features = false }
 qstring = "0.7.2"
 rand = { version = "0.7.0", optional = true }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -47,6 +47,7 @@ pub mod inflation;
 pub mod log;
 pub mod native_loader;
 pub mod nonce_account;
+pub mod offchain_message;
 pub mod packet;
 pub mod poh_config;
 pub mod precompiles;

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -1,0 +1,273 @@
+//! Off-Chain Message container for storing non-transaction messages.
+
+#![cfg(feature = "full")]
+
+use crate::{
+    hash::Hash,
+    pubkey::Pubkey,
+    sanitize::SanitizeError,
+    signature::{Signature, Signer},
+};
+
+#[allow(clippy::integer_arithmetic)]
+pub mod v0 {
+    use {
+        super::OffchainMessage as Base,
+        crate::{
+            hash::{Hash, Hasher},
+            sanitize::SanitizeError,
+        },
+    };
+
+    /// OffchainMessage Version 0.
+    /// Struct always contains a non-empty valid message.
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub struct OffchainMessage {
+        format: u8,
+        message: Vec<u8>,
+    }
+
+    impl OffchainMessage {
+        pub const MAX_LEN: usize = 65515;
+        pub const MAX_LEN_LEDGER: usize = 1212;
+        pub const HEADER_LEN: usize = 20;
+
+        /// Construct a new OffchainMessage object from the given message
+        pub fn new(message: &[u8]) -> Result<Self, SanitizeError> {
+            let format = if message.is_empty() {
+                return Err(SanitizeError::InvalidValue);
+            } else if message.len() <= OffchainMessage::MAX_LEN_LEDGER {
+                if OffchainMessage::is_printable_ascii(message) {
+                    0
+                } else if OffchainMessage::is_utf8(message) {
+                    1
+                } else {
+                    return Err(SanitizeError::InvalidValue);
+                }
+            } else if message.len() <= OffchainMessage::MAX_LEN {
+                if OffchainMessage::is_utf8(message) {
+                    2
+                } else {
+                    return Err(SanitizeError::InvalidValue);
+                }
+            } else {
+                return Err(SanitizeError::ValueOutOfBounds);
+            };
+            Ok(Self {
+                format,
+                message: message.to_vec(),
+            })
+        }
+
+        /// Serialize the message to bytes, including the full header
+        pub fn serialize(&self) -> Result<Vec<u8>, SanitizeError> {
+            // invalid messages shouldn't be possible, but a quick sanity check never hurts
+            assert!(
+                self.format <= 2 && !self.message.is_empty() && self.message.len() <= Self::MAX_LEN
+            );
+            let mut res: Vec<u8> = vec![0; Self::HEADER_LEN + self.message.len()];
+            let domain_len = Base::SIGNING_DOMAIN.len();
+            // signing domain
+            res[..domain_len].copy_from_slice(Base::SIGNING_DOMAIN);
+            // version
+            res[domain_len] = 0;
+            // format
+            res[domain_len + 1] = self.format;
+            // message length
+            res[(domain_len + 2)..(domain_len + 4)]
+                .copy_from_slice(&(self.message.len() as u16).to_le_bytes());
+            // message
+            res[(domain_len + 4)..].copy_from_slice(&self.message);
+            Ok(res)
+        }
+
+        /// Deserialize the message from bytes that include a full header
+        pub fn deserialize(data: &[u8]) -> Result<Self, SanitizeError> {
+            // validate data length
+            if data.len() <= Self::HEADER_LEN || data.len() > Self::HEADER_LEN + Self::MAX_LEN {
+                return Err(SanitizeError::ValueOutOfBounds);
+            }
+            // decode header
+            let domain_len = Base::SIGNING_DOMAIN.len();
+            let version = data[domain_len];
+            let format = data[domain_len + 1];
+            let message_len =
+                u16::from_le_bytes([data[domain_len + 2], data[domain_len + 3]]) as usize;
+            // check header
+            if version != 0 || format > 2 || message_len + Self::HEADER_LEN != data.len() {
+                return Err(SanitizeError::InvalidValue);
+            }
+            let message = &data[(domain_len + 4)..];
+            // check format
+            let is_valid = match format {
+                0 => message.len() <= Self::MAX_LEN_LEDGER && Self::is_printable_ascii(message),
+                1 => message.len() <= Self::MAX_LEN_LEDGER && Self::is_utf8(message),
+                2 => message.len() <= Self::MAX_LEN && Self::is_utf8(message),
+                _ => false,
+            };
+
+            if is_valid {
+                Ok(Self {
+                    format,
+                    message: message.to_vec(),
+                })
+            } else {
+                Err(SanitizeError::InvalidValue)
+            }
+        }
+
+        /// Compute the SHA256 hash of the off-chain message
+        pub fn hash(&self) -> Result<Hash, SanitizeError> {
+            let mut hasher = Hasher::default();
+            hasher.hash(&self.serialize()?);
+            Ok(hasher.result())
+        }
+
+        /// Check if given bytes contain only printable ASCII characters
+        pub fn is_printable_ascii(data: &[u8]) -> bool {
+            for &char in data {
+                if !(0x20..=0x7e).contains(&char) {
+                    return false;
+                }
+            }
+            true
+        }
+
+        /// Check if given bytes contain valid UTF8 string
+        pub fn is_utf8(data: &[u8]) -> bool {
+            std::str::from_utf8(data).is_ok()
+        }
+
+        pub fn get_format(&self) -> u8 {
+            self.format
+        }
+
+        pub fn get_message(&self) -> &Vec<u8> {
+            &self.message
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum OffchainMessage {
+    V0(v0::OffchainMessage),
+}
+
+impl OffchainMessage {
+    pub const SIGNING_DOMAIN: &'static [u8] = b"\xffsolana offchain";
+    pub const HEADER_LEN: usize = Self::SIGNING_DOMAIN.len() + 1;
+
+    /// Construct a new OffchainMessage object from the given version and message
+    pub fn new(version: u8, message: &[u8]) -> Result<Self, SanitizeError> {
+        match version {
+            0 => Ok(Self::V0(v0::OffchainMessage::new(message)?)),
+            _ => Err(SanitizeError::ValueOutOfBounds),
+        }
+    }
+
+    /// Serialize the off-chain message to bytes including full header
+    pub fn serialize(&self) -> Result<Vec<u8>, SanitizeError> {
+        match self {
+            Self::V0(msg) => msg.serialize(),
+        }
+    }
+
+    /// Deserialize the off-chain message from bytes that include full header
+    pub fn deserialize(data: &[u8]) -> Result<Self, SanitizeError> {
+        if data.len() < Self::HEADER_LEN {
+            return Err(SanitizeError::ValueOutOfBounds);
+        }
+        let version = data[Self::SIGNING_DOMAIN.len()];
+        match version {
+            0 => Ok(Self::V0(v0::OffchainMessage::deserialize(data)?)),
+            _ => Err(SanitizeError::ValueOutOfBounds),
+        }
+    }
+
+    /// Compute the hash of the off-chain message
+    pub fn hash(&self) -> Result<Hash, SanitizeError> {
+        match self {
+            Self::V0(msg) => msg.hash(),
+        }
+    }
+
+    pub fn get_version(&self) -> u8 {
+        match self {
+            Self::V0(_) => 0,
+        }
+    }
+
+    pub fn get_format(&self) -> u32 {
+        match self {
+            Self::V0(msg) => msg.get_format() as u32,
+        }
+    }
+
+    pub fn get_message(&self) -> &Vec<u8> {
+        match self {
+            Self::V0(msg) => msg.get_message(),
+        }
+    }
+
+    /// Sign the message with provided keypair
+    pub fn sign(&self, signer: &dyn Signer) -> Result<Signature, SanitizeError> {
+        Ok(signer.sign_message(&self.serialize()?))
+    }
+
+    /// Verify that the message signature is valid for the given public key
+    pub fn verify(&self, signer: &Pubkey, signature: &Signature) -> Result<bool, SanitizeError> {
+        Ok(signature.verify(signer.as_ref(), &self.serialize()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::signature::Keypair, std::str::FromStr};
+
+    #[test]
+    fn test_offchain_message_ascii() {
+        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+        assert_eq!(message.get_version(), 0);
+        assert_eq!(message.get_format(), 0);
+        assert_eq!(message.get_message().as_slice(), b"Test Message");
+        assert!(matches!(message, OffchainMessage::V0(ref msg) if msg.get_format() == 0));
+        let serialized = [
+            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 0, 12, 0,
+            84, 101, 115, 116, 32, 77, 101, 115, 115, 97, 103, 101,
+        ];
+        let hash = Hash::from_str("HG5JydBGjtjTfD3sSn21ys5NTWPpXzmqifiGC2BVUjkD").unwrap();
+        assert_eq!(message.serialize().unwrap(), serialized);
+        assert_eq!(message.hash().unwrap(), hash);
+        assert_eq!(message, OffchainMessage::deserialize(&serialized).unwrap());
+    }
+
+    #[test]
+    fn test_offchain_message_utf8() {
+        let message = OffchainMessage::new(0, "Тестовое сообщение".as_bytes()).unwrap();
+        assert_eq!(message.get_version(), 0);
+        assert_eq!(message.get_format(), 1);
+        assert_eq!(
+            message.get_message().as_slice(),
+            "Тестовое сообщение".as_bytes()
+        );
+        assert!(matches!(message, OffchainMessage::V0(ref msg) if msg.get_format() == 1));
+        let serialized = [
+            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 1, 35, 0,
+            208, 162, 208, 181, 209, 129, 209, 130, 208, 190, 208, 178, 208, 190, 208, 181, 32,
+            209, 129, 208, 190, 208, 190, 208, 177, 209, 137, 208, 181, 208, 189, 208, 184, 208,
+            181,
+        ];
+        let hash = Hash::from_str("6GXTveatZQLexkX4WeTpJ3E7uk1UojRXpKp43c4ArSun").unwrap();
+        assert_eq!(message.serialize().unwrap(), serialized);
+        assert_eq!(message.hash().unwrap(), hash);
+        assert_eq!(message, OffchainMessage::deserialize(&serialized).unwrap());
+    }
+
+    #[test]
+    fn test_offchain_message_sign_and_verify() {
+        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+        let keypair = Keypair::new();
+        let signature = message.sign(&keypair).unwrap();
+        assert!(message.verify(&keypair.pubkey(), &signature).unwrap());
+    }
+}


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/21366

#### Summary of Changes
Adds signing of non-transaction messages with a Solana wallet. This feature can be used to authenticate users or provide proof of wallet ownership.
See [Docs](https://github.com/solana-labs/solana/pull/27456/files#diff-6259934a49f0f3a75b91507a9aec073ca7726d632c7d84fc13c9f3790c0d979b) for more details.
In accordance with the [Proposal](https://github.com/solana-labs/solana/blob/e80f67dd58b7fa3901168055211f346164efa43a/docs/src/proposals/off-chain-message-signing.md).
Off-chain messages can be signed and verfied using Solana CLI and any of the supported wallets including Ledger. Latest firmware and Solana Ledger App v1.3.0 or higher is required for this feature to work.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
