### PR TITLE
BorrowedAccount: tweak data APIs

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1185,13 +1185,13 @@ mod tests {
                 MockInstruction::NoopFail => return Err(InstructionError::GenericError),
                 MockInstruction::ModifyOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&[1])?,
+                    .set_data(vec![1])?,
                 MockInstruction::ModifyNotOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 1)?
-                    .set_data(&[1])?,
+                    .set_data(vec![1])?,
                 MockInstruction::ModifyReadonly => instruction_context
                     .try_borrow_instruction_account(transaction_context, 2)?
-                    .set_data(&[1])?,
+                    .set_data(vec![1])?,
                 MockInstruction::UnbalancedPush => {
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
@@ -1239,7 +1239,7 @@ mod tests {
                 }
                 MockInstruction::Resize { new_len } => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&vec![0; new_len as usize])?,
+                    .set_data(vec![0; new_len as usize])?,
             }
         } else {
             return Err(InstructionError::InvalidInstructionData);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -160,7 +160,7 @@ pub fn builtin_process_instruction(
                     .is_ok()
                     && borrowed_account.can_data_be_changed().is_ok()
                 {
-                    borrowed_account.set_data(&account_info.data.borrow())?;
+                    borrowed_account.set_data(account_info.data.borrow().to_vec())?;
                 }
                 if borrowed_account.get_owner() != account_info.owner {
                     borrowed_account.set_owner(account_info.owner.as_ref())?;
@@ -286,7 +286,9 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
                 .can_data_be_resized(account_info_data.len())
                 .and_then(|_| borrowed_account.can_data_be_changed())
             {
-                Ok(()) => borrowed_account.set_data(&account_info_data).unwrap(),
+                Ok(()) => borrowed_account
+                    .set_data(account_info_data.to_vec())
+                    .unwrap(),
                 Err(err) if borrowed_account.get_data() != *account_info_data => {
                     panic!("{:?}", err);
                 }

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -306,12 +306,13 @@ impl Processor {
         )?;
 
         {
-            let mut table_data = lookup_table_account.get_data_mut()?.to_vec();
-            AddressLookupTable::overwrite_meta_data(&mut table_data, lookup_table_meta)?;
+            AddressLookupTable::overwrite_meta_data(
+                lookup_table_account.get_data_mut()?,
+                lookup_table_meta,
+            )?;
             for new_address in new_addresses {
-                table_data.extend_from_slice(new_address.as_ref());
+                lookup_table_account.extend_from_slice(new_address.as_ref())?;
             }
-            lookup_table_account.set_data(&table_data)?;
         }
         drop(lookup_table_account);
 
@@ -462,7 +463,7 @@ impl Processor {
 
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        lookup_table_account.set_data(&[])?;
+        lookup_table_account.set_data(vec![])?;
         lookup_table_account.set_lamports(0)?;
 
         Ok(())

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3458,7 +3458,7 @@ fn test_program_bpf_realloc_invoke() {
     let pre_len = 100;
     let new_len = pre_len * 2;
     let mut invoke_account = AccountSharedData::new(START_BALANCE, pre_len, &realloc_program_id);
-    invoke_account.set_data_from_slice(&vec![1; pre_len]);
+    invoke_account.set_data(vec![1; pre_len]);
     bank.store_account(&invoke_pubkey, &invoke_account);
     let mut instruction_data = vec![];
     instruction_data.extend_from_slice(&[INVOKE_DEALLOC_AND_ASSIGN, 1]);

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -192,7 +192,7 @@ pub fn deserialize_parameters_unaligned(
                 .can_data_be_resized(data.len())
                 .and_then(|_| borrowed_account.can_data_be_changed())
             {
-                Ok(()) => borrowed_account.set_data(data)?,
+                Ok(()) => borrowed_account.set_data(data.to_vec())?,
                 Err(err) if borrowed_account.get_data() != data => return Err(err),
                 _ => {}
             }
@@ -355,7 +355,7 @@ pub fn deserialize_parameters_aligned(
                 .can_data_be_resized(data.len())
                 .and_then(|_| borrowed_account.can_data_be_changed())
             {
-                Ok(()) => borrowed_account.set_data(data)?,
+                Ok(()) => borrowed_account.set_data(data.to_vec())?,
                 Err(err) if borrowed_account.get_data() != data => return Err(err),
                 _ => {}
             }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -6,6 +6,10 @@ use {
     },
 };
 
+/// Account data as stored in the caller address space during CPI, translated to host memory.
+///
+/// At the start of a CPI, this can be different from the data stored in the
+/// corresponding BorrowedAccount, and needs to be synched.
 struct CallerAccount<'a> {
     lamports: &'a mut u64,
     owner: &'a mut Pubkey,
@@ -663,6 +667,11 @@ where
                 invoke_context,
             )?;
             {
+                // before initiating CPI, the caller may have modified the
+                // account (caller_account). We need to update the corresponding
+                // BorrowedAccount (callee_account) so the callee can see the
+                // changes.
+
                 if callee_account.get_lamports() != *caller_account.lamports {
                     callee_account
                         .set_lamports(*caller_account.lamports)
@@ -674,7 +683,7 @@ where
                     .and_then(|_| callee_account.can_data_be_changed())
                 {
                     Ok(()) => callee_account
-                        .set_data(caller_account.data)
+                        .set_data(caller_account.data.to_vec())
                         .map_err(SyscallError::InstructionError)?,
                     Err(err) if callee_account.get_data() != caller_account.data => {
                         return Err(EbpfError::UserError(BpfError::SyscallError(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -17308,7 +17308,7 @@ pub(crate) mod tests {
             let instruction_context = transaction_context.get_current_instruction_context()?;
             instruction_context
                 .try_borrow_instruction_account(transaction_context, 1)?
-                .set_data(&[0; 40])?;
+                .set_data(vec![0; 40])?;
             Ok(())
         }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -238,7 +238,7 @@ mod tests {
                     MockSystemInstruction::ChangeData { data } => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 1)?
-                            .set_data(&[data])?;
+                            .set_data(vec![data])?;
                         Ok(())
                     }
                 }
@@ -466,7 +466,7 @@ mod tests {
                             .try_borrow_instruction_account(transaction_context, 2)?;
                         dup_account.checked_sub_lamports(lamports)?;
                         to_account.checked_add_lamports(lamports)?;
-                        dup_account.set_data(&[data])?;
+                        dup_account.set_data(vec![data])?;
                         drop(dup_account);
                         let mut from_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?;

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -108,7 +108,7 @@ fn allocate(
         return Err(SystemError::InvalidAccountDataLength.into());
     }
 
-    account.set_data(&vec![0; space as usize])?;
+    account.set_data(vec![0; space as usize])?;
 
     Ok(())
 }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -538,14 +538,6 @@ impl Account {
 }
 
 impl AccountSharedData {
-    pub fn set_data_from_slice(&mut self, data: &[u8]) {
-        let len = self.data.len();
-        let len_different = len != data.len();
-        let different = len_different || data != &self.data[..];
-        if different {
-            self.data = Arc::new(data.to_vec());
-        }
-    }
     pub fn set_data(&mut self, data: Vec<u8>) {
         self.data = Arc::new(data);
     }
@@ -718,27 +710,6 @@ pub mod tests {
         account2.copy_into_owner_from_slice(key2.as_ref());
         assert!(accounts_equal(&account1, &account2));
         assert_eq!(account1.owner(), &key2);
-    }
-
-    #[test]
-    fn test_account_set_data_from_slice() {
-        let key = Pubkey::new_unique();
-        let (_, mut account) = make_two_accounts(&key);
-        assert_eq!(account.data(), &vec![0, 0]);
-        account.set_data_from_slice(&[1, 2]);
-        assert_eq!(account.data(), &vec![1, 2]);
-        account.set_data_from_slice(&[1, 2, 3]);
-        assert_eq!(account.data(), &vec![1, 2, 3]);
-        account.set_data_from_slice(&[4, 5, 6]);
-        assert_eq!(account.data(), &vec![4, 5, 6]);
-        account.set_data_from_slice(&[4, 5, 6, 0]);
-        assert_eq!(account.data(), &vec![4, 5, 6, 0]);
-        account.set_data_from_slice(&[]);
-        assert_eq!(account.data().len(), 0);
-        account.set_data_from_slice(&[44]);
-        assert_eq!(account.data(), &vec![44]);
-        account.set_data_from_slice(&[44]);
-        assert_eq!(account.data(), &vec![44]);
     }
 
     #[test]


### PR DESCRIPTION
Introduce `extend_from_slice(data)`, so that the following:

	let mut data = account.get_data_mut(); // malloc + memcpy if the underlying refcount > 1
	data.extend_from_slice(data_to_append); // memcpy
	account.set_data(&data) // malloc + memcpy to make the data owned, free(data)

Becomes:

	// malloc + memcpy if the underlying refcount > 1, + memcpy to append the data
	account.extend_from_slice(data_to_append);

Also make `set_data(data)` itself take data by value. Most callers were doing `set_data(&vec![...])`, which incurs in the extra malloc + memcpy + free as shown above.

Finally, this removes `AccountSharedData::set_data_from_slice(data)`. There are no users left and it had bad perf characteristics. 