### PR TITLE
move if let destructuring out of for loop

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -587,7 +587,7 @@ pub fn process_new_vote_state(
     let mut finalized_slot_count = 1_u64;
 
     if let Some(new_root) = new_root {
-        for current_vote in &self.votes {
+        for current_vote in &vote_state.votes {
             // Find the first vote in the current vote state for a slot greater
             // than the new proposed root
             if current_vote.slot <= new_root {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -586,10 +586,10 @@ pub fn process_new_vote_state(
     //   new vote state; these have been "popped off the back" of the tower and thus represent finalized slots
     let mut finalized_slot_count = 1_u64;
 
-    for current_vote in &vote_state.votes {
-        // Find the first vote in the current vote state for a slot greater
-        // than the new proposed root
-        if let Some(new_root) = new_root {
+    if let Some(new_root) = new_root {
+        for current_vote in &self.votes {
+            // Find the first vote in the current vote state for a slot greater
+            // than the new proposed root
             if current_vote.slot <= new_root {
                 current_vote_state_index += 1;
                 if current_vote.slot != new_root {
@@ -597,9 +597,9 @@ pub fn process_new_vote_state(
                 }
                 continue;
             }
+            
+            break;
         }
-
-        break;
     }
 
     // All the votes in our current vote state that are missing from the new vote state

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -597,7 +597,7 @@ pub fn process_new_vote_state(
                 }
                 continue;
             }
-            
+
             break;
         }
     }


### PR DESCRIPTION
#### Problem
if let destructuring within for loop is not necessary and not efficient compared to move it out of for loop

#### Summary of Changes
move if let destructuring out of for loop

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
