### PR TITLE
patches range check in get_signed_message_range

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -623,7 +623,7 @@ pub mod layout {
                 merkle::ShredData::get_signed_message_range(proof_size)?
             }
         };
-        (shred.len() <= range.end).then_some(range)
+        (range.end <= shred.len()).then_some(range)
     }
 
     pub(crate) fn get_reference_tick(shred: &[u8]) -> Result<u8, Error> {


### PR DESCRIPTION
#### Problem
Inequality is reversed.

For current shreds `range.end == shred.len()`, so this is a no-op.
But for upcoming Merkle shreds this will cause shreds to incorrectly fail sig-verify.

#### Summary of Changes
Corrected the inequality direction.