### PR TITLE
stop adding shrunk entries to add_to_dirty_stores

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -388,6 +388,7 @@ impl<'a> SnapshotMinimizer<'a> {
             slot,
             &mut dead_storages.lock().unwrap(),
             |store| !append_vec_set.contains(&store.append_vec_id()),
+            true,
         );
     }
 


### PR DESCRIPTION
#### Problem

When we shrink, the only useful information for clean is the list of pubkeys that are now dead and have been removed. (Is this true? Could we perhaps mark a slot as dead now by just removing all the dead accounts from it?)

This is especially troublesome for ancient appendvecs, where we have many accounts in the store. Marking the entire ancient appendvec as possible for clean will hit the disk index heavy for likely not much gain(?). Occasionally we do need to visit ancient append vecs to clean out old accounts in them. Clean may not be the ideal process to do that.

#### Summary of Changes

for shrink and combine_ancient_slots, stop adding the entire old append vec to dirty_stores.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
