### PR TITLE
Include the Epoch Accounts Hash in the Bank hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1185,7 +1185,6 @@ pub struct AccountsDb {
     pub(crate) log_dead_slots: AtomicBool,
 
     /// A special accounts hash that occurs once per epoch
-    #[allow(dead_code)]
     pub(crate) epoch_accounts_hash: Mutex<Option<EpochAccountsHash>>,
 }
 

--- a/runtime/src/epoch_accounts_hash.rs
+++ b/runtime/src/epoch_accounts_hash.rs
@@ -38,7 +38,6 @@ pub fn calculation_offset_start(bank: &Bank) -> Slot {
 /// and referred to as the "stop" slot for the EAH calculation.  All nodes must complete the EAH
 /// calculation before this slot!
 #[must_use]
-#[allow(dead_code)]
 pub fn calculation_offset_stop(bank: &Bank) -> Slot {
     let slots_per_epoch = bank.epoch_schedule().slots_per_epoch;
     slots_per_epoch / 4 * 3

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -514,6 +514,10 @@ pub mod cap_accounts_data_allocations_per_transaction {
     solana_sdk::declare_id!("9gxu85LYRAcZL38We8MYJ4A9AwgBBPtVBAqebMcT1241");
 }
 
+pub mod epoch_accounts_hash {
+    solana_sdk::declare_id!("5GpmAKxaGsWWbPp4bNXFLJxZVvG92ctxf7jQnzTQjF3n");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -637,6 +641,7 @@ lazy_static! {
         (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
         (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
         (cap_accounts_data_allocations_per_transaction::id(), "cap accounts data allocations per transaction #27375"),
+        (epoch_accounts_hash::id(), "enable epoch accounts hash calculation #27539"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

The Epoch Accounts Hash needs to be part of a predetermined Bank, once per epoch.

#### Summary of Changes

* Add feature gate
* Conditionally include the Epoch Accounts Hash in the Bank hash

Feature Gate Issue: #27539 

