### PR TITLE
acctidx: unref returns whether refcount went negative

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -8,6 +8,7 @@ use {
         bucket_map_holder_stats::BucketMapHolderStats,
         waitable_condvar::WaitableCondvar,
     },
+    log::*,
     rand::{thread_rng, Rng},
     solana_bucket_map::bucket_api::BucketApi,
     solana_measure::measure::Measure,
@@ -439,7 +440,9 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     pub fn unref(&self, pubkey: &Pubkey) {
         self.get_internal(pubkey, |entry| {
             if let Some(entry) = entry {
-                entry.unref();
+                if entry.unref() {
+                    info!("refcount of item already at 0: {pubkey}");
+                }
             }
             (true, ())
         })


### PR DESCRIPTION
#### Problem

While tracking down over/under refcounting issues, it is useful to identify a specific pubkey that is incorrect. That can illuminate the sequence that could lead to the incorrect unref.

#### Summary of Changes
return whether an error occurred or not from `unref`. If so, info! log the offending pubkey.
On a healthy validator, this code should never run.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
