### PR TITLE
fix: replace bigint literals with `BigInt` constructors

### DIFF
--- a/web3.js/src/programs/address-lookup-table/state.ts
+++ b/web3.js/src/programs/address-lookup-table/state.ts
@@ -32,7 +32,7 @@ export class AddressLookupTableAccount {
   }
 
   isActive(): boolean {
-    const U64_MAX = 18446744073709551615n;
+    const U64_MAX = BigInt('0xffffffffffffffff');
     return this.state.deactivationSlot === U64_MAX;
   }
 

--- a/web3.js/test/message-tests/compiled-keys.test.ts
+++ b/web3.js/test/message-tests/compiled-keys.test.ts
@@ -12,7 +12,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 18446744073709551615n;
+  const U64_MAX = BigInt('0xffffffffffffffff');
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {

--- a/web3.js/test/message-tests/v0.test.ts
+++ b/web3.js/test/message-tests/v0.test.ts
@@ -18,7 +18,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 18446744073709551615n;
+  const U64_MAX = BigInt('0xffffffffffffffff');
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {

--- a/web3.js/test/transaction-tests/message.test.ts
+++ b/web3.js/test/transaction-tests/message.test.ts
@@ -17,7 +17,7 @@ function createTestKeys(count: number): Array<PublicKey> {
 function createTestLookupTable(
   addresses: Array<PublicKey>,
 ): AddressLookupTableAccount {
-  const U64_MAX = 18446744073709551615n;
+  const U64_MAX = BigInt('0xffffffffffffffff');
   return new AddressLookupTableAccount({
     key: PublicKey.unique(),
     state: {


### PR DESCRIPTION
#### Problem

Some JavaScript runtimes support `BigInt` but not bigint literals.

#### Summary of Changes

* Replace `18446744073709551615n` with `BigInt('0xffffffffffffffff')`

This makes web3.js compatible with runtimes that don't understand bigint literals but _do_ understand `BigInt` constructors. For whatever that's worth.