### PR TITLE
Add EpochAccountsHash::new()

### DIFF
--- a/runtime/src/epoch_accounts_hash.rs
+++ b/runtime/src/epoch_accounts_hash.rs
@@ -17,6 +17,14 @@ use {
 #[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct EpochAccountsHash(Hash);
 
+impl EpochAccountsHash {
+    /// Make an EpochAccountsHash from a regular accounts hash
+    #[must_use]
+    pub fn new(accounts_hash: Hash) -> Self {
+        Self(accounts_hash)
+    }
+}
+
 impl AsRef<Hash> for EpochAccountsHash {
     fn as_ref(&self) -> &Hash {
         &self.0


### PR DESCRIPTION
#### Problem

There is not a way to create a new EpochAccountsHash, since the inner field is not public.

#### Summary of Changes

Add `EpochAccountsHash::new()`.