### PR TITLE
Make Accounts Background Services aware of Epoch Accounts Hash

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -9,10 +9,11 @@ use {
     solana_measure::measure::Measure,
     solana_runtime::{
         accounts_hash::{CalcAccountsHashConfig, HashStats},
+        epoch_accounts_hash::EpochAccountsHash,
         snapshot_config::SnapshotConfig,
         snapshot_package::{
-            retain_max_n_elements, AccountsPackage, PendingAccountsPackage, PendingSnapshotPackage,
-            SnapshotPackage, SnapshotType,
+            retain_max_n_elements, AccountsPackage, AccountsPackageType, PendingAccountsPackage,
+            PendingSnapshotPackage, SnapshotPackage, SnapshotType,
         },
         sorted_storages::SortedStorages,
     },
@@ -97,6 +98,8 @@ impl AccountsHashVerifier {
         snapshot_config: Option<&SnapshotConfig>,
     ) {
         let accounts_hash = Self::calculate_and_verify_accounts_hash(&accounts_package);
+
+        Self::save_epoch_accounts_hash(&accounts_package, accounts_hash);
 
         Self::push_accounts_hashes_to_cluster(
             &accounts_package,
@@ -228,6 +231,21 @@ impl AccountsHashVerifier {
         accounts_hash
     }
 
+    fn save_epoch_accounts_hash(accounts_package: &AccountsPackage, accounts_hash: Hash) {
+        if accounts_package.package_type == AccountsPackageType::EpochAccountsHash {
+            let new_epoch_accounts_hash = EpochAccountsHash::new(accounts_hash);
+            let old_epoch_accounts_hash = accounts_package
+                .accounts
+                .accounts_db
+                .epoch_accounts_hash
+                .lock()
+                .unwrap()
+                .replace(new_epoch_accounts_hash);
+            // Old epoch accounts hash must be NONE, because a previous bank must have taken it to hash into itself
+            assert!(old_epoch_accounts_hash.is_none());
+        }
+    }
+
     fn generate_fault_hash(original_hash: &Hash) -> Hash {
         use {
             rand::{thread_rng, Rng},
@@ -280,14 +298,17 @@ impl AccountsHashVerifier {
         snapshot_config: Option<&SnapshotConfig>,
         accounts_hash: Hash,
     ) {
-        if accounts_package.snapshot_type.is_none()
-            || pending_snapshot_package.is_none()
+        if pending_snapshot_package.is_none()
             || !snapshot_config
                 .map(|snapshot_config| snapshot_config.should_generate_snapshots())
                 .unwrap_or(false)
+            || !matches!(
+                accounts_package.package_type,
+                AccountsPackageType::Snapshot(_)
+            )
         {
             return;
-        };
+        }
 
         let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash);
         let pending_snapshot_package = pending_snapshot_package.unwrap();
@@ -444,6 +465,7 @@ mod tests {
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {
+                package_type: AccountsPackageType::AccountsHashVerifier,
                 slot: full_snapshot_archive_interval_slots + i as u64,
                 block_height: full_snapshot_archive_interval_slots + i as u64,
                 slot_deltas: vec![],
@@ -456,7 +478,6 @@ mod tests {
                 expected_capitalization: 0,
                 accounts_hash_for_testing: None,
                 cluster_type: ClusterType::MainnetBeta,
-                snapshot_type: None,
                 accounts: Arc::clone(&accounts),
                 epoch_schedule: EpochSchedule::default(),
                 rent_collector: RentCollector::default(),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -25,8 +25,8 @@ use {
         snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_config::SnapshotConfig,
         snapshot_package::{
-            AccountsPackage, PendingAccountsPackage, PendingSnapshotPackage, SnapshotPackage,
-            SnapshotType,
+            AccountsPackage, AccountsPackageType, PendingAccountsPackage, PendingSnapshotPackage,
+            SnapshotPackage, SnapshotType,
         },
         snapshot_utils::{
             self, ArchiveFormat,
@@ -240,6 +240,7 @@ fn run_bank_forks_snapshot_n<F>(
         .expect("no bank snapshots found in path");
     let slot_deltas = last_bank.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new(
+        AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
         &last_bank,
         &last_bank_snapshot_info,
         bank_snapshots_dir,
@@ -250,7 +251,6 @@ fn run_bank_forks_snapshot_n<F>(
         ArchiveFormat::TarBzip2,
         snapshot_version,
         None,
-        Some(SnapshotType::FullSnapshot),
     )
     .unwrap();
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
@@ -391,7 +391,7 @@ fn test_concurrent_snapshot_packaging(
             snapshot_config.snapshot_version,
             snapshot_config.archive_format,
             None,
-            Some(SnapshotType::FullSnapshot),
+            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
         )
         .unwrap();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1195,7 +1195,7 @@ pub struct AccountsDb {
     /// The cadence is once per epoch, all nodes calculate a full accounts hash as of a known slot calculated using 'N'
     /// Some time later (to allow for slow calculation time), the bank hash at a slot calculated using 'M' includes the full accounts hash.
     /// Thus, the state of all accounts on a validator is known to be correct at least once per epoch.
-    pub(crate) epoch_accounts_hash: Mutex<Option<EpochAccountsHash>>,
+    pub epoch_accounts_hash: Mutex<Option<EpochAccountsHash>>,
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequest},
+        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestType},
         bank::Bank,
         snapshot_config::SnapshotConfig,
     },
@@ -290,6 +290,7 @@ impl BankForks {
                             SnapshotRequest {
                                 snapshot_root_bank,
                                 status_cache_slot_deltas,
+                                request_type: SnapshotRequestType::Snapshot,
                             },
                         ) {
                             warn!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,7 +34,7 @@ pub mod commitment;
 pub mod contains;
 pub mod cost_model;
 pub mod cost_tracker;
-mod epoch_accounts_hash;
+pub mod epoch_accounts_hash;
 pub mod epoch_stakes;
 pub mod execute_cost_table;
 mod expected_rent_collection;

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -32,6 +32,7 @@ pub type PendingSnapshotPackage = Arc<Mutex<Option<SnapshotPackage>>>;
 
 #[derive(Debug)]
 pub struct AccountsPackage {
+    pub package_type: AccountsPackageType,
     pub slot: Slot,
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
@@ -44,7 +45,6 @@ pub struct AccountsPackage {
     pub expected_capitalization: u64,
     pub accounts_hash_for_testing: Option<Hash>,
     pub cluster_type: ClusterType,
-    pub snapshot_type: Option<SnapshotType>,
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
@@ -54,6 +54,7 @@ impl AccountsPackage {
     /// Package up bank files, storages, and slot deltas for a snapshot
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        package_type: AccountsPackageType,
         bank: &Bank,
         bank_snapshot_info: &BankSnapshotInfo,
         bank_snapshots_dir: impl AsRef<Path>,
@@ -64,22 +65,21 @@ impl AccountsPackage {
         archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
         accounts_hash_for_testing: Option<Hash>,
-        snapshot_type: Option<SnapshotType>,
     ) -> Result<Self> {
-        info!(
-            "Package snapshot for bank {} has {} account storage entries (snapshot type: {:?})",
-            bank.slot(),
-            snapshot_storages.len(),
-            snapshot_type,
-        );
-
-        if let Some(SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot)) =
-            snapshot_type
-        {
-            assert!(
-                bank.slot() > incremental_snapshot_base_slot,
-                "Incremental snapshot base slot must be less than the bank being snapshotted!"
+        if let AccountsPackageType::Snapshot(snapshot_type) = package_type {
+            info!(
+                "Package snapshot for bank {} has {} account storage entries (snapshot type: {:?})",
+                bank.slot(),
+                snapshot_storages.len(),
+                snapshot_type,
             );
+            if let SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot) = snapshot_type
+            {
+                assert!(
+                    bank.slot() > incremental_snapshot_base_slot,
+                    "Incremental snapshot base slot must be less than the bank being snapshotted!"
+                );
+            }
         }
 
         // Hard link the snapshot into a tmpdir, to ensure its not removed prior to packaging.
@@ -100,6 +100,7 @@ impl AccountsPackage {
         }
 
         Ok(Self {
+            package_type,
             slot: bank.slot(),
             block_height: bank.block_height(),
             slot_deltas,
@@ -114,12 +115,21 @@ impl AccountsPackage {
             expected_capitalization: bank.capitalization(),
             accounts_hash_for_testing,
             cluster_type: bank.cluster_type(),
-            snapshot_type,
             accounts: bank.accounts(),
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
         })
     }
+}
+
+/// Accounts packages are sent to the Accounts Hash Verifier for processing.  There are multiple
+/// types of accounts packages, which are specified as variants in this enum.  All accounts
+/// packages do share some processing: such as calculating the accounts hash.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum AccountsPackageType {
+    AccountsHashVerifier,
+    Snapshot(SnapshotType),
+    EpochAccountsHash,
 }
 
 pub struct SnapshotPackage {
@@ -134,40 +144,46 @@ pub struct SnapshotPackage {
 
 impl SnapshotPackage {
     pub fn new(accounts_package: AccountsPackage, accounts_hash: Hash) -> Self {
-        assert!(
-            accounts_package.snapshot_type.is_some(),
-            "Cannot make a SnapshotPackage from an AccountsPackage when SnapshotType is None!"
-        );
-
         let mut snapshot_storages = accounts_package.snapshot_storages;
-        let snapshot_archive_path = match accounts_package.snapshot_type.unwrap() {
-            SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                accounts_package.full_snapshot_archives_dir,
-                accounts_package.slot,
-                &accounts_hash,
-                accounts_package.archive_format,
-            ),
-            SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot) => {
-                snapshot_storages.retain(|storages| {
-                    storages
-                        .first() // storages are grouped by slot in the outer Vec, so all storages will have the same slot as the first
-                        .map(|storage| storage.slot() > incremental_snapshot_base_slot)
-                        .unwrap_or_default()
-                });
-                assert!(
-                    snapshot_storages.iter().all(|storage| storage
-                        .iter()
-                        .all(|entry| entry.slot() > incremental_snapshot_base_slot)),
-                    "Incremental snapshot package must only contain storage entries where slot > incremental snapshot base slot (i.e. full snapshot slot)!"
+        let (snapshot_type, snapshot_archive_path) = match accounts_package.package_type {
+            AccountsPackageType::Snapshot(snapshot_type) => match snapshot_type {
+                SnapshotType::FullSnapshot => (
+                    snapshot_type,
+                    snapshot_utils::build_full_snapshot_archive_path(
+                        accounts_package.full_snapshot_archives_dir,
+                        accounts_package.slot,
+                        &accounts_hash,
+                        accounts_package.archive_format,
+                    ),
+                ),
+                SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot) => {
+                    snapshot_storages.retain(|storages| {
+                        storages
+                            .first() // storages are grouped by slot in the outer Vec, so all storages will have the same slot as the first
+                            .map(|storage| storage.slot() > incremental_snapshot_base_slot)
+                            .unwrap_or_default()
+                    });
+                    assert!(
+                        snapshot_storages.iter().all(|storage| storage
+                            .iter()
+                            .all(|entry| entry.slot() > incremental_snapshot_base_slot)),
+                            "Incremental snapshot package must only contain storage entries where slot > incremental snapshot base slot (i.e. full snapshot slot)!"
                     );
-                snapshot_utils::build_incremental_snapshot_archive_path(
-                    accounts_package.incremental_snapshot_archives_dir,
-                    incremental_snapshot_base_slot,
-                    accounts_package.slot,
-                    &accounts_hash,
-                    accounts_package.archive_format,
-                )
-            }
+                    (
+                        snapshot_type,
+                        snapshot_utils::build_incremental_snapshot_archive_path(
+                            accounts_package.incremental_snapshot_archives_dir,
+                            incremental_snapshot_base_slot,
+                            accounts_package.slot,
+                            &accounts_hash,
+                            accounts_package.archive_format,
+                        ),
+                    )
+                }
+            },
+            _ => panic!(
+                "The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!"
+            ),
         };
 
         Self {
@@ -182,7 +198,7 @@ impl SnapshotPackage {
             snapshot_links: accounts_package.snapshot_links,
             snapshot_storages,
             snapshot_version: accounts_package.snapshot_version,
-            snapshot_type: accounts_package.snapshot_type.unwrap(),
+            snapshot_type,
         }
     }
 }


### PR DESCRIPTION
#### Problem

Accounts Background Services does not know about Epoch Accounts Hash.

#### Summary of Changes

Add an `EpochAccountsHash` request type to pass into ABS, and then plumb that through the the snapshot request handler, snapshot utils, and AccountsHashVerifier.

#### Notes

There's a lot changes due to plumbing, which makes this PR look big and noisy. I am happy to clarify any/all sections of code; whatever is helpful!