### PR TITLE
Skip loadedAddresses for jsonParsed tx meta

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -379,7 +379,7 @@ impl UiTransactionStatusMeta {
                 .post_token_balances
                 .map(|balance| balance.into_iter().map(Into::into).collect()),
             rewards: meta.rewards,
-            loaded_addresses: Some(UiLoadedAddresses::from(&meta.loaded_addresses)),
+            loaded_addresses: None,
             return_data: meta.return_data,
             compute_units_consumed: meta.compute_units_consumed,
         }


### PR DESCRIPTION
#### Problem
Now that the `jsonParsed` accounts list[ includes the account source](https://github.com/solana-labs/solana/pull/27552) (transaction or address lookup-table), the `loadedAddresses` array is redundant.

#### Summary of Changes
Only return `loadedAddresses` when other types of encoding are requested.
