### PR TITLE
web3.js: remove Buffer from signature verification

### DIFF
--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -699,14 +699,17 @@ export class Transaction {
   /**
    * @internal
    */
-  _verifySignatures(signData: Buffer, requireAllSignatures: boolean): boolean {
+  _verifySignatures(
+    signData: Uint8Array,
+    requireAllSignatures: boolean,
+  ): boolean {
     for (const {signature, publicKey} of this.signatures) {
       if (signature === null) {
         if (requireAllSignatures) {
           return false;
         }
       } else {
-        if (!verify(signature, signData, publicKey.toBuffer())) {
+        if (!verify(signature, signData, publicKey.toBytes())) {
           return false;
         }
       }


### PR DESCRIPTION
#### Problem

Removes use of Buffer from signature verification.


