### PR TITLE
web3.js: fix typo in PublicKey.unique

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -77,7 +77,7 @@ export class PublicKey extends Struct {
   }
 
   /**
-   * Returns a unique PublicKey for tests and benchmarks using acounter
+   * Returns a unique PublicKey for tests and benchmarks using a counter
    */
   static unique(): PublicKey {
     const key = new PublicKey(uniquePublicKeyCounter);


### PR DESCRIPTION
Fixes a typo
