### PR TITLE
zk-token-sdk: update errors in comments

### DIFF
--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -42,10 +42,10 @@ lazy_static::lazy_static! {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferData {
-    /// Group encryption of the low 32 bits of the transfer amount
+    /// Group encryption of the low 16 bits of the transfer amount
     pub ciphertext_lo: pod::TransferAmountEncryption,
 
-    /// Group encryption of the high 32 bits of the transfer amount
+    /// Group encryption of the high 48 bits of the transfer amount
     pub ciphertext_hi: pod::TransferAmountEncryption,
 
     /// The public encryption keys associated with the transfer: source, dest, and auditor

--- a/zk-token-sdk/src/instruction/withdraw_withheld.rs
+++ b/zk-token-sdk/src/instruction/withdraw_withheld.rs
@@ -21,9 +21,9 @@ use {
 /// This struct includes the cryptographic proof *and* the account data information needed to verify
 /// the proof
 ///
-/// - The pre-instruction should call WithdrawData::verify_proof(&self)
-/// - The actual program should check that `current_ct` is consistent with what is
-///   currently stored in the confidential token account TODO: update this statement
+/// - The pre-instruction should call WithdrawWithheldTokensData::verify_proof(&self)
+/// - The actual program should check that the ciphertext in this struct is consistent with what is
+/// currently stored in the confidential token account
 ///
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -34,7 +34,7 @@ impl InnerProductProof {
     /// protocols).
     ///
     /// The lengths of the vectors must all be the same, and must all be
-    /// either 0 or a power of 2.
+    /// a power of 2.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         Q: &RistrettoPoint,


### PR DESCRIPTION
Update errors in the comments in the zk-token-sdk