### PR TITLE
UnprocessedPacketBatches pop_max fn are only used in tests

### DIFF
--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -269,7 +269,8 @@ impl UnprocessedPacketBatches {
         }
     }
 
-    pub fn pop_max(&mut self) -> Option<DeserializedPacket> {
+    #[cfg(test)]
+    fn pop_max(&mut self) -> Option<DeserializedPacket> {
         self.packet_priority_queue
             .pop_max()
             .map(|immutable_packet| {
@@ -281,7 +282,8 @@ impl UnprocessedPacketBatches {
 
     /// Pop up to the next `n` highest priority transactions from the queue.
     /// Returns `None` if the queue is empty
-    pub fn pop_max_n(&mut self, n: usize) -> Option<Vec<DeserializedPacket>> {
+    #[cfg(test)]
+    fn pop_max_n(&mut self, n: usize) -> Option<Vec<DeserializedPacket>> {
         let current_len = self.len();
         if self.is_empty() {
             None


### PR DESCRIPTION
#### Problem
`UnprocessedPacketBatches::{pop_max, pop_max_n}` are only used by tests, and *should* only be used by tests. These provide a somewhat confusing interface, since when we are popping from the priority queue during banking stage we don't want to remove from the map until they are fully processed.

#### Summary of Changes
Remove pub, and mark as `#[cfg(test)]`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
