### PR TITLE
root_bank_cache

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,6 +55,7 @@ mod read_only_accounts_cache;
 pub mod rent_collector;
 mod rent_paying_accounts_by_partition;
 mod rolling_bit_field;
+pub mod root_bank_cache;
 pub mod runtime_config;
 pub mod secondary_index;
 pub mod serde_snapshot;

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -7,14 +7,12 @@ use {
         bank::Bank,
         bank_forks::{BankForks, ReadOnlyAtomicSlot},
     },
-    solana_sdk::slot_history::Slot,
     std::sync::{Arc, RwLock},
 };
 
 /// Cached root bank that only loads from bank forks if the root has been updated.
 pub struct RootBankCache {
     bank_forks: Arc<RwLock<BankForks>>,
-    cached_root_slot: Slot,
     cached_root_bank: Arc<Bank>,
     root_slot: ReadOnlyAtomicSlot,
 }
@@ -27,7 +25,6 @@ impl RootBankCache {
         };
         Self {
             bank_forks,
-            cached_root_slot: cached_root_bank.slot(),
             cached_root_bank,
             root_slot,
         }
@@ -35,10 +32,9 @@ impl RootBankCache {
 
     pub fn root_bank(&mut self) -> Arc<Bank> {
         let current_root_slot = self.root_slot.get();
-        if self.cached_root_slot != current_root_slot {
+        if self.cached_root_bank.slot() != current_root_slot {
             let lock = self.bank_forks.read().unwrap();
-            let new_root_bank = lock.root_bank();
-            self.cached_root_slot = new_root_bank.slot();
+            self.cached_root_bank = lock.root_bank();
         }
         self.cached_root_bank.clone()
     }

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -1,0 +1,45 @@
+//! A wrapper around a root `Bank` that only loads from bank forks if the root has been updated.
+//! This can be useful to avoid read-locking the bank forks until the root has been updated.
+//!
+
+use {
+    crate::{
+        bank::Bank,
+        bank_forks::{BankForks, ReadOnlyAtomicSlot},
+    },
+    solana_sdk::slot_history::Slot,
+    std::sync::{Arc, RwLock},
+};
+
+/// Cached root bank that only loads from bank forks if the root has been updated.
+pub struct RootBankCache {
+    bank_forks: Arc<RwLock<BankForks>>,
+    cached_root_slot: Slot,
+    cached_root_bank: Arc<Bank>,
+    root_slot: ReadOnlyAtomicSlot,
+}
+
+impl RootBankCache {
+    pub fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
+        let (cached_root_bank, root_slot) = {
+            let lock = bank_forks.read().unwrap();
+            (lock.root_bank(), lock.get_atomic_root())
+        };
+        Self {
+            bank_forks,
+            cached_root_slot: cached_root_bank.slot(),
+            cached_root_bank,
+            root_slot,
+        }
+    }
+
+    pub fn root_bank(&mut self) -> Arc<Bank> {
+        let current_root_slot = self.root_slot.get();
+        if self.cached_root_slot != current_root_slot {
+            let lock = self.bank_forks.read().unwrap();
+            let new_root_bank = lock.root_bank();
+            self.cached_root_slot = new_root_bank.slot();
+        }
+        self.cached_root_bank.clone()
+    }
+}

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -39,3 +39,46 @@ impl RootBankCache {
         self.cached_root_bank.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            accounts_background_service::AbsRequestSender,
+            bank_forks::BankForks,
+            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        },
+        solana_sdk::pubkey::Pubkey,
+    };
+
+    #[test]
+    fn test_root_bank_cache() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+
+        let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
+
+        let bank = bank_forks.read().unwrap().root_bank();
+        assert_eq!(bank, root_bank_cache.root_bank());
+
+        {
+            let child_bank = Bank::new_from_parent(&bank, &Pubkey::default(), 1);
+            bank_forks.write().unwrap().insert(child_bank);
+
+            // cached slot is still 0 since we have not set root
+            assert_eq!(bank.slot(), root_bank_cache.cached_root_bank.slot());
+        }
+        {
+            bank_forks
+                .write()
+                .unwrap()
+                .set_root(1, &AbsRequestSender::default(), None);
+            let bank = bank_forks.read().unwrap().root_bank();
+            assert!(bank.slot() != root_bank_cache.cached_root_bank.slot());
+            assert!(bank != root_bank_cache.cached_root_bank);
+            assert_eq!(bank, root_bank_cache.root_bank());
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
Locking is bad for performance. If the root bank hasn't changed we do not need to lock again. 

#### Summary of Changes
* root_slot on BankForks is now an atomic
* BankForks can return a read-only wrapper of root_slot
* added a caching root bank that only locks the bank forks if the root bank has changed

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
