### PR TITLE
Attempt to fix recv_mmsg by testing for socket readiness every packet

### DIFF
--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -15,10 +15,10 @@ pub async fn recv_mmsg(
 ) -> io::Result</*num packets:*/ usize> {
     debug_assert!(packets.iter().all(|pkt| pkt.meta == Meta::default()));
     let count = cmp::min(NUM_RCVMMSGS, packets.len());
-    socket.readable().await?;
     let mut i = 0;
     for p in packets.iter_mut().take(count) {
         p.meta.size = 0;
+        socket.readable().await?;
         match socket.try_recv_from(p.buffer_mut()) {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;


### PR DESCRIPTION
#### Problem
We seem to be using try_recv_from incorrectly in async recv_mmsg by not testing for socket readiness on every read, meaning we may sometimes get Err(io::ErrorKind::WouldBlock) depending on the timing.

#### Summary of Changes
Test socket readiness every read

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
