### PR TITLE
Add --process-ledger-before-service flag to solana-validator

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -162,6 +162,7 @@ pub struct ValidatorConfig {
     pub no_os_disk_stats_reporting: bool,
     pub poh_pinned_cpu_core: usize,
     pub poh_hashes_per_batch: u64,
+    pub process_ledger_before_services: bool,
     pub account_indexes: AccountSecondaryIndexes,
     pub accounts_db_caching_enabled: bool,
     pub accounts_db_config: Option<AccountsDbConfig>,
@@ -226,6 +227,7 @@ impl Default for ValidatorConfig {
             no_os_disk_stats_reporting: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
+            process_ledger_before_services: false,
             account_indexes: AccountSecondaryIndexes::default(),
             accounts_db_caching_enabled: false,
             warp_slot: None,
@@ -671,6 +673,9 @@ impl Validator {
             &leader_schedule_cache,
         )?;
 
+        if config.process_ledger_before_services {
+            process_blockstore.process()?;
+        }
         *start_progress.write().unwrap() = ValidatorStartProgress::StartingServices;
 
         let sample_performance_service =

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -59,6 +59,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         staked_nodes_overrides: config.staked_nodes_overrides.clone(),
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
+        process_ledger_before_services: config.process_ledger_before_services,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
         accounts_shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_config: config.accounts_db_config.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1650,6 +1650,12 @@ pub fn main() {
                 .help("Specify hashes per batch in PoH service"),
         )
         .arg(
+            Arg::with_name("process_ledger_before_services")
+                .long("process-ledger-before-services")
+                .hidden(true)
+                .help("Process the local ledger fully before starting networking services")
+        )
+        .arg(
             Arg::with_name("account_indexes")
                 .long("account-index")
                 .takes_value(true)
@@ -2789,6 +2795,7 @@ pub fn main() {
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         poh_hashes_per_batch: value_of(&matches, "poh_hashes_per_batch")
             .unwrap_or(poh_service::DEFAULT_HASHES_PER_BATCH),
+        process_ledger_before_services: matches.is_present("process_ledger_before_services"),
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),


### PR DESCRIPTION
v1.11 and newer process the ledger on validator startup after networking services are started. Add the `--process-ledger-before-service` flag to revert back to the v1.10 ledger processing behaviour, which can be useful when comparing v1.10 startup performance to v1.11