### PR TITLE
Create all shared buffer readers before spawning threads

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1191,6 +1191,7 @@ fn spawn_unpack_snapshot_thread(
 }
 
 /// Streams unpacked files across channel
+#[allow(clippy::needless_collect)]
 fn streaming_unarchive_snapshot(
     file_sender: Sender<PathBuf>,
     account_paths: Vec<PathBuf>,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1191,7 +1191,6 @@ fn spawn_unpack_snapshot_thread(
 }
 
 /// Streams unpacked files across channel
-#[allow(clippy::needless_collect)]
 fn streaming_unarchive_snapshot(
     file_sender: Sender<PathBuf>,
     account_paths: Vec<PathBuf>,
@@ -1203,13 +1202,16 @@ fn streaming_unarchive_snapshot(
     let account_paths = Arc::new(account_paths);
     let ledger_dir = Arc::new(ledger_dir);
     let shared_buffer = untar_snapshot_create_shared_buffer(&snapshot_archive_path, archive_format);
+
     // All shared buffer readers need to be created before the threads are spawned
+    #[allow(clippy::needless_collect)]
     let archives: Vec<_> = (0..num_threads)
         .map(|_| {
             let reader = SharedBufferReader::new(&shared_buffer);
             Archive::new(reader)
         })
         .collect();
+
     archives
         .into_iter()
         .enumerate()


### PR DESCRIPTION
#### Problem
```
thread 'snapshot_utils::tests::test_incremental_snapshots_handle_zero_lamport_accounts' panicked at 'SharedBufferReaders must all be created before the first one reads', runtime/src/shared_buffer_reader.rs:324:17
```

#### Summary of Changes
Create all shared buffer readers before spawning threads for unpacking snapshots.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
