### PR TITLE
chore: update the README for web3.js with compatibility notes

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -87,6 +87,24 @@ console.log(solanaWeb3);
 console.log(solanaWeb3);
 ```
 
+## Compatibility
+
+This library requires a JavaScript runtime that supports [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) and the [exponentiation operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation). Both are supported in the following runtimes:
+
+- Browsers, by [release date](https://caniuse.com/bigint):
+  - Chrome: May 2018
+  - Firefox: July 2019
+  - Safari: September 2020
+  - Mobile Safari: September 2020
+  - Edge: January 2020
+  - Opera: June 2018
+  - Samsung Internet: April 2019
+- Runtimes, [by version](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt):
+  - Deno: >=1.0
+  - Node: >=10.4.0
+- React Native:
+  - \>=0.7.0 using the [Hermes](https://reactnative.dev/blog/2022/07/08/hermes-as-the-default) engine ([integration guide](https://solanacookbook.com/integrations/react-native.html#how-to-use-solana-web3-js-in-a-react-native-app)):
+
 ## Flow Support (Discontinued)
 
 Flow types are no longer supported in new releases. The last release with Flow support is v1.37.2 and its


### PR DESCRIPTION
This was mostly so that there's a note about React Native compatibility in there.

Addresses: #27685.