### PR TITLE
abs: Update last_full_snapshot_slot before calling clean_accounts()

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -156,6 +156,10 @@ impl SnapshotRequestHandler {
                 // we should not rely on the state of this validator until startup verification is complete
                 assert!(snapshot_root_bank.is_startup_verification_complete());
 
+                if accounts_package_type == AccountsPackageType::Snapshot(SnapshotType::FullSnapshot) {
+                    *last_full_snapshot_slot = Some(snapshot_root_bank.slot());
+                }
+
                 let previous_hash = if test_hash_calculation {
                     // We have to use the index version here.
                     // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality. This comment is out of date and can be re-evaluated.
@@ -227,10 +231,6 @@ impl SnapshotRequestHandler {
                     shrink_time = Measure::start("shrink_time");
                     snapshot_root_bank.shrink_candidate_slots();
                     shrink_time.stop();
-                }
-
-                if accounts_package_type == AccountsPackageType::Snapshot(SnapshotType::FullSnapshot) {
-                    *last_full_snapshot_slot = Some(snapshot_root_bank.slot());
                 }
 
                 // Snapshot the bank and send over an accounts package


### PR DESCRIPTION
#### Problem

Accounts Background Service tracks the last full snapshot slot, which is used when calling `clean_accounts()`. When handling a full snapshot request, the `last_full_snapshot_slot` value is updated _after_ calling `clean_accounts()`. This means that zero-lamport accounts will be kept based on the _previous_ full snapshot slot, instead of this current slot. By default, that's 25,000 slots-worth of zero-lamport accounts that are _not_ getting cleaned up when they could be.

Edit to add: The _next_ time `clean_accounts()` gets called (after a full snapshot, in the main ABS loop) will correctly clean up those zero-lamport accounts. This change allowed cleaning before taking the snapshot, so the snapshot archive should be a bit smaller if this was able to remove accounts and shrink append vecs.

#### Summary of Changes

Update `last_full_snapshot_slot` _before_ calling `clean_accounts()`.