### PR TITLE
chore: bump shellcheck v0.8.0

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")/.."
 (
   set -x
   git ls-files -- '*.sh' ':(exclude)ci/semver_bash' \
-    | xargs ci/docker-run.sh koalaman/shellcheck@sha256:fe24ab9a9b6b62d3adb162f4a80e006b6a63cae8c6ffafbae45772bab85e7294 --color=always --external-sources --shell=bash
+    | xargs ci/docker-run.sh koalaman/shellcheck:v0.8.0 --color=always --external-sources --shell=bash
 )
 echo --- ok

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -397,6 +397,7 @@ cloud_ForEachInstance() {
     declare name publicIp privateIp
     IFS=: read -r name publicIp privateIp zone < <(echo "$info")
 
+    # shellcheck disable=SC2294
     eval "$cmd" "$name" "$publicIp" "$privateIp" "$zone" "$count" "$@"
     count=$((count + 1))
   done

--- a/net/net.sh
+++ b/net/net.sh
@@ -601,7 +601,7 @@ deploy() {
     if $bootstrapLeader; then
       SECONDS=0
       declare bootstrapNodeDeployTime=
-      startBootstrapLeader "$nodeAddress" $nodeIndex "$netLogDir/bootstrap-validator-$ipAddress.log"
+      startBootstrapLeader "$nodeAddress" "$nodeIndex" "$netLogDir/bootstrap-validator-$ipAddress.log"
       bootstrapNodeDeployTime=$SECONDS
       $metricsWriteDatapoint "testnet-deploy net-bootnode-leader-started=1"
 
@@ -609,7 +609,7 @@ deploy() {
       SECONDS=0
       pids=()
     else
-      startNode "$ipAddress" $nodeType $nodeIndex
+      startNode "$ipAddress" "$nodeType" "$nodeIndex"
 
       # Stagger additional node start time. If too many nodes start simultaneously
       # the bootstrap node gets more rsync requests from the additional nodes than
@@ -1124,7 +1124,7 @@ startnode)
   nodeType=
   nodeIndex=
   getNodeType
-  startNode "$nodeAddress" $nodeType $nodeIndex
+  startNode "$nodeAddress" "$nodeType" "$nodeIndex"
   ;;
 startclients)
   startClients

--- a/net/scripts/colo-node-onfree.sh
+++ b/net/scripts/colo-node-onfree.sh
@@ -4,7 +4,7 @@
 SOLANA_LOCK_FILE="${SOLANA_LOCK_FILE:?}"
 SECONDARY_DISK_MOUNT_POINT="${SECONDARY_DISK_MOUNT_POINT:?}"
 SSH_AUTHORIZED_KEYS="${SSH_AUTHORIZED_KEYS:?}"
-FORCE_DELETE="${FORCE_DELETE}"
+NEED_TO_FORCE_DELETE="${FORCE_DELETE}"
 
 RC=false
 if [[ -f "${SOLANA_LOCK_FILE}" ]]; then
@@ -12,7 +12,7 @@ if [[ -f "${SOLANA_LOCK_FILE}" ]]; then
   flock -x -n 9 || ( echo "Failed to acquire lock!" 1>&2 && exit 1 )
   # shellcheck disable=SC1090
   . "${SOLANA_LOCK_FILE}"
-  if [[ "${SOLANA_LOCK_USER}" = "${SOLANA_USER}"  || -n "${FORCE_DELETE}" ]]; then
+  if [[ "${SOLANA_LOCK_USER}" = "${SOLANA_USER}"  || -n "${NEED_TO_FORCE_DELETE}" ]]; then
     # Begin running process cleanup
     CLEANUP_PID=$$
     CLEANUP_PIDS=()

--- a/net/scripts/colo-node-onfree.sh
+++ b/net/scripts/colo-node-onfree.sh
@@ -4,7 +4,7 @@
 SOLANA_LOCK_FILE="${SOLANA_LOCK_FILE:?}"
 SECONDARY_DISK_MOUNT_POINT="${SECONDARY_DISK_MOUNT_POINT:?}"
 SSH_AUTHORIZED_KEYS="${SSH_AUTHORIZED_KEYS:?}"
-NEED_TO_FORCE_DELETE="${FORCE_DELETE}"
+FORCE_DELETE="${FORCE_DELETE:?}"
 
 RC=false
 if [[ -f "${SOLANA_LOCK_FILE}" ]]; then
@@ -12,7 +12,7 @@ if [[ -f "${SOLANA_LOCK_FILE}" ]]; then
   flock -x -n 9 || ( echo "Failed to acquire lock!" 1>&2 && exit 1 )
   # shellcheck disable=SC1090
   . "${SOLANA_LOCK_FILE}"
-  if [[ "${SOLANA_LOCK_USER}" = "${SOLANA_USER}"  || -n "${NEED_TO_FORCE_DELETE}" ]]; then
+  if [[ "${SOLANA_LOCK_USER}" = "${SOLANA_USER}"  || -n "${FORCE_DELETE}" ]]; then
     # Begin running process cleanup
     CLEANUP_PID=$$
     CLEANUP_PIDS=()

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -13,7 +13,7 @@ Test failed during step:
 ${STEP}
 
 Failure occured when running the following command:
-$(eval echo "$@")"
+$*"
   fi
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
#### Problem

Seems we used v0.7.0 shellcheck and the current stable version is v0.8.0.

#### Summary of Changes

1. use shellcheck v0.8.0
2. fix some info/warn after upgrade.
    - add quote to variable 
    - rename a variable, `FORCE_DELETE`, to prevent self assignment
    - ignore check for `eval ... $@`
    - use `$*` to replace `$(eval echo "$@")`
