### PR TITLE
Show Glow ID account information in the Explorer

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -18,7 +18,10 @@ import {
   getBonfidaDomainInfo,
   hasBonfidaDomainSyntax,
 } from "utils/bonfida-name-service";
-import { getGlowIdFromHandle, hasGlowIdSyntax } from "./account/glow-id/glow-id-utils";
+import {
+  getGlowIdFromHandle,
+  hasGlowIdSyntax,
+} from "./account/glow-id/glow-id-utils";
 
 interface SearchOptions {
   label: string;

--- a/explorer/src/components/account/DomainsCard.tsx
+++ b/explorer/src/components/account/DomainsCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PublicKey } from "@solana/web3.js";
-import { useUserDomains, DomainInfo } from "../../utils/name-service";
+import { useUserDomains, DomainInfo } from "../../utils/bonfida-name-service";
 import { LoadingCard } from "components/common/LoadingCard";
 import { ErrorCard } from "components/common/ErrorCard";
 import { Address } from "components/common/Address";

--- a/explorer/src/components/account/glow-id/GlowIDAccountSection.tsx
+++ b/explorer/src/components/account/glow-id/GlowIDAccountSection.tsx
@@ -1,0 +1,89 @@
+import { Address } from "components/common/Address";
+import { TableCardBody } from "components/common/TableCardBody";
+import { Account, useFetchAccountInfo } from "providers/accounts";
+import { Suspense } from "react";
+import { UnknownAccountCard } from "../UnknownAccountCard";
+import { useParseGlowID } from "./useParseGlowID";
+
+export function GlowIDAccountSection({ account }: { account: Account }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <GlowIdCard account={account} />
+    </Suspense>
+  );
+}
+
+const GlowIdCard = ({ account }: { account: Account }) => {
+  const fetchInfo = useFetchAccountInfo();
+  const refresh = () => fetchInfo(account.pubkey);
+  const { data: glowId } = useParseGlowID(account);
+
+  if (!glowId) {
+    return <UnknownAccountCard account={account} />;
+  }
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3 className="card-header-title mb-0 d-flex align-items-center">
+          Overview
+        </h3>
+        <button className="btn btn-white btn-sm" onClick={refresh}>
+          <span className="fe fe-refresh-cw me-2"></span>
+          Refresh
+        </button>
+      </div>
+
+      <TableCardBody>
+        <tr>
+          <td>Handle Address</td>
+          <td className="text-lg-end">
+            <Address pubkey={glowId.address} alignRight link />
+          </td>
+        </tr>
+        <tr>
+          <td>Wallet Address</td>
+          <td className="text-lg-end">
+            <Address pubkey={glowId.resolved} alignRight link />
+          </td>
+        </tr>
+        <tr>
+          <td>Joined At</td>
+          <td className="text-lg-end">
+            {Intl.DateTimeFormat(undefined, { dateStyle: "full" }).format(
+              glowId.joined_at
+            )}
+          </td>
+        </tr>
+        <tr>
+          <td>Twitter</td>
+          <td className="text-lg-end">
+            {glowId.twitter ? (
+              <a
+                href={`https://twitter.com/${glowId.twitter}`}
+                target={"_blank"}
+                rel="noreferrer noopener"
+              >
+                {glowId.twitter}
+              </a>
+            ) : (
+              <span>Not Linked</span>
+            )}
+          </td>
+        </tr>
+        <tr>
+          <td>Website</td>
+          <td className="text-lg-end">
+            <a
+              href={`https://glow.xyz/${glowId.handle}`}
+              target={"_blank"}
+              rel="noreferrer noopener"
+            >
+              glow.xyz/{glowId.handle}
+            </a>
+          </td>
+        </tr>
+      </TableCardBody>
+    </div>
+  );
+};

--- a/explorer/src/components/account/glow-id/GlowIdAccountHeader.tsx
+++ b/explorer/src/components/account/glow-id/GlowIdAccountHeader.tsx
@@ -55,4 +55,3 @@ function GlowIdWithDataHeader({ account }: { account: Account }) {
     </div>
   );
 }
-

