### PR TITLE
Visualize transaction execution timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,11 +994,10 @@ dependencies = [
 [[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+source = "git+https://github.com/solana-labs/crossbeam?rev=f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4#f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.11",
 ]
 
 [[package]]
@@ -999,7 +1008,7 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.8",
 ]
 
 [[package]]
@@ -1008,7 +1017,7 @@ version = "0.9.5"
 source = "git+https://github.com/solana-labs/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.8",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -1022,6 +1031,15 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "git+https://github.com/solana-labs/crossbeam?rev=f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4#f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
 ]
 
 [[package]]
@@ -3792,7 +3810,7 @@ checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.8",
  "num_cpus",
 ]
 
@@ -6097,6 +6115,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bzip2",
+ "cpu-time",
  "crossbeam-channel",
  "dashmap 4.0.2",
  "dir-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
-source = "git+https://github.com/solana-labs/crossbeam?rev=f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4#f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4"
+source = "git+https://github.com/solana-labs/crossbeam?rev=212e86290a5268c0c08a39b11892118dd19a975a#212e86290a5268c0c08a39b11892118dd19a975a"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.11",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "crossbeam-utils"
 version = "0.8.11"
-source = "git+https://github.com/solana-labs/crossbeam?rev=f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4#f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4"
+source = "git+https://github.com/solana-labs/crossbeam?rev=212e86290a5268c0c08a39b11892118dd19a975a#212e86290a5268c0c08a39b11892118dd19a975a"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "strsim 0.10.0",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +2172,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4295,6 +4336,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6143,6 +6206,8 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
+ "serde_json",
+ "serde_with",
  "solana-address-lookup-table-program",
  "solana-bucket-map",
  "solana-compute-budget-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
-source = "git+https://github.com/solana-labs/crossbeam?rev=212e86290a5268c0c08a39b11892118dd19a975a#212e86290a5268c0c08a39b11892118dd19a975a"
+source = "git+https://github.com/solana-labs/crossbeam?rev=a8ef2a217c1ee3b54b57cc9117dceb8b64890a4b#a8ef2a217c1ee3b54b57cc9117dceb8b64890a4b"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.11",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "crossbeam-utils"
 version = "0.8.11"
