### PR TITLE
remove AccountsDb::initial_blockstore_processing_complete

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -104,7 +104,6 @@ impl SnapshotTestConfig {
         );
         bank0.freeze();
         bank0.set_startup_verification_complete();
-        bank0.initial_blockstore_processing_completed();
         let mut bank_forks = BankForks::new(bank0);
         bank_forks.accounts_hash_interval_slots = accounts_hash_interval_slots;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -859,8 +859,6 @@ pub fn process_blockstore_from_root(
 
     let processing_time = now.elapsed();
 
-    bank.initial_blockstore_processing_completed();
-
     datapoint_info!(
         "process_blockstore_from_root",
         ("total_time_us", processing_time.as_micros(), i64),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1154,10 +1154,6 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .path(),
     );
     info!("validator full snapshot archives: {validator_full_snapshot_archives:#?}");
-    info!(
-        "bprumo DEBUG: leader full snapshot archive for comparison: {:#?}",
-        leader_full_snapshot_archive_for_comparison
-    );
     let validator_full_snapshot_archive_for_comparison = validator_full_snapshot_archives
         .into_iter()
         .find(|validator_full_snapshot_archive| {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1204,9 +1204,6 @@ pub struct AccountsDb {
     /// debug feature to scan every append vec and verify refcounts are equal
     exhaustively_verify_refcounts: bool,
 
-    /// true once all accounts hash calculations that may take place at startup have been requested
-    pub initial_blockstore_processing_complete: AtomicBool,
-
     /// the full accounts hash calculation as of a predetermined block height 'N'
     /// to be included in the bank hash at a predetermined block height 'M'
     /// The cadence is once per epoch, all nodes calculate a full accounts hash as of a known slot calculated using 'N'
@@ -2023,7 +2020,6 @@ impl AccountsDb {
             num_hash_scan_passes,
             log_dead_slots: AtomicBool::new(true),
             exhaustively_verify_refcounts: false,
-            initial_blockstore_processing_complete: AtomicBool::new(false),
             epoch_accounts_hash: Mutex::new(None),
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -163,7 +163,7 @@ use {
         sync::{
             atomic::{
                 AtomicBool, AtomicI64, AtomicU64, AtomicUsize,
-                Ordering::{AcqRel, Acquire, Relaxed, Release},
+                Ordering::{AcqRel, Acquire, Relaxed},
             },
             Arc, LockResult, RwLock, RwLockReadGuard, RwLockWriteGuard,
         },
@@ -7231,28 +7231,6 @@ impl Bank {
         self.update_accounts_hash_with_index_option(true, false, false)
     }
 
-    /// When the validator starts up, there is an initial hash calculation verification of the snapshot.
-    /// Then, in some conditions, there are additional slots replayed and a second hash calculation verification occurs.
-    /// This function is called when all initial hash calculations have been requested or completed.
-    pub fn initial_blockstore_processing_completed(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .initial_blockstore_processing_complete
-            .store(true, Release);
-    }
-
-    /// until this occurs, no additional accounts hash calculations can be started
-    /// There will be 0..=2 of these requests.
-    pub fn is_initial_blockstore_processing_complete(&self) -> bool {
-        self.rc
-            .accounts
-            .accounts_db
-            .initial_blockstore_processing_complete
-            .load(Acquire)
-            && self.is_startup_verification_complete()
-    }
-
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(
@@ -8174,7 +8152,9 @@ pub(crate) mod tests {
                 MAX_LOCKOUT_HISTORY,
             },
         },
-        std::{result, str::FromStr, thread::Builder, time::Duration},
+        std::{
+            result, str::FromStr, sync::atomic::Ordering::Release, thread::Builder, time::Duration,
+        },
         test_utils::goto_end_of_slot,
     };
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -276,7 +276,7 @@ impl BankForks {
             if self.snapshot_config.is_some()
                 && accounts_background_request_sender.is_snapshot_creation_enabled()
             {
-                if bank.is_initial_blockstore_processing_complete() {
+                if bank.is_startup_verification_complete() {
                     // Save off the status cache because these may get pruned if another
                     // `set_root()` is called before the snapshots package can be generated
                     let status_cache_slot_deltas =

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -606,11 +606,6 @@ impl TestValidator {
             .unwrap()
             .root_bank()
             .set_startup_verification_complete();
-        self.bank_forks()
-            .read()
-            .unwrap()
-            .root_bank()
-            .initial_blockstore_processing_completed();
     }
 
     /// Initialize the ledger directory


### PR DESCRIPTION
#### Problem

Building on https://github.com/solana-labs/solana/pull/27942, I went to update the local-cluster test that was failing before that PR was merged and found out the test was still failing after my changes!

The test, `test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup`, is designed to take a full snapshot during startup in the scenario where a node has enough roots in its blockstore that cross a full snapshot interval. I was observing that this was no longer happening. Unfortunately the test was modified beforehand to less stringent on the results that constituted a success, and inadvertently masked this change in behavior.

For example:
- Given a full snapshot interval of 10,000
- A node starts from a snapshot at slot 123,000
- In its blockstore it has roots up to 133,000
- When processing blockstore, it will cross slot 130,000 and should take a full snapshot
- However, this snapshot was not taken. Instead the node's next snapshot would be at slot 140,000 during normal replay.
- Originally the test checked for a full snapshot at slot 130,000, but that was relaxed to check for either 130,000 or 140,000

Investigating further, the newly added `initial_blockstore_processing_complete` flag will prevent sending snapshot requests from `set_root` until this flag is true. This is exactly the case we're hitting; I expect a full snapshot to be taken _before_ the initial blockstore processing has completed, but this flag prevent that from happening.

Now that the unnecessary extra accounts hash calculation has been removed from blockstore processor (just before the `initial_blockstore_processing_complete` flag was set), we can also remove the flag.

#### Summary of Changes

- Remove the `initial_blockstore_processing_complete` flag from `AccountsDb`
- Make `test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup` more stringent so that it requires checking for the very next full snapshot.