### PR TITLE
Respect rewards parameter in getBlock transaction-level rewards

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -437,6 +437,12 @@ The result field will be an object with the following fields:
       - `preTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from before the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
       - `postTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from after the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
       - `logMessages: <array|null>` - array of string log messages or `null` if log message recording was not enabled during this transaction
+      - `rewards: <array|null>` - transaction-level rewards, populated if rewards are requested; an array of JSON objects containing:
+        - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
+        - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
+        - `postBalance: <u64>` - account balance in lamports after the reward was applied
+        - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting", "staking"
+        - `commission: <u8|undefined>` - vote account commission when the reward was credited, only present for voting and staking rewards
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -445,7 +451,7 @@ The result field will be an object with the following fields:
         - `readonly: <array[string]>` - Ordered list of base-58 encoded addresses for readonly loaded accounts
     - `version: <"legacy"|number|undefined>` - Transaction version. Undefined if `maxSupportedTransactionVersion` is not set in request params.
   - `signatures: <array>` - present if "signatures" are requested for transaction details; an array of signatures strings, corresponding to the transaction order in the block
-  - `rewards: <array>` - present if rewards are requested; an array of JSON objects containing:
+  - `rewards: <array|undefined>` - block-level rewards, present if rewards are requested; an array of JSON objects containing:
     - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
@@ -486,6 +492,7 @@ Result:
           "postTokenBalances": [],
           "preBalances": [499998937500, 26858640, 1, 1, 1],
           "preTokenBalances": [],
+          "rewards": null,
           "status": {
             "Ok": null
           }
@@ -557,6 +564,7 @@ Result:
           "postTokenBalances": [],
           "preBalances": [499998937500, 26858640, 1, 1, 1],
           "preTokenBalances": [],
+          "rewards": [],
           "status": {
             "Ok": null
           }
@@ -3036,7 +3044,7 @@ Returns transaction details for a confirmed transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError
-    - `rewards: <array>` - present if rewards are requested; an array of JSON objects containing:
+    - `rewards: <array|null>` - transaction-level rewards, populated if rewards are requested; an array of JSON objects containing:
       - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
       - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
       - `postBalance: <u64>` - account balance in lamports after the reward was applied
@@ -3079,6 +3087,7 @@ Result:
       "postTokenBalances": [],
       "preBalances": [499998937500, 26858640, 1, 1, 1],
       "preTokenBalances": [],
+      "rewards": [],
       "status": {
         "Ok": null
       }
@@ -3149,6 +3158,7 @@ Result:
       "postTokenBalances": [],
       "preBalances": [499998937500, 26858640, 1, 1, 1],
       "preTokenBalances": [],
+      "rewards": null,
       "status": {
         "Ok": null
       }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -213,7 +213,7 @@ async fn confirm(
                 let decoded_tx = confirmed_tx.get_transaction();
                 let encoded_tx_with_meta = confirmed_tx
                     .tx_with_meta
-                    .encode(UiTransactionEncoding::Json, Some(0))
+                    .encode(UiTransactionEncoding::Json, Some(0), true)
                     .map_err(|_| "Failed to encode transaction in block".to_string())?;
                 transaction = Some(CliTransaction {
                     transaction: encoded_tx_with_meta.transaction,


### PR DESCRIPTION
#### Problem
The `getBlock` parameter `rewards` currently only affects whether block-level rewards are returned. Transaction-level rewards are returned regardless. While this isn't super critical with very few Rent payment, current behavior is a bit counterintuitive and may force clients to consume more data than they want to.

#### Summary of Changes
Pass `show_rewards` into UiTransactionStatusMeta constructors and only populate rewards when true.
Also fixup docs to be correct
