### PR TITLE
add --accounts-db-verify-refcounts for debugging

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1228,6 +1228,12 @@ fn main() {
             "Enables faster starting of ledger-tool by skipping shrink. \
                       This option is for use during testing.",
         );
+    let accountsdb_verify_refcounts = Arg::with_name("accounts_db_verify_refcounts")
+        .long("accounts-db-verify-refcounts")
+        .help(
+            "Debug option to scan all append vecs and verify account index refcounts prior to clean",
+        )
+        .hidden(true);
     let accounts_filler_count = Arg::with_name("accounts_filler_count")
         .long("accounts-filler-count")
         .value_name("COUNT")
@@ -1651,6 +1657,7 @@ fn main() {
             .arg(&accounts_index_limit)
             .arg(&disable_disk_index)
             .arg(&accountsdb_skip_shrink)
+            .arg(&accountsdb_verify_refcounts)
             .arg(&accounts_filler_count)
             .arg(&accounts_filler_size)
             .arg(&verify_index_arg)
@@ -2859,6 +2866,8 @@ fn main() {
                     ancient_append_vecs: arg_matches.is_present("accounts_db_ancient_append_vecs"),
                     skip_initial_hash_calc: arg_matches
                         .is_present("accounts_db_skip_initial_hash_calculation"),
+                    exhaustively_verify_refcounts: arg_matches
+                        .is_present("accounts_db_verify_refcounts"),
                     ..AccountsDbConfig::default()
                 });
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1675,6 +1675,12 @@ pub fn main() {
                 .help("Disables accounts caching"),
         )
         .arg(
+            Arg::with_name("accounts_db_verify_refcounts")
+                .long("accounts-db-verify-refcounts")
+                .help("Debug option to scan all append vecs and verify account index refcounts prior to clean")
+                .hidden(true)
+        )
+        .arg(
             Arg::with_name("accounts_db_skip_shrink")
                 .long("accounts-db-skip-shrink")
                 .help("Enables faster starting of validators by skipping shrink. \
@@ -2560,6 +2566,7 @@ pub fn main() {
             .map(|mb| mb * MB as u64),
         skip_rewrites: matches.is_present("accounts_db_skip_rewrites"),
         ancient_append_vecs: matches.is_present("accounts_db_ancient_append_vecs"),
+        exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

accounts index stores a refcount and a list of alive account info (store id, offset, size) for each pubkey. There is 1 refcount for each appendvec that references this pubkey.
There have been bugs with refcounts. Refcounts are used in clean to throw away old accounts.
In order to verify correctness, a full scan of all appendvecs must be performed. That is expensive and an ever moving target.

#### Summary of Changes

Add a debug option to exhuastively compare append vecs and the index's refcount as of a slot. This is enabled with a hiddent cli argument. This code could be useful in the future or to run periodically to ensure we are correctly handling all issues with refcounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
