### PR TITLE
fix: replace `TransactionMessage` `accountKeys` field with `payerKey`

### DIFF
--- a/web3.js/test/transaction-tests/message.test.ts
+++ b/web3.js/test/transaction-tests/message.test.ts
@@ -76,7 +76,7 @@ describe('TransactionMessage', () => {
       addressLookupTableAccounts,
     });
 
-    expect(decompiledMessage.accountKeys).to.eql(accountKeys);
+    expect(decompiledMessage.payerKey).to.eql(payerKey);
     expect(decompiledMessage.recentBlockhash).to.eq(recentBlockhash);
     expect(decompiledMessage.instructions).to.eql(instructions);
 


### PR DESCRIPTION
#### Problem
The `accountKeys` field on `TransactionMessage` is redundant because the instructions already list all the account keys. Also, there is no easy way to get or set the `payerKey` on a `TransactionMessage` instance.

#### Summary of Changes
- Replace `accountKeys` with `payerKey`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
