### PR TITLE
remove vote-program dep from account-decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,7 +4521,6 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-config-program",
  "solana-sdk 1.15.0",
- "solana-vote-program",
  "spl-token",
  "spl-token-2022",
  "thiserror",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0.83"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.15.0" }
 solana-config-program = { path = "../programs/config", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -11,7 +11,9 @@ use {
     },
     inflector::Inflector,
     serde_json::Value,
-    solana_sdk::{instruction::InstructionError, pubkey::Pubkey, stake, system_program, sysvar},
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, stake, system_program, sysvar, vote,
+    },
     std::collections::HashMap,
     thiserror::Error,
 };
@@ -23,7 +25,7 @@ lazy_static! {
     static ref STAKE_PROGRAM_ID: Pubkey = stake::program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref SYSVAR_PROGRAM_ID: Pubkey = sysvar::id();
-    static ref VOTE_PROGRAM_ID: Pubkey = solana_vote_program::id();
+    static ref VOTE_PROGRAM_ID: Pubkey = vote::program::id();
     pub static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableAccount> = {
         let mut m = HashMap::new();
         m.insert(
@@ -127,11 +129,16 @@ pub fn parse_account_data(
 mod test {
     use {
         super::*,
-        solana_sdk::nonce::{
-            state::{Data, Versions},
-            State,
+        solana_sdk::{
+            nonce::{
+                state::{Data, Versions},
+                State,
+            },
+            vote::{
+                program::id as vote_program_id,
+                state::{VoteState, VoteStateVersions},
+            },
         },
-        solana_vote_program::vote_state::{VoteState, VoteStateVersions},
     };
 
     #[test]
@@ -147,7 +154,7 @@ mod test {
         VoteState::serialize(&versioned, &mut vote_account_data).unwrap();
         let parsed = parse_account_data(
             &account_pubkey,
-            &solana_vote_program::id(),
+            &vote_program_id(),
             &vote_account_data,
             None,
         )

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -3,8 +3,8 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot},
         pubkey::Pubkey,
+        vote::state::{BlockTimestamp, Lockout, VoteState},
     },
-    solana_vote_program::vote_state::{BlockTimestamp, Lockout, VoteState},
 };
 
 pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
@@ -123,7 +123,7 @@ struct UiEpochCredits {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_vote_program::vote_state::VoteStateVersions};
+    use {super::*, solana_sdk::vote::state::VoteStateVersions};
 
     #[test]
     fn test_parse_vote() {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4088,7 +4088,6 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-config-program",
  "solana-sdk 1.15.0",
- "solana-vote-program",
  "spl-token",
  "spl-token-2022",
  "thiserror",


### PR DESCRIPTION
See also: #27845 

#### Problem

`solana-account-decoder` depends on `solana-vote-program` which has a lot of dependencies. But it only needs the parts of `solana-vote-program` that are re-exported from `solana-sdk`.


#### Summary of Changes

Use `solana_sdk::vote` instead of `solana_vote_program` in `solana_account_decoder` and remove `solana-vote-program` from the dependencies.
