### PR TITLE
Skip untarring the accounts appendvec files if they already exist.

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -19,9 +19,7 @@ use {
             is_parsable, is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
         },
     },
-    solana_core::{
-        system_monitor_service::SystemMonitorService, validator::move_and_async_delete_path,
-    },
+    solana_core::system_monitor_service::SystemMonitorService,
     solana_entry::entry::Entry,
     solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
     solana_ledger::{
@@ -1070,11 +1068,14 @@ fn load_bank_forks(
         );
 
         if non_primary_accounts_path.exists() {
+            info!("Skip accounts clearing, to save the snapshot unpacking work.")
+            /*
             info!("Clearing {:?}", non_primary_accounts_path);
             let mut measure_time = Measure::start("clean_non_primary_accounts_paths");
             move_and_async_delete_path(&non_primary_accounts_path);
             measure_time.stop();
             info!("done. {}", measure_time);
+            */
         }
 
         vec![non_primary_accounts_path]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1068,14 +1068,10 @@ fn load_bank_forks(
         );
 
         if non_primary_accounts_path.exists() {
-            info!("Skip accounts clearing, to save the snapshot unpacking work.")
-            /*
-            info!("Clearing {:?}", non_primary_accounts_path);
-            let mut measure_time = Measure::start("clean_non_primary_accounts_paths");
-            move_and_async_delete_path(&non_primary_accounts_path);
-            measure_time.stop();
-            info!("done. {}", measure_time);
-            */
+            info!(
+                "Skip clearing {}, to save the snapshot unpacking work.",
+                non_primary_accounts_path.display()
+            );
         }
 
         vec![non_primary_accounts_path]

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -199,9 +199,7 @@ fn bank_forks_from_snapshot(
         process::exit(1);
     }
 
-    // The first try is to skip unpacking the appendvec files from the snapshot
-    // if they already exist on disk.
-    let result_try_using_existing_accounts_files =
+    let (deserialized_bank, full_snapshot_archive_info, incremental_snapshot_archive_info) =
         snapshot_utils::bank_from_latest_snapshot_archives(
             &snapshot_config.bank_snapshots_dir,
             &snapshot_config.full_snapshot_archives_dir,
@@ -221,49 +219,10 @@ fn bank_forks_from_snapshot(
             process_options.accounts_db_skip_shrink,
             process_options.verify_index,
             process_options.accounts_db_config.clone(),
-            accounts_update_notifier.clone(),
+            accounts_update_notifier,
             exit,
-        );
-    let (deserialized_bank, full_snapshot_archive_info, incremental_snapshot_archive_info) =
-        match result_try_using_existing_accounts_files {
-            Ok(val) => val,
-            Err(e) => {
-                info!("bank_from_latest_snapshot_archives failed with error {}, clear the accounts files and try again", e);
-                // Clear the account path and try again with the appendvec files unpacked from the snapshot
-                for path in &account_paths {
-                    let mut top_path = path.clone();
-                    top_path.push("accounts");
-                    if let Err(err) = std::fs::remove_dir_all(top_path) {
-                        panic!("error deleting accounts path {:?}: {}", path, err);
-                    }
-                }
-
-                let val = snapshot_utils::bank_from_latest_snapshot_archives(
-                    &snapshot_config.bank_snapshots_dir,
-                    &snapshot_config.full_snapshot_archives_dir,
-                    &snapshot_config.incremental_snapshot_archives_dir,
-                    &account_paths,
-                    genesis_config,
-                    &process_options.runtime_config,
-                    process_options.debug_keys.clone(),
-                    Some(&crate::builtins::get(
-                        process_options.runtime_config.bpf_jit,
-                    )),
-                    process_options.account_indexes.clone(),
-                    process_options.accounts_db_caching_enabled,
-                    process_options.limit_load_slot_count_from_snapshot,
-                    process_options.shrink_ratio,
-                    process_options.accounts_db_test_hash_calculation,
-                    process_options.accounts_db_skip_shrink,
-                    process_options.verify_index,
-                    process_options.accounts_db_config.clone(),
-                    accounts_update_notifier,
-                    exit,
-                )
-                .expect("Load from snapshot failed");
-                val
-            }
-        };
+        )
+        .expect("Load from snapshot failed");
 
     if let Some(shrink_paths) = shrink_paths {
         deserialized_bank.set_shrink_paths(shrink_paths);

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -328,7 +328,7 @@ impl SnapshotRequestHandler {
             SnapshotError::NoSnapshotArchives => true,
             SnapshotError::MismatchedSlotHash(..) => true,
             SnapshotError::VerifySlotDeltas(..) => true,
-            SnapshotError::BankVerifyFailed => true,
+            SnapshotError::BankVerifyFailed(..) => true,
         }
     }
 }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -328,6 +328,7 @@ impl SnapshotRequestHandler {
             SnapshotError::NoSnapshotArchives => true,
             SnapshotError::MismatchedSlotHash(..) => true,
             SnapshotError::VerifySlotDeltas(..) => true,
+            SnapshotError::BankVerifyFailed => true,
         }
     }
 }

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -192,7 +192,6 @@ pub struct AppendVec {
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
-        /*
         if self.remove_on_drop {
             if let Err(_e) = remove_file(&self.path) {
                 // promote this to panic soon.
@@ -201,7 +200,7 @@ impl Drop for AppendVec {
                 //error!("AppendVec failed to remove {:?}: {:?}", &self.path, e);
                 inc_new_counter_info!("append_vec_drop_fail", 1);
             }
-        }*/
+        }
     }
 }
 
