### PR TITLE
Bump version to v1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
  "regex",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "regex",
 ]
@@ -3756,15 +3756,15 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 3.1.8",
  "serde",
  "serde_json",
  "solana-bpf-loader-program",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana_rbpf",
 ]
 
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4487,7 +4487,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4497,21 +4497,21 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "log",
  "rayon",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -4524,11 +4524,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4547,28 +4547,28 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-program 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-program 1.13.0",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-address-lookup-table-program",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-banking-bench"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4579,27 +4579,27 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-perf",
  "solana-poh",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
  "solana-banks-server",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4608,16 +4608,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "serde",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
@@ -4663,13 +4663,13 @@ dependencies = [
  "solana-genesis",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-version",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4688,14 +4688,14 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4706,26 +4706,26 @@ dependencies = [
  "solana-metrics",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.12.0",
- "solana-zk-token-sdk 1.12.0",
+ "solana-sdk 1.13.0",
+ "solana-zk-token-sdk 1.13.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-bpf-loader-program",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "fs_extra",
  "log",
@@ -4733,24 +4733,24 @@ dependencies = [
  "modular-bitfield",
  "rand 0.7.3",
  "rayon",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-cargo-build-bpf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
@@ -4759,14 +4759,14 @@ dependencies = [
  "regex",
  "serial_test",
  "solana-download-utils",
- "solana-logger 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-logger 1.13.0",
+ "solana-sdk 1.13.0",
  "tar",
 ]
 
 [[package]]
 name = "solana-cargo-test-bpf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4782,14 +4782,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4799,14 +4799,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap 3.1.8",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -4843,10 +4843,10 @@ dependencies = [
  "solana-client",
  "solana-config-program",
  "solana-faucet",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-program-runtime",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4870,13 +4870,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4894,7 +4894,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4938,12 +4938,12 @@ dependencies = [
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-faucet",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4959,14 +4959,14 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "futures-util",
  "serde_json",
  "serial_test",
  "solana-client",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
@@ -4974,7 +4974,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4985,28 +4985,28 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -5038,12 +5038,12 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -5053,7 +5053,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-streamer",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5089,42 +5089,42 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-net-utils",
  "solana-perf",
  "solana-rpc",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-download-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
  "rand 0.7.3",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5136,18 +5136,18 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5158,9 +5158,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -5216,8 +5216,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "subtle",
  "thiserror",
 ]
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "clap 2.33.3",
@@ -5257,9 +5257,9 @@ dependencies = [
  "solana-cli-config",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-version",
  "solana-vote-program",
@@ -5268,26 +5268,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -5300,14 +5300,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bv",
@@ -5334,17 +5334,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "solana-install"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "atty",
  "bincode",
@@ -5374,8 +5374,8 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-config-program",
- "solana-logger 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-logger 1.13.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "tar",
  "tempfile",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bs58",
  "clap 3.1.8",
@@ -5395,14 +5395,14 @@ dependencies = [
  "solana-clap-v3-utils",
  "solana-cli-config",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "solana-ledger"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5436,16 +5436,16 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger-tool"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -5486,10 +5486,10 @@ dependencies = [
  "solana-core",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-transaction-status",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -5519,9 +5519,9 @@ dependencies = [
  "solana-entry",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-streamer",
  "solana-vote-program",
@@ -5530,13 +5530,13 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "byte-unit",
  "clap 3.1.8",
  "serde",
  "serde_json",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-version",
 ]
 
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5562,38 +5562,38 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "fast-math",
  "hex",
  "matches",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -5603,23 +5603,23 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "serial_test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-net-shaper"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 3.1.8",
  "rand 0.7.3",
  "serde",
  "serde_json",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5630,8 +5630,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-logger 1.13.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
  "reqwest",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5666,16 +5666,16 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "core_affinity",
@@ -5685,29 +5685,29 @@ dependencies = [
  "rand 0.7.3",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-sys-tuner",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-poh-bench"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 3.1.8",
  "log",
  "rand 0.7.3",
  "rayon",
  "solana-entry",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-perf",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
 ]
 
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5793,10 +5793,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
- "solana-sdk-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
+ "solana-sdk-macro 1.13.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5820,18 +5820,18 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5843,10 +5843,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5873,14 +5873,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver 1.0.10",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5916,7 +5916,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5947,9 +5947,9 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-client",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-rpc",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -5998,18 +5998,18 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.12.0",
+ "solana-zk-token-sdk 1.13.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6112,11 +6112,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
- "solana-program 1.12.0",
- "solana-sdk-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
+ "solana-program 1.13.0",
+ "solana-sdk-macro 1.13.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6150,21 +6150,21 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "log",
  "solana-client",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-stake-accounts"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -6172,13 +6172,13 @@ dependencies = [
  "solana-client",
  "solana-remote-wallet",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6190,12 +6190,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "test-case",
  "thiserror",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -6224,7 +6224,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -6244,25 +6244,25 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-store-tool"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-runtime",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6279,10 +6279,10 @@ dependencies = [
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -6290,13 +6290,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -6316,20 +6316,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-tokens"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -6345,9 +6345,9 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6374,11 +6374,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -6401,7 +6401,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -6451,14 +6451,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -6471,21 +6471,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
  "rustc_version 0.4.0",
  "semver 1.0.10",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "itertools",
@@ -6496,18 +6496,18 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-watchtower"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -6516,24 +6516,24 @@ dependencies = [
  "solana-cli-config",
  "solana-cli-output",
  "solana-client",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-notifier",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
- "solana-zk-token-sdk 1.12.0",
+ "solana-sdk 1.13.0",
+ "solana-zk-token-sdk 1.13.0",
 ]
 
 [[package]]
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6588,8 +6588,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-program 1.13.0",
+ "solana-sdk 1.13.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
  "regex",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "regex",
 ]
@@ -3756,15 +3756,15 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 3.1.8",
  "serde",
  "serde_json",
  "solana-bpf-loader-program",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana_rbpf",
 ]
 
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4487,7 +4487,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4497,21 +4497,21 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "log",
  "rayon",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -4524,11 +4524,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4547,28 +4547,28 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-program 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-program 1.14.0",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-address-lookup-table-program",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-banking-bench"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4579,27 +4579,27 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-perf",
  "solana-poh",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
  "solana-banks-server",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4608,16 +4608,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "serde",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
@@ -4663,13 +4663,13 @@ dependencies = [
  "solana-genesis",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-version",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4688,14 +4688,14 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4706,26 +4706,26 @@ dependencies = [
  "solana-metrics",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.13.0",
- "solana-zk-token-sdk 1.13.0",
+ "solana-sdk 1.14.0",
+ "solana-zk-token-sdk 1.14.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-bpf-loader-program",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "fs_extra",
  "log",
@@ -4733,24 +4733,24 @@ dependencies = [
  "modular-bitfield",
  "rand 0.7.3",
  "rayon",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-cargo-build-bpf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
@@ -4759,14 +4759,14 @@ dependencies = [
  "regex",
  "serial_test",
  "solana-download-utils",
- "solana-logger 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-logger 1.14.0",
+ "solana-sdk 1.14.0",
  "tar",
 ]
 
 [[package]]
 name = "solana-cargo-test-bpf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4782,14 +4782,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4799,14 +4799,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "clap 3.1.8",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -4843,10 +4843,10 @@ dependencies = [
  "solana-client",
  "solana-config-program",
  "solana-faucet",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-program-runtime",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4870,13 +4870,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4894,7 +4894,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4938,12 +4938,12 @@ dependencies = [
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-faucet",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4959,14 +4959,14 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "futures-util",
  "serde_json",
  "serial_test",
  "solana-client",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
@@ -4974,7 +4974,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4985,28 +4985,28 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -5038,12 +5038,12 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -5053,7 +5053,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-streamer",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5089,42 +5089,42 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-net-utils",
  "solana-perf",
  "solana-rpc",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-download-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
  "rand 0.7.3",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5136,18 +5136,18 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5158,9 +5158,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -5216,8 +5216,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "subtle",
  "thiserror",
 ]
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "clap 2.33.3",
@@ -5257,9 +5257,9 @@ dependencies = [
  "solana-cli-config",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-version",
  "solana-vote-program",
@@ -5268,26 +5268,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -5300,14 +5300,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bv",
@@ -5334,17 +5334,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "solana-install"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "atty",
  "bincode",
@@ -5374,8 +5374,8 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-config-program",
- "solana-logger 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-logger 1.14.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "tar",
  "tempfile",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bs58",
  "clap 3.1.8",
@@ -5395,14 +5395,14 @@ dependencies = [
  "solana-clap-v3-utils",
  "solana-cli-config",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "solana-ledger"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5436,16 +5436,16 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger-tool"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -5486,10 +5486,10 @@ dependencies = [
  "solana-core",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-transaction-status",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -5519,9 +5519,9 @@ dependencies = [
  "solana-entry",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-streamer",
  "solana-vote-program",
@@ -5530,13 +5530,13 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "byte-unit",
  "clap 3.1.8",
  "serde",
  "serde_json",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-version",
 ]
 
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5562,38 +5562,38 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "fast-math",
  "hex",
  "matches",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -5603,23 +5603,23 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "serial_test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-net-shaper"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 3.1.8",
  "rand 0.7.3",
  "serde",
  "serde_json",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5630,8 +5630,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-logger 1.14.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
  "reqwest",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5666,16 +5666,16 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "core_affinity",
@@ -5685,29 +5685,29 @@ dependencies = [
  "rand 0.7.3",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-sys-tuner",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-poh-bench"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 3.1.8",
  "log",
  "rand 0.7.3",
  "rayon",
  "solana-entry",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-perf",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
 ]
 
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5793,10 +5793,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
- "solana-sdk-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
+ "solana-sdk-macro 1.14.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5820,18 +5820,18 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5843,10 +5843,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5873,14 +5873,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver 1.0.10",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5916,7 +5916,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5947,9 +5947,9 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-client",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-rpc",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -5998,18 +5998,18 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.13.0",
+ "solana-zk-token-sdk 1.14.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6112,11 +6112,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
- "solana-program 1.13.0",
- "solana-sdk-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
+ "solana-program 1.14.0",
+ "solana-sdk-macro 1.14.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6150,21 +6150,21 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "log",
  "solana-client",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-stake-accounts"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -6172,13 +6172,13 @@ dependencies = [
  "solana-client",
  "solana-remote-wallet",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6190,12 +6190,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "test-case",
  "thiserror",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -6224,7 +6224,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -6244,25 +6244,25 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-store-tool"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-runtime",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6279,10 +6279,10 @@ dependencies = [
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -6290,13 +6290,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -6316,20 +6316,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-tokens"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -6345,9 +6345,9 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6374,11 +6374,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -6401,7 +6401,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -6451,14 +6451,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -6471,21 +6471,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
  "rustc_version 0.4.0",
  "semver 1.0.10",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "itertools",
@@ -6496,18 +6496,18 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-watchtower"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -6516,24 +6516,24 @@ dependencies = [
  "solana-cli-config",
  "solana-cli-output",
  "solana-client",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-notifier",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
- "solana-zk-token-sdk 1.13.0",
+ "solana-sdk 1.14.0",
+ "solana-zk-token-sdk 1.14.0",
 ]
 
 [[package]]
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6588,8 +6588,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-program 1.14.0",
+ "solana-sdk 1.14.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
  "regex",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "regex",
 ]
@@ -3756,15 +3756,15 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 3.1.8",
  "serde",
  "serde_json",
  "solana-bpf-loader-program",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana_rbpf",
 ]
 
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4487,7 +4487,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4497,21 +4497,21 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "log",
  "rayon",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -4524,11 +4524,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4547,28 +4547,28 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-program 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-program 1.12.0",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-address-lookup-table-program",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-banking-bench"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4579,27 +4579,27 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-perf",
  "solana-poh",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
  "solana-banks-server",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4608,16 +4608,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "serde",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
@@ -4663,13 +4663,13 @@ dependencies = [
  "solana-genesis",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-version",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4688,14 +4688,14 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4706,26 +4706,26 @@ dependencies = [
  "solana-metrics",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.11.11",
- "solana-zk-token-sdk 1.11.11",
+ "solana-sdk 1.12.0",
+ "solana-zk-token-sdk 1.12.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "bincode",
  "solana-bpf-loader-program",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "fs_extra",
  "log",
@@ -4733,24 +4733,24 @@ dependencies = [
  "modular-bitfield",
  "rand 0.7.3",
  "rayon",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-cargo-build-bpf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
@@ -4759,14 +4759,14 @@ dependencies = [
  "regex",
  "serial_test",
  "solana-download-utils",
- "solana-logger 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-logger 1.12.0",
+ "solana-sdk 1.12.0",
  "tar",
 ]
 
 [[package]]
 name = "solana-cargo-test-bpf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.1.8",
@@ -4782,14 +4782,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4799,14 +4799,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "clap 3.1.8",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tempfile",
  "thiserror",
  "tiny-bip39",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -4843,10 +4843,10 @@ dependencies = [
  "solana-client",
  "solana-config-program",
  "solana-faucet",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-program-runtime",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4870,13 +4870,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4894,7 +4894,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4938,12 +4938,12 @@ dependencies = [
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-faucet",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4959,14 +4959,14 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "futures-util",
  "serde_json",
  "serial_test",
  "solana-client",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
@@ -4974,7 +4974,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -4985,28 +4985,28 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -5038,12 +5038,12 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -5053,7 +5053,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-streamer",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5089,42 +5089,42 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-net-utils",
  "solana-perf",
  "solana-rpc",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-download-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
  "rand 0.7.3",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5136,18 +5136,18 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5158,9 +5158,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -5216,8 +5216,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "subtle",
  "thiserror",
 ]
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "clap 2.33.3",
@@ -5257,9 +5257,9 @@ dependencies = [
  "solana-cli-config",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-version",
  "solana-vote-program",
@@ -5268,26 +5268,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -5300,14 +5300,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bv",
@@ -5334,17 +5334,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "solana-install"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "atty",
  "bincode",
@@ -5374,8 +5374,8 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-config-program",
- "solana-logger 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-logger 1.12.0",
+ "solana-sdk 1.12.0",
  "solana-version",
  "tar",
  "tempfile",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bs58",
  "clap 3.1.8",
@@ -5395,14 +5395,14 @@ dependencies = [
  "solana-clap-v3-utils",
  "solana-cli-config",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "solana-ledger"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5436,16 +5436,16 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger-tool"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -5486,10 +5486,10 @@ dependencies = [
  "solana-core",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-transaction-status",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -5519,9 +5519,9 @@ dependencies = [
  "solana-entry",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-streamer",
  "solana-vote-program",
@@ -5530,13 +5530,13 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "byte-unit",
  "clap 3.1.8",
  "serde",
  "serde_json",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-version",
 ]
 
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5562,38 +5562,38 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "fast-math",
  "hex",
  "matches",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -5603,23 +5603,23 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "serial_test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-net-shaper"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 3.1.8",
  "rand 0.7.3",
  "serde",
  "serde_json",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "clap 3.1.8",
@@ -5630,8 +5630,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-logger 1.12.0",
+ "solana-sdk 1.12.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
  "reqwest",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5666,16 +5666,16 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "core_affinity",
@@ -5685,29 +5685,29 @@ dependencies = [
  "rand 0.7.3",
  "solana-entry",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-sys-tuner",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-poh-bench"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 3.1.8",
  "log",
  "rand 0.7.3",
  "rayon",
  "solana-entry",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-perf",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
 ]
 
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5793,10 +5793,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
- "solana-sdk-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
+ "solana-sdk-macro 1.12.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5820,18 +5820,18 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5843,10 +5843,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5873,14 +5873,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver 1.0.10",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5916,7 +5916,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5947,9 +5947,9 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-client",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-rpc",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -5998,18 +5998,18 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.11.11",
+ "solana-zk-token-sdk 1.12.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6112,11 +6112,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
- "solana-program 1.11.11",
- "solana-sdk-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
+ "solana-program 1.12.0",
+ "solana-sdk-macro 1.12.0",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6150,21 +6150,21 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "log",
  "solana-client",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-stake-accounts"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -6172,13 +6172,13 @@ dependencies = [
  "solana-client",
  "solana-remote-wallet",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6190,12 +6190,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "test-case",
  "thiserror",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -6224,7 +6224,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -6244,25 +6244,25 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-store-tool"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "log",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-runtime",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6279,10 +6279,10 @@ dependencies = [
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.6",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -6290,13 +6290,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -6316,20 +6316,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-tokens"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -6345,9 +6345,9 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-test-validator",
  "solana-transaction-status",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6374,11 +6374,11 @@ dependencies = [
  "solana-faucet",
  "solana-gossip",
  "solana-local-cluster",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-net-utils",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -6401,7 +6401,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -6451,14 +6451,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -6471,21 +6471,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
  "rustc_version 0.4.0",
  "semver 1.0.10",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "itertools",
@@ -6496,18 +6496,18 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-watchtower"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -6516,24 +6516,24 @@ dependencies = [
  "solana-cli-config",
  "solana-cli-output",
  "solana-client",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-notifier",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
- "solana-zk-token-sdk 1.11.11",
+ "solana-sdk 1.12.0",
+ "solana-zk-token-sdk 1.12.0",
 ]
 
 [[package]]
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6588,8 +6588,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-program 1.12.0",
+ "solana-sdk 1.12.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-account-decoder"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana account decoder"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-config-program = { path = "../programs/config", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-config-program = { path = "../programs/config", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-account-decoder"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana account decoder"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-config-program = { path = "../programs/config", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-config-program = { path = "../programs/config", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-account-decoder"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana account decoder"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-config-program = { path = "../programs/config", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-config-program = { path = "../programs/config", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-bench"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,11 +12,11 @@ publish = false
 clap = "2.33.1"
 log = "0.4.17"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-bench"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,11 +12,11 @@ publish = false
 clap = "2.33.1"
 log = "0.4.17"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-bench"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,11 +12,11 @@ publish = false
 clap = "2.33.1"
 log = "0.4.17"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-cluster-bench"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,25 +13,25 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-cluster-bench"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,25 +13,25 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-local-cluster = { path = "../local-cluster", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-accounts-cluster-bench"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,25 +13,25 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-banking-bench"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,18 +14,18 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-poh = { path = "../poh", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-poh = { path = "../poh", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-banking-bench"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,18 +14,18 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-poh = { path = "../poh", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-poh = { path = "../poh", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-banking-bench"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,18 +14,18 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-poh = { path = "../poh", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-poh = { path = "../poh", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-client"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana banks client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,17 +12,17 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.11.11" }
-solana-program = { path = "../sdk/program", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.12.0" }
+solana-program = { path = "../sdk/program", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 
 [dev-dependencies]
-solana-banks-server = { path = "../banks-server", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
+solana-banks-server = { path = "../banks-server", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-client"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana banks client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,17 +12,17 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.12.0" }
-solana-program = { path = "../sdk/program", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.13.0" }
+solana-program = { path = "../sdk/program", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 
 [dev-dependencies]
-solana-banks-server = { path = "../banks-server", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-banks-server = { path = "../banks-server", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-client"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana banks client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,17 +12,17 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.13.0" }
-solana-program = { path = "../sdk/program", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.14.0" }
+solana-program = { path = "../sdk/program", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 
 [dev-dependencies]
-solana-banks-server = { path = "../banks-server", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-banks-server = { path = "../banks-server", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-interface"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana banks RPC interface"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.138", features = ["derive"] }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 
 [lib]

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-interface"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana banks RPC interface"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.138", features = ["derive"] }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 
 [lib]

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-interface"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana banks RPC interface"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.138", features = ["derive"] }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 
 [lib]

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-server"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana banks server"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,11 +13,11 @@ edition = "2021"
 bincode = "1.3.3"
 crossbeam-channel = "0.5"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-server"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana banks server"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,11 +13,11 @@ edition = "2021"
 bincode = "1.3.3"
 crossbeam-channel = "0.5"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.14.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-banks-server"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana banks server"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,11 +13,11 @@ edition = "2021"
 bincode = "1.3.3"
 crossbeam-channel = "0.5"
 futures = "0.3"
-solana-banks-interface = { path = "../banks-interface", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.11" }
+solana-banks-interface = { path = "../banks-interface", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
 tarpc = { version = "0.29.0", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-streamer"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,9 +11,9 @@ publish = false
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 crossbeam-channel = "0.5"
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-streamer"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,9 +11,9 @@ publish = false
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 crossbeam-channel = "0.5"
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-streamer"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,9 +11,9 @@ publish = false
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 crossbeam-channel = "0.5"
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-tps"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,28 +15,28 @@ log = "0.4.17"
 rayon = "1.5.3"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-genesis = { path = "../genesis", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-genesis = { path = "../genesis", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-tps"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,28 +15,28 @@ log = "0.4.17"
 rayon = "1.5.3"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-genesis = { path = "../genesis", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-genesis = { path = "../genesis", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-bench-tps"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,28 +15,28 @@ log = "0.4.17"
 rayon = "1.5.3"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-genesis = { path = "../genesis", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-genesis = { path = "../genesis", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bloom"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana bloom filter"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,9 +17,9 @@ rand = "0.7.0"
 rayon = "1.5.3"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bloom"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana bloom filter"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,9 +17,9 @@ rand = "0.7.0"
 rayon = "1.5.3"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bloom"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana bloom filter"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,9 +17,9 @@ rand = "0.7.0"
 rayon = "1.5.3"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bucket-map"
-version = "1.11.11"
+version = "1.12.0"
 description = "solana-bucket-map"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bucket-map"
@@ -15,14 +15,14 @@ log = { version = "0.4.17" }
 memmap2 = "0.5.3"
 modular-bitfield = "0.11.2"
 rand = "0.7.0"
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 fs_extra = "1.2.0"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bucket-map"
-version = "1.12.0"
+version = "1.13.0"
 description = "solana-bucket-map"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bucket-map"
@@ -15,14 +15,14 @@ log = { version = "0.4.17" }
 memmap2 = "0.5.3"
 modular-bitfield = "0.11.2"
 rand = "0.7.0"
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 fs_extra = "1.2.0"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bucket-map"
-version = "1.13.0"
+version = "1.14.0"
 description = "solana-bucket-map"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bucket-map"
@@ -15,14 +15,14 @@ log = { version = "0.4.17" }
 memmap2 = "0.5.3"
 modular-bitfield = "0.11.2"
 rand = "0.7.0"
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 fs_extra = "1.2.0"
 rayon = "1.5.3"
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-utils"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana utilities for the clap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = "2.33.0"
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-utils"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana utilities for the clap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = "2.33.0"
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-utils"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana utilities for the clap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = "2.33.0"
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-v3-utils"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana utilities for the clap v3"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = { version = "3.1.5", features = ["cargo"] }
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-v3-utils"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana utilities for the clap v3"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = { version = "3.1.5", features = ["cargo"] }
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clap-v3-utils"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana utilities for the clap v3"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ edition = "2021"
 chrono = "0.4"
 clap = { version = "3.1.5", features = ["cargo"] }
 rpassword = "6.0"
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0", default-features = false }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0", default-features = false }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 uriparse = "0.6.4"

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-config"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,8 +15,8 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-config"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,8 +15,8 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-config"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,8 +15,8 @@ lazy_static = "1.4.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-output"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -21,13 +21,13 @@ pretty-hex = "0.3.0"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 
 [dev-dependencies]

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-output"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -21,13 +21,13 @@ pretty-hex = "0.3.0"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 
 [dev-dependencies]

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli-output"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -21,13 +21,13 @@ pretty-hex = "0.3.0"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 
 [dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,29 +27,29 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-cli-output = { path = "../cli-output", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-config-program = { path = "../programs/config", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-config-program = { path = "../programs/config", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 solana_rbpf = "=0.2.31"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 
 [dev-dependencies]
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,29 +27,29 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-config-program = { path = "../programs/config", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-config-program = { path = "../programs/config", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 solana_rbpf = "=0.2.31"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 
 [dev-dependencies]
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-cli"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,29 +27,29 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-config-program = { path = "../programs/config", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-config-program = { path = "../programs/config", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 solana_rbpf = "=0.2.31"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"
 
 [dev-dependencies]
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client-test"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,25 +14,25 @@ publish = false
 futures-util = "0.3.21"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 systemstat = "0.1.11"
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client-test"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,25 +14,25 @@ publish = false
 futures-util = "0.3.21"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 systemstat = "0.1.11"
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client-test"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,25 +14,25 @@ publish = false
 futures-util = "0.3.21"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 systemstat = "0.1.11"
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -38,17 +38,17 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -61,8 +61,8 @@ url = "2.2.2"
 anyhow = "1.0.58"
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -38,17 +38,17 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -61,8 +61,8 @@ url = "2.2.2"
 anyhow = "1.0.58"
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Client"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -38,17 +38,17 @@ semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -61,8 +61,8 @@ url = "2.2.2"
 anyhow = "1.0.58"
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-core"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-core"
 readme = "../README.md"
@@ -35,30 +35,30 @@ rand_chacha = "0.2.2"
 rayon = "1.5.3"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.11.11" }
-solana-bloom = { path = "../bloom", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-poh = { path = "../poh", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
+solana-bloom = { path = "../bloom", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-poh = { path = "../poh", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 sys-info = "0.9.1"
 tempfile = "3.3.0"
 thiserror = "1.0"
@@ -70,9 +70,9 @@ matches = "0.1.9"
 raptorq = "1.7.0"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
 static_assertions = "1.1.0"
 systemstat = "0.1.11"
 test-case = "2.1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-core"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-core"
 readme = "../README.md"
@@ -35,30 +35,30 @@ rand_chacha = "0.2.2"
 rayon = "1.5.3"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
-solana-bloom = { path = "../bloom", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-poh = { path = "../poh", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
+solana-bloom = { path = "../bloom", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-poh = { path = "../poh", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 sys-info = "0.9.1"
 tempfile = "3.3.0"
 thiserror = "1.0"
@@ -70,9 +70,9 @@ matches = "0.1.9"
 raptorq = "1.7.0"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
 static_assertions = "1.1.0"
 systemstat = "0.1.11"
 test-case = "2.1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-core"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-core"
 readme = "../README.md"
@@ -35,30 +35,30 @@ rand_chacha = "0.2.2"
 rayon = "1.5.3"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
-solana-bloom = { path = "../bloom", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-poh = { path = "../poh", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.14.0" }
+solana-bloom = { path = "../bloom", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-poh = { path = "../poh", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 sys-info = "0.9.1"
 tempfile = "3.3.0"
 thiserror = "1.0"
@@ -70,9 +70,9 @@ matches = "0.1.9"
 raptorq = "1.7.0"
 serde_json = "1.0.81"
 serial_test = "0.8.0"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
 static_assertions = "1.1.0"
 systemstat = "0.1.11"
 test-case = "2.1.0"

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -214,7 +214,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.12.0 |   |
+| Address Lookup | v1.13.0 |   |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |
@@ -1948,7 +1948,7 @@ Returns all accounts owned by the provided program Pubkey
   - `offset: <usize>` - offset into program account data to start comparison
   - `bytes: <string>` - data to match, as encoded string
   - `encoding: <string>` - encoding for filter `bytes` data, either "base58" or "base64". Data is limited in size to 128 or fewer decoded bytes.
-    **NEW: This field, and base64 support generally, is only available in solana-core v1.12.0 or newer. Please omit when querying nodes on earlier versions**
+    **NEW: This field, and base64 support generally, is only available in solana-core v1.13.0 or newer. Please omit when querying nodes on earlier versions**
 
 - `dataSize: <u64>` - compares the program account data length with the provided data size
 
@@ -3176,7 +3176,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 
 ```json
-{ "jsonrpc": "2.0", "result": { "solana-core": "1.12.0" }, "id": 1 }
+{ "jsonrpc": "2.0", "result": { "solana-core": "1.13.0" }, "id": 1 }
 ```
 
 ### getVoteAccounts

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -214,7 +214,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.13.0 |   |
+| Address Lookup | v1.14.0 |   |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |
@@ -1948,7 +1948,7 @@ Returns all accounts owned by the provided program Pubkey
   - `offset: <usize>` - offset into program account data to start comparison
   - `bytes: <string>` - data to match, as encoded string
   - `encoding: <string>` - encoding for filter `bytes` data, either "base58" or "base64". Data is limited in size to 128 or fewer decoded bytes.
-    **NEW: This field, and base64 support generally, is only available in solana-core v1.13.0 or newer. Please omit when querying nodes on earlier versions**
+    **NEW: This field, and base64 support generally, is only available in solana-core v1.14.0 or newer. Please omit when querying nodes on earlier versions**
 
 - `dataSize: <u64>` - compares the program account data length with the provided data size
 
@@ -3176,7 +3176,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 
 ```json
-{ "jsonrpc": "2.0", "result": { "solana-core": "1.13.0" }, "id": 1 }
+{ "jsonrpc": "2.0", "result": { "solana-core": "1.14.0" }, "id": 1 }
 ```
 
 ### getVoteAccounts

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1948,7 +1948,7 @@ Returns all accounts owned by the provided program Pubkey
   - `offset: <usize>` - offset into program account data to start comparison
   - `bytes: <string>` - data to match, as encoded string
   - `encoding: <string>` - encoding for filter `bytes` data, either "base58" or "base64". Data is limited in size to 128 or fewer decoded bytes.
-    **NEW: This field, and base64 support generally, is only available in solana-core v1.11.11 or newer. Please omit when querying nodes on earlier versions**
+    **NEW: This field, and base64 support generally, is only available in solana-core v1.12.0 or newer. Please omit when querying nodes on earlier versions**
 
 - `dataSize: <u64>` - compares the program account data length with the provided data size
 
@@ -3176,7 +3176,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 
 ```json
-{ "jsonrpc": "2.0", "result": { "solana-core": "1.11.11" }, "id": 1 }
+{ "jsonrpc": "2.0", "result": { "solana-core": "1.12.0" }, "id": 1 }
 ```
 
 ### getVoteAccounts

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-dos"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -17,23 +17,23 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 serde = "1.0.138"
-solana-bench-tps = { path = "../bench-tps", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-bench-tps = { path = "../bench-tps", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.14.0" }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-dos"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -17,23 +17,23 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 serde = "1.0.138"
-solana-bench-tps = { path = "../bench-tps", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-bench-tps = { path = "../bench-tps", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.11.11" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-dos"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -17,23 +17,23 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 serde = "1.0.138"
-solana-bench-tps = { path = "../bench-tps", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-bench-tps = { path = "../bench-tps", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-download-utils"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Download Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ console = "0.15.0"
 indicatif = "0.16.2"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-download-utils"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Download Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ console = "0.15.0"
 indicatif = "0.16.2"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-download-utils"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Download Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ console = "0.15.0"
 indicatif = "0.16.2"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-entry"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Entry"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,16 +19,16 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-entry"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Entry"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,16 +19,16 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-entry"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Entry"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,16 +19,16 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-merkle-tree = { path = "../merkle-tree", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-faucet"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Faucet"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,12 +17,12 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-faucet"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Faucet"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,12 +17,12 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-faucet"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Faucet"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,12 +17,12 @@ crossbeam-channel = "0.5"
 log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Frozen ABI"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.2"
-solana-frozen-abi-macro = { path = "macro", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "macro", version = "=1.13.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -43,7 +43,7 @@ rand_core = { version = "0.6.3", features = ["alloc", "getrandom", "std"] }
 subtle = { version = "2.4.1", features = ["default", "i128", "std"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Frozen ABI"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.2"
-solana-frozen-abi-macro = { path = "macro", version = "=1.11.11" }
+solana-frozen-abi-macro = { path = "macro", version = "=1.12.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -43,7 +43,7 @@ rand_core = { version = "0.6.3", features = ["alloc", "getrandom", "std"] }
 subtle = { version = "2.4.1", features = ["default", "i128", "std"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Frozen ABI"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.2"
-solana-frozen-abi-macro = { path = "macro", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "macro", version = "=1.14.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -43,7 +43,7 @@ rand_core = { version = "0.6.3", features = ["alloc", "getrandom", "std"] }
 subtle = { version = "2.4.1", features = ["default", "i128", "std"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi-macro"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Frozen ABI Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi-macro"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Frozen ABI Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-frozen-abi-macro"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Frozen ABI Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-genesis-utils"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Genesis Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/solana-download-utils"
 edition = "2021"
 
 [dependencies]
-solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-genesis-utils"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Genesis Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/solana-download-utils"
 edition = "2021"
 
 [dependencies]
-solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-genesis-utils"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Genesis Utils"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/solana-download-utils"
 edition = "2021"
 
 [dependencies]
-solana-download-utils = { path = "../download-utils", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-genesis"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,16 +15,16 @@ clap = "2.33.1"
 serde = "1.0.138"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-genesis"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,16 +15,16 @@ clap = "2.33.1"
 serde = "1.0.138"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-genesis"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -15,16 +15,16 @@ clap = "2.33.1"
 serde = "1.0.138"
 serde_json = "1.0.81"
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 tempfile = "3.3.0"
 
 [[bin]]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-interface"
 description = "The Solana Geyser plugin interface."
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/solana-geyser-plugin-interface"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-interface"
 description = "The Solana Geyser plugin interface."
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/solana-geyser-plugin-interface"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-interface"
 description = "The Solana Geyser plugin interface."
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/solana-geyser-plugin-interface"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-manager"
 description = "The Solana Geyser plugin manager."
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,13 +16,13 @@ json5 = "0.4.1"
 libloading = "0.7.3"
 log = "0.4.17"
 serde_json = "1.0.81"
-solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-manager"
 description = "The Solana Geyser plugin manager."
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,13 +16,13 @@ json5 = "0.4.1"
 libloading = "0.7.3"
 log = "0.4.17"
 serde_json = "1.0.81"
-solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
+solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-manager"
 description = "The Solana Geyser plugin manager."
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,13 +16,13 @@ json5 = "0.4.1"
 libloading = "0.7.3"
 log = "0.4.17"
 serde_json = "1.0.81"
-solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-geyser-plugin-interface = { path = "../geyser-plugin-interface", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
 thiserror = "1.0.31"
 
 [package.metadata.docs.rs]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-gossip"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,24 +27,24 @@ rayon = "1.5.3"
 serde = "1.0.138"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
-solana-bloom = { path = "../bloom", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-bloom = { path = "../bloom", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-gossip"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,24 +27,24 @@ rayon = "1.5.3"
 serde = "1.0.138"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
-solana-bloom = { path = "../bloom", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-bloom = { path = "../bloom", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-gossip"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -27,24 +27,24 @@ rayon = "1.5.3"
 serde = "1.0.138"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
-solana-bloom = { path = "../bloom", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-bloom = { path = "../bloom", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-install"
 description = "The solana cluster software installer"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -26,12 +26,12 @@ reqwest = { version = "0.11.11", default-features = false, features = ["blocking
 semver = "1.0.10"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-config-program = { path = "../programs/config", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-config-program = { path = "../programs/config", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 tar = "0.4.38"
 tempfile = "3.3.0"
 url = "2.2.2"

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-install"
 description = "The solana cluster software installer"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -26,12 +26,12 @@ reqwest = { version = "0.11.11", default-features = false, features = ["blocking
 semver = "1.0.10"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-config-program = { path = "../programs/config", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-config-program = { path = "../programs/config", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 tar = "0.4.38"
 tempfile = "3.3.0"
 url = "2.2.2"

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-install"
 description = "The solana cluster software installer"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -26,12 +26,12 @@ reqwest = { version = "0.11.11", default-features = false, features = ["blocking
 semver = "1.0.10"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_yaml = "0.8.26"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-config-program = { path = "../programs/config", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-config-program = { path = "../programs/config", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 tar = "0.4.38"
 tempfile = "3.3.0"
 url = "2.2.2"

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-keygen"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana key generation utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bs58 = "0.4.0"
 clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = "2.0.0"
 num_cpus = "1.13.1"
-solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 tiny-bip39 = "0.8.2"
 
 [[bin]]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-keygen"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana key generation utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bs58 = "0.4.0"
 clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = "2.0.0"
 num_cpus = "1.13.1"
-solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 tiny-bip39 = "0.8.2"
 
 [[bin]]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-keygen"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana key generation utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bs58 = "0.4.0"
 clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = "2.0.0"
 num_cpus = "1.13.1"
-solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 tiny-bip39 = "0.8.2"
 
 [[bin]]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-ledger-tool"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -22,20 +22,20 @@ log = { version = "0.4.17" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-ledger-tool"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -22,20 +22,20 @@ log = { version = "0.4.17" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-ledger-tool"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -22,20 +22,20 @@ log = { version = "0.4.17" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-output = { path = "../cli-output", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ledger"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana ledger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -34,23 +34,23 @@ reed-solomon-erasure = { version = "5.0.3", features = ["simd-accel"] }
 serde = "1.0.138"
 serde_bytes = "0.11.6"
 sha2 = "0.10.2"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.11" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
@@ -71,8 +71,8 @@ features = ["lz4"]
 assert_matches = "1.5.0"
 bs58 = "0.4.0"
 matches = "0.1.9"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ledger"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana ledger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -34,23 +34,23 @@ reed-solomon-erasure = { version = "5.0.3", features = ["simd-accel"] }
 serde = "1.0.138"
 serde_bytes = "0.11.6"
 sha2 = "0.10.2"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
@@ -71,8 +71,8 @@ features = ["lz4"]
 assert_matches = "1.5.0"
 bs58 = "0.4.0"
 matches = "0.1.9"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ledger"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana ledger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -34,23 +34,23 @@ reed-solomon-erasure = { version = "5.0.3", features = ["simd-accel"] }
 serde = "1.0.138"
 serde_bytes = "0.11.6"
 sha2 = "0.10.2"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.14.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
@@ -71,8 +71,8 @@ features = ["lz4"]
 assert_matches = "1.5.0"
 bs58 = "0.4.0"
 matches = "0.1.9"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-local-cluster"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,25 +16,25 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-config-program = { path = "../programs/config", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-config-program = { path = "../programs/config", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 gag = "1.0.0"
 serial_test = "0.8.0"
-solana-download-utils = { path = "../download-utils", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-local-cluster"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,25 +16,25 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-config-program = { path = "../programs/config", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-config-program = { path = "../programs/config", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 gag = "1.0.0"
 serial_test = "0.8.0"
-solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-local-cluster"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -16,25 +16,25 @@ itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-config-program = { path = "../programs/config", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-config-program = { path = "../programs/config", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 tempfile = "3.3.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 gag = "1.0.0"
 serial_test = "0.8.0"
-solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2021"
 name = "solana-log-analyzer"
 description = "The solana cluster network analysis tool"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ byte-unit = "4.0.14"
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [[bin]]
 name = "solana-log-analyzer"

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2021"
 name = "solana-log-analyzer"
 description = "The solana cluster network analysis tool"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ byte-unit = "4.0.14"
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [[bin]]
 name = "solana-log-analyzer"

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2021"
 name = "solana-log-analyzer"
 description = "The solana cluster network analysis tool"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ byte-unit = "4.0.14"
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [[bin]]
 name = "solana-log-analyzer"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-logger"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Logger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-logger"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Logger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-logger"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Logger"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-measure"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-measure"
 readme = "../README.md"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-measure"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-measure"
 readme = "../README.md"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-measure"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-measure"
 readme = "../README.md"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/merkle-root-bench/Cargo.toml
+++ b/merkle-root-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-merkle-root-bench"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/merkle-root-bench/Cargo.toml
+++ b/merkle-root-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-merkle-root-bench"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/merkle-root-bench/Cargo.toml
+++ b/merkle-root-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-merkle-root-bench"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-merkle-tree"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 fast-math = "0.1"
-solana-program = { path = "../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../sdk/program", version = "=1.14.0" }
 
 # This can go once the BPF toolchain target Rust 1.42.0+
 [target.bpfel-unknown-unknown.dependencies]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-merkle-tree"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 fast-math = "0.1"
-solana-program = { path = "../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../sdk/program", version = "=1.12.0" }
 
 # This can go once the BPF toolchain target Rust 1.42.0+
 [target.bpfel-unknown-unknown.dependencies]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-merkle-tree"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 fast-math = "0.1"
-solana-program = { path = "../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../sdk/program", version = "=1.13.0" }
 
 # This can go once the BPF toolchain target Rust 1.42.0+
 [target.bpfel-unknown-unknown.dependencies]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-metrics"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Metrics"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ gethostname = "0.2.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-metrics"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Metrics"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ gethostname = "0.2.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-metrics"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Metrics"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ gethostname = "0.2.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-net-shaper"
 description = "The solana cluster network shaping tool"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,7 +14,7 @@ clap = { version = "3.1.5", features = ["cargo"] }
 rand = "0.7.0"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [[bin]]
 name = "solana-net-shaper"

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-net-shaper"
 description = "The solana cluster network shaping tool"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,7 +14,7 @@ clap = { version = "3.1.5", features = ["cargo"] }
 rand = "0.7.0"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [[bin]]
 name = "solana-net-shaper"

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-net-shaper"
 description = "The solana cluster network shaping tool"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,7 +14,7 @@ clap = { version = "3.1.5", features = ["cargo"] }
 rand = "0.7.0"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.81"
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [[bin]]
 name = "solana-net-shaper"

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-net-utils"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Network Utilities"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ rand = "0.7.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 socket2 = "0.4.4"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 tokio = { version = "1", features = ["full"] }
 url = "2.2.2"
 

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-net-utils"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Network Utilities"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ rand = "0.7.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 socket2 = "0.4.4"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 tokio = { version = "1", features = ["full"] }
 url = "2.2.2"
 

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-net-utils"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Network Utilities"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,9 +19,9 @@ rand = "0.7.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 socket2 = "0.4.4"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 tokio = { version = "1", features = ["full"] }
 url = "2.2.2"
 

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-notifier"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Notifier"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-notifier"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Notifier"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-notifier"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Notifier"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-perf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Performance APIs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -22,10 +22,10 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 
 [target."cfg(target_os = \"linux\")".dependencies]
 caps = "0.5.3"
@@ -37,7 +37,7 @@ name = "solana_perf"
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [[bench]]
 name = "sigverify"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-perf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Performance APIs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -22,10 +22,10 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 
 [target."cfg(target_os = \"linux\")".dependencies]
 caps = "0.5.3"
@@ -37,7 +37,7 @@ name = "solana_perf"
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [[bench]]
 name = "sigverify"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-perf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Performance APIs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -22,10 +22,10 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.138"
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 
 [target."cfg(target_os = \"linux\")".dependencies]
 caps = "0.5.3"
@@ -37,7 +37,7 @@ name = "solana_perf"
 
 [dev-dependencies]
 matches = "0.1.9"
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [[bench]]
 name = "sigverify"

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-poh-bench"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,12 +14,12 @@ clap = { version = "3.1.5", features = ["cargo"] }
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-poh-bench"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,12 +14,12 @@ clap = { version = "3.1.5", features = ["cargo"] }
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-poh-bench"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,12 +14,12 @@ clap = { version = "3.1.5", features = ["cargo"] }
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-poh"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana PoH"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,21 +13,21 @@ edition = "2021"
 core_affinity = "0.5.10"
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-sys-tuner = { path = "../sys-tuner", version = "=1.11.11" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sys-tuner = { path = "../sys-tuner", version = "=1.12.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
 matches = "0.1.9"
 rand = "0.7.0"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-poh"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana PoH"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,21 +13,21 @@ edition = "2021"
 core_affinity = "0.5.10"
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-sys-tuner = { path = "../sys-tuner", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sys-tuner = { path = "../sys-tuner", version = "=1.13.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
 matches = "0.1.9"
 rand = "0.7.0"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-poh"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana PoH"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,21 +13,21 @@ edition = "2021"
 core_affinity = "0.5.10"
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-sys-tuner = { path = "../sys-tuner", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-sys-tuner = { path = "../sys-tuner", version = "=1.14.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
 matches = "0.1.9"
 rand = "0.7.0"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program-runtime"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana program runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,16 +20,16 @@ log = "0.4.14"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 serde = { version = "1.0.129", features = ["derive", "rc"] }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 thiserror = "1.0"
 enum-iterator = "0.8.1"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program-runtime"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana program runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,16 +20,16 @@ log = "0.4.14"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 serde = { version = "1.0.129", features = ["derive", "rc"] }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0"
 enum-iterator = "0.8.1"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program-runtime"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana program runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,16 +20,16 @@ log = "0.4.14"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 serde = { version = "1.0.129", features = ["derive", "rc"] }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 thiserror = "1.0"
 enum-iterator = "0.8.1"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "solana-program-test"
 repository = "https://github.com/solana-labs/solana"
-version = "1.11.11"
+version = "1.12.0"
 
 [dependencies]
 assert_matches = "1.5.0"
@@ -15,13 +15,13 @@ bincode = "1.3.3"
 chrono-humanize = "0.2.1"
 log = "0.4.17"
 serde = "1.0.138"
-solana-banks-client = { path = "../banks-client", version = "=1.11.11" }
-solana-banks-server = { path = "../banks-server", version = "=1.11.11" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-banks-client = { path = "../banks-client", version = "=1.12.0" }
+solana-banks-server = { path = "../banks-server", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "solana-program-test"
 repository = "https://github.com/solana-labs/solana"
-version = "1.12.0"
+version = "1.13.0"
 
 [dependencies]
 assert_matches = "1.5.0"
@@ -15,13 +15,13 @@ bincode = "1.3.3"
 chrono-humanize = "0.2.1"
 log = "0.4.17"
 serde = "1.0.138"
-solana-banks-client = { path = "../banks-client", version = "=1.12.0" }
-solana-banks-server = { path = "../banks-server", version = "=1.12.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-banks-client = { path = "../banks-client", version = "=1.13.0" }
+solana-banks-server = { path = "../banks-server", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "solana-program-test"
 repository = "https://github.com/solana-labs/solana"
-version = "1.13.0"
+version = "1.14.0"
 
 [dependencies]
 assert_matches = "1.5.0"
@@ -15,13 +15,13 @@ bincode = "1.3.3"
 chrono-humanize = "0.2.1"
 log = "0.4.17"
 serde = "1.0.138"
-solana-banks-client = { path = "../banks-client", version = "=1.13.0" }
-solana-banks-server = { path = "../banks-server", version = "=1.13.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-banks-client = { path = "../banks-client", version = "=1.14.0" }
+solana-banks-server = { path = "../banks-server", version = "=1.14.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/programs/address-lookup-table-tests/Cargo.toml
+++ b/programs/address-lookup-table-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-address-lookup-table-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.12.0" }
-solana-program-test = { path = "../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.13.0" }
+solana-program-test = { path = "../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/address-lookup-table-tests/Cargo.toml
+++ b/programs/address-lookup-table-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-address-lookup-table-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.13.0" }
-solana-program-test = { path = "../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.14.0" }
+solana-program-test = { path = "../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/address-lookup-table-tests/Cargo.toml
+++ b/programs/address-lookup-table-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-address-lookup-table-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.11.11" }
-solana-program-test = { path = "../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-address-lookup-table-program = { path = "../address-lookup-table", version = "=1.12.0" }
+solana-program-test = { path = "../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-address-lookup-table-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana address lookup table program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,14 +16,14 @@ log = "0.4.17"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0.138", features = ["derive"] }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
-solana-program = { path = "../../sdk/program", version = "=1.12.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
+solana-program = { path = "../../sdk/program", version = "=1.13.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-address-lookup-table-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana address lookup table program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,14 +16,14 @@ log = "0.4.17"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0.138", features = ["derive"] }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
-solana-program = { path = "../../sdk/program", version = "=1.13.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.14.0" }
+solana-program = { path = "../../sdk/program", version = "=1.14.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-address-lookup-table-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana address lookup table program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,14 +16,14 @@ log = "0.4.17"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0.138", features = ["derive"] }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.11.11" }
-solana-program = { path = "../../sdk/program", version = "=1.11.11" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
+solana-program = { path = "../../sdk/program", version = "=1.12.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-loader-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.13.0" }
-solana-program-test = { path = "../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.14.0" }
+solana-program-test = { path = "../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-loader-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.11.11" }
-solana-program-test = { path = "../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.12.0" }
+solana-program-test = { path = "../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-loader-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -14,9 +14,9 @@ publish = false
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.12.0" }
-solana-program-test = { path = "../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.13.0" }
+solana-program-test = { path = "../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4074,7 +4074,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4093,23 +4093,23 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-program 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-program 1.13.0",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
- "solana-program 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-program 1.13.0",
+ "solana-sdk 1.13.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4118,16 +4118,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "serde",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4135,7 +4135,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4155,14 +4155,14 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4171,15 +4171,15 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
- "solana-zk-token-sdk 1.12.0",
+ "solana-sdk 1.13.0",
+ "solana-zk-token-sdk 1.13.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-programs"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4195,11 +4195,11 @@ dependencies = [
  "solana-bpf-rust-realloc-invoke",
  "solana-cli-output",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "solana_rbpf",
  "walkdir",
@@ -4207,385 +4207,385 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-128bit"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-128bit-dep",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-alloc"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-call-depth"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-caller-access"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-curve25519"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
- "solana-zk-token-sdk 1.12.0",
+ "solana-program 1.13.0",
+ "solana-zk-token-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-custom-heap"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dep-crate"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "byteorder 1.4.3",
  "solana-address-lookup-table-program",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-error-handling"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "num-derive",
  "num-traits",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-rust-external-spend"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-finalize"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-invoked",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoked"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-iter"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-log-data"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-many-args-dep",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-mem"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-membuiltins"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-mem",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-noop"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-panic"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-param-passing-dep",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-rand"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "getrandom 0.1.14",
  "rand 0.7.3",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-bpf-rust-realloc",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-modify"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sanity"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "libsecp256k1 0.7.0",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sha"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "blake3",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-simulation"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-logger 1.12.0",
- "solana-program 1.12.0",
+ "solana-logger 1.13.0",
+ "solana-program 1.13.0",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-validator",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sysvar"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgradeable"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgraded"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
  "memmap2",
  "modular-bitfield",
  "rand 0.7.3",
  "solana-measure",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
  "tiny-bip39",
  "uriparse",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4602,13 +4602,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4685,27 +4685,27 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -4733,8 +4733,8 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -4747,7 +4747,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-streamer",
  "solana-transaction-status",
@@ -4763,19 +4763,19 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4791,12 +4791,12 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4807,9 +4807,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -4865,7 +4865,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi-macro 1.13.0",
  "subtle",
  "thiserror",
 ]
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -4894,26 +4894,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -4926,14 +4926,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bv",
@@ -4957,17 +4957,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -5007,15 +5007,15 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5053,36 +5053,36 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "fast-math",
  "matches",
- "solana-program 1.12.0",
+ "solana-program 1.13.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "clap 3.1.6",
@@ -5093,8 +5093,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-logger 1.13.0",
+ "solana-sdk 1.13.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5121,13 +5121,13 @@ dependencies = [
  "serde",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5137,7 +5137,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-sys-tuner",
  "thiserror",
 ]
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5222,9 +5222,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-sdk-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-sdk-macro 1.13.0",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5247,17 +5247,17 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5269,10 +5269,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5298,14 +5298,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5338,7 +5338,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5392,17 +5392,17 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.12.0",
+ "solana-zk-token-sdk 1.13.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5502,11 +5502,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-logger 1.12.0",
- "solana-program 1.12.0",
- "solana-sdk-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-logger 1.13.0",
+ "solana-program 1.13.0",
+ "solana-sdk-macro 1.13.0",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5546,12 +5546,12 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "log",
@@ -5561,18 +5561,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -5593,7 +5593,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5612,14 +5612,14 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5638,7 +5638,7 @@ dependencies = [
  "rustls 0.20.6",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -5646,13 +5646,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -5672,20 +5672,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -5700,7 +5700,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -5742,14 +5742,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.12.0",
+ "solana-logger 1.13.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -5762,21 +5762,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "log",
  "rustc_version",
  "semver",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
+ "solana-sdk 1.13.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "log",
@@ -5785,25 +5785,25 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.12.0",
- "solana-frozen-abi-macro 1.12.0",
+ "solana-frozen-abi 1.13.0",
+ "solana-frozen-abi-macro 1.13.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
+ "solana-sdk 1.13.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.14",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.12.0",
- "solana-zk-token-sdk 1.12.0",
+ "solana-sdk 1.13.0",
+ "solana-zk-token-sdk 1.13.0",
 ]
 
 [[package]]
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5858,8 +5858,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.12.0",
- "solana-sdk 1.12.0",
+ "solana-program 1.13.0",
+ "solana-sdk 1.13.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4074,7 +4074,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4093,23 +4093,23 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-program 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-program 1.12.0",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
- "solana-program 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-program 1.12.0",
+ "solana-sdk 1.12.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4118,16 +4118,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "serde",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4135,7 +4135,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4155,14 +4155,14 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4171,15 +4171,15 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
- "solana-zk-token-sdk 1.11.11",
+ "solana-sdk 1.12.0",
+ "solana-zk-token-sdk 1.12.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-programs"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4195,11 +4195,11 @@ dependencies = [
  "solana-bpf-rust-realloc-invoke",
  "solana-cli-output",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "solana_rbpf",
  "walkdir",
@@ -4207,385 +4207,385 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-128bit"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-128bit-dep",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-alloc"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-call-depth"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-caller-access"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-curve25519"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
- "solana-zk-token-sdk 1.11.11",
+ "solana-program 1.12.0",
+ "solana-zk-token-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-custom-heap"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dep-crate"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "byteorder 1.4.3",
  "solana-address-lookup-table-program",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-error-handling"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "num-derive",
  "num-traits",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-rust-external-spend"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-finalize"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-invoked",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoked"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-iter"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-log-data"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-many-args-dep",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-mem"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-membuiltins"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-mem",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-noop"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-panic"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-param-passing-dep",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-rand"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "getrandom 0.1.14",
  "rand 0.7.3",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-bpf-rust-realloc",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-modify"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sanity"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "libsecp256k1 0.7.0",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sha"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "blake3",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-simulation"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-logger 1.11.11",
- "solana-program 1.11.11",
+ "solana-logger 1.12.0",
+ "solana-program 1.12.0",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-validator",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sysvar"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgradeable"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgraded"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
  "memmap2",
  "modular-bitfield",
  "rand 0.7.3",
  "solana-measure",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
  "tiny-bip39",
  "uriparse",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4602,13 +4602,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4685,27 +4685,27 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -4733,8 +4733,8 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -4747,7 +4747,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-streamer",
  "solana-transaction-status",
@@ -4763,19 +4763,19 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4791,12 +4791,12 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4807,9 +4807,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -4865,7 +4865,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi-macro 1.12.0",
  "subtle",
  "thiserror",
 ]
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -4894,26 +4894,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -4926,14 +4926,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bv",
@@ -4957,17 +4957,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -5007,15 +5007,15 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5053,36 +5053,36 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "fast-math",
  "matches",
- "solana-program 1.11.11",
+ "solana-program 1.12.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "clap 3.1.6",
@@ -5093,8 +5093,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-logger 1.12.0",
+ "solana-sdk 1.12.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5121,13 +5121,13 @@ dependencies = [
  "serde",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5137,7 +5137,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-sys-tuner",
  "thiserror",
 ]
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5222,9 +5222,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-sdk-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-sdk-macro 1.12.0",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5247,17 +5247,17 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5269,10 +5269,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5298,14 +5298,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5338,7 +5338,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5392,17 +5392,17 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.11.11",
+ "solana-zk-token-sdk 1.12.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5502,11 +5502,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-logger 1.11.11",
- "solana-program 1.11.11",
- "solana-sdk-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-logger 1.12.0",
+ "solana-program 1.12.0",
+ "solana-sdk-macro 1.12.0",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5546,12 +5546,12 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "log",
@@ -5561,18 +5561,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -5593,7 +5593,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5612,14 +5612,14 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5638,7 +5638,7 @@ dependencies = [
  "rustls 0.20.6",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -5646,13 +5646,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -5672,20 +5672,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -5700,7 +5700,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -5742,14 +5742,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.11.11",
+ "solana-logger 1.12.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -5762,21 +5762,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "log",
  "rustc_version",
  "semver",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
+ "solana-sdk 1.12.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "log",
@@ -5785,25 +5785,25 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.11.11",
- "solana-frozen-abi-macro 1.11.11",
+ "solana-frozen-abi 1.12.0",
+ "solana-frozen-abi-macro 1.12.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
+ "solana-sdk 1.12.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.14",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.11.11",
- "solana-zk-token-sdk 1.11.11",
+ "solana-sdk 1.12.0",
+ "solana-zk-token-sdk 1.12.0",
 ]
 
 [[package]]
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5858,8 +5858,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.11.11",
- "solana-sdk 1.11.11",
+ "solana-program 1.12.0",
+ "solana-sdk 1.12.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4074,7 +4074,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "spl-token",
  "spl-token-2022",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4093,23 +4093,23 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-program 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-program 1.14.0",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "borsh",
  "futures 0.3.21",
  "solana-banks-interface",
- "solana-program 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-program 1.14.0",
+ "solana-sdk 1.14.0",
  "tarpc",
  "thiserror",
  "tokio",
@@ -4118,16 +4118,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "serde",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4135,7 +4135,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-client",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bv",
  "fnv",
@@ -4155,14 +4155,14 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4171,15 +4171,15 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
- "solana-zk-token-sdk 1.13.0",
+ "solana-sdk 1.14.0",
+ "solana-zk-token-sdk 1.14.0",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-programs"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4195,11 +4195,11 @@ dependencies = [
  "solana-bpf-rust-realloc-invoke",
  "solana-cli-output",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "solana_rbpf",
  "walkdir",
@@ -4207,385 +4207,385 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-128bit"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-128bit-dep",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-alloc"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-call-depth"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-caller-access"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-curve25519"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
- "solana-zk-token-sdk 1.13.0",
+ "solana-program 1.14.0",
+ "solana-zk-token-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-custom-heap"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dep-crate"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "byteorder 1.4.3",
  "solana-address-lookup-table-program",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-error-handling"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "num-derive",
  "num-traits",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bpf-rust-external-spend"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-finalize"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-invoked",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoked"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-iter"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-log-data"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-many-args-dep",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-mem"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-membuiltins"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-mem",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-noop"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-panic"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-param-passing-dep",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-rand"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "getrandom 0.1.14",
  "rand 0.7.3",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-bpf-rust-realloc",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-ro-modify"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sanity"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "libsecp256k1 0.7.0",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sha"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "blake3",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-simulation"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-logger 1.13.0",
- "solana-program 1.13.0",
+ "solana-logger 1.14.0",
+ "solana-program 1.14.0",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-validator",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-sysvar"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
  "solana-program-runtime",
  "solana-program-test",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgradeable"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-upgraded"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
  "memmap2",
  "modular-bitfield",
  "rand 0.7.3",
  "solana-measure",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
  "tiny-bip39",
  "uriparse",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4602,13 +4602,13 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4625,7 +4625,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "solana-vote-program",
  "spl-memo",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
@@ -4685,27 +4685,27 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -4733,8 +4733,8 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -4747,7 +4747,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-streamer",
  "solana-transaction-status",
@@ -4763,19 +4763,19 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "console",
  "indicatif",
  "log",
  "reqwest",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4791,12 +4791,12 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4807,9 +4807,9 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "spl-memo",
  "thiserror",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -4865,7 +4865,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi-macro 1.14.0",
  "subtle",
  "thiserror",
 ]
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -4894,26 +4894,26 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -4926,14 +4926,14 @@ dependencies = [
  "solana-metrics",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bv",
@@ -4957,17 +4957,17 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "solana-version",
  "solana-vote-program",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -5007,15 +5007,15 @@ dependencies = [
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5053,36 +5053,36 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "fast-math",
  "matches",
- "solana-program 1.13.0",
+ "solana-program 1.14.0",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "clap 3.1.6",
@@ -5093,8 +5093,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-logger 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-logger 1.14.0",
+ "solana-sdk 1.14.0",
  "solana-version",
  "tokio",
  "url 2.2.2",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -5121,13 +5121,13 @@ dependencies = [
  "serde",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5137,7 +5137,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-sys-tuner",
  "thiserror",
 ]
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5222,9 +5222,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-sdk-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-sdk-macro 1.14.0",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5247,17 +5247,17 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5269,10 +5269,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "thiserror",
  "tokio",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -5298,14 +5298,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5338,7 +5338,7 @@ dependencies = [
  "solana-poh",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5392,17 +5392,17 @@ dependencies = [
  "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-measure",
  "solana-metrics",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-stake-program",
  "solana-vote-program",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 1.13.0",
+ "solana-zk-token-sdk 1.14.0",
  "strum",
  "strum_macros",
  "symlink",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5502,11 +5502,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-logger 1.13.0",
- "solana-program 1.13.0",
- "solana-sdk-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-logger 1.14.0",
+ "solana-program 1.14.0",
+ "solana-sdk-macro 1.14.0",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5546,12 +5546,12 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "log",
@@ -5561,18 +5561,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -5593,7 +5593,7 @@ dependencies = [
  "serde_derive",
  "smpl_jwt",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-storage-proto",
  "solana-transaction-status",
  "thiserror",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -5612,14 +5612,14 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-transaction-status",
  "tonic-build 0.8.0",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5638,7 +5638,7 @@ dependencies = [
  "rustls 0.20.6",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -5646,13 +5646,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
  "nix",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-version",
  "sysctl",
  "unix_socket2",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -5672,20 +5672,20 @@ dependencies = [
  "solana-core",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-net-utils",
  "solana-program-runtime",
  "solana-program-test",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-streamer",
  "tokio",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -5700,7 +5700,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -5742,14 +5742,14 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-ledger",
- "solana-logger 1.13.0",
+ "solana-logger 1.14.0",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-rpc",
  "solana-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
@@ -5762,21 +5762,21 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "log",
  "rustc_version",
  "semver",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
+ "solana-sdk 1.14.0",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bincode",
  "log",
@@ -5785,25 +5785,25 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.13.0",
- "solana-frozen-abi-macro 1.13.0",
+ "solana-frozen-abi 1.14.0",
+ "solana-frozen-abi-macro 1.14.0",
  "solana-metrics",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
+ "solana-sdk 1.14.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.14",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
- "solana-sdk 1.13.0",
- "solana-zk-token-sdk 1.13.0",
+ "solana-sdk 1.14.0",
+ "solana-zk-token-sdk 1.14.0",
 ]
 
 [[package]]
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5858,8 +5858,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.13.0",
- "solana-sdk 1.13.0",
+ "solana-program 1.14.0",
+ "solana-sdk 1.14.0",
  "subtle",
  "thiserror",
  "zeroize",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-bpf-programs"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 documentation = "https://docs.rs/solana"
 homepage = "https://solana.com/"
 readme = "README.md"
@@ -26,22 +26,22 @@ itertools = "0.10.1"
 log = "0.4.11"
 miow = "0.3.6"
 net2 = "0.2.37"
-solana-account-decoder = { path = "../../account-decoder", version = "=1.13.0" }
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.13.0" }
-solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.13.0" }
-solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.13.0" }
-solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.13.0" }
-solana-cli-output = { path = "../../cli-output", version = "=1.13.0" }
-solana-logger = { path = "../../logger", version = "=1.13.0" }
-solana-measure = { path = "../../measure", version = "=1.13.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-runtime = { path = "../../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../../transaction-status", version = "=1.13.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.14.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.14.0" }
+solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.14.0" }
+solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.14.0" }
+solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.14.0" }
+solana-cli-output = { path = "../../cli-output", version = "=1.14.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
+solana-measure = { path = "../../measure", version = "=1.14.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-runtime = { path = "../../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../../transaction-status", version = "=1.14.0" }
 solana_rbpf = "=0.2.31"
 
 [dev-dependencies]
-solana-ledger = { path = "../../ledger", version = "=1.13.0" }
+solana-ledger = { path = "../../ledger", version = "=1.14.0" }
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-bpf-programs"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 documentation = "https://docs.rs/solana"
 homepage = "https://solana.com/"
 readme = "README.md"
@@ -26,22 +26,22 @@ itertools = "0.10.1"
 log = "0.4.11"
 miow = "0.3.6"
 net2 = "0.2.37"
-solana-account-decoder = { path = "../../account-decoder", version = "=1.12.0" }
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.12.0" }
-solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.12.0" }
-solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.12.0" }
-solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.12.0" }
-solana-cli-output = { path = "../../cli-output", version = "=1.12.0" }
-solana-logger = { path = "../../logger", version = "=1.12.0" }
-solana-measure = { path = "../../measure", version = "=1.12.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-runtime = { path = "../../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../../transaction-status", version = "=1.12.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.13.0" }
+solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.13.0" }
+solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.13.0" }
+solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.13.0" }
+solana-cli-output = { path = "../../cli-output", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-measure = { path = "../../measure", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-runtime = { path = "../../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../../transaction-status", version = "=1.13.0" }
 solana_rbpf = "=0.2.31"
 
 [dev-dependencies]
-solana-ledger = { path = "../../ledger", version = "=1.12.0" }
+solana-ledger = { path = "../../ledger", version = "=1.13.0" }
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-bpf-programs"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 documentation = "https://docs.rs/solana"
 homepage = "https://solana.com/"
 readme = "README.md"
@@ -26,22 +26,22 @@ itertools = "0.10.1"
 log = "0.4.11"
 miow = "0.3.6"
 net2 = "0.2.37"
-solana-account-decoder = { path = "../../account-decoder", version = "=1.11.11" }
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.11.11" }
-solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.11.11" }
-solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.11.11" }
-solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.11.11" }
-solana-cli-output = { path = "../../cli-output", version = "=1.11.11" }
-solana-logger = { path = "../../logger", version = "=1.11.11" }
-solana-measure = { path = "../../measure", version = "=1.11.11" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-runtime = { path = "../../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../../transaction-status", version = "=1.11.11" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.12.0" }
+solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.12.0" }
+solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.12.0" }
+solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.12.0" }
+solana-cli-output = { path = "../../cli-output", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-measure = { path = "../../measure", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-runtime = { path = "../../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../../transaction-status", version = "=1.12.0" }
 solana_rbpf = "=0.2.31"
 
 [dev-dependencies]
-solana-ledger = { path = "../../ledger", version = "=1.11.11" }
+solana-ledger = { path = "../../ledger", version = "=1.12.0" }
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.11.11" }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.13.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.14.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.12.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/128bit_dep/Cargo.toml
+++ b/programs/bpf/rust/128bit_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/128bit_dep/Cargo.toml
+++ b/programs/bpf/rust/128bit_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/128bit_dep/Cargo.toml
+++ b/programs/bpf/rust/128bit_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-128bit-dep"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-alloc"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-alloc"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-alloc"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-alloc"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-alloc"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-alloc"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/call_depth/Cargo.toml
+++ b/programs/bpf/rust/call_depth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-call-depth"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-call-depth"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/call_depth/Cargo.toml
+++ b/programs/bpf/rust/call_depth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-call-depth"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-call-depth"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/call_depth/Cargo.toml
+++ b/programs/bpf/rust/call_depth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-call-depth"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-call-depth"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/caller_access/Cargo.toml
+++ b/programs/bpf/rust/caller_access/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-caller-access"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-caller-access"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/caller_access/Cargo.toml
+++ b/programs/bpf/rust/caller_access/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-caller-access"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-caller-access"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/caller_access/Cargo.toml
+++ b/programs/bpf/rust/caller_access/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-caller-access"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-caller-access"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/curve25519/Cargo.toml
+++ b/programs/bpf/rust/curve25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-curve25519"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
-solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
+solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/curve25519/Cargo.toml
+++ b/programs/bpf/rust/curve25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-curve25519"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
-solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/curve25519/Cargo.toml
+++ b/programs/bpf/rust/curve25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-curve25519"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
-solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/custom_heap/Cargo.toml
+++ b/programs/bpf/rust/custom_heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-custom-heap"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-custom-heap"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [features]
 default = ["custom-heap"]

--- a/programs/bpf/rust/custom_heap/Cargo.toml
+++ b/programs/bpf/rust/custom_heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-custom-heap"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-custom-heap"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [features]
 default = ["custom-heap"]

--- a/programs/bpf/rust/custom_heap/Cargo.toml
+++ b/programs/bpf/rust/custom_heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-custom-heap"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-custom-heap"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [features]
 default = ["custom-heap"]

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dep-crate"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,8 +12,8 @@ edition = "2021"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 # list of crates which must be buildable for bpf programs
-solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.13.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.14.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dep-crate"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,8 +12,8 @@ edition = "2021"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 # list of crates which must be buildable for bpf programs
-solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.12.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dep-crate"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,8 +12,8 @@ edition = "2021"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 # list of crates which must be buildable for bpf programs
-solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.11.11" }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/deprecated_loader/Cargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-deprecated-loader"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/deprecated_loader/Cargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-deprecated-loader"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/deprecated_loader/Cargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-deprecated-loader"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-deprecated-loader"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dup_accounts/Cargo.toml
+++ b/programs/bpf/rust/dup_accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-dup-accounts"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dup_accounts/Cargo.toml
+++ b/programs/bpf/rust/dup_accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-dup-accounts"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dup_accounts/Cargo.toml
+++ b/programs/bpf/rust/dup_accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-dup-accounts"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-dup-accounts"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/error_handling/Cargo.toml
+++ b/programs/bpf/rust/error_handling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-error-handling"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 thiserror = "1.0"
 
 [lib]

--- a/programs/bpf/rust/error_handling/Cargo.toml
+++ b/programs/bpf/rust/error_handling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-error-handling"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 thiserror = "1.0"
 
 [lib]

--- a/programs/bpf/rust/error_handling/Cargo.toml
+++ b/programs/bpf/rust/error_handling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-error-handling"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 thiserror = "1.0"
 
 [lib]

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-external-spend"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-external-spend"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-external-spend"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-external-spend"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-external-spend"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-external-spend"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/finalize/Cargo.toml
+++ b/programs/bpf/rust/finalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-finalize"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-finalize"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/finalize/Cargo.toml
+++ b/programs/bpf/rust/finalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-finalize"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-finalize"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/finalize/Cargo.toml
+++ b/programs/bpf/rust/finalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-finalize"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-finalize"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/bpf/rust/get_minimum_delegation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-get-minimum-delegation"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/bpf/rust/get_minimum_delegation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-get-minimum-delegation"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/bpf/rust/get_minimum_delegation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-get-minimum-delegation"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-get-minimum-delegation"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-inner_instruction_alignment_che
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-inner_instruction_alignment_che
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-inner_instruction_alignment_check"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-inner_instruction_alignment_che
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/instruction_introspection/Cargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-instruction-introspection"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/instruction_introspection/Cargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-instruction-introspection"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/instruction_introspection/Cargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-instruction-introspection"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-instruction-introspection"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ program = []
 
 [dependencies]
 solana-bpf-rust-invoked = { path = "../invoked", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ program = []
 
 [dependencies]
 solana-bpf-rust-invoked = { path = "../invoked", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ program = []
 
 [dependencies]
 solana-bpf-rust-invoked = { path = "../invoked", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/invoke_and_error/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-error"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_error/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-error"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_error/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-error"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-error"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_ok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-ok"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_ok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-ok"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_ok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-ok"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-ok"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_return/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_return/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-return"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_return/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_return/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-return"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoke_and_return/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_return/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoke-and-return"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-invoke-and-return"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoked"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoked"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-invoked"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-iter"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-iter"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-iter"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-iter"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-iter"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-iter"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/log_data/Cargo.toml
+++ b/programs/bpf/rust/log_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-log-data"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/log_data/Cargo.toml
+++ b/programs/bpf/rust/log_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-log-data"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/log_data/Cargo.toml
+++ b/programs/bpf/rust/log_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-log-data"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.13.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.14.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.11.11" }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.12.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-many-args-dep"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/mem/Cargo.toml
+++ b/programs/bpf/rust/mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-mem"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 no-entrypoint = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/mem/Cargo.toml
+++ b/programs/bpf/rust/mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-mem"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 no-entrypoint = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.14.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/mem/Cargo.toml
+++ b/programs/bpf/rust/mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-mem"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 no-entrypoint = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.11.11" }
-solana-program-test = { path = "../../../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/membuiltins/Cargo.toml
+++ b/programs/bpf/rust/membuiltins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-membuiltins"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-mem"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-mem = { path = "../mem", version = "=1.13.0", features = [ "no-entrypoint" ] }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-bpf-rust-mem = { path = "../mem", version = "=1.14.0", features = [ "no-entrypoint" ] }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/membuiltins/Cargo.toml
+++ b/programs/bpf/rust/membuiltins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-membuiltins"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-mem"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-mem = { path = "../mem", version = "=1.12.0", features = [ "no-entrypoint" ] }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-bpf-rust-mem = { path = "../mem", version = "=1.13.0", features = [ "no-entrypoint" ] }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/membuiltins/Cargo.toml
+++ b/programs/bpf/rust/membuiltins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-membuiltins"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-mem"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-mem = { path = "../mem", version = "=1.11.11", features = [ "no-entrypoint" ] }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-bpf-rust-mem = { path = "../mem", version = "=1.12.0", features = [ "no-entrypoint" ] }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-noop"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-noop"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-noop"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-noop"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-noop"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-noop"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-panic"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-panic"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [features]
 default = ["custom-panic"]

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-panic"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-panic"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [features]
 default = ["custom-panic"]

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-panic"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-panic"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [features]
 default = ["custom-panic"]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.11.11" }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.13.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.14.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing"
 edition = "2021"
 
 [dependencies]
-solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.12.0" }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/param_passing_dep/Cargo.toml
+++ b/programs/bpf/rust/param_passing_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/param_passing_dep/Cargo.toml
+++ b/programs/bpf/rust/param_passing_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/param_passing_dep/Cargo.toml
+++ b/programs/bpf/rust/param_passing_dep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-param-passing-dep"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing-dep"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/rand/Cargo.toml
+++ b/programs/bpf/rust/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-rand"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 getrandom = { version = "0.1.14", features = ["dummy"] }
 rand = "0.7"
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/rand/Cargo.toml
+++ b/programs/bpf/rust/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-rand"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 getrandom = { version = "0.1.14", features = ["dummy"] }
 rand = "0.7"
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/rand/Cargo.toml
+++ b/programs/bpf/rust/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-rand"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 getrandom = { version = "0.1.14", features = ["dummy"] }
 rand = "0.7"
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/realloc/Cargo.toml
+++ b/programs/bpf/rust/realloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/realloc/Cargo.toml
+++ b/programs/bpf/rust/realloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/realloc/Cargo.toml
+++ b/programs/bpf/rust/realloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,7 +14,7 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/realloc_invoke/Cargo.toml
+++ b/programs/bpf/rust/realloc_invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-bpf-rust-realloc = { path = "../realloc", version = "=1.11.11", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-bpf-rust-realloc = { path = "../realloc", version = "=1.12.0", default-features = false }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/realloc_invoke/Cargo.toml
+++ b/programs/bpf/rust/realloc_invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-bpf-rust-realloc = { path = "../realloc", version = "=1.13.0", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-bpf-rust-realloc = { path = "../realloc", version = "=1.14.0", default-features = false }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/realloc_invoke/Cargo.toml
+++ b/programs/bpf/rust/realloc_invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-realloc-invoke"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,8 +14,8 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-bpf-rust-realloc = { path = "../realloc", version = "=1.12.0", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-bpf-rust-realloc = { path = "../realloc", version = "=1.13.0", default-features = false }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf/rust/ro_account_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_account_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/ro_account_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_account_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/ro_account_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_account_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-account_modify"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/ro_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-modify"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/ro_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-modify"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/ro_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_modify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-ro-modify"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sanity/Cargo.toml
+++ b/programs/bpf/rust/sanity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sanity"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.11.11" }
-solana-program-test = { path = "../../../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/sanity/Cargo.toml
+++ b/programs/bpf/rust/sanity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sanity"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/sanity/Cargo.toml
+++ b/programs/bpf/rust/sanity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sanity"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.14.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/bpf/rust/secp256k1_recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libsecp256k1 = { version = "0.7.0", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/bpf/rust/secp256k1_recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libsecp256k1 = { version = "0.7.0", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/bpf/rust/secp256k1_recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-secp256k1-recover"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libsecp256k1 = { version = "0.7.0", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sha/Cargo.toml
+++ b/programs/bpf/rust/sha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sha"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 blake3 = "1.0.0"
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sha/Cargo.toml
+++ b/programs/bpf/rust/sha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sha"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 blake3 = "1.0.0"
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sha/Cargo.toml
+++ b/programs/bpf/rust/sha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sha"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 blake3 = "1.0.0"
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling_inner-instructions"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/sibling_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/sibling_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/sibling_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_instruction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sibling-instructions"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-log-data"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [features]
 default = ["program"]

--- a/programs/bpf/rust/simulation/Cargo.toml
+++ b/programs/bpf/rust/simulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-simulation"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF Program Simulation Differences"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,13 +13,13 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../../../logger", version = "=1.13.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
-solana-validator = { path = "../../../../validator", version = "=1.13.0" }
+solana-logger = { path = "../../../../logger", version = "=1.14.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.14.0" }
+solana-validator = { path = "../../../../validator", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/simulation/Cargo.toml
+++ b/programs/bpf/rust/simulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-simulation"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF Program Simulation Differences"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,13 +13,13 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../../../logger", version = "=1.11.11" }
-solana-program-test = { path = "../../../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../../../sdk", version = "=1.11.11" }
-solana-validator = { path = "../../../../validator", version = "=1.11.11" }
+solana-logger = { path = "../../../../logger", version = "=1.12.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
+solana-validator = { path = "../../../../validator", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/simulation/Cargo.toml
+++ b/programs/bpf/rust/simulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-simulation"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF Program Simulation Differences"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,13 +13,13 @@ edition = "2021"
 test-bpf = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../../../logger", version = "=1.12.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
-solana-validator = { path = "../../../../validator", version = "=1.12.0" }
+solana-logger = { path = "../../../../logger", version = "=1.13.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
+solana-validator = { path = "../../../../validator", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/spoof1/Cargo.toml
+++ b/programs/bpf/rust/spoof1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/spoof1/Cargo.toml
+++ b/programs/bpf/rust/spoof1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/spoof1/Cargo.toml
+++ b/programs/bpf/rust/spoof1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/spoof1_system/Cargo.toml
+++ b/programs/bpf/rust/spoof1_system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1-system"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/spoof1_system/Cargo.toml
+++ b/programs/bpf/rust/spoof1_system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1-system"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/spoof1_system/Cargo.toml
+++ b/programs/bpf/rust/spoof1_system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-spoof1-system"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-spoof1-system"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/sysvar/Cargo.toml
+++ b/programs/bpf/rust/sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sysvar"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/solana-bpf-rust-sysvar"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/sysvar/Cargo.toml
+++ b/programs/bpf/rust/sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sysvar"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/solana-bpf-rust-sysvar"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.11.11" }
-solana-program-test = { path = "../../../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.12.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/sysvar/Cargo.toml
+++ b/programs/bpf/rust/sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-sysvar"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/solana-bpf-rust-sysvar"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-program-runtime = { path = "../../../../program-runtime", version = "=1.13.0" }
-solana-program-test = { path = "../../../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../../../program-runtime", version = "=1.14.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/bpf/rust/upgradeable/Cargo.toml
+++ b/programs/bpf/rust/upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgradeable"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgradeable"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 name = "solana_bpf_rust_upgradeable"

--- a/programs/bpf/rust/upgradeable/Cargo.toml
+++ b/programs/bpf/rust/upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgradeable"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgradeable"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 name = "solana_bpf_rust_upgradeable"

--- a/programs/bpf/rust/upgradeable/Cargo.toml
+++ b/programs/bpf/rust/upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgradeable"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgradeable"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 name = "solana_bpf_rust_upgradeable"

--- a/programs/bpf/rust/upgraded/Cargo.toml
+++ b/programs/bpf/rust/upgraded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgraded"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgraded"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.14.0" }
 
 [lib]
 name = "solana_bpf_rust_upgraded"

--- a/programs/bpf/rust/upgraded/Cargo.toml
+++ b/programs/bpf/rust/upgraded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgraded"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgraded"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../../../../sdk/program", version = "=1.13.0" }
 
 [lib]
 name = "solana_bpf_rust_upgraded"

--- a/programs/bpf/rust/upgraded/Cargo.toml
+++ b/programs/bpf/rust/upgraded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-upgraded"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-bpf-rust-upgraded"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../../../../sdk/program", version = "=1.12.0" }
 
 [lib]
 name = "solana_bpf_rust_upgraded"

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-loader-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana BPF loader"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,17 +14,17 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 libsecp256k1 = "0.6.0"
 log = "0.4.17"
-solana-measure = { path = "../../measure", version = "=1.13.0" }
-solana-metrics = { path = "../../metrics", version = "=1.13.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.13.0" }
+solana-measure = { path = "../../measure", version = "=1.14.0" }
+solana-metrics = { path = "../../metrics", version = "=1.14.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.14.0" }
 solana_rbpf = "=0.2.31"
 thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-solana-runtime = { path = "../../runtime", version = "=1.13.0" }
+solana-runtime = { path = "../../runtime", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-loader-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana BPF loader"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,17 +14,17 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 libsecp256k1 = "0.6.0"
 log = "0.4.17"
-solana-measure = { path = "../../measure", version = "=1.11.11" }
-solana-metrics = { path = "../../metrics", version = "=1.11.11" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.11" }
+solana-measure = { path = "../../measure", version = "=1.12.0" }
+solana-metrics = { path = "../../metrics", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.12.0" }
 solana_rbpf = "=0.2.31"
 thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-solana-runtime = { path = "../../runtime", version = "=1.11.11" }
+solana-runtime = { path = "../../runtime", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-loader-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana BPF loader"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,17 +14,17 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 libsecp256k1 = "0.6.0"
 log = "0.4.17"
-solana-measure = { path = "../../measure", version = "=1.12.0" }
-solana-metrics = { path = "../../metrics", version = "=1.12.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.12.0" }
+solana-measure = { path = "../../measure", version = "=1.13.0" }
+solana-metrics = { path = "../../metrics", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.13.0" }
 solana_rbpf = "=0.2.31"
 thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-solana-runtime = { path = "../../runtime", version = "=1.12.0" }
+solana-runtime = { path = "../../runtime", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader/gen-syscall-list/Cargo.toml
+++ b/programs/bpf_loader/gen-syscall-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-syscall-list"
-version = "1.11.11"
+version = "1.12.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/programs/bpf_loader/gen-syscall-list/Cargo.toml
+++ b/programs/bpf_loader/gen-syscall-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-syscall-list"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/programs/bpf_loader/gen-syscall-list/Cargo.toml
+++ b/programs/bpf_loader/gen-syscall-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-syscall-list"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-compute-budget-program"
 description = "Solana Compute Budget program"
-version = "1.12.0"
+version = "1.13.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-compute-budget-program"
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-compute-budget-program"
 description = "Solana Compute Budget program"
-version = "1.13.0"
+version = "1.14.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-compute-budget-program"
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-compute-budget-program"
 description = "Solana Compute Budget program"
-version = "1.11.11"
+version = "1.12.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-compute-budget-program"
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-config-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Config program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bincode = "1.3.3"
 chrono = { version = "0.4.11", features = ["serde"] }
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.11.11" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-config-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Config program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bincode = "1.3.3"
 chrono = { version = "0.4.11", features = ["serde"] }
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-config-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Config program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,11 +14,11 @@ bincode = "1.3.3"
 chrono = { version = "0.4.11", features = ["serde"] }
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ed25519-program-tests"
-version = "1.11.11"
+version = "1.12.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ publish = false
 assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 rand = "0.7.0"
-solana-program-test = { path = "../../program-test", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-program-test = { path = "../../program-test", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ed25519-program-tests"
-version = "1.13.0"
+version = "1.14.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ publish = false
 assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 rand = "0.7.0"
-solana-program-test = { path = "../../program-test", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-program-test = { path = "../../program-test", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-ed25519-program-tests"
-version = "1.12.0"
+version = "1.13.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ publish = false
 assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 rand = "0.7.0"
-solana-program-test = { path = "../../program-test", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-program-test = { path = "../../program-test", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Stake program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,19 +16,19 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-config-program = { path = "../config", version = "=1.12.0" }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
-solana-metrics = { path = "../../metrics", version = "=1.12.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
-solana-vote-program = { path = "../vote", version = "=1.12.0" }
+solana-config-program = { path = "../config", version = "=1.13.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
+solana-metrics = { path = "../../metrics", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-vote-program = { path = "../vote", version = "=1.13.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 proptest = "1.0"
-solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Stake program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,19 +16,19 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-config-program = { path = "../config", version = "=1.11.11" }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.11.11" }
-solana-metrics = { path = "../../metrics", version = "=1.11.11" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
-solana-vote-program = { path = "../vote", version = "=1.11.11" }
+solana-config-program = { path = "../config", version = "=1.12.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
+solana-metrics = { path = "../../metrics", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-vote-program = { path = "../vote", version = "=1.12.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 proptest = "1.0"
-solana-logger = { path = "../../logger", version = "=1.11.11" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Stake program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,19 +16,19 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-config-program = { path = "../config", version = "=1.13.0" }
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
-solana-metrics = { path = "../../metrics", version = "=1.13.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
-solana-vote-program = { path = "../vote", version = "=1.13.0" }
+solana-config-program = { path = "../config", version = "=1.14.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.14.0" }
+solana-metrics = { path = "../../metrics", version = "=1.14.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
+solana-vote-program = { path = "../vote", version = "=1.14.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 proptest = "1.0"
-solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
 test-case = "2.1.0"
 
 [build-dependencies]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-vote-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Vote program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,17 +16,17 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.11.11" }
-solana-metrics = { path = "../../metrics", version = "=1.11.11" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
+solana-metrics = { path = "../../metrics", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 itertools = "0.10.3"
 rand = "0.7.0"
-solana-logger = { path = "../../logger", version = "=1.11.11" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-vote-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Vote program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,17 +16,17 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
-solana-metrics = { path = "../../metrics", version = "=1.13.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.14.0" }
+solana-metrics = { path = "../../metrics", version = "=1.14.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 itertools = "0.10.3"
 rand = "0.7.0"
-solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-vote-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Vote program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,17 +16,17 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
-solana-metrics = { path = "../../metrics", version = "=1.12.0" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
+solana-metrics = { path = "../../metrics", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
 thiserror = "1.0"
 
 [dev-dependencies]
 itertools = "0.10.3"
 rand = "0.7.0"
-solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-proof-program"
 description = "Solana Zk Token Proof Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.12.0"
+version = "1.13.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,6 +12,6 @@ bytemuck = { version = "1.11.0", features = ["derive"] }
 getrandom = { version = "0.1", features = ["dummy"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../../sdk", version = "=1.12.0" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.12.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../../sdk", version = "=1.13.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.13.0" }

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-proof-program"
 description = "Solana Zk Token Proof Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.11.11"
+version = "1.12.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,6 +12,6 @@ bytemuck = { version = "1.11.0", features = ["derive"] }
 getrandom = { version = "0.1", features = ["dummy"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../../sdk", version = "=1.11.11" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.11" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.12.0" }

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-proof-program"
 description = "Solana Zk Token Proof Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.13.0"
+version = "1.14.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,6 +12,6 @@ bytemuck = { version = "1.11.0", features = ["derive"] }
 getrandom = { version = "0.1", features = ["dummy"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../../sdk", version = "=1.13.0" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.13.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../../sdk", version = "=1.14.0" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.14.0" }

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rayon-threadlimit"
-version = "1.13.0"
+version = "1.14.0"
 description = "solana-rayon-threadlimit"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-rayon-threadlimit"

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rayon-threadlimit"
-version = "1.11.11"
+version = "1.12.0"
 description = "solana-rayon-threadlimit"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-rayon-threadlimit"

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rayon-threadlimit"
-version = "1.12.0"
+version = "1.13.0"
 description = "solana-rayon-threadlimit"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-rayon-threadlimit"

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbpf-cli"
-version = "1.11.11"
+version = "1.12.0"
 description = "CLI to test and analyze eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"
@@ -13,8 +13,8 @@ publish = false
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 solana_rbpf = "=0.2.31"

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbpf-cli"
-version = "1.12.0"
+version = "1.13.0"
 description = "CLI to test and analyze eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"
@@ -13,8 +13,8 @@ publish = false
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 solana_rbpf = "=0.2.31"

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbpf-cli"
-version = "1.13.0"
+version = "1.14.0"
 description = "CLI to test and analyze eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"
@@ -13,8 +13,8 @@ publish = false
 clap = { version = "3.1.5", features = ["cargo"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 solana_rbpf = "=0.2.31"

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-remote-wallet"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,7 +19,7 @@ num-traits = { version = "0.2" }
 parking_lot = "0.12"
 qstring = "0.7.2"
 semver = "1.0"
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-remote-wallet"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,7 +19,7 @@ num-traits = { version = "0.2" }
 parking_lot = "0.12"
 qstring = "0.7.2"
 semver = "1.0"
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-remote-wallet"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,7 +19,7 @@ num-traits = { version = "0.2" }
 parking_lot = "0.12"
 qstring = "0.7.2"
 semver = "1.0"
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc-test"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,17 +19,17 @@ log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc-test"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,17 +19,17 @@ log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc-test"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana RPC Test"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -19,17 +19,17 @@ log = "0.4.17"
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
 tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana RPC"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -29,26 +29,26 @@ serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
 soketto = "0.7"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-poh = { path = "../poh", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-poh = { path = "../poh", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
@@ -58,9 +58,9 @@ tokio-util = { version = "0.6", features = ["codec", "compat"] }
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
 symlink = "0.1.0"
 
 [lib]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana RPC"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -29,26 +29,26 @@ serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
 soketto = "0.7"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-poh = { path = "../poh", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-poh = { path = "../poh", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
@@ -58,9 +58,9 @@ tokio-util = { version = "0.6", features = ["codec", "compat"] }
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
 symlink = "0.1.0"
 
 [lib]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rpc"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana RPC"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -29,26 +29,26 @@ serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
 soketto = "0.7"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-poh = { path = "../poh", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-poh = { path = "../poh", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
@@ -58,9 +58,9 @@ tokio-util = { version = "0.6", features = ["codec", "compat"] }
 
 [dev-dependencies]
 serial_test = "0.8.0"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
 symlink = "0.1.0"
 
 [lib]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-runtime"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -39,21 +39,21 @@ rayon = "1.5.3"
 regex = "1.5.6"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
-solana-bucket-map = { path = "../bucket_map", version = "=1.12.0" }
-solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.12.0" }
-solana-config-program = { path = "../programs/config", version = "=1.12.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
-solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.12.0" }
-solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.12.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
+solana-bucket-map = { path = "../bucket_map", version = "=1.13.0" }
+solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.13.0" }
+solana-config-program = { path = "../programs/config", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.13.0" }
+solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.13.0" }
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 symlink = "0.1.0"
@@ -71,7 +71,7 @@ assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 rand_chacha = "0.2.2"
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-runtime"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -39,21 +39,21 @@ rayon = "1.5.3"
 regex = "1.5.6"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.11.11" }
-solana-bucket-map = { path = "../bucket_map", version = "=1.11.11" }
-solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.11.11" }
-solana-config-program = { path = "../programs/config", version = "=1.11.11" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
-solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.11.11" }
-solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.11.11" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
+solana-bucket-map = { path = "../bucket_map", version = "=1.12.0" }
+solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.12.0" }
+solana-config-program = { path = "../programs/config", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.12.0" }
+solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.12.0" }
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 symlink = "0.1.0"
@@ -71,7 +71,7 @@ assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 rand_chacha = "0.2.2"
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-runtime"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana runtime"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -39,21 +39,21 @@ rayon = "1.5.3"
 regex = "1.5.6"
 serde = { version = "1.0.138", features = ["rc"] }
 serde_derive = "1.0.103"
-solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.13.0" }
-solana-bucket-map = { path = "../bucket_map", version = "=1.13.0" }
-solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.13.0" }
-solana-config-program = { path = "../programs/config", version = "=1.13.0" }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
-solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.13.0" }
-solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.13.0" }
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.14.0" }
+solana-bucket-map = { path = "../bucket_map", version = "=1.14.0" }
+solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.14.0" }
+solana-config-program = { path = "../programs/config", version = "=1.14.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
+solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.14.0" }
+solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.14.0" }
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 symlink = "0.1.0"
@@ -71,7 +71,7 @@ assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 rand_chacha = "0.2.2"
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/store-tool/Cargo.toml
+++ b/runtime/store-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-store-tool"
 description = "Tool to inspect append vecs"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,9 +12,9 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = { version = "0.4.17" }
-solana-logger = { path = "../../logger", version = "=1.11.11" }
-solana-runtime = { path = "..", version = "=1.11.11" }
-solana-version = { path = "../../version", version = "=1.11.11" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-runtime = { path = "..", version = "=1.12.0" }
+solana-version = { path = "../../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/store-tool/Cargo.toml
+++ b/runtime/store-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-store-tool"
 description = "Tool to inspect append vecs"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,9 +12,9 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = { version = "0.4.17" }
-solana-logger = { path = "../../logger", version = "=1.13.0" }
-solana-runtime = { path = "..", version = "=1.13.0" }
-solana-version = { path = "../../version", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
+solana-runtime = { path = "..", version = "=1.14.0" }
+solana-version = { path = "../../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/store-tool/Cargo.toml
+++ b/runtime/store-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-store-tool"
 description = "Tool to inspect append vecs"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,9 +12,9 @@ publish = false
 [dependencies]
 clap = "2.33.1"
 log = { version = "0.4.17" }
-solana-logger = { path = "../../logger", version = "=1.12.0" }
-solana-runtime = { path = "..", version = "=1.12.0" }
-solana-version = { path = "../../version", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-runtime = { path = "..", version = "=1.13.0" }
+solana-version = { path = "../../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -71,11 +71,11 @@ serde_derive = "1.0.103"
 serde_json = { version = "1.0.81", optional = true }
 sha2 = "0.10.2"
 sha3 = { version = "0.10.1", optional = true }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0", optional = true }
-solana-program = { path = "program", version = "=1.12.0" }
-solana-sdk-macro = { path = "macro", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0", optional = true }
+solana-program = { path = "program", version = "=1.13.0" }
+solana-sdk-macro = { path = "macro", version = "=1.13.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -71,11 +71,11 @@ serde_derive = "1.0.103"
 serde_json = { version = "1.0.81", optional = true }
 sha2 = "0.10.2"
 sha3 = { version = "0.10.1", optional = true }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11", optional = true }
-solana-program = { path = "program", version = "=1.11.11" }
-solana-sdk-macro = { path = "macro", version = "=1.11.11" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0", optional = true }
+solana-program = { path = "program", version = "=1.12.0" }
+solana-sdk-macro = { path = "macro", version = "=1.12.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -71,11 +71,11 @@ serde_derive = "1.0.103"
 serde_json = { version = "1.0.81", optional = true }
 sha2 = "0.10.2"
 sha3 = { version = "0.10.1", optional = true }
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0", optional = true }
-solana-program = { path = "program", version = "=1.13.0" }
-solana-sdk-macro = { path = "macro", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0", optional = true }
+solana-program = { path = "program", version = "=1.14.0" }
+solana-sdk-macro = { path = "macro", version = "=1.14.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2"

--- a/sdk/cargo-build-bpf/Cargo.toml
+++ b/sdk/cargo-build-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-bpf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
-solana-sdk = { path = "..", version = "=1.11.11" }
+solana-sdk = { path = "..", version = "=1.12.0" }
 
 [features]
 program = []

--- a/sdk/cargo-build-bpf/Cargo.toml
+++ b/sdk/cargo-build-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-bpf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
-solana-sdk = { path = "..", version = "=1.13.0" }
+solana-sdk = { path = "..", version = "=1.14.0" }
 
 [features]
 program = []

--- a/sdk/cargo-build-bpf/Cargo.toml
+++ b/sdk/cargo-build-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-bpf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
-solana-sdk = { path = "..", version = "=1.12.0" }
+solana-sdk = { path = "..", version = "=1.13.0" }
 
 [features]
 program = []

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-sbf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,9 +15,9 @@ cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { version = "0.4.14", features = ["std"] }
 regex = "1.5.6"
-solana-download-utils = { path = "../../download-utils", version = "=1.11.11" }
-solana-logger = { path = "../../logger", version = "=1.11.11" }
-solana-sdk = { path = "..", version = "=1.11.11" }
+solana-download-utils = { path = "../../download-utils", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-sdk = { path = "..", version = "=1.12.0" }
 tar = "0.4.38"
 
 [dev-dependencies]

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-sbf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,9 +15,9 @@ cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { version = "0.4.14", features = ["std"] }
 regex = "1.5.6"
-solana-download-utils = { path = "../../download-utils", version = "=1.13.0" }
-solana-logger = { path = "../../logger", version = "=1.13.0" }
-solana-sdk = { path = "..", version = "=1.13.0" }
+solana-download-utils = { path = "../../download-utils", version = "=1.14.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
+solana-sdk = { path = "..", version = "=1.14.0" }
 tar = "0.4.38"
 
 [dev-dependencies]

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-build-sbf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Compile a local package and all of its dependencies using the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,9 +15,9 @@ cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { version = "0.4.14", features = ["std"] }
 regex = "1.5.6"
-solana-download-utils = { path = "../../download-utils", version = "=1.12.0" }
-solana-logger = { path = "../../logger", version = "=1.12.0" }
-solana-sdk = { path = "..", version = "=1.12.0" }
+solana-download-utils = { path = "../../download-utils", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-sdk = { path = "..", version = "=1.13.0" }
 tar = "0.4.38"
 
 [dev-dependencies]

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.13.0" }
+solana-program = { path = "../../../../program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.11.11" }
+solana-program = { path = "../../../../program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.12.0" }
+solana-program = { path = "../../../../program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.12.0" }
+solana-program = { path = "../../../../program", version = "=1.13.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.13.0" }
+solana-program = { path = "../../../../program", version = "=1.14.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.11.11" }
+solana-program = { path = "../../../../program", version = "=1.12.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-test-bpf/Cargo.toml
+++ b/sdk/cargo-test-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-bpf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/cargo-test-bpf/Cargo.toml
+++ b/sdk/cargo-test-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-bpf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/cargo-test-bpf/Cargo.toml
+++ b/sdk/cargo-test-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-bpf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/cargo-test-sbf/Cargo.toml
+++ b/sdk/cargo-test-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-sbf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/cargo-test-sbf/Cargo.toml
+++ b/sdk/cargo-test-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-sbf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/cargo-test-sbf/Cargo.toml
+++ b/sdk/cargo-test-sbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-cargo-test-sbf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Execute all unit and integration tests after building with the Solana SBF SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/gen-headers/Cargo.toml
+++ b/sdk/gen-headers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-headers"
-version = "1.11.11"
+version = "1.12.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/sdk/gen-headers/Cargo.toml
+++ b/sdk/gen-headers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-headers"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/sdk/gen-headers/Cargo.toml
+++ b/sdk/gen-headers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-headers"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk-macro"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana SDK Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk-macro"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana SDK Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk-macro"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana SDK Macro"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -31,9 +31,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.0"
 sha3 = "0.10.0"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
-solana-sdk-macro = { path = "../macro", version = "=1.13.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.14.0" }
+solana-sdk-macro = { path = "../macro", version = "=1.14.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -50,7 +50,7 @@ wasm-bindgen = "0.2"
 zeroize = { version = "1.3", default-features = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.13.0" }
+solana-logger = { path = "../../logger", version = "=1.14.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -31,9 +31,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.0"
 sha3 = "0.10.0"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
-solana-sdk-macro = { path = "../macro", version = "=1.12.0" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.13.0" }
+solana-sdk-macro = { path = "../macro", version = "=1.13.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -50,7 +50,7 @@ wasm-bindgen = "0.2"
 zeroize = { version = "1.3", default-features = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.12.0" }
+solana-logger = { path = "../../logger", version = "=1.13.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -31,9 +31,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.0"
 sha3 = "0.10.0"
-solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.11.11" }
-solana-sdk-macro = { path = "../macro", version = "=1.11.11" }
+solana-frozen-abi = { path = "../../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.12.0" }
+solana-sdk-macro = { path = "../macro", version = "=1.12.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
@@ -50,7 +50,7 @@ wasm-bindgen = "0.2"
 zeroize = { version = "1.3", default-features = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-solana-logger = { path = "../../logger", version = "=1.11.11" }
+solana-logger = { path = "../../logger", version = "=1.12.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-send-transaction-service"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana send transaction service"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,14 +12,14 @@ edition = "2021"
 [dependencies]
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-send-transaction-service"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana send transaction service"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,14 +12,14 @@ edition = "2021"
 [dependencies]
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-send-transaction-service"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana send transaction service"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,14 +12,14 @@ edition = "2021"
 [dependencies]
 crossbeam-channel = "0.5"
 log = "0.4.17"
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-stake-accounts"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,15 +11,15 @@ documentation = "https://docs.rs/solana-stake-accounts"
 
 [dependencies]
 clap = "2.33.1"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-stake-accounts"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,15 +11,15 @@ documentation = "https://docs.rs/solana-stake-accounts"
 
 [dependencies]
 clap = "2.33.1"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-stake-program = { path = "../programs/stake", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-stake-accounts"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,15 +11,15 @@ documentation = "https://docs.rs/solana-stake-accounts"
 
 [dependencies]
 clap = "2.33.1"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-stake-program = { path = "../programs/stake", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-bigtable"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Storage BigTable"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -27,10 +27,10 @@ prost-types = "0.11.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 smpl_jwt = "0.7.1"
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
 thiserror = "1.0"
 tokio = "1"
 tonic = { version = "0.8.0", features = ["tls", "transport"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-bigtable"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Storage BigTable"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -27,10 +27,10 @@ prost-types = "0.11.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 smpl_jwt = "0.7.1"
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
 thiserror = "1.0"
 tokio = "1"
 tonic = { version = "0.8.0", features = ["tls", "transport"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-bigtable"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Storage BigTable"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -27,10 +27,10 @@ prost-types = "0.11.0"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 smpl_jwt = "0.7.1"
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-storage-proto = { path = "../storage-proto", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-storage-proto = { path = "../storage-proto", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 thiserror = "1.0"
 tokio = "1"
 tonic = { version = "0.8.0", features = ["tls", "transport"] }

--- a/storage-bigtable/build-proto/Cargo.lock
+++ b/storage-bigtable/build-proto/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "1.11.11"
+version = "1.12.0"
 dependencies = [
  "protobuf-src",
  "tonic-build",

--- a/storage-bigtable/build-proto/Cargo.lock
+++ b/storage-bigtable/build-proto/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "protobuf-src",
  "tonic-build",

--- a/storage-bigtable/build-proto/Cargo.lock
+++ b/storage-bigtable/build-proto/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "protobuf-src",
  "tonic-build",

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "proto"
 publish = false
 repository = "https://github.com/solana-labs/solana"
-version = "1.12.0"
+version = "1.13.0"
 
 [workspace]
 

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "proto"
 publish = false
 repository = "https://github.com/solana-labs/solana"
-version = "1.13.0"
+version = "1.14.0"
 
 [workspace]
 

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "proto"
 publish = false
 repository = "https://github.com/solana-labs/solana"
-version = "1.11.11"
+version = "1.12.0"
 
 [workspace]
 

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-proto"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Storage Protobuf Definitions"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 prost = "0.11.0"
 serde = "1.0.138"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
 
 [dev-dependencies]
 enum-iterator = "0.8.1"

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-proto"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Storage Protobuf Definitions"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 prost = "0.11.0"
 serde = "1.0.138"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
 
 [dev-dependencies]
 enum-iterator = "0.8.1"

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-proto"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Storage Protobuf Definitions"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 prost = "0.11.0"
 serde = "1.0.138"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
 
 [dev-dependencies]
 enum-iterator = "0.8.1"

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-streamer"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Streamer"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -25,15 +25,15 @@ quinn = "0.8.3"
 rand = "0.7.0"
 rcgen = "0.9.2"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 x509-parser = "0.14.0"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-streamer"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Streamer"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -25,15 +25,15 @@ quinn = "0.8.3"
 rand = "0.7.0"
 rcgen = "0.9.2"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 x509-parser = "0.14.0"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-streamer"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Streamer"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -25,15 +25,15 @@ quinn = "0.8.3"
 rand = "0.7.0"
 rcgen = "0.9.2"
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 x509-parser = "0.14.0"
 
 [dev-dependencies]
-solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-sys-tuner"
 description = "The solana cluster system tuner daemon"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ publish = true
 clap = "2.33.1"
 libc = "0.2.126"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [target."cfg(unix)".dependencies]
 unix_socket2 = "0.5.4"

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-sys-tuner"
 description = "The solana cluster system tuner daemon"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ publish = true
 clap = "2.33.1"
 libc = "0.2.126"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [target."cfg(unix)".dependencies]
 unix_socket2 = "0.5.4"

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-sys-tuner"
 description = "The solana cluster system tuner daemon"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,8 +14,8 @@ publish = true
 clap = "2.33.1"
 libc = "0.2.126"
 log = "0.4.17"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [target."cfg(unix)".dependencies]
 unix_socket2 = "0.5.4"

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-test-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-test-validator"
 readme = "../README.md"
@@ -15,19 +15,19 @@ base64 = "0.13.0"
 log = "0.4.17"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
-solana-program-test = { path = "../program-test", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
+solana-program-test = { path = "../program-test", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
 tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-test-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-test-validator"
 readme = "../README.md"
@@ -15,19 +15,19 @@ base64 = "0.13.0"
 log = "0.4.17"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-cli-output = { path = "../cli-output", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.11.11" }
-solana-program-test = { path = "../program-test", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
+solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.12.0" }
+solana-program-test = { path = "../program-test", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
 tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-test-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-test-validator"
 readme = "../README.md"
@@ -15,19 +15,19 @@ base64 = "0.13.0"
 log = "0.4.17"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-program-runtime = { path = "../program-runtime", version = "=1.13.0" }
-solana-program-test = { path = "../program-test", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-program-runtime = { path = "../program-runtime", version = "=1.14.0" }
+solana-program-test = { path = "../program-test", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
 tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-tokens"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,14 +19,14 @@ indexmap = "1.9.1"
 indicatif = "0.16.2"
 pickledb = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 spl-associated-token-account = { version = "=1.1.1" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 tempfile = "3.3.0"
@@ -34,6 +34,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-tokens"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,14 +19,14 @@ indexmap = "1.9.1"
 indicatif = "0.16.2"
 pickledb = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 spl-associated-token-account = { version = "=1.1.1" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 tempfile = "3.3.0"
@@ -34,6 +34,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-tokens"
 description = "Blockchain, Rebuilt for Scale"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -19,14 +19,14 @@ indexmap = "1.9.1"
 indicatif = "0.16.2"
 pickledb = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 spl-associated-token-account = { version = "=1.1.1" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 tempfile = "3.3.0"
@@ -34,6 +34,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-transaction-dos"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,23 +14,23 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli = { path = "../cli", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli = { path = "../cli", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [dev-dependencies]
-solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-transaction-dos"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,23 +14,23 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli = { path = "../cli", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli = { path = "../cli", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [dev-dependencies]
-solana-local-cluster = { path = "../local-cluster", version = "=1.11.11" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-transaction-dos"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -14,23 +14,23 @@ clap = "2.33.1"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli = { path = "../cli", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli = { path = "../cli", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [dev-dependencies]
-solana-local-cluster = { path = "../local-cluster", version = "=1.13.0" }
+solana-local-cluster = { path = "../local-cluster", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-transaction-status"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana transaction status types"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,11 +20,11 @@ log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
-solana-measure = { path = "../measure", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
+solana-measure = { path = "../measure", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-transaction-status"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana transaction status types"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,11 +20,11 @@ log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.11.11" }
-solana-measure = { path = "../measure", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.12.0" }
+solana-measure = { path = "../measure", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-transaction-status"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana transaction status types"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,11 +20,11 @@ log = "0.4.17"
 serde = "1.0.138"
 serde_derive = "1.0.103"
 serde_json = "1.0.81"
-solana-account-decoder = { path = "../account-decoder", version = "=1.13.0" }
-solana-measure = { path = "../measure", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=1.14.0" }
+solana-measure = { path = "../measure", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-upload-perf"
-version = "1.13.0"
+version = "1.14.0"
 description = "Metrics Upload Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 serde_json = "1.0.81"
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
 
 [[bin]]
 name = "solana-upload-perf"

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-upload-perf"
-version = "1.11.11"
+version = "1.12.0"
 description = "Metrics Upload Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 serde_json = "1.0.81"
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
 
 [[bin]]
 name = "solana-upload-perf"

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-upload-perf"
-version = "1.12.0"
+version = "1.13.0"
 description = "Metrics Upload Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 serde_json = "1.0.81"
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
 
 [[bin]]
 name = "solana-upload-perf"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -28,30 +28,30 @@ num_cpus = "1.13.1"
 rand = "0.7.0"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-core = { path = "../core", version = "=1.13.0" }
-solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
-solana-entry = { path = "../entry", version = "=1.13.0" }
-solana-faucet = { path = "../faucet", version = "=1.13.0" }
-solana-genesis-utils = { path = "../genesis-utils", version = "=1.13.0" }
-solana-gossip = { path = "../gossip", version = "=1.13.0" }
-solana-ledger = { path = "../ledger", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
-solana-perf = { path = "../perf", version = "=1.13.0" }
-solana-poh = { path = "../poh", version = "=1.13.0" }
-solana-rpc = { path = "../rpc", version = "=1.13.0" }
-solana-runtime = { path = "../runtime", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
-solana-streamer = { path = "../streamer", version = "=1.13.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-core = { path = "../core", version = "=1.14.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.14.0" }
+solana-entry = { path = "../entry", version = "=1.14.0" }
+solana-faucet = { path = "../faucet", version = "=1.14.0" }
+solana-genesis-utils = { path = "../genesis-utils", version = "=1.14.0" }
+solana-gossip = { path = "../gossip", version = "=1.14.0" }
+solana-ledger = { path = "../ledger", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.14.0" }
+solana-perf = { path = "../perf", version = "=1.14.0" }
+solana-poh = { path = "../poh", version = "=1.14.0" }
+solana-rpc = { path = "../rpc", version = "=1.14.0" }
+solana-runtime = { path = "../runtime", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.14.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.14.0" }
+solana-streamer = { path = "../streamer", version = "=1.14.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.14.0" }
 symlink = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -28,30 +28,30 @@ num_cpus = "1.13.1"
 rand = "0.7.0"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-core = { path = "../core", version = "=1.12.0" }
-solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
-solana-entry = { path = "../entry", version = "=1.12.0" }
-solana-faucet = { path = "../faucet", version = "=1.12.0" }
-solana-genesis-utils = { path = "../genesis-utils", version = "=1.12.0" }
-solana-gossip = { path = "../gossip", version = "=1.12.0" }
-solana-ledger = { path = "../ledger", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
-solana-perf = { path = "../perf", version = "=1.12.0" }
-solana-poh = { path = "../poh", version = "=1.12.0" }
-solana-rpc = { path = "../rpc", version = "=1.12.0" }
-solana-runtime = { path = "../runtime", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
-solana-streamer = { path = "../streamer", version = "=1.12.0" }
-solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-core = { path = "../core", version = "=1.13.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.13.0" }
+solana-entry = { path = "../entry", version = "=1.13.0" }
+solana-faucet = { path = "../faucet", version = "=1.13.0" }
+solana-genesis-utils = { path = "../genesis-utils", version = "=1.13.0" }
+solana-gossip = { path = "../gossip", version = "=1.13.0" }
+solana-ledger = { path = "../ledger", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.13.0" }
+solana-perf = { path = "../perf", version = "=1.13.0" }
+solana-poh = { path = "../poh", version = "=1.13.0" }
+solana-rpc = { path = "../rpc", version = "=1.13.0" }
+solana-runtime = { path = "../runtime", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.13.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.13.0" }
+solana-streamer = { path = "../streamer", version = "=1.13.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.13.0" }
 symlink = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -28,30 +28,30 @@ num_cpus = "1.13.1"
 rand = "0.7.0"
 serde = "1.0.138"
 serde_json = "1.0.81"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-core = { path = "../core", version = "=1.11.11" }
-solana-download-utils = { path = "../download-utils", version = "=1.11.11" }
-solana-entry = { path = "../entry", version = "=1.11.11" }
-solana-faucet = { path = "../faucet", version = "=1.11.11" }
-solana-genesis-utils = { path = "../genesis-utils", version = "=1.11.11" }
-solana-gossip = { path = "../gossip", version = "=1.11.11" }
-solana-ledger = { path = "../ledger", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-net-utils = { path = "../net-utils", version = "=1.11.11" }
-solana-perf = { path = "../perf", version = "=1.11.11" }
-solana-poh = { path = "../poh", version = "=1.11.11" }
-solana-rpc = { path = "../rpc", version = "=1.11.11" }
-solana-runtime = { path = "../runtime", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.11" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.11" }
-solana-streamer = { path = "../streamer", version = "=1.11.11" }
-solana-test-validator = { path = "../test-validator", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
-solana-vote-program = { path = "../programs/vote", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-core = { path = "../core", version = "=1.12.0" }
+solana-download-utils = { path = "../download-utils", version = "=1.12.0" }
+solana-entry = { path = "../entry", version = "=1.12.0" }
+solana-faucet = { path = "../faucet", version = "=1.12.0" }
+solana-genesis-utils = { path = "../genesis-utils", version = "=1.12.0" }
+solana-gossip = { path = "../gossip", version = "=1.12.0" }
+solana-ledger = { path = "../ledger", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-net-utils = { path = "../net-utils", version = "=1.12.0" }
+solana-perf = { path = "../perf", version = "=1.12.0" }
+solana-poh = { path = "../poh", version = "=1.12.0" }
+solana-rpc = { path = "../rpc", version = "=1.12.0" }
+solana-runtime = { path = "../runtime", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.12.0" }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.12.0" }
+solana-streamer = { path = "../streamer", version = "=1.12.0" }
+solana-test-validator = { path = "../test-validator", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
+solana-vote-program = { path = "../programs/vote", version = "=1.12.0" }
 symlink = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-version"
-version = "1.12.0"
+version = "1.13.0"
 description = "Solana Version"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ log = "0.4.17"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 
 [lib]
 name = "solana_version"

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-version"
-version = "1.11.11"
+version = "1.12.0"
 description = "Solana Version"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ log = "0.4.17"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.11.11" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.12.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 
 [lib]
 name = "solana_version"

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-version"
-version = "1.13.0"
+version = "1.14.0"
 description = "Solana Version"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -14,9 +14,9 @@ log = "0.4.17"
 semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"
-solana-frozen-abi = { path = "../frozen-abi", version = "=1.13.0" }
-solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.14.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 
 [lib]
 name = "solana_version"

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-watchtower"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.13.0"
+version = "1.14.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/solana-watchtower"
 clap = "2.33.1"
 humantime = "2.0.1"
 log = "0.4.17"
-solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
-solana-client = { path = "../client", version = "=1.13.0" }
-solana-logger = { path = "../logger", version = "=1.13.0" }
-solana-metrics = { path = "../metrics", version = "=1.13.0" }
-solana-notifier = { path = "../notifier", version = "=1.13.0" }
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
-solana-version = { path = "../version", version = "=1.13.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.14.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.14.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.14.0" }
+solana-client = { path = "../client", version = "=1.14.0" }
+solana-logger = { path = "../logger", version = "=1.14.0" }
+solana-metrics = { path = "../metrics", version = "=1.14.0" }
+solana-notifier = { path = "../notifier", version = "=1.14.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
+solana-version = { path = "../version", version = "=1.14.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-watchtower"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.11.11"
+version = "1.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/solana-watchtower"
 clap = "2.33.1"
 humantime = "2.0.1"
 log = "0.4.17"
-solana-clap-utils = { path = "../clap-utils", version = "=1.11.11" }
-solana-cli-config = { path = "../cli-config", version = "=1.11.11" }
-solana-cli-output = { path = "../cli-output", version = "=1.11.11" }
-solana-client = { path = "../client", version = "=1.11.11" }
-solana-logger = { path = "../logger", version = "=1.11.11" }
-solana-metrics = { path = "../metrics", version = "=1.11.11" }
-solana-notifier = { path = "../notifier", version = "=1.11.11" }
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
-solana-version = { path = "../version", version = "=1.11.11" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
+solana-client = { path = "../client", version = "=1.12.0" }
+solana-logger = { path = "../logger", version = "=1.12.0" }
+solana-metrics = { path = "../metrics", version = "=1.12.0" }
+solana-notifier = { path = "../notifier", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-version = { path = "../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-watchtower"
 description = "Blockchain, Rebuilt for Scale"
-version = "1.12.0"
+version = "1.13.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/solana-watchtower"
 clap = "2.33.1"
 humantime = "2.0.1"
 log = "0.4.17"
-solana-clap-utils = { path = "../clap-utils", version = "=1.12.0" }
-solana-cli-config = { path = "../cli-config", version = "=1.12.0" }
-solana-cli-output = { path = "../cli-output", version = "=1.12.0" }
-solana-client = { path = "../client", version = "=1.12.0" }
-solana-logger = { path = "../logger", version = "=1.12.0" }
-solana-metrics = { path = "../metrics", version = "=1.12.0" }
-solana-notifier = { path = "../notifier", version = "=1.12.0" }
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
-solana-version = { path = "../version", version = "=1.12.0" }
+solana-clap-utils = { path = "../clap-utils", version = "=1.13.0" }
+solana-cli-config = { path = "../cli-config", version = "=1.13.0" }
+solana-cli-output = { path = "../cli-output", version = "=1.13.0" }
+solana-client = { path = "../client", version = "=1.13.0" }
+solana-logger = { path = "../logger", version = "=1.13.0" }
+solana-metrics = { path = "../metrics", version = "=1.13.0" }
+solana-notifier = { path = "../notifier", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-version = { path = "../version", version = "=1.13.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-sdk"
 description = "Solana Zk Token SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.12.0"
+version = "1.13.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,7 +12,7 @@ base64 = "0.13"
 bytemuck = { version = "1.11.0", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../sdk/program", version = "=1.12.0" }
+solana-program = { path = "../sdk/program", version = "=1.13.0" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = "0.10.3"
@@ -29,7 +29,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.9"
-solana-sdk = { path = "../sdk", version = "=1.12.0" }
+solana-sdk = { path = "../sdk", version = "=1.13.0" }
 subtle = "2"
 thiserror = "1.0"
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-sdk"
 description = "Solana Zk Token SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.13.0"
+version = "1.14.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,7 +12,7 @@ base64 = "0.13"
 bytemuck = { version = "1.11.0", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../sdk/program", version = "=1.13.0" }
+solana-program = { path = "../sdk/program", version = "=1.14.0" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = "0.10.3"
@@ -29,7 +29,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.9"
-solana-sdk = { path = "../sdk", version = "=1.13.0" }
+solana-sdk = { path = "../sdk", version = "=1.14.0" }
 subtle = "2"
 thiserror = "1.0"
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-zk-token-sdk"
 description = "Solana Zk Token SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
-version = "1.11.11"
+version = "1.12.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -12,7 +12,7 @@ base64 = "0.13"
 bytemuck = { version = "1.11.0", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = { path = "../sdk/program", version = "=1.11.11" }
+solana-program = { path = "../sdk/program", version = "=1.12.0" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = "0.10.3"
@@ -29,7 +29,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.9"
-solana-sdk = { path = "../sdk", version = "=1.11.11" }
+solana-sdk = { path = "../sdk", version = "=1.12.0" }
 subtle = "2"
 thiserror = "1.0"
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }


### PR DESCRIPTION
#### Problem
In order to backport quic changes to v1.10 in the safest possible manner the version numbers are all being incremented 3 minor releases. See discussion on Discord in #releng and #proj-quic-tpu:
https://discord.com/channels/428295358100013066/910937142182682656/1019051275318476881

#### Solution
Bump version to v1.14.0