### PR TITLE
chore: remove failing request units test

### DIFF
--- a/web3.js/src/programs/compute-budget.ts
+++ b/web3.js/src/programs/compute-budget.ts
@@ -228,6 +228,9 @@ export class ComputeBudgetProgram {
     'ComputeBudget111111111111111111111111111111',
   );
 
+  /**
+   * @deprecated Instead, call {@link setComputeUnitLimit} and/or {@link setComputeUnitPrice}
+   */
   static requestUnits(params: RequestUnitsParams): TransactionInstruction {
     const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestUnits;
     const data = encodeData(type, params);

--- a/web3.js/test/program-tests/compute-budget.test.ts
+++ b/web3.js/test/program-tests/compute-budget.test.ts
@@ -72,51 +72,6 @@ describe('ComputeBudgetProgram', () => {
   });
 
   if (process.env.TEST_LIVE) {
-    it('send live request units ix', async () => {
-      const connection = new Connection(url, 'confirmed');
-      const FEE_AMOUNT = LAMPORTS_PER_SOL;
-      const STARTING_AMOUNT = 2 * LAMPORTS_PER_SOL;
-      const baseAccount = Keypair.generate();
-      const basePubkey = baseAccount.publicKey;
-      await helpers.airdrop({
-        connection,
-        address: basePubkey,
-        amount: STARTING_AMOUNT,
-      });
-
-      const additionalFeeTooHighTransaction = new Transaction().add(
-        ComputeBudgetProgram.requestUnits({
-          units: 150_000,
-          additionalFee: STARTING_AMOUNT,
-        }),
-      );
-
-      await expect(
-        sendAndConfirmTransaction(
-          connection,
-          additionalFeeTooHighTransaction,
-          [baseAccount],
-          {preflightCommitment: 'confirmed'},
-        ),
-      ).to.be.rejected;
-
-      const validAdditionalFeeTransaction = new Transaction().add(
-        ComputeBudgetProgram.requestUnits({
-          units: 150_000,
-          additionalFee: FEE_AMOUNT,
-        }),
-      );
-      await sendAndConfirmTransaction(
-        connection,
-        validAdditionalFeeTransaction,
-        [baseAccount],
-        {preflightCommitment: 'confirmed'},
-      );
-      expect(await connection.getBalance(baseAccount.publicKey)).to.be.at.most(
-        STARTING_AMOUNT - FEE_AMOUNT,
-      );
-    });
-
     it('send live request heap ix', async () => {
       const connection = new Connection(url, 'confirmed');
       const STARTING_AMOUNT = 2 * LAMPORTS_PER_SOL;


### PR DESCRIPTION
#### Problem
Now that the request units instruction is deprecated by the runtime, the test validator fails any transactions which use it.

#### Summary of Changes
- Remove failing test 
- Mark `ComputeBudget.requestUnits` function as deprecated

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
