### PR TITLE
suppress large debug message on test

### DIFF
--- a/runtime/src/rolling_bit_field.rs
+++ b/runtime/src/rolling_bit_field.rs
@@ -679,14 +679,16 @@ pub mod tests {
                                 for slot in slot..=slot2 {
                                     let slot_use = maybe_reverse(slot);
                                     tester.insert(slot_use);
+                                    /*
+                                    this is noisy on build machine
                                     debug!(
-                                    "slot: {}, bitfield: {:?}, reverse: {}, len: {}, excess: {:?}",
-                                    slot_use,
-                                    tester.bitfield,
-                                    reverse_slots,
-                                    tester.bitfield.len(),
-                                    tester.bitfield.excess
-                                );
+                                        "slot: {}, bitfield: {:?}, reverse: {}, len: {}, excess: {:?}",
+                                        slot_use,
+                                        tester.bitfield,
+                                        reverse_slots,
+                                        tester.bitfield.len(),
+                                        tester.bitfield.excess
+                                    );*/
                                     assert!(
                                         (reverse_slots && tester.bitfield.len() > 1)
                                             ^ tester.bitfield.excess.is_empty()


### PR DESCRIPTION
#### Problem

from ci logs, it appears debug traces make it to the log. This one in particular is large.

#### Summary of Changes

comment out the debug log

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
