### PR TITLE
Add feature gate to remove support for RequestUnitsDeprecated instruction

### DIFF
--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -5,7 +5,7 @@ type MicroLamports = u128;
 
 pub enum PrioritizationFeeType {
     ComputeUnitPrice(u64),
-    /// TODO: remove 'Deprecated' after feature remove_deprecated_request_unit_ix::id() is activated
+    // TODO: remove 'Deprecated' after feature remove_deprecated_request_unit_ix::id() is activated
     Deprecated(u64),
 }
 

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -5,6 +5,7 @@ type MicroLamports = u128;
 
 pub enum PrioritizationFeeType {
     ComputeUnitPrice(u64),
+    /// TODO: remove 'Deprecated' after feature remove_deprecated_request_unit_ix::id() is activated
     Deprecated(u64),
 }
 
@@ -17,6 +18,7 @@ pub struct PrioritizationFeeDetails {
 impl PrioritizationFeeDetails {
     pub fn new(fee_type: PrioritizationFeeType, compute_unit_limit: u64) -> Self {
         match fee_type {
+            // TODO: remove support of 'Deprecated' after feature remove_deprecated_request_unit_ix::id() is activated
             PrioritizationFeeType::Deprecated(fee) => {
                 let priority = if compute_unit_limit == 0 {
                     0

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3798,6 +3798,7 @@ fn test_program_fees() {
         congestion_multiplier,
         &fee_structure,
         true,
+        false,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3819,6 +3820,7 @@ fn test_program_fees() {
         congestion_multiplier,
         &fee_structure,
         true,
+        false,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -34,7 +34,10 @@ use {
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot, INITIAL_RENT_EPOCH},
-        feature_set::{self, use_default_units_in_fee_calculation, FeatureSet},
+        feature_set::{
+            self, remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation,
+            FeatureSet,
+        },
         fee::FeeStructure,
         genesis_config::ClusterType,
         hash::Hash,
@@ -553,6 +556,7 @@ impl Accounts {
                             lamports_per_signature,
                             fee_structure,
                             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
+                            !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1674,6 +1678,7 @@ mod tests {
             lamports_per_signature,
             &FeeStructure::default(),
             true,
+            false,
         );
         assert_eq!(fee, lamports_per_signature);
 

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -23,8 +23,8 @@ pub trait GetTransactionPriorityDetails {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 instructions,
-                true, // use default units per instruction
-                true, // support request_units_deprecated instruction
+                true,  // use default units per instruction
+                false, // stop supporting prioritization by request_units_deprecated instruction
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -24,6 +24,7 @@ pub trait GetTransactionPriorityDetails {
             .process_instructions(
                 instructions,
                 true, // use default units per instruction
+                true, // support request_units_deprecated instruction
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -22,7 +22,7 @@ crate::declare_id!("ComputeBudget111111111111111111111111111111");
 )]
 pub enum ComputeBudgetInstruction {
     /// Deprecated
-    /// TODO: after feature remove_deprecated_request_unit_ix::id() is activated, replace it with 'unused'
+    // TODO: after feature remove_deprecated_request_unit_ix::id() is activated, replace it with 'unused'
     RequestUnitsDeprecated {
         /// Units to request
         units: u32,

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -22,6 +22,7 @@ crate::declare_id!("ComputeBudget111111111111111111111111111111");
 )]
 pub enum ComputeBudgetInstruction {
     /// Deprecated
+    /// TODO: after feature remove_deprecated_request_unit_ix::id() is activated, replace it with 'unused'
     RequestUnitsDeprecated {
         /// Units to request
         units: u32,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -518,6 +518,10 @@ pub mod epoch_accounts_hash {
     solana_sdk::declare_id!("5GpmAKxaGsWWbPp4bNXFLJxZVvG92ctxf7jQnzTQjF3n");
 }
 
+pub mod remove_deprecated_request_unit_ix {
+    solana_sdk::declare_id!("EfhYd3SafzGT472tYQDUc4dPd2xdEfKs5fwkowUgVt4W");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -642,6 +646,7 @@ lazy_static! {
         (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
         (cap_accounts_data_allocations_per_transaction::id(), "cap accounts data allocations per transaction #27375"),
         (epoch_accounts_hash::id(), "enable epoch accounts hash calculation #27539"),
+        (remove_deprecated_request_unit_ix::id(), "remove support for RequestUnitsDeprecated instruction #27500"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Should remove `ComputeBudgetInstruction::RequestUnitsDeprecated`, need feature gate to stop supporting it.

#### Summary of Changes
- Pass `true` (existing behavior) to ComputeBudget::process_instructions() when new feature is not activated, pass `false`  (eg not supporting deprecated ix) when feature is activated. 
- Add `TODO` comments to replace deprecated enum variants, and remove deprecated code once feature's activated.

Fixes #27500 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
