### PR TITLE
Implement timely vote credits feature for both Vote and VoteStateUpda…

### DIFF
--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -23,7 +23,7 @@ pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
         .iter()
         .map(|lockout| UiLockout {
             slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            confirmation_count: lockout.confirmation_count(),
         })
         .collect();
     let authorized_voters = vote_state
@@ -93,7 +93,7 @@ impl From<&Lockout> for UiLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
             slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            confirmation_count: lockout.confirmation_count(),
         }
     }
 }

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -21,9 +21,9 @@ pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
     let votes = vote_state
         .votes
         .iter()
-        .map(|lockout| UiLockout {
-            slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count(),
+        .map(|landed_vote| UiLockout {
+            slot: landed_vote.lockout.slot,
+            confirmation_count: landed_vote.lockout.confirmation_count,
         })
         .collect();
     let authorized_voters = vote_state
@@ -93,7 +93,7 @@ impl From<&Lockout> for UiLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
             slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count(),
+            confirmation_count: lockout.confirmation_count,
         }
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1540,7 +1540,7 @@ impl From<&Lockout> for CliLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
             slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            confirmation_count: lockout.confirmation_count(),
         }
     }
 }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -23,7 +23,7 @@ use {
         offline::*,
     },
     solana_cli_output::{
-        return_signers_with_config, CliEpochVotingHistory, CliLockout, CliVoteAccount,
+        return_signers_with_config, CliEpochVotingHistory, CliLandedVote, CliVoteAccount,
         ReturnSignersConfig,
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -1212,7 +1212,7 @@ pub fn process_show_vote_account(
 
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
 
-    let mut votes: Vec<CliLockout> = vec![];
+    let mut votes: Vec<CliLandedVote> = vec![];
     let mut epoch_voting_history: Vec<CliEpochVotingHistory> = vec![];
     if !vote_state.votes.is_empty() {
         for vote in &vote_state.votes {

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -227,11 +227,14 @@ impl AggregateCommitmentService {
         }
 
         for vote in &vote_state.votes {
-            while ancestors[ancestors_index] <= vote.slot {
+            while ancestors[ancestors_index] <= vote.lockout.slot {
                 commitment
                     .entry(ancestors[ancestors_index])
                     .or_insert_with(BlockCommitment::default)
-                    .increase_confirmation_stake(vote.confirmation_count() as usize, lamports);
+                    .increase_confirmation_stake(
+                        vote.lockout.confirmation_count as usize,
+                        lamports,
+                    );
                 ancestors_index += 1;
 
                 if ancestors_index == ancestors.len() {

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -231,7 +231,7 @@ impl AggregateCommitmentService {
                 commitment
                     .entry(ancestors[ancestors_index])
                     .or_insert_with(BlockCommitment::default)
-                    .increase_confirmation_stake(vote.confirmation_count as usize, lamports);
+                    .increase_confirmation_stake(vote.confirmation_count() as usize, lamports);
                 ancestors_index += 1;
 
                 if ancestors_index == ancestors.len() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,6 +69,7 @@ pub mod snapshot_packager_service;
 pub mod staked_nodes_updater_service;
 pub mod stats_reporter_service;
 pub mod system_monitor_service;
+mod tower1_10_40;
 mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2776,9 +2776,9 @@ impl ReplayStage {
                                         // root (possible due to supermajority roots being set on
                                         // startup), then we need to adjust the tower
                                         bank_vote_state.root_slot = Some(local_root);
-                                        bank_vote_state
-                                            .votes
-                                            .retain(|lockout| lockout.slot > local_root);
+                                        bank_vote_state.votes.retain(|landed_vote| {
+                                            landed_vote.lockout.slot > local_root
+                                        });
                                         info!(
                                             "Local root is larger than on chain root,
                                             overwrote bank root {:?} and updated votes {:?}",
@@ -2787,7 +2787,7 @@ impl ReplayStage {
 
                                         if let Some(first_vote) = bank_vote_state.votes.front() {
                                             assert!(ancestors
-                                                .get(&first_vote.slot)
+                                                .get(&first_vote.lockout.slot)
                                                 .expect(
                                                     "Ancestors map must contain an
                                                         entry for all slots on this fork

--- a/core/src/tower1_10_40.rs
+++ b/core/src/tower1_10_40.rs
@@ -6,17 +6,19 @@ use {
         pubkey::Pubkey,
         signature::{Signature, Signer},
     },
-    solana_vote_program::vote_state::{vote_state_1_10_40::VoteState1_10_40, BlockTimestamp, Vote},
+    solana_vote_program::vote_state::{
+        vote_state_1_10_40::VoteState1_10_40, BlockTimestamp, VoteTransaction,
+    },
 };
 
-#[frozen_abi(digest = "9MMo5b68z9JTmbXvtAnedgGocnvF43wj2Z1TGjRixkgX")]
+#[frozen_abi(digest = "DaN2dZDHJ4JRAvJFBUWo7ByQ3MhhYRXoJABbxhJ5eqMk")]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
-pub struct Tower1_7_14 {
+pub struct Tower1_10_40 {
     pub(crate) node_pubkey: Pubkey,
     pub(crate) threshold_depth: usize,
     pub(crate) threshold_size: f64,
     pub(crate) vote_state: VoteState1_10_40,
-    pub(crate) last_vote: Vote,
+    pub(crate) last_vote: VoteTransaction,
     #[serde(skip)]
     // The blockhash used in the last vote transaction, may or may not equal the
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
@@ -36,17 +38,17 @@ pub struct Tower1_7_14 {
     pub(crate) last_switch_threshold_check: Option<(Slot, SwitchForkDecision)>,
 }
 
-#[frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52")]
+#[frozen_abi(digest = "39y8iHULqCJ2JqyxLnjxotdK4hCFNfhSpD1mmz5YA6Du")]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, AbiExample)]
-pub struct SavedTower1_7_14 {
+pub struct SavedTower1_10_40 {
     pub(crate) signature: Signature,
     pub(crate) data: Vec<u8>,
     #[serde(skip)]
     pub(crate) node_pubkey: Pubkey,
 }
 
-impl SavedTower1_7_14 {
-    pub fn new<T: Signer>(tower: &Tower1_7_14, keypair: &T) -> Result<Self, TowerError> {
+impl SavedTower1_10_40 {
+    pub fn new<T: Signer>(tower: &Tower1_10_40, keypair: &T) -> Result<Self, TowerError> {
         let node_pubkey = keypair.pubkey();
         if tower.node_pubkey != node_pubkey {
             return Err(TowerError::WrongTower(format!(

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -713,9 +713,8 @@ mod tests {
         // Now send some new votes
         for i in 101..201 {
             let slots = std::iter::zip((i - 30)..(i + 1), (1..32).rev())
-                .map(|(slot, confirmation_count)| Lockout {
-                    slot,
-                    confirmation_count,
+                .map(|(slot, confirmation_count)| {
+                    Lockout::new_with_confirmation_count(slot, confirmation_count)
                 })
                 .into_iter()
                 .collect::<VecDeque<Lockout>>();

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -713,8 +713,9 @@ mod tests {
         // Now send some new votes
         for i in 101..201 {
             let slots = std::iter::zip((i - 30)..(i + 1), (1..32).rev())
-                .map(|(slot, confirmation_count)| {
-                    Lockout::new_with_confirmation_count(slot, confirmation_count)
+                .map(|(slot, confirmation_count)| Lockout {
+                    slot,
+                    confirmation_count,
                 })
                 .into_iter()
                 .collect::<VecDeque<Lockout>>();

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -111,7 +111,7 @@ impl VoteSimulator {
                         .unwrap()
                         .votes
                         .iter()
-                        .any(|lockout| lockout.slot == parent));
+                        .any(|landed_vote| landed_vote.lockout.slot == parent));
                 }
             }
             while new_bank.tick_height() < new_bank.max_tick_height() {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -521,13 +521,18 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
             let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
             if let Some(last_vote) = vote_state.votes.iter().last() {
                 let entry = last_votes.entry(vote_state.node_pubkey).or_insert((
-                    last_vote.slot,
+                    last_vote.lockout.slot,
                     vote_state.clone(),
                     *stake,
                     total_stake,
                 ));
-                if entry.0 < last_vote.slot {
-                    *entry = (last_vote.slot, vote_state.clone(), *stake, total_stake);
+                if entry.0 < last_vote.lockout.slot {
+                    *entry = (
+                        last_vote.lockout.slot,
+                        vote_state.clone(),
+                        *stake,
+                        total_stake,
+                    );
                 }
             }
         }
@@ -563,7 +568,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                 if let Some(last_vote) = vote_state.votes.iter().last() {
                     let validator_votes = all_votes.entry(vote_state.node_pubkey).or_default();
                     validator_votes
-                        .entry(last_vote.slot)
+                        .entry(last_vote.lockout.slot)
                         .or_insert_with(|| vote_state.clone());
                 }
             }
@@ -667,8 +672,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                             .iter()
                             .map(|vote| format!(
                                 "slot {} (conf={})",
-                                vote.slot,
-                                vote.confirmation_count()
+                                vote.lockout.slot, vote.lockout.confirmation_count
                             ))
                             .collect::<Vec<_>>()
                             .join("\n")
@@ -679,7 +683,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                         vote_state
                             .votes
                             .back()
-                            .map(|vote| vote.slot.to_string())
+                            .map(|vote| vote.lockout.slot.to_string())
                             .unwrap_or_else(|| "none".to_string())
                     )
                 };
@@ -727,7 +731,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                     vote_state
                         .votes
                         .iter()
-                        .map(|vote| format!("slot {} (conf={})", vote.slot, vote.confirmation_count()))
+                        .map(|vote| format!("slot {} (conf={})", vote.lockout.slot, vote.lockout.confirmation_count))
                         .collect::<Vec<_>>()
                         .join("\n")
                 ));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -667,7 +667,8 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                             .iter()
                             .map(|vote| format!(
                                 "slot {} (conf={})",
-                                vote.slot, vote.confirmation_count
+                                vote.slot,
+                                vote.confirmation_count()
                             ))
                             .collect::<Vec<_>>()
                             .join("\n")
@@ -726,7 +727,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                     vote_state
                         .votes
                         .iter()
-                        .map(|vote| format!("slot {} (conf={})", vote.slot, vote.confirmation_count))
+                        .map(|vote| format!("slot {} (conf={})", vote.slot, vote.confirmation_count()))
                         .collect::<Vec<_>>()
                         .join("\n")
                 ));

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1075,7 +1075,7 @@ impl ProgramTestContext {
         for _ in 0..number_of_credits {
             vote_state.increment_credits(epoch, 1);
         }
-        let versioned = VoteStateVersions::new_current(vote_state);
+        let versioned = VoteStateVersions::new(vote_state, true);
         vote_state::to(&versioned, &mut vote_account).unwrap();
         bank.store_account(vote_account_address, &vote_account);
     }

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -54,7 +54,7 @@ fn create_accounts() -> (
         );
 
         for next_vote_slot in 0..num_initial_votes {
-            vote_state.process_next_vote_slot(next_vote_slot, 0);
+            vote_state.process_next_vote_slot(next_vote_slot, 0, None);
         }
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
         let versioned = VoteStateVersions::new_current(vote_state);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -987,7 +987,7 @@ impl JsonRpcRequestProcessor {
                 let vote_state = account.vote_state();
                 let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
                 let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
-                    vote.slot
+                    vote.lockout.slot
                 } else {
                     0
                 };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7321,12 +7321,16 @@ pub mod tests {
             .unwrap();
         assert_ne!(leader_info.activated_stake, 0);
         // Subtract one because the last vote always carries over to the next epoch
-        let expected_credits = TEST_SLOTS_PER_EPOCH - MAX_LOCKOUT_HISTORY as u64 - 1;
+        // Each slot earned maximum credits
+        let credits_per_slot =
+            solana_vote_program::vote_state::VOTE_CREDITS_MAXIMUM_PER_SLOT as u64;
+        let expected_credits =
+            (TEST_SLOTS_PER_EPOCH - MAX_LOCKOUT_HISTORY as u64 - 1) * credits_per_slot;
         assert_eq!(
             leader_info.epoch_credits,
             vec![
                 (0, expected_credits, 0),
-                (1, expected_credits + 1, expected_credits) // one vote in current epoch
+                (1, expected_credits + credits_per_slot, expected_credits) // one vote in current epoch earning max credits
             ]
         );
 

--- a/sdk/program/src/vote/state/vote_state_1_10_40.rs
+++ b/sdk/program/src/vote/state/vote_state_1_10_40.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+const MAX_ITEMS: usize = 32;
+
+#[derive(AbiExample, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteState1_10_40 {
+    /// the node that votes in this account
+    pub node_pubkey: Pubkey,
+
+    /// the signer for withdrawals
+    pub authorized_withdrawer: Pubkey,
+    /// percentage (0-100) that represents what part of a rewards
+    ///  payout should be given to this VoteAccount
+    pub commission: u8,
+
+    pub votes: VecDeque<Lockout>,
+
+    // This usually the last Lockout which was popped from self.votes.
+    // However, it can be arbitrary slot, when being used inside Tower
+    pub root_slot: Option<Slot>,
+
+    /// the signer for vote transactions
+    pub authorized_voters: AuthorizedVoters,
+
+    /// history of prior authorized voters and the epochs for which
+    /// they were set, the bottom end of the range is inclusive,
+    /// the top of the range is exclusive
+    pub prior_voters: CircBuf<(Pubkey, Epoch, Epoch)>,
+
+    /// history of how many credits earned by the end of each epoch
+    ///  each tuple is (Epoch, credits, prev_credits)
+    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+
+    /// most recent timestamp submitted with a vote
+    pub last_timestamp: BlockTimestamp,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
+pub struct CircBuf<I> {
+    pub buf: [I; MAX_ITEMS],
+    /// next pointer
+    pub idx: usize,
+    pub is_empty: bool,
+}
+
+impl<I: Default + Copy> Default for CircBuf<I> {
+    #[allow(clippy::integer_arithmetic)]
+    fn default() -> Self {
+        Self {
+            buf: [I::default(); MAX_ITEMS],
+            idx: MAX_ITEMS - 1,
+            is_empty: true,
+        }
+    }
+}
+
+impl<I> CircBuf<I> {
+    #[allow(clippy::integer_arithmetic)]
+    pub fn append(&mut self, item: I) {
+        // remember prior delegate and when we switched, to support later slashing
+        self.idx += 1;
+        self.idx %= MAX_ITEMS;
+
+        self.buf[self.idx] = item;
+        self.is_empty = false;
+    }
+
+    pub fn buf(&self) -> &[I; MAX_ITEMS] {
+        &self.buf
+    }
+
+    pub fn last(&self) -> Option<&I> {
+        if !self.is_empty {
+            Some(&self.buf[self.idx])
+        } else {
+            None
+        }
+    }
+}

--- a/sdk/program/src/vote/state/vote_state_versions.rs
+++ b/sdk/program/src/vote/state/vote_state_versions.rs
@@ -1,14 +1,44 @@
-use super::{vote_state_0_23_5::VoteState0_23_5, *};
+use super::{vote_state_0_23_5::VoteState0_23_5, vote_state_1_10_40::VoteState1_10_40, *};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum VoteStateVersions {
     V0_23_5(Box<VoteState0_23_5>),
+    V1_10_40(Box<VoteState1_10_40>),
     Current(Box<VoteState>),
 }
 
 impl VoteStateVersions {
-    pub fn new_current(vote_state: VoteState) -> Self {
-        Self::Current(Box::new(vote_state))
+    pub fn new(vote_state: VoteState, use_current: bool) -> Self {
+        // The version of vote state to use depends on the timely vote credits feature.  When this feature is enabled,
+        // it introduces the use of new fields, and so the vote state must include values for those new fields.
+        // Before this feature is enabled, the older version of vote state can be used since the fields in question
+        // have sensible default values and are not used until the feature is enabled anyway.  Allowing the older
+        // version to continue to be used until the feature is enabled will prevent incompatibilities in snapshot
+        // account loading.
+        if use_current {
+            Self::Current(Box::new(vote_state))
+        } else {
+            // Create a downgraded version of the vote state
+            Self::V1_10_40(Box::new(VoteState1_10_40 {
+                node_pubkey: vote_state.node_pubkey,
+                authorized_withdrawer: vote_state.authorized_withdrawer,
+                commission: vote_state.commission,
+                votes: vote_state
+                    .votes
+                    .iter()
+                    .map(|landed_vote| landed_vote.lockout)
+                    .collect(),
+                root_slot: vote_state.root_slot,
+                authorized_voters: vote_state.authorized_voters,
+                prior_voters: vote_state_1_10_40::CircBuf::<(Pubkey, Epoch, Epoch)> {
+                    buf: vote_state.prior_voters.buf,
+                    idx: vote_state.prior_voters.idx,
+                    is_empty: vote_state.prior_voters.is_empty,
+                },
+                epoch_credits: vote_state.epoch_credits,
+                last_timestamp: vote_state.last_timestamp,
+            }))
+        }
     }
 
     pub fn convert_to_current(self) -> VoteState {
@@ -27,7 +57,14 @@ impl VoteStateVersions {
                     ///  payout should be given to this VoteAccount
                     commission: state.commission,
 
-                    votes: state.votes.clone(),
+                    votes: state
+                        .votes
+                        .iter()
+                        .map(|lockout| LandedVote {
+                            latency: 0,
+                            lockout: lockout.clone(),
+                        })
+                        .collect(),
 
                     root_slot: state.root_slot,
 
@@ -47,6 +84,35 @@ impl VoteStateVersions {
                     last_timestamp: state.last_timestamp.clone(),
                 }
             }
+
+            VoteStateVersions::V1_10_40(state) => {
+                // Current version after v1.10.40 converted votes from Lockouts to LandedVotes, all other fields are
+                // unchanged
+                VoteState {
+                    node_pubkey: state.node_pubkey,
+                    authorized_withdrawer: state.authorized_withdrawer,
+                    commission: state.commission,
+                    /// When converting from an older version, 0 latency
+                    /// is stored here, which the voting code will understand as "latency
+                    /// not provided"
+                    votes: state
+                        .votes
+                        .iter()
+                        .map(|lockout| LandedVote {
+                            latency: 0,
+                            lockout: lockout.clone(),
+                        })
+                        .collect(),
+                    root_slot: state.root_slot,
+                    authorized_voters: state.authorized_voters.clone(),
+                    prior_voters: CircBuf::<(Pubkey, Epoch, Epoch)>::new_from_1_10_40(
+                        state.prior_voters,
+                    ),
+                    epoch_credits: state.epoch_credits.clone(),
+                    last_timestamp: state.last_timestamp.clone(),
+                }
+            }
+
             VoteStateVersions::Current(state) => *state,
         }
     }
@@ -56,6 +122,8 @@ impl VoteStateVersions {
             VoteStateVersions::V0_23_5(vote_state) => {
                 vote_state.authorized_voter == Pubkey::default()
             }
+
+            VoteStateVersions::V1_10_40(vote_state) => vote_state.authorized_voters.is_empty(),
 
             VoteStateVersions::Current(vote_state) => vote_state.authorized_voters.is_empty(),
         }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -550,6 +550,10 @@ pub mod alt_bn128_syscall_enabled {
     solana_sdk::declare_id!("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXALTBN128");
 }
 
+pub mod timely_vote_credits {
+    solana_sdk::declare_id!("Dq8BsQXXxvJfpSgzsD4YM3ydNwAbVwKQXgTy7HNTm5hE");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -682,6 +686,7 @@ lazy_static! {
         (enable_bpf_loader_set_authority_checked_ix::id(), "enable bpf upgradeable loader SetAuthorityChecked instruction #28424"),
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
         (alt_bn128_syscall_enabled::id(), "add alt_bn128 syscalls"),
+        (timely_vote_credits::id(), "use timeliness of votes in determining credits to award"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
…te transactions.

#### Problem

Validators can submit votes with induced latency in an attempt to predict forking behavior that leads to higher vote credits.


#### Summary of Changes

Re-purpose the top 8 bits of Lockout.confirmation_count to hold the "latency" of each slot voted on.  This latency is calculated as the difference between the slot that is being voted on and the slot in which the Vote or VoteStateUpdate transaction landed.  This latency is stored in the "remote VoteState" for each validator, and since all validators receive and process Vote and VoteStateUpdate transactions in the same slots, results in all validators always agreeing on these computed latencies.  The latencies are used whenever a voted on slot is rooted, which then uses a latency based credits award instead of a single credit for all rooted slots regardless of latency.

Fixes #19002 
