### PR TITLE
slot_has_updates should not check if slot is full (and connected)

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3822,14 +3822,13 @@ fn slot_has_updates(slot_meta: &SlotMeta, slot_meta_backup: &Option<SlotMeta>) -
     // from block 0, which is true iff:
     // 1) The block with index prev_block_index is itself part of the trunk of consecutive blocks
     // starting from block 0,
-    slot_meta.is_connected &&
         // AND either:
         // 1) The slot didn't exist in the database before, and now we have a consecutive
         // block for that slot
-        ((slot_meta_backup.is_none() && slot_meta.consumed != 0) ||
+        (slot_meta_backup.is_none() && slot_meta.consumed != 0) ||
         // OR
         // 2) The slot did exist, but now we have a new consecutive block for that slot
-        (slot_meta_backup.is_some() && slot_meta_backup.as_ref().unwrap().consumed != slot_meta.consumed))
+        (slot_meta_backup.is_some() && slot_meta_backup.as_ref().unwrap().consumed != slot_meta.consumed)
 }
 
 // Creates a new ledger with slot 0 full of ticks (and only ticks).

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3822,10 +3822,10 @@ fn slot_has_updates(slot_meta: &SlotMeta, slot_meta_backup: &Option<SlotMeta>) -
     // from block 0, which is true iff:
     // 1) The block with index prev_block_index is itself part of the trunk of consecutive blocks
     // starting from block 0,
-        // AND either:
-        // 1) The slot didn't exist in the database before, and now we have a consecutive
-        // block for that slot
-        (slot_meta_backup.is_none() && slot_meta.consumed != 0) ||
+    // AND either:
+    // 1) The slot didn't exist in the database before, and now we have a consecutive
+    // block for that slot
+    (slot_meta_backup.is_none() && slot_meta.consumed != 0) ||
         // OR
         // 2) The slot did exist, but now we have a new consecutive block for that slot
         (slot_meta_backup.is_some() && slot_meta_backup.as_ref().unwrap().consumed != slot_meta.consumed)


### PR DESCRIPTION
This allows the replay loop to process shreds earlier. The replay loop does not need to wait 100ms between processing of shreds and can process them as soon as these are available.

Expected speed up to replay loop 100-200 ms

direct impact on all RPC and Validator nodes.

No risk

#### Problem

See issue #27729 


#### Summary of Changes


Fixes #
#27729 
