### PR TITLE
Account data direct mapping

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -123,7 +123,8 @@ pub fn builtin_process_instruction(
         invoke_context
             .transaction_context
             .get_current_instruction_context()?,
-        true,
+        true, // should_cap_ix_accounts
+        true, // copy_account_data // There is no VM so direct mapping can not be implemented here
     )?;
 
     // Deserialize data back into instruction params

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -126,7 +126,8 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
     });
 }
 
@@ -138,7 +139,8 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
     });
 }
 
@@ -149,7 +151,8 @@ fn bench_serialize_unaligned_max_accounts(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
     });
 }
 
@@ -161,6 +164,7 @@ fn bench_serialize_aligned_max_accounts(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
     });
 }

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -132,6 +132,18 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
 }
 
 #[bench]
+fn bench_serialize_unaligned_copy_account_data(bencher: &mut Bencher) {
+    let transaction_context = create_inputs(bpf_loader_deprecated::id(), 7);
+    let instruction_context = transaction_context
+        .get_current_instruction_context()
+        .unwrap();
+    bencher.iter(|| {
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
+    });
+}
+
+#[bench]
 fn bench_serialize_aligned(bencher: &mut Bencher) {
     let transaction_context = create_inputs(bpf_loader::id(), 7);
     let instruction_context = transaction_context
@@ -141,6 +153,19 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
     bencher.iter(|| {
         let _ =
             serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+    });
+}
+
+#[bench]
+fn bench_serialize_aligned_copy_account_data(bencher: &mut Bencher) {
+    let transaction_context = create_inputs(bpf_loader::id(), 7);
+    let instruction_context = transaction_context
+        .get_current_instruction_context()
+        .unwrap();
+
+    bencher.iter(|| {
+        let _ =
+            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
     });
 }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -312,7 +312,7 @@ pub fn create_vm<'a, 'b>(
         heap,
         regions,
         Some(Box::new(move |index_in_transaction| {
-            // The two calls below can't relly fail. If they fail because of a bug,
+            // The two calls below can't really fail. If they fail because of a bug,
             // whatever is writing will trigger an EbpfError::AccessViolation like
             // if the region was readonly, and the transaction will fail gracefully.
             let mut account = accounts

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -404,7 +404,7 @@ fn serialize_parameters_aligned(
                 s.write::<u64>(borrowed_account.get_lamports().to_le());
                 s.write::<u64>((borrowed_account.get_data().len() as u64).to_le());
                 s.write_account(&mut borrowed_account)?;
-                s.write::<u64>((borrowed_account.get_rent_epoch() as u64).to_le());
+                s.write::<u64>((borrowed_account.get_rent_epoch()).to_le());
             }
             SerializeAccount::Duplicate(position) => {
                 s.write::<u8>(position as u8);

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -695,8 +695,7 @@ mod tests {
                 assert_eq!(
                     serialization_result.as_ref().err(),
                     expected_err.as_ref(),
-                    "{} test case failed",
-                    name
+                    "{name} test case failed",
                 );
                 if expected_err.is_some() {
                     continue;

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -524,6 +524,7 @@ pub fn deserialize_parameters_aligned(
 }
 
 #[cfg(test)]
+#[allow(clippy::indexing_slicing)]
 mod tests {
     use {
         super::*,

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -502,9 +502,14 @@ pub fn deserialize_parameters_aligned(
                         borrowed_account.set_data_length(post_len)?;
                         let allocated_bytes = post_len.saturating_sub(*pre_len);
                         if allocated_bytes > 0 {
-                            borrowed_account.get_data_mut()?
-                                [*pre_len..pre_len.saturating_add(allocated_bytes)]
-                                .copy_from_slice(&data[0..allocated_bytes]);
+                            borrowed_account
+                                .get_data_mut()?
+                                .get_mut(*pre_len..pre_len.saturating_add(allocated_bytes))
+                                .ok_or(InstructionError::InvalidArgument)?
+                                .copy_from_slice(
+                                    data.get(0..allocated_bytes)
+                                        .ok_or(InstructionError::InvalidArgument)?,
+                                );
                         }
                     }
                     Err(err) if borrowed_account.get_data().len() != post_len => return Err(err),

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1195,27 +1195,18 @@ fn update_caller_account(
                     .fill(0);
             }
         }
-        caller_account.serialized_data = translate_slice_mut::<u8>(
-            memory_mapping,
-            if direct_mapping {
-                caller_account
-                    .vm_data_addr
-                    .saturating_add(caller_account.original_data_len as u64)
-            } else {
-                caller_account.vm_data_addr
-            },
-            if direct_mapping {
-                if is_loader_deprecated {
-                    0
-                } else {
-                    MAX_PERMITTED_DATA_INCREASE
-                }
-            } else {
-                post_len
-            } as u64,
-            false, // Don't care since it is byte aligned
-            invoke_context.get_check_size(),
-        )?;
+
+        // with direct_mapping on, serialized_data is fixed and holds the
+        // realloc padding
+        if !direct_mapping {
+            caller_account.serialized_data = translate_slice_mut::<u8>(
+                memory_mapping,
+                caller_account.vm_data_addr,
+                post_len as u64,
+                false, // Don't care since it is byte aligned
+                invoke_context.get_check_size(),
+            )?;
+        }
         // this is the len field in the AccountInfo::data slice
         *caller_account.ref_to_len_in_vm = post_len as u64;
 

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1736,8 +1736,7 @@ mod tests {
                 let spare_capacity = &original_data_slice[original_data_len - data_len..];
                 assert!(
                     is_zeroed(spare_capacity),
-                    "dirty account spare capacity {:?}",
-                    spare_capacity
+                    "dirty account spare capacity {spare_capacity:?}",
                 );
             }
 
@@ -1751,8 +1750,7 @@ mod tests {
             // the unused realloc padding is always zeroed
             assert!(
                 is_zeroed(&realloc_area[expected_realloc_used..]),
-                "dirty realloc padding {:?}",
-                realloc_area
+                "dirty realloc padding {realloc_area:?}",
             );
         }
 

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -20,6 +20,10 @@ use {
 struct CallerAccount<'a> {
     lamports: &'a mut u64,
     owner: &'a mut Pubkey,
+    // The original data length of the account at the start of the current
+    // instruction. We use this to determine wether an account was shrunk or
+    // grown before or after CPI, and to derive the vm address of the realloc
+    // region.
     original_data_len: usize,
     // This points to the data section for this account, as serialized and
     // mapped inside the vm (see serialize_parameters() in

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     crate::declare_syscall,
+    solana_rbpf::memory_region::MemoryRegion,
     solana_sdk::{
         feature_set::enable_bpf_loader_set_authority_checked_ix,
         stable_layout::stable_instruction::StableInstruction,
@@ -20,7 +21,12 @@ struct CallerAccount<'a> {
     lamports: &'a mut u64,
     owner: &'a mut Pubkey,
     original_data_len: usize,
-    data: &'a mut [u8],
+    // After the activation of bpf_account_data_direct_mapping this
+    // no longer holds the account data followed by the reallocation padding,
+    // but only the reallocation padding. That is because after the activation
+    // we already share the account data between runtime and program and mapping it
+    // forward and backward would create aliasing mutable references.
+    account_data_or_only_realloc_padding: &'a mut [u8],
     // Given the corresponding input AccountInfo::data, vm_data_addr points to
     // the pointer field and ref_to_len_in_vm points to the length field.
     vm_data_addr: u64,
@@ -36,6 +42,7 @@ impl<'a> CallerAccount<'a> {
     fn from_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &MemoryMapping,
+        is_loader_deprecated: bool,
         _vm_addr: u64,
         account_info: &AccountInfo,
         original_data_len: usize,
@@ -58,7 +65,12 @@ impl<'a> CallerAccount<'a> {
             invoke_context.get_check_aligned(),
         )?;
 
-        let (data, vm_data_addr, ref_to_len_in_vm, serialized_len_ptr) = {
+        let (
+            account_data_or_only_realloc_padding,
+            vm_data_addr,
+            ref_to_len_in_vm,
+            serialized_len_ptr,
+        ) = {
             // Double translate data out of RefCell
             let data = *translate_type::<&[u8]>(
                 memory_mapping,
@@ -95,14 +107,32 @@ impl<'a> CallerAccount<'a> {
                 )?
             };
             let vm_data_addr = data.as_ptr() as u64;
+
+            let bpf_account_data_direct_mapping = invoke_context
+                .feature_set
+                .is_active(&feature_set::bpf_account_data_direct_mapping::id());
+            let account_data_or_only_realloc_padding = translate_slice_mut::<u8>(
+                memory_mapping,
+                if bpf_account_data_direct_mapping {
+                    vm_data_addr + original_data_len as u64
+                } else {
+                    vm_data_addr
+                },
+                if bpf_account_data_direct_mapping {
+                    if is_loader_deprecated {
+                        0
+                    } else {
+                        MAX_PERMITTED_DATA_INCREASE
+                    }
+                } else {
+                    data.len()
+                } as u64,
+                invoke_context.get_check_aligned(),
+                invoke_context.get_check_size(),
+            )?;
+
             (
-                translate_slice_mut::<u8>(
-                    memory_mapping,
-                    vm_data_addr,
-                    data.len() as u64,
-                    invoke_context.get_check_aligned(),
-                    invoke_context.get_check_size(),
-                )?,
+                account_data_or_only_realloc_padding,
                 vm_data_addr,
                 ref_to_len_in_vm,
                 serialized_len_ptr,
@@ -113,7 +143,7 @@ impl<'a> CallerAccount<'a> {
             lamports,
             owner,
             original_data_len,
-            data,
+            account_data_or_only_realloc_padding,
             vm_data_addr,
             ref_to_len_in_vm,
             serialized_len_ptr,
@@ -126,6 +156,7 @@ impl<'a> CallerAccount<'a> {
     fn from_sol_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &MemoryMapping,
+        is_loader_deprecated: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
         original_data_len: usize,
@@ -152,10 +183,25 @@ impl<'a> CallerAccount<'a> {
                 .saturating_div(invoke_context.get_compute_budget().cpi_bytes_per_unit),
         )?;
 
-        let data = translate_slice_mut::<u8>(
+        let bpf_account_data_direct_mapping = invoke_context
+            .feature_set
+            .is_active(&feature_set::bpf_account_data_direct_mapping::id());
+        let account_data_or_only_realloc_padding = translate_slice_mut::<u8>(
             memory_mapping,
-            vm_data_addr,
-            account_info.data_len,
+            if bpf_account_data_direct_mapping {
+                vm_data_addr + original_data_len as u64
+            } else {
+                vm_data_addr
+            },
+            if bpf_account_data_direct_mapping {
+                if is_loader_deprecated {
+                    0
+                } else {
+                    MAX_PERMITTED_DATA_INCREASE as u64
+                }
+            } else {
+                account_info.data_len
+            },
             invoke_context.get_check_aligned(),
             invoke_context.get_check_size(),
         )?;
@@ -194,7 +240,7 @@ impl<'a> CallerAccount<'a> {
             lamports,
             owner,
             original_data_len,
-            data,
+            account_data_or_only_realloc_padding,
             vm_data_addr,
             ref_to_len_in_vm,
             serialized_len_ptr,
@@ -218,6 +264,7 @@ trait SyscallInvokeSigned {
         program_indices: &[IndexOfAccount],
         account_infos_addr: u64,
         account_infos_len: u64,
+        is_loader_deprecated: bool,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
     ) -> Result<TranslatedAccounts<'a>, Error>;
@@ -310,6 +357,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         program_indices: &[IndexOfAccount],
         account_infos_addr: u64,
         account_infos_len: u64,
+        is_loader_deprecated: bool,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
     ) -> Result<TranslatedAccounts<'a>, Error> {
@@ -327,6 +375,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             &account_info_keys,
             account_infos,
             account_infos_addr,
+            is_loader_deprecated,
             invoke_context,
             memory_mapping,
             CallerAccount::from_account_info,
@@ -541,6 +590,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         program_indices: &[IndexOfAccount],
         account_infos_addr: u64,
         account_infos_len: u64,
+        is_loader_deprecated: bool,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
     ) -> Result<TranslatedAccounts<'a>, Error> {
@@ -558,6 +608,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
             &account_info_keys,
             account_infos,
             account_infos_addr,
+            is_loader_deprecated,
             invoke_context,
             memory_mapping,
             CallerAccount::from_sol_account_info,
@@ -657,12 +708,13 @@ fn translate_and_update_accounts<'a, T, F>(
     account_info_keys: &[&Pubkey],
     account_infos: &[T],
     account_infos_addr: u64,
+    is_loader_deprecated: bool,
     invoke_context: &mut InvokeContext,
     memory_mapping: &MemoryMapping,
     do_translate: F,
 ) -> Result<TranslatedAccounts<'a>, Error>
 where
-    F: Fn(&InvokeContext, &MemoryMapping, u64, &T, usize) -> Result<CallerAccount<'a>, Error>,
+    F: Fn(&InvokeContext, &MemoryMapping, bool, u64, &T, usize) -> Result<CallerAccount<'a>, Error>,
 {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -722,6 +774,7 @@ where
                 do_translate(
                     invoke_context,
                     memory_mapping,
+                    is_loader_deprecated,
                     account_infos_addr.saturating_add(
                         caller_account_index.saturating_mul(mem::size_of::<T>()) as u64,
                     ),
@@ -735,7 +788,12 @@ where
             // account (caller_account). We need to update the corresponding
             // BorrowedAccount (callee_account) so the callee can see the
             // changes.
-            update_callee_account(invoke_context, &caller_account, callee_account)?;
+            update_callee_account(
+                invoke_context,
+                is_loader_deprecated,
+                &caller_account,
+                callee_account,
+            )?;
 
             let caller_account = if instruction_account.is_writable {
                 Some(caller_account)
@@ -887,14 +945,20 @@ fn cpi_common<S: SyscallInvokeSigned>(
         memory_mapping,
         invoke_context,
     )?;
+    let is_loader_deprecated = *instruction_context
+        .try_borrow_last_program_account(transaction_context)?
+        .get_owner()
+        == bpf_loader_deprecated::id();
     let (instruction_accounts, program_indices) =
         invoke_context.prepare_instruction(&instruction, &signers)?;
     check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
+
     let mut accounts = S::translate_accounts(
         &instruction_accounts,
         &program_indices,
         account_infos_addr,
         account_infos_len,
+        is_loader_deprecated,
         memory_mapping,
         invoke_context,
     )?;
@@ -918,13 +982,14 @@ fn cpi_common<S: SyscallInvokeSigned>(
     // Synchronize the callee's account changes so the caller can see them.
     for (index_in_caller, caller_account) in accounts.iter_mut() {
         if let Some(caller_account) = caller_account {
-            let callee_account = instruction_context
+            let mut callee_account = instruction_context
                 .try_borrow_instruction_account(transaction_context, *index_in_caller)?;
             update_caller_account(
                 invoke_context,
                 memory_mapping,
+                is_loader_deprecated,
                 caller_account,
-                &callee_account,
+                &mut callee_account,
             )?;
         }
     }
@@ -942,27 +1007,60 @@ fn cpi_common<S: SyscallInvokeSigned>(
 // changes.
 fn update_callee_account(
     invoke_context: &InvokeContext,
+    is_loader_deprecated: bool,
     caller_account: &CallerAccount,
     mut callee_account: BorrowedAccount<'_>,
 ) -> Result<(), Error> {
     let is_disable_cpi_setting_executable_and_rent_epoch_active = invoke_context
         .feature_set
         .is_active(&disable_cpi_setting_executable_and_rent_epoch::id());
+    let bpf_account_data_direct_mapping = invoke_context
+        .feature_set
+        .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
     if callee_account.get_lamports() != *caller_account.lamports {
         callee_account.set_lamports(*caller_account.lamports)?;
     }
 
-    // The redundant check helps to avoid the expensive data comparison if we can
-    match callee_account
-        .can_data_be_resized(caller_account.data.len())
-        .and_then(|_| callee_account.can_data_be_changed())
-    {
-        Ok(()) => callee_account.set_data_from_slice(caller_account.data)?,
-        Err(err) if callee_account.get_data() != caller_account.data => {
-            return Err(Box::new(err));
+    if bpf_account_data_direct_mapping {
+        let prev_len = callee_account.get_data().len();
+        let post_len = *caller_account.ref_to_len_in_vm as usize;
+        match callee_account
+            .can_data_be_resized(post_len)
+            .and_then(|_| callee_account.can_data_be_changed())
+        {
+            Ok(()) => {
+                callee_account.set_data_length(post_len)?;
+                let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
+                if !is_loader_deprecated && realloc_bytes_used > 0 {
+                    callee_account.get_data_mut()?[caller_account.original_data_len..post_len]
+                        .copy_from_slice(
+                            &caller_account.account_data_or_only_realloc_padding
+                                [0..realloc_bytes_used],
+                        );
+                }
+            }
+            Err(err) if prev_len != post_len => {
+                return Err(Box::new(err));
+            }
+            _ => {}
         }
-        _ => {}
+    } else {
+        // The redundant check helps to avoid the expensive data comparison if we can
+        match callee_account
+            .can_data_be_resized(caller_account.account_data_or_only_realloc_padding.len())
+            .and_then(|_| callee_account.can_data_be_changed())
+        {
+            Ok(()) => callee_account
+                .set_data_from_slice(&caller_account.account_data_or_only_realloc_padding)?,
+            Err(err)
+                if callee_account.get_data()
+                    != caller_account.account_data_or_only_realloc_padding =>
+            {
+                return Err(Box::new(err));
+            }
+            _ => {}
+        }
     }
 
     if !is_disable_cpi_setting_executable_and_rent_epoch_active
@@ -1011,15 +1109,47 @@ fn update_callee_account(
 // changes.
 fn update_caller_account(
     invoke_context: &InvokeContext,
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &mut MemoryMapping,
+    is_loader_deprecated: bool,
     caller_account: &mut CallerAccount,
-    callee_account: &BorrowedAccount<'_>,
+    callee_account: &mut BorrowedAccount<'_>,
 ) -> Result<(), Error> {
+    let bpf_account_data_direct_mapping = invoke_context
+        .feature_set
+        .is_active(&feature_set::bpf_account_data_direct_mapping::id());
+
     *caller_account.lamports = callee_account.get_lamports();
     *caller_account.owner = *callee_account.get_owner();
-    let new_len = callee_account.get_data().len();
-    if caller_account.data.len() != new_len {
-        let data_overflow = new_len
+
+    if bpf_account_data_direct_mapping && caller_account.original_data_len > 0 {
+        let regions = memory_mapping.get_regions();
+        let memory_region_index = regions
+            .iter()
+            .position(|memory_region| memory_region.vm_addr == caller_account.vm_data_addr)
+            .ok_or(Box::new(InstructionError::ProgramEnvironmentSetupFailure))?;
+        let account_region = if let Ok(data) = callee_account.get_data_mut() {
+            let data = unsafe {
+                std::slice::from_raw_parts_mut(
+                    data.as_mut_ptr(),
+                    regions[memory_region_index].len as usize,
+                )
+            };
+            MemoryRegion::new_writable(data, caller_account.vm_data_addr)
+        } else {
+            let data = unsafe {
+                std::slice::from_raw_parts(
+                    callee_account.get_data().as_ptr(),
+                    regions[memory_region_index].len as usize,
+                )
+            };
+            MemoryRegion::new_readonly(data, caller_account.vm_data_addr)
+        };
+        memory_mapping.replace_region(memory_region_index, account_region)?;
+    }
+    let prev_len = *caller_account.ref_to_len_in_vm as usize;
+    let post_len = callee_account.get_data().len();
+    if prev_len != post_len {
+        let data_overflow = post_len
             > caller_account
                 .original_data_len
                 .saturating_add(MAX_PERMITTED_DATA_INCREASE);
@@ -1031,22 +1161,44 @@ fn update_caller_account(
             );
             return Err(Box::new(InstructionError::InvalidRealloc));
         }
-        if new_len < caller_account.data.len() {
-            caller_account
-                .data
-                .get_mut(new_len..)
-                .ok_or_else(|| Box::new(InstructionError::AccountDataTooSmall))?
-                .fill(0);
+        if post_len < prev_len {
+            if bpf_account_data_direct_mapping {
+                unsafe {
+                    std::slice::from_raw_parts_mut(
+                        callee_account.get_data_mut()?.as_mut_ptr().add(post_len),
+                        prev_len.saturating_sub(post_len),
+                    )
+                    .fill(0);
+                }
+            } else {
+                caller_account
+                    .account_data_or_only_realloc_padding
+                    .get_mut(post_len..)
+                    .ok_or_else(|| Box::new(InstructionError::AccountDataTooSmall))?
+                    .fill(0);
+            }
         }
-        caller_account.data = translate_slice_mut::<u8>(
+        caller_account.account_data_or_only_realloc_padding = translate_slice_mut::<u8>(
             memory_mapping,
-            caller_account.vm_data_addr,
-            new_len as u64,
+            if bpf_account_data_direct_mapping {
+                caller_account.vm_data_addr + caller_account.original_data_len as u64
+            } else {
+                caller_account.vm_data_addr
+            },
+            if bpf_account_data_direct_mapping {
+                if is_loader_deprecated {
+                    0
+                } else {
+                    MAX_PERMITTED_DATA_INCREASE
+                }
+            } else {
+                post_len
+            } as u64,
             false, // Don't care since it is byte aligned
             invoke_context.get_check_size(),
         )?;
         // this is the len field in the AccountInfo::data slice
-        *caller_account.ref_to_len_in_vm = new_len as u64;
+        *caller_account.ref_to_len_in_vm = post_len as u64;
 
         // this is the len field in the serialized parameters
         if invoke_context
@@ -1060,22 +1212,33 @@ fn update_caller_account(
                     .saturating_sub(std::mem::size_of::<u64>() as u64),
                 invoke_context.get_check_aligned(),
             )?;
-            *serialized_len_ptr = new_len as u64;
+            *serialized_len_ptr = post_len as u64;
         } else {
             unsafe {
-                *caller_account.serialized_len_ptr = new_len as u64;
+                *caller_account.serialized_len_ptr = post_len as u64;
             }
         }
     }
-    let to_slice = &mut caller_account.data;
-    let from_slice = callee_account
-        .get_data()
-        .get(0..new_len)
-        .ok_or(SyscallError::InvalidLength)?;
-    if to_slice.len() != from_slice.len() {
-        return Err(Box::new(InstructionError::AccountDataTooSmall));
+    let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
+    if !bpf_account_data_direct_mapping {
+        let to_slice = &mut caller_account.account_data_or_only_realloc_padding;
+        let from_slice = callee_account
+            .get_data()
+            .get(0..post_len)
+            .ok_or(SyscallError::InvalidLength)?;
+        if to_slice.len() != from_slice.len() {
+            return Err(Box::new(InstructionError::AccountDataTooSmall));
+        }
+        to_slice.copy_from_slice(from_slice);
+    } else if !is_loader_deprecated && realloc_bytes_used > 0 {
+        let to_slice =
+            &mut caller_account.account_data_or_only_realloc_padding[0..realloc_bytes_used];
+        let from_slice = callee_account
+            .get_data()
+            .get(caller_account.original_data_len..post_len)
+            .ok_or(SyscallError::InvalidLength)?;
+        to_slice.copy_from_slice(from_slice);
     }
-    to_slice.copy_from_slice(from_slice);
 
     Ok(())
 }
@@ -1092,6 +1255,7 @@ mod tests {
         solana_sdk::{
             account::{Account, AccountSharedData},
             clock::Epoch,
+            feature_set::bpf_account_data_direct_mapping,
             instruction::Instruction,
             transaction_context::TransactionAccount,
         },
@@ -1129,7 +1293,9 @@ mod tests {
                 .into_iter()
                 .map(|a| (a.0, a.1))
                 .collect::<Vec<TransactionAccount>>();
-            with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
+            with_mock_invoke_context!($invoke_context, $transaction_context, transaction_accounts);
+            let feature_set = Arc::make_mut(&mut $invoke_context.feature_set);
+            feature_set.deactivate(&bpf_account_data_direct_mapping::id());
             $invoke_context
                 .transaction_context
                 .get_next_instruction_context()
@@ -1246,6 +1412,7 @@ mod tests {
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
             &memory_mapping,
+            false,
             vm_addr,
             account_info,
             account.data().len(),
@@ -1258,7 +1425,10 @@ mod tests {
             *caller_account.ref_to_len_in_vm as usize,
             account.data().len()
         );
-        assert_eq!(caller_account.data, account.data());
+        assert_eq!(
+            caller_account.account_data_or_only_realloc_padding,
+            account.data()
+        );
         assert_eq!(caller_account.executable, account.executable());
         assert_eq!(caller_account.rent_epoch, account.rent_epoch());
     }
@@ -1288,7 +1458,7 @@ mod tests {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        let memory_mapping =
+        let mut memory_mapping =
             MemoryMapping::new(mock_caller_account.regions.split_off(0), &config).unwrap();
 
         let mut caller_account = mock_caller_account.caller_account();
@@ -1304,9 +1474,10 @@ mod tests {
 
         update_caller_account(
             &invoke_context,
-            &memory_mapping,
+            &mut memory_mapping,
+            false,
             &mut caller_account,
-            &callee_account,
+            &mut callee_account,
         )
         .unwrap();
 
@@ -1345,7 +1516,7 @@ mod tests {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        let memory_mapping =
+        let mut memory_mapping =
             MemoryMapping::new(mock_caller_account.regions.split_off(0), &config).unwrap();
 
         let data_slice = mock_caller_account.data_slice();
@@ -1366,22 +1537,32 @@ mod tests {
             (b"foobaz".to_vec(), MAX_PERMITTED_DATA_INCREASE),
             (b"foobazbad".to_vec(), MAX_PERMITTED_DATA_INCREASE - 3),
         ] {
-            assert_eq!(caller_account.data, callee_account.get_data());
+            assert_eq!(
+                caller_account.account_data_or_only_realloc_padding,
+                callee_account.get_data()
+            );
             callee_account.set_data_from_slice(&new_value).unwrap();
 
             update_caller_account(
                 &invoke_context,
-                &memory_mapping,
+                &mut memory_mapping,
+                false,
                 &mut caller_account,
-                &callee_account,
+                &mut callee_account,
             )
             .unwrap();
 
             let data_len = callee_account.get_data().len();
             assert_eq!(data_len, *caller_account.ref_to_len_in_vm as usize);
             assert_eq!(data_len, serialized_len());
-            assert_eq!(data_len, caller_account.data.len());
-            assert_eq!(callee_account.get_data(), &caller_account.data[..data_len]);
+            assert_eq!(
+                data_len,
+                caller_account.account_data_or_only_realloc_padding.len()
+            );
+            assert_eq!(
+                callee_account.get_data(),
+                &caller_account.account_data_or_only_realloc_padding[..data_len]
+            );
             assert_eq!(data_slice[data_len..].len(), expected_realloc_size);
             assert!(is_zeroed(&data_slice[data_len..]));
         }
@@ -1391,9 +1572,10 @@ mod tests {
             .unwrap();
         update_caller_account(
             &invoke_context,
-            &memory_mapping,
+            &mut memory_mapping,
+            false,
             &mut caller_account,
-            &callee_account,
+            &mut callee_account,
         )
         .unwrap();
         let data_len = callee_account.get_data().len();
@@ -1406,9 +1588,10 @@ mod tests {
         assert!(matches!(
             update_caller_account(
                 &invoke_context,
-                &memory_mapping,
+                &mut memory_mapping,
+                false,
                 &mut caller_account,
-                &callee_account,
+                &mut callee_account,
             ),
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::InvalidRealloc,
         ));
@@ -1450,7 +1633,7 @@ mod tests {
         *caller_account.lamports = 42;
         *caller_account.owner = Pubkey::new_unique();
 
-        update_callee_account(&invoke_context, &caller_account, callee_account).unwrap();
+        update_callee_account(&invoke_context, false, &caller_account, callee_account).unwrap();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
         assert_eq!(callee_account.get_lamports(), 42);
@@ -1479,12 +1662,15 @@ mod tests {
         let callee_account = borrow_instruction_account!(invoke_context, 0);
 
         let mut data = b"foo".to_vec();
-        caller_account.data = &mut data;
+        caller_account.account_data_or_only_realloc_padding = &mut data;
 
-        update_callee_account(&invoke_context, &caller_account, callee_account).unwrap();
+        update_callee_account(&invoke_context, false, &caller_account, callee_account).unwrap();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
-        assert_eq!(callee_account.get_data(), caller_account.data);
+        assert_eq!(
+            callee_account.get_data(),
+            caller_account.account_data_or_only_realloc_padding
+        );
     }
 
     #[test]
@@ -1538,6 +1724,7 @@ mod tests {
             &[0],
             vm_addr,
             1,
+            false,
             &mut memory_mapping,
             &mut invoke_context,
         )
@@ -1545,12 +1732,14 @@ mod tests {
         assert_eq!(accounts.len(), 2);
         assert!(accounts[0].1.is_none());
         let caller_account = accounts[1].1.as_ref().unwrap();
-        assert_eq!(caller_account.data, account.data());
+        assert_eq!(
+            caller_account.account_data_or_only_realloc_padding,
+            account.data()
+        );
         assert_eq!(caller_account.original_data_len, original_data_len);
     }
 
     pub type TestTransactionAccount = (Pubkey, AccountSharedData, bool);
-
     struct MockCallerAccount {
         lamports: u64,
         owner: Pubkey,
@@ -1571,7 +1760,7 @@ mod tests {
             // the memory region must include the realloc data
             let regions = vec![MemoryRegion::new_writable(d.as_mut_slice(), vm_addr)];
 
-            // caller_account.data must have the actual data length
+            // caller_account.account_data_or_only_realloc_padding must have the actual data length
             d.truncate(mem::size_of::<u64>() + data.len());
 
             MockCallerAccount {
@@ -1600,7 +1789,7 @@ mod tests {
                 lamports: &mut self.lamports,
                 owner: &mut self.owner,
                 original_data_len: data.len(),
-                data,
+                account_data_or_only_realloc_padding: data,
                 vm_data_addr: self.vm_addr + mem::size_of::<u64>() as u64,
                 ref_to_len_in_vm: &mut self.len,
                 serialized_len_ptr: std::ptr::null_mut(),

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -1,4 +1,4 @@
-use {super::*, crate::declare_syscall};
+use {super::*, crate::declare_syscall, solana_rbpf::memory_region::MemoryRegion, std::slice};
 
 fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), Error> {
     let compute_budget = invoke_context.get_compute_budget();
@@ -26,32 +26,8 @@ declare_syscall!(
             return Err(SyscallError::CopyOverlapping.into());
         }
 
-        let dst_ptr = translate_slice_mut::<u8>(
-            memory_mapping,
-            dst_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?
-        .as_mut_ptr();
-        let src_ptr = translate_slice::<u8>(
-            memory_mapping,
-            src_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?
-        .as_ptr();
-        if !is_nonoverlapping(src_ptr as usize, n as usize, dst_ptr as usize, n as usize) {
-            unsafe {
-                std::ptr::copy(src_ptr, dst_ptr, n as usize);
-            }
-        } else {
-            unsafe {
-                std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, n as usize);
-            }
-        }
-        Ok(0)
+        // host addresses can overlap so we always invoke memmove
+        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
     }
 );
 
@@ -69,24 +45,7 @@ declare_syscall!(
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
-        let dst = translate_slice_mut::<u8>(
-            memory_mapping,
-            dst_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?;
-        let src = translate_slice::<u8>(
-            memory_mapping,
-            src_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?;
-        unsafe {
-            std::ptr::copy(src.as_ptr(), dst.as_mut_ptr(), n as usize);
-        }
-        Ok(0)
+        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
     }
 );
 
@@ -104,33 +63,46 @@ declare_syscall!(
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
-        let s1 = translate_slice::<u8>(
-            memory_mapping,
-            s1_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?;
-        let s2 = translate_slice::<u8>(
-            memory_mapping,
-            s2_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?;
-        let cmp_result = translate_type_mut::<i32>(
-            memory_mapping,
-            cmp_result_addr,
-            invoke_context.get_check_aligned(),
-        )?;
+        if invoke_context
+            .feature_set
+            .is_active(&feature_set::bpf_account_data_direct_mapping::id())
+        {
+            let cmp_result = translate_type_mut::<i32>(
+                memory_mapping,
+                cmp_result_addr,
+                invoke_context.get_check_aligned(),
+            )?;
+            *cmp_result = memcmp_non_contiguous(s1_addr, s2_addr, n, memory_mapping)?;
+        } else {
+            let s1 = translate_slice::<u8>(
+                memory_mapping,
+                s1_addr,
+                n,
+                invoke_context.get_check_aligned(),
+                invoke_context.get_check_size(),
+            )?;
+            let s2 = translate_slice::<u8>(
+                memory_mapping,
+                s2_addr,
+                n,
+                invoke_context.get_check_aligned(),
+                invoke_context.get_check_size(),
+            )?;
+            let cmp_result = translate_type_mut::<i32>(
+                memory_mapping,
+                cmp_result_addr,
+                invoke_context.get_check_aligned(),
+            )?;
 
-        debug_assert_eq!(s1.len(), n as usize);
-        debug_assert_eq!(s2.len(), n as usize);
-        // Safety:
-        // memcmp is marked unsafe since it assumes that the inputs are at least
-        // `n` bytes long. `s1` and `s2` are guaranteed to be exactly `n` bytes
-        // long because `translate_slice` would have failed otherwise.
-        *cmp_result = unsafe { memcmp(s1, s2, n as usize) };
+            debug_assert_eq!(s1.len(), n as usize);
+            debug_assert_eq!(s2.len(), n as usize);
+            // Safety:
+            // memcmp is marked unsafe since it assumes that the inputs are at least
+            // `n` bytes long. `s1` and `s2` are guaranteed to be exactly `n` bytes
+            // long because `translate_slice` would have failed otherwise.
+            *cmp_result = unsafe { memcmp(s1, s2, n as usize) };
+        }
+
         Ok(0)
     }
 );
@@ -140,7 +112,7 @@ declare_syscall!(
     SyscallMemset,
     fn inner_call(
         invoke_context: &mut InvokeContext,
-        s_addr: u64,
+        dst_addr: u64,
         c: u64,
         n: u64,
         _arg4: u64,
@@ -149,20 +121,89 @@ declare_syscall!(
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
-        let s = translate_slice_mut::<u8>(
-            memory_mapping,
-            s_addr,
-            n,
-            invoke_context.get_check_aligned(),
-            invoke_context.get_check_size(),
-        )?;
-        s.fill(c as u8);
-        Ok(0)
+        if invoke_context
+            .feature_set
+            .is_active(&feature_set::bpf_account_data_direct_mapping::id())
+        {
+            memset_non_contiguous(dst_addr, c as u8, n, memory_mapping)
+        } else {
+            let s = translate_slice_mut::<u8>(
+                memory_mapping,
+                dst_addr,
+                n,
+                invoke_context.get_check_aligned(),
+                invoke_context.get_check_size(),
+            )?;
+            s.fill(c as u8);
+            Ok(0)
+        }
     }
 );
 
+fn memmove(
+    invoke_context: &mut InvokeContext,
+    dst_addr: u64,
+    src_addr: u64,
+    n: u64,
+    memory_mapping: &MemoryMapping,
+) -> Result<u64, EbpfError> {
+    if invoke_context
+        .feature_set
+        .is_active(&feature_set::bpf_account_data_direct_mapping::id())
+    {
+        memmove_non_contiguous(dst_addr, src_addr, n, memory_mapping)
+    } else {
+        let dst_ptr = translate_slice_mut::<u8>(
+            memory_mapping,
+            dst_addr,
+            n,
+            invoke_context.get_check_aligned(),
+            invoke_context.get_check_size(),
+        )?
+        .as_mut_ptr();
+        let src_ptr = translate_slice::<u8>(
+            memory_mapping,
+            src_addr,
+            n,
+            invoke_context.get_check_aligned(),
+            invoke_context.get_check_size(),
+        )?
+        .as_ptr();
+
+        unsafe { std::ptr::copy(src_ptr, dst_ptr, n as usize) };
+        Ok(0)
+    }
+}
+
+fn memmove_non_contiguous(
+    dst_addr: u64,
+    src_addr: u64,
+    n: u64,
+    memory_mapping: &MemoryMapping,
+) -> Result<u64, EbpfError> {
+    let reverse = dst_addr.wrapping_sub(src_addr) < n;
+    iter_memory_pair_chunks(
+        AccessType::Load,
+        src_addr,
+        AccessType::Store,
+        dst_addr,
+        n,
+        memory_mapping,
+        reverse,
+        |src_host_addr, dst_host_addr, chunk_len| {
+            unsafe {
+                std::ptr::copy(
+                    src_host_addr as *const u8,
+                    dst_host_addr as *mut u8,
+                    chunk_len,
+                )
+            };
+            Ok(0)
+        },
+    )
+}
+
 // Marked unsafe since it assumes that the slices are at least `n` bytes long.
-#[allow(clippy::indexing_slicing)]
 unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
     for i in 0..n {
         let a = *s1.get_unchecked(i);
@@ -173,4 +214,560 @@ unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
     }
 
     0
+}
+
+fn memcmp_non_contiguous(
+    src_addr: u64,
+    dst_addr: u64,
+    n: u64,
+    memory_mapping: &MemoryMapping,
+) -> Result<i32, EbpfError> {
+    match iter_memory_pair_chunks(
+        AccessType::Load,
+        src_addr,
+        AccessType::Load,
+        dst_addr,
+        n,
+        memory_mapping,
+        false,
+        |s1_addr, s2_addr, chunk_len| {
+            let res = unsafe {
+                let s1 = slice::from_raw_parts(s1_addr as *const u8, chunk_len);
+                let s2 = slice::from_raw_parts(s2_addr as *const u8, chunk_len);
+                // Safety:
+                // memcmp is marked unsafe since it assumes that s1 and s2 are exactly chunk_len
+                // long. The whole point of iter_memory_pair_chunks is to find same length chunks
+                // across two memory regions.
+                memcmp(s1, s2, chunk_len)
+            };
+            if res != 0 {
+                return Err(MemcmpError::Diff(res));
+            }
+            Ok(0)
+        },
+    ) {
+        Ok(res) => Ok(res),
+        Err(MemcmpError::Diff(diff)) => Ok(diff),
+        Err(MemcmpError::Ebpf(e)) => Err(e),
+    }
+}
+
+#[derive(Debug)]
+enum MemcmpError {
+    Ebpf(EbpfError),
+    Diff(i32),
+}
+
+impl From<EbpfError> for MemcmpError {
+    fn from(err: EbpfError) -> Self {
+        MemcmpError::Ebpf(err)
+    }
+}
+
+fn memset_non_contiguous(
+    dst_addr: u64,
+    c: u8,
+    n: u64,
+    memory_mapping: &MemoryMapping,
+) -> Result<u64, EbpfError> {
+    let dst_chunk_iter = MemoryChunkIterator::new(memory_mapping, AccessType::Store, dst_addr, n);
+    for item in dst_chunk_iter {
+        let (dst_region, dst_vm_addr, dst_len) = item?;
+        let dst_host_addr = Result::from(dst_region.vm_to_host(dst_vm_addr, dst_len as u64))?;
+        unsafe { slice::from_raw_parts_mut(dst_host_addr as *mut u8, dst_len).fill(c) }
+    }
+
+    Ok(0)
+}
+
+fn iter_memory_pair_chunks<T, E, F>(
+    src_access: AccessType,
+    src_addr: u64,
+    dst_access: AccessType,
+    mut dst_addr: u64,
+    n: u64,
+    memory_mapping: &MemoryMapping,
+    reverse: bool,
+    mut fun: F,
+) -> Result<T, E>
+where
+    T: Default,
+    E: From<EbpfError>,
+    F: FnMut(*const u8, *const u8, usize) -> Result<T, E>,
+{
+    let mut src_chunk_iter = MemoryChunkIterator::new(memory_mapping, src_access, src_addr, n);
+    loop {
+        // iterate source chunks
+        let (src_region, src_vm_addr, mut src_len) = match if reverse {
+            src_chunk_iter.next_back()
+        } else {
+            src_chunk_iter.next()
+        } {
+            Some(item) => item?,
+            None => break,
+        };
+
+        let mut src_host_addr = Result::from(src_region.vm_to_host(src_vm_addr, src_len as u64))?;
+        let mut dst_chunk_iter = MemoryChunkIterator::new(memory_mapping, dst_access, dst_addr, n);
+        // iterate over destination chunks until this source chunk has been completely copied
+        while src_len > 0 {
+            loop {
+                let (dst_region, dst_vm_addr, dst_len) = match if reverse {
+                    dst_chunk_iter.next_back()
+                } else {
+                    dst_chunk_iter.next()
+                } {
+                    Some(item) => item?,
+                    None => break,
+                };
+                let dst_host_addr =
+                    Result::from(dst_region.vm_to_host(dst_vm_addr, dst_len as u64))?;
+                let chunk_len = src_len.min(dst_len);
+                fun(
+                    src_host_addr as *const u8,
+                    dst_host_addr as *const u8,
+                    chunk_len as usize,
+                )?;
+                src_len = src_len.saturating_sub(chunk_len);
+                if reverse {
+                    dst_addr = dst_addr.saturating_sub(chunk_len as u64);
+                } else {
+                    dst_addr = dst_addr.saturating_add(chunk_len as u64);
+                }
+                if src_len == 0 {
+                    break;
+                }
+                src_host_addr = src_host_addr.saturating_add(chunk_len as u64);
+            }
+        }
+    }
+
+    Ok(T::default())
+}
+
+struct MemoryChunkIterator<'a> {
+    memory_mapping: &'a MemoryMapping<'a>,
+    access_type: AccessType,
+    initial_vm_addr: u64,
+    vm_addr_start: u64,
+    // exclusive end index (start + len, so one past the last valid address)
+    vm_addr_end: u64,
+    len: u64,
+}
+
+impl<'a> MemoryChunkIterator<'a> {
+    fn new(
+        memory_mapping: &'a MemoryMapping,
+        access_type: AccessType,
+        vm_addr: u64,
+        len: u64,
+    ) -> MemoryChunkIterator<'a> {
+        MemoryChunkIterator {
+            memory_mapping,
+            access_type,
+            initial_vm_addr: vm_addr,
+            len,
+            vm_addr_start: vm_addr,
+            vm_addr_end: vm_addr.saturating_add(len),
+        }
+    }
+
+    fn region(&mut self, vm_addr: u64) -> Result<&'a MemoryRegion, EbpfError> {
+        match self.memory_mapping.region(self.access_type, vm_addr) {
+            Ok(region) => Ok(region),
+            Err(EbpfError::AccessViolation(pc, access_type, _vm_addr, _len, name)) => Err(
+                EbpfError::AccessViolation(pc, access_type, self.initial_vm_addr, self.len, name),
+            ),
+            Err(EbpfError::StackAccessViolation(pc, access_type, _vm_addr, _len, frame)) => {
+                Err(EbpfError::StackAccessViolation(
+                    pc,
+                    access_type,
+                    self.initial_vm_addr,
+                    self.len,
+                    frame,
+                ))
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<'a> Iterator for MemoryChunkIterator<'a> {
+    type Item = Result<(&'a MemoryRegion, u64, usize), EbpfError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.vm_addr_start == self.vm_addr_end {
+            return None;
+        }
+
+        let region = match self.region(self.vm_addr_start) {
+            Ok(region) => region,
+            Err(e) => {
+                self.vm_addr_start = self.vm_addr_end;
+                return Some(Err(e));
+            }
+        };
+
+        let vm_addr = self.vm_addr_start;
+
+        let chunk_len = if region.vm_addr_end <= self.vm_addr_end {
+            // consume the whole region
+            let len = region.vm_addr_end.saturating_sub(self.vm_addr_start);
+            self.vm_addr_start = region.vm_addr_end;
+            len
+        } else {
+            // consume part of the region
+            let len = self.vm_addr_end.saturating_sub(self.vm_addr_start);
+            self.vm_addr_start = self.vm_addr_end;
+            len
+        };
+
+        Some(Ok((region, vm_addr, chunk_len as usize)))
+    }
+}
+
+impl<'a> DoubleEndedIterator for MemoryChunkIterator<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.vm_addr_start == self.vm_addr_end {
+            return None;
+        }
+
+        let region = match self.region(self.vm_addr_end.saturating_sub(1)) {
+            Ok(region) => region,
+            Err(e) => {
+                self.vm_addr_start = self.vm_addr_end;
+                return Some(Err(e));
+            }
+        };
+
+        let chunk_len = if region.vm_addr >= self.vm_addr_start {
+            // consume the whole region
+            let len = self.vm_addr_end.saturating_sub(region.vm_addr);
+            self.vm_addr_end = region.vm_addr;
+            len
+        } else {
+            // consume part of the region
+            let len = self.vm_addr_end.saturating_sub(self.vm_addr_start);
+            self.vm_addr_end = self.vm_addr_start;
+            len
+        };
+
+        Some(Ok((region, self.vm_addr_end, chunk_len as usize)))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use {super::*, solana_rbpf::ebpf::MM_PROGRAM_START};
+
+    #[test]
+    fn test_memory_chunk_iterator_empty() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(vec![], &config).unwrap();
+        let mut src_chunk_iter = MemoryChunkIterator::new(&memory_mapping, AccessType::Load, 0, 1);
+        assert!(src_chunk_iter.next().unwrap().is_err());
+    }
+
+    fn to_chunk_vec<'a>(
+        iter: impl Iterator<Item = Result<(&'a MemoryRegion, u64, usize), EbpfError>>,
+    ) -> Vec<(u64, usize)> {
+        iter.flat_map(|res| res.map(|(_, vm_addr, len)| (vm_addr, len)))
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    #[should_panic(expected = "AccessViolation")]
+    fn test_memory_chunk_iterator_no_regions() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(vec![], &config).unwrap();
+
+        let mut src_chunk_iter = MemoryChunkIterator::new(&memory_mapping, AccessType::Load, 0, 1);
+        src_chunk_iter.next().unwrap().unwrap();
+    }
+
+    #[test]
+    fn test_memory_chunk_iterator_one() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = vec![0xFF; 42];
+        let memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START)],
+            &config,
+        )
+        .unwrap();
+
+        let mut src_chunk_iter =
+            MemoryChunkIterator::new(&memory_mapping, AccessType::Load, MM_PROGRAM_START - 1, 1);
+        assert!(src_chunk_iter.next().unwrap().is_err());
+
+        for (vm_addr, len) in [
+            (MM_PROGRAM_START, 0),
+            (MM_PROGRAM_START + 42, 0),
+            (MM_PROGRAM_START, 1),
+            (MM_PROGRAM_START, 42),
+            (MM_PROGRAM_START + 41, 1),
+        ] {
+            for rev in [true, false] {
+                let iter =
+                    MemoryChunkIterator::new(&memory_mapping, AccessType::Load, vm_addr, len);
+                let res = if rev {
+                    to_chunk_vec(iter.rev())
+                } else {
+                    to_chunk_vec(iter)
+                };
+                if len == 0 {
+                    assert_eq!(res, &[]);
+                } else {
+                    assert_eq!(res, &[(vm_addr, len as usize)]);
+                }
+            }
+        }
+
+        let mut src_chunk_iter =
+            MemoryChunkIterator::new(&memory_mapping, AccessType::Load, MM_PROGRAM_START + 42, 1);
+        assert!(src_chunk_iter.next().unwrap().is_err());
+    }
+
+    #[test]
+    fn test_memory_chunk_iterator_two() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = vec![0x11; 8];
+        let mem2 = vec![0x22; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START),
+                MemoryRegion::new_readonly(&mem2, MM_PROGRAM_START + 8),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        for (vm_addr, len, mut expected) in [
+            (MM_PROGRAM_START, 8, vec![(MM_PROGRAM_START, 8)]),
+            (
+                MM_PROGRAM_START + 7,
+                2,
+                vec![(MM_PROGRAM_START + 7, 1), (MM_PROGRAM_START + 8, 1)],
+            ),
+            (MM_PROGRAM_START + 8, 4, vec![(MM_PROGRAM_START + 8, 4)]),
+        ] {
+            for rev in [false, true] {
+                let iter =
+                    MemoryChunkIterator::new(&memory_mapping, AccessType::Load, vm_addr, len);
+                let res = if rev {
+                    expected.reverse();
+                    to_chunk_vec(iter.rev())
+                } else {
+                    to_chunk_vec(iter)
+                };
+
+                assert_eq!(res, expected);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "AccessViolation(0, Store, 4294967296, 4")]
+    fn test_memmove_non_contiguous_readonly() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = vec![0x11; 8];
+        let mem2 = vec![0x22; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START),
+                MemoryRegion::new_readonly(&mem2, MM_PROGRAM_START + 8),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        memmove_non_contiguous(MM_PROGRAM_START, MM_PROGRAM_START + 8, 4, &memory_mapping).unwrap();
+    }
+
+    #[test]
+    fn test_overlapping_memmove_non_contiguous_right() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = vec![0x11; 1];
+        let mut mem2 = vec![0x22; 2];
+        let mut mem3 = vec![0x33; 3];
+        let mut mem4 = vec![0x44; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START),
+                MemoryRegion::new_writable(&mut mem2, MM_PROGRAM_START + 1),
+                MemoryRegion::new_writable(&mut mem3, MM_PROGRAM_START + 3),
+                MemoryRegion::new_writable(&mut mem4, MM_PROGRAM_START + 6),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        // overlapping memmove right - the implementation will copy backwards
+        assert_eq!(
+            memmove_non_contiguous(MM_PROGRAM_START + 1, MM_PROGRAM_START, 7, &memory_mapping)
+                .unwrap(),
+            0
+        );
+        assert_eq!(&mem1, &[0x11]);
+        assert_eq!(&mem2, &[0x11, 0x22]);
+        assert_eq!(&mem3, &[0x22, 0x33, 0x33]);
+        assert_eq!(&mem4, &[0x33, 0x44, 0x44, 0x44]);
+    }
+
+    #[test]
+    fn test_overlapping_memmove_non_contiguous_left() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mut mem1 = vec![0x11; 1];
+        let mut mem2 = vec![0x22; 2];
+        let mut mem3 = vec![0x33; 3];
+        let mut mem4 = vec![0x44; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_writable(&mut mem1, MM_PROGRAM_START),
+                MemoryRegion::new_writable(&mut mem2, MM_PROGRAM_START + 1),
+                MemoryRegion::new_writable(&mut mem3, MM_PROGRAM_START + 3),
+                MemoryRegion::new_writable(&mut mem4, MM_PROGRAM_START + 6),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        // overlapping memmove left - the implementation will copy forward
+        assert_eq!(
+            memmove_non_contiguous(MM_PROGRAM_START, MM_PROGRAM_START + 1, 7, &memory_mapping)
+                .unwrap(),
+            0
+        );
+        assert_eq!(&mem1, &[0x22]);
+        assert_eq!(&mem2, &[0x22, 0x33]);
+        assert_eq!(&mem3, &[0x33, 0x33, 0x44]);
+        assert_eq!(&mem4, &[0x44, 0x44, 0x44, 0x44]);
+    }
+
+    #[test]
+    #[should_panic(expected = "AccessViolation(0, Store, 4294967296, 9")]
+    fn test_memset_non_contiguous_readonly() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mut mem1 = vec![0x11; 8];
+        let mem2 = vec![0x22; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_writable(&mut mem1, MM_PROGRAM_START),
+                MemoryRegion::new_readonly(&mem2, MM_PROGRAM_START + 8),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(
+            memset_non_contiguous(MM_PROGRAM_START, 0x33, 9, &memory_mapping).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_memset_non_contiguous() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = vec![0x11; 1];
+        let mut mem2 = vec![0x22; 2];
+        let mut mem3 = vec![0x33; 3];
+        let mut mem4 = vec![0x44; 4];
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START),
+                MemoryRegion::new_writable(&mut mem2, MM_PROGRAM_START + 1),
+                MemoryRegion::new_writable(&mut mem3, MM_PROGRAM_START + 3),
+                MemoryRegion::new_writable(&mut mem4, MM_PROGRAM_START + 6),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(
+            memset_non_contiguous(MM_PROGRAM_START + 1, 0x55, 7, &memory_mapping).unwrap(),
+            0
+        );
+        assert_eq!(&mem1, &[0x11]);
+        assert_eq!(&mem2, &[0x55, 0x55]);
+        assert_eq!(&mem3, &[0x55, 0x55, 0x55]);
+        assert_eq!(&mem4, &[0x55, 0x55, 0x44, 0x44]);
+    }
+
+    #[test]
+    fn test_memcmp_non_contiguous() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = b"foo".to_vec();
+        let mem2 = b"barbad".to_vec();
+        let mem3 = b"foobarbad".to_vec();
+        let memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, MM_PROGRAM_START),
+                MemoryRegion::new_readonly(&mem2, MM_PROGRAM_START + 3),
+                MemoryRegion::new_readonly(&mem3, MM_PROGRAM_START + 9),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        // non contiguous src
+        assert_eq!(
+            memcmp_non_contiguous(MM_PROGRAM_START, MM_PROGRAM_START + 9, 9, &memory_mapping)
+                .unwrap(),
+            0
+        );
+
+        // non contiguous dst
+        assert_eq!(
+            memcmp_non_contiguous(
+                MM_PROGRAM_START + 10,
+                MM_PROGRAM_START + 1,
+                8,
+                &memory_mapping
+            )
+            .unwrap(),
+            0
+        );
+
+        // diff
+        assert_eq!(
+            memcmp_non_contiguous(
+                MM_PROGRAM_START + 1,
+                MM_PROGRAM_START + 11,
+                5,
+                &memory_mapping
+            )
+            .unwrap(),
+            unsafe { memcmp(b"oobar", b"obarb", 5) }
+        );
+    }
 }

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -156,9 +156,7 @@ declare_syscall!(
             invoke_context.get_check_aligned(),
             invoke_context.get_check_size(),
         )?;
-        for val in s.iter_mut().take(n as usize) {
-            *val = c as u8;
-        }
+        s.fill(c as u8);
         Ok(0)
     }
 );

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -326,7 +326,7 @@ where
                 fun(
                     src_host_addr as *const u8,
                     dst_host_addr as *const u8,
-                    chunk_len as usize,
+                    chunk_len,
                 )?;
                 src_len = src_len.saturating_sub(chunk_len);
                 if reverse {

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -267,7 +267,7 @@ enum MemcmpError {
 impl std::fmt::Display for MemcmpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MemcmpError::Diff(diff) => write!(f, "memcmp diff: {}", diff),
+            MemcmpError::Diff(diff) => write!(f, "memcmp diff: {diff}"),
         }
     }
 }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -30,6 +30,7 @@ use {
         big_mod_exp::{big_mod_exp, BigModExpParams},
         blake3, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, SUCCESS},
+        feature_set::bpf_account_data_direct_mapping,
         feature_set::FeatureSet,
         feature_set::{
             self, blake3_syscall_enabled, check_syscall_outputs_do_not_overlap,
@@ -174,7 +175,7 @@ pub fn create_loader<'a>(
         enable_elf_vaddr: false,
         reject_rodata_stack_overlap: false,
         new_elf_parser: feature_set.is_active(&switch_to_new_elf_parser::id()),
-        aligned_memory_mapping: true,
+        aligned_memory_mapping: !feature_set.is_active(&bpf_account_data_direct_mapping::id()),
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
 

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -691,7 +691,7 @@ mod tests {
                 authority_address,
             })
             .unwrap();
-        program_account.data_mut()[loader_v3::LoaderV3State::program_data_offset()..]
+        program_account.data_as_mut_slice()[loader_v3::LoaderV3State::program_data_offset()..]
             .copy_from_slice(&elf_bytes);
         program_account
     }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -69,7 +69,7 @@ macro_rules! with_mock_invoke_context {
             index_in_caller: 2,
             index_in_callee: 0,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         }];
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -245,6 +245,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         true, // should_cap_ix_accounts
+        true, // copy_account_data
     )
     .unwrap();
 
@@ -275,6 +276,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         true, // should_cap_ix_accounts
+        true, // copy_account_data
     )
     .unwrap();
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -3,9 +3,10 @@
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::integer_arithmetic)]
 
-use {solana_rbpf::memory_region::MemoryState, std::slice};
-
-use {solana_rbpf::memory_region::MemoryState, std::slice};
+use {
+    solana_rbpf::memory_region::MemoryState,
+    solana_sdk::feature_set::bpf_account_data_direct_mapping, std::slice,
+};
 
 extern crate test;
 
@@ -225,6 +226,9 @@ fn bench_create_vm(bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
+    let direct_mapping = invoke_context
+        .feature_set
+        .is_active(&bpf_account_data_direct_mapping::id());
     let loader = create_loader(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
@@ -246,8 +250,8 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true, // should_cap_ix_accounts
-        true, // copy_account_data
+        true,            // should_cap_ix_accounts
+        !direct_mapping, // copy_account_data
     )
     .unwrap();
 
@@ -270,6 +274,10 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
+    let direct_mapping = invoke_context
+        .feature_set
+        .is_active(&bpf_account_data_direct_mapping::id());
+
     // Serialize account data
     let (_serialized, regions, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,
@@ -277,8 +285,8 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true, // should_cap_ix_accounts
-        true, // copy_account_data
+        true,            // should_cap_ix_accounts
+        !direct_mapping, // copy_account_data
     )
     .unwrap();
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -5,6 +5,8 @@
 
 use {solana_rbpf::memory_region::MemoryState, std::slice};
 
+use {solana_rbpf::memory_region::MemoryState, std::slice};
+
 extern crate test;
 
 use {

--- a/programs/sbf/rust/realloc/src/instructions.rs
+++ b/programs/sbf/rust/realloc/src/instructions.rs
@@ -15,6 +15,7 @@ pub const DEALLOC_AND_ASSIGN_TO_CALLER: u8 = 7;
 pub const CHECK: u8 = 8;
 pub const ZERO_INIT: u8 = 9;
 pub const REALLOC_EXTEND_AND_UNDO: u8 = 10;
+pub const EXTEND_AND_WRITE_U64: u8 = 11;
 
 pub fn realloc(program_id: &Pubkey, address: &Pubkey, size: usize, bump: &mut u8) -> Instruction {
     let mut instruction_data = vec![REALLOC, *bump];
@@ -81,6 +82,17 @@ pub fn realloc_extend_and_undo(
     instruction_data.extend_from_slice(&size.to_le_bytes());
 
     *bump = bump.saturating_add(1);
+
+    Instruction::new_with_bytes(
+        *program_id,
+        &instruction_data,
+        vec![AccountMeta::new(*address, false)],
+    )
+}
+
+pub fn extend_and_write_u64(program_id: &Pubkey, address: &Pubkey, value: u64) -> Instruction {
+    let mut instruction_data = vec![EXTEND_AND_WRITE_U64];
+    instruction_data.extend_from_slice(&value.to_le_bytes());
 
     Instruction::new_with_bytes(
         *program_id,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1110,7 +1110,7 @@ fn test_program_sbf_invoke_sanity() {
             .map(|ix| &message.account_keys[ix.instruction.program_id_index as usize])
             .cloned()
             .collect();
-        assert_eq!(invoked_programs, vec![system_program::id()]);
+        assert_eq!(invoked_programs, vec![]);
         assert_eq!(
             result.unwrap_err(),
             TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -39,7 +39,7 @@ use {
         clock::MAX_PROCESSING_AGE,
         compute_budget::ComputeBudgetInstruction,
         entrypoint::MAX_PERMITTED_DATA_INCREASE,
-        feature_set::FeatureSet,
+        feature_set::{self, FeatureSet},
         fee::FeeStructure,
         loader_instruction,
         message::{v0::LoadedAddresses, SanitizedMessage},
@@ -2761,234 +2761,57 @@ fn test_program_sbf_realloc() {
     } = create_genesis_config(1_000_000_000_000);
     let mint_pubkey = mint_keypair.pubkey();
     let signer = &[&mint_keypair];
+    for direct_mapping in [false, true] {
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let feature_set = Arc::make_mut(&mut bank.feature_set);
+        // by default test banks have all features enabled, so we only need to
+        // disable when needed
+        if !direct_mapping {
+            feature_set.deactivate(&feature_set::bpf_account_data_direct_mapping::id());
+        }
+        let bank = Arc::new(bank);
+        let bank_client = BankClient::new_shared(&bank);
 
-    let bank = Bank::new_for_tests(&genesis_config);
-    let bank = Arc::new(bank);
-    let bank_client = BankClient::new_shared(&bank);
+        let program_id = load_program(
+            &bank_client,
+            &bpf_loader::id(),
+            &mint_keypair,
+            "solana_sbf_rust_realloc",
+        );
 
-    let program_id = load_program(
-        &bank_client,
-        &bpf_loader::id(),
-        &mint_keypair,
-        "solana_sbf_rust_realloc",
-    );
+        let mut bump = 0;
+        let keypair = Keypair::new();
+        let pubkey = keypair.pubkey();
+        let account = AccountSharedData::new(START_BALANCE, 5, &program_id);
+        bank.store_account(&pubkey, &account);
 
-    let mut bump = 0;
-    let keypair = Keypair::new();
-    let pubkey = keypair.pubkey();
-    let account = AccountSharedData::new(START_BALANCE, 5, &program_id);
-    bank.store_account(&pubkey, &account);
+        // Realloc RO account
+        let mut instruction = realloc(&program_id, &pubkey, 0, &mut bump);
+        instruction.accounts[0].is_writable = false;
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(signer, Message::new(&[instruction], Some(&mint_pubkey),),)
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified)
+        );
 
-    // Realloc RO account
-    let mut instruction = realloc(&program_id, &pubkey, 0, &mut bump);
-    instruction.accounts[0].is_writable = false;
-    assert_eq!(
-        bank_client
-            .send_and_confirm_message(signer, Message::new(&[instruction], Some(&mint_pubkey),),)
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified)
-    );
-
-    // Realloc account to overflow
-    assert_eq!(
-        bank_client
-            .send_and_confirm_message(
-                signer,
-                Message::new(
-                    &[realloc(&program_id, &pubkey, usize::MAX, &mut bump)],
-                    Some(&mint_pubkey),
-                ),
-            )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
-    );
-
-    // Realloc account to 0
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[realloc(&program_id, &pubkey, 0, &mut bump)],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(0, data.len());
-
-    // Realloc account to max then undo
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[realloc_extend_and_undo(
-                    &program_id,
-                    &pubkey,
-                    MAX_PERMITTED_DATA_INCREASE,
-                    &mut bump,
-                )],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(0, data.len());
-
-    // Realloc account to max + 1 then undo
-    assert_eq!(
-        bank_client
-            .send_and_confirm_message(
-                signer,
-                Message::new(
-                    &[realloc_extend_and_undo(
-                        &program_id,
-                        &pubkey,
-                        MAX_PERMITTED_DATA_INCREASE + 1,
-                        &mut bump,
-                    )],
-                    Some(&mint_pubkey),
-                ),
-            )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
-    );
-
-    // Realloc to max + 1
-    assert_eq!(
-        bank_client
-            .send_and_confirm_message(
-                signer,
-                Message::new(
-                    &[realloc(
-                        &program_id,
-                        &pubkey,
-                        MAX_PERMITTED_DATA_INCREASE + 1,
-                        &mut bump
-                    )],
-                    Some(&mint_pubkey),
-                ),
-            )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
-    );
-
-    // Realloc to max length in max increase increments
-    for i in 0..MAX_PERMITTED_DATA_LENGTH as usize / MAX_PERMITTED_DATA_INCREASE {
-        let mut bump = i as u64;
-        bank_client
-            .send_and_confirm_message(
-                signer,
-                Message::new(
-                    &[realloc_extend_and_fill(
-                        &program_id,
-                        &pubkey,
-                        MAX_PERMITTED_DATA_INCREASE,
-                        1,
-                        &mut bump,
-                    )],
-                    Some(&mint_pubkey),
-                ),
-            )
-            .unwrap();
-        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-        assert_eq!((i + 1) * MAX_PERMITTED_DATA_INCREASE, data.len());
-    }
-    for i in 0..data.len() {
-        assert_eq!(data[i], 1);
-    }
-
-    // and one more time should fail
-    assert_eq!(
-        bank_client
-            .send_and_confirm_message(
-                signer,
-                Message::new(
-                    &[realloc_extend(
-                        &program_id,
-                        &pubkey,
-                        MAX_PERMITTED_DATA_INCREASE,
-                        &mut bump
-                    )],
-                    Some(&mint_pubkey),
+        // Realloc account to overflow
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc(&program_id, &pubkey, usize::MAX, &mut bump)],
+                        Some(&mint_pubkey),
+                    ),
                 )
-            )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
-    );
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
+        );
 
-    // Realloc to 6 bytes
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[
-                    realloc(&program_id, &pubkey, 6, &mut bump),
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(u32::MAX),
-                ],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(6, data.len());
-
-    // Extend by 2 bytes and write a u64. This ensures that we can do writes that span the original
-    // account length (6 bytes) and the realloc data (2 bytes).
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[
-                    extend_and_write_u64(&program_id, &pubkey, 0x1122334455667788),
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(u32::MAX),
-                ],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(8, data.len());
-    assert_eq!(0x1122334455667788, unsafe { *data.as_ptr().cast::<u64>() });
-
-    // Realloc to 0
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[realloc(&program_id, &pubkey, 0, &mut bump)],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(0, data.len());
-
-    // Realloc and assign
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[Instruction::new_with_bytes(
-                    program_id,
-                    &[REALLOC_AND_ASSIGN],
-                    vec![AccountMeta::new(pubkey, false)],
-                )],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let account = bank.get_account(&pubkey).unwrap();
-    assert_eq!(&solana_sdk::system_program::id(), account.owner());
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(MAX_PERMITTED_DATA_INCREASE, data.len());
-
-    // Realloc to 0 with wrong owner
-    assert_eq!(
+        // Realloc account to 0
         bank_client
             .send_and_confirm_message(
                 signer,
@@ -2997,82 +2820,264 @@ fn test_program_sbf_realloc() {
                     Some(&mint_pubkey),
                 ),
             )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
-    );
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(0, data.len());
 
-    // realloc and assign to self via cpi
-    assert_eq!(
+        // Realloc account to max then undo
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[realloc_extend_and_undo(
+                        &program_id,
+                        &pubkey,
+                        MAX_PERMITTED_DATA_INCREASE,
+                        &mut bump,
+                    )],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(0, data.len());
+
+        // Realloc account to max + 1 then undo
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc_extend_and_undo(
+                            &program_id,
+                            &pubkey,
+                            MAX_PERMITTED_DATA_INCREASE + 1,
+                            &mut bump,
+                        )],
+                        Some(&mint_pubkey),
+                    ),
+                )
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
+        );
+
+        // Realloc to max + 1
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc(
+                            &program_id,
+                            &pubkey,
+                            MAX_PERMITTED_DATA_INCREASE + 1,
+                            &mut bump
+                        )],
+                        Some(&mint_pubkey),
+                    ),
+                )
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
+        );
+
+        // Realloc to max length in max increase increments
+        for i in 0..MAX_PERMITTED_DATA_LENGTH as usize / MAX_PERMITTED_DATA_INCREASE {
+            let mut bump = i as u64;
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc_extend_and_fill(
+                            &program_id,
+                            &pubkey,
+                            MAX_PERMITTED_DATA_INCREASE,
+                            1,
+                            &mut bump,
+                        )],
+                        Some(&mint_pubkey),
+                    ),
+                )
+                .unwrap();
+            let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+            assert_eq!((i + 1) * MAX_PERMITTED_DATA_INCREASE, data.len());
+        }
+        for i in 0..data.len() {
+            assert_eq!(data[i], 1);
+        }
+
+        // and one more time should fail
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc_extend(
+                            &program_id,
+                            &pubkey,
+                            MAX_PERMITTED_DATA_INCREASE,
+                            &mut bump
+                        )],
+                        Some(&mint_pubkey),
+                    )
+                )
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
+        );
+
+        // Realloc to 6 bytes
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[realloc(&program_id, &pubkey, 6, &mut bump)],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(6, data.len());
+
+        // Extend by 2 bytes and write a u64. This ensures that we can do writes that span the original
+        // account length (6 bytes) and the realloc data (2 bytes).
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[extend_and_write_u64(
+                        &program_id,
+                        &pubkey,
+                        0x1122334455667788,
+                    )],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(8, data.len());
+        assert_eq!(0x1122334455667788, unsafe { *data.as_ptr().cast::<u64>() });
+
+        // Realloc to 0
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[realloc(&program_id, &pubkey, 0, &mut bump)],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(0, data.len());
+
+        // Realloc and assign
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[Instruction::new_with_bytes(
+                        program_id,
+                        &[REALLOC_AND_ASSIGN],
+                        vec![AccountMeta::new(pubkey, false)],
+                    )],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let account = bank.get_account(&pubkey).unwrap();
+        assert_eq!(&solana_sdk::system_program::id(), account.owner());
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(MAX_PERMITTED_DATA_INCREASE, data.len());
+
+        // Realloc to 0 with wrong owner
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    signer,
+                    Message::new(
+                        &[realloc(&program_id, &pubkey, 0, &mut bump)],
+                        Some(&mint_pubkey),
+                    ),
+                )
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+        );
+
+        // realloc and assign to self via cpi
+        assert_eq!(
+            bank_client
+                .send_and_confirm_message(
+                    &[&mint_keypair, &keypair],
+                    Message::new(
+                        &[Instruction::new_with_bytes(
+                            program_id,
+                            &[REALLOC_AND_ASSIGN_TO_SELF_VIA_SYSTEM_PROGRAM],
+                            vec![
+                                AccountMeta::new(pubkey, true),
+                                AccountMeta::new(solana_sdk::system_program::id(), false),
+                            ],
+                        )],
+                        Some(&mint_pubkey),
+                    )
+                )
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+        );
+
+        // Assign to self and realloc via cpi
         bank_client
             .send_and_confirm_message(
                 &[&mint_keypair, &keypair],
                 Message::new(
                     &[Instruction::new_with_bytes(
                         program_id,
-                        &[REALLOC_AND_ASSIGN_TO_SELF_VIA_SYSTEM_PROGRAM],
+                        &[ASSIGN_TO_SELF_VIA_SYSTEM_PROGRAM_AND_REALLOC],
                         vec![
                             AccountMeta::new(pubkey, true),
                             AccountMeta::new(solana_sdk::system_program::id(), false),
                         ],
                     )],
                     Some(&mint_pubkey),
-                )
+                ),
             )
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
-    );
+            .unwrap();
+        let account = bank.get_account(&pubkey).unwrap();
+        assert_eq!(&program_id, account.owner());
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(2 * MAX_PERMITTED_DATA_INCREASE, data.len());
 
-    // Assign to self and realloc via cpi
-    bank_client
-        .send_and_confirm_message(
-            &[&mint_keypair, &keypair],
-            Message::new(
-                &[Instruction::new_with_bytes(
-                    program_id,
-                    &[ASSIGN_TO_SELF_VIA_SYSTEM_PROGRAM_AND_REALLOC],
-                    vec![
-                        AccountMeta::new(pubkey, true),
-                        AccountMeta::new(solana_sdk::system_program::id(), false),
-                    ],
-                )],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let account = bank.get_account(&pubkey).unwrap();
-    assert_eq!(&program_id, account.owner());
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(2 * MAX_PERMITTED_DATA_INCREASE, data.len());
+        // Realloc to 0
+        bank_client
+            .send_and_confirm_message(
+                signer,
+                Message::new(
+                    &[realloc(&program_id, &pubkey, 0, &mut bump)],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+        let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
+        assert_eq!(0, data.len());
 
-    // Realloc to 0
-    bank_client
-        .send_and_confirm_message(
-            signer,
-            Message::new(
-                &[realloc(&program_id, &pubkey, 0, &mut bump)],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
-    let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
-    assert_eq!(0, data.len());
-
-    // zero-init
-    bank_client
-        .send_and_confirm_message(
-            &[&mint_keypair, &keypair],
-            Message::new(
-                &[Instruction::new_with_bytes(
-                    program_id,
-                    &[ZERO_INIT],
-                    vec![AccountMeta::new(pubkey, true)],
-                )],
-                Some(&mint_pubkey),
-            ),
-        )
-        .unwrap();
+        // zero-init
+        bank_client
+            .send_and_confirm_message(
+                &[&mint_keypair, &keypair],
+                Message::new(
+                    &[Instruction::new_with_bytes(
+                        program_id,
+                        &[ZERO_INIT],
+                        vec![AccountMeta::new(pubkey, true)],
+                    )],
+                    Some(&mint_pubkey),
+                ),
+            )
+            .unwrap();
+    }
 }
 
 #[test]

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -235,6 +235,7 @@ before execting it in the virtual machine.",
             .get_current_instruction_context()
             .unwrap(),
         true, // should_cap_ix_accounts
+        true,
     )
     .unwrap();
 

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -12,8 +12,8 @@ use {
         with_mock_invoke_context,
     },
     solana_rbpf::{
-        aligned_memory::AlignedMemory, assembler::assemble, ebpf::HOST_ALIGN, elf::Executable,
-        static_analysis::Analysis, verifier::RequisiteVerifier, vm::VerifiedExecutable,
+        assembler::assemble, elf::Executable, static_analysis::Analysis,
+        verifier::RequisiteVerifier, vm::VerifiedExecutable,
     },
     solana_sdk::{
         account::AccountSharedData,

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -12,8 +12,8 @@ use {
         with_mock_invoke_context,
     },
     solana_rbpf::{
-        assembler::assemble, elf::Executable, static_analysis::Analysis,
-        verifier::RequisiteVerifier, vm::VerifiedExecutable,
+        aligned_memory::AlignedMemory, assembler::assemble, ebpf::HOST_ALIGN, elf::Executable,
+        static_analysis::Analysis, verifier::RequisiteVerifier, vm::VerifiedExecutable,
     },
     solana_sdk::{
         account::AccountSharedData,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7496,7 +7496,7 @@ fn test_bank_load_program() {
             upgrade_authority_address: None,
         })
         .unwrap();
-    programdata_account.data_mut()[programdata_data_offset..].copy_from_slice(&elf);
+    programdata_account.data_as_mut_slice()[programdata_data_offset..].copy_from_slice(&elf);
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7445,7 +7445,9 @@ fn test_bank_executor_cache() {
             upgrade_authority_address: None,
         })
         .unwrap();
-    programdata_account.data_mut()[programdata_data_offset..].copy_from_slice(&elf);
+    let mut data = programdata_account.data().to_vec();
+    data[programdata_data_offset..].copy_from_slice(&elf);
+    programdata_account.set_data_from_slice(&data);
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -533,6 +533,14 @@ impl Account {
 }
 
 impl AccountSharedData {
+    pub fn is_shared(&self) -> bool {
+        Arc::strong_count(&self.data) > 1
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.data_mut().reserve(additional)
+    }
+
     fn data_mut(&mut self) -> &mut Vec<u8> {
         Arc::make_mut(&mut self.data)
     }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -541,6 +541,10 @@ impl AccountSharedData {
         self.data_mut().reserve(additional)
     }
 
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
     fn data_mut(&mut self) -> &mut Vec<u8> {
         Arc::make_mut(&mut self.data)
     }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -13,7 +13,9 @@ use {
     solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::Sysvar},
     std::{
         cell::{Ref, RefCell},
-        fmt, ptr,
+        fmt,
+        mem::MaybeUninit,
+        ptr,
         rc::Rc,
         sync::Arc,
     },
@@ -599,6 +601,10 @@ impl AccountSharedData {
 
     pub fn set_data(&mut self, data: Vec<u8>) {
         self.data = Arc::new(data);
+    }
+
+    pub fn spare_data_capacity_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.data_mut().spare_capacity_mut()
     }
 
     pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Self {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -617,6 +617,9 @@ pub mod delay_visibility_of_program_deployment {
 pub mod apply_cost_tracker_during_replay {
     solana_sdk::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
+pub mod bpf_account_data_direct_mapping {
+    solana_sdk::declare_id!("9gwzizfABsKUereT6phZZxbTzuAnovkgwpVVpdcSxv9h");
+}
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {
     solana_sdk::declare_id!("G6vbf1UBok8MWb8m25ex86aoQHeKTzDKzuZADHkShqm6");
@@ -822,6 +825,7 @@ lazy_static! {
         (clean_up_delegation_errors::id(), "Return InsufficientDelegation instead of InsufficientFunds or InsufficientStake where applicable #31206"),
         (vote_state_add_vote_latency::id(), "replace Lockout with LandedVote (including vote latency) in vote state #31264"),
         (checked_arithmetic_in_fee_validation::id(), "checked arithmetic in fee validation #31273"),
+        (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -59,13 +59,13 @@ pub type TransactionAccount = (Pubkey, AccountSharedData);
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransactionAccounts {
     accounts: Vec<RefCell<AccountSharedData>>,
-    // FIXME: use bitfield
+    // FIXXME: use bitfield
     touched_flags: RefCell<Box<[bool]>>,
     is_early_verification_of_account_modifications_enabled: bool,
 }
 
-#[cfg(not(target_os = "solana"))]
 impl TransactionAccounts {
+    #[cfg(not(target_os = "solana"))]
     fn new(
         accounts: Vec<RefCell<AccountSharedData>>,
         is_early_verification_of_account_modifications_enabled: bool,
@@ -85,6 +85,7 @@ impl TransactionAccounts {
         self.accounts.get(index as usize)
     }
 
+    #[cfg(not(target_os = "solana"))]
     pub fn touch(&self, index: IndexOfAccount) -> Result<(), InstructionError> {
         if self.is_early_verification_of_account_modifications_enabled {
             *self
@@ -96,6 +97,7 @@ impl TransactionAccounts {
         Ok(())
     }
 
+    #[cfg(not(target_os = "solana"))]
     pub fn touched_count(&self) -> usize {
         self.touched_flags
             .borrow()
@@ -142,7 +144,6 @@ impl TransactionAccounts {
 pub struct TransactionContext {
     account_keys: Pin<Box<[Pubkey]>>,
     accounts: Arc<TransactionAccounts>,
-    #[cfg(not(target_os = "solana"))]
     instruction_stack_capacity: usize,
     instruction_trace_capacity: usize,
     instruction_stack: Vec<usize>,

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -866,6 +866,7 @@ impl<'a> BorrowedAccount<'a> {
         Ok(())
     }
 
+    #[cfg(not(target_os = "solana"))]
     fn make_data_mut(&mut self) {
         // if the account is still shared, it means this is the first time we're
         // about to write into it. Make the account mutable by copying it in a

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -59,7 +59,6 @@ pub type TransactionAccount = (Pubkey, AccountSharedData);
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransactionAccounts {
     accounts: Vec<RefCell<AccountSharedData>>,
-    // FIXXME: use bitfield
     touched_flags: RefCell<Box<[bool]>>,
     is_early_verification_of_account_modifications_enabled: bool,
 }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -832,7 +832,7 @@ impl<'a> BorrowedAccount<'a> {
         }
         self.touch()?;
         self.update_accounts_resize_delta(new_length)?;
-        self.account.data_mut().resize(new_length, 0);
+        self.account.resize(new_length, 0);
         Ok(())
     }
 
@@ -849,7 +849,7 @@ impl<'a> BorrowedAccount<'a> {
 
         self.touch()?;
         self.update_accounts_resize_delta(new_len)?;
-        self.account.data_mut().extend_from_slice(data);
+        self.account.extend_from_slice(data);
         Ok(())
     }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -4,12 +4,15 @@
 #[cfg(all(not(target_os = "solana"), debug_assertions))]
 use crate::signature::Signature;
 #[cfg(not(target_os = "solana"))]
-use crate::{
-    account::WritableAccount,
-    rent::Rent,
-    system_instruction::{
-        MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION, MAX_PERMITTED_DATA_LENGTH,
+use {
+    crate::{
+        account::WritableAccount,
+        rent::Rent,
+        system_instruction::{
+            MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION, MAX_PERMITTED_DATA_LENGTH,
+        },
     },
+    solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE,
 };
 use {
     crate::{
@@ -17,7 +20,6 @@ use {
         instruction::InstructionError,
         pubkey::Pubkey,
     },
-    solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE,
     std::{
         cell::{RefCell, RefMut},
         collections::HashSet,


### PR DESCRIPTION
This PR introduces the `bpf_account_data_direct_mapping` feature. When enabled, account data is directly mapped into vm memory at vm setup time. This removes the need to have large copies during transaction execution, going in and out of the vm at each instruction/CPI boundary.

The only data copy left now is when an account is first mapped as writable during a transaction. That copy is unavoidable at the moment since accounts are cached in memory and written back only every N slots. I'm planning to try and remove that copy in a separate PR.

Feature gate issue: #29708