### PR TITLE
Minor shred constant cleanup

### DIFF
--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -1,18 +1,25 @@
 use {
-    crate::shred::{
-        common::dispatch,
-        legacy, merkle,
-        traits::{Shred, ShredCode as ShredCodeTrait},
-        CodingShredHeader, Error, ShredCommonHeader, ShredType, DATA_SHREDS_PER_FEC_BLOCK,
-        MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+    crate::{
+        shred::{
+            common::dispatch,
+            legacy, merkle,
+            traits::{Shred, ShredCode as ShredCodeTrait},
+            CodingShredHeader, Error, ShredCommonHeader, ShredType, DATA_SHREDS_PER_FEC_BLOCK,
+            MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+        },
+        shredder::ERASURE_BATCH_SIZE,
     },
     solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
 };
 
-// See ERASURE_BATCH_SIZE.
-const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768 * 17);
-pub(crate) const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT * 17;
+const MAX_CODE_TO_DATA_SHRED_RATIO: usize = ERASURE_BATCH_SIZE[1] - 1;
+const_assert_eq!(
+    MAX_CODE_SHREDS_PER_SLOT,
+    32_768 * MAX_CODE_TO_DATA_SHRED_RATIO
+);
+pub(crate) const MAX_CODE_SHREDS_PER_SLOT: usize =
+    MAX_DATA_SHREDS_PER_SLOT * MAX_CODE_TO_DATA_SHRED_RATIO;
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -13,13 +13,9 @@ use {
     static_assertions::const_assert_eq,
 };
 
-const MAX_CODE_TO_DATA_SHRED_RATIO: usize = ERASURE_BATCH_SIZE[1] - 1;
-const_assert_eq!(
-    MAX_CODE_SHREDS_PER_SLOT,
-    32_768 * MAX_CODE_TO_DATA_SHRED_RATIO
-);
+const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768 * 17);
 pub(crate) const MAX_CODE_SHREDS_PER_SLOT: usize =
-    MAX_DATA_SHREDS_PER_SLOT * MAX_CODE_TO_DATA_SHRED_RATIO;
+    MAX_DATA_SHREDS_PER_SLOT * (ERASURE_BATCH_SIZE[1] - 1);
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -26,7 +26,7 @@ lazy_static! {
 
 // Maps number of data shreds to the optimal erasure batch size which has the
 // same recovery probabilities as a 32:32 erasure batch.
-const ERASURE_BATCH_SIZE: [usize; 33] = [
+pub(crate) const ERASURE_BATCH_SIZE: [usize; 33] = [
     0, 18, 20, 22, 23, 25, 27, 28, 30, // 8
     32, 33, 35, 36, 38, 39, 41, 42, // 16
     43, 45, 46, 48, 49, 51, 52, 53, // 24


### PR DESCRIPTION
#### Problem
Currently magic number exists for defining max code shreds.

#### Summary of Changes
Replace magic number 17 with source of this number (worst case code to data shred ratio).