-source = "git+https://github.com/solana-labs/crossbeam?rev=212e86290a5268c0c08a39b11892118dd19a975a#212e86290a5268c0c08a39b11892118dd19a975a"
+source = "git+https://github.com/solana-labs/crossbeam?rev=a8ef2a217c1ee3b54b57cc9117dceb8b64890a4b#a8ef2a217c1ee3b54b57cc9117dceb8b64890a4b"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,3 +104,4 @@ resolver = "2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 [patch.crates-io]
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+crossbeam-channel = { git = "https://github.com/solana-labs/crossbeam", rev = "f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,4 +104,4 @@ resolver = "2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 [patch.crates-io]
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-crossbeam-channel = { git = "https://github.com/solana-labs/crossbeam", rev = "f2ff9b27a0b71ed5c6dc8da19cb22d6308f4eaa4" }
+crossbeam-channel = { git = "https://github.com/solana-labs/crossbeam", rev = "212e86290a5268c0c08a39b11892118dd19a975a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,4 +104,4 @@ resolver = "2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 [patch.crates-io]
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-crossbeam-channel = { git = "https://github.com/solana-labs/crossbeam", rev = "212e86290a5268c0c08a39b11892118dd19a975a" }
+crossbeam-channel = { git = "https://github.com/solana-labs/crossbeam", rev = "a8ef2a217c1ee3b54b57cc9117dceb8b64890a4b" }

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -60,6 +60,15 @@ impl DataPoint {
         }
     }
 
+    pub fn at(timestamp: SystemTime, name: &'static str) -> Self {
+        DataPoint {
+            name,
+            timestamp,
+            tags: vec![],
+            fields: vec![],
+        }
+    }
+
     pub fn add_tag(&mut self, name: &'static str, value: &str) -> &mut Self {
         self.tags.push((name, value.to_string()));
         self
@@ -151,6 +160,56 @@ macro_rules! create_datapoint {
 }
 
 #[macro_export]
+macro_rules! create_datapoint_at {
+    (@field $point:ident $name:expr, $string:expr, String) => {
+        $point.add_field_str($name, &$string);
+    };
+    (@field $point:ident $name:expr, $value:expr, i64) => {
+        $point.add_field_i64($name, $value as i64);
+    };
+    (@field $point:ident $name:expr, $value:expr, f64) => {
+        $point.add_field_f64($name, $value as f64);
+    };
+    (@field $point:ident $name:expr, $value:expr, bool) => {
+        $point.add_field_bool($name, $value as bool);
+    };
+    (@tag $point:ident $tag_name:expr, $tag_value:expr) => {
+        $point.add_tag($tag_name, &$tag_value);
+    };
+
+    (@fields $point:ident) => {};
+
+    // process tags
+    (@fields $point:ident $tag_name:expr => $tag_value:expr, $($rest:tt)*) => {
+        $crate::create_datapoint!(@tag $point $tag_name, $tag_value);
+        $crate::create_datapoint!(@fields $point $($rest)*);
+    };
+    (@fields $point:ident $tag_name:expr => $tag_value:expr) => {
+        $crate::create_datapoint!(@tag $point $tag_name, $tag_value);
+    };
+
+    // process fields
+    (@fields $point:ident ($name:expr, $value:expr, $type:ident) , $($rest:tt)*) => {
+        $crate::create_datapoint!(@field $point $name, $value, $type);
+        $crate::create_datapoint!(@fields $point $($rest)*);
+    };
+    (@fields $point:ident ($name:expr, $value:expr, $type:ident)) => {
+        $crate::create_datapoint!(@field $point $name, $value, $type);
+    };
+
+    (@point $name:expr, $at:expr, $($fields:tt)+) => {
+        {
+            let mut point = $crate::datapoint::DataPoint::at($at, &$name);
+            $crate::create_datapoint!(@fields point $($fields)+);
+            point
+        }
+    };
+    (@point $name:expr, $at:expr) => {
+        $crate::datapoint::DataPoint::at($at, &$name)
+    };
+}
+
+#[macro_export]
 macro_rules! datapoint {
     ($level:expr, $name:expr) => {
         if log::log_enabled!($level) {
@@ -160,6 +219,20 @@ macro_rules! datapoint {
     ($level:expr, $name:expr, $($fields:tt)+) => {
         if log::log_enabled!($level) {
             $crate::submit($crate::create_datapoint!(@point $name, $($fields)+), $level);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! datapoint_at {
+    ($level:expr, $at:expr, $name:expr) => {
+        if log::log_enabled!($level) {
+            $crate::submit($crate::create_datapoint_at!(@point $name, $at), $level);
+        }
+    };
+    ($level:expr, $at:expr, $name:expr, $($fields:tt)+) => {
+        if log::log_enabled!($level) {
+            $crate::submit($crate::create_datapoint_at!(@point $name, $at, $($fields)+), $level);
         }
     };
 }
@@ -190,6 +263,16 @@ macro_rules! datapoint_info {
     };
     ($name:expr, $($fields:tt)+) => {
         $crate::datapoint!(log::Level::Info, $name, $($fields)+);
+    };
+}
+
+#[macro_export]
+macro_rules! datapoint_info_at {
+    ($at:expr, $name:expr) => {
+        $crate::datapoint_at!(log::Level::Info, $at, $name);
+    };
+    ($at:expr, $name:expr, $($fields:tt)+) => {
+        $crate::datapoint_at!(log::Level::Info, $at, $name, $($fields)+);
     };
 }
 

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -160,7 +160,7 @@ impl Default for MetricsAgent {
 
         Self::new(
             Arc::new(InfluxDbMetricsWriter::new()),
-            Duration::from_secs(10),
+            Duration::from_secs(1),
             max_points_per_sec,
         )
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,6 +41,8 @@ rayon = "1.5.3"
 regex = "1.5.6"
 serde = { version = "1.0.143", features = ["rc"] }
 serde_derive = "1.0.103"
+serde_json = "1.0.81"
+serde_with = "1.14.0"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.12.0" }
 solana-bucket-map = { path = "../bucket_map", version = "=1.12.0" }
 solana-compute-budget-program = { path = "../programs/compute-budget", version = "=1.12.0" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,6 +17,7 @@ bv = { version = "0.11.1", features = ["serde"] }
 bytemuck = "1.11.0"
 byteorder = "1.4.3"
 bzip2 = "0.4.3"
+cpu-time = "1.0.0"
 crossbeam-channel = "0.5"
 dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 dir-diff = "0.3.2"

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -212,7 +212,7 @@ fn record_transaction_timings(
         let (sender, receiver) = crossbeam_channel::unbounded::<TransactionTimings>();
         let _handle = std::thread::Builder::new()
             .name("solTxTimings".into())
-            .spawn(move || {
+            .spawn(move || loop {
                 while let Ok(transaction_timings) =
                     receiver.recv_timeout(std::time::Duration::from_millis(20))
                 {
@@ -223,7 +223,7 @@ fn record_transaction_timings(
                         ("index", transaction_timings.transaction_index, i64),
                         ("thread", transaction_timings.thread_name, String),
                         ("signature", &format!("{}", transaction_timings.sig), String),
-                        ("account_locks_in_json", "{}", String),
+                        ("account_locks_in_json", "{}", String), // todo
                         (
                             "status",
                             format!(
@@ -247,7 +247,7 @@ fn record_transaction_timings(
         sender
             .send_buffered(TransactionTimings {
                 slot,
-                transaction_index: 0,
+                transaction_index: 0, // todo
                 sig,
                 cu,
                 execution_result: Some(execution_result.clone().map(|_| ())),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4537,7 +4537,7 @@ impl Bank {
             std::thread::current().name().unwrap().into(),
             &process_message_time,
             &cpu_elapsed,
-            tx.get_transaction_priority_details().unwrap().priority,
+            tx.get_transaction_priority_details().map(|d| d.priority).unwrap_or_default(),
             account_locks_in_json,
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -197,7 +197,7 @@ fn record_transaction_timings(
         Option<crossbeam_channel::Sender<TransactionTimings>>,
     > = once_cell::sync::OnceCell::new();
     let maybe_sender = INSTANCE.get_or_init(|| {
-        let enable = std::env::var("TRANSACTION_TIMINGS").is_ok();
+        let enable = std::env::var("SOLANA_TRANSACTION_TIMINGS").is_ok();
         if !enable {
             return None;
         }


### PR DESCRIPTION
#### Problem

1. there's no easy way to see how's going with regards with scheduling for **both replay stage and banking stage**.

2. ryoqun never try to merge things, piling half-baked prs.

#### Summary of Changes

Try vizsualize it to solve the 1:

![image](https://user-images.githubusercontent.com/117807/192797155-9bf8f6c4-0128-4ed7-aae1-ca83f8461805.png)



for 2., ...meh. ;)


#### bare minimum docs for your fun:

Summary:

transaction timings are sent to influxdb first. then we fetch it via influxdb's ajax api from codepen-hosted front-end (d3.js/plot.js) directly inside browser.

alternatively, you can use binaries from https://github.com/ryoqun/solana/tree/banking-simulator-wip-with-unified-scheduler-from-tokyo-5-grand-integration in similar way

A: data recording setup

A.1. cherry-pick (and backport if needed) this
A.2. run local influxdb and initial configuration
A.3. run solana-ledger-tool with XXXXX

B: data viewing setup 

B.1. run lcp (a) with paired ssh tunnels (b)
B.2. open codepen (fork it and edit the query source code as you like)

Detailed steps:

A.1.

```
$ git
```

A.2.

```
$ sudo docker run --detach --publish 8086:8086 influxdb:1.7
```

**note that it's quick to fill up the docker image's data dir with sheer amount of individual transaction execution timings data!**

```
$ influx -host localhost
...
> CREATE DATABASE "transaction-timings"
```


A.3.

like this:

```
$ (set -x && SOLANA_METRICS_CONFIG="host=http://localhost:8086,db=transaction-timings,u=foo,p=bar" SOLANA_METRICS_MAX_POINTS_PER_SECOND=1000000 SOLANA_TRANSACTION_TIMINGS=1 EXECUTING_THREAD_COUNT=1 $(type -ap work/solana/target/release/solana-ledger-tool) --ledger mainnet-beta-bench-2022-09/ verify --accounts-db-skip-shrink --skip-poh-verify) &> ledger-tool-capitalization.log.$(date '+%Yy%mm%dd%Hh%Mm%Ss%Nns')
```

**NOTE: There's `assert!()`, but never spam solana's official influxdb with normal `SOLANA_METRICS_CONFIG`!**

B.1a.

install https://github.com/garmeeh/local-cors-proxy for your fav way on your local machine for your web browser. then run it like this (replace the ip; for convenience, this ip is publicly accessible for trouble-shooting):

```
$ ./node_modules/.bin/lcp --proxyUrl http://34.168.201.175:8088/ --port 8011
```

note: this is needed due to https://github.com/influxdata/influxdb/issues/1268

B.1b:

given:

```
$ sudo docker ps
CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS        PORTS                                       NAMES
ba9f0217c6ed   influxdb:1.7   "/entrypoint.sh infl…"   3 months ago   Up 3 months   0.0.0.0:8086->8086/tcp, :::8086->8086/tcp   admiring_mahavira
```

```
ssh -L localhost:8086:localhost:8086 you@your-host
```

B.2.

open and interact with the ui (i.e. source code): https://codepen.io/ryoqun/full/yLvmPrr


spin-off from: #27666 
context: #23548