### PR TITLE
Explorer: Fix balance delta display

### DIFF
--- a/explorer/src/components/common/BalanceDelta.tsx
+++ b/explorer/src/components/common/BalanceDelta.tsx
@@ -12,7 +12,7 @@ export function BalanceDelta({
   let sols;
 
   if (isSol) {
-    sols = <SolBalance lamports={delta.toNumber()} />;
+    sols = <SolBalance lamports={Math.abs(delta.toNumber())} />;
   }
 
   if (delta.gt(0)) {


### PR DESCRIPTION
#### Problem
Lamport conversion utils previously had a side effect of taking the absolute value of the lamport value which the balance delta component relied on. Once the side effect was fixed in https://github.com/solana-labs/solana/pull/28040, the balance delta display broke.

#### Summary of Changes
Fix balance delta display

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
