### PR TITLE
chore: tee target/cov/coverage-stderr.log

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -79,7 +79,7 @@ NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 
 RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
+if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> >(tee target/cov/coverage-stderr.log >&2); then
   test_status=0
 else
   test_status=$?


### PR DESCRIPTION
#### Problem

seems we swallow error log to target/cov/coverage-stderr.log. I use tee to make it print to stdout as well.
