### PR TITLE
web3.js: remove use of Buffer in PublicKey.createWithSeed

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -147,10 +147,10 @@ export class PublicKey extends Struct {
     seed: string,
     programId: PublicKey,
   ): Promise<PublicKey> {
-    const buffer = Buffer.concat([
-      fromPublicKey.toBuffer(),
-      Buffer.from(seed),
-      programId.toBuffer(),
+    const buffer = Uint8Array.from([
+      ...fromPublicKey.toBytes(),
+      ...new TextEncoder().encode(seed),
+      ...programId.toBytes(),
     ]);
     const publicKeyBytes = sha256(buffer);
     return new PublicKey(publicKeyBytes);


### PR DESCRIPTION
#### Problem

Removes use of Buffer in PublicKey.createWithSeed.


