### PR TITLE
Rework 'remove_dead_slots_metadata: slots' info log message

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7880,7 +7880,11 @@ impl AccountsDb {
         measure.stop();
         accounts_index_root_stats.clean_dead_slot_us += measure.as_us();
         if self.log_dead_slots.load(Ordering::Relaxed) {
-            info!("remove_dead_slots_metadata: slots {:?}", dead_slots);
+            info!(
+                "remove_dead_slots_metadata: {} dead slots",
+                dead_slots.len()
+            );
+            trace!("remove_dead_slots_metadata: dead_slots: {:?}", dead_slots);
         }
 
         accounts_index_root_stats.rooted_cleaned_count += rooted_cleaned_count;


### PR DESCRIPTION
This `info!()` log can pump out a log message thats ~500kb in length.