### PR TITLE
allow accounts hash calc to specify enable_rehashing

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -130,6 +130,8 @@ impl AccountsHashVerifier {
         };
         timings.calc_storage_size_quartiles(&accounts_package.snapshot_storages);
 
+        let enable_rehashing = true;
+
         let (accounts_hash, lamports) = accounts_package
             .accounts
             .accounts_db
@@ -143,6 +145,7 @@ impl AccountsHashVerifier {
                     rent_collector: &accounts_package.rent_collector,
                     store_detailed_debug_info_on_failure: false,
                     full_snapshot: None,
+                    enable_rehashing,
                 },
                 &sorted_storages,
                 timings,
@@ -166,6 +169,7 @@ impl AccountsHashVerifier {
                         rent_collector: &accounts_package.rent_collector,
                         store_detailed_debug_info_on_failure: false,
                         full_snapshot: None,
+                        enable_rehashing,
                     },
                 );
             info!(
@@ -186,6 +190,7 @@ impl AccountsHashVerifier {
                         // now that we've failed, store off the failing contents that produced a bad capitalization
                         store_detailed_debug_info_on_failure: true,
                         full_snapshot: None,
+                        enable_rehashing,
                     },
                     &sorted_storages,
                     HashStats::default(),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -195,6 +195,7 @@ impl SnapshotRequestHandler {
                             rent_collector: snapshot_root_bank.rent_collector(),
                             store_detailed_debug_info_on_failure: false,
                             full_snapshot: None,
+                            enable_rehashing: true,
                         },
                     ).unwrap();
                     assert_eq!(previous_hash, this_hash);

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -54,6 +54,8 @@ pub struct CalcAccountsHashConfig<'a> {
     pub rent_collector: &'a RentCollector,
     /// used for tracking down hash mismatches after the fact
     pub store_detailed_debug_info_on_failure: bool,
+    /// true if hash calculation can rehash based on skipped rewrites
+    pub enable_rehashing: bool,
     /// `Some` if this is an incremental snapshot which only hashes slots since the base full snapshot
     pub full_snapshot: Option<FullSnapshotAccountsHashInfo>,
 }


### PR DESCRIPTION
#### Problem
When we activate the feature #26491, we will no longer store accounts on rewrites during rent collection.
As a result, as of that moment, the hash value per account will be frozen forever until the account is written again. Thus, we need to disable the rehashing during the accounts hash as of this feature activation. To disable the rehashing, we need to be able to pass that to config for the accounts hash calculation. The requestor of the hash knows which bank to use and thus, whether a feature has been activated. As a result, if `enable_rehashing` is false, then whatever hash is found in the most recent append vec per account is used directly.

#### Summary of Changes
add `enable_rehashing` to `CalcAccountsHashConfig` for use on feature activation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
