### PR TITLE
Bump stable rust version to 1.60.0

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.59.0
+FROM solanalabs/rust:1.60.0
 ARG date
 
 RUN set -x \

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.59.0
+  stable_version=1.60.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then


### PR DESCRIPTION
#### Problem
ci downstream projects is failing:
https://buildkite.com/solana-labs/solana/builds/81755#0183384c-112c-4e56-879f-006c1a1e0bcc

#### Summary of Changes
Bump rust to 1.60.0. This fixes the problem when I run locally. Creating PR to see if it causes any other problems in CI.