### PR TITLE
remove unused deps from transaction-status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6590,8 +6590,6 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-address-lookup-table-program",
- "solana-measure",
- "solana-metrics",
  "solana-sdk 1.15.0",
  "spl-associated-token-account",
  "spl-memo",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5825,8 +5825,6 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-address-lookup-table-program",
- "solana-measure",
- "solana-metrics",
  "solana-sdk 1.15.0",
  "spl-associated-token-account",
  "spl-memo",

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -22,8 +22,6 @@ serde_derive = "1.0.103"
 serde_json = "1.0.83"
 solana-account-decoder = { path = "../account-decoder", version = "=1.15.0" }
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.15.0" }
-solana-measure = { path = "../measure", version = "=1.15.0" }
-solana-metrics = { path = "../metrics", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }


### PR DESCRIPTION
#### Problem

solana-transaction-status has some unused dependencies.


#### Summary of Changes

Remove them.
Related to #27339 but less ambitious
