### PR TITLE
Handling snapshot requests is now required

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -925,11 +925,11 @@ fn test_snapshots_with_background_services(
     }
 
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
-    let snapshot_request_handler = Some(SnapshotRequestHandler {
+    let snapshot_request_handler = SnapshotRequestHandler {
         snapshot_config: snapshot_test_config.snapshot_config.clone(),
         snapshot_request_receiver,
         pending_accounts_package: Arc::clone(&pending_accounts_package),
-    });
+    };
     let pruned_banks_request_handler = PrunedBanksRequestHandler {
         pruned_banks_receiver,
     };

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -24,7 +24,7 @@ use {
     solana_sdk::{
         account::{Account, AccountSharedData},
         client::SyncClient,
-        clock::{Slot, DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
+        clock::{DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
         commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
         genesis_config::{ClusterType, GenesisConfig},
@@ -741,8 +741,6 @@ impl LocalCluster {
         // node lifecycle.
         // There must be some place holder for now...
         SnapshotConfig {
-            full_snapshot_archive_interval_slots: Slot::MAX,
-            incremental_snapshot_archive_interval_slots: Slot::MAX,
             full_snapshot_archives_dir: DUMMY_SNAPSHOT_CONFIG_PATH_MARKER.into(),
             bank_snapshots_dir: DUMMY_SNAPSHOT_CONFIG_PATH_MARKER.into(),
             ..SnapshotConfig::new_load_only()

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -394,7 +394,7 @@ impl PrunedBanksRequestHandler {
 }
 
 pub struct AbsRequestHandlers {
-    pub snapshot_request_handler: Option<SnapshotRequestHandler>,
+    pub snapshot_request_handler: SnapshotRequestHandler,
     pub pruned_banks_request_handler: PrunedBanksRequestHandler,
 }
 
@@ -407,16 +407,12 @@ impl AbsRequestHandlers {
         non_snapshot_time_us: u128,
         last_full_snapshot_slot: &mut Option<Slot>,
     ) -> Option<Result<u64, SnapshotError>> {
-        self.snapshot_request_handler
-            .as_ref()
-            .and_then(|snapshot_request_handler| {
-                snapshot_request_handler.handle_snapshot_requests(
-                    accounts_db_caching_enabled,
-                    test_hash_calculation,
-                    non_snapshot_time_us,
-                    last_full_snapshot_slot,
-                )
-            })
+        self.snapshot_request_handler.handle_snapshot_requests(
+            accounts_db_caching_enabled,
+            test_hash_calculation,
+            non_snapshot_time_us,
+            last_full_snapshot_slot,
+        )
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2950,8 +2950,9 @@ pub fn main() {
     validator_config.accounts_hash_interval_slots =
         value_t_or_exit!(matches, "accounts-hash-interval-slots", u64);
     if !is_snapshot_config_valid(
-        full_snapshot_archive_interval_slots,
-        incremental_snapshot_archive_interval_slots,
+        // SAFETY: Calling `.unwrap()` is safe here because `validator_config.snapshot_config` must
+        // be `Some`. The Option<> wrapper will be removed later to solidify this requirement.
+        validator_config.snapshot_config.as_ref().unwrap(),
         validator_config.accounts_hash_interval_slots,
     ) {
         eprintln!("Invalid snapshot configuration provided: snapshot intervals are incompatible. \


### PR DESCRIPTION
#### Problem

For [Epoch Accounts Hash](https://github.com/orgs/solana-labs/projects/9/views/1) support, more background services will be required to run, which are currently optional. Specifically, the current snapshot requests will also be used to handle non-optional Epoch Accounts Hash Calculation requests. So this channel is required and so is Accounts Hash Verifier.

Building on PR #27508, since the snapshot request handler will now also accept requests for Epoch Accounts Hash calculations, it no longer is optional.

#### Summary of Changes

The `SnapshotRequestHandler` in `AbsRequestHandlers` is no longer optional.
