### PR TITLE
ci: Add spl-token-upgrade to downstream program build

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -45,6 +45,7 @@ spl() {
       token/program-2022
       token/program-2022-test
       associated-token-account/program
+      token-upgrade/program
       feature-proposal/program
       governance/addin-mock/program
       governance/program


### PR DESCRIPTION
#### Problem

After adding the token upgrade CLI, the downstream build fails because it's trying to test the token-upgrade CLI without the token-ugprade program built.

#### Summary of Changes

Add the token-upgrade program to the list of programs to build and test.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
