### PR TITLE
Remove unnecessary call to `set_startup_verification_complete()`

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -912,10 +912,6 @@ fn test_snapshots_with_background_services(
     let pending_accounts_package = PendingAccountsPackage::default();
     let pending_snapshot_package = PendingSnapshotPackage::default();
 
-    snapshot_test_config
-        .bank_forks
-        .root_bank()
-        .set_startup_verification_complete();
     let bank_forks = Arc::new(RwLock::new(snapshot_test_config.bank_forks));
     let callback = bank_forks
         .read()


### PR DESCRIPTION
#### Problem

Snapshot integration test `test_snapshots_with_background_services` unnecessarily calls `set_startup_verification_complete()`, which is already done in `SnapshotTestConfig::new()`.

#### Summary of Changes

Remove the call.