--- a/explorer/src/components/account/glow-id/GlowIdAccountHeader.tsx
+++ b/explorer/src/components/account/glow-id/GlowIdAccountHeader.tsx
@@ -1,0 +1,58 @@
+import React, { Suspense } from "react";
+import { Account } from "../../../providers/accounts";
+import { CachedImageContent } from "../../common/NFTArt";
+import { isGlowIdAccount } from "./isGlowIdAccount";
+import { useParseGlowID } from "./useParseGlowID";
+
+export function GlowIdAccountHeader({ account }: { account: Account }) {
+  const glowId = isGlowIdAccount(account);
+
+  if (glowId) {
+    return (
+      <Suspense fallback={<div>Loading...</div>}>
+        <GlowIdWithDataHeader account={account} />
+      </Suspense>
+    );
+  }
+
+  return (
+    <>
+      <h6 className="header-pretitle">Details</h6>
+      <h2 className="header-title">Account</h2>
+    </>
+  );
+}
+
+function GlowIdWithDataHeader({ account }: { account: Account }) {
+  const { data: glowId } = useParseGlowID(account);
+
+  if (!glowId) {
+    return (
+      <>
+        <h6 className="header-pretitle">Details</h6>
+        <h2 className="header-title">Account</h2>
+      </>
+    );
+  }
+
+  return (
+    <div className="row">
+      <div className="col-auto ms-2 d-flex align-items-center">
+        <CachedImageContent uri={glowId?.image ?? undefined} />
+      </div>
+
+      <div className="col mb-3 ms-0.5 mt-3">
+        <h6 className="header-pretitle ms-1">Glow ID</h6>
+
+        <h2 className="header-title align-items-center no-overflow-with-ellipsis">
+          {glowId?.name || "No Name"}
+        </h2>
+
+        <h2 className="header-subtitle align-items-center">
+          {glowId.handle}.glow
+        </h2>
+      </div>
+    </div>
+  );
+}
+

--- a/explorer/src/components/account/glow-id/glow-id-utils.tsx
+++ b/explorer/src/components/account/glow-id/glow-id-utils.tsx
@@ -1,0 +1,130 @@
+import * as BufferLayout from "@solana/buffer-layout";
+import { Connection, PublicKey } from "@solana/web3.js";
+import axios from "axios";
+
+export const GLOW_ID_ADDRESS = "GLoW6kDXmQHFjtQQ44ccmXjosqrKkE54bVbUTA4bA3zs";
+
+export const hasGlowIdSyntax = (value: string) => {
+  return value.length > 6 && value.substring(value.length - 5) === ".glow";
+};
+
+export namespace GlowIdTypes {
+  export type Info = {
+    handle: string;
+    name: string | null;
+    image: string | null;
+    metadata_url: string;
+    twitter: string | null;
+    resolved: PublicKey;
+    joined_at: Date;
+    controller: PublicKey;
+    address: PublicKey;
+  };
+}
+
+export async function getGlowIdFromHandle(
+  query: string,
+  connection: Connection
+): Promise<GlowIdTypes.Info | null> {
+  const [handle] = query.split(".");
+
+  const handleBuffer = Buffer.alloc(16);
+  handleBuffer.write(handle);
+
+  const [handlePubkey] = PublicKey.findProgramAddressSync(
+    [Buffer.from("handle@"), handleBuffer],
+    new PublicKey(GLOW_ID_ADDRESS)
+  );
+  const handleAccount = await connection.getAccountInfo(handlePubkey);
+
+  if (!handleAccount) {
+    return null;
+  }
+
+  return parseGlowIdAccount({ data: handleAccount.data, handlePubkey });
+}
+
+const glowIdAccountDisc = "5QbX+qna3us=";
+
+const arrToStr = (arr: Uint8Array | Buffer): string => {
+  return Buffer.from(Array.from(arr).filter((byte) => byte !== 0)).toString();
+};
+
+export const parseGlowIdAccount = async ({
+  data,
+  handlePubkey,
+}: {
+  data: Buffer | null | undefined;
+  handlePubkey: PublicKey;
+}): Promise<GlowIdTypes.Info | null> => {
+  if (!data) {
+    return null;
+  }
+
+  const parsed = glowIdAccountLayout.decode(data);
+
+  const disc = Buffer.from(parsed.discriminator).toString("base64");
+  if (disc !== glowIdAccountDisc) {
+    return null;
+  }
+
+  const metadata_url = parsed.metadata_url?.replace(/\0/g, "");
+  const controller = new PublicKey(parsed.controller);
+  const resolved = new PublicKey(parsed.resolved);
+  const handle = arrToStr(parsed.handle);
+  const joined_at = new Date(parsed.joined_at * 1000);
+
+  try {
+    const { data } = await axios.get(metadata_url);
+    return {
+      handle,
+      name: data.name ?? null,
+      image: data.image ?? null,
+      metadata_url,
+      twitter: arrToStr(parsed.twitter?.handle) ?? null,
+      joined_at,
+      resolved,
+      controller,
+      address: handlePubkey,
+    };
+  } catch {
+    return {
+      handle,
+      name: null,
+      joined_at,
+      image: null,
+      metadata_url,
+      twitter: arrToStr(parsed.twitter?.handle) ?? null,
+      resolved,
+      controller,
+      address: handlePubkey,
+    };
+  }
+};
+
+const publicKey = (property: string) => {
+  return BufferLayout.blob(32, property);
+};
+
+const twitter = BufferLayout.union(
+  BufferLayout.u8("has_twitter"),
+  null,
+  "twitter"
+);
+twitter.addVariant(0, BufferLayout.u8("no_twitter"), "no_twitter");
+twitter.addVariant(1, BufferLayout.blob(16, "handle"), "handle");
+
+const glowIdAccountLayout = BufferLayout.struct([
+  BufferLayout.blob(8, "discriminator"),
+  BufferLayout.u8("version"),
+  BufferLayout.blob(16, "handle"),
+  BufferLayout.blob(16, "invited_by_handle"),
+  publicKey("resolved"),
+  publicKey("controller"),
+  BufferLayout.u8("bump"),
+  BufferLayout.nu64("joined_at"),
+  publicKey("nft_collection"),
+  twitter, // Figure out how to do a coption
+  BufferLayout.u32("metadata_url_length"),
+  BufferLayout.utf8(400, "metadata_url"),
+]);

