### PR TITLE
acctidx: avoid extra addref in combine ancient slots

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -627,16 +627,12 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 
                     if matched_slot {
                         found_slot = true;
-                        if !is_cur_account_cached {
-                            // current info at 'slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
-                            addref = false;
-                        }
                     } else {
                         found_other_slot = true;
-                        if !is_cur_account_cached {
-                            // current info at 'other_slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
-                            addref = false;
-                        }
+                    }
+                    if !is_cur_account_cached {
+                        // current info at 'slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
+                        addref = false;
                     }
                 }
             });
@@ -1829,7 +1825,9 @@ mod tests {
                     // calculate expected results
                     let mut expected_reclaims = Vec::default();
                     // addref iff the slot_list did NOT previously contain an entry at 'new_slot' and it also did not contain an entry at 'other_slot'
-                    let expected_result = !expected.iter().any(|(slot, _info)| slot == &new_slot || Some(*slot) == other_slot);
+                    let expected_result = !expected
+                        .iter()
+                        .any(|(slot, _info)| slot == &new_slot || Some(*slot) == other_slot);
                     {
                         // this is the logical equivalent of 'InMemAccountsIndex::update_slot_list', but slower (and ignoring addref)
                         expected.retain(|(slot, info)| {


### PR DESCRIPTION
#### Problem
`InMemAccountsIndex::update_slot_list` is used by ancient append vecs, and later by flushing the cache, to move or merge account index entries from one slot to another. Account index entries keep 1 refcount for each slot that has an appendvec that contains account data. When we are doing `update_slot_list`, we need to addref if the new slot does not already contain a refcount. The situation that was missed was when the old slot already had a refcount, we did not want to add another refcount. The old slot will be going away, so any refcount from that old slot can be transferred to the new slot.

#### Summary of Changes
If an uncached entry already exists in the old slot, then don't addref.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
