### PR TITLE
use exit signal for acct idx bg threads

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1458,6 +1458,7 @@ fn load_blockstore(
                 .cache_block_meta_sender
                 .as_ref(),
             accounts_update_notifier,
+            exit,
         );
 
     // Before replay starts, set the callbacks in each of the banks in BankForks so that

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -176,6 +176,7 @@ fn restore_from_snapshot(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
 
@@ -849,6 +850,7 @@ fn restore_from_snapshots_and_check_banks_are_equal(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )?;
 
     assert_eq!(bank, &deserialized_bank);
@@ -1044,6 +1046,7 @@ fn test_snapshots_with_background_services(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1093,6 +1093,7 @@ fn load_bank_forks(
             &process_options,
             None,
             accounts_update_notifier,
+            &Arc::default(),
         );
 
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2180,6 +2180,7 @@ fn create_snapshot_to_hard_fork(
         None,
         None,
         None,
+        &Arc::default(),
     )
     .unwrap();
     let bank = bank_forks.read().unwrap().get(snapshot_slot).unwrap();

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -12,6 +12,7 @@ use {
         },
     },
     solana_sdk::{account::AccountSharedData, pubkey},
+    std::sync::Arc,
     test::Bencher,
 };
 
@@ -23,7 +24,10 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_FORKS: u64 = 16;
 
     let mut reclaims = vec![];
-    let index = AccountsIndex::<AccountInfo>::new(Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS));
+    let index = AccountsIndex::<AccountInfo>::new(
+        Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
+        &Arc::default(),
+    );
     for f in 0..NUM_FORKS {
         for pubkey in pubkeys.iter().take(NUM_PUBKEYS) {
             index.upsert(

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -61,7 +61,7 @@ use {
         ops::RangeBounds,
         path::PathBuf,
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc, Mutex,
         },
     },
@@ -164,6 +164,7 @@ impl Accounts {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
     }
 
@@ -182,6 +183,7 @@ impl Accounts {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
             None,
+            &Arc::default(),
         )
     }
 
@@ -193,6 +195,7 @@ impl Accounts {
         shrink_ratio: AccountShrinkThreshold,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -203,6 +206,7 @@ impl Accounts {
                 shrink_ratio,
                 accounts_db_config,
                 accounts_update_notifier,
+                exit,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2013,6 +2013,7 @@ impl AccountsDb {
             AccountShrinkThreshold::default(),
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
     }
 
@@ -2025,6 +2026,7 @@ impl AccountsDb {
             AccountShrinkThreshold::default(),
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
     }
 
@@ -2036,9 +2038,12 @@ impl AccountsDb {
         shrink_ratio: AccountShrinkThreshold,
         mut accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
-        let accounts_index =
-            AccountsIndex::new(accounts_db_config.as_mut().and_then(|x| x.index.take()));
+        let accounts_index = AccountsIndex::new(
+            accounts_db_config.as_mut().and_then(|x| x.index.take()),
+            exit,
+        );
         let accounts_hash_cache_path = accounts_db_config
             .as_ref()
             .and_then(|x| x.accounts_hash_cache_path.clone());
@@ -9109,6 +9114,7 @@ impl AccountsDb {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
     }
 

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -21,6 +21,7 @@ pub struct AccountsIndexStorage<T: IndexValue> {
 
     pub storage: Arc<BucketMapHolder<T>>,
     pub in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
+    exit: Arc<AtomicBool>,
 
     /// set_startup(true) creates bg threads which are kept alive until set_startup(false)
     startup_worker_threads: Mutex<Option<BgThreads>>,
@@ -57,9 +58,10 @@ impl BgThreads {
         in_mem: &[Arc<InMemAccountsIndex<T>>],
         threads: usize,
         can_advance_age: bool,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
         // stop signal used for THIS batch of bg threads
-        let exit = Arc::new(AtomicBool::default());
+        let local_exit = Arc::new(AtomicBool::default());
         let handles = Some(
             (0..threads)
                 .into_iter()
@@ -67,14 +69,19 @@ impl BgThreads {
                     // the first thread we start is special
                     let can_advance_age = can_advance_age && idx == 0;
                     let storage_ = Arc::clone(storage);
-                    let exit_ = Arc::clone(&exit);
+                    let local_exit_ = Arc::clone(&local_exit);
+                    let system_exit_ = Arc::clone(exit);
                     let in_mem_ = in_mem.to_vec();
 
                     // note that using rayon here causes us to exhaust # rayon threads and many tests running in parallel deadlock
                     Builder::new()
                         .name(format!("solIdxFlusher{:02}", idx))
                         .spawn(move || {
-                            storage_.background(exit_, in_mem_, can_advance_age);
+                            storage_.background(
+                                vec![local_exit_, system_exit_],
+                                in_mem_,
+                                can_advance_age,
+                            );
                         })
                         .unwrap()
                 })
@@ -82,7 +89,7 @@ impl BgThreads {
         );
 
         BgThreads {
-            exit,
+            exit: local_exit,
             handles,
             wait: Arc::clone(&storage.wait_dirty_or_aged),
         }
@@ -117,6 +124,7 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
                 &self.in_mem,
                 Self::num_threads(),
                 false, // cannot advance age from any of these threads
+                &self.exit,
             ));
         }
         self.storage.set_startup(value);
@@ -147,7 +155,7 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
     }
 
     /// allocate BucketMapHolder and InMemAccountsIndex[]
-    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>) -> Self {
+    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>, exit: &Arc<AtomicBool>) -> Self {
         let threads = config
             .as_ref()
             .and_then(|config| config.flush_threads)
@@ -161,10 +169,11 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
             .collect::<Vec<_>>();
 
         Self {
-            _bg_threads: BgThreads::new(&storage, &in_mem, threads, true),
+            _bg_threads: BgThreads::new(&storage, &in_mem, threads, true, exit),
             storage,
             in_mem,
             startup_worker_threads: Mutex::default(),
+            exit: Arc::clone(exit),
         }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1588,6 +1588,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
     }
 
@@ -1604,6 +1605,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
             None,
+            &Arc::default(),
         )
     }
 