--- a/explorer/src/components/account/glow-id/isGlowIdAccount.ts
+++ b/explorer/src/components/account/glow-id/isGlowIdAccount.ts
@@ -1,0 +1,9 @@
+import { GLOW_ID_ADDRESS } from "./glow-id-utils";
+import { Account } from "../../../providers/accounts";
+
+export function isGlowIdAccount(account: Account): boolean {
+  return Boolean(
+    account.details?.owner.toBase58() === GLOW_ID_ADDRESS &&
+      account.details.rawData
+  );
+}

--- a/explorer/src/components/account/glow-id/useParseGlowID.tsx
+++ b/explorer/src/components/account/glow-id/useParseGlowID.tsx
@@ -1,0 +1,27 @@
+import useSWR, { SWRResponse } from "swr";
+import { Account } from "../../../providers/accounts";
+import { GlowIdTypes, parseGlowIdAccount } from "./glow-id-utils";
+
+export const useParseGlowID = (
+  account: Account,
+): {
+  data: GlowIdTypes.Info | null;
+  error: any;
+  mutate: SWRResponse<GlowIdTypes.Info | null, never>["mutate"];
+} => {
+  const swrKey = [account.pubkey.toBase58()];
+  const { data, error, mutate } = useSWR(
+    swrKey,
+    async () => {
+      return await parseGlowIdAccount({
+        data: account.details?.rawData,
+        handlePubkey: account.pubkey,
+      });
+    },
+    {
+      suspense: true,
+    },
+  );
+  // Not nullable since we use suspense
+  return { data: data!, error, mutate };
+};

--- a/explorer/src/components/account/glow-id/useParseGlowID.tsx
+++ b/explorer/src/components/account/glow-id/useParseGlowID.tsx
@@ -3,7 +3,7 @@ import { Account } from "../../../providers/accounts";
 import { GlowIdTypes, parseGlowIdAccount } from "./glow-id-utils";
 
 export const useParseGlowID = (
-  account: Account,
+  account: Account
 ): {
   data: GlowIdTypes.Info | null;
   error: any;
@@ -20,7 +20,7 @@ export const useParseGlowID = (
     },
     {
       suspense: true,
-    },
+    }
   );
   // Not nullable since we use suspense
   return { data: data!, error, mutate };

--- a/explorer/src/components/account/nftoken/NFTokenAccountHeader.tsx
+++ b/explorer/src/components/account/nftoken/NFTokenAccountHeader.tsx
@@ -37,7 +37,7 @@ export function NFTokenAccountHeader({ account }: { account: Account }) {
   );
 }
 
