### PR TITLE
Update poh_config to have hashrate be private, with a getter and setter

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4123,12 +4123,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2419,7 +2419,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -2635,7 +2635,7 @@ mod tests {
                 &pubkey,
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -2772,7 +2772,7 @@ mod tests {
                 &pubkey,
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -2846,7 +2846,7 @@ mod tests {
                 &pubkey,
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -3000,7 +3000,7 @@ mod tests {
                 &pubkey,
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -3078,7 +3078,7 @@ mod tests {
                 &solana_sdk::pubkey::new_rand(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -3145,7 +3145,7 @@ mod tests {
             &Pubkey::new_unique(),
             &Arc::new(blockstore),
             &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &Arc::new(PohConfig::default()),
+            PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
         let recorder = poh_recorder.recorder();
@@ -3351,7 +3351,7 @@ mod tests {
                 &pubkey,
                 &blockstore,
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -3520,7 +3520,7 @@ mod tests {
                 &Pubkey::new_unique(),
                 &blockstore,
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
@@ -3627,7 +3627,7 @@ mod tests {
             &solana_sdk::pubkey::new_rand(),
             &Arc::new(blockstore),
             &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &Arc::new(PohConfig::default()),
+            PohConfig::default(),
             exit,
         );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2103,10 +2103,9 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                target_tick_count: Some(bank.max_tick_height() + num_extra_ticks),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            poh_config.target_tick_count = Some(bank.max_tick_height() + num_extra_ticks);
+
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -2180,12 +2179,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -2336,12 +2333,10 @@ mod tests {
                     Blockstore::open(ledger_path.path())
                         .expect("Expected to be able to open database ledger"),
                 );
-                let poh_config = PohConfig {
-                    // limit tick count to avoid clearing working_bank at
-                    // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                    target_tick_count: Some(bank.max_tick_height() - 1),
-                    ..PohConfig::default()
-                };
+                let mut poh_config = PohConfig::default();
+                // limit tick count to avoid clearing working_bank at
+                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+                poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
                 let (exit, poh_recorder, poh_service, entry_receiver) =
                     create_test_recorder(&bank, &blockstore, Some(poh_config), None);
                 let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -3902,12 +3897,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at
-                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at
+            // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
 
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
@@ -4009,12 +4002,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at
-                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at
+            // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
 
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3666,7 +3666,7 @@ pub(crate) mod tests {
                 &Pubkey::default(),
                 &blockstore,
                 &leader_schedule_cache,
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::new(false)),
             )
             .0,

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -360,6 +360,7 @@ pub fn retransmitter(
     let mut stats = RetransmitStats::new(Instant::now());
     let mut shreds_received = LruCache::<ShredId, _>::new(DEFAULT_LRU_SIZE);
     let mut packet_hasher = PacketHasher::default();
+    #[allow(clippy::manual_clamp)]
     let num_threads = get_thread_count().min(8).max(sockets.len());
     let thread_pool = ThreadPoolBuilder::new()
         .num_threads(num_threads)

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -360,7 +360,6 @@ pub fn retransmitter(
     let mut stats = RetransmitStats::new(Instant::now());
     let mut shreds_received = LruCache::<ShredId, _>::new(DEFAULT_LRU_SIZE);
     let mut packet_hasher = PacketHasher::default();
-    #[allow(clippy::manual_clamp)]
     let num_threads = get_thread_count().min(8).max(sockets.len());
     let thread_pool = ThreadPoolBuilder::new()
         .num_threads(num_threads)

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -721,7 +721,7 @@ impl Validator {
             max_slots.clone(),
         );
 
-        let poh_config = Arc::new(genesis_config.poh_config.clone());
+        let poh_config = genesis_config.poh_config;
         let startup_verification_complete;
         let (poh_recorder, entry_receiver, record_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
@@ -736,7 +736,7 @@ impl Validator {
                 &blockstore,
                 blockstore.get_new_shred_signal(0),
                 &leader_schedule_cache,
-                &poh_config,
+                poh_config,
                 Some(poh_timing_point_sender),
                 exit.clone(),
             )
@@ -907,7 +907,7 @@ impl Validator {
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
-            &poh_config,
+            poh_config,
             &exit,
             bank_forks.read().unwrap().root_bank().ticks_per_slot(),
             config.poh_pinned_cpu_core,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2480,12 +2480,12 @@ mod tests {
     #[test]
     fn test_poh_speed() {
         solana_logger::setup();
-        let poh_config = PohConfig {
-            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+        let poh_config = PohConfig::new(
+            Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            None,
             // make PoH rate really fast to cause the panic condition
-            hashes_per_tick: Some(100 * solana_sdk::clock::DEFAULT_HASHES_PER_TICK),
-            ..PohConfig::default()
-        };
+            Some(100 * solana_sdk::clock::DEFAULT_HASHES_PER_TICK),
+        );
         let genesis_config = GenesisConfig {
             poh_config,
             ..GenesisConfig::default()
@@ -2495,11 +2495,11 @@ mod tests {
 
     #[test]
     fn test_poh_speed_no_hashes_per_tick() {
-        let poh_config = PohConfig {
-            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
-            hashes_per_tick: None,
-            ..PohConfig::default()
-        };
+        let poh_config = PohConfig::new(
+            Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            None,
+            None,
+        );
         let genesis_config = GenesisConfig {
             poh_config,
             ..GenesisConfig::default()

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -350,7 +350,7 @@ pub fn initialize_state(
         vec![stake; validator_keypairs.len()],
     );
 
-    genesis_config.poh_config.hashes_per_tick = Some(2);
+    genesis_config.poh_config.set_hashes_per_tick(Some(2));
     let bank0 = Bank::new_for_tests(&genesis_config);
 
     for pubkey in validator_keypairs_map.keys() {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -446,14 +446,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
     fee_rate_governor.burn_percent = value_t_or_exit!(matches, "fee_burn_percentage", u8);
 
-    let mut poh_config = PohConfig {
-        target_tick_duration: if matches.is_present("target_tick_duration") {
+    let mut poh_config = PohConfig::new(
+        if matches.is_present("target_tick_duration") {
             Duration::from_micros(value_t_or_exit!(matches, "target_tick_duration", u64))
         } else {
             Duration::from_micros(default_target_tick_duration)
         },
-        ..PohConfig::default()
-    };
+        None,
+        None,
+    );
 
     let cluster_type = cluster_type_of(&matches, "cluster_type").unwrap();
 
@@ -462,17 +463,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             ClusterType::Development => {
                 let hashes_per_tick =
                     compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
-                poh_config.hashes_per_tick = Some(hashes_per_tick / 2); // use 50% of peak ability
+                poh_config.set_hashes_per_tick(Some(hashes_per_tick / 2)); // use 50% of peak ability
             }
             ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => {
-                poh_config.hashes_per_tick = Some(clock::DEFAULT_HASHES_PER_TICK);
+                poh_config.set_hashes_per_tick(Some(clock::DEFAULT_HASHES_PER_TICK));
             }
         },
         "sleep" => {
-            poh_config.hashes_per_tick = None;
+            poh_config.set_hashes_per_tick(None);
         }
         _ => {
-            poh_config.hashes_per_tick = Some(value_t_or_exit!(matches, "hashes_per_tick", u64));
+            poh_config.set_hashes_per_tick(Some(value_t_or_exit!(matches, "hashes_per_tick", u64)));
         }
     }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2376,11 +2376,13 @@ fn main() {
                 }
 
                 if let Some(hashes_per_tick) = arg_matches.value_of("hashes_per_tick") {
-                    genesis_config.poh_config.set_hashes_per_tick(match hashes_per_tick {
-                        // Note: Unlike `solana-genesis`, "auto" is not supported here.
-                        "sleep" => None,
-                        _ => Some(value_t_or_exit!(arg_matches, "hashes_per_tick", u64)),
-                    })
+                    genesis_config
+                        .poh_config
+                        .set_hashes_per_tick(match hashes_per_tick {
+                            // Note: Unlike `solana-genesis`, "auto" is not supported here.
+                            "sleep" => None,
+                            _ => Some(value_t_or_exit!(arg_matches, "hashes_per_tick", u64)),
+                        })
                 }
 
                 create_new_ledger(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2376,11 +2376,11 @@ fn main() {
                 }
 
                 if let Some(hashes_per_tick) = arg_matches.value_of("hashes_per_tick") {
-                    genesis_config.poh_config.hashes_per_tick = match hashes_per_tick {
+                    genesis_config.poh_config.set_hashes_per_tick(match hashes_per_tick {
                         // Note: Unlike `solana-genesis`, "auto" is not supported here.
                         "sleep" => None,
                         _ => Some(value_t_or_exit!(arg_matches, "hashes_per_tick", u64)),
-                    }
+                    })
                 }
 
                 create_new_ledger(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3856,7 +3856,7 @@ pub fn create_new_ledger(
         },
     )?;
     let ticks_per_slot = genesis_config.ticks_per_slot;
-    let hashes_per_tick = genesis_config.poh_config.hashes_per_tick.unwrap_or(0);
+    let hashes_per_tick = genesis_config.poh_config.get_hashes_per_tick().unwrap_or(0);
     let entries = create_ticks(ticks_per_slot, hashes_per_tick, genesis_config.hash());
     let last_hash = entries.last().unwrap().hash;
     let version = solana_sdk::shred_version::version_from_hash(&last_hash);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1947,7 +1947,9 @@ pub mod tests {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.set_hashes_per_tick(Some(hashes_per_tick));
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(hashes_per_tick));
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         let (ledger_path, blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
@@ -2639,7 +2641,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(mint, &leader_pubkey, 50);
-        genesis_config.poh_config.set_hashes_per_tick(Some(hashes_per_tick));
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(hashes_per_tick));
         let (ledger_path, mut last_entry_hash) =
             create_new_tmp_ledger_auto_delete!(&genesis_config);
         debug!("ledger_path: {:?}", ledger_path);
@@ -4185,7 +4189,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.set_hashes_per_tick(Some(HASHES_PER_TICK));
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 
@@ -4453,7 +4459,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.set_hashes_per_tick(Some(HASHES_PER_TICK));
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1947,7 +1947,7 @@ pub mod tests {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(hashes_per_tick);
+        genesis_config.poh_config.set_hashes_per_tick(Some(hashes_per_tick));
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         let (ledger_path, blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
@@ -2639,7 +2639,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(mint, &leader_pubkey, 50);
-        genesis_config.poh_config.hashes_per_tick = Some(hashes_per_tick);
+        genesis_config.poh_config.set_hashes_per_tick(Some(hashes_per_tick));
         let (ledger_path, mut last_entry_hash) =
             create_new_tmp_ledger_auto_delete!(&genesis_config);
         debug!("ledger_path: {:?}", ledger_path);
@@ -2670,7 +2670,7 @@ pub mod tests {
         // Fill up the rest of slot 1 with ticks
         entries.extend(create_ticks(
             genesis_config.ticks_per_slot - 1,
-            genesis_config.poh_config.hashes_per_tick.unwrap(),
+            genesis_config.poh_config.get_hashes_per_tick().unwrap(),
             last_entry_hash,
         ));
         let last_blockhash = entries.last().unwrap().hash;
@@ -4185,7 +4185,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(HASHES_PER_TICK);
+        genesis_config.poh_config.set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 
@@ -4453,7 +4453,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(HASHES_PER_TICK);
+        genesis_config.poh_config.set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -239,7 +239,7 @@ impl LocalCluster {
             config.stakers_slot_offset,
             !config.skip_warmup_slots,
         );
-        genesis_config.poh_config = config.poh_config.clone();
+        genesis_config.poh_config = config.poh_config;
         genesis_config
             .native_instruction_processors
             .extend_from_slice(&config.native_instruction_processors);

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -462,7 +462,7 @@ impl PohRecorder {
         let blockhash = reset_bank.last_blockhash();
         let poh_hash = {
             let mut poh = self.poh.lock().unwrap();
-            poh.reset(blockhash, self.poh_config.hashes_per_tick);
+            poh.reset(blockhash, self.poh_config.get_hashes_per_tick());
             poh.hash
         };
         info!(
@@ -830,7 +830,7 @@ impl PohRecorder {
         let tick_number = 0;
         let poh = Arc::new(Mutex::new(Poh::new_with_slot_info(
             last_entry_hash,
-            poh_config.hashes_per_tick,
+            poh_config.get_hashes_per_tick(),
             ticks_per_slot,
             tick_number,
         )));

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -221,7 +221,7 @@ pub struct PohRecorder {
     id: Pubkey,
     blockstore: Arc<Blockstore>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
-    poh_config: Arc<PohConfig>,
+    poh_config: PohConfig,
     ticks_per_slot: u64,
     target_ns_per_tick: u64,
     record_lock_contention_us: u64,
@@ -823,7 +823,7 @@ impl PohRecorder {
         blockstore: &Arc<Blockstore>,
         clear_bank_signal: Option<Sender<bool>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        poh_config: &Arc<PohConfig>,
+        poh_config: PohConfig,
         poh_timing_point_sender: Option<PohTimingSender>,
         is_exited: Arc<AtomicBool>,
     ) -> (Self, Receiver<WorkingBankEntry>, Receiver<Record>) {
@@ -862,7 +862,7 @@ impl PohRecorder {
                 leader_schedule_cache: leader_schedule_cache.clone(),
                 ticks_per_slot,
                 target_ns_per_tick,
-                poh_config: poh_config.clone(),
+                poh_config,
                 record_lock_contention_us: 0,
                 flush_cache_tick_us: 0,
                 flush_cache_no_tick_us: 0,
@@ -894,7 +894,7 @@ impl PohRecorder {
         id: &Pubkey,
         blockstore: &Arc<Blockstore>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        poh_config: &Arc<PohConfig>,
+        poh_config: PohConfig,
         is_exited: Arc<AtomicBool>,
     ) -> (Self, Receiver<WorkingBankEntry>, Receiver<Record>) {
         Self::new_with_clear_signal(
@@ -956,7 +956,7 @@ pub fn create_test_recorder(
         None => Arc::new(LeaderScheduleCache::new_from_bank(bank)),
     };
     let exit = Arc::new(AtomicBool::new(false));
-    let poh_config = Arc::new(poh_config.unwrap_or_default());
+    let poh_config = poh_config.unwrap_or_default();
     let (mut poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
         bank.tick_height(),
         bank.last_blockhash(),
@@ -966,7 +966,7 @@ pub fn create_test_recorder(
         &Pubkey::default(),
         blockstore,
         &leader_schedule_cache,
-        &poh_config,
+        poh_config,
         exit.clone(),
     );
     poh_recorder.set_bank(bank, false);
@@ -974,7 +974,7 @@ pub fn create_test_recorder(
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let poh_service = PohService::new(
         poh_recorder.clone(),
-        &poh_config,
+        poh_config,
         &exit,
         bank.ticks_per_slot(),
         crate::poh_service::DEFAULT_PINNED_CPU_CORE,
@@ -1015,7 +1015,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1045,7 +1045,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1074,7 +1074,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1103,7 +1103,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1133,7 +1133,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1196,7 +1196,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1245,7 +1245,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1288,7 +1288,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1330,7 +1330,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1386,7 +1386,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1426,7 +1426,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1498,7 +1498,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1554,7 +1554,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1583,7 +1583,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1614,7 +1614,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::default()),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             poh_recorder.tick();
@@ -1648,7 +1648,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1680,7 +1680,7 @@ mod tests {
                     &Arc::new(blockstore),
                     Some(sender),
                     &Arc::new(LeaderScheduleCache::default()),
-                    &Arc::new(PohConfig::default()),
+                    PohConfig::default(),
                     None,
                     Arc::new(AtomicBool::default()),
                 );
@@ -1715,7 +1715,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1763,7 +1763,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &leader_schedule_cache,
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1826,7 +1826,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -1987,7 +1987,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 
@@ -2039,7 +2039,7 @@ mod tests {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
             //create a new bank

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -96,7 +96,7 @@ impl PohTiming {
 impl PohService {
     pub fn new(
         poh_recorder: Arc<RwLock<PohRecorder>>,
-        poh_config: &Arc<PohConfig>,
+        poh_config: PohConfig,
         poh_exit: &Arc<AtomicBool>,
         ticks_per_slot: u64,
         pinned_cpu_core: usize,
@@ -104,7 +104,6 @@ impl PohService {
         record_receiver: Receiver<Record>,
     ) -> Self {
         let poh_exit_ = poh_exit.clone();
-        let poh_config = poh_config.clone();
         let tick_producer = Builder::new()
             .name("solPohTickProd".to_string())
             .spawn(move || {
@@ -414,11 +413,11 @@ mod tests {
             let default_target_tick_duration =
                 timing::duration_as_us(&PohConfig::default().target_tick_duration);
             let target_tick_duration = Duration::from_micros(default_target_tick_duration);
-            let poh_config = Arc::new(PohConfig::new(
+            let poh_config = PohConfig::new(
                 target_tick_duration,
                 None,
                 Some(clock::DEFAULT_HASHES_PER_TICK),
-            ));
+            );
             let exit = Arc::new(AtomicBool::new(false));
 
             let ticks_per_slot = bank.ticks_per_slot();
@@ -433,7 +432,7 @@ mod tests {
                 &Pubkey::default(),
                 &blockstore,
                 &leader_schedule_cache,
-                &poh_config,
+                poh_config,
                 exit.clone(),
             );
             let poh_recorder = Arc::new(RwLock::new(poh_recorder));
@@ -493,7 +492,7 @@ mod tests {
                 .unwrap_or(DEFAULT_HASHES_PER_BATCH);
             let poh_service = PohService::new(
                 poh_recorder.clone(),
-                &poh_config,
+                poh_config,
                 &exit,
                 0,
                 DEFAULT_PINNED_CPU_CORE,

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -109,7 +109,7 @@ impl PohService {
             .name("solPohTickProd".to_string())
             .spawn(move || {
                 solana_sys_tuner::request_realtime_poh();
-                if poh_config.hashes_per_tick.is_none() {
+                if poh_config.get_hashes_per_tick().is_none() {
                     if poh_config.target_tick_count.is_none() {
                         Self::sleepy_tick_producer(
                             poh_recorder,
@@ -414,11 +414,11 @@ mod tests {
             let default_target_tick_duration =
                 timing::duration_as_us(&PohConfig::default().target_tick_duration);
             let target_tick_duration = Duration::from_micros(default_target_tick_duration);
-            let poh_config = Arc::new(PohConfig {
-                hashes_per_tick: Some(clock::DEFAULT_HASHES_PER_TICK),
+            let poh_config = Arc::new(PohConfig::new(
                 target_tick_duration,
-                target_tick_count: None,
-            });
+                None,
+                Some(clock::DEFAULT_HASHES_PER_TICK),
+            ));
             let exit = Arc::new(AtomicBool::new(false));
 
             let ticks_per_slot = bank.ticks_per_slot();
@@ -516,13 +516,13 @@ mod tests {
                 if entry.is_tick() {
                     num_ticks += 1;
                     assert!(
-                        entry.num_hashes <= poh_config.hashes_per_tick.unwrap(),
+                        entry.num_hashes <= poh_config.get_hashes_per_tick().unwrap(),
                         "{} <= {}",
                         entry.num_hashes,
-                        poh_config.hashes_per_tick.unwrap()
+                        poh_config.get_hashes_per_tick().unwrap()
                     );
 
-                    if entry.num_hashes == poh_config.hashes_per_tick.unwrap() {
+                    if entry.num_hashes == poh_config.get_hashes_per_tick().unwrap() {
                         need_tick = false;
                     } else {
                         need_partial = false;
@@ -530,7 +530,7 @@ mod tests {
 
                     hashes += entry.num_hashes;
 
-                    assert_eq!(hashes, poh_config.hashes_per_tick.unwrap());
+                    assert_eq!(hashes, poh_config.get_hashes_per_tick().unwrap());
 
                     hashes = 0;
                 } else {

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -108,7 +108,7 @@ mod test {
                 &Pubkey::default(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &Arc::new(PohConfig::default()),
+                PohConfig::default(),
                 Arc::new(AtomicBool::default()),
             );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10204,7 +10204,7 @@ pub(crate) mod tests {
                 .collect(),
             // set it up so the first epoch is a full year long
             poh_config: PohConfig::new_sleep(Duration::from_secs(
-                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH as u64 / DEFAULT_TICKS_PER_SLOT,
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
             )),
             cluster_type: ClusterType::MainnetBeta,
 
@@ -10327,7 +10327,7 @@ pub(crate) mod tests {
                 .collect(),
             // set it up so the first epoch is a full year long
             poh_config: PohConfig::new_sleep(Duration::from_secs(
-                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH as u64 / DEFAULT_TICKS_PER_SLOT,
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
             )),
             cluster_type: ClusterType::MainnetBeta,
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2038,10 +2038,7 @@ impl Bank {
             "Bank snapshot genesis creation time does not match genesis.bin creation time.\
              The snapshot and genesis.bin might pertain to different clusters"
         );
-        assert_eq!(
-            bank.hashes_per_tick,
-            genesis_config.hashes_per_tick()
-        );
+        assert_eq!(bank.hashes_per_tick, genesis_config.hashes_per_tick());
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
         assert_eq!(
             bank.ns_per_slot,
@@ -10329,7 +10326,6 @@ pub(crate) mod tests {
                 })
                 .collect(),
             // set it up so the first epoch is a full year long
-
             poh_config: PohConfig::new_sleep(Duration::from_secs(
                 SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH as u64 / DEFAULT_TICKS_PER_SLOT,
             )),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2040,7 +2040,7 @@ impl Bank {
         );
         assert_eq!(
             bank.hashes_per_tick,
-            genesis_config.poh_config.hashes_per_tick
+            genesis_config.hashes_per_tick()
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
         assert_eq!(
@@ -10206,13 +10206,10 @@ pub(crate) mod tests {
                 })
                 .collect(),
             // set it up so the first epoch is a full year long
-            poh_config: PohConfig {
-                target_tick_duration: Duration::from_secs(
-                    SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
-                ),
-                hashes_per_tick: None,
-                target_tick_count: None,
-            },
+            poh_config: PohConfig::new_sleep(Duration::from_secs(
+                SECONDS_PER_YEAR as u64
+                    / MINIMUM_SLOTS_PER_EPOCH as u64
+                    / DEFAULT_TICKS_PER_SLOT)),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()
@@ -10333,13 +10330,11 @@ pub(crate) mod tests {
                 })
                 .collect(),
             // set it up so the first epoch is a full year long
-            poh_config: PohConfig {
-                target_tick_duration: Duration::from_secs(
-                    SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
-                ),
-                hashes_per_tick: None,
-                target_tick_count: None,
-            },
+
+            poh_config: PohConfig::new_sleep(Duration::from_secs(
+                SECONDS_PER_YEAR as u64
+                    / MINIMUM_SLOTS_PER_EPOCH as u64
+                    / DEFAULT_TICKS_PER_SLOT)),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10207,9 +10207,8 @@ pub(crate) mod tests {
                 .collect(),
             // set it up so the first epoch is a full year long
             poh_config: PohConfig::new_sleep(Duration::from_secs(
-                SECONDS_PER_YEAR as u64
-                    / MINIMUM_SLOTS_PER_EPOCH as u64
-                    / DEFAULT_TICKS_PER_SLOT)),
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH as u64 / DEFAULT_TICKS_PER_SLOT,
+            )),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()
@@ -10332,9 +10331,8 @@ pub(crate) mod tests {
             // set it up so the first epoch is a full year long
 
             poh_config: PohConfig::new_sleep(Duration::from_secs(
-                SECONDS_PER_YEAR as u64
-                    / MINIMUM_SLOTS_PER_EPOCH as u64
-                    / DEFAULT_TICKS_PER_SLOT)),
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH as u64 / DEFAULT_TICKS_PER_SLOT,
+            )),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -246,11 +246,20 @@ pub struct SnapshotPackage {
 
 impl SnapshotPackage {
     pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHash) -> Self {
-        let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type else {
-            panic!("The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!");
-        };
-        let Some(snapshot_info) = accounts_package.snapshot_info else {
-            panic!("The AccountsPackage must have snapshot info in order to make a SnapshotPackage!");
+        let snapshot_type =
+            if let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type {
+                snapshot_type
+            } else {
+                panic!(
+                "The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!"
+            );
+            };
+        let snapshot_info = if let Some(snapshot_info) = accounts_package.snapshot_info {
+            snapshot_info
+        } else {
+            panic!(
+                "The AccountsPackage must have snapshot info in order to make a SnapshotPackage!"
+            );
         };
         let snapshot_hash =
             SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref());

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -212,7 +212,11 @@ impl GenesisConfig {
     }
 
     pub fn hashes_per_tick(&self) -> Option<u64> {
-        self.poh_config.hashes_per_tick
+        self.poh_config.get_hashes_per_tick()
+    }
+
+    pub fn set_hashes_per_tick(&mut self, hashes: Option<u64>) {
+        self.poh_config.set_hashes_per_tick(hashes)
     }
 
     pub fn ticks_per_slot(&self) -> u64 {
@@ -262,7 +266,7 @@ impl fmt::Display for GenesisConfig {
             self.hash(),
             compute_shred_version(&self.hash(), None),
             self.ticks_per_slot,
-            self.poh_config.hashes_per_tick,
+            self.hashes_per_tick(),
             self.poh_config.target_tick_duration,
             self.epoch_schedule.slots_per_epoch,
             if self.epoch_schedule.warmup {

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -3,7 +3,7 @@ use {
     std::time::Duration,
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug, AbiExample, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, AbiExample, Eq, PartialEq)]
 pub struct PohConfig {
     /// The target tick rate of the cluster.
     pub target_tick_duration: Duration,

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -30,7 +30,7 @@ impl PohConfig {
     pub fn new(
         target_tick_duration: Duration,
         target_tick_count: Option<u64>,
-        hashes_per_tick: Option<u64>
+        hashes_per_tick: Option<u64>,
     ) -> Self {
         PohConfig {
             target_tick_duration,

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -24,12 +24,7 @@ impl PohConfig {
     }
 
     pub fn get_hashes_per_tick(&self) -> Option<u64> {
-        if let Some(hashes) = self.hashes_per_tick {
-            Some(hashes)
-        }
-        else {
-            None
-        }
+        self.hashes_per_tick
     }
 
     pub fn new(
@@ -38,9 +33,9 @@ impl PohConfig {
         hashes_per_tick: Option<u64>
     ) -> Self {
         PohConfig {
-            target_tick_duration: target_tick_duration,
-            target_tick_count: target_tick_count,
-            hashes_per_tick: hashes_per_tick,
+            target_tick_duration,
+            target_tick_count,
+            hashes_per_tick,
         }
     }
 

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -15,10 +15,35 @@ pub struct PohConfig {
     /// None enables "Low power mode", which implies:
     /// * sleep for `target_tick_duration` instead of hashing
     /// * the number of hashes per tick will be variable
-    pub hashes_per_tick: Option<u64>,
+    hashes_per_tick: Option<u64>,
 }
 
 impl PohConfig {
+    pub fn set_hashes_per_tick(&mut self, hashes: Option<u64>) {
+        self.hashes_per_tick = hashes;
+    }
+
+    pub fn get_hashes_per_tick(&self) -> Option<u64> {
+        if let Some(hashes) = self.hashes_per_tick {
+            Some(hashes)
+        }
+        else {
+            None
+        }
+    }
+
+    pub fn new(
+        target_tick_duration: Duration,
+        target_tick_count: Option<u64>,
+        hashes_per_tick: Option<u64>
+    ) -> Self {
+        PohConfig {
+            target_tick_duration: target_tick_duration,
+            target_tick_count: target_tick_count,
+            hashes_per_tick: hashes_per_tick,
+        }
+    }
+
     pub fn new_sleep(target_tick_duration: Duration) -> Self {
         Self {
             target_tick_duration,


### PR DESCRIPTION
In order to increase the hashes-per-tick rate, we need to add a feature gate on it. Since it's a constant, we can't directly add a gate; instead we need to gate the getter for the struct that holds it.

Added getter and setter for hashes-per-tick in poh_config struct. Added "new" as well, to support existing usage by test functions. Updated code and tests.

There should be no functional change to any code.