@@ -257,7 +256,7 @@ impl AppendVec {
             append_lock: Mutex::new(()),
             current_len: AtomicUsize::new(initial_len),
             file_size: size as u64,
-            remove_on_drop: true,
+            remove_on_drop: false,
         }
     }
 
@@ -364,7 +363,7 @@ impl AppendVec {
             append_lock: Mutex::new(()),
             current_len: AtomicUsize::new(current_len),
             file_size,
-            remove_on_drop: true,
+            remove_on_drop: false,
         })
     }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -192,6 +192,7 @@ pub struct AppendVec {
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
+        /*
         if self.remove_on_drop {
             if let Err(_e) = remove_file(&self.path) {
                 // promote this to panic soon.
@@ -200,7 +201,7 @@ impl Drop for AppendVec {
                 //error!("AppendVec failed to remove {:?}: {:?}", &self.path, e);
                 inc_new_counter_info!("append_vec_drop_fail", 1);
             }
-        }
+        }*/
     }
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -979,7 +979,7 @@ pub fn bank_from_snapshot_archives(
     let result_try_using_existing_accounts_files = bank_from_snapshot_archives_inner(
         account_paths,
         bank_snapshots_dir.as_ref(),
-        &full_snapshot_archive_info,
+        full_snapshot_archive_info,
         incremental_snapshot_archive_info,
         genesis_config,
         runtime_config,
@@ -1013,7 +1013,7 @@ pub fn bank_from_snapshot_archives(
             bank_from_snapshot_archives_inner(
                 account_paths,
                 bank_snapshots_dir.as_ref(),
-                &full_snapshot_archive_info,
+                full_snapshot_archive_info,
                 incremental_snapshot_archive_info,
                 genesis_config,
                 runtime_config,


### PR DESCRIPTION
If the files are modified, the bank hash check will fail.  In that case, the files are deleted, and then
bank_from_latest_snapshot_archives will be called again without skipping the account files unpacking.

#### Problem
https://github.com/solana-labs/solana/issues/27787

#### Summary of Changes
make sure the appendvec files are not removed (at the beginning, and exiting times)
modify snapshot expanding code to avoid expanding the files
If he appendvec files exist. if they do, it should work as before;
if not, exit and run the snapshot in the full way.
if checksum fails, delete the accounts files, and run the snapshot full way.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
