### PR TITLE
explorer: Don't show token holdings for accounts with too many tokens

### DIFF
--- a/explorer/src/components/account/OwnedTokensCard.tsx
+++ b/explorer/src/components/account/OwnedTokensCard.tsx
@@ -66,6 +66,12 @@ export function OwnedTokensCard({ pubkey }: { pubkey: PublicKey }) {
     );
   }
 
+  if (tokens.length > 100) {
+    return (
+      <ErrorCard text="Token holdings is not available for accounts with over 100 token accounts" />
+    );
+  }
+
   return (
     <>
       {showDropdown && (

--- a/explorer/src/providers/accounts/tokens.tsx
+++ b/explorer/src/providers/accounts/tokens.tsx
@@ -66,7 +66,7 @@ async function fetchAccountTokens(
       "processed"
     ).getParsedTokenAccountsByOwner(pubkey, { programId: TOKEN_PROGRAM_ID });
     data = {
-      tokens: value.map((accountInfo) => {
+      tokens: value.slice(0, 101).map((accountInfo) => {
         const parsedInfo = accountInfo.account.data.parsed.info;
         const info = create(parsedInfo, TokenAccountInfo);
         return { info, pubkey: accountInfo.pubkey };


### PR DESCRIPTION
#### Problem
Explorer hangs when viewing the token holdings of accounts with many tokens like the incinerator account.

#### Summary of Changes
Truncate token holdings and hide token holdings if an account has over 100 tokens

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
