### PR TITLE
Add RocksSlotTtl storage type: A slot-based FIFO compatible with Level

### DIFF
--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -108,6 +108,7 @@ impl LedgerColumnOptions {
     pub fn get_storage_type_string(&self) -> &'static str {
         match self.shred_storage_type {
             ShredStorageType::RocksLevel => "rocks_level",
+            ShredStorageType::RocksSlotTtl => "rocks_slot_ttl",
             ShredStorageType::RocksFifo(_) => "rocks_fifo",
         }
     }
@@ -126,6 +127,11 @@ impl LedgerColumnOptions {
 pub enum ShredStorageType {
     // Stores shreds under RocksDB's default compaction (level).
     RocksLevel,
+    // Stores shreds under RocksDB with slot-based TTL that purges older
+    // files.  This storage type is compatible to RocksLevel and has similar
+    // to performance benefits as RocksFifo in that it also allows ledger
+    // store to reclaim storage more efficiently with lower I/O overhead.
+    RocksSlotTtl,
     // (Experimental) Stores shreds under RocksDB's FIFO compaction which
     // allows ledger store to reclaim storage more efficiently with
     // lower I/O overhead.
@@ -153,6 +159,9 @@ impl ShredStorageType {
     pub fn blockstore_directory(&self) -> &str {
         match self {
             ShredStorageType::RocksLevel => BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+            // Use the same directory as RocksLevel since RocksSlotTtl is
+            // compatible with RocksLevel.
+            ShredStorageType::RocksSlotTtl => BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
             ShredStorageType::RocksFifo(_) => BLOCKSTORE_DIRECTORY_ROCKS_FIFO,
         }
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1039,14 +1039,17 @@ pub fn main() {
                 .long("rocksdb-shred-compaction")
                 .value_name("ROCKSDB_COMPACTION_STYLE")
                 .takes_value(true)
-                .possible_values(&["level", "fifo"])
+                .possible_values(&["level", "fifo", "slot-ttl"])
                 .default_value("level")
                 .help("EXPERIMENTAL: Controls how RocksDB compacts shreds. \
                        *WARNING*: You will lose your ledger data when you switch between options. \
                        Possible values are: \
                        'level': stores shreds using RocksDB's default (level) compaction. \
                        'fifo': stores shreds under RocksDB's FIFO compaction. \
-                           This option is more efficient on disk-write-bytes of the ledger store."),
+                           This option is more efficient on disk-write-bytes of the ledger store. \
+                       'slot-ttl': stores shreds using RocksDB's with Solana's slot-based TTL. \
+                           This option offers efficient disk-write-bytes and disk-space reclaiming. \
+                           This shred compaction is compatible with 'level'."),
         )
         .arg(
             Arg::with_name("rocksdb_fifo_shred_storage_size")
@@ -3000,6 +3003,7 @@ pub fn main() {
             None => ShredStorageType::default(),
             Some(shred_compaction_string) => match shred_compaction_string {
                 "level" => ShredStorageType::RocksLevel,
+                "slot-ttl" => ShredStorageType::RocksSlotTtl,
                 "fifo" => {
                     let shred_storage_size =
                         value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);


### PR DESCRIPTION
#### Summary of Changes
This PR introduces ShredStorageType::RocksSlotTtl.  The shred storage type
that works similarly to FIFO except it uses a slot-based TTL to purge files and
it's compatible with level compaction.

Under the hood, RocksSlotTtl has no background compaction, and it relies on
the recently introduced #26651 that enables LedgerCleanupService to directly
purge any sst files that are older than both --limit-ledger-size and root.

I am still baking the PR and will soon start running experiments.  If the experimental
results sound, then RocksSlotTtl should have similar performance as FIFO but
have a stronger consistency guarantee than FIFO and is compatible with the existing
level compaction.