### PR TITLE
add enable_rehashing to AccountsPackage

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -133,8 +133,6 @@ impl AccountsHashVerifier {
         };
         timings.calc_storage_size_quartiles(&accounts_package.snapshot_storages);
 
-        let enable_rehashing = true;
-
         let (accounts_hash, lamports) = accounts_package
             .accounts
             .accounts_db
@@ -148,7 +146,7 @@ impl AccountsHashVerifier {
                     rent_collector: &accounts_package.rent_collector,
                     store_detailed_debug_info_on_failure: false,
                     full_snapshot: None,
-                    enable_rehashing,
+                    enable_rehashing: accounts_package.enable_rehashing,
                 },
                 &sorted_storages,
                 timings,
@@ -172,7 +170,7 @@ impl AccountsHashVerifier {
                         rent_collector: &accounts_package.rent_collector,
                         store_detailed_debug_info_on_failure: false,
                         full_snapshot: None,
-                        enable_rehashing,
+                        enable_rehashing: accounts_package.enable_rehashing,
                     },
                 );
             info!(
@@ -193,7 +191,7 @@ impl AccountsHashVerifier {
                         // now that we've failed, store off the failing contents that produced a bad capitalization
                         store_detailed_debug_info_on_failure: true,
                         full_snapshot: None,
-                        enable_rehashing,
+                        enable_rehashing: accounts_package.enable_rehashing,
                     },
                     &sorted_storages,
                     HashStats::default(),
@@ -481,6 +479,7 @@ mod tests {
                 accounts: Arc::clone(&accounts),
                 epoch_schedule: EpochSchedule::default(),
                 rent_collector: RentCollector::default(),
+                enable_rehashing: true,
             };
 
             AccountsHashVerifier::process_accounts_package(

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -48,6 +48,7 @@ pub struct AccountsPackage {
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
+    pub enable_rehashing: bool,
 }
 
 impl AccountsPackage {
@@ -118,6 +119,7 @@ impl AccountsPackage {
             accounts: bank.accounts(),
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
+            enable_rehashing: true, // this will be feature driven using bank
         })
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4189,6 +4189,7 @@ mod tests {
             accounts: Arc::new(crate::accounts::Accounts::default_for_tests()),
             epoch_schedule: solana_sdk::epoch_schedule::EpochSchedule::default(),
             rent_collector: crate::rent_collector::RentCollector::default(),
+            enable_rehashing: true,
         }
     }
 


### PR DESCRIPTION
#### Problem

The bank knows whether the skip rewrites feature is enabled or not. We need that information when we calculate the hash. It needs to go into `AccountsPackage`

#### Summary of Changes
add `enable_rehashing` to `AccountsPackage`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
