### PR TITLE
chore: fix flakey partialSign test

### DIFF
--- a/web3.js/test/transaction.test.ts
+++ b/web3.js/test/transaction.test.ts
@@ -418,7 +418,7 @@ describe('Transaction', () => {
     expect(partialTransaction).to.eql(transaction);
 
     invariant(partialTransaction.signatures[0].signature);
-    partialTransaction.signatures[0].signature[0] = 0;
+    partialTransaction.signatures[0].signature.fill(1);
     expect(() =>
       partialTransaction.serialize({requireAllSignatures: false}),
     ).to.throw();


### PR DESCRIPTION
#### Problem
There is a `partialSign` test which tries to cause an exception by changing the first value in a signature to `0` but sometimes that byte is already a `0` and no exception is thrown.

#### Summary of Changes
- Ensure that the test always throws an exception by using an invalid signature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
