### PR TITLE
chore: tee coverage test stderr

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -79,7 +79,7 @@ NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 
 RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
+if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> >(tee target/cov/coverage-stderr.log >&2); then
   test_status=0
 else
   test_status=$?

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -79,7 +79,7 @@ NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 
 RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> >(tee target/cov/coverage-stderr.log >&2); then
+if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" -- --nocapture 2> >(tee target/cov/coverage-stderr.log >&2); then
   test_status=0
 else
   test_status=$?


### PR DESCRIPTION
#### Problem

We can't read logs from a failed coverage test cuz we redirect stderr to a file. when it failed, it didn't upload the file.
This change will make this test become very noisy. It prints a lot of things due to `RUST_LOG=solana=trace`.

#### Summary of Changes

Tee target/cov/coverage-stderr.log

