### PR TITLE
Fix partialeq_to_none clippy lint

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -33,7 +33,7 @@ impl<'a> ProofEntry<'a> {
         left_sibling: Option<&'a Hash>,
         right_sibling: Option<&'a Hash>,
     ) -> Self {
-        assert!((None == left_sibling) ^ (None == right_sibling));
+        assert!(left_sibling.is_none() ^ right_sibling.is_none());
         Self(target, left_sibling, right_sibling)
     }
 }
@@ -154,7 +154,7 @@ impl MerkleTree {
             let level = &self.nodes[level_start..(level_start + level_len)];
 
             let target = &level[node_index];
-            if lsib != None || rsib != None {
+            if lsib.is_some() || rsib.is_some() {
                 path.push(ProofEntry::new(target, lsib, rsib));
             }
             if node_index % 2 == 0 {


### PR DESCRIPTION
#### Problem
```
warning: binary comparison to literal `Option::None`
   --> merkle-tree/src/merkle_tree.rs:157:32
    |
157 |             if lsib != None || rsib != None {
    |                                ^^^^^^^^^^^^ help: use `Option::is_some()` instead: `rsib.is_some()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
```

#### Summary of Changes
Appease clippy
