### PR TITLE
Use unchecked AlignedMemory methods to write into the serialization buffer

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::integer_arithmetic)]
 
 use {
-    byteorder::{ByteOrder, LittleEndian, WriteBytesExt},
+    byteorder::{ByteOrder, LittleEndian},
     solana_rbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     solana_sdk::{
         bpf_loader_deprecated,
@@ -11,7 +11,7 @@ use {
         system_instruction::MAX_PERMITTED_DATA_LENGTH,
         transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
     },
-    std::{io::prelude::*, mem::size_of},
+    std::mem::size_of,
 };
 
 /// Maximum number of instruction accounts that can be serialized into the
@@ -108,50 +108,49 @@ pub fn serialize_parameters_unaligned(
          + size_of::<Pubkey>(); // program id
     let mut v = AlignedMemory::<HOST_ALIGN>::with_capacity(size);
 
-    v.write_u64::<LittleEndian>(instruction_context.get_number_of_instruction_accounts() as u64)
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts() {
-        let duplicate =
-            instruction_context.is_instruction_account_duplicate(instruction_account_index)?;
-        if let Some(position) = duplicate {
-            v.write_u8(position as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-        } else {
-            let borrowed_account = instruction_context
-                .try_borrow_instruction_account(transaction_context, instruction_account_index)?;
-            v.write_u8(NON_DUP_MARKER)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_signer() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_writable() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(borrowed_account.get_key().as_ref())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_lamports())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_data().len() as u64)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(borrowed_account.get_data())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(borrowed_account.get_owner().as_ref())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_executable() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_rent_epoch() as u64)
-                .map_err(|_| InstructionError::InvalidArgument)?;
+    // Safety:
+    // We just allocated the buffer we're going to do unchecked writes into,
+    // sizing it according to what we're going to write. All the _unchecked
+    // methods used below debug_assert!() to ensure we don't overflow the
+    // buffer, so if we ever have a mismatch between alloc and writes, tests are
+    // going to fail.
+    unsafe {
+        v.write_u64_unchecked(
+            (instruction_context.get_number_of_instruction_accounts() as u64).to_le(),
+        );
+        for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts()
+        {
+            let duplicate =
+                instruction_context.is_instruction_account_duplicate(instruction_account_index)?;
+
+            if let Some(position) = duplicate {
+                v.write_u8_unchecked(position as u8);
+            } else {
+                let borrowed_account = instruction_context.try_borrow_instruction_account(
+                    transaction_context,
+                    instruction_account_index,
+                )?;
+                v.write_u8_unchecked(NON_DUP_MARKER);
+                v.write_u8_unchecked(borrowed_account.is_signer() as u8);
+                v.write_u8_unchecked(borrowed_account.is_writable() as u8);
+                v.write_all_unchecked(borrowed_account.get_key().as_ref());
+                v.write_u64_unchecked(borrowed_account.get_lamports().to_le());
+                v.write_u64_unchecked((borrowed_account.get_data().len() as u64).to_le());
+                v.write_all_unchecked(borrowed_account.get_data());
+                v.write_all_unchecked(borrowed_account.get_owner().as_ref());
+                v.write_u8_unchecked(borrowed_account.is_executable() as u8);
+                v.write_u64_unchecked((borrowed_account.get_rent_epoch() as u64).to_le());
+            }
         }
+        v.write_u64_unchecked((instruction_context.get_instruction_data().len() as u64).to_le());
+        v.write_all_unchecked(instruction_context.get_instruction_data());
+        v.write_all_unchecked(
+            instruction_context
+                .try_borrow_last_program_account(transaction_context)?
+                .get_key()
+                .as_ref(),
+        );
     }
-    v.write_u64::<LittleEndian>(instruction_context.get_instruction_data().len() as u64)
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    v.write_all(instruction_context.get_instruction_data())
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    v.write_all(
-        instruction_context
-            .try_borrow_last_program_account(transaction_context)?
-            .get_key()
-            .as_ref(),
-    )
-    .map_err(|_| InstructionError::InvalidArgument)?;
     Ok(v)
 }
 
@@ -241,61 +240,58 @@ pub fn serialize_parameters_aligned(
     + size_of::<Pubkey>(); // program id;
     let mut v = AlignedMemory::<HOST_ALIGN>::with_capacity(size);
 
-    // Serialize into the buffer
-    v.write_u64::<LittleEndian>(instruction_context.get_number_of_instruction_accounts() as u64)
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts() {
-        let duplicate =
-            instruction_context.is_instruction_account_duplicate(instruction_account_index)?;
-        if let Some(position) = duplicate {
-            v.write_u8(position as u8)
+    // Safety:
+    // We just allocated the buffer we're going to do unchecked writes into,
+    // sizing it according to what we're going to write. All the _unchecked
+    // methods used below debug_assert!() to ensure we don't overflow the
+    // buffer, so if we ever have a mismatch between alloc and writes, tests are
+    // going to fail.
+    unsafe {
+        // Serialize into the buffer
+        v.write_u64_unchecked(
+            (instruction_context.get_number_of_instruction_accounts() as u64).to_le(),
+        );
+        for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts()
+        {
+            let duplicate =
+                instruction_context.is_instruction_account_duplicate(instruction_account_index)?;
+            if let Some(position) = duplicate {
+                v.write_u8_unchecked(position as u8);
+                v.write_all_unchecked(&[0u8, 0, 0, 0, 0, 0, 0]);
+            } else {
+                let borrowed_account = instruction_context.try_borrow_instruction_account(
+                    transaction_context,
+                    instruction_account_index,
+                )?;
+                v.write_u8_unchecked(NON_DUP_MARKER);
+                v.write_u8_unchecked(borrowed_account.is_signer() as u8);
+                v.write_u8_unchecked(borrowed_account.is_writable() as u8);
+                v.write_u8_unchecked(borrowed_account.is_executable() as u8);
+                v.write_all_unchecked(&[0u8, 0, 0, 0]);
+                v.write_all_unchecked(borrowed_account.get_key().as_ref());
+                v.write_all_unchecked(borrowed_account.get_owner().as_ref());
+                v.write_u64_unchecked(borrowed_account.get_lamports().to_le());
+                v.write_u64_unchecked((borrowed_account.get_data().len() as u64).to_le());
+                v.write_all_unchecked(borrowed_account.get_data());
+                v.fill_write(
+                    MAX_PERMITTED_DATA_INCREASE
+                        + (borrowed_account.get_data().len() as *const u8)
+                            .align_offset(BPF_ALIGN_OF_U128),
+                    0,
+                )
                 .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(&[0u8, 0, 0, 0, 0, 0, 0])
-                .map_err(|_| InstructionError::InvalidArgument)?; // 7 bytes of padding to make 64-bit aligned
-        } else {
-            let borrowed_account = instruction_context
-                .try_borrow_instruction_account(transaction_context, instruction_account_index)?;
-            v.write_u8(NON_DUP_MARKER)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_signer() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_writable() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u8(borrowed_account.is_executable() as u8)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(&[0u8, 0, 0, 0])
-                .map_err(|_| InstructionError::InvalidArgument)?; // 4 bytes of padding to make 128-bit aligned
-            v.write_all(borrowed_account.get_key().as_ref())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(borrowed_account.get_owner().as_ref())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_lamports())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_data().len() as u64)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_all(borrowed_account.get_data())
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            v.fill_write(
-                MAX_PERMITTED_DATA_INCREASE
-                    + (v.write_index() as *const u8).align_offset(BPF_ALIGN_OF_U128),
-                0,
-            )
-            .map_err(|_| InstructionError::InvalidArgument)?;
-            v.write_u64::<LittleEndian>(borrowed_account.get_rent_epoch() as u64)
-                .map_err(|_| InstructionError::InvalidArgument)?;
+                v.write_u64_unchecked((borrowed_account.get_rent_epoch() as u64).to_le());
+            }
         }
+        v.write_u64_unchecked((instruction_context.get_instruction_data().len() as u64).to_le());
+        v.write_all_unchecked(instruction_context.get_instruction_data());
+        v.write_all_unchecked(
+            instruction_context
+                .try_borrow_last_program_account(transaction_context)?
+                .get_key()
+                .as_ref(),
+        );
     }
-    v.write_u64::<LittleEndian>(instruction_context.get_instruction_data().len() as u64)
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    v.write_all(instruction_context.get_instruction_data())
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    v.write_all(
-        instruction_context
-            .try_borrow_last_program_account(transaction_context)?
-            .get_key()
-            .as_ref(),
-    )
-    .map_err(|_| InstructionError::InvalidArgument)?;
     Ok(v)
 }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -690,11 +690,13 @@ pub struct BorrowedAccount<'a> {
 
 impl<'a> BorrowedAccount<'a> {
     /// Returns the index of this account (transaction wide)
+    #[inline]
     pub fn get_index_in_transaction(&self) -> IndexOfAccount {
         self.index_in_transaction
     }
 
     /// Returns the public key of this account (transaction wide)
+    #[inline]
     pub fn get_key(&self) -> &Pubkey {
         self.transaction_context
             .get_key_of_account_at_index(self.index_in_transaction)
@@ -702,6 +704,7 @@ impl<'a> BorrowedAccount<'a> {
     }
 
     /// Returns the owner of this account (transaction wide)
+    #[inline]
     pub fn get_owner(&self) -> &Pubkey {
         self.account.owner()
     }
@@ -750,6 +753,7 @@ impl<'a> BorrowedAccount<'a> {
     }
 
     /// Returns the number of lamports of this account (transaction wide)
+    #[inline]
     pub fn get_lamports(&self) -> u64 {
         self.account.lamports()
     }
@@ -814,6 +818,7 @@ impl<'a> BorrowedAccount<'a> {
     }
 
     /// Returns a read-only slice of the account data (transaction wide)
+    #[inline]
     pub fn get_data(&self) -> &[u8] {
         self.account.data()
     }
@@ -902,6 +907,7 @@ impl<'a> BorrowedAccount<'a> {
     }
 
     /// Returns whether this account is executable (transaction wide)
+    #[inline]
     pub fn is_executable(&self) -> bool {
         self.account.executable()
     }
@@ -948,6 +954,7 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns the rent epoch of this account (transaction wide)
     #[cfg(not(target_os = "solana"))]
+    #[inline]
     pub fn get_rent_epoch(&self) -> u64 {
         self.account.rent_epoch()
     }


### PR DESCRIPTION
We serialize in two steps: first we compute the size of the buffer, then we write into it. Therefore there's no need to check if each individual write fits the buffer - we know it does we just computed the required size.

Add inline hints the getters we call during serialization as otherwise LLVM doesn't seem to be inlining them.

Depends on https://github.com/solana-labs/rbpf/pull/379