### PR TITLE
avoid buffer copy in generate_coding_shreds

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -650,7 +650,7 @@ mod tests {
             &packet_hasher
         ));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 0, 1, 1, 0, version);
+        let shred = Shred::new_code(slot, index, None, 0, 1, 1, 0, version);
         // Coding at (1, 5) passes
         assert!(!should_skip_retransmit(
             shred.id(),
@@ -666,7 +666,7 @@ mod tests {
             &packet_hasher
         ));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 2, 1, 1, 0, version);
+        let shred = Shred::new_code(slot, index, None, 2, 1, 1, 0, version);
         // 2nd unique coding at (1, 5) passes
         assert!(!should_skip_retransmit(
             shred.id(),
@@ -682,7 +682,7 @@ mod tests {
             &packet_hasher
         ));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 3, 1, 1, 0, version);
+        let shred = Shred::new_code(slot, index, None, 3, 1, 1, 0, version);
         // Another unique coding at (1, 5) always blocked
         assert!(should_skip_retransmit(
             shred.id(),

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -572,15 +572,15 @@ mod test {
             std::net::{IpAddr, Ipv4Addr},
         };
         solana_logger::setup();
-        let shred = Shred::new_from_parity_shard(
-            5,   // slot
-            5,   // index
-            &[], // parity_shard
-            5,   // fec_set_index
-            6,   // num_data_shreds
-            6,   // num_coding_shreds
-            4,   // position
-            0,   // version
+        let shred = Shred::new_code(
+            5,    // slot
+            5,    // index
+            None, // parity_shard
+            5,    // fec_set_index
+            6,    // num_data_shreds
+            6,    // num_coding_shreds
+            4,    // position
+            0,    // version
         );
         let mut shreds = vec![shred.clone(), shred.clone(), shred];
         let _from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6063,15 +6063,15 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let slot = 1;
-        let coding_shred = Shred::new_from_parity_shard(
-            slot,
-            11,  // index
-            &[], // parity_shard
-            11,  // fec_set_index
-            11,  // num_data_shreds
-            11,  // num_coding_shreds
-            8,   // position
-            0,   // version
+        let coding_shred = Shred::new_code(
+            slot, // slot
+            11,   // index
+            None, // parity_shard
+            11,   // fec_set_index
+            11,   // num_data_shreds
+            11,   // num_coding_shreds
+            8,    // position
+            0,    // version
         );
 
         let mut erasure_metas = HashMap::new();
@@ -6121,15 +6121,15 @@ pub mod tests {
         let last_root = RwLock::new(0);
 
         let slot = 1;
-        let mut coding_shred = Shred::new_from_parity_shard(
-            slot,
-            11,  // index
-            &[], // parity_shard
-            11,  // fec_set_index
-            11,  // num_data_shreds
-            11,  // num_coding_shreds
-            8,   // position
-            0,   // version
+        let mut coding_shred = Shred::new_code(
+            slot, // slot
+            11,   // index
+            None, // parity_shard
+            11,   // fec_set_index
+            11,   // num_data_shreds
+            11,   // num_coding_shreds
+            8,    // position
+            0,    // version
         );
 
         // Insert a good coding shred

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -312,6 +312,7 @@ impl Shred {
     dispatch!(pub(crate) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
     // Like Shred::erasure_shard but returning a slice.
     dispatch!(pub(crate) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(crate) fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error>);
     // Returns the shard index within the erasure coding set.
     dispatch!(pub(crate) fn erasure_shard_index(&self) -> Result<usize, Error>);
 
@@ -374,10 +375,10 @@ impl Shred {
         })
     }
 
-    pub fn new_from_parity_shard(
+    pub fn new_code(
         slot: Slot,
         index: u32,
-        parity_shard: &[u8],
+        parity_shard: Option<&[u8]>,
         fec_set_index: u32,
         num_data_shreds: u16,
         num_coding_shreds: u16,
@@ -1073,14 +1074,14 @@ mod tests {
         ));
         assert_eq!(stats.bad_parent_offset, 1);
 
-        let shred = Shred::new_from_parity_shard(
-            8,   // slot
-            2,   // index
-            &[], // parity_shard
-            10,  // fec_set_index
-            30,  // num_data
-            4,   // num_code
-            1,   // position
+        let shred = Shred::new_code(
+            8,    // slot
+            2,    // index
+            None, // parity_shard
+            10,   // fec_set_index
+            30,   // num_data
+            4,    // num_code
+            1,    // position
             shred_version,
         );
         shred.copy_to_packet(&mut packet);
@@ -1112,14 +1113,14 @@ mod tests {
         ));
         assert_eq!(1, stats.index_out_of_bounds);
 
-        let shred = Shred::new_from_parity_shard(
-            8,   // slot
-            2,   // index
-            &[], // parity_shard
-            10,  // fec_set_index
-            30,  // num_data_shreds
-            4,   // num_coding_shreds
-            3,   // position
+        let shred = Shred::new_code(
+            8,    // slot
+            2,    // index
+            None, // parity_shard
+            10,   // fec_set_index
+            30,   // num_data_shreds
+            4,    // num_coding_shreds
+            3,    // position
             shred_version,
         );
         shred.copy_to_packet(&mut packet);
@@ -1429,10 +1430,10 @@ mod tests {
         let mut parity_shard = vec![0u8; legacy::SIZE_OF_ERASURE_ENCODED_SLICE];
         rng.fill(&mut parity_shard[..]);
         let keypair = Keypair::generate(&mut rng);
-        let mut shred = Shred::new_from_parity_shard(
+        let mut shred = Shred::new_code(
             141945197, // slot
             23418,     // index
-            &parity_shard,
+            Some(&parity_shard),
             21259, // fec_set_index
             32,    // num_data_shreds
             58,    // num_coding_shreds

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -386,6 +386,18 @@ impl ShredTrait for ShredData {
             .ok_or(Error::InvalidPayloadSize(self.payload.len()))
     }
 
+    fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error> {
+        if self.payload.len() != Self::SIZE_OF_PAYLOAD {
+            return Err(Error::InvalidPayloadSize(self.payload.len()));
+        }
+        let proof_size = self.proof_size()?;
+        let data_buffer_size = Self::capacity(proof_size)?;
+        let payload_len = self.payload.len();
+        self.payload
+            .get_mut(SIZE_OF_SIGNATURE..Self::SIZE_OF_HEADERS + data_buffer_size)
+            .ok_or(Error::InvalidPayloadSize(payload_len))
+    }
+
     fn sanitize(&self) -> Result<(), Error> {
         match self.common_header.shred_variant {
             ShredVariant::MerkleData(proof_size) => {
@@ -468,6 +480,18 @@ impl ShredTrait for ShredCode {
         self.payload
             .get(Self::SIZE_OF_HEADERS..Self::SIZE_OF_HEADERS + shard_size)
             .ok_or(Error::InvalidPayloadSize(self.payload.len()))
+    }
+
+    fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error> {
+        if self.payload.len() != Self::SIZE_OF_PAYLOAD {
+            return Err(Error::InvalidPayloadSize(self.payload.len()));
+        }
+        let proof_size = self.proof_size()?;
+        let shard_size = Self::capacity(proof_size)?;
+        let payload_len = self.payload.len();
+        self.payload
+            .get_mut(Self::SIZE_OF_HEADERS..Self::SIZE_OF_HEADERS + shard_size)
+            .ok_or(Error::InvalidPayloadSize(payload_len))
     }
 
     fn sanitize(&self) -> Result<(), Error> {

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -30,6 +30,7 @@ impl ShredCode {
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
     dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
     dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);
     dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
@@ -45,7 +46,7 @@ impl ShredCode {
     pub(super) fn new_from_parity_shard(
         slot: Slot,
         index: u32,
-        parity_shard: &[u8],
+        parity_shard: Option<&[u8]>,
         fec_set_index: u32,
         num_data_shreds: u16,
         num_coding_shreds: u16,

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -23,6 +23,7 @@ impl ShredData {
     dispatch!(pub(super) fn data(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
     dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
     dispatch!(pub(super) fn parent(&self) -> Result<Slot, Error>);

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -25,6 +25,7 @@ pub(super) trait Shred: Sized {
     fn erasure_shard(self) -> Result<Vec<u8>, Error>;
     // Like Shred::erasure_shard but returning a slice.
     fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>;
+    fn erasure_shard_as_slice_mut(&mut self) -> Result<&mut [u8], Error>;
 
     // Portion of the payload which is signed.
     fn signed_message(&self) -> &[u8];


### PR DESCRIPTION
#### Problem

`Shredder::generate_coding_shreds` allocates and zeros buffers for parity shreds, then copies parity data into shred buffers.

#### Summary of Changes

Use shred buffers directly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
