### PR TITLE
fix: add compute units to jsonrpc parser

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -888,6 +888,8 @@ export type ParsedTransactionMeta = {
   err: TransactionError | null;
   /** The collection of addresses loaded using address lookup tables */
   loadedAddresses?: LoadedAddresses;
+  /** The compute units consumed after processing the transaction */
+  computeUnitsConsumed?: number;
 };
 
 export type CompiledInnerInstruction = {
@@ -917,6 +919,8 @@ export type ConfirmedTransactionMeta = {
   err: TransactionError | null;
   /** The collection of addresses loaded using address lookup tables */
   loadedAddresses?: LoadedAddresses;
+  /** The compute units consumed after processing the transaction */
+  computeUnitsConsumed?: number;
 };
 
 /**
@@ -1993,6 +1997,7 @@ const ConfirmedTransactionMetaResult = pick({
   preTokenBalances: optional(nullable(array(TokenBalanceResult))),
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
+  computeUnitsConsumed: optional(number()),
 });
 
 /**
@@ -2017,6 +2022,7 @@ const ParsedConfirmedTransactionMetaResult = pick({
   preTokenBalances: optional(nullable(array(TokenBalanceResult))),
   postTokenBalances: optional(nullable(array(TokenBalanceResult))),
   loadedAddresses: optional(LoadedAddressesResult),
+  computeUnitsConsumed: optional(number()),
 });
 
 const TransactionVersionStruct = union([literal(0), literal('legacy')]);

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -4460,6 +4460,8 @@ describe('Connection', function () {
           readonly: [],
           writable: [lookupTableAddresses[0]],
         });
+        expect(fetchedTransaction.meta?.computeUnitsConsumed).to.not.be
+          .undefined;
         expect(
           fetchedTransaction.transaction.message.addressTableLookups,
         ).to.eql(addressTableLookups);
@@ -4489,6 +4491,8 @@ describe('Connection', function () {
           readonly: [],
           writable: [lookupTableAddresses[0]],
         });
+        expect(parsedTransaction?.meta?.computeUnitsConsumed).to.not.be
+          .undefined;
         expect(
           parsedTransaction?.transaction.message.addressTableLookups,
         ).to.eql(addressTableLookups);


### PR DESCRIPTION
#### Problem
`computeUnitsConsumed` is returned in RPC transaction metadata responses but it's not included in the exported type

#### Summary of Changes
Re-applies the changes from the reverted https://github.com/solana-labs/solana/pull/27466 change

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
