### PR TITLE
serialize epoch_accounts_hash

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -214,6 +214,7 @@ impl AccountsHashVerifier {
             accounts_package.slot,
             &accounts_hash,
             None,
+            None,
         );
         datapoint_info!(
             "accounts_hash_verifier",

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -258,6 +258,7 @@ fn run_bank_forks_snapshot_n<F>(
         accounts_package.slot,
         &last_bank.get_accounts_hash(),
         None,
+        None,
     );
     let snapshot_package = SnapshotPackage::new(accounts_package, last_bank.get_accounts_hash());
     snapshot_utils::archive_snapshot_package(
@@ -494,6 +495,7 @@ fn test_concurrent_snapshot_packaging(
                 accounts_package.slot,
                 &Hash::default(),
                 None,
+                None,
             );
             let snapshot_package = SnapshotPackage::new(accounts_package, Hash::default());
             pending_snapshot_package
@@ -537,6 +539,7 @@ fn test_concurrent_snapshot_packaging(
         saved_snapshots_dir.path(),
         saved_slot,
         &Hash::default(),
+        None,
         None,
     );
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1190,7 +1190,11 @@ pub struct AccountsDb {
     /// debug feature to scan every append vec and verify refcounts are equal
     exhaustively_verify_refcounts: bool,
 
-    /// A special accounts hash that occurs once per epoch
+    /// the full accounts hash calculation as of a predetermined block height 'N'
+    /// to be included in the bank hash at a predetermined block height 'M'
+    /// The cadence is once per epoch, all nodes calculate a full accounts hash as of a known slot calculated using 'N'
+    /// Some time later (to allow for slow calculation time), the bank hash at a slot calculated using 'M' includes the full accounts hash.
+    /// Thus, the state of all accounts on a validator is known to be correct at least once per epoch.
     pub(crate) epoch_accounts_hash: Mutex<Option<EpochAccountsHash>>,
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2285,6 +2285,19 @@ impl Bank {
         bank
     }
 
+    /// if we were to serialize THIS bank, what value should be saved for the prior accounts hash?
+    /// This depends on the proximity to the time to take the snapshot and the time to use the snapshot.
+    pub(crate) fn get_epoch_accounts_hash_to_serialize(&self) -> Option<Hash> {
+        self.rc
+            .accounts
+            .accounts_db
+            .epoch_accounts_hash
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|hash| *hash.as_ref())
+    }
+
     /// Return subset of bank fields representing serializable state
     pub(crate) fn get_fields_to_serialize<'a>(
         &'a self,

--- a/runtime/src/epoch_accounts_hash.rs
+++ b/runtime/src/epoch_accounts_hash.rs
@@ -23,6 +23,14 @@ impl AsRef<Hash> for EpochAccountsHash {
     }
 }
 
+impl EpochAccountsHash {
+    /// Make an EpochAccountsHash from a regular accounts hash
+    #[must_use]
+    pub fn new(accounts_hash: Hash) -> Self {
+        Self(accounts_hash)
+    }
+}
+
 /// Calculation of the EAH occurs once per epoch.  All nodes in the cluster must agree on which
 /// slot the EAH is based on.  This slot will be at an offset into the epoch, and referred to as
 /// the "start" slot for the EAH calculation.

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -212,6 +212,9 @@ impl<'a> TypeContext<'a> for Context {
             // TODO: if we do a snapshot version bump, consider moving this out.
             lamports_per_signature,
             None::<BankIncrementalSnapshotPersistence>,
+            serializable_bank
+                .bank
+                .get_epoch_accounts_hash_to_serialize(),
         )
             .serialize(serializer)
     }
@@ -344,6 +347,7 @@ impl<'a> TypeContext<'a> for Context {
         stream_writer: &mut BufWriter<W>,
         accounts_hash: &Hash,
         incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
+        epoch_accounts_hash: Option<&Hash>,
     ) -> std::result::Result<(), Box<bincode::ErrorKind>>
     where
         R: Read,
@@ -356,6 +360,7 @@ impl<'a> TypeContext<'a> for Context {
         let blockhash_queue = RwLock::new(rhs.blockhash_queue.clone());
         let hard_forks = RwLock::new(rhs.hard_forks.clone());
         let lamports_per_signature = rhs.fee_rate_governor.lamports_per_signature;
+        let epoch_accounts_hash = epoch_accounts_hash.or(rhs.epoch_accounts_hash.as_ref());
 
         let bank = SerializableVersionedBank {
             blockhash_queue: &blockhash_queue,
@@ -399,6 +404,7 @@ impl<'a> TypeContext<'a> for Context {
                 accounts_db_fields,
                 lamports_per_signature,
                 incremental_snapshot_persistence,
+                epoch_accounts_hash,
             ),
         )
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2297,6 +2297,7 @@ pub fn package_and_archive_full_snapshot(
         accounts_package.slot,
         &bank.get_accounts_hash(),
         None,
+        None, // todo: this needs to be passed through
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());
@@ -2350,6 +2351,7 @@ pub fn package_and_archive_incremental_snapshot(
         accounts_package.slot,
         &bank.get_accounts_hash(),
         None,
+        None, // todo: this needs to be passed through
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());


### PR DESCRIPTION
#### Problem

follow on to:
#27513

related to issue:
#26847

#### Summary of Changes
Write epoch_accounts_hash to serialization in snapshot.
For now, this always writes None.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
