### PR TITLE
chore: tell Codecov about the web3.js move, a few years later

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,6 @@ comment:
   layout: "diff"
   behavior: default
   require_changes: no
+
+fixes:
+  - "src/::web3.js/src/"


### PR DESCRIPTION
#### Problem

Codecov doesn't actually pick up any code changes. It still thinks all the files live at `src/`.

#### Summary of Changes

* Give it the bad news.