### PR TITLE
replay_stage: clippy nightly fixes

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3102,7 +3102,7 @@ impl ReplayStage {
         loop {
             // These cases mean confirmation of propagation on any earlier
             // leader blocks must have been reached
-            if current_leader_slot == None || current_leader_slot.unwrap() < root {
+            if current_leader_slot.is_none() || current_leader_slot.unwrap() < root {
                 break;
             }
 


### PR DESCRIPTION
#### Problem
clippy nightly is reccomending using `is_some()` and `is_none()` instead of checking `!= None` or `== None`.
I imagine this clippy change will make its way into stable, so just hitting it preemptively. 

#### Summary of Changes
Use `is_some()` and `is_none()` in replay_stage.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
