### PR TITLE
ci: Fix steps in run-local

### DIFF
--- a/ci/run-local.sh
+++ b/ci/run-local.sh
@@ -18,7 +18,8 @@ steps+=(test-downstream-builds)
 steps+=(test-bench)
 steps+=(test-local-cluster)
 steps+=(test-local-cluster-flakey)
-steps+=(test-local-cluster-slow)
+steps+=(test-local-cluster-slow-1)
+steps+=(test-local-cluster-slow-2)
 
 step_index=0
 if [[ -n "$1" ]]; then


### PR DESCRIPTION
#### Problem

The `run-local` CI script does not have the correct steps for local-cluster-slow.

#### Summary of Changes

Update steps.