### PR TITLE
Fixup docs formatting re: commitment configuration

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1048,6 +1048,7 @@ Get the fee the network will charge for a particular Message
 - `message: <string>` - Base-64 encoded Message
 - `<object>` - (optional) Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
+  - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
 #### Results:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -657,7 +657,7 @@ Returns recent block production information from the current or previous epoch.
 #### Parameters:
 
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `range: <object>` - Slot range to return block production for. If parameter not provided, defaults to current epoch.
     - `firstSlot: <u64>` - first slot to return block production information for (inclusive)
     - (optional) `lastSlot: <u64>` - last slot to return block production information for (inclusive). If parameter not provided, defaults to the highest slot
@@ -805,7 +805,8 @@ Returns a list of confirmed blocks between two slots
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - (optional) end_slot, as u64 integer (must be no more than 500,000 blocks higher than the `start_slot`)
-- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -837,7 +838,8 @@ Returns a list of confirmed blocks starting at the given slot
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - limit, as u64 integer (must be no more than 500,000 blocks higher than the `start_slot`)
-- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -1044,7 +1046,8 @@ Get the fee the network will charge for a particular Message
 #### Parameters:
 
 - `message: <string>` - Base-64 encoded Message
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
+- `<object>` - (optional) Configuration object containing the following optional fields:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
 
 #### Results:
 
