### PR TITLE
cluster_slot_state_verifier: clippy nightly fixes

### DIFF
--- a/core/src/cluster_slot_state_verifier.rs
+++ b/core/src/cluster_slot_state_verifier.rs
@@ -299,7 +299,7 @@ pub enum ResultingStateChange {
 impl SlotStateUpdate {
     fn into_state_changes(self, slot: Slot) -> Vec<ResultingStateChange> {
         let bank_frozen_hash = self.bank_hash();
-        if bank_frozen_hash == None {
+        if bank_frozen_hash.is_none() {
             // If the bank hasn't been frozen yet, then there's nothing to do
             // since replay of the slot hasn't finished yet.
             return vec![];


### PR DESCRIPTION
#### Problem
clippy nightly is reccomending using `is_some()` and `is_none()` instead of checking `!= None` or `== None`.
I imagine this clippy change will make its way into stable, so just hitting it preemptively. 

#### Summary of Changes
Use `is_some()` and `is_none()` in cluster_slot_state_verifier.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
