### PR TITLE
RPC: include resolved keys from table lookups in parsed message response

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -3,7 +3,7 @@
 pub use {crate::extract_memos::extract_and_fmt_memos, solana_sdk::reward_type::RewardType};
 use {
     crate::{
-        parse_accounts::{parse_accounts, parse_static_accounts, ParsedAccount},
+        parse_accounts::{parse_legacy_message_accounts, parse_v0_message_accounts, ParsedAccount},
         parse_instruction::{parse, ParsedInstruction},
     },
     solana_account_decoder::parse_token::UiTokenAmount,
@@ -904,7 +904,7 @@ impl Encodable for Message {
         if encoding == UiTransactionEncoding::JsonParsed {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             UiMessage::Parsed(UiParsedMessage {
-                account_keys: parse_accounts(self),
+                account_keys: parse_legacy_message_accounts(self),
                 recent_blockhash: self.recent_blockhash.to_string(),
                 instructions: self
                     .instructions
@@ -936,7 +936,7 @@ impl EncodableWithMeta for v0::Message {
             let account_keys = AccountKeys::new(&self.account_keys, Some(&meta.loaded_addresses));
             let loaded_message = LoadedMessage::new_borrowed(self, &meta.loaded_addresses);
             UiMessage::Parsed(UiParsedMessage {
-                account_keys: parse_static_accounts(&loaded_message),
+                account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),
                 instructions: self
                     .instructions

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -6,7 +6,7 @@ pub struct ParsedAccount {
     pub pubkey: String,
     pub writable: bool,
     pub signer: bool,
-    pub source: ParsedAccountSource,
+    pub source: Option<ParsedAccountSource>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -23,7 +23,7 @@ pub fn parse_legacy_message_accounts(message: &Message) -> Vec<ParsedAccount> {
             pubkey: account_key.to_string(),
             writable: message.is_writable(i),
             signer: message.is_signer(i),
-            source: ParsedAccountSource::Transaction,
+            source: Some(ParsedAccountSource::Transaction),
         });
     }
     accounts
@@ -41,7 +41,7 @@ pub fn parse_v0_message_accounts(message: &LoadedMessage) -> Vec<ParsedAccount> 
             pubkey: account_key.to_string(),
             writable: message.is_writable(i),
             signer: message.is_signer(i),
-            source,
+            source: Some(source),
         });
     }
     accounts
@@ -80,25 +80,25 @@ mod test {
                     pubkey: pubkey0.to_string(),
                     writable: true,
                     signer: true,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey1.to_string(),
                     writable: false,
                     signer: true,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey2.to_string(),
                     writable: true,
                     signer: false,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey3.to_string(),
                     writable: false,
                     signer: false,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
             ]
         );
@@ -135,37 +135,37 @@ mod test {
                     pubkey: pubkey0.to_string(),
                     writable: true,
                     signer: true,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey1.to_string(),
                     writable: false,
                     signer: true,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey2.to_string(),
                     writable: true,
                     signer: false,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey3.to_string(),
                     writable: false,
                     signer: false,
-                    source: ParsedAccountSource::Transaction,
+                    source: Some(ParsedAccountSource::Transaction),
                 },
                 ParsedAccount {
                     pubkey: pubkey4.to_string(),
                     writable: true,
                     signer: false,
-                    source: ParsedAccountSource::LookupTable,
+                    source: Some(ParsedAccountSource::LookupTable),
                 },
                 ParsedAccount {
                     pubkey: pubkey5.to_string(),
                     writable: false,
                     signer: false,
-                    source: ParsedAccountSource::LookupTable,
+                    source: Some(ParsedAccountSource::LookupTable),
                 },
             ]
         );

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -8,7 +8,7 @@ pub struct ParsedAccount {
     pub signer: bool,
 }
 
-pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
+pub fn parse_legacy_message_accounts(message: &Message) -> Vec<ParsedAccount> {
     let mut accounts: Vec<ParsedAccount> = vec![];
     for (i, account_key) in message.account_keys.iter().enumerate() {
         accounts.push(ParsedAccount {
@@ -20,9 +20,9 @@ pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
     accounts
 }
 
-pub fn parse_static_accounts(message: &LoadedMessage) -> Vec<ParsedAccount> {
+pub fn parse_v0_message_accounts(message: &LoadedMessage) -> Vec<ParsedAccount> {
     let mut accounts: Vec<ParsedAccount> = vec![];
-    for (i, account_key) in message.static_account_keys().iter().enumerate() {
+    for (i, account_key) in message.account_keys().iter().enumerate() {
         accounts.push(ParsedAccount {
             pubkey: account_key.to_string(),
             writable: message.is_writable(i),
@@ -43,7 +43,7 @@ mod test {
     };
 
     #[test]
-    fn test_parse_accounts() {
+    fn test_parse_legacy_message_accounts() {
         let pubkey0 = Pubkey::new_unique();
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -59,7 +59,7 @@ mod test {
         };
 
         assert_eq!(
-            parse_accounts(&message),
+            parse_legacy_message_accounts(&message),
             vec![
                 ParsedAccount {
                     pubkey: pubkey0.to_string(),
@@ -86,11 +86,13 @@ mod test {
     }
 
     #[test]
-    fn test_parse_static_accounts() {
+    fn test_parse_v0_message_accounts() {
         let pubkey0 = Pubkey::new_unique();
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
         let pubkey3 = Pubkey::new_unique();
+        let pubkey4 = Pubkey::new_unique();
+        let pubkey5 = Pubkey::new_unique();
         let message = LoadedMessage::new(
             v0::Message {
                 header: MessageHeader {
@@ -102,13 +104,13 @@ mod test {
                 ..v0::Message::default()
             },
             LoadedAddresses {
-                writable: vec![Pubkey::new_unique()],
-                readonly: vec![Pubkey::new_unique()],
+                writable: vec![pubkey4],
+                readonly: vec![pubkey5],
             },
         );
 
         assert_eq!(
-            parse_static_accounts(&message),
+            parse_v0_message_accounts(&message),
             vec![
                 ParsedAccount {
                     pubkey: pubkey0.to_string(),
@@ -127,6 +129,16 @@ mod test {
                 },
                 ParsedAccount {
                     pubkey: pubkey3.to_string(),
+                    writable: false,
+                    signer: false,
+                },
+                ParsedAccount {
+                    pubkey: pubkey4.to_string(),
+                    writable: true,
+                    signer: false,
+                },
+                ParsedAccount {
+                    pubkey: pubkey5.to_string(),
                     writable: false,
                     signer: false,
                 },


### PR DESCRIPTION
#### Problem
The `jsonParsed` encoded response for versioned transactions and blocks doesn't include account keys resolved from lookup tables in the parsed message account keys list. I consider this a bug because the parsed message response is meant to be a user-friendly response which indicates all the account keys and whether they were writable or signers.

#### Summary of Changes
- Include resolved keys from table lookups in parsed message response
- Add `source` field to `ParsedAccount` to indicate whether the account key came from a transaction or lookup table

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
