### PR TITLE
Remove priority from vote transactions 

### DIFF
--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -53,9 +53,14 @@ impl ImmutableDeserializedPacket {
         let is_simple_vote = packet.meta.is_simple_vote_tx();
 
         // drop transaction if prioritization fails.
-        let priority_details = priority_details
+        let mut priority_details = priority_details
             .or_else(|| sanitized_transaction.get_transaction_priority_details())
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
+
+        // set priority to zero for vote transactions
+        if is_simple_vote {
+            priority_details.priority = 0;
+        };
 
         Ok(Self {
             original_packet: packet,


### PR DESCRIPTION
#### Problem
 Vote transactions do not require prioritization.

#### Summary of Changes
- reset all vote transactions' priority to default. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
