### PR TITLE
fix duplicate local variable

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1053,7 +1053,6 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 
         // merge all items into the disk index now
         let disk = self.bucket.as_ref().unwrap();
-        let mut duplicate = vec![];
         let mut count = 0;
         insert.into_iter().for_each(|(slot, k, v)| {
             let entry = (slot, v);
@@ -1066,7 +1065,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         slot_list.extend_from_slice(current_slot_list);
                         slot_list.push(entry); // will never be from the same slot that already exists in the list
                         ref_count += new_ref_count;
-                        duplicate.push((slot, k));
+                        duplicates.push((slot, k));
                         Some((slot_list, ref_count))
                     }
                     None => {


### PR DESCRIPTION
#### Problem

accidentally had a singular and plural version of 'duplicate'. Both were used so no compiler warnings.
The result was we were never cleaning initial old duplicate accounts we loaded from a snapshot.
Initial old duplicates could possibly not get cleaned for a very long time, leaving us a possible trail of old append vecs.

#### Summary of Changes
Remove duplicate 'duplicate' and use the same one.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
