### PR TITLE
(LedgerStore) Use delete() to remove a single entry

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -505,15 +505,11 @@ impl Blockstore {
         )? {
             *columns_purged &= self
                 .db
-                .delete_range_cf::<cf::TransactionStatus>(write_batch, purged_index, purged_index)
+                .delete_cf::<cf::TransactionStatus>(write_batch, purged_index)
                 .is_ok()
                 & self
                     .db
-                    .delete_range_cf::<cf::AddressSignatures>(
-                        write_batch,
-                        purged_index,
-                        purged_index,
-                    )
+                    .delete_cf::<cf::AddressSignatures>(write_batch, purged_index)
                     .is_ok();
         }
         Ok(())


### PR DESCRIPTION
#### Problem
rocksdb::range_delete() is heavier than rocksdb::delete().

#### Summary of Changes
Use delete() instead of range_delete() when deleting a single entry.