@@ -1620,6 +1622,7 @@ impl Bank {
         debug_do_not_add_builtins: bool,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
         let accounts = Accounts::new_with_config(
             paths,
@@ -1629,6 +1632,7 @@ impl Bank {
             shrink_ratio,
             accounts_db_config,
             accounts_update_notifier,
+            exit,
         );
         let mut bank = Self::default_with_accounts(accounts);
         bank.ancestors = Ancestors::from(vec![bank.slot()]);

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -327,7 +327,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
     // intended to execute in a bg thread
     pub fn background(
         &self,
-        exit: Arc<AtomicBool>,
+        exit: Vec<Arc<AtomicBool>>,
         in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
         can_advance_age: bool,
     ) {
@@ -370,7 +370,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
             }
             throttling_wait_ms = None;
 
-            if exit.load(Ordering::Relaxed) {
+            if exit.iter().any(|exit| exit.load(Ordering::Relaxed)) {
                 break;
             }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -40,7 +40,7 @@ use {
         path::{Path, PathBuf},
         result::Result,
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc,
         },
         thread::Builder,
@@ -317,6 +317,7 @@ pub(crate) fn bank_from_streams<R>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -338,6 +339,7 @@ where
         verify_index,
         accounts_db_config,
         accounts_update_notifier,
+        exit,
     )
 }
 
@@ -531,6 +533,7 @@ fn reconstruct_bank_from_fields<E>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -547,6 +550,7 @@ where
         verify_index,
         accounts_db_config,
         accounts_update_notifier,
+        exit,
         bank_fields.epoch_accounts_hash,
     )?;
 
@@ -668,6 +672,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
     epoch_accounts_hash: Option<Hash>,
 ) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error>
 where
@@ -681,6 +686,7 @@ where
         shrink_ratio,
         accounts_db_config,
         accounts_update_notifier,
+        exit,
     );
     *accounts_db.epoch_accounts_hash.lock().unwrap() =
         epoch_accounts_hash.map(EpochAccountsHash::new);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -116,6 +116,7 @@ where
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
         None,
     )
     .map(|(accounts_db, _)| accounts_db)
@@ -405,6 +406,7 @@ fn test_bank_serialize_style(
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
     dbank.status_cache = Arc::new(RwLock::new(status_cache));
@@ -551,6 +553,7 @@ fn test_extra_fields_eof() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
 
@@ -613,6 +616,7 @@ fn test_extra_fields_full_snapshot_archive() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
 
@@ -674,6 +678,7 @@ fn test_blank_extra_fields() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        &Arc::default(),
     )
     .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -47,7 +47,10 @@ use {
         path::{Path, PathBuf},
         process::ExitStatus,
         str::FromStr,
-        sync::{atomic::AtomicU32, Arc},
+        sync::{
+            atomic::{AtomicBool, AtomicU32},
+            Arc,
+        },
     },
     tar::{self, Archive},
     tempfile::TempDir,
@@ -966,6 +969,7 @@ pub fn bank_from_snapshot_archives(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     let (unarchived_full_snapshot, mut unarchived_incremental_snapshot, next_append_vec_id) =
         verify_and_unarchive_snapshots(
@@ -1008,6 +1012,7 @@ pub fn bank_from_snapshot_archives(
         verify_index,
         accounts_db_config,
         accounts_update_notifier,
+        exit,
     )?;
     measure_rebuild.stop();
     info!("{}", measure_rebuild);
@@ -1056,6 +1061,7 @@ pub fn bank_from_latest_snapshot_archives(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
 ) -> Result<(
     Bank,
     FullSnapshotArchiveInfo,
@@ -1100,6 +1106,7 @@ pub fn bank_from_latest_snapshot_archives(
         verify_index,
         accounts_db_config,
         accounts_update_notifier,
+        exit,
     )?;
 
     datapoint_info!(
@@ -1802,6 +1809,7 @@ fn rebuild_bank_from_snapshots(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    exit: &Arc<AtomicBool>,
 ) -> Result<Bank> {
     let (full_snapshot_version, full_snapshot_root_paths) =
         verify_unpacked_snapshots_dir_and_version(
@@ -1851,6 +1859,7 @@ fn rebuild_bank_from_snapshots(
                     verify_index,
                     accounts_db_config,
                     accounts_update_notifier,
+                    exit,
                 ),
             }?,
         )
@@ -3384,6 +3393,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
 
@@ -3496,6 +3506,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
 
@@ -3628,6 +3639,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
 
@@ -3750,6 +3762,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
 
@@ -3890,6 +3903,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
         assert_eq!(
@@ -3954,6 +3968,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            &Arc::default(),
         )
         .unwrap();
         assert_eq!(


### PR DESCRIPTION
#### Problem

Acct idx spins up background threads for synchronizing with disk.
These threads need to quit when the validator says to quit.
https://discord.com/channels/428295358100013066/560503042458517505/1016840318840221726

#### Summary of Changes

Pass through an atomic bool that the threads will listen to.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
