### PR TITLE
Fix responsive in metaplex metadata json viewer

### DIFF
--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -479,3 +479,7 @@ p.updated-time {
 .security-txt-link-color-hack-reee {
   color: white;
 }
+
+.metadata-json-viewer .string-value {
+  word-break: break-all;
+}


### PR DESCRIPTION
#### Problem

The responsive is broken in metaplex metadata json viewer.

<img width="625" alt="CleanShot 2022-09-03 at 16 46 29@2x" src="https://user-images.githubusercontent.com/92621583/188263304-b420d092-3fff-4861-9d18-e40539792621.png">

#### Summary of Changes

Fixed responsive for metadata metadata json view.

<img width="631" alt="CleanShot 2022-09-03 at 16 47 41@2x" src="https://user-images.githubusercontent.com/92621583/188263342-fe0bbf84-da3b-4471-a8e8-11ac0ed0d5eb.png">
