### PR TITLE
Refactor: Use dynamic memory layout for `TransactionContext::instruction_trace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6273,6 +6273,7 @@ dependencies = [
  "solana-frozen-abi 1.15.0",
  "solana-frozen-abi-macro 1.15.0",
  "solana-logger 1.15.0",
+ "solana-memory-management",
  "solana-program 1.15.0",
  "solana-sdk-macro 1.15.0",
  "static_assertions",

--- a/memory-management/src/dynamic_layout.rs
+++ b/memory-management/src/dynamic_layout.rs
@@ -8,7 +8,7 @@ pub struct DynamicLayoutArray<'a, T> {
     _element_type: std::marker::PhantomData<&'a T>,
     element_count: u32,
     values_stride: u32,
-    values_offset: u32,
+    pub values_offset: u32,
 }
 
 impl<'a, T> DynamicLayoutArray<'a, T> {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -595,9 +595,10 @@ impl<'a> InvokeContext<'a> {
         let instruction_accounts = duplicate_indicies
             .into_iter()
             .map(|duplicate_index| {
-                Ok(*deduplicated_instruction_accounts
+                Ok(deduplicated_instruction_accounts
                     .get(duplicate_index)
-                    .ok_or(InstructionError::NotEnoughAccountKeys)?)
+                    .ok_or(InstructionError::NotEnoughAccountKeys)?
+                    .clone())
             })
             .collect::<Result<Vec<InstructionAccount>, InstructionError>>()?;
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -595,10 +595,9 @@ impl<'a> InvokeContext<'a> {
         let instruction_accounts = duplicate_indicies
             .into_iter()
             .map(|duplicate_index| {
-                Ok(deduplicated_instruction_accounts
+                Ok(*deduplicated_instruction_accounts
                     .get(duplicate_index)
-                    .ok_or(InstructionError::NotEnoughAccountKeys)?
-                    .clone())
+                    .ok_or(InstructionError::NotEnoughAccountKeys)?)
             })
             .collect::<Result<Vec<InstructionAccount>, InstructionError>>()?;
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4662,6 +4662,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-memory-management"
+version = "1.15.0"
+
+[[package]]
 name = "solana-merkle-tree"
 version = "1.15.0"
 dependencies = [
@@ -5584,6 +5588,7 @@ dependencies = [
  "solana-frozen-abi 1.15.0",
  "solana-frozen-abi-macro 1.15.0",
  "solana-logger 1.15.0",
+ "solana-memory-management",
  "solana-program 1.15.0",
  "solana-sdk-macro 1.15.0",
  "thiserror",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -75,6 +75,7 @@ sha3 = { version = "0.10.4", optional = true }
 solana-frozen-abi = { path = "../frozen-abi", version = "=1.15.0" }
 solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.15.0" }
 solana-logger = { path = "../logger", version = "=1.15.0", optional = true }
+solana-memory-management = { path = "../memory-management", version = "=1.15.0" }
 solana-program = { path = "program", version = "=1.15.0" }
 solana-sdk-macro = { path = "macro", version = "=1.15.0" }
 thiserror = "1.0"


### PR DESCRIPTION
#### Problem
The [ABIv2 design](https://github.com/solana-labs/solana/issues/27384) requires all shared (between SBF programs and the runtime) properties to be flattened and accessible form the `TransactionContext`.

#### Summary of Changes
Adds `DynamicLayoutArray`. Collapses two nesting levels: Inlines all `Vec`s of `InstructionContext` and the struct itself into `TransactionContext::instruction_trace`.