### PR TITLE
Revert "hash cache get_slice"

### DIFF
--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -43,26 +43,10 @@ impl CacheHashDataFile {
 
     /// get '&T' from cache file [ix]
     fn get<T: Sized>(&self, ix: u64) -> &T {
-        // get cache file[ix..]
-        let slice = self.get_slice::<T>(ix);
-        // return [0]
-        &slice[0]
-    }
-
-    /// get '&[T]' from cache file [ix..]
-    fn get_slice<T: Sized>(&self, ix: u64) -> &[T] {
-        let start = (ix * self.cell_size) as usize + std::mem::size_of::<Header>();
-        let item_slice: &[u8] = &self.mmap[start..];
-        let remaining_elements = item_slice.len() / std::mem::size_of::<T>();
-        assert!(
-            remaining_elements > 0,
-            "ix: {ix}, remaining_elements: {remaining_elements}, capacity: {}",
-            self.mmap.len()
-        );
-
+        let item_slice = self.get_slice_internal::<T>(ix);
         unsafe {
             let item = item_slice.as_ptr() as *const T;
-            std::slice::from_raw_parts(item, remaining_elements)
+            &*item
         }
     }
 


### PR DESCRIPTION
Reverts solana-labs/solana#28018

Looks like this may be undefined behavior.
reverting until I can get to the bottom of that.