### PR TITLE
Fix parsing versions in published docs

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -214,7 +214,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.14.2 |   |
+| Address Lookup | v1.15.0 | v1.15.0 |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |


### PR DESCRIPTION
#### Problem
JSON-RPC docs about jsonParsed support got caught in the crossfire of #27742

#### Summary of Changes
Correct versions
