### PR TITLE
BPF SDK relocation to adhere to the Linux Directory Structure

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -161,8 +161,8 @@ if [[ -z "$validatorOnly" ]]; then
   "$cargo" $maybeRustVersion build --manifest-path programs/bpf_loader/gen-syscall-list/Cargo.toml
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   "$cargo" $maybeRustVersion run --bin gen-headers
-  mkdir -p "$installDir"/bin/sdk/bpf
-  cp -a sdk/bpf/* "$installDir"/bin/sdk/bpf
+  mkdir -p "$installDir"/lib/solana/sdk/bpf
+  cp -a sdk/bpf/* "$installDir"/lib/solana/sdk/bpf
 fi
 
 (

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -46,7 +46,11 @@ impl Default for Config<'_> {
                 .expect("Unable to get current executable")
                 .parent()
                 .expect("Unable to get parent directory")
+                .parent()
+                .expect("Unable to get parent directory")
                 .to_path_buf()
+                .join("lib")
+                .join("solana")
                 .join("sdk")
                 .join("bpf"),
             sbf_out_dir: None,


### PR DESCRIPTION
#### Problem
Current location of the sdk folder does not adhere to the Linux Directory Structure, making it impossible for package manager maintainers to install files to the proper location without modifying the source code.

#### Summary of Changes
Change location of the sdk folder to INSTALLDIR/lib/solana/sdk instead of INSTALLDIR/bin/sdk and update installation script.
This allows for package managers to place the sdk in /usr/lib/solana without changing any expected behavior when installed in the supported way with the installation script.