### PR TITLE
web3.js: add deprecation notice for createProgramAddress

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -186,6 +186,8 @@ export class PublicKey extends Struct {
   /**
    * Async version of createProgramAddressSync
    * For backwards compatibility
+   *
+   * @deprecated Use {@link createProgramAddressSync} instead
    */
   /* eslint-disable require-await */
   static async createProgramAddress(


### PR DESCRIPTION
#### Problem

Deprecating createProgramAddress will encourage developers to use the synchronous version instead.

Fixes: #25648