### PR TITLE
Graph and Stream-Based Replay Algorithm (Arch Review)

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -255,6 +255,7 @@ impl ReplaySlotStats {
                     .verify_callee_us,
                 i64
             ),
+            ("planning_elapsed", self.planning_elapsed as i64, i64),
         );
 
         let mut per_pubkey_timings: Vec<_> = self

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -405,7 +405,7 @@ impl ReplayStage {
         );
 
         #[allow(clippy::cognitive_complexity)]
-        let t_replay = Builder::new()
+            let t_replay = Builder::new()
             .name("solana-replay-stage".to_string())
             .spawn(move || {
                 let verify_recyclers = VerifyRecyclers::default();
@@ -439,8 +439,7 @@ impl ReplayStage {
                 };
                 let in_vote_only_mode = bank_forks.read().unwrap().get_vote_only_mode_signal();
 
-                let replayer = Replayer::new(get_thread_count(), &exit);
-                let replayer_handle = replayer.handle();
+                let (replayer, replayer_handle) = Replayer::new(get_thread_count());
 
                 loop {
                     // Stop getting entries if we get exit signal
@@ -622,10 +621,10 @@ impl ReplayStage {
                                                     &authorized_voter_keypairs.read().unwrap(),
                                                     &mut voted_signatures,
                                                     has_new_vote_been_rooted, &mut
-                                                    last_vote_refresh_time,
+                                                        last_vote_refresh_time,
                                                     &voting_sender,
                                                     wait_to_vote_slot,
-                                                    );
+                            );
                         }
                     }
 
