### PR TITLE
web3.js: add sideEffects: false to package.json

### DIFF
--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -27,6 +27,7 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
+  "sideEffects": false,
   "browserslist": [
     "defaults",
     "not IE 11",


### PR DESCRIPTION
#### Problem

Adds `sideEffects: false` to help bundlers tree shake.

