### PR TITLE
Remove the const default for RocksFifo

### DIFF
--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -355,7 +355,7 @@ mod tests {
                         shred_storage_type: ShredStorageType::RocksFifo(
                             BlockstoreRocksFifoOptions {
                                 shred_data_cf_size: config.shred_data_cf_size,
-                                ..BlockstoreRocksFifoOptions::default()
+                                shred_code_cf_size: config.shred_data_cf_size,
                             },
                         ),
                         ..LedgerColumnOptions::default()

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -31,8 +31,9 @@ use {
         blockstore::{create_new_ledger, Blockstore, BlockstoreError, PurgeType},
         blockstore_db::{self, columns as cf, Column, ColumnName, Database},
         blockstore_options::{
-            AccessType, BlockstoreOptions, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-            LedgerColumnOptions, ShredStorageType, MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+            AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
+            ShredStorageType, BLOCKSTORE_DIRECTORY_ROCKS_FIFO,
+            MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
         },
         blockstore_processor::{self, BlockstoreProcessorError, ProcessOptions},
         shred::Shred,
@@ -2310,8 +2311,7 @@ fn main() {
                      the default RocksLevel will be used. \
                      If you want to use FIFO shred_storage_type on an empty target_db, \
                      create {} foldar the specified target_db directory.",
-                        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::default())
-                            .blockstore_directory()
+                        BLOCKSTORE_DIRECTORY_ROCKS_FIFO,
                     ),
                 );
 

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -138,8 +138,8 @@ impl Default for ShredStorageType {
     }
 }
 
-const BLOCKSTORE_DIRECTORY_ROCKS_LEVEL: &str = "rocksdb";
-const BLOCKSTORE_DIRECTORY_ROCKS_FIFO: &str = "rocksdb_fifo";
+pub const BLOCKSTORE_DIRECTORY_ROCKS_LEVEL: &str = "rocksdb";
+pub const BLOCKSTORE_DIRECTORY_ROCKS_FIFO: &str = "rocksdb_fifo";
 
 impl ShredStorageType {
     /// Returns ShredStorageType::RocksFifo where the specified
@@ -212,24 +212,20 @@ pub struct BlockstoreRocksFifoOptions {
     pub shred_code_cf_size: u64,
 }
 
-// The default storage size for storing shreds when `rocksdb-shred-compaction`
-// is set to `fifo` in the validator arguments.  This amount of storage size
-// in bytes will equally allocated to both data shreds and coding shreds.
-pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 * 1024;
-
 pub const MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = std::u64::MAX;
-
-impl Default for BlockstoreRocksFifoOptions {
-    fn default() -> Self {
-        BlockstoreRocksFifoOptions::new(DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES)
-    }
-}
 
 impl BlockstoreRocksFifoOptions {
     fn new(shred_storage_size: u64) -> Self {
         Self {
             shred_data_cf_size: shred_storage_size / 2,
             shred_code_cf_size: shred_storage_size / 2,
+        }
+    }
+
+    pub fn new_for_tests() -> Self {
+        Self {
+            shred_data_cf_size: 150_000_000_000,
+            shred_code_cf_size: 150_000_000_000,
         }
     }
 }
@@ -266,7 +262,11 @@ fn test_rocksdb_directory() {
         BLOCKSTORE_DIRECTORY_ROCKS_LEVEL
     );
     assert_eq!(
-        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::default()).blockstore_directory(),
+        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
+            shred_code_cf_size: 0,
+            shred_data_cf_size: 0
+        })
+        .blockstore_directory(),
         BLOCKSTORE_DIRECTORY_ROCKS_FIFO
     );
 }


### PR DESCRIPTION
#### Summary of Changes
Removes the constant default for ShredStorageType::RocksFifo
as the shred storage size is either user-specified or derived
from --limit-ledger-size in #27459.