@@ -1292,7 +1295,8 @@ Returns the current inflation governor
 
 #### Parameters:
 
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -1437,7 +1441,7 @@ Returns the 20 largest accounts, by lamport balance (results may be cached up to
 #### Parameters:
 
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `filter: <string>` - filter results by account type; currently supported: `circulating|nonCirculating`
 
 #### Results:
@@ -1611,7 +1615,7 @@ Returns the leader schedule for an epoch
 - `<u64>` - (optional) Fetch the leader schedule for the epoch that corresponds to the provided slot.
   If unspecified, the leader schedule for the current epoch is fetched
 - `<object>` - (optional) Configuration object containing the following field:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `identity: <string>` - Only return results for this validator identity (base-58 encoded)
 
 #### Results:
@@ -1740,7 +1744,8 @@ Returns minimum balance required to make account rent exempt.
 #### Parameters:
 
 - `<usize>` - account data length
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -2480,7 +2485,8 @@ Returns the stake minimum delegation, in lamports.
 
 #### Parameters:
 
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -2520,7 +2526,7 @@ Returns information about the current supply.
 #### Parameters:
 
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `excludeNonCirculatingAccountsList: <bool>` - exclude non circulating accounts list from response
 
 #### Results:
@@ -2574,7 +2580,8 @@ Returns the token balance of an SPL Token account.
 #### Parameters:
 
 - `<string>` - Pubkey of Token account to query, as base-58 encoded string
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -2838,7 +2845,8 @@ Returns the 20 largest accounts of a particular SPL Token type.
 #### Parameters:
 
 - `<string>` - Pubkey of token Mint to query, as base-58 encoded string
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -2895,7 +2903,8 @@ Returns the total supply of an SPL Token type.
 #### Parameters:
 
 - `<string>` - Pubkey of token Mint to query, as base-58 encoded string
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -2944,7 +2953,7 @@ Returns transaction details for a confirmed transaction
 - `<object>` - (optional) Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
   - (optional) `maxSupportedTransactionVersion: <number>` - set the max transaction version to return in responses. If the requested transaction is a higher version, an error will be returned. If this parameter is omitted, only legacy transactions will be returned, and any versioned transaction will prompt the error.
 
 #### Results:
@@ -3160,7 +3169,7 @@ Returns the account info and associated stake for all the voting accounts in the
 #### Parameters:
 
 - `<object>` - (optional) Configuration object containing the following field:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `votePubkey: <string>` - Only return results for this validator vote address (base-58 encoded)
   - (optional) `keepUnstakedDelinquents: <bool>` - Do not filter out delinquent validators with no stake
   - (optional) `delinquentSlotDistance: <u64>` - Specify the number of slots behind the tip that a validator must fall to be considered delinquent. **NOTE:** For the sake of consistency between ecosystem products, _it is **not** recommended that this argument be specified._
@@ -3356,7 +3365,8 @@ Requests an airdrop of lamports to a Pubkey
 
 - `<string>` - Pubkey of account to receive lamports, as base-58 encoded string
 - `<integer>` - lamports, as a u64
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
 
 #### Results:
 
@@ -3558,7 +3568,7 @@ Subscribe to an account to receive notifications when the lamports or data for a
 
 - `<string>` - account Pubkey, as base-58 encoded string
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
 
@@ -3709,7 +3719,7 @@ Subscribe to receive notification anytime a new block is Confirmed or Finalized.
   - "all" - include all transactions in block
   - `{ "mentionsAccountOrProgram": <string> }` - return only transactions that mention the provided public key (as base-58 encoded string). If no mentions in a given block, then no notification will be sent.
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to base64 encoding, detectable when the `data` field is type `<string>`. Default is "base64".
   - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
@@ -3999,7 +4009,7 @@ Subscribe to transaction logging
   - "allWithVotes" - subscribe to all transactions including simple vote transactions
   - `{ "mentions": [ <string> ] }` - subscribe to all transactions that mention the provided Pubkey (as base-58 encoded string)
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -4103,7 +4113,7 @@ Subscribe to a program to receive notifications when the lamports or data for a 
 
 - `<string>` - program_id Pubkey, as base-58 encoded string
 - `<object>` - (optional) Configuration object containing the following optional fields:
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to base64 encoding, detectable when the `data` field is type `<string>`.
   - (optional) `filters: <array>` - filter results using various [filter objects](jsonrpc-api.md#filters); account must meet all filter criteria to be included in results
@@ -4270,7 +4280,8 @@ Subscribe to a transaction signature to receive notification when the transactio
 #### Parameters:
 
 - `<string>` - Transaction Signature, as base-58 encoded string
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -4697,7 +4708,7 @@ Returns identity and transaction information about a confirmed block in the ledg
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
   - (optional) `rewards: bool` - whether to populate the `rewards` array. If parameter not provided, the default includes rewards.
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -4863,7 +4874,8 @@ Returns a list of confirmed blocks between two slots
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - (optional) end_slot, as u64 integer
-- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -4898,7 +4910,8 @@ Returns a list of confirmed blocks starting at the given slot
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - limit, as u64 integer
-- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -4938,7 +4951,7 @@ provided signature or most recent confirmed block
   - `before: <string>` - (optional) start searching backwards from this transaction signature.
     If not provided the search starts from the top of the highest max confirmed block.
   - `until: <string>` - (optional) search until this transaction signature, if found before limit reached.
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -5003,7 +5016,7 @@ Returns transaction details for a confirmed transaction
 - `<object>` - (optional) Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
-  - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -5261,7 +5274,8 @@ which the blockhash will be valid.
 
 #### Parameters:
 
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -5313,7 +5327,8 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Parameters:
 
-- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+- `<object>` - (optional) Configuration object containing the following field:
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -249,7 +249,7 @@ Returns all information associated with the account of provided Pubkey
 #### Parameters:
 
 - `<string>` - Pubkey of account to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd", or "jsonParsed".
     "base58" is limited to Account data of less than 129 bytes.
@@ -373,7 +373,7 @@ Returns the balance of the account of provided Pubkey
 #### Parameters:
 
 - `<string>` - Pubkey of account to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -408,7 +408,7 @@ Returns identity and transaction information about a confirmed block in the ledg
 #### Parameters:
 
 - `<u64>` - slot, as u64 integer
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
@@ -626,7 +626,7 @@ Returns the current block height of the node
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -656,7 +656,7 @@ Returns recent block production information from the current or previous epoch.
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `range: <object>` - Slot range to return block production for. If parameter not provided, defaults to current epoch.
     - `firstSlot: <u64>` - first slot to return block production information for (inclusive)
@@ -804,8 +804,8 @@ Returns a list of confirmed blocks between two slots
 #### Parameters:
 
 - `<u64>` - start_slot, as u64 integer
-- `<u64>` - (optional) end_slot, as u64 integer (must be no more than 500,000 blocks higher than the `start_slot`)
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<u64>` - end_slot, as u64 integer (must be no more than 500,000 blocks higher than the `start_slot`)
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
@@ -838,7 +838,7 @@ Returns a list of confirmed blocks starting at the given slot
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - limit, as u64 integer (must be no more than 500,000 blocks higher than the `start_slot`)
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
@@ -950,7 +950,7 @@ Returns information about the current epoch
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -1046,7 +1046,7 @@ Get the fee the network will charge for a particular Message
 #### Parameters:
 
 - `message: <string>` - Base-64 encoded Message
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -1296,7 +1296,7 @@ Returns the current inflation governor
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -1385,7 +1385,7 @@ Returns the inflation / staking reward for a list of addresses for an epoch
 #### Parameters:
 
 - `<array>` - An array of addresses to query, as base-58 encoded strings
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `epoch: <u64>` - An epoch for which the reward occurs. If omitted, the previous epoch will be used
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
@@ -1441,7 +1441,7 @@ Returns the 20 largest accounts, by lamport balance (results may be cached up to
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `filter: <string>` - filter results by account type; currently supported: `circulating|nonCirculating`
 
@@ -1560,7 +1560,7 @@ Returns the latest blockhash
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -1613,9 +1613,9 @@ Returns the leader schedule for an epoch
 
 #### Parameters:
 
-- `<u64>` - (optional) Fetch the leader schedule for the epoch that corresponds to the provided slot.
+- (optional) `<u64>` - Fetch the leader schedule for the epoch that corresponds to the provided slot.
   If unspecified, the leader schedule for the current epoch is fetched
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `identity: <string>` - Only return results for this validator identity (base-58 encoded)
 
@@ -1745,7 +1745,7 @@ Returns minimum balance required to make account rent exempt.
 #### Parameters:
 
 - `<usize>` - account data length
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -1775,7 +1775,7 @@ Returns the account information for a list of Pubkeys.
 #### Parameters:
 
 - `<array>` - An array of Pubkeys to query, as base-58 encoded strings (up to a maximum of 100).
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd", or "jsonParsed".
     "base58" is limited to Account data of less than 129 bytes.
@@ -1918,7 +1918,7 @@ Returns all accounts owned by the provided program Pubkey
 #### Parameters:
 
 - `<string>` - Pubkey of program, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd", or "jsonParsed".
     "base58" is limited to Account data of less than 129 bytes.
@@ -2044,7 +2044,7 @@ include the number of transactions and slots that occur in a given time window.
 
 #### Parameters:
 
-- `limit: <usize>` - (optional) number of samples to return (maximum 720)
+- (optional) `limit: <usize>` - number of samples to return (maximum 720)
 
 #### Results:
 
@@ -2111,7 +2111,7 @@ provided signature or most recent confirmed block
 #### Parameters:
 
 - `<string>` - account address as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `limit: <number>` - maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
   - (optional) `before: <string>` - start searching backwards from this transaction signature.
     If not provided the search starts from the top of the highest max confirmed block.
@@ -2179,7 +2179,7 @@ active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
 #### Parameters:
 
 - `<array>` - An array of transaction signatures to confirm, as base-58 encoded strings (up to a maximum of 256)
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - `searchTransactionHistory: <bool>` - if true, a Solana node will search its ledger cache for any signatures not found in the recent status cache
 
 #### Results:
@@ -2300,7 +2300,7 @@ Returns the slot that has reached the [given or default commitment level](jsonrp
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -2330,7 +2330,7 @@ Returns the current slot leader
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -2413,7 +2413,7 @@ Returns epoch activation information for a stake account
 #### Parameters:
 
 - `<string>` - Pubkey of stake account to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `epoch: <u64>` - epoch for which to calculate activation details. If parameter not provided, defaults to current epoch.
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
@@ -2486,7 +2486,7 @@ Returns the stake minimum delegation, in lamports.
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -2526,7 +2526,7 @@ Returns information about the current supply.
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `excludeNonCirculatingAccountsList: <bool>` - exclude non circulating accounts list from response
 
@@ -2581,7 +2581,7 @@ Returns the token balance of an SPL Token account.
 #### Parameters:
 
 - `<string>` - Pubkey of Token account to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -2636,7 +2636,7 @@ Returns all SPL Token accounts by approved Delegate.
 - `<object>` - Either:
   - `mint: <string>` - Pubkey of the specific token Mint to limit accounts to, as base-58 encoded string; or
   - `programId: <string>` - Pubkey of the Token program that owns the accounts, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd", or "jsonParsed".
     "base58" is limited to Account data of less than 129 bytes.
@@ -2742,7 +2742,7 @@ Returns all SPL Token accounts by token owner.
 - `<object>` - Either:
   - `mint: <string>` - Pubkey of the specific token Mint to limit accounts to, as base-58 encoded string; or
   - `programId: <string>` - Pubkey of the Token program that owns the accounts, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd", or "jsonParsed".
     "base58" is limited to Account data of less than 129 bytes.
@@ -2846,7 +2846,7 @@ Returns the 20 largest accounts of a particular SPL Token type.
 #### Parameters:
 
 - `<string>` - Pubkey of token Mint to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -2904,7 +2904,7 @@ Returns the total supply of an SPL Token type.
 #### Parameters:
 
 - `<string>` - Pubkey of token Mint to query, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -2951,7 +2951,7 @@ Returns transaction details for a confirmed transaction
 #### Parameters:
 
 - `<string>` - transaction signature as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
@@ -3109,7 +3109,7 @@ Returns the current Transaction count from the ledger
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -3169,7 +3169,7 @@ Returns the account info and associated stake for all the voting accounts in the
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `votePubkey: <string>` - Only return results for this validator vote address (base-58 encoded)
   - (optional) `keepUnstakedDelinquents: <bool>` - Do not filter out delinquent validators with no stake
@@ -3289,7 +3289,7 @@ Returns whether a blockhash is still valid or not
 #### Parameters:
 
 - `blockhash: <string>` - the blockhash of this block, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -3366,7 +3366,7 @@ Requests an airdrop of lamports to a Pubkey
 
 - `<string>` - Pubkey of account to receive lamports, as base-58 encoded string
 - `<integer>` - lamports, as a u64
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
 
 #### Results:
@@ -3426,11 +3426,11 @@ submission.
 #### Parameters:
 
 - `<string>` - fully-signed Transaction, as encoded string
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - `skipPreflight: <bool>` - if true, skip the preflight transaction checks (default: false)
-  - `preflightCommitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to use for preflight (default: `"finalized"`).
-  - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (_slow_, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
-  - `maxRetries: <usize>` - (optional) Maximum number of times for the RPC node to retry sending the transaction to the leader.
+  - (optional) `preflightCommitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) level to use for preflight (default: `"finalized"`).
+  - (optional) `encoding: <string>` - Encoding used for the transaction data. Either `"base58"` (_slow_, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
+  - (optional) `maxRetries: <usize>` - Maximum number of times for the RPC node to retry sending the transaction to the leader.
     If this parameter not provided, the RPC node will retry the transaction until it is finalized or until the blockhash expires.
   - (optional) `minContextSlot: <number>` - set the minimum slot at which to perform preflight transaction checks.
 
@@ -3471,14 +3471,14 @@ Simulate sending a transaction
 #### Parameters:
 
 - `<string>` - Transaction, as an encoded string. The transaction must have a valid blockhash, but is not required to be signed.
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false, conflicts with `replaceRecentBlockhash`)
-  - `commitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"finalized"`).
-  - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (_slow_, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
-  - `replaceRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be replaced with the most recent blockhash.
+  - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"finalized"`).
+  - (optional) `encoding: <string>` - Encoding used for the transaction data. Either `"base58"` (_slow_, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
+  - (optional) `replaceRecentBlockhash: <bool>` - if true the transaction recent blockhash will be replaced with the most recent blockhash.
     (default: false, conflicts with `sigVerify`)
-  - `accounts: <object>` - (optional) Accounts configuration object containing the following fields:
-    - `encoding: <string>` - (optional) encoding for returned Account data, either "base64" (default), "base64+zstd" or "jsonParsed".
+  - (optional) `accounts: <object>` - Accounts configuration object containing the following fields:
+    - (optional) `encoding: <string>` - encoding for returned Account data, either "base64" (default), "base64+zstd" or "jsonParsed".
       ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
     - `addresses: <array>` - An array of accounts to return, as base-58 encoded strings
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
@@ -3568,7 +3568,7 @@ Subscribe to an account to receive notifications when the lamports or data for a
 #### Parameters:
 
 - `<string>` - account Pubkey, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
@@ -3719,7 +3719,7 @@ Subscribe to receive notification anytime a new block is Confirmed or Finalized.
 - `filter: <string>|<object>` - filter criteria for the logs to receive results by account type; currently supported:
   - "all" - include all transactions in block
   - `{ "mentionsAccountOrProgram": <string> }` - return only transactions that mention the provided public key (as base-58 encoded string). If no mentions in a given block, then no notification will be sent.
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to base64 encoding, detectable when the `data` field is type `<string>`. Default is "base64".
@@ -4009,7 +4009,7 @@ Subscribe to transaction logging
   - "all" - subscribe to all transactions except for simple vote transactions
   - "allWithVotes" - subscribe to all transactions including simple vote transactions
   - `{ "mentions": [ <string> ] }` - subscribe to all transactions that mention the provided Pubkey (as base-58 encoded string)
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -4113,7 +4113,7 @@ Subscribe to a program to receive notifications when the lamports or data for a 
 #### Parameters:
 
 - `<string>` - program_id Pubkey, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - `encoding: <string>` - encoding for Account data, either "base58" (_slow_), "base64", "base64+zstd" or "jsonParsed".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to base64 encoding, detectable when the `data` field is type `<string>`.
@@ -4281,7 +4281,7 @@ Subscribe to a transaction signature to receive notification when the transactio
 #### Parameters:
 
 - `<string>` - Transaction Signature, as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -4704,7 +4704,7 @@ Returns identity and transaction information about a confirmed block in the ledg
 #### Parameters:
 
 - `<u64>` - slot, as u64 integer
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
@@ -4874,8 +4874,8 @@ Returns a list of confirmed blocks between two slots
 #### Parameters:
 
 - `<u64>` - start_slot, as u64 integer
-- `<u64>` - (optional) end_slot, as u64 integer
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<u64>` - end_slot, as u64 integer
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
@@ -4911,7 +4911,7 @@ Returns a list of confirmed blocks starting at the given slot
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - limit, as u64 integer
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
@@ -4947,11 +4947,11 @@ provided signature or most recent confirmed block
 #### Parameters:
 
 - `<string>` - account address as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
-  - `limit: <number>` - (optional) maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
-  - `before: <string>` - (optional) start searching backwards from this transaction signature.
+- (optional) `<object>` - Configuration object containing the following fields:
+  - (optional) `limit: <number>` - maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+  - (optional) `before: <string>` - start searching backwards from this transaction signature.
     If not provided the search starts from the top of the highest max confirmed block.
-  - `until: <string>` - (optional) search until this transaction signature, if found before limit reached.
+  - (optional) `until: <string>` - search until this transaction signature, if found before limit reached.
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
@@ -5014,7 +5014,7 @@ Returns transaction details for a confirmed transaction
 #### Parameters:
 
 - `<string>` - transaction signature as base-58 encoded string
-- `<object>` - (optional) Configuration object containing the following optional fields:
+- (optional) `<object>` - Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     ["jsonParsed" encoding](jsonrpc-api.md#parsed-responses) attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
@@ -5165,7 +5165,7 @@ Returns the fee calculator associated with the query blockhash, or `null` if the
 #### Parameters:
 
 - `<string>` - query blockhash as a Base58 encoded string
-- `<object>` - (optional) Configuration object containing the following fields:
+- (optional) `<object>` - Configuration object containing the following fields:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - (optional) `minContextSlot: <number>` - set the minimum slot that the request can be evaluated at.
 
@@ -5275,7 +5275,7 @@ which the blockhash will be valid.
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
@@ -5328,7 +5328,7 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Parameters:
 
-- `<object>` - (optional) Configuration object containing the following field:
+- (optional) `<object>` - Configuration object containing the following field:
   - (optional) `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/27557 fixed some inconsistencies around `commitment` format in the JSON-RPC docs, but there are a bunch more

#### Summary of Changes
Make commitment config handling consistent
Add a missing `minContextSlot` config param
Make `(optional)` tag placement consistent across all parameters and fields

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
