### PR TITLE
Make ledger cleanup service honor the replay progress.

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1732,12 +1732,12 @@ impl ReplayStage {
             bank,
             &mut w_replay_stats,
             &mut w_replay_progress,
-            false,
+            false, // skip_verification
             transaction_status_sender,
             Some(replay_vote_sender),
-            None,
+            None, // entry_callback
             verify_recyclers,
-            false,
+            false, // allow_dead_slots
             log_messages_bytes_limit,
             prioritization_fee_cache,
         )?;

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -367,6 +367,9 @@ mod tests {
             },
         )
         .unwrap();
+        // Set the lowest confirmed slot to max to make ledger cleanup service
+        // skips the check for replay progress during the test.
+        blockstore.set_lowest_confirmed_slot(std::u64::MAX);
         if config.no_compaction {
             blockstore.set_no_compaction(true);
         }
@@ -665,6 +668,9 @@ mod tests {
     fn test_compaction() {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
+        // Set the lowest confirmed slot to max to make ledger cleanup service
+        // skips the check for replay progress during the test.
+        blockstore.set_lowest_confirmed_slot(std::u64::MAX);
 
         let n = 10_000;
         let batch_size_slots = 100;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -176,6 +176,7 @@ pub struct Blockstore {
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
     pub shred_timing_point_sender: Option<PohTimingSender>,
     pub lowest_cleanup_slot: RwLock<Slot>,
+    lowest_confirmed_slot: RwLock<Slot>,
     no_compaction: bool,
     pub slots_stats: SlotsStats,
 }
@@ -334,6 +335,7 @@ impl Blockstore {
             insert_shreds_lock: Mutex::<()>::default(),
             last_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
+            lowest_confirmed_slot: RwLock::<Slot>::default(),
             no_compaction: false,
             slots_stats: SlotsStats::default(),
         };
@@ -2212,6 +2214,14 @@ impl Blockstore {
         // needed slots here at any given moment.
         // Blockstore callers, like rpc, can process concurrent read queries
         (lowest_cleanup_slot, lowest_available_slot)
+    }
+
+    pub fn set_lowest_confirmed_slot(&self, slot: Slot) {
+        *self.lowest_confirmed_slot.write().unwrap() = slot;
+    }
+
+    pub fn get_lowest_confirmed_slot(&self) -> Slot {
+        *self.lowest_confirmed_slot.read().unwrap()
     }
 
     // Returns a transaction status, as well as a loop counter for unit testing

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1120,7 +1120,7 @@ pub fn confirm_slot(
         load_result
     }?;
 
-    confirm_slot_entries(
+    let result = confirm_slot_entries(
         bank,
         slot_entries_load_result,
         timing,
@@ -1132,7 +1132,13 @@ pub fn confirm_slot(
         recyclers,
         log_messages_bytes_limit,
         prioritization_fee_cache,
-    )
+    );
+
+    if result.is_ok() {
+        blockstore.set_lowest_confirmed_slot(slot);
+    }
+
+    result
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
#### Problem
The current ledger cleanup service does not honor the replay progress.
As a result, if the replay progress is behind the configured --limit-ledger-size,
then ledger cleanup service might cleanup those slots that are older than
the --limit-ledger-size and make those slots unreplayable.

#### Summary of Changes
This PR makes ledger cleanup service honor the replay progress.
Under the hood, it allows Blockstore to maintain lowest_confirmed_slot,
which is updated upon successful confirm_slot.

A warning message will also be logged when the blockstore is not able
to keep its size under the specified  --limit-ledger-size due to the
behind replay progress.

