### PR TITLE
fix active_connections metric decr

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -470,6 +470,7 @@ async fn setup_connection(
                     .connection_add_failed_unstaked_node
                     .fetch_add(1, Ordering::Relaxed);
             }
+            stats.total_connections.fetch_sub(1, Ordering::Relaxed);
         } else {
             stats.connection_setup_error.fetch_add(1, Ordering::Relaxed);
         }
@@ -568,7 +569,6 @@ async fn handle_connection(
             .connection_remove_failed
             .fetch_add(1, Ordering::Relaxed);
     }
-    stats.total_connections.fetch_sub(1, Ordering::Relaxed);
 }
 
 // Return true if the server should drop the stream


### PR DESCRIPTION
#### Problem

`quic-connection.active_connections` metric is monotonically increasing as described in [issue](https://github.com/solana-labs/solana/issues/27597)

#### Summary of Changes

Decrement `total_connections` on the same level where we increment it.

