### PR TITLE
fix: improve `MessageV0.getAccountKeys` API ergonomics

### DIFF
--- a/web3.js/src/message/v0.ts
+++ b/web3.js/src/message/v0.ts
@@ -42,10 +42,10 @@ export type CompileV0Args = {
 
 export type GetAccountKeysArgs =
   | {
-      accountKeysFromLookups: AccountKeysFromLookups;
+      accountKeysFromLookups?: AccountKeysFromLookups | null;
     }
   | {
-      addressLookupTableAccounts: AddressLookupTableAccount[];
+      addressLookupTableAccounts?: AddressLookupTableAccount[] | null;
     };
 
 export class MessageV0 {
@@ -77,7 +77,11 @@ export class MessageV0 {
 
   getAccountKeys(args?: GetAccountKeysArgs): MessageAccountKeys {
     let accountKeysFromLookups: AccountKeysFromLookups | undefined;
-    if (args && 'accountKeysFromLookups' in args) {
+    if (
+      args &&
+      'accountKeysFromLookups' in args &&
+      args.accountKeysFromLookups
+    ) {
       if (
         this.numAccountKeysFromLookups !=
         args.accountKeysFromLookups.writable.length +
@@ -88,7 +92,11 @@ export class MessageV0 {
         );
       }
       accountKeysFromLookups = args.accountKeysFromLookups;
-    } else if (args && 'addressLookupTableAccounts' in args) {
+    } else if (
+      args &&
+      'addressLookupTableAccounts' in args &&
+      args.addressLookupTableAccounts
+    ) {
       accountKeysFromLookups = this.resolveAddressTableLookups(
         args.addressLookupTableAccounts,
       );


### PR DESCRIPTION
#### Problem
The ergonomics of `MessageV0.getAcccountKeys` isn't great when writing code that can handle legacy or v0 messages:

```js
const accountKeysFromLookups = txWithMeta.meta?.loadedAddresses;
const accountKeys = message.getAccountKeys(accountKeysFromLookups && {
  accountKeysFromLookups,
});
```

#### Summary of Changes
Allow args in `GetAccountKeysArgs` to be undefined or null for improved ergonomics:
```js

const accountKeys = message.getAccountKeys({
  accountKeysFromLookups: txWithMeta.meta?.loadedAddresses,
});
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
