### PR TITLE
web3.js: remove redundant 'Buffer' from 'Account' class

### DIFF
--- a/web3.js/src/account.ts
+++ b/web3.js/src/account.ts
@@ -23,7 +23,7 @@ export class Account {
    *
    * @param secretKey Secret key for the account
    */
-  constructor(secretKey?: Buffer | Uint8Array | Array<number>) {
+  constructor(secretKey?: Uint8Array | Array<number>) {
     if (secretKey) {
       const secretKeyBuffer = toBuffer(secretKey);
       if (secretKey.length !== 64) {


### PR DESCRIPTION
#### Problem

Removes a redundant 'Buffer' type from the `Account` class.


