### PR TITLE
remove extra accounts cap call at startup

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -859,21 +859,6 @@ pub fn process_blockstore_from_root(
 
     let processing_time = now.elapsed();
 
-    let debug_verify = opts.accounts_db_test_hash_calculation;
-    let mut time_cap = Measure::start("capitalization");
-    // We might be promptly restarted after bad capitalization was detected while creating newer snapshot.
-    // In that case, we're most likely restored from the last good snapshot and replayed up to this root.
-    // So again check here for the bad capitalization to avoid to continue until the next snapshot creation.
-    let bank = bank_forks.read().unwrap().root_bank();
-    if start_slot != bank.slot() && !bank.calculate_and_verify_capitalization(debug_verify) {
-        return Err(
-            BlockstoreProcessorError::RootBankWithMismatchedCapitalization(
-                bank_forks.read().unwrap().root(),
-            ),
-        );
-    }
-    time_cap.stop();
-
     bank.initial_blockstore_processing_completed();
 
     datapoint_info!(
@@ -886,7 +871,6 @@ pub fn process_blockstore_from_root(
         ),
         ("slot", bank_forks.read().unwrap().root(), i64),
         ("forks", bank_forks.read().unwrap().banks().len(), i64),
-        ("calculate_capitalization_us", time_cap.as_us(), i64),
     );
 
     info!("ledger processing timing: {:?}", timing);


### PR DESCRIPTION
#### Problem

At startup from a snapshot, we
1. check accounts hash capitalization after loading from a snapshot, verifying both cap and hash. This is done asynchronously as of recently to improve startup time.
2. starts accounts background service, where the write cache is flushed periodically
3. process whatever tx rocks has stored locally past the snapshot slot. Resulting slots are stored in the write cache.
4. check accounts hash capitalization again (this is done synchronously right now)
5. start the normal validator processing where the accounts background service calculates the accounts capitalization and verifies it against the bank and gossip periodically

(4) is redundant.
It only checks capitalization against the bank. The only side effect is to halt the validator if capitalization doesn't match.
This exactly what (5) does for each hash calculation. 

Importantly, it exposes a race condition now that (2) has occurred where it does.
The transactions we recently processed are likely in the write cache and not in append vecs yet. The hash calculation was prepared for this. However, now that accounts background service is running async to this hash calculation, the write cache can be flushed after the hash calculation gets append vecs but before the write cache for the slot is read. Previously, accounts background service did not start until after (4). had completed. The cache flush occurred synchronously with (4) during (3).

#### Summary of Changes
Remove the redundant capitalization check.

An alternative is to wait until the write cache is flushed. Another alternative is to plumb this request such that the hash calculation runs as part of accounts background service/accounts hash verifier for this slot.

Coming soon, we will validate every single account once per epoch as part of consensus.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