-export function NFTokenNFTHeader({ nft }: { nft: NftokenTypes.NftAccount }) {
+function NFTokenNFTHeader({ nft }: { nft: NftokenTypes.NftAccount }) {
   const { data: metadata } = useNftokenMetadata(nft.metadata_url);
 
   return (
@@ -47,7 +47,7 @@ export function NFTokenNFTHeader({ nft }: { nft: NftokenTypes.NftAccount }) {
       </div>
 
       <div className="col mb-3 ms-0.5 mt-3">
-        {<h6 className="header-pretitle ms-1">NFToken NFT</h6>}
+        <h6 className="header-pretitle ms-1">NFToken NFT</h6>
         <div className="d-flex align-items-center">
           <h2 className="header-title ms-1 align-items-center no-overflow-with-ellipsis">
             {metadata ? metadata.name || "No NFT name was found" : "Loading..."}
@@ -75,7 +75,7 @@ export function NFTokenNFTHeader({ nft }: { nft: NftokenTypes.NftAccount }) {
   );
 }
 
-export function NFTokenCollectionHeader({
+function NFTokenCollectionHeader({
   collection,
 }: {
   collection: NftokenTypes.CollectionAccount;

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -44,6 +44,10 @@ import { useTokenRegistry } from "providers/mints/token-registry";
 import React, { Suspense } from "react";
 import { NavLink, Redirect, useLocation } from "react-router-dom";
 import { clusterPath } from "utils/url";
+import { GLOW_ID_ADDRESS } from "../components/account/glow-id/glow-id-utils";
+import { GlowIdAccountHeader } from "../components/account/glow-id/GlowIdAccountHeader";
+import { GlowIDAccountSection } from "../components/account/glow-id/GlowIDAccountSection";
+import { isGlowIdAccount } from "../components/account/glow-id/isGlowIdAccount";
 import { NFTokenAccountHeader } from "../components/account/nftoken/NFTokenAccountHeader";
 import { NFTokenAccountSection } from "../components/account/nftoken/NFTokenAccountSection";
 import { NFTokenCollectionNFTGrid } from "../components/account/nftoken/NFTokenCollectionNFTGrid";
@@ -221,6 +225,11 @@ export function AccountHeader({
     return <NFTokenAccountHeader account={account} />;
   }
 
+  const glowId = account && isGlowIdAccount(account);
+  if (glowId && account) {
+    return <GlowIdAccountHeader account={account} />;
+  }
+
   if (isToken) {
     let token;
     let unverified = false;
@@ -361,6 +370,8 @@ function InfoSection({ account }: { account: Account }) {
     );
   } else if (account.details?.owner.toBase58() === NFTOKEN_ADDRESS) {
     return <NFTokenAccountSection account={account} />;
+  } else if (account.details?.owner.toBase58() === GLOW_ID_ADDRESS) {
+    return <GlowIDAccountSection account={account} />;
   } else if (data && data.program === "spl-token") {
     return <TokenAccountSection account={account} tokenAccount={data.parsed} />;
   } else if (data && data.program === "nonce") {

--- a/explorer/src/utils/bonfida-name-service.tsx
+++ b/explorer/src/utils/bonfida-name-service.tsx
@@ -19,7 +19,7 @@ export interface DomainInfo {
   name: string;
   address: PublicKey;
 }
-export const hasDomainSyntax = (value: string) => {
+export const hasBonfidaDomainSyntax = (value: string) => {
   return value.length > 4 && value.substring(value.length - 4) === ".sol";
 };
 
@@ -38,7 +38,7 @@ async function getDomainKey(
 }
 
 // returns non empty wallet string if a given .sol domain is owned by a wallet
-export async function getDomainInfo(domain: string, connection: Connection) {
+export async function getBonfidaDomainInfo(domain: string, connection: Connection) {
   const domainKey = await getDomainKey(
     domain.slice(0, -4), // remove .sol
     undefined,

--- a/explorer/src/utils/bonfida-name-service.tsx
+++ b/explorer/src/utils/bonfida-name-service.tsx
@@ -38,7 +38,10 @@ async function getDomainKey(
 }
 
 // returns non empty wallet string if a given .sol domain is owned by a wallet
-export async function getBonfidaDomainInfo(domain: string, connection: Connection) {
+export async function getBonfidaDomainInfo(
+  domain: string,
+  connection: Connection
+) {
   const domainKey = await getDomainKey(
     domain.slice(0, -4), // remove .sol
     undefined,


### PR DESCRIPTION
#### Summary of Changes

We are rolling out a Glow ID system that allows people to easily register and update their Glow ID on the Solana blockchain.

This adds an update to Solana explorer to support Glow ID in two ways:

- if you search for `x.glow`, we will search to see if a corresponding `.glow` exists
- if you open a `x.glow` account, you'll see information about the profile (screenshot below)

You can test this by typing in `victor.glow`. 

<img width="1178" alt="CleanShot 2022-09-18 at 11 00 01@2x" src="https://user-images.githubusercontent.com/1319079/190913806-2ce71102-6103-45c8-87a5-17c76a8fd3f1.png">
