### PR TITLE
Cleanup solana-ledger-tool slot output

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -215,13 +215,14 @@ fn output_slot(
 
     if *method == LedgerOutputMethod::Print {
         if let Ok(Some(meta)) = blockstore.meta(slot) {
-            if verbose_level >= 2 {
-                println!(" Slot Meta {:?} is_full: {}", meta, is_full);
+            if verbose_level >= 1 {
+                println!("  {:?} is_full: {}", meta, is_full);
             } else {
                 println!(
-                    " num_shreds: {}, parent_slot: {:?}, num_entries: {}, is_full: {}",
+                    "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, is_full: {}",
                     num_shreds,
                     meta.parent_slot,
+                    meta.next_slots,
                     entries.len(),
                     is_full,
                 );


### PR DESCRIPTION
#### Problem
In order to see the full SlotMeta, you have to pass `-vv`; this dumps out all the entries / transactions which is a massive wall of text.

#### Summary of Changes
- Display the full SlotMeta for `verbosity >= 1` instead of `verbosity >= 2`
- Print `next_slots` for `verbosity == 0`
- Remove "Slot Meta" text as `fmt` trait will display the struct name anyways
- Make leading spaces consistent

This is a pretty subtle change, but saves either a ton of scrolling or having to tack on `head -n X` to the command when using `-vv`

#### Before
```
// verbosity == 0
Slot 152886692
 num_shreds: 1358, parent_slot: Some(152886691), num_entries: 371, is_full: true

// verbosity == 1
Slot 152886692
 num_shreds: 1358, parent_slot: Some(152886691), num_entries: 371, is_full: true
  Transactions: 3458, hashes: 800000, block_hash: 2tc68Znwhw6oCkK1XjXxUK3hYxeJdhgk7MWVBEhdqtUo
  Programs:
Vote111111111111111111
...

// verbosity == 2
Slot 152886692
 Slot Meta SlotMeta { slot: 152886692, consumed: 1358, received: 1358, first_shred_timestamp: 1664424413090, last_index: Some(1357), parent_slot: Some(152886691), next_slots: [152886693], connected_flags: CONNECTED | PARENT_CONNECTED, completed_data_indexes: {0, 17, 21, 22, 24, 44, 46, 47, 48, 49, 50, 71, 72, 73, 74, 75, 100, 101, 103, 104, 105, 107, 108, 110, 111, 137, 160, 181, 182, 183, 204, 207, 209, 229, 230, 231, 252, 257, 258, 259, 262, 283, 284, 286, 287, 309, 310, 312, 313, 314, 335, 337, 339, 341, 342, 344, 345, 346, 348, 353, 355, 376, 377, 382, 384, 385, 406, 409, 411, 413, 414, 415, 438, 439, 440, 443, 464, 493, 495, 498, 505, 506, 507, 510, 511, 533, 536, 537, 538, 539, 541, 543, 546, 547, 551, 552, 553, 554, 555, 556, 577, 581, 585, 588, 589, 590, 591, 592, 615, 619, 622, 623, 625, 646, 647, 651, 672, 674, 677, 698, 700, 701, 703, 704, 726, 728, 731, 733, 754, 757, 782, 783, 784, 785, 786, 806, 808, 810, 811, 831, 856, 858, 860, 861, 865, 866, 890, 891, 892, 913, 915, 918, 919, 920, 921, 923, 924, 927, 950, 951, 952, 953, 976, 979, 981, 982, 983, 985, 986, 1008, 1010, 1014, 1035, 1036, 1039, 1042, 1043, 1044, 1064, 1065, 1066, 1068, 1069, 1070, 1090, 1091, 1092, 1093, 1094, 1095, 1097, 1118, 1119, 1141, 1142, 1144, 1165, 1169, 1170, 1171, 1194, 1195, 1196, 1199, 1222, 1225, 1226, 1227, 1229, 1250, 1253, 1256, 1278, 1299, 1300, 1301, 1328, 1353, 1355, 1356, 1357} } is_full: true
   Entry 0 - num_hashes: 12500, hash: AT2BkCJPHUgbweRPJ6L74TFTDmutgFdHLxWqBNJ5acxC, transactions: 0
   ...
```
#### After
```
// verbosity == 0
Slot 152886692
  num_shreds: 1358, parent_slot: Some(152886691), next_slots [152886693], num_entries: 371, is_full: true

// verbosity == 1
Slot 152886692
  SlotMeta { slot: 152886692, consumed: 1358, received: 1358, first_shred_timestamp: 1664424413090, last_index: Some(1357), parent_slot: Some(152886691), next_slots: [152886693], connected_flags: CONNECTED | PARENT_CONNECTED, completed_data_indexes: {0, 17, 21, 22, 24, 44, 46, 47, 48, 49, 50, 71, 72, 73, 74, 75, 100, 101, 103, 104, 105, 107, 108, 110, 111, 137, 160, 181, 182, 183, 204, 207, 209, 229, 230, 231, 252, 257, 258, 259, 262, 283, 284, 286, 287, 309, 310, 312, 313, 314, 335, 337, 339, 341, 342, 344, 345, 346, 348, 353, 355, 376, 377, 382, 384, 385, 406, 409, 411, 413, 414, 415, 438, 439, 440, 443, 464, 493, 495, 498, 505, 506, 507, 510, 511, 533, 536, 537, 538, 539, 541, 543, 546, 547, 551, 552, 553, 554, 555, 556, 577, 581, 585, 588, 589, 590, 591, 592, 615, 619, 622, 623, 625, 646, 647, 651, 672, 674, 677, 698, 700, 701, 703, 704, 726, 728, 731, 733, 754, 757, 782, 783, 784, 785, 786, 806, 808, 810, 811, 831, 856, 858, 860, 861, 865, 866, 890, 891, 892, 913, 915, 918, 919, 920, 921, 923, 924, 927, 950, 951, 952, 953, 976, 979, 981, 982, 983, 985, 986, 1008, 1010, 1014, 1035, 1036, 1039, 1042, 1043, 1044, 1064, 1065, 1066, 1068, 1069, 1070, 1090, 1091, 1092, 1093, 1094, 1095, 1097, 1118, 1119, 1141, 1142, 1144, 1165, 1169, 1170, 1171, 1194, 1195, 1196, 1199, 1222, 1225, 1226, 1227, 1229, 1250, 1253, 1256, 1278, 1299, 1300, 1301, 1328, 1353, 1355, 1356, 1357} } is_full: true
  Transactions: 3458, hashes: 800000, block_hash: 2tc68Znwhw6oCkK1XjXxUK3hYxeJdhgk7MWVBEhdqtUo
  Programs:
Vote111111111111111111111111111111111111111 : 3063
...

// verbosity == 2
Slot 152886692
  SlotMeta { slot: 152886692, consumed: 1358, received: 1358, first_shred_timestamp: 1664424413090, last_index: Some(1357), parent_slot: Some(152886691), next_slots: [152886693], connected_flags: CONNECTED | PARENT_CONNECTED, completed_data_indexes: {0, 17, 21, 22, 24, 44, 46, 47, 48, 49, 50, 71, 72, 73, 74, 75, 100, 101, 103, 104, 105, 107, 108, 110, 111, 137, 160, 181, 182, 183, 204, 207, 209, 229, 230, 231, 252, 257, 258, 259, 262, 283, 284, 286, 287, 309, 310, 312, 313, 314, 335, 337, 339, 341, 342, 344, 345, 346, 348, 353, 355, 376, 377, 382, 384, 385, 406, 409, 411, 413, 414, 415, 438, 439, 440, 443, 464, 493, 495, 498, 505, 506, 507, 510, 511, 533, 536, 537, 538, 539, 541, 543, 546, 547, 551, 552, 553, 554, 555, 556, 577, 581, 585, 588, 589, 590, 591, 592, 615, 619, 622, 623, 625, 646, 647, 651, 672, 674, 677, 698, 700, 701, 703, 704, 726, 728, 731, 733, 754, 757, 782, 783, 784, 785, 786, 806, 808, 810, 811, 831, 856, 858, 860, 861, 865, 866, 890, 891, 892, 913, 915, 918, 919, 920, 921, 923, 924, 927, 950, 951, 952, 953, 976, 979, 981, 982, 983, 985, 986, 1008, 1010, 1014, 1035, 1036, 1039, 1042, 1043, 1044, 1064, 1065, 1066, 1068, 1069, 1070, 1090, 1091, 1092, 1093, 1094, 1095, 1097, 1118, 1119, 1141, 1142, 1144, 1165, 1169, 1170, 1171, 1194, 1195, 1196, 1199, 1222, 1225, 1226, 1227, 1229, 1250, 1253, 1256, 1278, 1299, 1300, 1301, 1328, 1353, 1355, 1356, 1357} } is_full: true
  Entry 0 - num_hashes: 12500, hash: AT2BkCJPHUgbweRPJ6L74TFTDmutgFdHLxWqBNJ5acxC, transactions: 0
  ...
```  