### PR TITLE
Fixup log of Epoch Accounts Hash when freezing bank

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6837,7 +6837,8 @@ impl Bank {
         ]);
 
         let epoch_accounts_hash = self.epoch_accounts_hash();
-        if self.should_include_epoch_accounts_hash() {
+        let should_include_epoch_accounts_hash = self.should_include_epoch_accounts_hash();
+        if should_include_epoch_accounts_hash {
             // Nothing is writing a value into the epoch accounts hash yet—this is not a problem
             // for normal clusters, as the feature gating this `if` block is always false.
             // However, some tests enable all features, so this `if` block can be true.
@@ -6876,10 +6877,11 @@ impl Bank {
             self.signature_count(),
             self.last_blockhash(),
             self.capitalization(),
-            match epoch_accounts_hash {
-                None => "".to_string(),
-                Some(epoch_accounts_hash) => format!(", epoch_accounts_hash: {}", epoch_accounts_hash.as_ref()),
-            },
+            if should_include_epoch_accounts_hash {
+                format!(", epoch_accounts_hash: {:?}", epoch_accounts_hash)
+            } else {
+                "".to_string()
+            }
         );
 
         info!(


### PR DESCRIPTION
#### Problem

During testing, I found that the `bank frozen` log printed the EAH more than it was supposed to.

Since the EAH is not cleared in Bank (but rather in `set_root()`), once the EAH is saved by AHV, it'll be `Some`, and every bank that is frozen since will output the EAH. I don't think that is the desired behavior. I believe the behavior we want is to only log the EAH when it has been included in the bank's hash.

#### Summary of Changes

Conditionally log EAH.
