### PR TITLE
Apply 1.13 non-quic commits to v1.10

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,21 +31,25 @@ jobs:
 
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v19
+        uses: tj-actions/changed-files@v29.0.7
         with:
           files: |
+            .github/workflows/docs.yml
             docs/**
 
       - name: Pre Build
         id: prebuild
         run: |
+          echo "tag: ${{ steps.check.outputs.tag }}"
+          echo "channel: ${{ steps.check.outputs.channel }}"
+          echo "any changes: ${{ steps.changed-files-specific.outputs.any_changed }}"
           echo "::set-output name=need_to_build::${{
             steps.check.outputs.tag != ''
             ||
             (
               (steps.check.outputs.channel == 'edge' || steps.check.outputs.channel == 'beta')
               &&
-              steps.changed-files-specific.outputs.any_change != ''
+              steps.changed-files-specific.outputs.any_changed != ''
             )
           }}"
         shell: bash

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -216,33 +216,6 @@ EOF
       "Stable-perf skipped as no relevant files were modified"
   fi
 
-  # Downstream backwards compatibility
-  if affects \
-             .rs$ \
-             Cargo.lock$ \
-             Cargo.toml$ \
-             ^ci/rust-version.sh \
-             ^ci/test-stable-perf.sh \
-             ^ci/test-stable.sh \
-             ^ci/test-local-cluster.sh \
-             ^core/build.rs \
-             ^fetch-perf-libs.sh \
-             ^programs/ \
-             ^sdk/ \
-             ^scripts/build-downstream-projects.sh \
-      ; then
-    cat >> "$output_file" <<"EOF"
-  - command: "scripts/build-downstream-projects.sh"
-    name: "downstream-projects"
-    timeout_in_minutes: 30
-    agents:
-      - "queue=solana"
-EOF
-  else
-    annotate --style info \
-      "downstream-projects skipped as no relevant files were modified"
-  fi
-
   # Wasm support
   if affects \
              ^ci/test-wasm.sh \


### PR DESCRIPTION
#### Problem
v1.13 and v1.10 are intended to match except for specific quic related commits but I didn't manage the branches well enough and a couple of commits made it into v1.13 without being on v1.10:
```
9a161c56ad chore: fix docs pipeline (backport #27794) (#27795)
aa0b46cb23 Remove downstream project check from stable branch CI (#27775)
```

#### Summary of Changes
Cherry pick 9a161c56ad and aa0b46cb23 onto v1.10

I've combined into one PR to get through CI but will not squash these so they remain distinct.

