### PR TITLE
filters out zero lamport accounts deeper in call stack

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -254,7 +254,11 @@ fn bench_concurrent_read_write(bencher: &mut Bencher) {
                 let i = rng.gen_range(0, pubkeys.len());
                 test::black_box(
                     accounts
-                        .load_without_fixed_root(&Ancestors::default(), &pubkeys[i])
+                        .load_without_fixed_root(
+                            &Ancestors::default(),
+                            &pubkeys[i],
+                            true, // return_none_for_zero_lamport_accounts
+                        )
                         .unwrap(),
                 );
             }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2146,7 +2146,7 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             ),
             Err(AddressLookupError::InvalidAccountOwner),
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2114,6 +2114,7 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
+                true, // return_none_for_zero_lamport_accounts
             ),
             Err(AddressLookupError::LookupTableAccountNotFound),
         );
@@ -2145,6 +2146,7 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
+                true, // return_none_for_zero_lamport_accounts
             ),
             Err(AddressLookupError::InvalidAccountOwner),
         );
@@ -2177,6 +2179,7 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
+                true, // return_none_for_zero_lamport_accounts
             ),
             Err(AddressLookupError::InvalidAccountData),
         );
@@ -2221,6 +2224,7 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
+                true, // return_none_for_zero_lamport_accounts
             ),
             Ok(LoadedAddresses {
                 writable: vec![table_addresses[0]],
@@ -2535,6 +2539,7 @@ mod tests {
                 &mut vec![(keypair.pubkey(), account)],
                 0,
                 &mut error_counters,
+                true, // return_none_for_zero_lamport_accounts
             ),
             Err(TransactionError::ProgramAccountNotFound)
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, LoadHint, LoadZeroLamports, LoadedAccount, ScanStorageResult,
+            BankHashInfo, LoadHint, LoadedAccount, ScanStorageResult,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
@@ -35,8 +35,8 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot, INITIAL_RENT_EPOCH},
         feature_set::{
-            self, remove_deprecated_request_unit_ix, return_none_for_zero_lamport_accounts,
-            use_default_units_in_fee_calculation, FeatureSet,
+            self, remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation,
+            FeatureSet,
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
@@ -258,13 +258,6 @@ impl Accounts {
         feature_set: &FeatureSet,
         account_overrides: Option<&AccountOverrides>,
     ) -> Result<LoadedTransaction> {
-        let load_zero_lamports =
-            if feature_set.is_active(&return_none_for_zero_lamport_accounts::id()) {
-                LoadZeroLamports::None
-            } else {
-                LoadZeroLamports::SomeWithZeroLamportAccount
-            };
-
         // Copy all the accounts
         let message = tx.message();
         // NOTE: this check will never fail because `tx` is sanitized
@@ -300,7 +293,7 @@ impl Accounts {
                             (account_override.clone(), 0)
                         } else {
                             self.accounts_db
-                                .load_with_fixed_root(ancestors, key, load_zero_lamports)
+                                .load_with_fixed_root(ancestors, key)
                                 .map(|(mut account, _)| {
                                     if message.is_writable(i) {
                                         let rent_due = rent_collector
@@ -349,12 +342,9 @@ impl Accounts {
                                     programdata_address,
                                 }) = account.state()
                                 {
-                                    if let Some((programdata_account, _)) =
-                                        self.accounts_db.load_with_fixed_root(
-                                            ancestors,
-                                            &programdata_address,
-                                            load_zero_lamports,
-                                        )
+                                    if let Some((programdata_account, _)) = self
+                                        .accounts_db
+                                        .load_with_fixed_root(ancestors, &programdata_address)
                                     {
                                         account_deps
                                             .push((programdata_address, programdata_account));
@@ -398,7 +388,6 @@ impl Accounts {
                             &mut accounts,
                             instruction.program_id_index as IndexOfAccount,
                             error_counters,
-                            load_zero_lamports,
                         )
                     })
                     .collect::<Result<Vec<Vec<IndexOfAccount>>>>()?;
@@ -470,7 +459,6 @@ impl Accounts {
         accounts: &mut Vec<TransactionAccount>,
         mut program_account_index: IndexOfAccount,
         error_counters: &mut TransactionErrorMetrics,
-        load_zero_lamports: LoadZeroLamports,
     ) -> Result<Vec<IndexOfAccount>> {
         let mut account_indices = Vec::new();
         let mut program_id = match accounts.get(program_account_index as usize) {
@@ -488,11 +476,10 @@ impl Accounts {
             }
             depth += 1;
 
-            program_account_index = match self.accounts_db.load_with_fixed_root(
-                ancestors,
-                &program_id,
-                load_zero_lamports,
-            ) {
+            program_account_index = match self
+                .accounts_db
+                .load_with_fixed_root(ancestors, &program_id)
+            {
                 Some((program_account, _)) => {
                     let account_index = accounts.len() as IndexOfAccount;
                     accounts.push((program_id, program_account));
@@ -518,11 +505,10 @@ impl Accounts {
                     programdata_address,
                 }) = program.state()
                 {
-                    let programdata_account_index = match self.accounts_db.load_with_fixed_root(
-                        ancestors,
-                        &programdata_address,
-                        load_zero_lamports,
-                    ) {
+                    let programdata_account_index = match self
+                        .accounts_db
+                        .load_with_fixed_root(ancestors, &programdata_address)
+                    {
                         Some((programdata_account, _)) => {
                             let account_index = accounts.len() as IndexOfAccount;
                             accounts.push((programdata_address, programdata_account));
@@ -620,15 +606,10 @@ impl Accounts {
         ancestors: &Ancestors,
         address_table_lookup: &MessageAddressTableLookup,
         slot_hashes: &SlotHashes,
-        load_zero_lamports: LoadZeroLamports,
     ) -> std::result::Result<LoadedAddresses, AddressLookupError> {
         let table_account = self
             .accounts_db
-            .load_with_fixed_root(
-                ancestors,
-                &address_table_lookup.account_key,
-                load_zero_lamports,
-            )
+            .load_with_fixed_root(ancestors, &address_table_lookup.account_key)
             .map(|(account, _rent)| account)
             .ok_or(AddressLookupError::LookupTableAccountNotFound)?;
 
@@ -2097,7 +2078,6 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
-                LoadZeroLamports::SomeWithZeroLamportAccount,
             ),
             Err(AddressLookupError::LookupTableAccountNotFound),
         );
@@ -2115,8 +2095,7 @@ mod tests {
         );
 
         let invalid_table_key = Pubkey::new_unique();
-        let mut invalid_table_account = AccountSharedData::default();
-        invalid_table_account.set_lamports(1);
+        let invalid_table_account = AccountSharedData::default();
         accounts.store_slow_uncached(0, &invalid_table_key, &invalid_table_account);
 
         let address_table_lookup = MessageAddressTableLookup {
@@ -2130,7 +2109,6 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
-                LoadZeroLamports::SomeWithZeroLamportAccount,
             ),
             Err(AddressLookupError::InvalidAccountOwner),
         );
@@ -2163,7 +2141,6 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
-                LoadZeroLamports::SomeWithZeroLamportAccount,
             ),
             Err(AddressLookupError::InvalidAccountData),
         );
@@ -2208,7 +2185,6 @@ mod tests {
                 &ancestors,
                 &address_table_lookup,
                 &SlotHashes::default(),
-                LoadZeroLamports::SomeWithZeroLamportAccount,
             ),
             Ok(LoadedAddresses {
                 writable: vec![table_addresses[0]],
@@ -2523,7 +2499,6 @@ mod tests {
                 &mut vec![(keypair.pubkey(), account)],
                 0,
                 &mut error_counters,
-                LoadZeroLamports::SomeWithZeroLamportAccount,
             ),
             Err(TransactionError::ProgramAccountNotFound)
         );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10249,7 +10249,9 @@ pub mod tests {
         db.add_root(0);
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key),
+            db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account0, 0))
         );
     }
@@ -10268,13 +10270,21 @@ pub mod tests {
 
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account1
         );
 
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account1
         );
 
@@ -10304,13 +10314,21 @@ pub mod tests {
 
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account1
         );
 
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account1
         );
     }
@@ -10344,14 +10362,22 @@ pub mod tests {
         // at the Accounts level)
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account1
         );
 
         // we should see 1 token in slot 2
         let ancestors = vec![(0, 0), (2, 2)].into_iter().collect();
         assert_eq!(
-            &db.load_without_fixed_root(&ancestors, &key).unwrap().0,
+            &db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0,
             &account0
         );
 
@@ -10359,12 +10385,16 @@ pub mod tests {
 
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key),
+            db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account1, 1))
         );
         let ancestors = vec![(2, 2)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key),
+            db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account0, 0))
         ); // original value
     }
