### PR TITLE
fix: change type of data to Uint8Array

### DIFF
--- a/web3.js/src/instruction.ts
+++ b/web3.js/src/instruction.ts
@@ -27,7 +27,7 @@ export function encodeData<TInputData extends IInstructionInputData>(
 ): Buffer {
   const allocLength =
     type.layout.span >= 0 ? type.layout.span : Layout.getAlloc(type, fields);
-  const data = Buffer.alloc(allocLength);
+  const data = new Uint8Array(Buffer.alloc(allocLength));
   const layoutFields = Object.assign({instruction: type.index}, fields);
   type.layout.encode(layoutFields, data);
   return data;


### PR DESCRIPTION
#### Problem

I got error when trying to create transaction

```js
const transferTransaction = new Transaction().add(
        SystemProgram.transfer({
          fromPubkey: this.solKeyPair.publicKey,
          toPubkey: toPubkey,
          lamports: amount * LAMPORTS_PER_SOL,
        })
      );
```

it throw the error `TypeError: b must be a Uint8Array`, cause by this line in the web3 library:

```js
type.layout.encode(layoutFields, data);
``` 

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
