### PR TITLE
fix: ensure that Keypair.secretKey is a Uint8Array

### DIFF
--- a/web3.js/src/keypair.ts
+++ b/web3.js/src/keypair.ts
@@ -88,6 +88,6 @@ export class Keypair {
    * The raw secret key for this keypair
    */
   get secretKey(): Uint8Array {
-    return this._keypair.secretKey;
+    return new Uint8Array(this._keypair.secretKey);
   }
 }

--- a/web3.js/test/keypair.test.ts
+++ b/web3.js/test/keypair.test.ts
@@ -24,6 +24,11 @@ describe('Keypair', () => {
     expect(keypair.publicKey.toBase58()).to.eq(
       '2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF',
     );
+    expect(keypair.secretKey.toString()).to.eq(
+      '153,218,149,89,225,94,145,62,233,171,46,83,227,223,173,87,93,163,59,73,' +
+        '190,17,37,187,146,46,51,73,79,73,136,40,27,47,73,9,110,62,93,189,15,207,' +
+        '169,192,192,205,146,217,171,59,33,84,75,52,213,221,74,101,217,139,135,139,153,34',
+    );
   });
 
   it('creating keypair from invalid secret key throws error', () => {


### PR DESCRIPTION
#### Problem
An unintended side effect of https://github.com/solana-labs/solana/pull/27435 is that the `Keypair.secretKey` property is no longer coerced into a `Uint8Array` and therefore the `toString` behavior has been changed.

#### Summary of Changes
Ensure that `Keypair.secretKey` is always a proper `Uint8Array` and not a `Buffer` in disguise

Fixes https://github.com/solana-labs/solana/issues/27684
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
