### PR TITLE
re-enable caching of hash calculation

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -64,7 +64,8 @@ impl<'a> CalcAccountsHashConfig<'a> {
     /// return true if we should cache accounts hash intermediate data between calls
     pub fn get_should_cache_hash_data() -> bool {
         // when we are skipping rewrites, we cannot rely on the cached data from old append vecs, so we have to disable caching for now
-        false
+        // skipping rewrites is not enabled in this branch. It requires a cli argument.
+        true
     }
 }
 


### PR DESCRIPTION
#### Problem
This was introduced in #24437.
As part of development of 
#26491

We don't have to be able to process snapshots that contain either rewritten accounts anymore except during testing, so we don't need to penalize the entire cluster for that.

Normal validators will not be skipping rewrites, so their appendvecs will be correct. Probably, only the validators that I am running as tests will be generating snapshots that do not include rewrites during rent collection. For those validators, I'll need to disable caching to get the correct answer.

If a validator needed to rehash skipped rewrites, the result will now be a hash mismatch error - either against known validators on gossip during runtime or at startup relative to the expected startup accounts hash from the snapshot.

Calculating the accounts hash runs continuously with the default options at today's mnb account count.
Without the accounts hash cache, calculating the accounts hash scans EVERY append vec twice for every accounts hash calculation. That churns through over 100G of data twice, scanning for the latest hash and lamports for each pubkey.

With this cache enabled, the append vecs are grouped into sections of 2,500 append vecs. If NONE of those appendvecs have changed since the last accounts hash calculation, then the pre-sorted results are re-used from last time, eliminating the need to scan ~95% of the appendvecs at all.

#### Summary of Changes

Re-enable caching of accounts hash calculation.
This is far more performant and far less taxing on disk i/o.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
