### PR TITLE
Added option to turn on UDP for TPU transaction and make UDP based TPU off by default (backport #27462) (#27658)

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -37,6 +37,8 @@ pub const DEFAULT_TPU_USE_QUIC: bool = true;
 /// Default TPU connection pool size per remote address
 pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;
 
+pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
+
 #[derive(Default)]
 pub struct ConnectionCacheStats {
     cache_hits: AtomicU64,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -6,6 +6,7 @@ use {
         result::{Error, Result},
     },
     crossbeam_channel::{unbounded, RecvTimeoutError},
+    solana_client::connection_cache::DEFAULT_TPU_ENABLE_UDP,
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
     solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
     solana_poh::poh_recorder::PohRecorder,
@@ -57,6 +58,7 @@ impl FetchStage {
                 poh_recorder,
                 coalesce_ms,
                 None,
+                DEFAULT_TPU_ENABLE_UDP,
             ),
             receiver,
             vote_receiver,
@@ -76,6 +78,7 @@ impl FetchStage {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
+        tpu_enable_udp: bool,
     ) -> Self {
         let tx_sockets = sockets.into_iter().map(Arc::new).collect();
         let tpu_forwards_sockets = tpu_forwards_sockets.into_iter().map(Arc::new).collect();
@@ -92,6 +95,7 @@ impl FetchStage {
             poh_recorder,
             coalesce_ms,
             in_vote_only_mode,
+            tpu_enable_udp,
         )
     }
 
@@ -150,42 +154,52 @@ impl FetchStage {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
+        tpu_enable_udp: bool,
     ) -> Self {
         let recycler: PacketBatchRecycler = Recycler::warmed(1000, 1024);
 
         let tpu_stats = Arc::new(StreamerReceiveStats::new("tpu_receiver"));
-        let tpu_threads: Vec<_> = tpu_sockets
-            .into_iter()
-            .map(|socket| {
-                streamer::receiver(
-                    socket,
-                    exit.clone(),
-                    sender.clone(),
-                    recycler.clone(),
-                    tpu_stats.clone(),
-                    coalesce_ms,
-                    true,
-                    in_vote_only_mode.clone(),
-                )
-            })
-            .collect();
+
+        let tpu_threads: Vec<_> = if tpu_enable_udp {
+            tpu_sockets
+                .into_iter()
+                .map(|socket| {
+                    streamer::receiver(
+                        socket,
+                        exit.clone(),
+                        sender.clone(),
+                        recycler.clone(),
+                        tpu_stats.clone(),
+                        coalesce_ms,
+                        true,
+                        in_vote_only_mode.clone(),
+                    )
+                })
+                .collect()
+        } else {
+            Vec::default()
+        };
 
         let tpu_forward_stats = Arc::new(StreamerReceiveStats::new("tpu_forwards_receiver"));
-        let tpu_forwards_threads: Vec<_> = tpu_forwards_sockets
-            .into_iter()
-            .map(|socket| {
-                streamer::receiver(
-                    socket,
-                    exit.clone(),
-                    forward_sender.clone(),
-                    recycler.clone(),
-                    tpu_forward_stats.clone(),
-                    coalesce_ms,
-                    true,
-                    in_vote_only_mode.clone(),
-                )
-            })
-            .collect();
+        let tpu_forwards_threads: Vec<_> = if tpu_enable_udp {
+            tpu_forwards_sockets
+                .into_iter()
+                .map(|socket| {
+                    streamer::receiver(
+                        socket,
+                        exit.clone(),
+                        forward_sender.clone(),
+                        recycler.clone(),
+                        tpu_forward_stats.clone(),
+                        coalesce_ms,
+                        true,
+                        in_vote_only_mode.clone(),
+                    )
+                })
+                .collect()
+        } else {
+            Vec::default()
+        };
 
         let tpu_vote_stats = Arc::new(StreamerReceiveStats::new("tpu_vote_receiver"));
         let tpu_vote_threads: Vec<_> = tpu_vote_sockets

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -100,6 +100,7 @@ impl Tpu {
         connection_cache: &Arc<ConnectionCache>,
         keypair: &Keypair,
         staked_nodes: &Arc<RwLock<StakedNodes>>,
+        tpu_enable_udp: bool,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -125,6 +126,7 @@ impl Tpu {
             poh_recorder,
             tpu_coalesce_ms,
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
+            tpu_enable_udp,
         );
 
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -375,6 +375,7 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         use_quic: bool,
         tpu_connection_pool_size: usize,
+        tpu_enable_udp: bool,
     ) -> Self {
         let id = identity_keypair.pubkey();
         assert_eq!(id, node.info.id);
@@ -995,6 +996,7 @@ impl Validator {
             &connection_cache,
             &identity_keypair,
             &staked_nodes,
+            tpu_enable_udp,
         );
 
         datapoint_info!(
@@ -1850,7 +1852,9 @@ mod tests {
     use {
         super::*,
         crossbeam_channel::{bounded, RecvTimeoutError},
-        solana_client::connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
+        solana_client::connection_cache::{
+            DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        },
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
         std::{fs::remove_dir_all, thread, time::Duration},
@@ -1888,7 +1892,9 @@ mod tests {
             SocketAddrSpace::Unspecified,
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            DEFAULT_TPU_ENABLE_UDP,
         );
+
         assert_eq!(
             *start_progress.read().unwrap(),
             ValidatorStartProgress::Running
@@ -1984,6 +1990,7 @@ mod tests {
                     SocketAddrSpace::Unspecified,
                     DEFAULT_TPU_USE_QUIC,
                     DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                    DEFAULT_TPU_ENABLE_UDP,
                 )
             })
             .collect();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -8,7 +8,8 @@ use {
     log::*,
     solana_client::{
         connection_cache::{
-            ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
+            ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP,
+            DEFAULT_TPU_USE_QUIC,
         },
         thin_client::ThinClient,
     },
@@ -260,6 +261,7 @@ impl LocalCluster {
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            DEFAULT_TPU_ENABLE_UDP,
         );
 
         let mut validators = HashMap::new();
@@ -459,6 +461,7 @@ impl LocalCluster {
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            DEFAULT_TPU_ENABLE_UDP,
         );
 
         let validator_pubkey = validator_keypair.pubkey();
@@ -807,6 +810,7 @@ impl Cluster for LocalCluster {
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            DEFAULT_TPU_ENABLE_UDP,
         );
         cluster_validator_info.validator = Some(restarted_node);
         cluster_validator_info

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -61,6 +61,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --tpu-disable-quic ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-enable-udp ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --rpc-send-batch-ms ]]; then
       args+=("$1" "$2")
       shift 2

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -147,6 +147,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --tpu-use-quic ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-enable-udp ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --rpc-send-batch-ms ]]; then
       args+=("$1" "$2")
       shift 2

--- a/net/net.sh
+++ b/net/net.sh
@@ -107,6 +107,10 @@ Operate a configured testnet
                                       - Boot from a snapshot that has warped ahead to WARP_SLOT rather than a slot 0 genesis.
    --full-rpc
                                       - Support full RPC services on all nodes
+
+   --tpu-enable-udp
+                                      - Enable UDP for tpu transactions
+
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -316,6 +320,7 @@ startBootstrapLeader() {
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
          \"$TMPFS_ACCOUNTS\" \
+         \"$enableUdp\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -388,6 +393,7 @@ startNode() {
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
          \"$TMPFS_ACCOUNTS\" \
+         \"$enableUdp\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!
@@ -795,6 +801,7 @@ maybeWarpSlot=
 maybeFullRpc=false
 waitForNodeInit=true
 extraPrimordialStakes=0
+enableUdp=false
 
 command=$1
 [[ -n $command ]] || usage
@@ -903,6 +910,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 == --full-rpc ]]; then
       maybeFullRpc=true
+      shift 1
+    elif [[ $1 == --tpu-enable-udp ]]; then
+      enableUdp=true
       shift 1
     elif [[ $1 == --async-node-init ]]; then
       waitForNodeInit=false

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -28,6 +28,8 @@ maybeFullRpc="${19}"
 waitForNodeInit="${20}"
 extraPrimordialStakes="${21:=0}"
 tmpfsAccounts="${22:false}"
+enableUdp="${23}"
+
 set +x
 
 missing() {
@@ -283,6 +285,10 @@ EOF
       args+=(--enable-cpi-and-log-storage)
     fi
 
+    if $enableUdp; then
+      args+=(--tpu-enable-udp)
+    fi
+
     if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
       ./multinode-demo/faucet.sh > faucet.log 2>&1 &
@@ -409,6 +415,10 @@ EOF
     if $maybeFullRpc; then
       args+=(--enable-rpc-transaction-history)
       args+=(--enable-cpi-and-log-storage)
+    fi
+
+    if $enableUdp; then
+      args+=(--tpu-enable-udp)
     fi
 
 cat >> ~/solana/on-reboot <<EOF

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -237,7 +237,7 @@ fn test_rpc_subscriptions() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     transactions_socket.connect(test_validator.tpu()).unwrap();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -3,7 +3,9 @@ use {
     log::*,
     solana_cli_output::CliAccount,
     solana_client::{
-        connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
+        connection_cache::{
+            DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        },
         nonblocking,
         rpc_client::RpcClient,
     },
@@ -115,6 +117,7 @@ pub struct TestValidatorGenesis {
     pub geyser_plugin_config_files: Option<Vec<PathBuf>>,
     pub accounts_db_caching_enabled: bool,
     deactivate_feature_set: HashSet<Pubkey>,
+    pub tpu_enable_udp: bool,
 }
 
 impl Default for TestValidatorGenesis {
@@ -142,6 +145,7 @@ impl Default for TestValidatorGenesis {
             geyser_plugin_config_files: Option::<Vec<PathBuf>>::default(),
             accounts_db_caching_enabled: bool::default(),
             deactivate_feature_set: HashSet::<Pubkey>::default(),
+            tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
         }
     }
 }
@@ -167,6 +171,11 @@ impl TestValidatorGenesis {
     /// Check if a given TestValidator ledger has already been initialized
     pub fn ledger_exists(ledger_path: &Path) -> bool {
         ledger_path.join("vote-account-keypair.json").exists()
+    }
+
+    pub fn tpu_enable_udp(&mut self, tpu_enable_udp: bool) -> &mut Self {
+        self.tpu_enable_udp = tpu_enable_udp;
+        self
     }
 
     pub fn fee_rate_governor(&mut self, fee_rate_governor: FeeRateGovernor) -> &mut Self {
@@ -485,6 +494,25 @@ impl TestValidator {
             .expect("validator start failed")
     }
 
+    /// Create a test validator using udp for TPU.
+    pub fn with_no_fees_udp(
+        mint_address: Pubkey,
+        faucet_addr: Option<SocketAddr>,
+        socket_addr_space: SocketAddrSpace,
+    ) -> Self {
+        TestValidatorGenesis::default()
+            .tpu_enable_udp(true)
+            .fee_rate_governor(FeeRateGovernor::new(0, 0))
+            .rent(Rent {
+                lamports_per_byte_year: 1,
+                exemption_threshold: 1.0,
+                ..Rent::default()
+            })
+            .faucet_addr(faucet_addr)
+            .start_with_mint_address(mint_address, socket_addr_space)
+            .expect("validator start failed")
+    }
+
     /// Create and start a `TestValidator` with custom transaction fees and minimal rent.
     /// Faucet optional.
     ///
@@ -728,6 +756,7 @@ impl TestValidator {
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            config.tpu_enable_udp,
         ));
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -19,8 +19,10 @@ use {
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
     solana_client::{
-        connection_cache::DEFAULT_TPU_CONNECTION_POOL_SIZE, rpc_client::RpcClient,
-        rpc_config::RpcLeaderScheduleConfig, rpc_request::MAX_MULTIPLE_ACCOUNTS,
+        connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP},
+        rpc_client::RpcClient,
+        rpc_config::RpcLeaderScheduleConfig,
+        rpc_request::MAX_MULTIPLE_ACCOUNTS,
     },
     solana_core::{
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
@@ -1177,6 +1179,12 @@ pub fn main() {
                 .help("Do not use QUIC to send transactions."),
         )
         .arg(
+            Arg::with_name("tpu_enable_udp")
+                .long("tpu-enable-udp")
+                .takes_value(false)
+                .help("Enable UDP for receiving/sending transactions."),
+        )
+        .arg(
             Arg::with_name("disable_quic_servers")
                 .long("disable-quic-servers")
                 .takes_value(false)
@@ -2245,6 +2253,12 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = !matches.is_present("tpu_disable_quic");
+    let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
+        true
+    } else {
+        DEFAULT_TPU_ENABLE_UDP
+    };
+
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
@@ -2976,6 +2990,7 @@ pub fn main() {
         socket_addr_space,
         tpu_use_quic,
         tpu_connection_pool_size,
+        tpu_enable_udp,
     );
     *admin_service_post_init.write().unwrap() =
         Some(admin_rpc_service::AdminRpcRequestMetadataPostInit {


### PR DESCRIPTION

* Added option to turn on UDP for TPU transaction and make UDP based TPU off by default (#27462)

--tpu-enable-udp is introduced. And when this is on, the transaction receive and transaction forward is enabled using udp.

Except for a few tests which was hard-coded sending transactions using udp, most tests are being done with udp based tpu disabled.

(cherry picked from commit 7f223dc582dee5ec65739105907a9108b1a46bc7)

* Fixed merge conflicts

* Fixed another conflict

* Fixed a fmt

Co-authored-by: Lijun Wang <83639177+lijunwangs@users.noreply.github.com>

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
