### PR TITLE
pass 'enable_rehashing' through all accounts hash functions

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -125,6 +125,7 @@ fn main() {
                 &ancestors,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
+                true,
             );
             time.stop();
             let mut time_store = Measure::start("hash using store");
@@ -138,6 +139,7 @@ fn main() {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
+                true,
             );
             time_store.stop();
             if results != results_store {

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -99,6 +99,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         &ancestors,
         &EpochSchedule::default(),
         &RentCollector::default(),
+        true,
     );
     let test_hash_calculation = false;
     bencher.iter(|| {
@@ -135,6 +136,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
             &ancestors,
             &EpochSchedule::default(),
             &RentCollector::default(),
+            true,
         );
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -808,6 +808,7 @@ impl Accounts {
                 epoch_schedule,
                 rent_collector,
                 is_startup,
+                true,
             )
             .1
     }
@@ -837,6 +838,7 @@ impl Accounts {
             can_cached_slot_be_unflushed,
             ignore_mismatch,
             store_detailed_debug_info,
+            true,
         ) {
             warn!("verify_bank_hash failed: {:?}, slot: {}", err, slot);
             false

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6537,6 +6537,7 @@ impl AccountsDb {
         ancestors: &Ancestors,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        enable_rehashing: bool,
     ) -> (Hash, u64) {
         self.update_accounts_hash_with_index_option(
             true,
@@ -6548,6 +6549,7 @@ impl AccountsDb {
             epoch_schedule,
             rent_collector,
             false,
+            enable_rehashing,
         )
     }
 
@@ -6563,6 +6565,7 @@ impl AccountsDb {
             &EpochSchedule::default(),
             &RentCollector::default(),
             false,
+            true,
         )
     }
 
@@ -6988,6 +6991,7 @@ impl AccountsDb {
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
         is_startup: bool,
+        enable_rehashing: bool,
     ) -> (Hash, u64) {
         let check_hash = false;
         let (hash, total_lamports) = self
@@ -7004,7 +7008,7 @@ impl AccountsDb {
                     rent_collector,
                     store_detailed_debug_info_on_failure: false,
                     full_snapshot: None,
-                    enable_rehashing: true,
+                    enable_rehashing,
                 },
                 expected_capitalization,
             )
@@ -7255,6 +7259,7 @@ impl AccountsDb {
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
         can_cached_slot_be_unflushed: bool,
+        enable_rehashing: bool,
     ) -> Result<(), BankHashVerificationError> {
         self.verify_bank_hash_and_lamports_new(
             slot,
@@ -7266,6 +7271,7 @@ impl AccountsDb {
             can_cached_slot_be_unflushed,
             false,
             false,
+            enable_rehashing,
         )
     }
 
@@ -7282,6 +7288,7 @@ impl AccountsDb {
         can_cached_slot_be_unflushed: bool,
         ignore_mismatch: bool,
         store_hash_raw_data_for_debug: bool,
+        enable_rehashing: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
@@ -7303,7 +7310,7 @@ impl AccountsDb {
                     rent_collector,
                     store_detailed_debug_info_on_failure: store_hash_raw_data_for_debug,
                     full_snapshot: None,
-                    enable_rehashing: true,
+                    enable_rehashing,
                 },
                 None,
             )?;
@@ -11275,13 +11282,15 @@ pub mod tests {
                 latest_slot,
                 &ancestors,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                true,
             ),
             accounts.update_accounts_hash(
                 latest_slot,
                 &ancestors,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                true,
             )
         );
     }
@@ -11565,6 +11574,7 @@ pub mod tests {
             &Ancestors::default(),
             &EpochSchedule::default(),
             &RentCollector::default(),
+            true,
         );
 
         let accounts = f(accounts, current_slot);
@@ -11585,6 +11595,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
+                true,
             )
             .unwrap();
     }
@@ -11990,6 +12001,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
+                true,
             ),
             Ok(_)
         );
@@ -12004,6 +12016,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
+                true,
             ),
             Err(MissingBankHash)
         );
@@ -12027,6 +12040,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
+                true,
             ),
             Err(MismatchedBankHash)
         );
@@ -12055,7 +12069,8 @@ pub mod tests {
                 true,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
-                false
+                false,
+                true,
             ),
             Ok(_)
         );
@@ -12077,13 +12092,14 @@ pub mod tests {
                 true,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
-                false
+                false,
+                true,
             ),
             Ok(_)
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default(), false),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default(), false, true,),
             Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }
@@ -12110,7 +12126,8 @@ pub mod tests {
                 true,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
-                false
+                false,
+                true,
             ),
             Ok(_)
         );
@@ -12154,7 +12171,8 @@ pub mod tests {
                 true,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
-                false
+                false,
+                true,
             ),
             Err(MismatchedBankHash)
         );
@@ -12764,6 +12782,7 @@ pub mod tests {
                 &no_ancestors,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
+                true,
             );
             accounts
                 .verify_bank_hash_and_lamports(
@@ -12774,6 +12793,7 @@ pub mod tests {
                     &EpochSchedule::default(),
                     &RentCollector::default(),
                     false,
+                    true,
                 )
                 .unwrap();
 
@@ -12787,6 +12807,7 @@ pub mod tests {
                     &EpochSchedule::default(),
                     &RentCollector::default(),
                     false,
+                    true,
                 )
                 .unwrap();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7149,6 +7149,7 @@ impl Bank {
                 self.epoch_schedule(),
                 &self.rent_collector,
                 is_startup,
+                true,
             );
         if total_lamports != self.capitalization() {
             datapoint_info!(
@@ -7175,6 +7176,7 @@ impl Bank {
                         self.epoch_schedule(),
                         &self.rent_collector,
                         is_startup,
+                        true,
                     );
             }
 


### PR DESCRIPTION
#### Problem

we will need to enable/disable rehashing during accounts hash calculation when we activate #26599

#### Summary of Changes

add parameter to various functions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
