### PR TITLE
Add new compute-budget instruction to set transaction-wide accounts data size limit

### DIFF
--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -54,8 +54,9 @@ to.
 As the transaction is processed compute units are consumed by its
 instruction's programs performing operations such as executing BPF instructions,
 calling syscalls, etc... When the transaction consumes its entire budget, or
-exceeds a bound such as attempting a call stack that is too deep, the runtime
-halts the transaction processing and returns an error.
+exceeds a bound such as attempting a call stack that is too deep, or loaded
+account data exceeds limit, the runtime halts the transaction processing and
+returns an error.
 
 The following operations incur a compute cost:
 
@@ -142,6 +143,21 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
 
 ```rust
 let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
+```
+
+### Accounts data size limit
+
+A transaction should request the maximum bytes of accounts data it is
+allowed to load by including a `SetAccountsDataSizeLimit` instruction, requested
+limit is capped by `get_max_loaded_accounts_data_limit()`. If no
+`SetAccountsDataSizeLimit` is provided, the transaction is defaulted to
+have limit of `get_default_loaded_accounts_data_limit()`.
+
+The `ComputeBudgetInstruction::set_accounts_data_size_limit` function can be used
+to create this instruction:
+
+```rust
+let instruction = ComputeBudgetInstruction::set_accounts_data_size_limit(100_000);
 ```
 
 ## New Features

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -14,6 +14,33 @@ pub const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
 
