### PR TITLE
Fix explicit_auto_deref clippy lint

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -647,7 +647,7 @@ fn process_loader_upgradeable_instruction(
                 instruction_context.get_last_program_key(transaction_context)?;
             let signers = [&[new_program_id.as_ref(), &[bump_seed]]]
                 .iter()
-                .map(|seeds| Pubkey::create_program_address(*seeds, caller_program_id))
+                .map(|seeds| Pubkey::create_program_address(seeds, caller_program_id))
                 .collect::<Result<Vec<Pubkey>, solana_sdk::pubkey::PubkeyError>>()?;
             invoke_context.native_invoke(instruction, signers.as_slice())?;
 

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -867,7 +867,7 @@ fn call<'a, 'b: 'a>(
 
     // Translate and verify caller's data
     let instruction =
-        syscall.translate_instruction(instruction_addr, memory_mapping, *invoke_context)?;
+        syscall.translate_instruction(instruction_addr, memory_mapping, invoke_context)?;
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context
         .get_current_instruction_context()
@@ -880,19 +880,19 @@ fn call<'a, 'b: 'a>(
         signers_seeds_addr,
         signers_seeds_len,
         memory_mapping,
-        *invoke_context,
+        invoke_context,
     )?;
     let (instruction_accounts, program_indices) = invoke_context
         .prepare_instruction(&instruction, &signers)
         .map_err(SyscallError::InstructionError)?;
-    check_authorized_program(&instruction.program_id, &instruction.data, *invoke_context)?;
+    check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
     let mut accounts = syscall.translate_accounts(
         &instruction_accounts,
         &program_indices,
         account_infos_addr,
         account_infos_len,
         memory_mapping,
-        *invoke_context,
+        invoke_context,
     )?;
 
     // Process instruction


### PR DESCRIPTION
#### Problem
```
warning: deref which would be done by auto-deref
   --> programs/bpf_loader/src/syscalls/cpi.rs:870:73
    |
870 |         syscall.translate_instruction(instruction_addr, memory_mapping, *invoke_context)?;
    |                                                                         ^^^^^^^^^^^^^^^ help: try this: `invoke_context`
    |
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```

#### Summary of Changes
Appease clippy
