### PR TITLE
Add assertions for computed block cost limit constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6144,6 +6144,7 @@ dependencies = [
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk 1.15.0",
+ "static_assertions",
  "strum",
  "strum_macros",
  "symlink",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,6 +73,7 @@ ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 rand_chacha = "0.2.2"
 solana-logger = { path = "../logger", version = "=1.15.0" }
+static_assertions = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -56,13 +56,24 @@ lazy_static! {
 /// data size and built-in and BPF instructions.
 pub const MAX_BLOCK_UNITS: u64 =
     MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO * MAX_CONCURRENCY;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(MAX_BLOCK_UNITS, 48_000_000);
+
 /// Number of compute units that a writable account in a block is allowed. The
 /// limit is to prevent too many transactions write to same account, therefore
 /// reduce block's parallelism.
 pub const MAX_WRITABLE_ACCOUNT_UNITS: u64 = MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(MAX_WRITABLE_ACCOUNT_UNITS, 12_000_000);
+
 /// Number of compute units that a block can have for vote transactions,
 /// sets at ~75% of MAX_BLOCK_UNITS to leave room for non-vote transactions
 pub const MAX_VOTE_UNITS: u64 = (MAX_BLOCK_UNITS as f64 * 0.75_f64) as u64;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(MAX_VOTE_UNITS, 36_000_000);
 
 /// The maximum allowed size, in bytes, that accounts data can grow, per block.
 /// This can also be thought of as the maximum size of new allocations per block.


### PR DESCRIPTION
#### Problem
Hard to see what the block cost limit is because it is a computed constant

#### Summary of Changes
Add assertions to easily see what the computed constant values are

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
