### PR TITLE
web3.js: Remove Buffer from Transaction.serialize

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4758,7 +4758,7 @@ export class Connection {
     const message = transaction._compile();
     const signData = message.serialize();
     const wireTransaction = transaction._serialize(signData);
-    const encodedTransaction = wireTransaction.toString('base64');
+    const encodedTransaction = Buffer.from(wireTransaction).toString('base64');
     const config: any = {
       encoding: 'base64',
       commitment: this.commitment,

--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -717,7 +717,7 @@ export class Transaction {
   /**
    * Serialize the Transaction in the wire format.
    */
-  serialize(config?: SerializeConfig): Buffer {
+  serialize(config?: SerializeConfig): Uint8Array {
     const {requireAllSignatures, verifySignatures} = Object.assign(
       {requireAllSignatures: true, verifySignatures: true},
       config,
@@ -737,15 +737,15 @@ export class Transaction {
   /**
    * @internal
    */
-  _serialize(signData: Buffer): Buffer {
+  _serialize(signData: Uint8Array): Uint8Array {
     const {signatures} = this;
     const signatureCount: number[] = [];
     shortvec.encodeLength(signatureCount, signatures.length);
     const transactionLength =
       signatureCount.length + signatures.length * 64 + signData.length;
-    const wireTransaction = Buffer.alloc(transactionLength);
+    const wireTransaction = new Uint8Array(transactionLength);
     invariant(signatures.length < 256);
-    Buffer.from(signatureCount).copy(wireTransaction, 0);
+    wireTransaction.set(signatureCount, 0);
     signatures.forEach(({signature}, index) => {
       if (signature !== null) {
         invariant(signature.length === 64, `signature has invalid length`);
@@ -755,8 +755,8 @@ export class Transaction {
         );
       }
     });
-    signData.copy(
-      wireTransaction,
+    wireTransaction.set(
+      signData,
       signatureCount.length + signatures.length * 64,
     );
     invariant(


### PR DESCRIPTION
#### Problem

Buffer is not necessary within Transaction.serialize.

See: https://twitter.com/armaniferrante/status/1569871757687029761

