### PR TITLE
web3.js: deprecate PublicKey.findProgramAddress

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -227,6 +227,8 @@ export class PublicKey extends Struct {
   /**
    * Async version of findProgramAddressSync
    * For backwards compatibility
+   *
+   * @deprecated Use {@link findProgramAddressSync} instead
    */
   static async findProgramAddress(
     seeds: Array<Buffer | Uint8Array>,


### PR DESCRIPTION
#### Problem

Deprecate `findProgramAddress` to encourage developers to use the synchronous version instead.


#### Summary of Changes


Addresses #25648
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
