### PR TITLE
web3.js: use Uint8Array instead of Buffer for Transaction.addSignature

### DIFF
--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -668,7 +668,7 @@ export class Transaction {
    * must correspond to either the fee payer or a signer account in the transaction
    * instructions.
    */
-  addSignature(pubkey: PublicKey, signature: Buffer) {
+  addSignature(pubkey: PublicKey, signature: Uint8Array) {
     this._compile(); // Ensure signatures array is populated
     this._addSignature(pubkey, signature);
   }
@@ -676,7 +676,7 @@ export class Transaction {
   /**
    * @internal
    */
-  _addSignature(pubkey: PublicKey, signature: Buffer) {
+  _addSignature(pubkey: PublicKey, signature: Uint8Array) {
     invariant(signature.length === 64);
 
     const index = this.signatures.findIndex(sigpair =>
@@ -796,7 +796,7 @@ export class Transaction {
   /**
    * Parse a wire transaction into a Transaction object.
    */
-  static from(buffer: Buffer | Uint8Array | Array<number>): Transaction {
+  static from(buffer: Uint8Array | Array<number>): Transaction {
     // Slice up wire data
     let byteArray = [...buffer];
 
@@ -805,7 +805,7 @@ export class Transaction {
     for (let i = 0; i < signatureCount; i++) {
       const signature = byteArray.slice(0, SIGNATURE_LENGTH_IN_BYTES);
       byteArray = byteArray.slice(SIGNATURE_LENGTH_IN_BYTES);
-      signatures.push(bs58.encode(Buffer.from(signature)));
+      signatures.push(bs58.encode(Uint8Array.from(signature)));
     }
 
     return Transaction.populate(Message.from(byteArray), signatures);


### PR DESCRIPTION
#### Problem

`Buffer` is used where `Uint8Array` is sufficient, making Browserify required for simple libraries.

See: https://twitter.com/armaniferrante/status/1569871757687029761



<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
