### PR TITLE
Increase downstream-projects timeout

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -234,7 +234,7 @@ EOF
     cat >> "$output_file" <<"EOF"
   - command: "scripts/build-downstream-projects.sh"
     name: "downstream-projects"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     agents:
       queue: "solana"
 EOF


### PR DESCRIPTION
#### Problem
downstream-projects stage of CI has been failing intermittently due to timeout issues.

Example:
https://buildkite.com/solana-labs/solana/builds/80851#_


#### Summary of Changes
Increase timeout from 30 mins to 35 mins