### PR TITLE
Use 2,000,000 for vm.max_map_count, a new requirement for larger banks.

### DIFF
--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -92,7 +92,7 @@ fn tune_kernel_udp_buffers_and_vmmap() {
     sysctl_write("net.core.wmem_default", "134217728");
 
     // increase mmap counts for many append_vecs
-    sysctl_write("vm.max_map_count", "1000000");
+    sysctl_write("vm.max_map_count", "2000000");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Problem

The vm.max_map_count setting of 1,000,000 is out of date and causes validators to crash on start-up.

#### Summary of Changes

Doubled vm.max_map_count to 2,000,000.