@@ -658,7 +657,7 @@ impl ReplayStage {
                         for r in heaviest_fork_failures {
                             if let HeaviestForkFailures::NoPropagatedConfirmation(slot) = r {
                                 if let Some(latest_leader_slot) =
-                                    progress.get_latest_leader_slot_must_exist(slot)
+                                progress.get_latest_leader_slot_must_exist(slot)
                                 {
                                     progress.log_propagated_stats(latest_leader_slot, &bank_forks);
                                 }
@@ -671,7 +670,7 @@ impl ReplayStage {
                     // Vote on a fork
                     if let Some((ref vote_bank, ref switch_fork_decision)) = vote_bank {
                         if let Some(votable_leader) =
-                            leader_schedule_cache.slot_leader_at(vote_bank.slot(), Some(vote_bank))
+                        leader_schedule_cache.slot_leader_at(vote_bank.slot(), Some(vote_bank))
                         {
                             Self::log_leader_change(
                                 &my_pubkey,
@@ -1143,8 +1142,8 @@ impl ReplayStage {
                         *duplicate_slot,
                     );
                     true
-                // TODO: Send signal to repair to repair the correct version of
-                // `duplicate_slot` with hash == `correct_hash`
+                    // TODO: Send signal to repair to repair the correct version of
+                    // `duplicate_slot` with hash == `correct_hash`
                 } else {
                     warn!(
                         "PoH bank for slot {} is building on duplicate slot {}",
@@ -2021,8 +2020,8 @@ impl ReplayStage {
         }
         if my_latest_landed_vote >= last_voted_slot
             || heaviest_bank_on_same_fork
-                .check_hash_age(&tower.last_vote_tx_blockhash(), MAX_PROCESSING_AGE)
-                .unwrap_or(false)
+            .check_hash_age(&tower.last_vote_tx_blockhash(), MAX_PROCESSING_AGE)
+            .unwrap_or(false)
             // In order to avoid voting on multiple forks all past MAX_PROCESSING_AGE that don't
             // include the last voted blockhash
             || last_vote_refresh_time.last_refresh_time.elapsed().as_millis() < MAX_VOTE_REFRESH_INTERVAL_MILLIS as u128
@@ -2802,7 +2801,7 @@ impl ReplayStage {
                 // newly achieved threshold, then there's no further
                 // information to propagate backwards to past leader blocks
                 (newly_voted_pubkeys.is_empty() && cluster_slot_pubkeys.is_empty() &&
-                !did_newly_reach_threshold)
+                    !did_newly_reach_threshold)
             {
                 break;
             }

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -22,12 +22,7 @@ use {
         snapshot_utils,
     },
     solana_sdk::genesis_config::GenesisConfig,
-    std::{
-        fs,
-        path::PathBuf,
-        process, result,
-        sync::{atomic::AtomicBool, Arc},
-    },
+    std::{fs, path::PathBuf, process, result},
 };
 
 pub type LoadResult = result::Result<
@@ -122,9 +117,7 @@ pub fn load_bank_forks(
         false
     };
 
-    let exit = Arc::new(AtomicBool::new(false));
-    let replayer = Replayer::new(get_thread_count(), &exit);
-    let replayer_handle = replayer.handle();
+    let (_relayer, replayer_handle) = Replayer::new(get_thread_count());
 
     let (bank_forks, starting_snapshot_hashes) = if snapshot_present {
         bank_forks_from_snapshot(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -127,7 +127,7 @@ pub type Result<T> = std::result::Result<T, BlockstoreError>;
 
 impl std::fmt::Display for BlockstoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "blockstore error")
+        write!(f, "blockstore error: {}", self)
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1,21 +1,26 @@
 use {
     crate::{
-        block_error::BlockError, blockstore::Blockstore, blockstore_db::BlockstoreError,
-        blockstore_meta::SlotMeta, leader_schedule_cache::LeaderScheduleCache,
-        token_balances::collect_token_balances,
+        block_error::BlockError,
+        blockstore::Blockstore,
+        blockstore_db::BlockstoreError,
+        blockstore_meta::SlotMeta,
+        leader_schedule_cache::LeaderScheduleCache,
+        replayer::{ReplayRequest, ReplayResponse, Replayer, ReplayerHandle},
     },
     chrono_humanize::{Accuracy, HumanTime, Tense},
     crossbeam_channel::{unbounded, Sender},
     itertools::Itertools,
     log::*,
-    rand::{seq::SliceRandom, thread_rng},
-    rayon::{prelude::*, ThreadPool},
+    rayon::{
+        iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
+        ThreadPool,
+    },
     solana_entry::entry::{
         self, create_ticks, Entry, EntrySlice, EntryType, EntryVerificationStatus, VerifyRecyclers,
     },
     solana_measure::measure::Measure,
-    solana_metrics::{datapoint_error, inc_new_counter_debug},
-    solana_program_runtime::timings::{ExecuteTimingType, ExecuteTimings},
+    solana_metrics::datapoint_error,
+    solana_program_runtime::timings::ExecuteTimings,
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::{
         accounts_background_service::DroppedSlotsReceiver,
@@ -24,13 +29,11 @@ use {
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank::{
             Bank, RentDebits, TransactionBalancesSet, TransactionExecutionDetails,
-            TransactionExecutionResult, TransactionResults,
+            TransactionExecutionResult,
         },
         bank_forks::BankForks,
-        bank_utils,
         block_cost_limits::*,
         commitment::VOTE_THRESHOLD_SIZE,
-        cost_model::CostModel,
         snapshot_config::SnapshotConfig,
         snapshot_package::{AccountsPackageSender, SnapshotType},
         snapshot_utils,
@@ -40,17 +43,15 @@ use {
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
-        clock::{Slot, MAX_PROCESSING_AGE},
-        feature_set,
+        clock::Slot,
         genesis_config::GenesisConfig,
         hash::Hash,
-        instruction::InstructionError,
         pubkey::Pubkey,
         signature::{Keypair, Signature},
         timing,
         transaction::{
-            Result, SanitizedTransaction, TransactionError, TransactionVerificationMode,
-            VersionedTransaction,
+            Result, SanitizedTransaction, TransactionAccountLocks, TransactionError,
+            TransactionVerificationMode, VersionedTransaction,
         },
     },
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
@@ -60,7 +61,7 @@ use {
         collections::{HashMap, HashSet},
         path::PathBuf,
         result,
-        sync::{Arc, RwLock},
+        sync::{atomic::AtomicBool, Arc, RwLock},
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -142,154 +143,6 @@ fn get_first_error(
     first_err
 }
 
-fn aggregate_total_execution_units(execute_timings: &ExecuteTimings) -> u64 {
-    let mut execute_cost_units: u64 = 0;
-    for (program_id, timing) in &execute_timings.details.per_program_timings {
-        if timing.count < 1 {
-            continue;
-        }
-        execute_cost_units =
-            execute_cost_units.saturating_add(timing.accumulated_units / timing.count as u64);
-        trace!("aggregated execution cost of {:?} {:?}", program_id, timing);
-    }
-    execute_cost_units
-}
-
-fn execute_batch(
-    batch: &TransactionBatch,
-    bank: &Arc<Bank>,
-    transaction_status_sender: Option<&TransactionStatusSender>,
-    replay_vote_sender: Option<&ReplayVoteSender>,
-    timings: &mut ExecuteTimings,
-    cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
-) -> Result<()> {
-    let record_token_balances = transaction_status_sender.is_some();
-
-    let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
-
-    let pre_token_balances = if record_token_balances {
-        collect_token_balances(bank, batch, &mut mint_decimals)
-    } else {
-        vec![]
-    };
-
-    let pre_process_units: u64 = aggregate_total_execution_units(timings);
-
-    let (tx_results, balances) = batch.bank().load_execute_and_commit_transactions(
-        batch,
-        MAX_PROCESSING_AGE,
-        transaction_status_sender.is_some(),
-        transaction_status_sender.is_some(),
-        transaction_status_sender.is_some(),
-        timings,
-    );
-
-    if bank
-        .feature_set
-        .is_active(&feature_set::gate_large_block::id())
-    {
-        let execution_cost_units = aggregate_total_execution_units(timings) - pre_process_units;
-        let remaining_block_cost_cap = cost_capacity_meter
-            .write()
-            .unwrap()
-            .accumulate(execution_cost_units);
-
-        debug!(
-            "bank {} executed a batch, number of transactions {}, total execute cu {}, remaining block cost cap {}",
-            bank.slot(),
-            batch.sanitized_transactions().len(),
-            execution_cost_units,
-            remaining_block_cost_cap,
-        );
-
-        if remaining_block_cost_cap == 0_u64 {
-            return Err(TransactionError::WouldExceedMaxBlockCostLimit);
-        }
-    }
-
-    bank_utils::find_and_send_votes(
-        batch.sanitized_transactions(),
-        &tx_results,
-        replay_vote_sender,
-    );
-
-    let TransactionResults {
-        fee_collection_results,
-        execution_results,
-        rent_debits,
-        ..
-    } = tx_results;
-
-    check_accounts_data_size(bank, &execution_results)?;
-
-    if let Some(transaction_status_sender) = transaction_status_sender {
-        let transactions = batch.sanitized_transactions().to_vec();
-        let post_token_balances = if record_token_balances {
-            collect_token_balances(bank, batch, &mut mint_decimals)
-        } else {
-            vec![]
-        };
-
-        let token_balances =
-            TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
-
-        transaction_status_sender.send_transaction_status_batch(
-            bank.clone(),
-            transactions,
-            execution_results,
-            balances,
-            token_balances,
-            rent_debits,
-        );
-    }
-
-    let first_err = get_first_error(batch, fee_collection_results);
-    first_err.map(|(result, _)| result).unwrap_or(Ok(()))
-}
-
-fn execute_batches_internal(
-    bank: &Arc<Bank>,
-    batches: &[TransactionBatch],
-    entry_callback: Option<&ProcessCallback>,
-    transaction_status_sender: Option<&TransactionStatusSender>,
-    replay_vote_sender: Option<&ReplayVoteSender>,
-    timings: &mut ExecuteTimings,
-    cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
-) -> Result<()> {
-    inc_new_counter_debug!("bank-par_execute_entries-count", batches.len());
-    let (results, new_timings): (Vec<Result<()>>, Vec<ExecuteTimings>) =
-        PAR_THREAD_POOL.with(|thread_pool| {
-            thread_pool.borrow().install(|| {
-                batches
-                    .into_par_iter()
-                    .map(|batch| {
-                        let mut timings = ExecuteTimings::default();
-                        let result = execute_batch(
-                            batch,
-                            bank,
-                            transaction_status_sender,
-                            replay_vote_sender,
-                            &mut timings,
-                            cost_capacity_meter.clone(),
-                        );
-                        if let Some(entry_callback) = entry_callback {
-                            entry_callback(bank);
-                        }
-                        (result, timings)
-                    })
-                    .unzip()
-            })
-        });
-
-    timings.saturating_add_in_place(ExecuteTimingType::TotalBatchesLen, batches.len() as u64);
-    timings.saturating_add_in_place(ExecuteTimingType::NumExecuteBatches, 1);
-    for timing in new_timings {
-        timings.accumulate(&timing);
-    }
-
-    first_err(&results)
-}
-
 fn rebatch_transactions<'a>(
     lock_results: &'a [Result<()>],
     bank: &'a Arc<Bank>,
@@ -307,72 +160,196 @@ fn rebatch_transactions<'a>(
 
 fn execute_batches(
     bank: &Arc<Bank>,
-    batches: &[TransactionBatch],
+    transactions: &[SanitizedTransaction],
     entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     timings: &mut ExecuteTimings,
     cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+    replayer_handle: &ReplayerHandle,
 ) -> Result<()> {
-    let (lock_results, sanitized_txs): (Vec<_>, Vec<_>) = batches
+    let now = Instant::now();
+    let tx_account_locks_results: Vec<Result<_>> = transactions
         .iter()
-        .flat_map(|batch| {
-            batch
-                .lock_results()
-                .iter()
-                .cloned()
-                .zip(batch.sanitized_transactions().to_vec())
-        })
-        .unzip();
+        .map(|tx| tx.get_account_locks(&bank.feature_set))
+        .collect();
+    let dependency_graph = build_dependency_graphs(&tx_account_locks_results)?;
+    let batches_indices = build_batch_indices(&dependency_graph);
+    info!(
+        "slot: {:?} planning elapsed: {:?}",
+        bank.slot(),
+        now.elapsed().as_micros()
+    );
+    timings.planning_elapsed += now.elapsed().as_micros() as u64;
 
-    let cost_model = CostModel::new();
-    let mut minimal_tx_cost = u64::MAX;
-    let mut total_cost: u64 = 0;
-    // Allowing collect here, since it also computes the minimal tx cost, and aggregate cost.
-    // These two values are later used for checking if the tx_costs vector needs to be iterated over.
-    #[allow(clippy::needless_collect)]
-    let tx_costs = sanitized_txs
+    for batch_indices in batches_indices {
+        let sanitized_txs: Vec<SanitizedTransaction> = batch_indices
+            .iter()
+            .map(|i| transactions.get(*i).unwrap().clone())
+            .collect();
+        let batches = vec![bank.prepare_sanitized_batch(&sanitized_txs)];
+
+        let (lock_results, sanitized_txs): (Vec<_>, Vec<_>) = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .lock_results()
+                    .iter()
+                    .cloned()
+                    .zip(batch.sanitized_transactions().to_vec())
+            })
+            .unzip();
+
+        if let Some(r) = lock_results.iter().find(|r| r.is_err()) {
+            info!("lock error: {:?}", r);
+            r.clone()?;
+        }
+
+        let responses: Vec<_> = sanitized_txs
+            .into_iter()
+            .map(|tx| {
+                replayer_handle.send(ReplayRequest {
+                    bank: bank.clone(),
+                    tx,
+                    transaction_status_sender: transaction_status_sender.cloned(),
+                    replay_vote_sender: replay_vote_sender.cloned(),
+                    cost_capacity_meter: cost_capacity_meter.clone(),
+                    entry_callback: entry_callback.cloned(),
+                })
+            })
+            .collect();
+
+        // TODO (LB): wait for all the txs to return
+        let mut results = vec![];
+        let mut new_timings = vec![];
+        for r in responses {
+            match r {
+                Ok(receiver) => match receiver.recv() {
+                    Ok(ReplayResponse { result, timings }) => {
+                        results.push(result);
+                        new_timings.push(timings);
+                    }
+                    Err(_) => {
+                        error!("ReplayResponse recv error");
+                    }
+                },
+                Err(e) => {
+                    error!("error yooooo!!! error: {:?}", e);
+                }
+            }
+        }
+
+        // timings.saturating_add_in_place(ExecuteTimingType::TotalBatchesLen, batches.len() as u64);
+        // timings.saturating_add_in_place(ExecuteTimingType::NumExecuteBatches, 1);
+        for timing in new_timings {
+            timings.accumulate(&timing);
+        }
+
+        first_err(&results)?;
+    }
+
+    Ok(())
+}
+
+// for each index, builds a transaction dependency graph of indices that need to execute before
+// the current one.
+fn build_dependency_graphs(
+    tx_account_locks_results: &Vec<Result<TransactionAccountLocks>>,
+) -> Result<Vec<HashSet<usize>>> {
+    if let Some(err) = tx_account_locks_results.iter().find(|r| r.is_err()) {
+        err.clone()?;
+    }
+    let transaction_locks: Vec<_> = tx_account_locks_results
         .iter()
-        .map(|tx| {
-            let cost = cost_model.calculate_cost(tx).sum();
-            minimal_tx_cost = std::cmp::min(minimal_tx_cost, cost);
-            total_cost = total_cost.saturating_add(cost);
-            cost
-        })
-        .collect::<Vec<_>>();
+        .map(|r| r.as_ref().unwrap())
+        .collect();
 
-    let target_batch_count = get_thread_count() as u64;
-
-    let mut tx_batches: Vec<TransactionBatch> = vec![];
-    let rebatched_txs = if total_cost > target_batch_count.saturating_mul(minimal_tx_cost) {
-        let target_batch_cost = total_cost / target_batch_count;
-        let mut batch_cost: u64 = 0;
-        let mut slice_start = 0;
-        tx_costs.into_iter().enumerate().for_each(|(index, cost)| {
-            let next_index = index + 1;
-            batch_cost = batch_cost.saturating_add(cost);
-            if batch_cost >= target_batch_cost || next_index == sanitized_txs.len() {
-                let tx_batch =
-                    rebatch_transactions(&lock_results, bank, &sanitized_txs, slice_start, index);
-                slice_start = next_index;
-                tx_batches.push(tx_batch);
-                batch_cost = 0;
+    // build a map whose key is a pubkey + value is a sorted vector of all indices that
+    // lock that account
+    let mut indices_read_locking_account = HashMap::new();
+    let mut indicies_write_locking_account = HashMap::new();
+    transaction_locks
+        .iter()
+        .enumerate()
+        .for_each(|(idx, tx_account_locks)| {
+            for account in &tx_account_locks.readonly {
+                indices_read_locking_account
+                    .entry(**account)
+                    .and_modify(|indices: &mut Vec<usize>| indices.push(idx))
+                    .or_insert_with(|| {
+                        let mut v = Vec::new();
+                        v.push(idx);
+                        v
+                    });
+            }
+            for account in &tx_account_locks.writable {
+                indicies_write_locking_account
+                    .entry(**account)
+                    .and_modify(|indices: &mut Vec<usize>| indices.push(idx))
+                    .or_insert_with(|| {
+                        let mut v = Vec::new();
+                        v.push(idx);
+                        v
+                    });
             }
         });
-        &tx_batches[..]
-    } else {
-        batches
-    };
 
-    execute_batches_internal(
-        bank,
-        rebatched_txs,
-        entry_callback,
-        transaction_status_sender,
-        replay_vote_sender,
-        timings,
-        cost_capacity_meter,
-    )
+    // TODO (LB): conditionally use par_iter here
+
+    Ok(transaction_locks
+        .par_iter()
+        .enumerate()
+        .map(|(idx, account_locks)| {
+            let mut dep_graph = HashSet::new();
+            let readlock_accs = account_locks.writable.iter();
+            let writelock_accs = account_locks
+                .readonly
+                .iter()
+                .chain(account_locks.writable.iter());
+
+            for acc in readlock_accs {
+                if let Some(indices) = indices_read_locking_account.get(acc) {
+                    dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+                }
+            }
+
+            for read_acc in writelock_accs {
+                if let Some(indices) = indicies_write_locking_account.get(read_acc) {
+                    dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+                }
+            }
+            dep_graph
+        })
+        .collect())
+}
+
+fn build_batch_indices(tx_dependency_graph: &Vec<HashSet<usize>>) -> Vec<Vec<usize>> {
+    let mut processed_indices = vec![false; tx_dependency_graph.len()];
+    let mut batches = Vec::new();
+
+    let mut batch = Vec::with_capacity(tx_dependency_graph.len());
+
+    while !processed_indices.iter().all(|processed| *processed) {
+        for tx_idx in 0..tx_dependency_graph.len() {
+            // if the transaction at tx_idx hasn't been processed
+            // AND all dependencies have been processed
+            if !processed_indices[tx_idx]
+                && tx_dependency_graph[tx_idx]
+                    .iter()
+                    .all(|deps_idx| processed_indices[*deps_idx])
+            {
+                batch.push(tx_idx);
+            }
+        }
+
+        for i in &batch {
+            processed_indices[*i] = true;
+        }
+        batches.push(batch.clone());
+        batch.clear();
+    }
+
+    batches
 }
 
 /// Process an ordered list of entries in parallel
@@ -386,6 +363,7 @@ pub fn process_entries_for_tests(
     randomize: bool,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
+    replayer_handle: &ReplayerHandle,
 ) -> Result<()> {
     let verify_transaction = {
         let bank = bank.clone();
@@ -406,6 +384,7 @@ pub fn process_entries_for_tests(
         None,
         &mut timings,
         Arc::new(RwLock::new(BlockCostCapacityMeter::default())),
+        replayer_handle,
     );
 
     debug!("process_entries: {:?}", timings);
@@ -415,19 +394,19 @@ pub fn process_entries_for_tests(
 // Note: If randomize is true this will shuffle entries' transactions in-place.
 fn process_entries_with_callback(
     bank: &Arc<Bank>,
-    entries: &mut [EntryType],
-    randomize: bool,
+    entries: &[EntryType],
+    _randomize: bool,
     entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     transaction_cost_metrics_sender: Option<&TransactionCostMetricsSender>,
     timings: &mut ExecuteTimings,
     cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+    replayer_handle: &ReplayerHandle,
 ) -> Result<()> {
-    // accumulator for entries that can be processed in parallel
-    let mut batches = vec![];
+    let mut executable_txs = vec![];
     let mut tick_hashes = vec![];
-    let mut rng = thread_rng();
+    // let mut rng = thread_rng();
 
     for entry in entries {
         match entry {
@@ -439,14 +418,15 @@ fn process_entries_with_callback(
                     // execute the group and register the tick
                     execute_batches(
                         bank,
-                        &batches,
+                        &executable_txs,
                         entry_callback,
                         transaction_status_sender,
                         replay_vote_sender,
                         timings,
                         cost_capacity_meter.clone(),
+                        replayer_handle,
                     )?;
-                    batches.clear();
+                    executable_txs.clear();
                     for hash in &tick_hashes {
                         bank.register_tick(hash);
                     }
@@ -459,64 +439,22 @@ fn process_entries_with_callback(
                         .send_cost_details(bank.clone(), transactions.iter());
                 }
 
-                if randomize {
-                    transactions.shuffle(&mut rng);
-                }
-
-                loop {
-                    // try to lock the accounts
-                    let batch = bank.prepare_sanitized_batch(transactions);
-                    let first_lock_err = first_err(batch.lock_results());
-
-                    // if locking worked
-                    if first_lock_err.is_ok() {
-                        batches.push(batch);
-                        // done with this entry
-                        break;
-                    }
-                    // else we failed to lock, 2 possible reasons
-                    if batches.is_empty() {
-                        // An entry has account lock conflicts with *itself*, which should not happen
-                        // if generated by a properly functioning leader
-                        datapoint_error!(
-                            "validator_process_entry_error",
-                            (
-                                "error",
-                                format!(
-                                    "Lock accounts error, entry conflicts with itself, txs: {:?}",
-                                    transactions
-                                ),
-                                String
-                            )
-                        );
-                        // bail
-                        first_lock_err?;
-                    } else {
-                        // else we have an entry that conflicts with a prior entry
-                        // execute the current queue and try to process this entry again
-                        execute_batches(
-                            bank,
-                            &batches,
-                            entry_callback,
-                            transaction_status_sender,
-                            replay_vote_sender,
-                            timings,
-                            cost_capacity_meter.clone(),
-                        )?;
-                        batches.clear();
-                    }
-                }
+                // TODO (LB): add randomization back in
+                // TODO (LB): add back in lock check here.
+                // TODO (LB): avoid clone
+                executable_txs.extend(transactions.clone());
             }
         }
     }
     execute_batches(
         bank,
-        &batches,
+        &executable_txs,
         entry_callback,
         transaction_status_sender,
         replay_vote_sender,
         timings,
         cost_capacity_meter,
+        replayer_handle,
     )?;
     for hash in tick_hashes {
         bank.register_tick(hash);
@@ -611,6 +549,7 @@ pub(crate) fn process_blockstore_for_bank_0(
     opts: &ProcessOptions,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    replayer_handle: &ReplayerHandle,
 ) -> BankForks {
     // Setup bank for slot 0
     let bank0 = Bank::new_with_paths(
@@ -634,6 +573,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         opts,
         &VerifyRecyclers::default(),
         cache_block_meta_sender,
+        replayer_handle,
     );
     bank_forks
 }
@@ -815,6 +755,7 @@ fn confirm_full_slot(
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     timing: &mut ExecuteTimings,
+    replayer_handle: &ReplayerHandle,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let mut confirmation_timing = ConfirmationTiming::default();
     let skip_verification = !opts.poh_verify;
@@ -830,6 +771,7 @@ fn confirm_full_slot(
         opts.entry_callback.as_ref(),
         recyclers,
         opts.allow_dead_slots,
+        replayer_handle,
     )?;
 
     timing.accumulate(&confirmation_timing.execute_timings);
@@ -851,6 +793,7 @@ pub struct ConfirmationTiming {
     pub fetch_elapsed: u64,
     pub fetch_fail_elapsed: u64,
     pub execute_timings: ExecuteTimings,
+    pub planning_elapsed: u64,
 }
 
 impl Default for ConfirmationTiming {
@@ -863,6 +806,7 @@ impl Default for ConfirmationTiming {
             fetch_elapsed: 0,
             fetch_fail_elapsed: 0,
             execute_timings: ExecuteTimings::default(),
+            planning_elapsed: 0,
         }
     }
 }
@@ -898,6 +842,7 @@ pub fn confirm_slot(
     entry_callback: Option<&ProcessCallback>,
     recyclers: &VerifyRecyclers,
     allow_dead_slots: bool,
+    replayer_handle: &ReplayerHandle,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let slot = bank.slot();
 
@@ -986,7 +931,7 @@ pub fn confirm_slot(
             // Note: This will shuffle entries' transactions in-place.
             let process_result = process_entries_with_callback(
                 bank,
-                &mut entries.unwrap(),
+                &entries.unwrap(),
                 true, // shuffle transactions.
                 entry_callback,
                 transaction_status_sender,
@@ -994,10 +939,12 @@ pub fn confirm_slot(
                 transaction_cost_metrics_sender,
                 &mut execute_timings,
                 cost_capacity_meter,
+                replayer_handle,
             )
             .map_err(BlockstoreProcessorError::from);
             replay_elapsed.stop();
             timing.replay_elapsed += replay_elapsed.as_us();
+            timing.planning_elapsed += execute_timings.planning_elapsed;
 
             timing.execute_timings.accumulate(&execute_timings);
 
@@ -1049,6 +996,7 @@ fn process_bank_0(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
+    replayer_handle: &ReplayerHandle,
 ) {
     assert_eq!(bank0.slot(), 0);
     let mut progress = ConfirmationProgress::new(bank0.last_blockhash());
@@ -1061,6 +1009,7 @@ fn process_bank_0(
         None,
         None,
         &mut ExecuteTimings::default(),
+        replayer_handle,
     )
     .expect("processing for bank 0 must succeed");
     bank0.freeze();
@@ -1144,6 +1093,10 @@ fn load_frozen_forks(
     let mut root = bank_forks.root();
     let max_root = std::cmp::max(root, blockstore_max_root);
 
+    let exit = Arc::new(AtomicBool::new(false));
+    let replayer = Replayer::new(get_thread_count(), &exit);
+    let replayer_handle = replayer.handle();
+
     info!(
         "load_frozen_forks() latest root from blockstore: {}, max_root: {}",
         blockstore_max_root, max_root,
@@ -1191,6 +1144,7 @@ fn load_frozen_forks(
                 cache_block_meta_sender,
                 None,
                 timing,
+                &replayer_handle,
             )
             .is_err()
             {
@@ -1416,10 +1370,11 @@ fn process_single_slot(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     timing: &mut ExecuteTimings,
+    replayer_handle: &ReplayerHandle,
 ) -> result::Result<(), BlockstoreProcessorError> {
     // Mark corrupt slots as dead so validators don't replay this slot and
     // see AlreadyProcessed errors later in ReplayStage
-    confirm_full_slot(blockstore, bank, opts, recyclers, progress, transaction_status_sender, replay_vote_sender, timing).map_err(|err| {
+    confirm_full_slot(blockstore, bank, opts, recyclers, progress, transaction_status_sender, replay_vote_sender, timing, replayer_handle).map_err(|err| {
         let slot = bank.slot();
         warn!("slot {} failed to verify: {}", slot, err);
         if blockstore.is_primary_access() {
@@ -1547,64 +1502,6 @@ pub fn fill_blockstore_slot_with_ticks(
         .unwrap();
 
     last_entry_hash
-}
-
-/// Check to see if the transactions exceeded the accounts data size limits
-fn check_accounts_data_size<'a>(
-    bank: &Bank,
-    execution_results: impl IntoIterator<Item = &'a TransactionExecutionResult>,
-) -> Result<()> {
-    check_accounts_data_block_size(bank)?;
-    check_accounts_data_total_size(bank, execution_results)
-}
-
-/// Check to see if transactions exceeded the accounts data size limit per block
-fn check_accounts_data_block_size(bank: &Bank) -> Result<()> {
-    if !bank
-        .feature_set
-        .is_active(&feature_set::cap_accounts_data_size_per_block::id())
-    {
-        return Ok(());
-    }
-
-    debug_assert!(MAX_ACCOUNT_DATA_BLOCK_LEN <= i64::MAX as u64);
-    if bank.load_accounts_data_size_delta_on_chain() > MAX_ACCOUNT_DATA_BLOCK_LEN as i64 {
-        Err(TransactionError::WouldExceedAccountDataBlockLimit)
-    } else {
-        Ok(())
-    }
-}
-
-/// Check the transaction execution results to see if any instruction errored by exceeding the max
-/// accounts data size limit for all slots.  If yes, the whole block needs to be failed.
-fn check_accounts_data_total_size<'a>(
-    bank: &Bank,
-    execution_results: impl IntoIterator<Item = &'a TransactionExecutionResult>,
-) -> Result<()> {
-    if !bank
-        .feature_set
-        .is_active(&feature_set::cap_accounts_data_len::id())
-    {
-        return Ok(());
-    }
-
-    if let Some(result) = execution_results
-        .into_iter()
-        .map(|execution_result| execution_result.flattened_result())
-        .find(|result| {
-            matches!(
-                result,
-                Err(TransactionError::InstructionError(
-                    _,
-                    InstructionError::MaxAccountsDataSizeExceeded
-                )),
-            )
-        })
-    {
-        return result;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -219,7 +219,6 @@ fn execute_batches(
             })
             .collect();
 
-        // TODO (LB): wait for all the txs to return
         let mut results = vec![];
         let mut new_timings = vec![];
         for r in responses {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -23,6 +23,7 @@ pub mod leader_schedule_utils;
 pub mod next_slots_iterator;
 pub mod replayer;
 pub mod rooted_slot_iterator;
+pub mod scheduler;
 pub mod shred;
 pub mod shred_stats;
 pub mod sigverify_shreds;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -21,6 +21,7 @@ pub mod leader_schedule;
 pub mod leader_schedule_cache;
 pub mod leader_schedule_utils;
 pub mod next_slots_iterator;
+pub mod replayer;
 pub mod rooted_slot_iterator;
 pub mod shred;
 pub mod shred_stats;

--- a/ledger/src/replayer.rs
+++ b/ledger/src/replayer.rs
@@ -1,0 +1,369 @@
+use {
+    crate::{
+        blockstore_processor::{BlockCostCapacityMeter, ProcessCallback, TransactionStatusSender},
+        token_balances::collect_token_balances,
+    },
+    crossbeam_channel::{unbounded, Receiver, Sender},
+    solana_program_runtime::timings::ExecuteTimings,
+    solana_runtime::{
+        bank::{Bank, TransactionExecutionResult, TransactionResults},
+        bank_utils,
+        block_cost_limits::MAX_ACCOUNT_DATA_BLOCK_LEN,
+        transaction_batch::TransactionBatch,
+        vote_sender_types::ReplayVoteSender,
+    },
+    solana_sdk::{
+        clock::MAX_PROCESSING_AGE,
+        feature_set,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signature,
+        transaction::{self, SanitizedTransaction, TransactionError},
+    },
+    solana_transaction_status::token_balances::TransactionTokenBalancesSet,
+    std::{
+        borrow::Cow,
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        thread::{self, Builder, JoinHandle},
+    },
+};
+
+#[derive(Debug)]
+pub enum ReplayerHandleError {
+    Disconnected,
+}
+
+pub type ReplayerHandleResult<T> = Result<T, ReplayerHandleError>;
+type RequestSender = Sender<(Sender<ReplayResponse>, ReplayRequest)>;
+type RequestReceiver = Receiver<(Sender<ReplayResponse>, ReplayRequest)>;
+
+pub struct ReplayResponse {
+    pub result: transaction::Result<()>,
+    pub timings: ExecuteTimings,
+}
+
+/// Request for replay, sends responses back on this channel
+pub struct ReplayRequest {
+    pub bank: Arc<Bank>,
+    pub tx: SanitizedTransaction,
+    pub transaction_status_sender: Option<TransactionStatusSender>,
+    pub replay_vote_sender: Option<ReplayVoteSender>,
+    pub cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+    pub entry_callback: Option<ProcessCallback>,
+}
+
+pub struct ReplayerHandle {
+    request_sender: RequestSender,
+}
+
+impl ReplayerHandle {
+    pub fn new(request_sender: RequestSender) -> ReplayerHandle {
+        ReplayerHandle { request_sender }
+    }
+
+    pub fn send(&self, request: ReplayRequest) -> ReplayerHandleResult<Receiver<ReplayResponse>> {
+        let (request_sender, request_receiver) = unbounded();
+        self.request_sender
+            .send((request_sender, request))
+            .map_err(|_| ReplayerHandleError::Disconnected)?;
+        Ok(request_receiver)
+    }
+}
+
+pub struct Replayer {
+    request_sender: RequestSender,
+    threads: Vec<JoinHandle<()>>,
+}
+
+impl Replayer {
+    pub fn new(num_threads: usize, exit: &Arc<AtomicBool>) -> Replayer {
+        let (request_sender, request_receiver) = unbounded();
+        let threads = Self::start_replay_threads(num_threads, request_receiver, exit);
+        Replayer {
+            request_sender,
+            threads,
+        }
+    }
+
+    pub fn handle(&self) -> ReplayerHandle {
+        ReplayerHandle {
+            request_sender: self.request_sender.clone(),
+        }
+    }
+
+    pub fn start_replay_threads(
+        num_threads: usize,
+        request_receiver: RequestReceiver,
+        exit: &Arc<AtomicBool>,
+    ) -> Vec<JoinHandle<()>> {
+        (0..num_threads)
+            .map(|i| {
+                let request_receiver = request_receiver.clone();
+                let exit = exit.clone();
+                Builder::new()
+                    .name(format!("solReplayer-{}", i))
+                    .spawn(move || {
+                        info!("started replayer");
+                        while !exit.load(Ordering::Relaxed) {
+                            match request_receiver.recv() {
+                                Ok((
+                                    response_sender,
+                                    ReplayRequest {
+                                        bank,
+                                        tx,
+                                        transaction_status_sender,
+                                        replay_vote_sender,
+                                        cost_capacity_meter,
+                                        entry_callback,
+                                    },
+                                )) => {
+                                    // info!("got replay request");
+                                    let mut timings = ExecuteTimings::default();
+
+                                    let batch = TransactionBatch::new(
+                                        vec![Ok(())],
+                                        &bank,
+                                        Cow::Owned(vec![tx]),
+                                    );
+                                    let result = execute_batch(
+                                        &batch,
+                                        &bank,
+                                        transaction_status_sender.as_ref(),
+                                        replay_vote_sender.as_ref(),
+                                        &mut timings,
+                                        cost_capacity_meter.clone(),
+                                    );
+
+                                    if let Some(entry_callback) = entry_callback {
+                                        entry_callback(&bank);
+                                    }
+
+                                    // info!("sending response");
+                                    if response_sender
+                                        .send(ReplayResponse { result, timings })
+                                        .is_err()
+                                    {
+                                        warn!("response_sender disconnected");
+                                    }
+                                }
+                                Err(_) => {
+                                    return;
+                                }
+                            }
+                        }
+                        info!("stopped replayer");
+                    })
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    pub fn join(mut self) -> thread::Result<()> {
+        info!("joining relayer");
+        drop(self.request_sender);
+        info!("dropped sender");
+        for t in self.threads {
+            t.join()?;
+        }
+        info!("joined threads");
+        Ok(())
+    }
+}
+
+fn aggregate_total_execution_units(execute_timings: &ExecuteTimings) -> u64 {
+    let mut execute_cost_units: u64 = 0;
+    for (program_id, timing) in &execute_timings.details.per_program_timings {
+        if timing.count < 1 {
+            continue;
+        }
+        execute_cost_units =
+            execute_cost_units.saturating_add(timing.accumulated_units / timing.count as u64);
+        trace!("aggregated execution cost of {:?} {:?}", program_id, timing);
+    }
+    execute_cost_units
+}
+
+fn execute_batch(
+    batch: &TransactionBatch,
+    bank: &Arc<Bank>,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+    replay_vote_sender: Option<&ReplayVoteSender>,
+    timings: &mut ExecuteTimings,
+    cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+) -> transaction::Result<()> {
+    let record_token_balances = transaction_status_sender.is_some();
+
+    let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
+
+    let pre_token_balances = if record_token_balances {
+        collect_token_balances(bank, batch, &mut mint_decimals)
+    } else {
+        vec![]
+    };
+
+    let pre_process_units: u64 = aggregate_total_execution_units(timings);
+
+    let (tx_results, balances) = batch.bank().load_execute_and_commit_transactions(
+        batch,
+        MAX_PROCESSING_AGE,
+        transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
+        timings,
+    );
+
+    if bank
+        .feature_set
+        .is_active(&feature_set::gate_large_block::id())
+    {
+        let execution_cost_units = aggregate_total_execution_units(timings) - pre_process_units;
+        let remaining_block_cost_cap = cost_capacity_meter
+            .write()
+            .unwrap()
+            .accumulate(execution_cost_units);
+
+        debug!(
+            "bank {} executed a batch, number of transactions {}, total execute cu {}, remaining block cost cap {}",
+            bank.slot(),
+            batch.sanitized_transactions().len(),
+            execution_cost_units,
+            remaining_block_cost_cap,
+        );
+
+        if remaining_block_cost_cap == 0_u64 {
+            return Err(TransactionError::WouldExceedMaxBlockCostLimit);
+        }
+    }
+
+    bank_utils::find_and_send_votes(
+        batch.sanitized_transactions(),
+        &tx_results,
+        replay_vote_sender,
+    );
+
+    let TransactionResults {
+        fee_collection_results,
+        execution_results,
+        rent_debits,
+        ..
+    } = tx_results;
+
+    check_accounts_data_size(bank, &execution_results)?;
+
+    if let Some(transaction_status_sender) = transaction_status_sender {
+        let transactions = batch.sanitized_transactions().to_vec();
+        let post_token_balances = if record_token_balances {
+            collect_token_balances(bank, batch, &mut mint_decimals)
+        } else {
+            vec![]
+        };
+
+        let token_balances =
+            TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
+
+        transaction_status_sender.send_transaction_status_batch(
+            bank.clone(),
+            transactions,
+            execution_results,
+            balances,
+            token_balances,
+            rent_debits,
+        );
+    }
+
+    let first_err = get_first_error(batch, fee_collection_results);
+    first_err.map(|(result, _)| result).unwrap_or(Ok(()))
+}
+
+// Includes transaction signature for unit-testing
+fn get_first_error(
+    batch: &TransactionBatch,
+    fee_collection_results: Vec<transaction::Result<()>>,
+) -> Option<(transaction::Result<()>, Signature)> {
+    let mut first_err = None;
+    for (result, transaction) in fee_collection_results
+        .iter()
+        .zip(batch.sanitized_transactions())
+    {
+        if let Err(ref err) = result {
+            if first_err.is_none() {
+                first_err = Some((result.clone(), *transaction.signature()));
+            }
+            warn!(
+                "Unexpected validator error: {:?}, transaction: {:?}",
+                err, transaction
+            );
+            datapoint_error!(
+                "validator_process_entry_error",
+                (
+                    "error",
+                    format!("error: {:?}, transaction: {:?}", err, transaction),
+                    String
+                )
+            );
+        }
+    }
+    first_err
+}
+
+/// Check to see if the transactions exceeded the accounts data size limits
+fn check_accounts_data_size<'a>(
+    bank: &Bank,
+    execution_results: impl IntoIterator<Item = &'a TransactionExecutionResult>,
+) -> transaction::Result<()> {
+    check_accounts_data_block_size(bank)?;
+    check_accounts_data_total_size(bank, execution_results)
+}
+
+/// Check to see if transactions exceeded the accounts data size limit per block
+fn check_accounts_data_block_size(bank: &Bank) -> transaction::Result<()> {
+    if !bank
+        .feature_set
+        .is_active(&feature_set::cap_accounts_data_size_per_block::id())
+    {
+        return Ok(());
+    }
+
+    debug_assert!(MAX_ACCOUNT_DATA_BLOCK_LEN <= i64::MAX as u64);
+    if bank.load_accounts_data_size_delta_on_chain() > MAX_ACCOUNT_DATA_BLOCK_LEN as i64 {
+        Err(TransactionError::WouldExceedAccountDataBlockLimit)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check the transaction execution results to see if any instruction errored by exceeding the max
+/// accounts data size limit for all slots.  If yes, the whole block needs to be failed.
+fn check_accounts_data_total_size<'a>(
+    bank: &Bank,
+    execution_results: impl IntoIterator<Item = &'a TransactionExecutionResult>,
+) -> transaction::Result<()> {
+    if !bank
+        .feature_set
+        .is_active(&feature_set::cap_accounts_data_len::id())
+    {
+        return Ok(());
+    }
+
+    if let Some(result) = execution_results
+        .into_iter()
+        .map(|execution_result| execution_result.flattened_result())
+        .find(|result| {
+            matches!(
+                result,
+                Err(TransactionError::InstructionError(
+                    _,
+                    InstructionError::MaxAccountsDataSizeExceeded
+                )),
+            )
+        })
+    {
+        return result;
+    }
+
+    Ok(())
+}

--- a/ledger/src/scheduler.rs
+++ b/ledger/src/scheduler.rs
@@ -1,0 +1,110 @@
+use {
+    rayon::{
+        iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
+        ThreadPool,
+    },
+    solana_rayon_threadlimit::get_thread_count,
+    solana_sdk::transaction::{Result, TransactionAccountLocks},
+    std::{
+        cell::RefCell,
+        collections::{HashMap, HashSet},
+    },
+};
+
+thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
+                    .num_threads(get_thread_count())
+                    .thread_name(|ix| format!("blockstore_processor_{}", ix))
+                    .build()
+                    .unwrap())
+);
+
+// for each index, builds a transaction dependency graph of indices that need to execute before
+// the current one.
+pub fn build_dependency_graphs(
+    tx_account_locks_results: &Vec<Result<TransactionAccountLocks>>,
+) -> Result<Vec<HashSet<usize>>> {
+    if let Some(err) = tx_account_locks_results.iter().find(|r| r.is_err()) {
+        err.clone()?;
+    }
+    let transaction_locks: Vec<_> = tx_account_locks_results
+        .iter()
+        .map(|r| r.as_ref().unwrap())
+        .collect();
+
+    // build a map whose key is a pubkey + value is a sorted vector of all indices that
+    // lock that account
+    let mut indices_read_locking_account = HashMap::new();
+    let mut indicies_write_locking_account = HashMap::new();
+    transaction_locks
+        .iter()
+        .enumerate()
+        .for_each(|(idx, tx_account_locks)| {
+            for account in &tx_account_locks.readonly {
+                indices_read_locking_account
+                    .entry(**account)
+                    .and_modify(|indices: &mut Vec<usize>| indices.push(idx))
+                    .or_insert_with(|| vec![idx]);
+            }
+            for account in &tx_account_locks.writable {
+                indicies_write_locking_account
+                    .entry(**account)
+                    .and_modify(|indices: &mut Vec<usize>| indices.push(idx))
+                    .or_insert_with(|| vec![idx]);
+            }
+        });
+
+    // Ok(PAR_THREAD_POOL.with(|thread_pool| {
+    //     thread_pool.borrow().install(|| {
+    //         transaction_locks
+    //             .par_iter()
+    //             .enumerate()
+    //             .map(|(idx, account_locks)| {
+    //                 let mut dep_graph = HashSet::new();
+    //                 let readlock_accs = account_locks.writable.iter();
+    //                 let writelock_accs = account_locks
+    //                     .readonly
+    //                     .iter()
+    //                     .chain(account_locks.writable.iter());
+    //
+    //                 for acc in readlock_accs {
+    //                     if let Some(indices) = indices_read_locking_account.get(acc) {
+    //                         dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+    //                     }
+    //                 }
+    //
+    //                 for read_acc in writelock_accs {
+    //                     if let Some(indices) = indicies_write_locking_account.get(read_acc) {
+    //                         dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+    //                     }
+    //                 }
+    //                 dep_graph
+    //             })
+    //             .collect()
+    //     })
+    // }))
+    Ok(transaction_locks
+        .par_iter()
+        .enumerate()
+        .map(|(idx, account_locks)| {
+            let mut dep_graph = HashSet::new();
+            let readlock_accs = account_locks.writable.iter();
+            let writelock_accs = account_locks
+                .readonly
+                .iter()
+                .chain(account_locks.writable.iter());
+
+            for acc in readlock_accs {
+                if let Some(indices) = indices_read_locking_account.get(acc) {
+                    dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+                }
+            }
+
+            for read_acc in writelock_accs {
+                if let Some(indices) = indicies_write_locking_account.get(read_acc) {
+                    dep_graph.extend(indices.iter().take_while(|l_idx| **l_idx < idx));
+                }
+            }
+            dep_graph
+        })
+        .collect())
+}

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -84,6 +84,7 @@ pub struct ExecuteTimings {
     pub metrics: Metrics,
     pub details: ExecuteDetailsTimings,
     pub execute_accessories: ExecuteAccessoryTimings,
+    pub planning_elapsed: u64,
 }
 
 impl ExecuteTimings {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -38,9 +38,11 @@ use {
         blockstore_db::BlockstoreError,
         get_tmp_ledger_path,
         leader_schedule_cache::LeaderScheduleCache,
+        replayer::Replayer,
     },
     solana_metrics::inc_new_counter_info,
     solana_perf::packet::PACKET_DATA_SIZE,
+    solana_rayon_threadlimit::get_thread_count,
     solana_runtime::{
         accounts::AccountAddressFilter,
         accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey, ScanConfig},
@@ -4493,6 +4495,10 @@ pub fn populate_blockstore_for_tests(
     blockstore.insert_shreds(shreds, None, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();
 
+    let exit = Arc::new(AtomicBool::new(false));
+    let replayer = Replayer::new(get_thread_count(), &exit);
+    let replayer_handle = replayer.handle();
+
     let (transaction_status_sender, transaction_status_receiver) = unbounded();
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let transaction_status_service =
@@ -4519,6 +4525,7 @@ pub fn populate_blockstore_for_tests(
                 },
             ),
             Some(&replay_vote_sender),
+            &replayer_handle,
         ),
         Ok(())
     );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4495,9 +4495,7 @@ pub fn populate_blockstore_for_tests(
     blockstore.insert_shreds(shreds, None, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();
 
-    let exit = Arc::new(AtomicBool::new(false));
-    let replayer = Replayer::new(get_thread_count(), &exit);
-    let replayer_handle = replayer.handle();
+    let (_replayer, replayer_handle) = Replayer::new(get_thread_count());
 
     let (transaction_status_sender, transaction_status_receiver) = unbounded();
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();


### PR DESCRIPTION
looking for early review/thoughts from labs on this approach. not mergable, needs lots of cleanup + work, need to get back into master if you guys likey.

### about the algorithm

given the following txs that write lock accounts:
AB
BC
CD
EF
FG
GH

the current algorithm will replay in the following order sequentially: [AB], [BC], [CD], [EF], [FG], [GH].

however, EF and onwards doesn't depend on the first three transactions, so in theory you should be able to execute something like [AB, EF], [BC, FG], [CD, GH].  **commits before 4d22daa implemented this algorithm, but the results weren't what was expected**

let's take it a step further. imagine the following scenario with the algo in the paragraph above. we send [AB, EF] to get executed and wait for both to return before moving onwards. What if AB takes 10ms and EF takes 100us? That would starve FG and GH from being executed. even though EF is done. this is where the improved algo comes in.

the new algorithm:
builds a transaction dependency graph and start blasting transactions to a multi-threaded replayer that replays a single tx at a time. 

when a transaction is done being replayed, it sends a signal back. The algorithm then determines if any other transactions that were previously not executed and blocked are now free to execute. It will do this until all transactions in a block are executed.