### PR TITLE
feat: add `TransactionMessage` class

### DIFF
--- a/web3.js/src/message/legacy.ts
+++ b/web3.js/src/message/legacy.ts
@@ -13,6 +13,9 @@ import {
   MessageAddressTableLookup,
   MessageCompiledInstruction,
 } from './index';
+import {TransactionInstruction} from '../transaction';
+import {CompiledKeys} from './compiled-keys';
+import {MessageAccountKeys} from './account-keys';
 
 /**
  * An instruction to execute by a program
@@ -37,11 +40,17 @@ export type MessageArgs = {
   /** The message header, identifying signed and read-only `accountKeys` */
   header: MessageHeader;
   /** All the account keys used by this transaction */
-  accountKeys: string[];
+  accountKeys: string[] | PublicKey[];
   /** The hash of a recent ledger block */
   recentBlockhash: Blockhash;
   /** Instructions that will be executed in sequence and committed in one atomic transaction if all succeed. */
   instructions: CompiledInstruction[];
+};
+
+export type CompileLegacyArgs = {
+  payerKey: PublicKey;
+  instructions: Array<TransactionInstruction>;
+  recentBlockhash: Blockhash;
 };
 
 /**
@@ -91,6 +100,29 @@ export class Message {
 
   get addressTableLookups(): Array<MessageAddressTableLookup> {
     return [];
+  }
+
+  getAccountKeys(): MessageAccountKeys {
+    return new MessageAccountKeys(this.staticAccountKeys);
+  }
+
+  static compile(args: CompileLegacyArgs): Message {
+    const compiledKeys = CompiledKeys.compile(args.instructions, args.payerKey);
+    const [header, staticAccountKeys] = compiledKeys.getMessageComponents();
+    const accountKeys = new MessageAccountKeys(staticAccountKeys);
+    const instructions = accountKeys.compileInstructions(args.instructions).map(
+      (ix: MessageCompiledInstruction): CompiledInstruction => ({
+        programIdIndex: ix.programIdIndex,
+        accounts: ix.accountKeyIndexes,
+        data: bs58.encode(ix.data),
+      }),
+    );
+    return new Message({
+      header,
+      accountKeys: staticAccountKeys,
+      recentBlockhash: args.recentBlockhash,
+      instructions,
+    });
   }
 
   isAccountSigner(index: number): boolean {
@@ -250,7 +282,7 @@ export class Message {
     for (let i = 0; i < accountCount; i++) {
       const account = byteArray.slice(0, PUBLIC_KEY_LENGTH);
       byteArray = byteArray.slice(PUBLIC_KEY_LENGTH);
-      accountKeys.push(bs58.encode(Buffer.from(account)));
+      accountKeys.push(new PublicKey(Buffer.from(account)));
     }
 
     const recentBlockhash = byteArray.slice(0, PUBLIC_KEY_LENGTH);

--- a/web3.js/src/transaction/index.ts
+++ b/web3.js/src/transaction/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
 export * from './expiry-custom-errors';
 export * from './legacy';
+export * from './message';
 export * from './versioned';

--- a/web3.js/src/transaction/message.ts
+++ b/web3.js/src/transaction/message.ts
@@ -1,0 +1,147 @@
+import {
+  AccountKeysFromLookups,
+  MessageAccountKeys,
+} from '../message/account-keys';
+import assert from '../utils/assert';
+import {toBuffer} from '../utils/to-buffer';
+import {Blockhash} from '../blockhash';
+import {Message, MessageV0, VersionedMessage} from '../message';
+import {AddressLookupTableAccount} from '../programs';
+import {AccountMeta, TransactionInstruction} from './legacy';
+
+export type TransactionMessageArgs = {
+  accountKeys: MessageAccountKeys;
+  instructions: Array<TransactionInstruction>;
+  recentBlockhash: Blockhash;
+};
+
+export type DecompileArgs =
+  | {
+      accountKeysFromLookups: AccountKeysFromLookups;
+    }
+  | {
+      addressLookupTableAccounts: AddressLookupTableAccount[];
+    };
+
+export class TransactionMessage {
+  accountKeys: MessageAccountKeys;
+  instructions: Array<TransactionInstruction>;
+  recentBlockhash: Blockhash;
+
+  constructor(args: TransactionMessageArgs) {
+    this.accountKeys = args.accountKeys;
+    this.instructions = args.instructions;
+    this.recentBlockhash = args.recentBlockhash;
+  }
+
+  static decompile(
+    message: VersionedMessage,
+    args?: DecompileArgs,
+  ): TransactionMessage {
+    const {header, compiledInstructions, recentBlockhash} = message;
+
+    const {
+      numRequiredSignatures,
+      numReadonlySignedAccounts,
+      numReadonlyUnsignedAccounts,
+    } = header;
+
+    const numWritableSignedAccounts =
+      numRequiredSignatures - numReadonlySignedAccounts;
+    assert(numWritableSignedAccounts > 0, 'Message header is invalid');
+
+    const numWritableUnsignedAccounts =
+      message.staticAccountKeys.length - numReadonlyUnsignedAccounts;
+    assert(numWritableUnsignedAccounts >= 0, 'Message header is invalid');
+
+    const accountKeys = message.getAccountKeys(args);
+    const instructions: TransactionInstruction[] = [];
+    for (const compiledIx of compiledInstructions) {
+      const keys: AccountMeta[] = [];
+
+      for (const keyIndex of compiledIx.accountKeyIndexes) {
+        const pubkey = accountKeys.get(keyIndex);
+        if (pubkey === undefined) {
+          throw new Error(
+            `Failed to find key for account key index ${keyIndex}`,
+          );
+        }
+
+        const isSigner = keyIndex < numRequiredSignatures;
+
+        let isWritable;
+        if (isSigner) {
+          isWritable = keyIndex < numWritableSignedAccounts;
+        } else if (keyIndex < accountKeys.staticAccountKeys.length) {
+          isWritable =
+            keyIndex - numRequiredSignatures < numWritableUnsignedAccounts;
+        } else {
+          isWritable =
+            keyIndex - accountKeys.staticAccountKeys.length <
+            // accountKeysFromLookups cannot be undefined because we already found a pubkey for this index above
+            accountKeys.accountKeysFromLookups!.writable.length;
+        }
+
+        keys.push({
+          pubkey,
+          isSigner: keyIndex < header.numRequiredSignatures,
+          isWritable,
+        });
+      }
+
+      const programId = accountKeys.get(compiledIx.programIdIndex);
+      if (programId === undefined) {
+        throw new Error(
+          `Failed to find program id for program id index ${compiledIx.programIdIndex}`,
+        );
+      }
+
+      instructions.push(
+        new TransactionInstruction({
+          programId,
+          data: toBuffer(compiledIx.data),
+          keys,
+        }),
+      );
+    }
+
+    return new TransactionMessage({
+      accountKeys,
+      instructions,
+      recentBlockhash,
+    });
+  }
+
+  compileToLegacyMessage(): Message {
+    const payerKey = this.accountKeys.get(0);
+    if (payerKey === undefined) {
+      throw new Error(
+        'Failed to compile message because no account keys were found',
+      );
+    }
+
+    return Message.compile({
+      payerKey,
+      recentBlockhash: this.recentBlockhash,
+      instructions: this.instructions,
+    });
+  }
+
+  compileToV0Message(
+    addressLookupTableAccounts?: AddressLookupTableAccount[],
+  ): MessageV0 {
+    const payerKey = this.accountKeys.get(0);
+    if (payerKey === undefined) {
+      throw new Error(
+        'Failed to compile message because no account keys were found',
+      );
+    }
+
+    return MessageV0.compile({
+      payerKey,
+      recentBlockhash: this.recentBlockhash,
+      instructions: this.instructions,
+      addressLookupTableAccounts,
+    });
+  }
+}

--- a/web3.js/test/message-tests/legacy.test.ts
+++ b/web3.js/test/message-tests/legacy.test.ts
@@ -1,0 +1,91 @@
+import bs58 from 'bs58';
+import {expect} from 'chai';
+import {sha256} from '@noble/hashes/sha256';
+
+import {Message} from '../../src/message';
+import {TransactionInstruction} from '../../src/transaction';
+import {PublicKey} from '../../src/publickey';
+
+function createTestKeys(count: number): Array<PublicKey> {
+  return new Array(count).fill(0).map(() => PublicKey.unique());
+}
+
+describe('Message', () => {
+  it('compile', () => {
+    const keys = createTestKeys(5);
+    const recentBlockhash = bs58.encode(sha256('test'));
+    const payerKey = keys[0];
+    const instructions = [
+      new TransactionInstruction({
+        programId: keys[4],
+        keys: [
+          {pubkey: keys[1], isSigner: true, isWritable: true},
+          {pubkey: keys[2], isSigner: false, isWritable: false},
+          {pubkey: keys[3], isSigner: false, isWritable: false},
+        ],
+        data: Buffer.alloc(1),
+      }),
+      new TransactionInstruction({
+        programId: keys[1],
+        keys: [
+          {pubkey: keys[2], isSigner: true, isWritable: false},
+          {pubkey: keys[3], isSigner: false, isWritable: true},
+        ],
+        data: Buffer.alloc(2),
+      }),
+    ];
+
+    const message = Message.compile({
+      payerKey,
+      recentBlockhash,
+      instructions,
+    });
+
+    expect(message.accountKeys).to.eql([
+      payerKey, // payer is first
+      keys[1], // other writable signer
+      keys[2], // sole readonly signer
+      keys[3], // sole writable non-signer
+      keys[4], // sole readonly non-signer
+    ]);
+    expect(message.header).to.eql({
+      numRequiredSignatures: 3,
+      numReadonlySignedAccounts: 1,
+      numReadonlyUnsignedAccounts: 1,
+    });
+    expect(message.addressTableLookups.length).to.eq(0);
+    expect(message.instructions).to.eql([
+      {
+        programIdIndex: 4,
+        accounts: [1, 2, 3],
+        data: bs58.encode(Buffer.alloc(1)),
+      },
+      {
+        programIdIndex: 1,
+        accounts: [2, 3],
+        data: bs58.encode(Buffer.alloc(2)),
+      },
+    ]);
+    expect(message.recentBlockhash).to.eq(recentBlockhash);
+  });
+
+  it('compile without instructions', () => {
+    const payerKey = PublicKey.unique();
+    const recentBlockhash = bs58.encode(sha256('test'));
+    const message = Message.compile({
+      payerKey,
+      instructions: [],
+      recentBlockhash,
+    });
+
+    expect(message.accountKeys).to.eql([payerKey]);
+    expect(message.header).to.eql({
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 0,
+    });
+    expect(message.addressTableLookups.length).to.eq(0);
+    expect(message.instructions.length).to.eq(0);
+    expect(message.recentBlockhash).to.eq(recentBlockhash);
+  });
+});

--- a/web3.js/test/transaction-tests/message.test.ts
+++ b/web3.js/test/transaction-tests/message.test.ts
@@ -1,0 +1,89 @@
+import bs58 from 'bs58';
+import {expect} from 'chai';
+import {sha256} from '@noble/hashes/sha256';
+
+import {
+  TransactionInstruction,
+  TransactionMessage,
+} from '../../src/transaction';
+import {PublicKey} from '../../src/publickey';
+import {AddressLookupTableAccount} from '../../src/programs';
+import {MessageV0} from '../../src/message';
+
+function createTestKeys(count: number): Array<PublicKey> {
+  return new Array(count).fill(0).map(() => PublicKey.unique());
+}
+
+function createTestLookupTable(
+  addresses: Array<PublicKey>,
+): AddressLookupTableAccount {
+  const U64_MAX = 2n ** 64n - 1n;
+  return new AddressLookupTableAccount({
+    key: PublicKey.unique(),
+    state: {
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      deactivationSlot: U64_MAX,
+      authority: PublicKey.unique(),
+      addresses,
+    },
+  });
+}
+
+describe('TransactionMessage', () => {
+  it('decompile', () => {
+    const keys = createTestKeys(7);
+    const recentBlockhash = bs58.encode(sha256('test'));
+    const payerKey = keys[0];
+    const instructions = [
+      new TransactionInstruction({
+        programId: keys[4],
+        keys: [
+          {pubkey: keys[1], isSigner: true, isWritable: true},
+          {pubkey: keys[2], isSigner: true, isWritable: false},
+          {pubkey: keys[3], isSigner: false, isWritable: true},
+          {pubkey: keys[5], isSigner: false, isWritable: true},
+          {pubkey: keys[6], isSigner: false, isWritable: false},
+        ],
+        data: Buffer.alloc(1),
+      }),
+      new TransactionInstruction({
+        programId: keys[1],
+        keys: [],
+        data: Buffer.alloc(2),
+      }),
+      new TransactionInstruction({
+        programId: keys[3],
+        keys: [],
+        data: Buffer.alloc(3),
+      }),
+    ];
+
+    const addressLookupTableAccounts = [createTestLookupTable(keys)];
+    const message = MessageV0.compile({
+      payerKey,
+      recentBlockhash,
+      instructions,
+      addressLookupTableAccounts,
+    });
+
+    expect(() => TransactionMessage.decompile(message)).to.throw(
+      'Failed to get account keys because address table lookups were not resolved',
+    );
+
+    const accountKeys = message.getAccountKeys({addressLookupTableAccounts});
+    const decompiledMessage = TransactionMessage.decompile(message, {
+      addressLookupTableAccounts,
+    });
+
+    expect(decompiledMessage.accountKeys).to.eql(accountKeys);
+    expect(decompiledMessage.recentBlockhash).to.eq(recentBlockhash);
+    expect(decompiledMessage.instructions).to.eql(instructions);
+
+    expect(decompiledMessage).to.eql(
+      TransactionMessage.decompile(message, {
+        accountKeysFromLookups: accountKeys.accountKeysFromLookups!,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
#### Problem
Lack of a common interface for creating and displaying transactions which supports both legacy and versioned transactions

#### Summary of Changes
- Add `TransactionMessage` class which can be used to construct or decompile legacy and v0 transactions.
- Add `Message.compile` method to the legacy message class to mirror the equivalent `MessageV0.compile` method added in https://github.com/solana-labs/solana/pull/27524
- Add `getAccountKeys` method to both `Message` and `MessageV0` classes for use in transaction decompilation and to allow devs to conveniently resolve account indexes with a common interface for legacy and versioned transactions
- Add `resolveAddressTableLookups` method to `MessageV0` which is used to decompile v0 transactions


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
