### PR TITLE
fix: recursively size variable size structs in your buffer layouts

### DIFF
--- a/web3.js/src/layout.ts
+++ b/web3.js/src/layout.ts
@@ -152,6 +152,9 @@ export function getAlloc(type: any, fields: any): number {
       if (Array.isArray(field)) {
         return field.length * getItemAlloc(item.elementLayout);
       }
+    } else if ('fields' in item) {
+      // This is a `Structure` whose size needs to be recursively measured.
+      return getAlloc({layout: item}, fields[item.property]);
     }
     // Couldn't determine allocated size of layout
     return 0;


### PR DESCRIPTION
#### Problem

Imagine you have a data structure like this:

```
Layout.structure([
  u8('instruction'),
  Layout.structure([
    rustString('variableSizeString'),
  ]);
]);
```

The present implementation of `getAlloc` will not dive into that inner structure and size it, so the total size of this entire layout will – incorrectly – be 1.

#### Summary of Changes

* When `getAlloc` encounters a structure it recurses into it to obtain its size.