### PR TITLE
Implement retry count and error state for stateful subscription.

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -5117,7 +5117,10 @@ export class Connection {
                 const isErrorSubscription =
                   isErrorStatefulSubscription(subscription);
 
-                if (isErrorSubscription && subscription.retryCount + 1 > 3) {
+                if (
+                  isErrorSubscription &&
+                  subscription.retryCount + 1 > SUBSCRIPTION_ERROR_RETRY_LIMIT
+                ) {
                   console.error(
                     `${method} error, max retries reached`,
                     args,

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -74,7 +74,7 @@ const BufferFromRawAccountData = coerce(
 export const BLOCKHASH_CACHE_TIMEOUT_MS = 30 * 1000;
 
 /**
- *  Number of times a websocket can fail before subscription is dropped.
+ *  Number of times a subscription update can fail before subscription is dropped.
  */
 export const SUBSCRIPTION_ERROR_RETRY_LIMIT = 3;
 

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -5114,11 +5114,8 @@ export class Connection {
                   return;
                 }
 
-                const isErrorSubscription =
-                  isErrorStatefulSubscription(subscription);
-
                 if (
-                  isErrorSubscription &&
+                  subscription.state === 'error' &&
                   subscription.retryCount + 1 > SUBSCRIPTION_ERROR_RETRY_LIMIT
                 ) {
                   console.error(
@@ -5131,7 +5128,7 @@ export class Connection {
                 } else {
                   this._subscriptionsByHash[hash] = {
                     ...subscription,
-                    retryCount: isErrorSubscription
+                    retryCount: subscription.state === 'error'
                       ? subscription.retryCount + 1
                       : 0,
                     state: 'error',


### PR DESCRIPTION
#### Problem

Running into infinite recursion bug defined in #26198, in environment in node v16, web3.js 1.56.2. Causes lambda to stall and timeout.

Error example:
```
 signatureSubscribe error for argument [
'{transactionSignature}',
{ commitment: 'confirmed' }
] socket not ready
```

#### Summary of Changes

Implement `error` state type which tracks retries and logs error + deletes subscription when max retries hit for stateful subscription.

Fixes #26198
