### PR TITLE
Use batch send in bench-tps to send transactions

### DIFF
--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -14,9 +14,7 @@ impl BenchTpsClient for TpuClient {
         Ok(signature)
     }
     fn send_batch(&self, transactions: Vec<Transaction>) -> Result<()> {
-        for transaction in transactions {
-            BenchTpsClient::send_transaction(self, transaction)?;
-        }
+        self.try_send_transaction_batch(&transactions)?;
         Ok(())
     }
     fn get_latest_blockhash(&self) -> Result<Hash> {

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -231,6 +231,15 @@ async fn send_wire_transaction_to_addr(
     conn.send_wire_transaction(wire_transaction.clone()).await
 }
 
+async fn send_wire_transaction_batch_to_addr(
+    connection_cache: &ConnectionCache,
+    addr: &SocketAddr,
+    wire_transactions: &[Vec<u8>],
+) -> TransportResult<()> {
+    let conn = connection_cache.get_nonblocking_connection(addr);
+    conn.send_wire_transaction_batch(wire_transactions).await
+}
+
 impl TpuClient {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
@@ -254,6 +263,18 @@ impl TpuClient {
         self.try_send_wire_transaction(wire_transaction).await
     }
 
+    pub async fn try_send_transaction_batch(
+        &self,
+        transactions: &[Transaction],
+    ) -> TransportResult<()> {
+        let wire_transactions = transactions
+            .iter()
+            .map(|tx| serialize(tx).expect("serialization should succeed"))
+            .collect();
+        self.try_send_wire_transaction_batch(wire_transactions)
+            .await
+    }
+
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
     pub async fn try_send_wire_transaction(
@@ -270,6 +291,47 @@ impl TpuClient {
                     &self.connection_cache,
                     addr,
                     wire_transaction.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let results: Vec<TransportResult<()>> = join_all(futures).await;
+
+        let mut last_error: Option<TransportError> = None;
+        let mut some_success = false;
+        for result in results {
+            if let Err(e) = result {
+                if last_error.is_none() {
+                    last_error = Some(e);
+                }
+            } else {
+                some_success = true;
+            }
+        }
+        if !some_success {
+            Err(if let Some(err) = last_error {
+                err
+            } else {
+                std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted").into()
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn try_send_wire_transaction_batch(
+        &self,
+        wire_transactions: Vec<Vec<u8>>,
+    ) -> TransportResult<()> {
+        let leaders = self
+            .leader_tpu_service
+            .leader_tpu_sockets(self.fanout_slots);
+        let futures = leaders
+            .iter()
+            .map(|addr| {
+                send_wire_transaction_batch_to_addr(
+                    &self.connection_cache,
+                    addr,
+                    &wire_transactions,
                 )
             })
             .collect::<Vec<_>>();

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -263,18 +263,6 @@ impl TpuClient {
         self.try_send_wire_transaction(wire_transaction).await
     }
 
-    pub async fn try_send_transaction_batch(
-        &self,
-        transactions: &[Transaction],
-    ) -> TransportResult<()> {
-        let wire_transactions = transactions
-            .iter()
-            .map(|tx| serialize(tx).expect("serialization should succeed"))
-            .collect();
-        self.try_send_wire_transaction_batch(wire_transactions)
-            .await
-    }
-
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
     pub async fn try_send_wire_transaction(
@@ -318,6 +306,9 @@ impl TpuClient {
         }
     }
 
+    /// Send a batch of wire transactions to the current and upcoming leader TPUs according to
+    /// fanout size
+    /// Returns the last error if all sends fail
     pub async fn try_send_wire_transaction_batch(
         &self,
         wire_transactions: Vec<Vec<u8>>,

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -77,6 +77,10 @@ impl TpuClient {
         self.invoke(self.tpu_client.try_send_transaction(transaction))
     }
 
+    pub fn try_send_transaction_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
+        self.invoke(self.tpu_client.try_send_transaction_batch(transactions))
+    }
+
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
     pub fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {


### PR DESCRIPTION
#### Problem
The `bench-tps` performance is not great when QUIC is used for sending transactions.

#### Summary of Changes
The client was sending individual transaction from batch one at a time, and waiting for the QUIC to finish sending it. This throttles the transaction send rate.
This PR implements a `batch_send` wrapper using the existing client APIs, and uses that that in the bench-tps client.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
