### PR TITLE
merkle_tree: clippy nightly fixes

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -33,7 +33,7 @@ impl<'a> ProofEntry<'a> {
         left_sibling: Option<&'a Hash>,
         right_sibling: Option<&'a Hash>,
     ) -> Self {
-        assert!((None == left_sibling) ^ (None == right_sibling));
+        assert!(left_sibling.is_none() ^ right_sibling.is_none());
         Self(target, left_sibling, right_sibling)
     }
 }
@@ -154,7 +154,7 @@ impl MerkleTree {
             let level = &self.nodes[level_start..(level_start + level_len)];
 
             let target = &level[node_index];
-            if lsib != None || rsib != None {
+            if lsib.is_some() || rsib.is_some() {
                 path.push(ProofEntry::new(target, lsib, rsib));
             }
             if node_index % 2 == 0 {


### PR DESCRIPTION
#### Problem
clippy nightly is reccomending using `is_some()` and `is_none()` instead of checking `!= None` or `== None`.
I imagine this clippy change will make its way into stable, so just hitting it preemptively. 

#### Summary of Changes
Use `is_some()` and `is_none()` in merkle_tree.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
