### PR TITLE
shredder: clippy nightly fixes

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -203,7 +203,7 @@ fn bench_shredder_decoding_raptorq(bencher: &mut Bencher) {
         let mut result = None;
         for packet in &packets {
             result = decoder.decode(packet.clone());
-            if result != None {
+            if result.is_some() {
                 break;
             }
         }


### PR DESCRIPTION
#### Problem
clippy nightly is reccomending using `is_some()` and `is_none()` instead of checking `!= None` or `== None`.
I imagine this clippy change will make its way into stable, so just hitting it preemptively. 

#### Summary of Changes
Use `is_some()` and `is_none()` in shredder.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
