### PR TITLE
Limit the maximum staked streams to avoid excessive streams from staked nodes

### DIFF
--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -7,6 +7,9 @@ pub const QUIC_MIN_STAKED_CONCURRENT_STREAMS: usize = 128;
 
 pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 
+// Set the maximum concurrent stream numbers to avoid excessive streams
+pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 2048;
+
 pub const QUIC_MAX_TIMEOUT_MS: u32 = 2_000;
 pub const QUIC_KEEP_ALIVE_MS: u64 = 1_000;
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -207,8 +207,10 @@ pub fn compute_max_allowed_uni_streams(
 
                     (((peer_stake as f64 / total_stake as f64) * delta) as usize
                         + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                        .max(QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                        .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
+                        .clamp(
+                            QUIC_MIN_STAKED_CONCURRENT_STREAMS,
+                            QUIC_MAX_STAKED_CONCURRENT_STREAMS,
+                        )
                 }
             }
             _ => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -19,10 +19,10 @@ use {
         packet::{Packet, PACKET_DATA_SIZE},
         pubkey::Pubkey,
         quic::{
-            QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS, QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO,
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
-            QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO, QUIC_TOTAL_STAKED_CONCURRENT_STREAMS,
-            QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
+            QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS, QUIC_MAX_STAKED_CONCURRENT_STREAMS,
+            QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
+            QUIC_MIN_STAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO,
+            QUIC_TOTAL_STAKED_CONCURRENT_STREAMS, QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
         },
         signature::Keypair,
         timing,
@@ -205,8 +205,10 @@ pub fn compute_max_allowed_uni_streams(
                         - QUIC_MIN_STAKED_CONCURRENT_STREAMS)
                         as f64;
 
-                    ((peer_stake as f64 / total_stake as f64) * delta) as usize
-                        + QUIC_MIN_STAKED_CONCURRENT_STREAMS
+                    (((peer_stake as f64 / total_stake as f64) * delta) as usize
+                        + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
+                        .max(QUIC_MIN_STAKED_CONCURRENT_STREAMS)
+                        .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
                 }
             }
             _ => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
@@ -1636,7 +1638,7 @@ pub mod test {
             (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
         assert_eq!(
             compute_max_allowed_uni_streams(ConnectionPeerType::Staked, 1000, 10000),
-            (delta / (10_f64)) as usize + QUIC_MIN_STAKED_CONCURRENT_STREAMS
+            QUIC_MAX_STAKED_CONCURRENT_STREAMS,
         );
         assert_eq!(
             compute_max_allowed_uni_streams(ConnectionPeerType::Staked, 100, 10000),


### PR DESCRIPTION
#### Problem

Address one of the security review findings.

Initially QUIC concurrent streams were capped at 2048, an empirical number
that maximized TPS as measured on GCP, and based on tests results higher
values had no impact on TPS nor on overall performance. Since then,
this limitation was replaced with QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
and QUIC_MIN_STAKED_CONCURRENT_STREAMS which are both set to 128. Cur-
rently compute_max_allowed_uni_streams returns the amount of unidirec-
tional streams for a specific peer based on stake weight and there is no
upper limit to the number of streams.
Consequently, a highly staked node can open an excessive number of unidi-
rectional streams, which do not provide any significant benefits in terms
of TPS, while those streams could otherwise be reused by other staked
nodes.

#### Summary of Changes

Maximum concurrent streams should be limited to a reasonable number, such as 2048, as it was initially implemented. QUIC_MAX_STAKED_CONCURRENT_STREAMS could be added and returned when the
number of streams calculated based on stake weight is greater than the
upper limit.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
