### PR TITLE
fix: replace computed max u64 constant with literal

### DIFF
--- a/web3.js/src/programs/address-lookup-table/state.ts
+++ b/web3.js/src/programs/address-lookup-table/state.ts
@@ -32,7 +32,7 @@ export class AddressLookupTableAccount {
   }
 
   isActive(): boolean {
-    const U64_MAX = 2n ** 64n - 1n;
+    const U64_MAX = 18446744073709551615n;
     return this.state.deactivationSlot === U64_MAX;
   }
 

--- a/web3.js/test/message-tests/compiled-keys.test.ts
+++ b/web3.js/test/message-tests/compiled-keys.test.ts
@@ -12,7 +12,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 2n ** 64n - 1n;
+  const U64_MAX = 18446744073709551615n;
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {

--- a/web3.js/test/message-tests/v0.test.ts
+++ b/web3.js/test/message-tests/v0.test.ts
@@ -18,7 +18,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 2n ** 64n - 1n;
+  const U64_MAX = 18446744073709551615n;
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {

--- a/web3.js/test/transaction-tests/message.test.ts
+++ b/web3.js/test/transaction-tests/message.test.ts
@@ -17,7 +17,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 2n ** 64n - 1n;
+  const U64_MAX = 18446744073709551615n;
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {


### PR DESCRIPTION
#### Problem
Some bundlers convert `**` to `Math.pow` which breaks bigint exponentiation used in the web3 sdk

#### Summary of Changes
- Replace calculated max u64 with a literal value for improved compatibility

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
