### PR TITLE
validator: clippy nightly fixes

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -315,7 +315,7 @@ fn wait_for_restart_window(
                                 .incremental
                                 .unwrap_or(snapshot_slot_info.full)
                         });
-                        if restart_snapshot == None {
+                        if restart_snapshot.is_none() {
                             restart_snapshot = snapshot_slot;
                         }
                         if restart_snapshot == snapshot_slot && !monitoring_another_validator {


### PR DESCRIPTION
#### Problem
clippy nightly is reccomending using `is_some()` and `is_none()` instead of checking `!= None` or `== None`.
I imagine this clippy change will make its way into stable, so just hitting it preemptively. 

#### Summary of Changes
Use `is_some()` and `is_none()` in validator's main.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
