### PR TITLE
log metric in case of race condition

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -277,6 +277,10 @@ impl AccountsCache {
         }
     }
 
+    pub fn contains_any_slots(&self, max_slot_inclusive: Slot) -> bool {
+        self.cache.iter().any(|e| e.key() <= &max_slot_inclusive)
+    }
+
     // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
     // otherwise the slot removed could still be undergoing replay!
     pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7103,6 +7103,11 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         if !use_index {
+            if !config.use_write_cache && self.accounts_cache.contains_any_slots(slot) {
+                // this indicates a race condition
+                inc_new_counter_info!("accounts_hash_items_in_write_cache", 1);
+            }
+
             let mut collect_time = Measure::start("collect");
             let (combined_maps, slots) = self.get_snapshot_storages(slot, None, config.ancestors);
             collect_time.stop();


### PR DESCRIPTION
#### Problem

I suspect there may be non-determinism for flushing the cache and calculating the accounts hash.

#### Summary of Changes

log metrics if there is non-determinism. This is true if the write cache isn't flushed sufficiently before hash calc runs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
