### PR TITLE
enable caching on create snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2879,6 +2879,7 @@ fn main() {
                         new_hard_forks,
                         halt_at_slot: Some(snapshot_slot),
                         poh_verify: false,
+                        accounts_db_caching_enabled: true,
                         accounts_db_config,
                         ..ProcessOptions::default()
                     },


### PR DESCRIPTION
#### Problem
I'm seeing that without passing this, we end up creating multiple appendvecs per slot while replaying slots from the starting snapshot until we hit the snapshot slot to create. I think this was just an oversight?

#### Summary of Changes
Enable caching when creating a snapshot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
