### PR TITLE
[wip] Goodbye manual rocksdb compaction

### DIFF
--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -6,20 +6,19 @@
 
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
-    rand::{thread_rng, Rng},
     solana_ledger::{
         blockstore::{Blockstore, PurgeType},
         blockstore_db::Result as BlockstoreResult,
     },
     solana_measure::measure::Measure,
-    solana_sdk::clock::{Slot, DEFAULT_TICKS_PER_SLOT, TICKS_PER_DAY},
+    solana_sdk::clock::Slot,
     std::{
         string::ToString,
         sync::{
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicBool, Ordering},
             Arc,
         },
-        thread::{self, sleep, Builder, JoinHandle},
+        thread::{self, Builder, JoinHandle},
         time::Duration,
     },
 };
@@ -60,9 +59,6 @@ impl LedgerCleanupService {
             max_ledger_shreds
         );
 
-        let exit_compact = exit.clone();
-        let blockstore_compact = blockstore.clone();
-
         let t_cleanup = Builder::new()
             .name("solLedgerClean".to_string())
             .spawn(move || loop {
@@ -84,9 +80,7 @@ impl LedgerCleanupService {
             })
             .unwrap();
 
-        Self {
-            t_cleanup,
-        }
+        Self { t_cleanup }
     }
 
     /// A helper function to `cleanup_ledger` which returns a tuple of the

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -81,8 +81,6 @@ pub struct TvuConfig {
     pub max_ledger_shreds: Option<u64>,
     pub shred_version: u16,
     pub repair_validators: Option<HashSet<Pubkey>>,
-    pub rocksdb_compaction_interval: Option<u64>,
-    pub rocksdb_max_compaction_jitter: Option<u64>,
     pub wait_for_vote_to_start_leader: bool,
     pub replay_slots_concurrently: bool,
 }
@@ -298,8 +296,6 @@ impl Tvu {
                 blockstore.clone(),
                 max_ledger_shreds,
                 exit,
-                tvu_config.rocksdb_compaction_interval,
-                tvu_config.rocksdb_max_compaction_jitter,
             )
         });
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -141,9 +141,6 @@ pub struct ValidatorConfig {
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub halt_on_known_validators_accounts_hash_mismatch: bool,
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
-    pub no_rocksdb_compaction: bool,
-    pub rocksdb_compaction_interval: Option<u64>,
-    pub rocksdb_max_compaction_jitter: Option<u64>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,
@@ -205,9 +202,6 @@ impl Default for ValidatorConfig {
             gossip_validators: None,
             halt_on_known_validators_accounts_hash_mismatch: false,
             accounts_hash_fault_injection_slots: 0,
-            no_rocksdb_compaction: false,
-            rocksdb_compaction_interval: None,
-            rocksdb_max_compaction_jitter: None,
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             wal_recovery_mode: None,
@@ -984,8 +978,6 @@ impl Validator {
                 max_ledger_shreds: config.max_ledger_shreds,
                 shred_version: node.info.shred_version,
                 repair_validators: config.repair_validators.clone(),
-                rocksdb_compaction_interval: config.rocksdb_compaction_interval,
-                rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
                 wait_for_vote_to_start_leader,
                 replay_slots_concurrently: config.replay_slots_concurrently,
             },
@@ -1415,7 +1407,6 @@ fn load_blockstore(
         },
     )
     .expect("Failed to open ledger database");
-    blockstore.set_no_compaction(config.no_rocksdb_compaction);
     blockstore.shred_timing_point_sender = poh_timing_point_sender;
     // following boot sequence (esp BankForks) could set root. so stash the original value
     // of blockstore root away here as soon as possible.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1032,6 +1032,7 @@ impl Blockstore {
             .expect("Couldn't fetch from SlotMeta column family")
         {
             // Clear all slot related information
+            // todo: is this new PurgeType correct in this context?
             self.run_purge(slot, slot, PurgeType::CompactionFilter)
                 .expect("Purge database operations failed");
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -176,7 +176,6 @@ pub struct Blockstore {
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
     pub shred_timing_point_sender: Option<PohTimingSender>,
     pub lowest_cleanup_slot: RwLock<Slot>,
-    no_compaction: bool,
     pub slots_stats: SlotsStats,
 }
 
@@ -334,7 +333,6 @@ impl Blockstore {
             insert_shreds_lock: Mutex::<()>::default(),
             last_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
-            no_compaction: false,
             slots_stats: SlotsStats::default(),
         };
         if initialize_transaction_status_index {
@@ -406,18 +404,6 @@ impl Blockstore {
             }
             walk.forward();
         }
-    }
-
-    /// Whether to disable compaction in [`Blockstore::compact_storage`], which is used
-    /// by the ledger cleanup service and `solana_core::validator::backup_and_clear_blockstore`.
-    ///
-    /// Note that this setting is not related to the RocksDB's background
-    /// compaction.
-    ///
-    /// To disable RocksDB's background compaction, open the Blockstore
-    /// with AccessType::PrimaryForMaintenance.
-    pub fn set_no_compaction(&mut self, no_compaction: bool) {
-        self.no_compaction = no_compaction;
     }
 
     /// Deletes the blockstore at the specified path.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2046,8 +2046,6 @@ impl Blockstore {
         )
     }
 
