### PR TITLE
width of hash calc bins was off by 1

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6895,7 +6895,7 @@ impl AccountsDb {
         let first_boundary =
             ((slot0 + MAX_ITEMS_PER_CHUNK) / MAX_ITEMS_PER_CHUNK) * MAX_ITEMS_PER_CHUNK;
 
-        let width = max_slot_inclusive - slot0;
+        let width = max_slot_inclusive - slot0 + 1;
         // 2 is for 2 special chunks - unaligned slots at the beginning and end
         let chunks = ancient_slot_count + 2 + (width as Slot / MAX_ITEMS_PER_CHUNK);
         (0..chunks)


### PR DESCRIPTION
#### Problem

correct off by 1 error in width calculation
This does not appear to have a practical effect, but it is an incorrect calculation of 'width'

#### Summary of Changes
add 1

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
