### PR TITLE
feat: add source field to parsed account key responses

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1029,6 +1029,8 @@ export type ParsedMessageAccount = {
   signer: boolean;
   /** Indicates if the account is writable for this transaction */
   writable: boolean;
+  /** Indicates if the account key came from the transaction or a lookup table */
+  source?: 'transaction' | 'lookupTable';
 };
 
 /**
@@ -1966,6 +1968,9 @@ const ParsedConfirmedTransactionResult = pick({
         pubkey: PublicKeyFromString,
         signer: boolean(),
         writable: boolean(),
+        source: optional(
+          union([literal('transaction'), literal('lookupTable')]),
+        ),
       }),
     ),
     instructions: array(ParsedOrRawInstruction),

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -4564,15 +4564,33 @@ describe('Connection', function () {
         );
         expect(parsedTransaction).to.not.be.null;
         expect(parsedTransaction?.version).to.eq(0);
-        expect(parsedTransaction?.meta?.loadedAddresses).to.eql({
-          readonly: [],
-          writable: [lookupTableAddresses[0]],
-        });
+        // loaded addresses are not returned for parsed transactions
+        expect(parsedTransaction?.meta?.loadedAddresses).to.be.undefined;
         expect(parsedTransaction?.meta?.computeUnitsConsumed).to.not.be
           .undefined;
         expect(
           parsedTransaction?.transaction.message.addressTableLookups,
         ).to.eql(addressTableLookups);
+        expect(parsedTransaction?.transaction.message.accountKeys).to.eql([
+          {
+            pubkey: payer.publicKey,
+            signer: true,
+            writable: true,
+            source: 'transaction',
+          },
+          {
+            pubkey: SystemProgram.programId,
+            signer: false,
+            writable: false,
+            source: 'transaction',
+          },
+          {
+            pubkey: lookupTableAddresses[0],
+            signer: false,
+            writable: true,
+            source: 'lookupTable',
+          },
+        ]);
       });
 
       it('getBlock (failure)', async () => {


### PR DESCRIPTION
#### Problem
The `source` field for parsed account keys is not made available by the sdk yet

#### Summary of Changes
- Parse the `source` of parsed account keys

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
