### PR TITLE
deserialize(or eof) snapshot epoch_accounts_hash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1005,6 +1005,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
     pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
+    pub(crate) epoch_accounts_hash: Option<Hash>,
 }
 
 // Bank's common fields shared by all supported snapshot versions for serialization.

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -97,6 +97,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             epoch_stakes: dvb.epoch_stakes,
             is_delta: dvb.is_delta,
             incremental_snapshot_persistence: None,
+            epoch_accounts_hash: None,
         }
     }
 }
@@ -317,8 +318,11 @@ impl<'a> TypeContext<'a> for Context {
             .fee_rate_governor
             .clone_with_lamports_per_signature(lamports_per_signature);
 
-        let incremental_snapshot_persistence = ignore_eof_error(deserialize_from(stream))?;
+        let incremental_snapshot_persistence = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
+
+        let epoch_accounts_hash = ignore_eof_error(deserialize_from(stream))?;
+        bank_fields.epoch_accounts_hash = epoch_accounts_hash;
 
         Ok((bank_fields, accounts_db_fields))
     }


### PR DESCRIPTION
#### Problem

We need to add Option<Hash> representing the epoch accounts hash into the snapshot persistence so it can be used later.
#26847

Doing the deserialize first in its own pr.
This can be easily backported without separating out the serialization part in the backport.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
