### PR TITLE
web3.js: store signatures as Uint8Arrays

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4736,7 +4736,7 @@ export class Connection {
           throw new Error('!signature'); // should never happen
         }
 
-        const signature = transaction.signature.toString('base64');
+        const signature = Buffer.from(transaction.signature).toString('base64');
         if (
           !this._blockhashInfo.simulatedSignatures.includes(signature) &&
           !this._blockhashInfo.transactionSignatures.includes(signature)
@@ -4861,7 +4861,7 @@ export class Connection {
           throw new Error('!signature'); // should never happen
         }
 
-        const signature = transaction.signature.toString('base64');
+        const signature = Buffer.from(transaction.signature).toString('base64');
         if (!this._blockhashInfo.transactionSignatures.includes(signature)) {
           // The signature of this transaction has not been seen before with the
           // current recentBlockhash, all done. Let's break

--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -121,7 +121,7 @@ export class TransactionInstruction {
  * Pair of signature and corresponding public key
  */
 export type SignaturePubkeyPair = {
-  signature: Buffer | null;
+  signature: Uint8Array | null;
   publicKey: PublicKey;
 };
 
@@ -195,7 +195,7 @@ export class Transaction {
   /**
    * The first (payer) Transaction signature
    */
-  get signature(): Buffer | null {
+  get signature(): Uint8Array | null {
     if (this.signatures.length > 0) {
       return this.signatures[0].signature;
     }
@@ -686,7 +686,7 @@ export class Transaction {
       throw new Error(`unknown signer: ${pubkey.toString()}`);
     }
 
-    this.signatures[index].signature = Buffer.from(signature);
+    this.signatures[index].signature = Uint8Array.from(signature);
   }
 
   /**


### PR DESCRIPTION
#### Problem

Buffer is used where Uint8Array works.

See: https://twitter.com/armaniferrante/status/1569871757687029761
