### PR TITLE
Optimize get_slots_since() using the batched version of multi_get()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2972,12 +2972,10 @@ impl Blockstore {
 
     // Returns slots connecting to any element of the list `slots`.
     pub fn get_slots_since(&self, slots: &[u64]) -> Result<HashMap<u64, Vec<u64>>> {
-        // Return error if there was a database error during lookup of any of the
-        // slot indexes
         let slot_metas: Result<Vec<Option<SlotMeta>>> =
-            slots.iter().map(|slot| self.meta(*slot)).collect();
-
+            self.meta_cf.multi_get(slots.to_vec()).into_iter().collect();
         let slot_metas = slot_metas?;
+
         let result: HashMap<u64, Vec<u64>> = slots
             .iter()
             .zip(slot_metas)


### PR DESCRIPTION
#### Problem
The current implementation of get_slots_since() invokes multiple rocksdb::get().
As a result, each get() operation may end up requiring one disk read.  This leads
to poor performance of get_slots_since described in #24878.

#### Summary of Changes
This PR makes get_slots_since() use the batched version of multi_get() instead,
which allows multiple get operations to be processed in batch so that they can
be answered with fewer disk reads.

