### PR TITLE
Change Blockstore::get_slots_since() to return Vec instead of HashMap

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3367,15 +3367,11 @@ impl ReplayStage {
             Measure::start("generate_new_bank_forks_get_slots_since");
         let next_slots = blockstore
             .get_slots_since(&frozen_bank_slots)
-            .expect("Db error");
+            .expect("Expected Blockstore::get_slots_since() to succeed");
         generate_new_bank_forks_get_slots_since.stop();
 
         // Filter out what we've already seen
-        trace!("generate new forks {:?}", {
-            let mut next_slots = next_slots.iter().collect::<Vec<_>>();
-            next_slots.sort();
-            next_slots
-        });
+        trace!("generate new forks {:?}", next_slots.clone().sort());
         let mut generate_new_bank_forks_loop = Measure::start("generate_new_bank_forks_loop");
         let mut new_banks = HashMap::new();
         for (parent_slot, children) in next_slots {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2972,12 +2972,13 @@ impl Blockstore {
 
     // Returns slots connecting to any element of the list `slots`.
     pub fn get_slots_since(&self, slots: &[u64]) -> Result<HashMap<u64, Vec<u64>>> {
-        // Return error if there was a database error during lookup of any of the
-        // slot indexes
-        let slot_metas: Result<Vec<Option<SlotMeta>>> =
-            slots.iter().map(|slot| self.meta(*slot)).collect();
+        let slot_metas: Vec<_> = self
+            .meta_cf
+            .multi_get(slots.to_vec())
+            .into_iter()
+            .map(|meta| meta.unwrap())
+            .collect();
 
-        let slot_metas = slot_metas?;
         let result: HashMap<u64, Vec<u64>> = slots
             .iter()
             .zip(slot_metas)

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -159,18 +159,14 @@ pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
     let ledger = Blockstore::open(ledger_path).unwrap();
     let zeroth_slot = ledger.get_slot_entries(0, 0).unwrap();
     let last_id = zeroth_slot.last().unwrap().hash;
-    let next_slots = ledger.get_slots_since(&[0]).unwrap().remove(&0).unwrap();
+    let (_, next_slots) = ledger.get_slots_since(&[0]).unwrap().pop().unwrap();
     let mut pending_slots: Vec<_> = next_slots
         .into_iter()
         .map(|slot| (slot, 0, last_id))
         .collect();
     while !pending_slots.is_empty() {
         let (slot, parent_slot, last_id) = pending_slots.pop().unwrap();
-        let next_slots = ledger
-            .get_slots_since(&[slot])
-            .unwrap()
-            .remove(&slot)
-            .unwrap();
+        let (_, next_slots) = ledger.get_slots_since(&[slot]).unwrap().pop().unwrap();
 
         // If you're not the last slot, you should have a full set of ticks
         let should_verify_ticks = if !next_slots.is_empty() {


### PR DESCRIPTION
#### Problem
The only non-test caller of this function just iterates over the
elemnts, so need to incur extra cost of hashing.

#### Summary of Changes
Use Vec instead of HashMap.

Depends on https://github.com/solana-labs/solana/pull/27686 - the first commit is from that PR, so only need to review 2nd commit. Will rebase once that PR ships.