+/// To change `default` and/or `max` values for `accounts_data_size_limit` in the future,
+/// add new enum type here, link to feature gate, and implement the enum in
+/// `get_default_loaded_accounts_data_limit()` and/or `get_max_loaded_accounts_data_limit()`.
+#[derive(Debug, Clone)]
+pub enum LoadedAccountsDataLimitType {
+    V0,
+    // add future versions here
+}
+
+/// Get default value of `ComputeBudget::accounts_data_size_limit` if not set specifically. It
+/// sets to 10MB initially, may be changed with feature gate.
+const DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 10_000_000;
+pub fn get_default_loaded_accounts_data_limit(limit_type: &LoadedAccountsDataLimitType) -> u32 {
+    match limit_type {
+        LoadedAccountsDataLimitType::V0 => DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT,
+    }
+}
+/// Get max value of `ComputeBudget::accounts_data_size_limit`, it caps value user
+/// sets via `ComputeBudgetInstruction::set_compute_unit_limit`. It is set to 100MB
+/// initially, can be changed with feature gate.
+const MAX_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 100_000_000;
+pub fn get_max_loaded_accounts_data_limit(limit_type: &LoadedAccountsDataLimitType) -> u32 {
+    match limit_type {
+        LoadedAccountsDataLimitType::V0 => MAX_LOADED_ACCOUNTS_DATA_LIMIT,
+    }
+}
+
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl ::solana_frozen_abi::abi_example::AbiExample for ComputeBudget {
     fn example() -> Self {
@@ -28,6 +55,8 @@ pub struct ComputeBudget {
     /// allowed to consume. Compute units are consumed by program execution,
     /// resources they use, etc...
     pub compute_unit_limit: u64,
+    /// Maximum accounts data size, in bytes, that a transaction is allowed to load
+    pub accounts_data_size_limit: u64,
     /// Number of compute units consumed by a log_u64 call
     pub log_64_units: u64,
     /// Number of compute units consumed by a create_program_address call
@@ -98,6 +127,7 @@ impl ComputeBudget {
     pub fn new(compute_unit_limit: u64) -> Self {
         ComputeBudget {
             compute_unit_limit,
+            accounts_data_size_limit: DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT as u64,
             log_64_units: 100,
             create_program_address_units: 1500,
             invoke_units: 1000,
@@ -134,11 +164,13 @@ impl ComputeBudget {
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
         default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
+        loaded_accounts_data_limit_type: LoadedAccountsDataLimitType,
     ) -> Result<PrioritizationFeeDetails, TransactionError> {
         let mut num_non_compute_budget_instructions: usize = 0;
         let mut updated_compute_unit_limit = None;
         let mut requested_heap_size = None;
         let mut prioritization_fee = None;
+        let mut updated_accounts_data_size_limit = None;
 
         for (i, (program_id, instruction)) in instructions.enumerate() {
             if compute_budget::check_id(program_id) {
@@ -182,6 +214,12 @@ impl ComputeBudget {
                         prioritization_fee =
                             Some(PrioritizationFeeType::ComputeUnitPrice(micro_lamports));
                     }
+                    Ok(ComputeBudgetInstruction::SetAccountsDataSizeLimit(bytes)) => {
+                        if updated_accounts_data_size_limit.is_some() {
+                            return Err(duplicate_instruction_error);
+                        }
+                        updated_accounts_data_size_limit = Some(bytes);
+                    }
                     _ => return Err(invalid_instruction_data_error),
                 }
             } else {
@@ -217,6 +255,14 @@ impl ComputeBudget {
         .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
         .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
 
+        self.accounts_data_size_limit = updated_accounts_data_size_limit
+            .unwrap_or_else(|| {
+                get_default_loaded_accounts_data_limit(&loaded_accounts_data_limit_type)
+            })
+            .min(get_max_loaded_accounts_data_limit(
+                &loaded_accounts_data_limit_type,
+            )) as u64;
+
         Ok(prioritization_fee
             .map(|fee_type| PrioritizationFeeDetails::new(fee_type, self.compute_unit_limit))
             .unwrap_or_default())
@@ -251,6 +297,7 @@ mod tests {
                 tx.message().program_instructions_iter(),
                 true,
                 false, /*not support request_units_deprecated*/
+                LoadedAccountsDataLimitType::V0,
             );
             assert_eq!($expected_result, result);
             assert_eq!(compute_budget, $expected_budget);
@@ -513,6 +560,86 @@ mod tests {
                 0,
                 InstructionError::InvalidInstructionData,
             )),
+            ComputeBudget::default()
+        );
+    }
+
+    #[test]
+    fn test_process_accounts_data_size_limit_instruction() {
+        test!(
+            &[],
+            Ok(PrioritizationFeeDetails::default()),
+            ComputeBudget {
+                compute_unit_limit: 0,
+                ..ComputeBudget::default()
+            }
+        );
+        test!(
+            &[
+                ComputeBudgetInstruction::set_accounts_data_size_limit(1),
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+            ],
+            Ok(PrioritizationFeeDetails::default()),
+            ComputeBudget {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                accounts_data_size_limit: 1,
+                ..ComputeBudget::default()
+            }
+        );
+        test!(
+            &[
+                ComputeBudgetInstruction::set_accounts_data_size_limit(
+                    get_max_loaded_accounts_data_limit(&LoadedAccountsDataLimitType::V0) + 1
+                ),
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+            ],
+            Ok(PrioritizationFeeDetails::default()),
+            ComputeBudget {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                accounts_data_size_limit: get_max_loaded_accounts_data_limit(
+                    &LoadedAccountsDataLimitType::V0
+                ) as u64,
+                ..ComputeBudget::default()
+            }
+        );
+        test!(
+            &[
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ComputeBudgetInstruction::set_accounts_data_size_limit(
+                    get_max_loaded_accounts_data_limit(&LoadedAccountsDataLimitType::V0)
+                ),
+            ],
+            Ok(PrioritizationFeeDetails::default()),
+            ComputeBudget {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                accounts_data_size_limit: get_max_loaded_accounts_data_limit(
+                    &LoadedAccountsDataLimitType::V0
+                ) as u64,
+                ..ComputeBudget::default()
+            }
+        );
+        test!(
+            &[
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ComputeBudgetInstruction::set_accounts_data_size_limit(1),
+            ],
+            Ok(PrioritizationFeeDetails::default()),
+            ComputeBudget {
+                compute_unit_limit: 3 * DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                accounts_data_size_limit: 1,
+                ..ComputeBudget::default()
+            }
+        );
+
+        test!(
+            &[
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ComputeBudgetInstruction::set_accounts_data_size_limit(1),
+                ComputeBudgetInstruction::set_accounts_data_size_limit(1),
+            ],
+            Err(TransactionError::DuplicateInstruction(2)),
             ComputeBudget::default()
         );
     }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -13,7 +13,10 @@ use {
     solana_bpf_rust_realloc::instructions::*,
     solana_bpf_rust_realloc_invoke::instructions::*,
     solana_ledger::token_balances::collect_token_balances,
-    solana_program_runtime::{compute_budget::ComputeBudget, timings::ExecuteTimings},
+    solana_program_runtime::{
+        compute_budget::{self, ComputeBudget},
+        timings::ExecuteTimings,
+    },
     solana_runtime::{
         bank::{
             DurableNonceFee, TransactionBalancesSet, TransactionExecutionDetails,
@@ -3799,6 +3802,7 @@ fn test_program_fees() {
         &fee_structure,
         true,
         false,
+        compute_budget::LoadedAccountsDataLimitType::V0,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3821,6 +3825,7 @@ fn test_program_fees() {
         &fee_structure,
         true,
         false,
+        compute_budget::LoadedAccountsDataLimitType::V0,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -561,6 +561,7 @@ impl Accounts {
                             fee_structure,
                             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
+                            Bank::get_loaded_accounts_data_limit_type(feature_set),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1425,7 +1426,7 @@ mod tests {
         },
         assert_matches::assert_matches,
         solana_address_lookup_table_program::state::LookupTableMeta,
-        solana_program_runtime::invoke_context::Executors,
+        solana_program_runtime::{compute_budget, invoke_context::Executors},
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             epoch_schedule::EpochSchedule,
@@ -1683,6 +1684,7 @@ mod tests {
             &FeeStructure::default(),
             true,
             false,
+            compute_budget::LoadedAccountsDataLimitType::V0,
         );
         assert_eq!(fee, lamports_per_signature);
 

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -1,5 +1,5 @@
 use {
-    solana_program_runtime::compute_budget::ComputeBudget,
+    solana_program_runtime::compute_budget::{self, ComputeBudget},
     solana_sdk::{
         instruction::CompiledInstruction,
         pubkey::Pubkey,
@@ -25,6 +25,8 @@ pub trait GetTransactionPriorityDetails {
                 instructions,
                 true,  // use default units per instruction
                 false, // stop supporting prioritization by request_units_deprecated instruction
+                compute_budget::LoadedAccountsDataLimitType::V0, // transaction priority doesn't
+                       // care about accounts data size.
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -39,6 +39,8 @@ pub enum ComputeBudgetInstruction {
     /// Set a compute unit price in "micro-lamports" to pay a higher transaction
     /// fee for higher transaction prioritization.
     SetComputeUnitPrice(u64),
+    /// Set a specific transaction-wide account data size limit, in bytes, is allowed to allocate.
+    SetAccountsDataSizeLimit(u32),
 }
 
 impl ComputeBudgetInstruction {
@@ -55,5 +57,10 @@ impl ComputeBudgetInstruction {
     /// Create a `ComputeBudgetInstruction::SetComputeUnitPrice` `Instruction`
     pub fn set_compute_unit_price(micro_lamports: u64) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::SetComputeUnitPrice(micro_lamports), vec![])
+    }
+
+    /// Create a `ComputeBudgetInstruction::SetAccountsDataSizeLimit` `Instruction`
+    pub fn set_accounts_data_size_limit(bytes: u32) -> Instruction {
+        Instruction::new_with_borsh(id(), &Self::SetAccountsDataSizeLimit(bytes), vec![])
     }
 }


### PR DESCRIPTION
#### Problem
Would be useful to have a separate instruction to specify max accounts data size a transaction can load.  As @jstarry mentioned it [here](https://github.com/solana-labs/solana/pull/27840#discussion_r974101253).

#### Summary of Changes
- Added new instruction, with default maximum value currently set to 100MB

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
