### PR TITLE
add bank.bank_enable_rehashing_on_accounts_hash

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -208,7 +208,7 @@ impl SnapshotRequestHandler {
                             rent_collector: snapshot_root_bank.rent_collector(),
                             store_detailed_debug_info_on_failure: false,
                             full_snapshot: None,
-                            enable_rehashing: true,
+                            enable_rehashing: snapshot_root_bank.bank_enable_rehashing_on_accounts_hash(),
                         },
                     ).unwrap();
                     assert_eq!(previous_hash, this_hash);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5449,6 +5449,13 @@ impl Bank {
         }
     }
 
+    /// If we are skipping rewrites for bank hash, then we don't want to
+    ///  allow accounts hash calculation to rehash anything.
+    ///  We should use whatever hash found for each account as-is.
+    pub fn bank_enable_rehashing_on_accounts_hash(&self) -> bool {
+        true // this will be goverened by a feature later
+    }
+
     /// Collect rent from `accounts`
     ///
     /// This fn is called inside a parallel loop from `collect_rent_in_partition()`.  Avoid adding
@@ -7107,7 +7114,7 @@ impl Bank {
             debug_verify,
             self.epoch_schedule(),
             &self.rent_collector,
-            true,
+            self.bank_enable_rehashing_on_accounts_hash(),
         )
     }
 
@@ -7171,7 +7178,7 @@ impl Bank {
                 self.epoch_schedule(),
                 &self.rent_collector,
                 is_startup,
-                true,
+                self.bank_enable_rehashing_on_accounts_hash(),
             );
         if total_lamports != self.capitalization() {
             datapoint_info!(
@@ -7198,7 +7205,7 @@ impl Bank {
                         self.epoch_schedule(),
                         &self.rent_collector,
                         is_startup,
-                        true,
+                        self.bank_enable_rehashing_on_accounts_hash(),
                     );
             }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -119,7 +119,7 @@ impl AccountsPackage {
             accounts: bank.accounts(),
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
-            enable_rehashing: true, // this will be feature driven using bank
+            enable_rehashing: bank.bank_enable_rehashing_on_accounts_hash(),
         })
     }
 }


### PR DESCRIPTION
#### Problem

during feature activation of skipping rewrites (#26491), we'll need to be able to let the bank govern whether rehashes are allowed or not on accounts hash calculation.

#### Summary of Changes
Add `bank`.`bank_enable_rehashing_on_accounts_hash` as a clear way to answer the question of whether to allow rehashes or not.
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
