### PR TITLE
Backport reading new 1.12 snapshot persistence fields.

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -200,6 +200,25 @@ impl RentDebit {
     }
 }
 
+/// Incremental snapshots only calculate their accounts hash based on the account changes WITHIN the incremental slot range.
+/// So, we need to keep track of the full snapshot expected accounts hash results.
+/// We also need to keep track of the hash and capitalization specific to the incremental snapshot slot range.
+/// The capitalization we calculate for the incremental slot will NOT be consistent with the bank's capitalization.
+/// It is not feasible to calculate a capitalization delta that is correct given just incremental slots account data and the full snapshot's capitalization.
+#[derive(Serialize, Deserialize, AbiExample, Clone, Debug, Default, PartialEq, Eq)]
+pub struct BankIncrementalSnapshotPersistence {
+    /// slot of full snapshot
+    pub full_slot: Slot,
+    /// accounts hash from the full snapshot
+    pub full_hash: Hash,
+    /// capitalization from the full snapshot
+    pub full_capitalization: u64,
+    /// hash of the accounts in the incremental snapshot slot range, including zero-lamport accounts
+    pub incremental_hash: Hash,
+    /// capitalization of the accounts in the incremental snapshot slot range
+    pub incremental_capitalization: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct RentDebits(HashMap<Pubkey, RentDebit>);
 impl RentDebits {

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -307,6 +307,10 @@ impl<'a> TypeContext<'a> for Context {
         bank_fields.fee_rate_governor = bank_fields
             .fee_rate_governor
             .clone_with_lamports_per_signature(lamports_per_signature);
+
+        let incremental_snapshot_persistence = ignore_eof_error(deserialize_from(stream))?;
+        bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
+
         Ok((bank_fields, accounts_db_fields))
     }
 

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -206,7 +206,6 @@ impl<'a> TypeContext<'a> for Context {
             // Field that isn't part SerializableVersionedBank, but that we want to
             // be able to store / read back on restart
             lamports_per_signature,
-            // None::<BankIncrementalSnapshotPersistence>, this will be saved starting in 1.12
         )
             .serialize(serializer)
     }

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -314,7 +314,9 @@ impl<'a> TypeContext<'a> for Context {
             .clone_with_lamports_per_signature(lamports_per_signature);
 
         let _incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence> =
-            ignore_eof_error(deserialize_from(stream))?;
+            ignore_eof_error(deserialize_from(&mut stream))?;
+
+        let _epoch_accounts_hash: Option<Hash> = ignore_eof_error(deserialize_from(stream))?;
 
         Ok((bank_fields, accounts_db_fields))
     }

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -202,6 +202,7 @@ impl<'a> TypeContext<'a> for Context {
             // Field that isn't part SerializableVersionedBank, but that we want to
             // be able to store / read back on restart
             lamports_per_signature,
+            // None::<BankIncrementalSnapshotPersistence>, this will be saved starting in 1.12
         )
             .serialize(serializer)
     }

--- a/sdk/src/deserialize_utils.rs
+++ b/sdk/src/deserialize_utils.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Deserializer};
 
-
 /// This helper function enables successful deserialization of versioned structs; new structs may
 /// include additional fields if they impl Default and are added to the end of the struct. Right
 /// now, this function is targeted at `bincode` deserialization; the error match may need to be

--- a/sdk/src/deserialize_utils.rs
+++ b/sdk/src/deserialize_utils.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Deserializer};
 
+
 /// This helper function enables successful deserialization of versioned structs; new structs may
 /// include additional fields if they impl Default and are added to the end of the struct. Right
 /// now, this function is targeted at `bincode` deserialization; the error match may need to be
@@ -10,6 +11,14 @@ where
     T: Deserialize<'de> + Default,
 {
     let result = T::deserialize(d);
+    ignore_eof_error::<'de, T, D::Error>(result)
+}
+
+pub fn ignore_eof_error<'de, T, D>(result: Result<T, D>) -> Result<T, D>
+where
+    T: Deserialize<'de> + Default,
+    D: std::fmt::Display,
+{
     match result {
         Err(err) if err.to_string() == "io error: unexpected end of file" => Ok(T::default()),
         Err(err) if err.to_string() == "io error: failed to fill whole buffer" => Ok(T::default()),


### PR DESCRIPTION
#### Problem

Several fields were added to the end of snapshot persistence in 1.12. These fields will be written by 1.12. Without this deserialization, snapshots created by 1.12 will cause 1.10 to fail to load and report:
```
thread 'main' panicked at 'Load from snapshot failed: Io(Custom { kind: Other, error: "invalid snapshot data file: /home/sol/ledger/snapshot/tmp-snapshot-archive-p9SUJF/snapshots/150355422/150355422 has 499507533 bytes, however consumed 499507531 bytes to deserialize" })', ledger/src/bank_forks_utils.rs:233:10
```

https://discord.com/channels/428295358100013066/439194979856809985/1019242700266020914

#### Summary of Changes
Attempt to deserialize (and then ignore) new fields in snapshot persistence.
This pr combines changes from 3 different 1.11 backport prs. There were multiple merge errors in 1.10 and the backports into 1.11 were a little messed up (the first 1.11 backport ALSO wrote the new data, which would have caused incompatibility between 1.11 and 1.10). The most straightforward, easy to verify route was to combine these into 1 custom 1.10 backport PR.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