-    /// Toggles the active primary index between `0` and `1`, and clears the
-    /// stored max-slot of the frozen index in preparation for pruning.
     fn get_primary_index_to_write(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -152,7 +152,7 @@ impl Blockstore {
             .batch()
             .expect("Database Error: Failed to get write batch");
         let mut delete_range_timer = Measure::start("delete_range");
-        let mut columns_purged = self
+        let columns_purged = self
             .db
             .delete_range_cf::<cf::SlotMeta>(&mut write_batch, from_slot, to_slot)
             .is_ok()
@@ -212,7 +212,7 @@ impl Blockstore {
                 .db
                 .delete_range_cf::<cf::OptimisticSlots>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
-        let mut w_active_transaction_status_index =
+        let w_active_transaction_status_index =
             self.active_transaction_status_index.write().unwrap();
         match purge_type {
             PurgeType::Exact => {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -441,6 +441,7 @@ pub mod tests {
                 .unwrap();
         }
         // Purge to freeze index 0
+        // todo: is this new PurgeType correct in this context?
         blockstore.run_purge(0, 1, PurgeType::Exact).unwrap();
 
         for x in max_slot..2 * max_slot {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -74,13 +74,6 @@ impl Blockstore {
 
     pub fn purge_and_compact_slots(&self, from_slot: Slot, to_slot: Slot) {
         self.purge_slots(from_slot, to_slot, PurgeType::Exact);
-        if let Err(e) = self.compact_storage(from_slot, to_slot) {
-            // This error is not fatal and indicates an internal error?
-            error!(
-                "Error: {:?}; Couldn't compact storage from {:?} to {:?}",
-                e, from_slot, to_slot
-            );
-        }
     }
 
     /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
@@ -333,97 +326,6 @@ impl Blockstore {
                 .db
                 .delete_file_in_range_cf::<cf::OptimisticSlots>(from_slot, to_slot)
                 .is_ok()
-    }
-
-    pub fn compact_storage(&self, from_slot: Slot, to_slot: Slot) -> Result<bool> {
-        if self.no_compaction {
-            info!("compact_storage: compaction disabled");
-            return Ok(false);
-        }
-        info!("compact_storage: from {} to {}", from_slot, to_slot);
-        let mut compact_timer = Measure::start("compact_range");
-        let result = self
-            .meta_cf
-            .compact_range(from_slot, to_slot)
-            .unwrap_or(false)
-            && self
-                .db
-                .column::<cf::Root>()
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .data_shred_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .code_shred_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .dead_slots_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .duplicate_slots_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .erasure_meta_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .orphans_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .bank_hash_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .index_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .transaction_status_cf
-                .compact_range(0, 2)
-                .unwrap_or(false)
-            && self
-                .address_signatures_cf
-                .compact_range(0, 2)
-                .unwrap_or(false)
-            && self
-                .transaction_status_index_cf
-                .compact_range(0, 2)
-                .unwrap_or(false)
-            && self
-                .rewards_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .blocktime_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .perf_samples_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .block_height_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .optimistic_slots_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false);
-        compact_timer.stop();
-        if !result {
-            info!("compact_storage incomplete");
-        }
-        datapoint_info!(
-            "blockstore-compact",
-            ("compact_range_us", compact_timer.as_us() as i64, i64),
-        );
-        Ok(result)
     }
 
     /// Purges special columns (using a non-Slot primary-index) exactly, by

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -784,7 +784,6 @@ impl TestValidator {
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,
             validator_exit: config.validator_exit.clone(),
-            rocksdb_compaction_interval: Some(100), // Compact every 100 slots
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
             staked_nodes_overrides: config.staked_nodes_overrides.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1263,13 +1263,6 @@ pub fn main() {
                             Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}"),
         )
         .arg(
-            Arg::with_name("rocksdb_max_compaction_jitter")
-                .long("rocksdb-max-compaction-jitter-slots")
-                .value_name("ROCKSDB_MAX_COMPACTION_JITTER_SLOTS")
-                .takes_value(true)
-                .help("Introduce jitter into the compaction to offset compaction operation"),
-        )
-        .arg(
             Arg::with_name("bind_address")
                 .long("bind-address")
                 .value_name("HOST")
@@ -2347,8 +2340,6 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
-    let rocksdb_max_compaction_jitter =
-        value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();
     let tpu_coalesce_ms =
         value_t!(matches, "tpu_coalesce_ms", u64).unwrap_or(DEFAULT_TPU_COALESCE_MS);
     let wal_recovery_mode = matches

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1211,19 +1211,6 @@ pub fn main() {
                       [default: all validators]")
         )
         .arg(
-            Arg::with_name("no_rocksdb_compaction")
-                .long("no-rocksdb-compaction")
-                .takes_value(false)
-                .help("Disable manual compaction of the ledger database (this is ignored).")
-        )
-        .arg(
-            Arg::with_name("rocksdb_compaction_interval")
-                .long("rocksdb-compaction-interval-slots")
-                .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")
-                .takes_value(true)
-                .help("Number of slots between compacting ledger"),
-        )
-        .arg(
             Arg::with_name("tpu_coalesce_ms")
                 .long("tpu-coalesce-ms")
                 .value_name("MILLISECS")
@@ -2360,8 +2347,6 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
-    let no_rocksdb_compaction = true;
-    let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
     let rocksdb_max_compaction_jitter =
         value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();
     let tpu_coalesce_ms =
@@ -2731,9 +2716,6 @@ pub fn main() {
         known_validators,
         repair_validators,
         gossip_validators,
-        no_rocksdb_compaction,
-        rocksdb_compaction_interval,
-        rocksdb_max_compaction_jitter,
         wal_recovery_mode,
         poh_verify: !matches.is_present("skip_poh_verify"),
         debug_keys,


### PR DESCRIPTION
#### Problem

manual compaction code and its accompanying `PrimaryIndex` purge mechanism can be decommissioned, now that we've transitioned to the compaction filter, which is initially introduced at #16697 (1+ year ago)

also, these unused code is still maintained, indicating confusion for newer team members due to my laziness: ref #27201 

Ideally, i'd like this to be merged before the shiny new fifo compaction come in across all the live clusters to avoid three separate impls.

#### Summary of Changes

Remove it

