### PR TITLE
 fix ledger tool final hash calc

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1559,7 +1559,7 @@ fn load_frozen_forks(
 
 fn run_final_hash_calc(bank: &Bank, on_halt_store_hash_raw_data_for_debug: bool) {
     bank.force_flush_accounts_cache();
-    let can_cached_slot_be_unflushed = true;
+    let can_cached_slot_be_unflushed = false;
     // note that this slot may not be a root
     let _ = bank.verify_bank_hash(VerifyBankHash {
         test_hash_calculation: false,


### PR DESCRIPTION
#### Problem
when running final hash calculation after ledger tool halts at a slot, we used to allow the hash calculation to use the write cache. This is incompatible with dumping accounts hash final data to disk, which is an optional ledger tool argument for debugging.

#### Summary of Changes
After flushing the write cache, tell accounts hash calc it may not use the write cache (since there is nothing in the write cache anyway).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
