### PR TITLE
boxes StakeState in stake_account::Error::InvalidDelegation

### DIFF
--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[error(transparent)]
     InstructionError(#[from] InstructionError),
     #[error("Invalid delegation: {0:?}")]
-    InvalidDelegation(StakeState),
+    InvalidDelegation(Box<StakeState>),
     #[error("Invalid stake account owner: {0}")]
     InvalidOwner(/*owner:*/ Pubkey),
 }
@@ -79,7 +79,9 @@ impl TryFrom<AccountSharedData> for StakeAccount<Delegation> {
     fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
         let stake_account = StakeAccount::<()>::try_from(account)?;
         if stake_account.stake_state.delegation().is_none() {
-            return Err(Error::InvalidDelegation(stake_account.stake_state));
+            return Err(Error::InvalidDelegation(Box::new(
+                stake_account.stake_state,
+            )));
         }
         Ok(Self {
             account: stake_account.account,


### PR DESCRIPTION

#### Problem
`clippy::result_large_err` error on newer rust versions.

#### Summary of Changes
Boxed `StakeState`.
