### PR TITLE
calculate_capitalization gets 'enable_rehashing'

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -799,6 +799,7 @@ impl Accounts {
         debug_verify: bool,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        enable_rehashing: bool,
     ) -> u64 {
         let use_index = false;
         let is_startup = true;
@@ -816,7 +817,7 @@ impl Accounts {
                 epoch_schedule,
                 rent_collector,
                 is_startup,
-                true,
+                enable_rehashing,
             )
             .1
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7107,6 +7107,7 @@ impl Bank {
             debug_verify,
             self.epoch_schedule(),
             &self.rent_collector,
+            true,
         )
     }
 


### PR DESCRIPTION
#### Problem

during feature activation of skipping rewrites (#26491), we'll need to be able to let the bank govern whether rehashes are allowed or not on accounts hash calculation.

#### Summary of Changes
Add `enable_rehashing` to `accounts`.`calculate_capitalization` allowing a caller to specify whether to allow rehashes or not.
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->