### PR TITLE
removes redundant shred.sanitize() from blockstore

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/solana-ledger"
 edition = "2021"
 
 [dependencies]
+assert_matches = "1.5.0"
 bincode = "1.3.3"
 bitflags = "1.3.1"
 byteorder = "1.4.3"
@@ -68,7 +69,6 @@ default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 bs58 = "0.4.0"
 matches = "0.1.9"
 solana-account-decoder = { path = "../account-decoder", version = "=1.15.0" }

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -15,6 +15,7 @@ use {
         },
         shredder::{self, ReedSolomon},
     },
+    assert_matches::debug_assert_matches,
     itertools::Itertools,
     rayon::{prelude::*, ThreadPool},
     reed_solomon_erasure::Error::{InvalidIndex, TooFewParityShards, TooFewShards},
@@ -996,7 +997,7 @@ fn make_erasure_batch(
         shred.set_merkle_branch(merkle_branch)?;
         shred.set_signature(signature);
         debug_assert!(shred.verify(&keypair.pubkey()));
-        debug_assert!(shred.sanitize().is_ok());
+        debug_assert_matches!(shred.sanitize(), Ok(()));
         // Assert that shred payload is fully populated.
         debug_assert_eq!(shred, {
             let shred = shred.payload().clone();

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4963,6 +4963,7 @@ dependencies = [
 name = "solana-ledger"
 version = "1.15.0"
 dependencies = [
+ "assert_matches",
  "bincode",
  "bitflags",
  "byteorder 1.4.3",


### PR DESCRIPTION
#### Problem
Shreds received from other nodes over the socket are sanitized when the payload is deserialized:
https://github.com/solana-labs/solana/blob/315707504/ledger/src/shred/legacy.rs#L137 
https://github.com/solana-labs/solana/blob/315707504/ledger/src/shred/legacy.rs#L77 
https://github.com/solana-labs/solana/blob/315707504/ledger/src/shred/merkle.rs#L355 
https://github.com/solana-labs/solana/blob/315707504/ledger/src/shred/merkle.rs#L439

Similarly, shreds recovered from erasure codes are also sanitized at deserialization:
https://github.com/solana-labs/solana/blob/f02fe9c7e/ledger/src/shredder.rs#L330
or explicitly so for Merkle shreds:
https://github.com/solana-labs/solana/blob/f02fe9c7e/ledger/src/shred/merkle.rs#L753

Shreds generated locally by the node itself during its leader slots do not need to be sanitized.

So sanitizing shreds in blockstore is redundant and wasteful. In particular this becomes more wasteful with Merkle shreds because sanitizing shreds would require verifying Merkle proof. As such the commit removes redundant shred.sanitize() from blockstore.


#### Summary of Changes
Removed redundant shred.sanitize() from blockstore.