### PR TITLE
Feature/batch_locking

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -18,6 +18,7 @@ use {
     solana_program_runtime::timings::{ExecuteTimingType, ExecuteTimings, ThreadExecuteTimings},
     solana_rayon_threadlimit::{get_max_thread_count, get_thread_count},
     solana_runtime::{
+        accounts::StagedAccountLocks,
         accounts_background_service::AbsRequestSender,
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
         accounts_index::AccountSecondaryIndexes,
@@ -364,7 +365,12 @@ fn rebatch_transactions<'a>(
 ) -> TransactionBatchWithIndexes<'a, 'a> {
     let txs = &sanitized_txs[start..=end];
     let results = &lock_results[start..=end];
-    let mut tx_batch = TransactionBatch::new(results.to_vec(), bank, Cow::from(txs));
+    let mut tx_batch = TransactionBatch::new(
+        results.to_vec(),
+        StagedAccountLocks::default(),
+        bank,
+        Cow::from(txs),
+    );
     tx_batch.set_needs_unlock(false);
 
     let transaction_indexes = transaction_indexes[start..=end].to_vec();

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -16,24 +16,10 @@ pub struct TransactionBatch<'a, 'b> {
 impl<'a, 'b> TransactionBatch<'a, 'b> {
     pub fn new(
         lock_results: Vec<Result<()>>,
-        bank: &'a Bank,
-        sanitized_txs: Cow<'b, [SanitizedTransaction]>,
-    ) -> Self {
-        Self::new_with_staged_locks(
-            lock_results,
-            StagedAccountLocks::default(),
-            bank,
-            sanitized_txs,
-        )
-    }
-
-    pub fn new_with_staged_locks(
-        lock_results: Vec<Result<()>>,
         staged_locks: StagedAccountLocks,
         bank: &'a Bank,
         sanitized_txs: Cow<'b, [SanitizedTransaction]>,
     ) -> Self {
-        assert_eq!(lock_results.len(), sanitized_txs.len());
         Self {
             lock_results,
             staged_locks,
@@ -61,10 +47,6 @@ impl<'a, 'b> TransactionBatch<'a, 'b> {
 
     pub fn needs_unlock(&self) -> bool {
         self.needs_unlock
-    }
-
-    pub fn has_staged_locks(&self) -> bool {
-        !self.staged_locks.is_empty()
     }
 
     pub fn staged_locks(&self) -> &StagedAccountLocks {


### PR DESCRIPTION
#### Problem
Will become possible for scheduler to send down a batch that has conflicting account access in a single "batch" of transactions. The current locking mechanism ("one-at-a-time") would return any secondary conflicts with errors, even though they won't actually conflict as they are on the same thread.

#### Summary of Changes
Stage and commit account locks.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
