### PR TITLE
fix total_connections metric

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -390,7 +390,6 @@ async fn setup_connection(
     .await
     {
         if let Ok(new_connection) = connecting_result {
-            stats.total_connections.fetch_add(1, Ordering::Relaxed);
             stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
 
             let params = get_connection_stake(&new_connection.connection, staked_nodes.clone())
@@ -499,6 +498,7 @@ async fn handle_connection(
         stats.total_streams.load(Ordering::Relaxed),
         stats.total_connections.load(Ordering::Relaxed),
     );
+    stats.total_connections.fetch_add(1, Ordering::Relaxed);
     while !stream_exit.load(Ordering::Relaxed) {
         if let Ok(stream) = tokio::time::timeout(
             Duration::from_millis(WAIT_FOR_STREAM_TIMEOUT_MS),


### PR DESCRIPTION
#### Problem

To address https://github.com/solana-labs/solana/issues/27597

It looks like with this fix number of connections is stable:

<img width="1124" alt="Screenshot 2022-09-06 at 11 49 01" src="https://user-images.githubusercontent.com/687962/188604332-9dc5ca3a-632c-4301-b2b3-25f191be02f8.png">

#### Summary of Changes
