### PR TITLE
Revert "chore: bump serde_yaml from 0.8.26 to 0.9.13 (#27970)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,7 +3230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c53a5ade47760e8cc4986bdc5e72daeffaaaee64cbc374f9cfe0a00c1cd87b1f"
 dependencies = [
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -4279,19 +4279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
-dependencies = [
- "indexmap",
- "itoa 1.0.1",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4691,7 +4678,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml",
  "serial_test",
  "solana-clap-utils",
  "solana-cli-config",
@@ -4918,7 +4905,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "serde_yaml 0.9.13",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-sdk 1.15.0",
  "url 2.2.2",
@@ -5277,7 +5264,7 @@ dependencies = [
  "clap 2.33.3",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-entry",
@@ -5396,7 +5383,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.14",
  "serde",
- "serde_yaml 0.9.13",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-config-program",
  "solana-logger 1.15.0",
@@ -6632,7 +6619,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml",
  "signal-hook",
  "solana-clap-utils",
  "solana-cli-config",
@@ -7764,12 +7751,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "untrusted"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde_json = "1.0.83"
-serde_yaml = "0.9.13"
+serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-client = { path = "../client", version = "=1.15.0" }

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -14,7 +14,7 @@ dirs-next = "2.0.0"
 lazy_static = "1.4.0"
 serde = "1.0.144"
 serde_derive = "1.0.103"
-serde_yaml = "0.9.13"
+serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 url = "2.2.2"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.13.0"
 clap = "2.33.1"
 serde = "1.0.144"
 serde_json = "1.0.83"
-serde_yaml = "0.9.13"
+serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-entry = { path = "../entry", version = "=1.15.0" }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -25,7 +25,7 @@ nix = "0.25.0"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.14"
 serde = { version = "1.0.144", features = ["derive"] }
-serde_yaml = "0.9.13"
+serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-config-program = { path = "../programs/config", version = "=1.15.0" }
 solana-logger = { path = "../logger", version = "=1.15.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2309,6 +2309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,15 +3872,14 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.13"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
- "itoa",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -6923,12 +6928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7325,6 +7324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -29,7 +29,7 @@ rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.144"
 serde_json = "1.0.83"
-serde_yaml = "0.9.13"
+serde_yaml = "0.8.26"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-core = { path = "../core", version = "=1.15.0" }


### PR DESCRIPTION
https://github.com/solana-labs/solana/pull/27970#issuecomment-1257039425

This reverts commit da9206fb87c2e07738699cfc0567d52a7b8d9ad8.
