### PR TITLE
Impl Borrow<[u8; 32]> for Pubkey

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -7,6 +7,7 @@ use {
     bytemuck::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     std::{
+        borrow,
         convert::{Infallible, TryFrom},
         fmt, mem,
         str::FromStr,
@@ -634,6 +635,12 @@ impl AsRef<[u8]> for Pubkey {
 impl AsMut<[u8]> for Pubkey {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0[..]
+    }
+}
+
+impl borrow::Borrow<[u8; 32]> for Pubkey {
+    fn borrow(&self) -> &[u8; 32] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Because there is no way to fetch the internal array, only the slice representation of the same array. `Deref` is being used instead of `AsRef` to avoid breaking type inference.