@@ -10379,7 +10409,11 @@ pub mod tests {
             let idx = thread_rng().gen_range(0, 99);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account = db
-                .load_without_fixed_root(&ancestors, &pubkeys[idx])
+                .load_without_fixed_root(
+                    &ancestors,
+                    &pubkeys[idx],
+                    true, // return_none_for_zero_lamport_accounts
+                )
                 .unwrap();
             let default_account = AccountSharedData::from(Account {
                 lamports: (idx + 1) as u64,
@@ -10395,11 +10429,19 @@ pub mod tests {
             let idx = thread_rng().gen_range(0, 99);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account0 = db
-                .load_without_fixed_root(&ancestors, &pubkeys[idx])
+                .load_without_fixed_root(
+                    &ancestors,
+                    &pubkeys[idx],
+                    true, // return_none_for_zero_lamport_accounts
+                )
                 .unwrap();
             let ancestors = vec![(1, 1)].into_iter().collect();
             let account1 = db
-                .load_without_fixed_root(&ancestors, &pubkeys[idx])
+                .load_without_fixed_root(
+                    &ancestors,
+                    &pubkeys[idx],
+                    true, // return_none_for_zero_lamport_accounts
+                )
                 .unwrap();
             let default_account = AccountSharedData::from(Account {
                 lamports: (idx + 1) as u64,
@@ -10487,12 +10529,16 @@ pub mod tests {
         // original account
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
         assert_eq!(
-            db0.load_without_fixed_root(&ancestors, &key),
+            db0.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account1, 1))
         );
         let ancestors = vec![(0, 0)].into_iter().collect();
         assert_eq!(
-            db0.load_without_fixed_root(&ancestors, &key),
+            db0.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account0, 0))
         );
     }
@@ -10522,7 +10568,11 @@ pub mod tests {
 
         // Purge the slot
         db.remove_unrooted_slots(&[(unrooted_slot, unrooted_bank_id)]);
-        assert!(db.load_without_fixed_root(&ancestors, &key).is_none());
+        assert!(db
+            .load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .is_none(),);
         assert!(db.bank_hashes.read().unwrap().get(&unrooted_slot).is_none());
         assert!(db.accounts_cache.slot_cache(unrooted_slot).is_none());
         assert!(db.storage.map.get(&unrooted_slot).is_none());
@@ -10576,7 +10626,11 @@ pub mod tests {
         // Check purged account stays gone
         let unrooted_slot_ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
         assert!(db
-            .load_without_fixed_root(&unrooted_slot_ancestors, &key)
+            .load_without_fixed_root(
+                &unrooted_slot_ancestors,
+                &key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .is_none());
     }
 
@@ -10595,7 +10649,9 @@ pub mod tests {
                 AccountSharedData::new((t + 1) as u64, space, AccountSharedData::default().owner());
             pubkeys.push(pubkey);
             assert!(accounts
-                .load_without_fixed_root(&ancestors, &pubkey)
+                .load_without_fixed_root(
+                    &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true
+                )
                 .is_none());
             accounts.store_uncached(slot, &[(&pubkey, &account)]);
         }
@@ -10606,7 +10662,9 @@ pub mod tests {
             pubkeys.push(pubkey);
             let ancestors = vec![(slot, 0)].into_iter().collect();
             assert!(accounts
-                .load_without_fixed_root(&ancestors, &pubkey)
+                .load_without_fixed_root(
+                    &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true
+                )
                 .is_none());
             accounts.store_uncached(slot, &[(&pubkey, &account)]);
         }
@@ -10616,15 +10674,21 @@ pub mod tests {
         for _ in 1..1000 {
             let idx = thread_rng().gen_range(0, range);
             let ancestors = vec![(slot, 0)].into_iter().collect();
-            if let Some((mut account, _)) =
-                accounts.load_without_fixed_root(&ancestors, &pubkeys[idx])
-            {
+            if let Some((mut account, _)) = accounts.load_without_fixed_root(
+                &ancestors,
+                &pubkeys[idx],
+                true, // return_none_for_zero_lamport_accounts
+            ) {
                 account.checked_add_lamports(1).unwrap();
                 accounts.store_uncached(slot, &[(&pubkeys[idx], &account)]);
                 if account.is_zero_lamport() {
                     let ancestors = vec![(slot, 0)].into_iter().collect();
                     assert!(accounts
-                        .load_without_fixed_root(&ancestors, &pubkeys[idx])
+                        .load_without_fixed_root(
+                            &ancestors,
+                            &pubkeys[idx],
+                            true, // return_none_for_zero_lamport_accounts
+                        )
                         .is_none());
                 } else {
                     let default_account = AccountSharedData::from(Account {
@@ -10680,7 +10744,11 @@ pub mod tests {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         for _ in 0..num {
             let idx = thread_rng().gen_range(0, num);
-            let account = accounts.load_without_fixed_root(&ancestors, &pubkeys[idx]);
+            let account = accounts.load_without_fixed_root(
+                &ancestors,
+                &pubkeys[idx],
+                true, // return_none_for_zero_lamport_accounts
+            );
             let account1 = Some((
                 AccountSharedData::new(
                     (idx + count) as u64,
@@ -10718,7 +10786,13 @@ pub mod tests {
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_account(&db, &mut pubkeys, 0, 1, 0, 0);
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let account = db.load_without_fixed_root(&ancestors, &pubkeys[0]).unwrap();
+        let account = db
+            .load_without_fixed_root(
+                &ancestors,
+                &pubkeys[0],
+                true, // return_none_for_zero_lamport_accounts
+            )
+            .unwrap();
         let default_account = AccountSharedData::from(Account {
             lamports: 1,
             ..Account::default()
@@ -10760,7 +10834,9 @@ pub mod tests {
         for (i, key) in keys.iter().enumerate() {
             assert_eq!(
                 accounts
-                    .load_without_fixed_root(&ancestors, key)
+                    .load_without_fixed_root(
+                        &ancestors, key, /*return_none_for_zero_lamport_accounts:*/ true
+                    )
                     .unwrap()
                     .0
                     .lamports(),
@@ -10813,14 +10889,18 @@ pub mod tests {
         let ancestors = vec![(0, 0)].into_iter().collect();
         assert_eq!(
             accounts
-                .load_without_fixed_root(&ancestors, &pubkey1)
+                .load_without_fixed_root(
+                    &ancestors, &pubkey1, /*return_none_for_zero_lamport_accounts:*/ true
+                )
                 .unwrap()
                 .0,
             account1
         );
         assert_eq!(
             accounts
-                .load_without_fixed_root(&ancestors, &pubkey2)
+                .load_without_fixed_root(
+                    &ancestors, &pubkey2, /*return_none_for_zero_lamport_accounts:*/ true
+                )
                 .unwrap()
                 .0,
             account2
@@ -10839,14 +10919,18 @@ pub mod tests {
             let ancestors = vec![(0, 0)].into_iter().collect();
             assert_eq!(
                 accounts
-                    .load_without_fixed_root(&ancestors, &pubkey1)
+                    .load_without_fixed_root(
+                        &ancestors, &pubkey1, /*return_none_for_zero_lamport_accounts:*/ true
+                    )
                     .unwrap()
                     .0,
                 account1
             );
             assert_eq!(
                 accounts
-                    .load_without_fixed_root(&ancestors, &pubkey2)
+                    .load_without_fixed_root(
+                        &ancestors, &pubkey2, /*return_none_for_zero_lamport_accounts:*/ true
+                    )
                     .unwrap()
                     .0,
                 account2
@@ -10900,7 +10984,9 @@ pub mod tests {
         //new value is there
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
-            accounts.load_without_fixed_root(&ancestors, &pubkey),
+            accounts.load_without_fixed_root(
+                &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account, 1))
         );
     }
@@ -11478,14 +11564,18 @@ pub mod tests {
     ) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         let (account, slot) = accounts
-            .load_without_fixed_root(&ancestors, &pubkey)
+            .load_without_fixed_root(
+                &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true,
+            )
             .unwrap();
         assert_eq!((account.lamports(), slot), (expected_lamports, slot));
     }
 
     fn assert_not_load_account(accounts: &AccountsDb, slot: Slot, pubkey: Pubkey) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
-        let load = accounts.load_without_fixed_root(&ancestors, &pubkey);
+        let load = accounts.load_without_fixed_root(
+            &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true,
+        );
         assert!(load.is_none(), "{:?}", load);
     }
 
@@ -11822,7 +11912,11 @@ pub mod tests {
                             db.store_uncached(slot, &[(&pubkey, &account)]);
 
                             let (account, slot) = db
-                                .load_without_fixed_root(&Ancestors::default(), &pubkey)
+                                .load_without_fixed_root(
+                                    &Ancestors::default(),
+                                    &pubkey,
+                                    true, // return_none_for_zero_lamport_accounts
+                                )
                                 .unwrap_or_else(|| {
                                     panic!("Could not fetch stored account {}, iter {}", pubkey, i)
                                 });
@@ -11904,10 +11998,12 @@ pub mod tests {
         db.print_accounts_stats("post");
         let ancestors = vec![(2, 0)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key1)
-                .unwrap()
-                .0
-                .lamports(),
+            db.load_without_fixed_root(
+                &ancestors, &key1, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .unwrap()
+            .0
+            .lamports(),
             3
         );
     }
@@ -11924,7 +12020,11 @@ pub mod tests {
         db.store_uncached(0, &[(&key, &account)]);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let ret = db.load_without_fixed_root(&ancestors, &key).unwrap();
+        let ret = db
+            .load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true,
+            )
+            .unwrap();
         assert_eq!(ret.0.data().len(), data_len);
     }
 
@@ -12036,7 +12136,12 @@ pub mod tests {
         let ancestors = vec![(some_slot, 0)].into_iter().collect();
 
         db.store_uncached(some_slot, &[(&key, &account)]);
-        let mut account = db.load_without_fixed_root(&ancestors, &key).unwrap().0;
+        let mut account = db
+            .load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true,
+            )
+            .unwrap()
+            .0;
         account.checked_sub_lamports(1).unwrap();
         account.set_executable(true);
         db.store_uncached(some_slot, &[(&key, &account)]);
@@ -13624,7 +13729,12 @@ pub mod tests {
         ancestors.insert(2, 1);
         for (key, account_ref) in keys[..num_to_store].iter().zip(account_refs) {
             assert_eq!(
-                accounts.load_without_fixed_root(&ancestors, key).unwrap().0,
+                accounts
+                    .load_without_fixed_root(
+                        &ancestors, key, /*return_none_for_zero_lamport_accounts:*/ true
+                    )
+                    .unwrap()
+                    .0,
                 account_ref
             );
         }
@@ -13651,7 +13761,11 @@ pub mod tests {
         assert_eq!(slots - 1, db.next_id.load(Ordering::Acquire));
         let ancestors = Ancestors::default();
         keys.iter().for_each(|key| {
-            assert!(db.load_without_fixed_root(&ancestors, key).is_some());
+            assert!(db
+                .load_without_fixed_root(
+                    &ancestors, key, /*return_none_for_zero_lamport_accounts:*/ true
+                )
+                .is_some(),);
         });
     }
 
@@ -13678,7 +13792,11 @@ pub mod tests {
         });
         let ancestors = Ancestors::default();
         keys.iter().for_each(|key| {
-            assert!(db.load_without_fixed_root(&ancestors, key).is_some());
+            assert!(db
+                .load_without_fixed_root(
+                    &ancestors, key, /*return_none_for_zero_lamport_accounts:*/ true
+                )
+                .is_some(),);
         });
     }
 
@@ -13702,7 +13820,11 @@ pub mod tests {
 
         // Should still be able to find zero lamport account in slot 1
         assert_eq!(
-            db.load_without_fixed_root(&Ancestors::default(), &account_key),
+            db.load_without_fixed_root(
+                &Ancestors::default(),
+                &account_key,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((zero_lamport_account, 1))
         );
     }
@@ -13718,24 +13840,38 @@ pub mod tests {
 
         // Load with no ancestors and no root will return nothing
         assert!(db
-            .load_without_fixed_root(&Ancestors::default(), &key)
+            .load_without_fixed_root(
+                &Ancestors::default(),
+                &key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .is_none());
 
         // Load with ancestors not equal to `slot` will return nothing
         let ancestors = vec![(slot + 1, 1)].into_iter().collect();
-        assert!(db.load_without_fixed_root(&ancestors, &key).is_none());
+        assert!(db
+            .load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            )
+            .is_none(),);
 
         // Load with ancestors equal to `slot` will return the account
         let ancestors = vec![(slot, 1)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key),
+            db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account0.clone(), slot))
         );
 
         // Adding root will return the account even without ancestors
         db.add_root(slot);
         assert_eq!(
-            db.load_without_fixed_root(&Ancestors::default(), &key),
+            db.load_without_fixed_root(
+                &Ancestors::default(),
+                &key,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((account0, slot))
         );
     }
@@ -13755,7 +13891,9 @@ pub mod tests {
         db.flush_accounts_cache(true, None);
         let ancestors = vec![(slot, 1)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &key),
+            db.load_without_fixed_root(
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+            ),
             Some((account0.clone(), slot))
         );
 
@@ -13763,7 +13901,11 @@ pub mod tests {
         db.add_root(slot);
         db.flush_accounts_cache(true, None);
         assert_eq!(
-            db.load_without_fixed_root(&Ancestors::default(), &key),
+            db.load_without_fixed_root(
+                &Ancestors::default(),
+                &key,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((account0, slot))
         );
     }
@@ -13792,14 +13934,22 @@ pub mod tests {
         // Unrooted slot should be able to be fetched before the flush
         let ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
         assert_eq!(
-            db.load_without_fixed_root(&ancestors, &unrooted_key),
+            db.load_without_fixed_root(
+                &ancestors,
+                &unrooted_key,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((account0.clone(), unrooted_slot))
         );
         db.flush_accounts_cache(true, None);
 
         // After the flush, the unrooted slot is still in the cache
         assert!(db
-            .load_without_fixed_root(&ancestors, &unrooted_key)
+            .load_without_fixed_root(
+                &ancestors,
+                &unrooted_key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .is_some());
         assert!(db
             .accounts_index
@@ -13808,11 +13958,19 @@ pub mod tests {
         assert_eq!(db.accounts_cache.num_slots(), 1);
         assert!(db.accounts_cache.slot_cache(unrooted_slot).is_some());
         assert_eq!(
-            db.load_without_fixed_root(&Ancestors::default(), &key5),
+            db.load_without_fixed_root(
+                &Ancestors::default(),
+                &key5,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((account0.clone(), root5))
         );
         assert_eq!(
-            db.load_without_fixed_root(&Ancestors::default(), &key6),
+            db.load_without_fixed_root(
+                &Ancestors::default(),
+                &key6,
+                true, // return_none_for_zero_lamport_accounts
+            ),
             Some((account0, root6))
         );
     }
@@ -13887,7 +14045,9 @@ pub mod tests {
                 vec![(slot, 1)].into_iter().collect()
             };
             assert_eq!(
-                db.load_without_fixed_root(&ancestors, &key),
+                db.load_without_fixed_root(
+                    &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                ),
                 Some((account0.clone(), slot))
             );
         }
@@ -13926,13 +14086,21 @@ pub mod tests {
 
         assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key)
+            .load_with_fixed_root(
+                &Ancestors::default(),
+                &account_key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key)
+            .load_with_fixed_root(
+                &Ancestors::default(),
+                &account_key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
@@ -13940,7 +14108,11 @@ pub mod tests {
         db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key)
+            .load_with_fixed_root(
+                &Ancestors::default(),
+                &account_key,
+                true, // return_none_for_zero_lamport_accounts
+            )
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 0);
@@ -13976,6 +14148,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), 0);
@@ -13991,7 +14164,8 @@ pub mod tests {
                 &Ancestors::default(),
                 &account_key,
                 Some(0),
-                LoadHint::Unspecified
+                LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .is_none());
     }
@@ -14075,7 +14249,8 @@ pub mod tests {
                 &Ancestors::default(),
                 &zero_lamport_account_key,
                 max_root,
-                load_hint
+                load_hint,
+                true, // return_none_for_zero_lamport_accounts
             )
             .unwrap()
             .0
@@ -14204,6 +14379,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), zero_lamport_account.lamports());
@@ -14217,6 +14393,7 @@ pub mod tests {
                 &account_key,
                 Some(max_scan_root),
                 LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), slot1_account.lamports());
@@ -14231,6 +14408,7 @@ pub mod tests {
                 &account_key,
                 Some(max_scan_root),
                 LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), slot1_account.lamports());
@@ -14243,7 +14421,8 @@ pub mod tests {
                 &scan_ancestors,
                 &account_key,
                 Some(max_scan_root),
-                LoadHint::Unspecified
+                LoadHint::Unspecified,
+                true, // return_none_for_zero_lamport_accounts
             )
             .is_none());
     }
@@ -14407,7 +14586,8 @@ pub mod tests {
                     &Ancestors::default(),
                     key,
                     Some(last_dead_slot),
-                    LoadHint::Unspecified
+                    LoadHint::Unspecified,
+                    true, // return_none_for_zero_lamport_accounts
                 )
                 .is_some());
         }
@@ -14435,7 +14615,8 @@ pub mod tests {
                     &Ancestors::default(),
                     key,
                     Some(last_dead_slot),
-                    LoadHint::Unspecified
+                    LoadHint::Unspecified,
+                    true, // return_none_for_zero_lamport_accounts
                 )
                 .is_none());
         }
@@ -14968,7 +15149,12 @@ pub mod tests {
                         .store(thread_rng().gen_range(0, 10) as u64, Ordering::Relaxed);
 
                     // Load should never be unable to find this key
-                    let loaded_account = db.do_load(&ancestors, &pubkey, None, load_hint).unwrap();
+                    let loaded_account = db
+                        .do_load(
+                            &ancestors, &pubkey, None, load_hint,
+                            true, // return_none_for_zero_lamport_accounts
+                        )
+                        .unwrap();
                     // slot + 1 == account.lamports because of the account-cache-flush thread
                     assert_eq!(
                         loaded_account.0.lamports(),
@@ -15323,7 +15509,8 @@ pub mod tests {
                     .load(
                         &Ancestors::from(vec![(*slot, 0)]),
                         &account_in_slot,
-                        LoadHint::FixedMaxRoot
+                        LoadHint::FixedMaxRoot,
+                        true, // return_none_for_zero_lamport_accounts
                     )
                     .is_some());
                 // Clear for next iteration so that `assert!(self.storage.get_slot_stores(purged_slot).is_none());`

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4674,22 +4674,6 @@ impl AccountsDb {
         )
     }
 
-    pub fn load_account_into_read_cache(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        return_none_for_zero_lamport_accounts: bool,
-    ) {
-        self.do_load_with_populate_read_cache(
-            ancestors,
-            pubkey,
-            None,
-            LoadHint::Unspecified,
-            true,
-            return_none_for_zero_lamport_accounts,
-        );
-    }
-
     pub fn load_with_fixed_root(
         &self,
         ancestors: &Ancestors,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -145,17 +145,6 @@ pub enum StoreReclaims {
     Ignore,
 }
 
-/// specifies how to return zero lamport accounts
-/// This will only be useful until a feature activation occurs.
-#[derive(Clone, Copy)]
-pub enum LoadZeroLamports {
-    /// return None if loaded account has zero lamports
-    None,
-    /// return Some(account with zero lamports) if loaded account has zero lamports
-    /// Today this is the default. With feature activation, this will no longer be possible.
-    SomeWithZeroLamportAccount,
-}
-
 // the current best way to add filler accounts is gradually.
 // In other scenarios, such as monitoring catchup with large # of accounts, it may be useful to be able to
 // add filler accounts at the beginning, so that code path remains but won't execute at the moment.
@@ -4686,15 +4675,8 @@ impl AccountsDb {
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
-        load_zero_lamports: LoadZeroLamports,
     ) -> Option<(AccountSharedData, Slot)> {
         self.load(ancestors, pubkey, LoadHint::FixedMaxRoot)
-            .filter(|(account, _)| {
-                matches!(
-                    load_zero_lamports,
-                    LoadZeroLamports::SomeWithZeroLamportAccount
-                ) || !account.is_zero_lamport()
-            })
     }
 
     pub fn load_without_fixed_root(
@@ -13914,13 +13896,13 @@ pub mod tests {
 
         assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key, LoadZeroLamports::None)
+            .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key, LoadZeroLamports::None)
+            .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
@@ -13928,9 +13910,10 @@ pub mod tests {
         db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
-            .load_with_fixed_root(&Ancestors::default(), &account_key, LoadZeroLamports::None)
-            .map(|(account, _)| account);
-        assert!(account.is_none());
+            .load_with_fixed_root(&Ancestors::default(), &account_key)
+            .map(|(account, _)| account)
+            .unwrap();
+        assert_eq!(account.lamports(), 0);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10271,7 +10271,7 @@ pub mod tests {
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
             &db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             )
             .unwrap()
             .0,
@@ -10281,7 +10281,7 @@ pub mod tests {
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
         assert_eq!(
             &db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             )
             .unwrap()
             .0,
@@ -10315,7 +10315,7 @@ pub mod tests {
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
             &db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             )
             .unwrap()
             .0,
@@ -10325,7 +10325,7 @@ pub mod tests {
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
         assert_eq!(
             &db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             )
             .unwrap()
             .0,
@@ -10363,7 +10363,7 @@ pub mod tests {
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
         assert_eq!(
             &db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             )
             .unwrap()
             .0,
@@ -10386,7 +10386,7 @@ pub mod tests {
         let ancestors = vec![(1, 1)].into_iter().collect();
         assert_eq!(
             db.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             ),
             Some((account1, 1))
         );
@@ -10530,7 +10530,7 @@ pub mod tests {
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
         assert_eq!(
             db0.load_without_fixed_root(
-                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ true
+                &ancestors, &key, /*return_none_for_zero_lamport_accounts:*/ false
             ),
             Some((account1, 1))
         );
@@ -11565,7 +11565,7 @@ pub mod tests {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         let (account, slot) = accounts
             .load_without_fixed_root(
-                &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ true,
+                &ancestors, &pubkey, /*return_none_for_zero_lamport_accounts:*/ false,
             )
             .unwrap();
         assert_eq!((account.lamports(), slot), (expected_lamports, slot));
@@ -13823,7 +13823,7 @@ pub mod tests {
             db.load_without_fixed_root(
                 &Ancestors::default(),
                 &account_key,
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             ),
             Some((zero_lamport_account, 1))
         );
@@ -14111,7 +14111,7 @@ pub mod tests {
             .load_with_fixed_root(
                 &Ancestors::default(),
                 &account_key,
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             )
             .map(|(account, _)| account)
             .unwrap();
@@ -14148,7 +14148,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), 0);
@@ -14250,7 +14250,7 @@ pub mod tests {
                 &zero_lamport_account_key,
                 max_root,
                 load_hint,
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             )
             .unwrap()
             .0
@@ -14379,7 +14379,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
-                true, // return_none_for_zero_lamport_accounts
+                false, // return_none_for_zero_lamport_accounts
             )
             .unwrap();
         assert_eq!(account.0.lamports(), zero_lamport_account.lamports());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7169,14 +7169,6 @@ impl Bank {
         &self.rc.accounts.accounts_db.thread_pool_clean
     }
 
-    pub fn load_account_into_read_cache(&self, key: &Pubkey) {
-        self.rc.accounts.accounts_db.load_account_into_read_cache(
-            &self.ancestors,
-            key,
-            self.return_none_for_zero_lamport_accounts(),
-        );
-    }
-
     pub fn update_accounts_hash_with_index_option(
         &self,
         use_index: bool,

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -30,6 +30,7 @@ impl AddressLoader for &Bank {
                     &self.ancestors,
                     address_table_lookup,
                     &slot_hashes,
+                    self.return_none_for_zero_lamport_accounts(),
                 )
             })
             .collect::<Result<_, AddressLookupError>>()?)

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -1,9 +1,7 @@
 use {
     super::Bank,
-    crate::accounts_db::LoadZeroLamports,
     solana_address_lookup_table_program::error::AddressLookupError,
     solana_sdk::{
-        feature_set::return_none_for_zero_lamport_accounts,
         message::v0::{LoadedAddresses, MessageAddressTableLookup},
         transaction::{AddressLoader, Result as TransactionResult, TransactionError},
     },
@@ -17,15 +15,6 @@ impl AddressLoader for &Bank {
         if !self.versioned_tx_message_enabled() {
             return Err(TransactionError::UnsupportedVersion);
         }
-
-        let load_zero_lamports = if self
-            .feature_set
-            .is_active(&return_none_for_zero_lamport_accounts::id())
-        {
-            LoadZeroLamports::None
-        } else {
-            LoadZeroLamports::SomeWithZeroLamportAccount
-        };
 
         let slot_hashes = self
             .sysvar_cache
@@ -41,7 +30,6 @@ impl AddressLoader for &Bank {
                     &self.ancestors,
                     address_table_lookup,
                     &slot_hashes,
-                    load_zero_lamports,
                 )
             })
             .collect::<Result<_, AddressLookupError>>()?)

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -77,7 +77,11 @@ fn check_accounts(accounts: &Accounts, pubkeys: &[Pubkey], num: usize) {
     for _ in 1..num {
         let idx = thread_rng().gen_range(0, num - 1);
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let account = accounts.load_without_fixed_root(&ancestors, &pubkeys[idx]);
+        let account = accounts.load_without_fixed_root(
+            &ancestors,
+            &pubkeys[idx],
+            true, // return_none_for_zero_lamport_accounts
+        );
         let account1 = Some((
             AccountSharedData::new((idx + 1) as u64, 0, AccountSharedData::default().owner()),
             0,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -514,10 +514,6 @@ pub mod cap_accounts_data_allocations_per_transaction {
     solana_sdk::declare_id!("9gxu85LYRAcZL38We8MYJ4A9AwgBBPtVBAqebMcT1241");
 }
 
-pub mod return_none_for_zero_lamport_accounts {
-    solana_sdk::declare_id!("7K5HFrS1WAq6ND7RQbShXZXbtAookyTfaDQPTJNuZpze");
-}
-
 pub mod epoch_accounts_hash {
     solana_sdk::declare_id!("5GpmAKxaGsWWbPp4bNXFLJxZVvG92ctxf7jQnzTQjF3n");
 }
@@ -653,7 +649,6 @@ lazy_static! {
         (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
         (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
         (cap_accounts_data_allocations_per_transaction::id(), "cap accounts data allocations per transaction #27375"),
-        (return_none_for_zero_lamport_accounts::id(), "return none for zero lamport accounts #27800"),
         (epoch_accounts_hash::id(), "enable epoch accounts hash calculation #27539"),
         (remove_deprecated_request_unit_ix::id(), "remove support for RequestUnitsDeprecated instruction #27500"),
         (increase_tx_account_lock_limit::id(), "increase tx account lock limit to 128 #27241"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -514,6 +514,10 @@ pub mod cap_accounts_data_allocations_per_transaction {
     solana_sdk::declare_id!("9gxu85LYRAcZL38We8MYJ4A9AwgBBPtVBAqebMcT1241");
 }
 
+pub mod return_none_for_zero_lamport_accounts {
+    solana_sdk::declare_id!("7K5HFrS1WAq6ND7RQbShXZXbtAookyTfaDQPTJNuZpze");
+}
+
 pub mod epoch_accounts_hash {
     solana_sdk::declare_id!("5GpmAKxaGsWWbPp4bNXFLJxZVvG92ctxf7jQnzTQjF3n");
 }
@@ -649,6 +653,7 @@ lazy_static! {
         (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
         (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
         (cap_accounts_data_allocations_per_transaction::id(), "cap accounts data allocations per transaction #27375"),
+        (return_none_for_zero_lamport_accounts::id(), "return none for zero lamport accounts #27800"),
         (epoch_accounts_hash::id(), "enable epoch accounts hash calculation #27539"),
         (remove_deprecated_request_unit_ix::id(), "remove support for RequestUnitsDeprecated instruction #27500"),
         (increase_tx_account_lock_limit::id(), "increase tx account lock limit to 128 #27241"),


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/27793 still leaves accounts-db api where it may bypass zero lamport accounts filtering.

#### Summary of Changes
filter out zero lamport accounts deeper in call stack