### PR TITLE
precompile verify: &Arc<FeatureSet> to &FeatureSet

### DIFF
--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -4,7 +4,6 @@ use {
     crate::{feature_set::FeatureSet, instruction::Instruction, precompiles::PrecompileError},
     bytemuck::{bytes_of, Pod, Zeroable},
     ed25519_dalek::{ed25519::signature::Signature, Signer, Verifier},
-    std::sync::Arc,
 };
 
 pub const PUBKEY_SERIALIZED_SIZE: usize = 32;
@@ -82,7 +81,7 @@ pub fn new_ed25519_instruction(keypair: &ed25519_dalek::Keypair, message: &[u8])
 pub fn verify(
     data: &[u8],
     instruction_datas: &[&[u8]],
-    _feature_set: &Arc<FeatureSet>,
+    _feature_set: &FeatureSet,
 ) -> Result<(), PrecompileError> {
     if data.len() < SIGNATURE_OFFSETS_START {
         return Err(PrecompileError::InvalidInstructionDataSize);
@@ -186,7 +185,6 @@ pub mod test {
             transaction::Transaction,
         },
         rand::{thread_rng, Rng},
-        std::sync::Arc,
     };
 
     fn test_case(
@@ -205,7 +203,7 @@ pub mod test {
         verify(
             &instruction_data,
             &[&[0u8; 100]],
-            &Arc::new(FeatureSet::all_enabled()),
+            &FeatureSet::all_enabled(),
         )
     }
 
@@ -223,7 +221,7 @@ pub mod test {
             verify(
                 &instruction_data,
                 &[&[0u8; 100]],
-                &Arc::new(FeatureSet::all_enabled()),
+                &FeatureSet::all_enabled(),
             ),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
@@ -349,7 +347,7 @@ pub mod test {
         let message_arr = b"hello";
         let mut instruction = new_ed25519_instruction(&privkey, message_arr);
         let mint_keypair = Keypair::new();
-        let feature_set = Arc::new(FeatureSet::all_enabled());
+        let feature_set = FeatureSet::all_enabled();
 
         let tx = Transaction::new_signed_with_payer(
             &[instruction.clone()],

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -8,7 +8,6 @@ use {
         pubkey::Pubkey,
     },
     lazy_static::lazy_static,
-    std::sync::Arc,
     thiserror::Error,
 };
 
@@ -33,7 +32,7 @@ impl<T> DecodeError<T> for PrecompileError {
 }
 
 /// All precompiled programs must implement the `Verify` function
-pub type Verify = fn(&[u8], &[&[u8]], &Arc<FeatureSet>) -> std::result::Result<(), PrecompileError>;
+pub type Verify = fn(&[u8], &[&[u8]], &FeatureSet) -> std::result::Result<(), PrecompileError>;
 
 /// Information on a precompiled program
 pub struct Precompile {
@@ -68,7 +67,7 @@ impl Precompile {
         &self,
         data: &[u8],
         instruction_datas: &[&[u8]],
-        feature_set: &Arc<FeatureSet>,
+        feature_set: &FeatureSet,
     ) -> std::result::Result<(), PrecompileError> {
         (self.verify_fn)(data, instruction_datas, feature_set)
     }
@@ -109,7 +108,7 @@ pub fn verify_if_precompile(
     program_id: &Pubkey,
     precompile_instruction: &CompiledInstruction,
     all_instructions: &[CompiledInstruction],
-    feature_set: &Arc<FeatureSet>,
+    feature_set: &FeatureSet,
 ) -> Result<(), PrecompileError> {
     for precompile in PRECOMPILES.iter() {
         if precompile.check_id(program_id, |feature_id| feature_set.is_active(feature_id)) {

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -798,7 +798,6 @@ use {
     },
     digest::Digest,
     serde_derive::{Deserialize, Serialize},
-    std::sync::Arc,
 };
 
 pub const HASHED_PUBKEY_SERIALIZED_SIZE: usize = 20;
@@ -929,11 +928,11 @@ pub fn construct_eth_pubkey(
 /// `feature_set` is the set of active Solana features. It is used to enable or
 /// disable a few minor additional checks that were activated on chain
 /// subsequent to the addition of the secp256k1 native program. For many
-/// purposes passing `Arc::new<FeatureSet::all_enabled()>` is reasonable.
+/// purposes passing `FeatureSet::all_enabled()` is reasonable.
 pub fn verify(
     data: &[u8],
     instruction_datas: &[&[u8]],
-    feature_set: &Arc<FeatureSet>,
+    feature_set: &FeatureSet,
 ) -> Result<(), PrecompileError> {
     if data.is_empty() {
         return Err(PrecompileError::InvalidInstructionDataSize);
@@ -1061,7 +1060,6 @@ pub mod test {
             transaction::Transaction,
         },
         rand::{thread_rng, Rng},
-        std::sync::Arc,
     };
 
     fn test_case(
@@ -1080,7 +1078,7 @@ pub mod test {
             .inactive
             .insert(libsecp256k1_0_5_upgrade_enabled::id());
 
-        verify(&instruction_data, &[&[0u8; 100]], &Arc::new(feature_set))
+        verify(&instruction_data, &[&[0u8; 100]], &feature_set)
     }
 
     #[test]
@@ -1102,7 +1100,7 @@ pub mod test {
             .insert(libsecp256k1_0_5_upgrade_enabled::id());
 
         assert_eq!(
-            verify(&instruction_data, &[&[0u8; 100]], &Arc::new(feature_set)),
+            verify(&instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
 
@@ -1237,7 +1235,7 @@ pub mod test {
             .insert(libsecp256k1_0_5_upgrade_enabled::id());
 
         assert_eq!(
-            verify(&instruction_data, &[&[0u8; 100]], &Arc::new(feature_set)),
+            verify(&instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
     }
@@ -1262,7 +1260,7 @@ pub mod test {
         feature_set
             .inactive
             .insert(feature_set::libsecp256k1_0_5_upgrade_enabled::id());
-        let feature_set = Arc::new(feature_set);
+        let feature_set = feature_set;
 
         let tx = Transaction::new_signed_with_payer(
             &[secp_instruction.clone()],
@@ -1349,7 +1347,7 @@ pub mod test {
         verify(
             &instruction_data,
             &[&instruction_data],
-            &Arc::new(FeatureSet::all_enabled()),
+            &FeatureSet::all_enabled(),
         )
         .unwrap();
     }

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -129,7 +129,7 @@ use {
     serde::Serialize,
     solana_program::{system_instruction::SystemInstruction, system_program},
     solana_sdk::feature_set,
-    std::{result, sync::Arc},
+    std::result,
 };
 
 mod error;
@@ -1014,7 +1014,7 @@ impl Transaction {
     }
 
     /// Verify the precompiled programs in this transaction.
-    pub fn verify_precompiles(&self, feature_set: &Arc<feature_set::FeatureSet>) -> Result<()> {
+    pub fn verify_precompiles(&self, feature_set: &feature_set::FeatureSet) -> Result<()> {
         for instruction in &self.message().instructions {
             // The Transaction may not be sanitized at this point
             if instruction.program_id_index as usize >= self.message().account_keys.len() {

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -17,7 +17,6 @@ use {
         transaction::{Result, Transaction, TransactionError, VersionedTransaction},
     },
     solana_program::message::SanitizedVersionedMessage,
-    std::sync::Arc,
 };
 
 /// Maximum number of accounts that a transaction may lock.
@@ -287,7 +286,7 @@ impl SanitizedTransaction {
     }
 
     /// Verify the precompiled programs in this transaction
-    pub fn verify_precompiles(&self, feature_set: &Arc<feature_set::FeatureSet>) -> Result<()> {
+    pub fn verify_precompiles(&self, feature_set: &feature_set::FeatureSet) -> Result<()> {
         for (program_id, instruction) in self.message.program_instructions_iter() {
             verify_if_precompile(
                 program_id,


### PR DESCRIPTION
#### Problem
Looking through code and noticed this is (maybe?) more restrictive than necessary

#### Summary of Changes
Don't require precompile verify to pass a reference to `Arc<FeatureSet>`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
