### PR TITLE
Graph-based Replay Algorithm and Other Latency/Throughput Changes

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -64,6 +64,7 @@ impl ReplaySlotStats {
                     i64
                 ),
                 ("replay_time", self.replay_elapsed as i64, i64),
+                ("planning_elapsed", self.planning_elapsed as i64, i64),
                 ("execute_batches_us", self.execute_batches_us as i64, i64),
                 (
                     "replay_total_elapsed",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4182,6 +4182,8 @@ pub(crate) mod tests {
                 validator_keypairs,
                 ..
             } = vote_simulator;
+            let replayer = Replayer::new(get_thread_count());
+            let replayer_handle = replayer.handle();
 
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
             assert!(bank0.is_frozen());
@@ -4209,6 +4211,7 @@ pub(crate) mod tests {
                 &VerifyRecyclers::default(),
                 None,
                 &PrioritizationFeeCache::new(0u64),
+                &replayer_handle,
             );
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
             let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -441,7 +441,7 @@ impl ReplayStage {
         );
 
         #[allow(clippy::cognitive_complexity)]
-            let t_replay = Builder::new()
+        let t_replay = Builder::new()
             .name("solReplayStage".to_string())
             .spawn(move || {
                 let verify_recyclers = VerifyRecyclers::default();
@@ -671,7 +671,7 @@ impl ReplayStage {
                                                     &authorized_voter_keypairs.read().unwrap(),
                                                     &mut voted_signatures,
                                                     has_new_vote_been_rooted, &mut
-                                                        last_vote_refresh_time,
+                                                    last_vote_refresh_time,
                                                     &voting_sender,
                                                     wait_to_vote_slot,
                             );

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1733,6 +1733,10 @@ impl ReplayStage {
         let tx_count_before = w_replay_progress.num_txs;
 
         let mut did_process_entries = true;
+
+        // more entries may have been received while replaying this slot.
+        // looping over this ensures that slots will be processed as fast as possible with the
+        // lowest latency.
         while did_process_entries {
             // All errors must lead to marking the slot as dead, otherwise,
             // the `check_slot_agrees_with_cluster()` called by `replay_active_banks()`

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1716,6 +1716,7 @@ impl ReplayStage {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn replay_blockstore_into_bank(
         bank: &Arc<Bank>,
         blockstore: &Blockstore,
@@ -2266,7 +2267,7 @@ impl ReplayStage {
         let longest_replay_time_us = AtomicU64::new(0);
 
         let bank_slots_replayers: Vec<_> = active_bank_slots
-            .into_iter()
+            .iter()
             .map(|s| (s, replayer.handle()))
             .collect();
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -14,7 +14,6 @@ use {
     itertools::Itertools,
     log::*,
     rand::{seq::SliceRandom, thread_rng},
-    rayon::prelude::*,
     solana_entry::entry::{
         self, create_ticks, Entry, EntrySlice, EntryType, EntryVerificationStatus, VerifyRecyclers,
     },
@@ -763,7 +762,7 @@ impl ConfirmationTiming {
         let ConfirmationTiming {
             execute_timings: ref mut cumulative_execute_timings,
             execute_batches_us: ref mut cumulative_execute_batches_us,
-            ref mut end_to_end_execute_timings,
+            end_to_end_execute_timings: _,
             ..
         } = self;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -179,9 +179,11 @@ fn execute_batches_internal(
                          batch_idx,
                      }| {
                         let batch_idx = batch_idx.unwrap();
+
                         processing_state[batch_idx] = ExecutionState::Processed;
-                        num_left_to_process -= 1;
                         transaction_results[batch_idx] = result;
+
+                        num_left_to_process -= 1;
                     },
                 );
 
@@ -208,7 +210,7 @@ fn execute_batches_internal(
                 .iter()
                 .enumerate()
                 .filter_map(|(i, dependencies)| {
-                    if matches!(processing_state[i], ExecutionState::Processed)
+                    if matches!(processing_state[i], ExecutionState::Blocked)
                         && dependencies.iter().all(|dependency_idx| {
                             matches!(processing_state[*dependency_idx], ExecutionState::Processed)
                         })

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -107,6 +107,7 @@ enum ExecutionState {
     Processed,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_batches_internal(
     bank: &Arc<Bank>,
     transactions_indices_to_schedule: &[(SanitizedTransaction, usize)],
@@ -140,7 +141,7 @@ fn execute_batches_internal(
     let mut indices_need_scheduling: Vec<usize> = dependency_graph
         .iter()
         .enumerate()
-        .filter_map(|(idx, indices)| indices.is_empty().then(|| idx))
+        .filter_map(|(idx, indices)| indices.is_empty().then_some(idx))
         .collect();
 
     while num_left_to_process > 0 {
@@ -158,7 +159,7 @@ fn execute_batches_internal(
                     replay_vote_sender: replay_vote_sender.cloned(),
                     cost_capacity_meter: cost_capacity_meter.clone(),
                     tx_cost: tx_costs[*idx],
-                    log_messages_bytes_limit: log_messages_bytes_limit.clone(),
+                    log_messages_bytes_limit,
                     entry_callback: entry_callback.cloned(),
                     batch_idx: Some(*idx),
                 })
@@ -231,6 +232,7 @@ fn execute_batches_internal(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_batches(
     bank: &Arc<Bank>,
     transactions_indices_to_schedule: &[(SanitizedTransaction, usize)],
@@ -391,7 +393,7 @@ fn process_entries_with_callback(
                     transactions_indices_to_schedule.extend(
                         transactions
                             .iter()
-                            .map(|tx| tx.clone())
+                            .cloned()
                             .zip(indices.into_iter())
                             .into_iter(),
                     );
@@ -1367,6 +1369,7 @@ fn supermajority_root_from_vote_accounts(
 
 // Processes and replays the contents of a single slot, returns Error
 // if failed to play the slot
+#[allow(clippy::too_many_arguments)]
 fn process_single_slot(
     blockstore: &Blockstore,
     bank: &Arc<Bank>,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4320,10 +4320,10 @@ pub mod tests {
             vec![
                 HashSet::from_iter([]),
                 HashSet::from_iter([0]),
-                HashSet::from_iter([0, 1]),
+                HashSet::from_iter([1]),
                 HashSet::from_iter([]),
                 HashSet::from_iter([3]),
-                HashSet::from_iter([3, 4]),
+                HashSet::from_iter([4]),
                 HashSet::from_iter([0, 3]),
             ]
         );

--- a/ledger/src/executor.rs
+++ b/ledger/src/executor.rs
@@ -1,0 +1,279 @@
+use {
+    crate::{
+        blockstore_processor::{BlockCostCapacityMeter, TransactionStatusSender},
+        token_balances::collect_token_balances,
+    },
+    crossbeam_channel::{unbounded, Receiver, RecvError, SendError, Sender},
+    solana_program_runtime::timings::ExecuteTimings,
+    solana_runtime::{
+        bank::{Bank, TransactionResults},
+        bank_utils,
+        transaction_batch::TransactionBatch,
+        vote_sender_types::ReplayVoteSender,
+    },
+    solana_sdk::{
+        clock::MAX_PROCESSING_AGE,
+        feature_set,
+        pubkey::Pubkey,
+        transaction::{self, SanitizedTransaction, TransactionError},
+    },
+    solana_transaction_status::token_balances::TransactionTokenBalancesSet,
+    std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+        thread::{self, Builder, JoinHandle},
+    },
+};
+
+pub(crate) struct TransactionBatchWithIndexes<'a, 'b> {
+    pub batch: TransactionBatch<'a, 'b>,
+    pub transaction_indexes: Vec<usize>,
+}
+
+/// Callback for accessing bank state while processing the blockstore
+pub type ProcessCallback = Arc<dyn Fn(&Bank) + Sync + Send>;
+
+pub struct ReplayResponse {
+    pub result: transaction::Result<()>,
+    pub timing: ExecuteTimings,
+    pub idx: Option<usize>,
+}
+
+/// Request for replay, sends responses back on this channel
+pub struct ReplayRequest {
+    pub bank: Arc<Bank>,
+    pub tx: SanitizedTransaction,
+    pub transaction_status_sender: Option<TransactionStatusSender>,
+    pub replay_vote_sender: Option<ReplayVoteSender>,
+    pub cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+    pub entry_callback: Option<ProcessCallback>,
+    pub idx: Option<usize>,
+}
+
+pub struct Replayer {
+    threads: Vec<JoinHandle<()>>,
+}
+
+pub struct ReplayerHandle {
+    request_sender: Sender<ReplayRequest>,
+    response_receiver: Receiver<ReplayResponse>,
+}
+
+impl ReplayerHandle {
+    pub fn new(
+        request_sender: Sender<ReplayRequest>,
+        response_receiver: Receiver<ReplayResponse>,
+    ) -> ReplayerHandle {
+        ReplayerHandle {
+            request_sender,
+            response_receiver,
+        }
+    }
+
+    pub fn send(&self, request: ReplayRequest) -> Result<(), SendError<ReplayRequest>> {
+        self.request_sender.send(request)
+    }
+
+    pub fn recv_and_drain(&self) -> Result<Vec<ReplayResponse>, RecvError> {
+        let mut results = vec![self.response_receiver.recv()?];
+        results.extend(self.response_receiver.try_iter());
+        Ok(results)
+    }
+}
+
+impl Replayer {
+    pub fn new(num_threads: usize) -> (Replayer, ReplayerHandle) {
+        let (request_sender, request_receiver) = unbounded();
+        let (response_sender, response_receiver) = unbounded();
+        let threads = Self::start_replay_threads(num_threads, request_receiver, response_sender);
+        (
+            Replayer { threads },
+            ReplayerHandle {
+                request_sender,
+                response_receiver,
+            },
+        )
+    }
+
+    pub fn start_replay_threads(
+        num_threads: usize,
+        request_receiver: Receiver<ReplayRequest>,
+        response_sender: Sender<ReplayResponse>,
+    ) -> Vec<JoinHandle<()>> {
+        (0..num_threads)
+            .map(|i| {
+                let request_receiver = request_receiver.clone();
+                let response_sender = response_sender.clone();
+                Builder::new()
+                    .name(format!("solReplayer-{}", i))
+                    .spawn(move || loop {
+                        match request_receiver.recv() {
+                            Ok(ReplayRequest {
+                                bank,
+                                tx,
+                                transaction_status_sender,
+                                replay_vote_sender,
+                                cost_capacity_meter,
+                                entry_callback,
+                                idx,
+                            }) => {
+                                // let mut timing = ExecuteTimings::default();
+                                //
+                                // let txs = vec![tx];
+                                // let batch =
+                                //     TransactionBatch::new(vec![Ok(())], &bank, Cow::Borrowed(&txs));
+                                // let result = execute_batch(
+                                //     &batch,
+                                //     &bank,
+                                //     transaction_status_sender.as_ref(),
+                                //     replay_vote_sender.as_ref(),
+                                //     &mut timing,
+                                //     cost_capacity_meter.clone(),
+                                // );
+                                //
+                                // if let Some(entry_callback) = entry_callback {
+                                //     entry_callback(&bank);
+                                // }
+                                //
+                                // if response_sender
+                                //     .send(ReplayResponse {
+                                //         result,
+                                //         timing,
+                                //         idx,
+                                //     })
+                                //     .is_err()
+                                // {
+                                //     break;
+                                // }
+                            }
+                            Err(_) => {
+                                return;
+                            }
+                        }
+                    })
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        for t in self.threads {
+            t.join()?;
+        }
+        Ok(())
+    }
+}
+
+fn aggregate_total_execution_units(execute_timings: &ExecuteTimings) -> u64 {
+    let mut execute_cost_units: u64 = 0;
+    for (program_id, timing) in &execute_timings.details.per_program_timings {
+        if timing.count < 1 {
+            continue;
+        }
+        execute_cost_units =
+            execute_cost_units.saturating_add(timing.accumulated_units / timing.count as u64);
+        trace!("aggregated execution cost of {:?} {:?}", program_id, timing);
+    }
+    execute_cost_units
+}
+
+fn execute_batch(
+    batch: &TransactionBatchWithIndexes,
+    bank: &Arc<Bank>,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+    replay_vote_sender: Option<&ReplayVoteSender>,
+    timings: &mut ExecuteTimings,
+    cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
+    tx_cost: u64,
+    log_messages_bytes_limit: Option<usize>,
+) -> transaction::Result<()> {
+    let TransactionBatchWithIndexes {
+        batch,
+        transaction_indexes,
+    } = batch;
+    let record_token_balances = transaction_status_sender.is_some();
+
+    let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
+
+    let pre_token_balances = if record_token_balances {
+        collect_token_balances(bank, batch, &mut mint_decimals)
+    } else {
+        vec![]
+    };
+
+    let pre_process_units: u64 = aggregate_total_execution_units(timings);
+
+    let (tx_results, balances) = batch.bank().load_execute_and_commit_transactions(
+        batch,
+        MAX_PROCESSING_AGE,
+        transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
+        timings,
+        log_messages_bytes_limit,
+    );
+
+    if bank
+        .feature_set
+        .is_active(&feature_set::gate_large_block::id())
+    {
+        let execution_cost_units = aggregate_total_execution_units(timings) - pre_process_units;
+        let remaining_block_cost_cap = cost_capacity_meter
+            .write()
+            .unwrap()
+            .accumulate(execution_cost_units + tx_cost);
+
+        debug!(
+            "bank {} executed a batch, number of transactions {}, total execute cu {}, total additional cu {}, remaining block cost cap {}",
+            bank.slot(),
+            batch.sanitized_transactions().len(),
+            execution_cost_units,
+            tx_cost,
+            remaining_block_cost_cap,
+        );
+
+        if remaining_block_cost_cap == 0_u64 {
+            return Err(TransactionError::WouldExceedMaxBlockCostLimit);
+        }
+    }
+
+    bank_utils::find_and_send_votes(
+        batch.sanitized_transactions(),
+        &tx_results,
+        replay_vote_sender,
+    );
+
+    let TransactionResults {
+        fee_collection_results,
+        execution_results,
+        rent_debits,
+        ..
+    } = tx_results;
+
+    if let Some(transaction_status_sender) = transaction_status_sender {
+        let transactions = batch.sanitized_transactions().to_vec();
+        let post_token_balances = if record_token_balances {
+            collect_token_balances(bank, batch, &mut mint_decimals)
+        } else {
+            vec![]
+        };
+
+        let token_balances =
+            TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
+
+        transaction_status_sender.send_transaction_status_batch(
+            bank.clone(),
+            transactions,
+            execution_results,
+            balances,
+            token_balances,
+            rent_debits,
+            transaction_indexes.to_vec(),
+        );
+    }
+
+    // let first_err = get_first_error(batch, fee_collection_results);
+    // first_err.map(|(result, _)| result).unwrap_or(Ok(()))
+    Ok(())
+}

--- a/ledger/src/executor.rs
+++ b/ledger/src/executor.rs
@@ -358,7 +358,7 @@ fn execute_batch(
 
 // The dependency graph contains a set of indices < N that must be executed before index N.
 pub fn build_dependency_graph(
-    tx_account_locks_results: &Vec<Result<TransactionAccountLocks>>,
+    tx_account_locks_results: &[Result<TransactionAccountLocks>],
 ) -> Result<Vec<HashSet<usize>>> {
     if let Some(err) = tx_account_locks_results.iter().find(|r| r.is_err()) {
         err.clone()?;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -17,6 +17,7 @@ pub mod blockstore_metrics;
 pub mod blockstore_options;
 pub mod blockstore_processor;
 pub mod builtins;
+pub mod executor;
 pub mod genesis_utils;
 pub mod leader_schedule;
 pub mod leader_schedule_cache;


### PR DESCRIPTION
Original discussion: https://github.com/solana-labs/solana/pull/27632
Metrics of similar code running on 1.10: https://metrics.solana.com:3000/d/KCLhfAbMz/replay?orgId=1&var-datasource=InfluxDB_main-beta&var-testnet=mainnet-beta&var-hostid=DuSw81G5jUYQ4Z3ujYmoY2ULbqwKYBLnNdwPLw4S2wSM&from=now-15m&to=now

#### Problem
given the following txs that write lock accounts:
AB
BC
CD
EF
FG
GH

the current algorithm will replay in the following order sequentially: [AB], [BC], [CD], [EF], [FG], [GH]. we should be able to execute these one at a time and determine if any transactions become unblocked.

#### Summary of Changes
- Uses a transaction dependency graph and multi-threaded executor to sped **25-100% less time** execution transactions.
- When replaying a bank, continue to call confirm_slot as long as you're receiving entries. This results in **~200ms-400ms** lower latency for slot processing.


#### Proof
yellow is a leader setting a new bank in maybe_start_leader, red is the improved replay algorithm and the confirm_slot change, and blue is default. this is all on 1.10.

![image](https://user-images.githubusercontent.com/85544055/189573993-fca29be2-ba5a-4644-b73d-239ec8435a21.png)

DuS running this modified code on 1.10
<img width="1652" alt="Screen Shot 2022-09-12 at 12 29 14 AM" src="https://user-images.githubusercontent.com/85544055/189574207-7d29338c-6328-4644-ad2b-86ada21bd7ab.png">

DuS constantly beating the unmodified validator by ~200ms on average
<img width="1636" alt="image" src="https://user-images.githubusercontent.com/85544055/189574306-07470039-772a-4c4e-b571-4636bcd0cd79.png">
