### PR TITLE
move create_store counting to create_store

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5122,9 +5122,6 @@ impl AccountsDb {
                                 .try_recycle_and_insert_store(slot, size as u64, std::u64::MAX)
                                 .is_none()
                             {
-                                self.stats
-                                    .create_store_count
-                                    .fetch_add(1, Ordering::Relaxed);
                                 self.create_and_insert_store(slot, self.file_size, "store extra");
                             } else {
                                 self.stats
@@ -5156,9 +5153,6 @@ impl AccountsDb {
                 .fetch_add(1, Ordering::Relaxed);
             store
         } else {
-            self.stats
-                .create_store_count
-                .fetch_add(1, Ordering::Relaxed);
             self.create_store(slot, self.file_size, "store", &self.paths)
         };
 
@@ -5195,6 +5189,9 @@ impl AccountsDb {
         from: &str,
         paths: &[PathBuf],
     ) -> Arc<AccountStorageEntry> {
+        self.stats
+            .create_store_count
+            .fetch_add(1, Ordering::Relaxed);
         let path_index = thread_rng().gen_range(0, paths.len());
         let store = Arc::new(self.new_storage_entry(
             slot,
@@ -5781,9 +5778,6 @@ impl AccountsDb {
                         .try_recycle_and_insert_store(slot, special_store_size, std::u64::MAX)
                         .is_none()
                     {
-                        self.stats
-                            .create_store_count
-                            .fetch_add(1, Ordering::Relaxed);
                         self.create_and_insert_store(slot, special_store_size, "large create");
                     } else {
                         self.stats


### PR DESCRIPTION
It looks like `accounts_db_store_timings2.create_store_count` is incremented not in all the places where `create_store` is indirectly called.

In particular, `create_store` is indirectly called also in at least one other place https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L6092

It might explain why this metric is always 0 for the private cluster simulations:
<img width="704" alt="Screenshot 2022-09-14 at 15 58 07" src="https://user-images.githubusercontent.com/687962/190176747-28bedc7a-ad2f-4061-abc0-08b69fb7d663.png">

After running with this change situation changes:
<img width="1204" alt="Screenshot 2022-09-14 at 18 28 40" src="https://user-images.githubusercontent.com/687962/190210712-8973e683-c21a-4264-bcc3-8a89307e0d4f.png">

#### Summary of Changes

Increment this metric inside the target function instead of doing that before calling it.