### PR TITLE
fix: add compute units to jsonrpc parser

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -867,6 +867,10 @@ export type ConfirmedTransactionMeta = {
   preTokenBalances?: Array<TokenBalance> | null;
   /** The token balances of the transaction accounts after processing */
   postTokenBalances?: Array<TokenBalance> | null;
+  /** The addresses of the accounts loaded for the transaction */
+  loadedAddresses?: LoadedAddresses | null;
+  /** The compute units consumed after processing the transaction */
+  computeUnitsConsumed?: number | null;
   /** The error result of transaction processing */
   err: TransactionError | null;
 };
@@ -1848,6 +1852,7 @@ const ConfirmedTransactionMetaResult = pick({
   preTokenBalances: optional(nullable(array(TokenBalanceResult))),
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
+  computeUnitsConsumed: optional(number()),
 });
 
 /**
@@ -1872,6 +1877,7 @@ const ParsedConfirmedTransactionMetaResult = pick({
   preTokenBalances: optional(nullable(array(TokenBalanceResult))),
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
+  computeUnitsConsumed: optional(number()),
 });
 
 /**


### PR DESCRIPTION
#### Problem

The auto-complete of my editor did not show the computeUnitsConsumed field.

Tested with this example script:

```
import { Connection } from "@solana/web3.js";

async function main() {
  const conn = new Connection("https://testnet.rpcpool.com");
  const commitment = "confirmed";
  const version = await conn.getVersion();
  console.log({ version });
  const slot = await conn.getSlot(commitment);
  console.log({ slot });
  const block = await conn.getBlock(slot, { commitment });
  console.log({ block });
  const tx = block?.transactions[0];
  console.log("tx", tx);
}

main();
```