### PR TITLE
Cleanup: `TransactionContext`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -895,15 +895,6 @@ impl<'a> InvokeContext<'a> {
         &self.sysvar_cache
     }
 
-    // Get pubkey of account at index
-    pub fn get_key_of_account_at_index(
-        &self,
-        index_in_transaction: usize,
-    ) -> Result<&Pubkey, InstructionError> {
-        self.transaction_context
-            .get_key_of_account_at_index(index_in_transaction)
-    }
-
     // Set this instruction syscall context
     pub fn set_syscall_context(
         &mut self,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1812,12 +1812,14 @@ declare_syscall!(
                 let account_metas = question_mark!(
                     (0..instruction_context.get_number_of_instruction_accounts())
                         .map(|instruction_account_index| Ok(AccountMeta {
-                            pubkey: *invoke_context.get_key_of_account_at_index(
-                                instruction_context
-                                    .get_index_of_instruction_account_in_transaction(
-                                        instruction_account_index
-                                    )?
-                            )?,
+                            pubkey: *invoke_context
+                                .transaction_context
+                                .get_key_of_account_at_index(
+                                    instruction_context
+                                        .get_index_of_instruction_account_in_transaction(
+                                            instruction_account_index
+                                        )?
+                                )?,
                             is_signer: instruction_context
                                 .is_instruction_account_signer(instruction_account_index)?,
                             is_writable: instruction_context

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -69,7 +69,7 @@ pub fn process_instruction(
         Ok(me)
     };
 
-    let signers = instruction_context.get_signers(transaction_context);
+    let signers = instruction_context.get_signers(transaction_context)?;
     match limited_deserialize(data) {
         Ok(StakeInstruction::Initialize(authorized, lockup)) => {
             let mut me = get_stake_account()?;

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -70,7 +70,7 @@ pub fn process_instruction(
         return Err(InstructionError::InvalidAccountOwner);
     }
 
-    let signers = instruction_context.get_signers(transaction_context);
+    let signers = instruction_context.get_signers(transaction_context)?;
     match limited_deserialize(data)? {
         VoteInstruction::InitializeAccount(vote_init) => {
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -324,7 +324,7 @@ pub fn process_instruction(
 
     trace!("process_instruction: {:?}", instruction);
 
-    let signers = instruction_context.get_signers(transaction_context);
+    let signers = instruction_context.get_signers(transaction_context)?;
     match instruction {
         SystemInstruction::CreateAccount {
             lamports,

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -23,8 +23,6 @@ use {
     },
 };
 
-pub type TransactionAccount = (Pubkey, AccountSharedData);
-
 /// For addressing (nested) properties of the TransactionContext
 #[repr(u16)]
 pub enum TransactionContextAttribute {
@@ -98,6 +96,9 @@ pub struct InstructionAccount {
     /// Is this account allowed to become writable
     pub is_writable: bool,
 }
+
+/// An account key and the matching account
+pub type TransactionAccount = (Pubkey, AccountSharedData);
 
 /// Loaded transaction shared between runtime and programs.
 ///

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -647,19 +647,20 @@ impl InstructionContext {
     }
 
     /// Calculates the set of all keys of signer instruction accounts in this Instruction
-    pub fn get_signers(&self, transaction_context: &TransactionContext) -> HashSet<Pubkey> {
+    pub fn get_signers(
+        &self,
+        transaction_context: &TransactionContext,
+    ) -> Result<HashSet<Pubkey>, InstructionError> {
         let mut result = HashSet::new();
         for instruction_account in self.instruction_accounts.iter() {
             if instruction_account.is_signer {
                 result.insert(
                     *transaction_context
-                        .account_keys
-                        .get(instruction_account.index_in_transaction)
-                        .unwrap(),
+                        .get_key_of_account_at_index(instruction_account.index_in_transaction)?,
                 );
             }
         }
-        result
+        Ok(result)
     }
 }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -296,7 +296,7 @@ impl TransactionContext {
             instruction_context.instruction_accounts_lamport_sum =
                 callee_instruction_accounts_lamport_sum;
         }
-        let index_in_trace = self.instruction_trace.len().saturating_sub(1);
+        let index_in_trace = self.get_instruction_trace_length();
         self.instruction_trace.push(InstructionContext::default());
         if nesting_level >= self.instruction_context_capacity {
             return Err(InstructionError::CallDepth);
@@ -547,7 +547,7 @@ impl InstructionContext {
         transaction_context: &'b TransactionContext,
     ) -> Result<&'b Pubkey, InstructionError> {
         self.get_index_of_program_account_in_transaction(
-            self.program_accounts.len().saturating_sub(1),
+            self.get_number_of_program_accounts().saturating_sub(1),
         )
         .and_then(|index_in_transaction| {
             transaction_context.get_key_of_account_at_index(index_in_transaction)
@@ -582,7 +582,7 @@ impl InstructionContext {
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
         let result = self.try_borrow_program_account(
             transaction_context,
-            self.program_accounts.len().saturating_sub(1),
+            self.get_number_of_program_accounts().saturating_sub(1),
         );
         debug_assert!(result.is_ok());
         result
@@ -614,8 +614,7 @@ impl InstructionContext {
         self.try_borrow_account(
             transaction_context,
             index_in_transaction,
-            self.program_accounts
-                .len()
+            self.get_number_of_program_accounts()
                 .saturating_add(instruction_account_index),
         )
     }
@@ -932,26 +931,26 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns whether this account is a signer (instruction wide)
     pub fn is_signer(&self) -> bool {
-        if self.index_in_instruction < self.instruction_context.program_accounts.len() {
+        if self.index_in_instruction < self.instruction_context.get_number_of_program_accounts() {
             return false;
         }
         self.instruction_context
             .is_instruction_account_signer(
                 self.index_in_instruction
-                    .saturating_sub(self.instruction_context.program_accounts.len()),
+                    .saturating_sub(self.instruction_context.get_number_of_program_accounts()),
             )
             .unwrap_or_default()
     }
 
     /// Returns whether this account is writable (instruction wide)
     pub fn is_writable(&self) -> bool {
-        if self.index_in_instruction < self.instruction_context.program_accounts.len() {
+        if self.index_in_instruction < self.instruction_context.get_number_of_program_accounts() {
             return false;
         }
         self.instruction_context
             .is_instruction_account_writable(
                 self.index_in_instruction
-                    .saturating_sub(self.instruction_context.program_accounts.len()),
+                    .saturating_sub(self.instruction_context.get_number_of_program_accounts()),
             )
             .unwrap_or_default()
     }


### PR DESCRIPTION
#### Problem
Preparation for upcoming refactoring.

#### Summary of Changes
- Lets `instruction_accounts_lamport_sum()` have the `&InstructionContext` as parameter directly.
- Updates docu comments.
- Uses accessors methods instead of accessing private properties of other structs.
- Adds `#![deny(clippy::indexing_slicing)]`.
- Has `InstructionContext::get_signers()` return a `Result` instead of using `unwrap()`.
- Removes `InvokeContext::get_key_of_account_at_index()`. 