### PR TITLE
testing if prioritization_fee_cache drop() panicked somehow during CI

### DIFF
--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -458,7 +458,7 @@ mod tests {
         let slot = bank.slot();
 
         let mut prioritization_fee_cache = PrioritizationFeeCache::default();
-        prioritization_fee_cache.update(bank, txs.iter());
+        sync_update(&mut prioritization_fee_cache, bank, txs.iter());
 
         // assert block minimum fee and account a, b, c fee accordingly
         {


### PR DESCRIPTION
#### Problem

CI intermittently fails on Cov test (101 error), checking if prioritization_fee_cache::drop() panicked during panicking. 

#### Summary of Changes
- remove drop() impl, it is not necessary: when sender is dropped, channel will hang up, which in turn finishes the thread. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
