### PR TITLE
Remove markdown file update from version increment-cargo-version.sh

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -215,7 +215,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.15.0 | v1.15.0 |
+| Address Lookup | v1.12.0 | v1.12.0 |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |
@@ -1949,7 +1949,7 @@ Returns all accounts owned by the provided program Pubkey
   - `offset: <usize>` - offset into program account data to start comparison
   - `bytes: <string>` - data to match, as encoded string
   - `encoding: <string>` - encoding for filter `bytes` data, either "base58" or "base64". Data is limited in size to 128 or fewer decoded bytes.
-    **NEW: This field, and base64 support generally, is only available in solana-core v1.15.0 or newer. Please omit when querying nodes on earlier versions**
+    **NEW: This field, and base64 support generally, is only available in solana-core v1.11.2 or newer. Please omit when querying nodes on earlier versions**
 
 - `dataSize: <u64>` - compares the program account data length with the provided data size
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -215,7 +215,7 @@ JSON parsing for the following native and SPL programs:
 
 | Program | Account State | Instructions |
 | --- | --- | --- |
-| Address Lookup | v1.12.0 | v1.12.0 |
+| Address Lookup | v1.15.0 | v1.15.0 |
 | BPF Loader | n/a | stable |
 | BPF Upgradeable Loader | stable | stable |
 | Config | stable |   |

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -33,8 +33,6 @@ done
 
 # shellcheck disable=2207
 Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml "${not_paths[@]}"))
-# shellcheck disable=2207
-markdownFiles=($(find . -name "*.md" "${not_paths[@]}"))
 
 # Collect the name of all the internal crates
 crates=()
@@ -136,15 +134,6 @@ for Cargo_toml in "${Cargo_tomls[@]}"; do
       "
     )
   done
-done
-
-# Update all the documentation references
-for file in "${markdownFiles[@]}"; do
-  # Set new crate version
-  (
-    set -x
-    sed -i "$file" -e "s/$currentVersion/$newVersion/g"
-  )
 done
 
 # Update cargo lock files


### PR DESCRIPTION
#### Problem
increment-cargo-version.sh increments version numbers in markdown files. This behavior is no longer necessary and sometimes increments version numbers that should be static.

Some discussion here:
https://discord.com/channels/428295358100013066/560503042458517505/1020445231004532810

#### Summary of Changes
* Remove markdown file update code
* Restore version numbers in jsonrpc-api.md

