### PR TITLE
move increment of accounts_db_store_timings2 metric to functions

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5105,9 +5105,6 @@ impl AccountsDb {
                                 .try_recycle_and_insert_store(slot, size as u64, std::u64::MAX)
                                 .is_none()
                             {
-                                self.stats
-                                    .create_store_count
-                                    .fetch_add(1, Ordering::Relaxed);
                                 self.create_and_insert_store(slot, self.file_size, "store extra");
                             } else {
                                 self.stats
@@ -5139,9 +5136,6 @@ impl AccountsDb {
                 .fetch_add(1, Ordering::Relaxed);
             store
         } else {
-            self.stats
-                .create_store_count
-                .fetch_add(1, Ordering::Relaxed);
             self.create_store(slot, self.file_size, "store", &self.paths)
         };
 
@@ -5178,6 +5172,9 @@ impl AccountsDb {
         from: &str,
         paths: &[PathBuf],
     ) -> Arc<AccountStorageEntry> {
+        self.stats
+            .create_store_count
+            .fetch_add(1, Ordering::Relaxed);
         let path_index = thread_rng().gen_range(0, paths.len());
         let store = Arc::new(self.new_storage_entry(
             slot,
@@ -5764,9 +5761,6 @@ impl AccountsDb {
                         .try_recycle_and_insert_store(slot, special_store_size, std::u64::MAX)
                         .is_none()
                     {
-                        self.stats
-                            .create_store_count
-                            .fetch_add(1, Ordering::Relaxed);
                         self.create_and_insert_store(slot, special_store_size, "large create");
                     } else {
                         self.stats

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5053,6 +5053,9 @@ impl AccountsDb {
                         ret.get_path(),
                         old_id
                     );
+                    self.stats
+                        .recycle_store_count
+                        .fetch_add(1, Ordering::Relaxed);
                     return Some(ret);
                 }
             }
@@ -5106,10 +5109,6 @@ impl AccountsDb {
                                 .is_none()
                             {
                                 self.create_and_insert_store(slot, self.file_size, "store extra");
-                            } else {
-                                self.stats
-                                    .recycle_store_count
-                                    .fetch_add(1, Ordering::Relaxed);
                             }
                         }
                         find_existing.stop();
@@ -5131,9 +5130,6 @@ impl AccountsDb {
             .fetch_add(find_existing.as_us(), Ordering::Relaxed);
 
         let store = if let Some(store) = self.try_recycle_store(slot, size as u64, std::u64::MAX) {
-            self.stats
-                .recycle_store_count
-                .fetch_add(1, Ordering::Relaxed);
             store
         } else {
             self.create_store(slot, self.file_size, "store", &self.paths)
@@ -5762,10 +5758,6 @@ impl AccountsDb {
                         .is_none()
                     {
                         self.create_and_insert_store(slot, special_store_size, "large create");
-                    } else {
-                        self.stats
-                            .recycle_store_count
-                            .fetch_add(1, Ordering::Relaxed);
                     }
                 }
                 continue;


### PR DESCRIPTION
#### Problem

It looks like `accounts_db_store_timings2.create_store_count` is incremented not in all the places where `create_store` is indirectly called.

In particular, `create_store` is indirectly called also in at least one other place https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L6092

It might explain why this metric is always 0 for the private cluster simulations:
<img width="704" alt="Screenshot 2022-09-14 at 15 58 07" src="https://user-images.githubusercontent.com/687962/190176747-28bedc7a-ad2f-4061-abc0-08b69fb7d663.png">

Similar situation with `try_recycle_store`.
This PR is draft until I verify that these metrics are not zero anylonger

#### Summary of Changes

Increment this metric inside the target function instead of doing that before calling it.