### PR TITLE
RPC Notifier Signal when Setup Complete

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -722,6 +722,7 @@ impl Validator {
             block_commitment_cache.clone(),
             optimistically_confirmed_bank.clone(),
             &config.pubsub_config,
+            None,
         ));
 
         let max_slots = Arc::new(MaxSlots::default());

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -573,7 +573,7 @@ impl RpcSubscriptions {
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         let blockstore = Arc::new(blockstore);
 
-        Self::new_with_config(
+        let rpc_subscriptions = Self::new_with_config(
             exit,
             max_complete_transaction_status_slot,
             blockstore,
@@ -581,7 +581,10 @@ impl RpcSubscriptions {
             block_commitment_cache,
             optimistically_confirmed_bank,
             &PubSubConfig::default_for_tests(),
-        )
+        );
+        // Ensure RPC notifier is ready to receive notifications before proceeding
+        std::thread::sleep(Duration::from_millis(100));
+        rpc_subscriptions
     }
 
     pub fn new_for_tests_with_blockstore(


### PR DESCRIPTION
#### Problem
See #27480. CI test flakiness

#### Summary of Changes
have `new_with_config` optionally signal back to callers when RPC Notifier thread pool routine has been installed. Have tests wait for setup to complete before proceeding with next steps.

Have `new_for_tests` call `new_for_tests_with_blockstore` to reduce redundant code