### PR TITLE
rename get_account_maps_read_lock to get_bin since we don't use a loc…

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8555,7 +8555,7 @@ impl AccountsDb {
                             let mut lookup_time = Measure::start("lookup_time");
                             for account in accounts_map.into_iter() {
                                 let (key, account_info) = account;
-                                let lock = self.accounts_index.get_account_maps_read_lock(&key);
+                                let lock = self.accounts_index.get_bin(&key);
                                 let x = lock.get(&key).unwrap();
                                 let sl = x.slot_list.read().unwrap();
                                 let mut count = 0;


### PR DESCRIPTION
#### Problem
Bins in the accounts index used to be held in a rwlock. Eventually, this got refactored away. 

#### Summary of Changes
Rename function to match behavior.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
