### PR TITLE
feat: add version getter to VersionedTransaction class

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4832,7 +4832,7 @@ export class Connection {
     signersOrOptions?: Array<Signer> | SendOptions,
     options?: SendOptions,
   ): Promise<TransactionSignature> {
-    if ('message' in transaction) {
+    if ('version' in transaction) {
       if (signersOrOptions && Array.isArray(signersOrOptions)) {
         throw new Error('Invalid arguments');
       }

--- a/web3.js/src/transaction/versioned.ts
+++ b/web3.js/src/transaction/versioned.ts
@@ -17,6 +17,10 @@ export class VersionedTransaction {
   signatures: Array<Uint8Array>;
   message: VersionedMessage;
 
+  get version(): TransactionVersion {
+    return this.message.version;
+  }
+
   constructor(message: VersionedMessage, signatures?: Array<Uint8Array>) {
     if (signatures !== undefined) {
       assert(


### PR DESCRIPTION
#### Problem
When differentiating between `VersionedTransaction` and `Transaction`, it's a little awkward to use `if ('message' in transaction')`. It'd be more natural to check for the existence of a `version` property.

#### Summary of Changes
Expose `VersionedTransaction.message.version` with a new `version` getter function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
