### PR TITLE
bootstrap: Sleep in loop to get rpc peers

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -618,6 +618,8 @@ fn get_rpc_nodes(
     let mut newer_cluster_snapshot_timeout = None;
     let mut retry_reason = None;
     loop {
+        // Give gossip some time to populate and not spin on grabbing the crds lock
+        std::thread::sleep(Duration::from_secs(1));
         info!("\n{}", cluster_info.rpc_info_trace());
 
         let rpc_peers = get_rpc_peers(


### PR DESCRIPTION
#### Problem

When searching for RPC peers during bootstrap, gossip is polled in a tight loop. This is bad for gossip, since it grabs the CRDS lock each time. It's also bad for the user/log since the RPC Peers table is logged each time.

I started up a new node against mnb, and let it run until it began downloading a snapshot. I did this three times, with a clean ledger each time. The log's were:

| run | log size | number of lines |
| ---: | ---: | ---: |
| 1 | 324 MB | 2,828,522 |
| 2 | 131 MB | 1,247,188 |
| 3 | 178 MB | 1,684,973 |

Original context in Discord:
https://discord.com/channels/428295358100013066/439194979856809985/1020102644095795270

#### Summary of Changes

Add a 1 second sleep in the loop to get rpc peers.

With this change, I started up another node. Here's the log results:

| run | log size | number of lines |
| ---: | ---: | ---: |
| 1 | 2 MB | 15,539 |