### PR TITLE
remove solana-vote-program dep from solana-transaction-status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,7 +6593,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk 1.15.0",
- "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5829,7 +5829,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk 1.15.0",
- "solana-vote-program",
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -25,7 +25,6 @@ solana-address-lookup-table-program = { path = "../programs/address-lookup-table
 solana-measure = { path = "../measure", version = "=1.15.0" }
 solana-metrics = { path = "../metrics", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -14,7 +14,7 @@ use {
     solana_account_decoder::parse_token::spl_token_ids,
     solana_sdk::{
         instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey, stake,
-        system_program,
+        system_program, vote,
     },
     std::{
         collections::HashMap,
@@ -32,7 +32,7 @@ lazy_static! {
     static ref MEMO_V3_PROGRAM_ID: Pubkey = spl_memo_id_v3();
     static ref STAKE_PROGRAM_ID: Pubkey = stake::program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
-    static ref VOTE_PROGRAM_ID: Pubkey = solana_vote_program::id();
+    static ref VOTE_PROGRAM_ID: Pubkey = vote::program::id();
     static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableProgram> = {
         let mut m = HashMap::new();
         m.insert(

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -4,8 +4,9 @@ use {
     },
     bincode::deserialize,
     serde_json::json,
-    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys},
-    solana_vote_program::vote_instruction::VoteInstruction,
+    solana_sdk::{
+        instruction::CompiledInstruction, message::AccountKeys, vote::instruction::VoteInstruction,
+    },
 };
 
 pub fn parse_vote(
@@ -247,10 +248,15 @@ fn check_num_vote_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInstr
 mod test {
     use {
         super::*,
-        solana_sdk::{hash::Hash, message::Message, pubkey::Pubkey, sysvar},
-        solana_vote_program::{
-            vote_instruction,
-            vote_state::{Vote, VoteAuthorize, VoteInit, VoteStateUpdate},
+        solana_sdk::{
+            hash::Hash,
+            message::Message,
+            pubkey::Pubkey,
+            sysvar,
+            vote::{
+                instruction as vote_instruction,
+                state::{Vote, VoteAuthorize, VoteInit, VoteStateUpdate},
+            },
         },
     };
 


### PR DESCRIPTION
#### Problem

`solana-transaction-status` depends on `solana-vote-program` which has a lot of dependencies. But it only needs the parts of `solana-vote-program` that are re-exported from `solana-sdk`.

#### Summary of Changes

Use `solana_sdk::vote` instead of `solana_vote_program` in `solana_transaction_status` and remove `solana-vote-program` from the dependencies.

