### PR TITLE
Optimize repair requests handling 

### DIFF
--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -24,6 +24,7 @@ use {
         blockstore::Blockstore,
         shred::{Nonce, Shred, ShredFetchStats, SIZE_OF_NONCE},
     },
+    solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_debug,
     solana_perf::{
         data_budget::DataBudget,
@@ -169,6 +170,8 @@ struct ServeRepairStats {
     err_sig_verify: usize,
     err_unsigned: usize,
     err_id_mismatch: usize,
+    receive_repair_request_us: u64,
+    handle_repair_request_us: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -456,6 +459,7 @@ impl ServeRepair {
     ) -> Result<()> {
         //TODO cache connections
         let timeout = Duration::new(1, 0);
+        let mut receive_repair_request_elapsed = Measure::start("receive_repair_request");
         let mut reqs_v = vec![requests_receiver.recv_timeout(timeout)?];
         const MAX_REQUESTS_PER_ITERATION: usize = 1024;
         let mut total_requests = reqs_v[0].len();
@@ -465,15 +469,17 @@ impl ServeRepair {
             total_requests += more.len();
             if total_requests > MAX_REQUESTS_PER_ITERATION {
                 dropped_requests += more.len();
-                break;
             } else {
                 reqs_v.push(more);
             }
         }
+        receive_repair_request_elapsed.stop();
+        stats.receive_repair_request_us += receive_repair_request_elapsed.as_us();
 
         stats.dropped_requests_load_shed += dropped_requests;
         stats.total_requests += total_requests;
 
+        let mut handle_repair_request_elapsed = Measure::start("handle_repair_request");
         let root_bank = self.bank_forks.read().unwrap().root_bank();
         for reqs in reqs_v {
             self.handle_packets(
@@ -487,6 +493,8 @@ impl ServeRepair {
                 data_budget,
             );
         }
+        handle_repair_request_elapsed.stop();
+        stats.handle_repair_request_us += handle_repair_request_elapsed.as_us();
         Ok(())
     }
 
@@ -540,6 +548,17 @@ impl ServeRepair {
             ("err_sig_verify", stats.err_sig_verify, i64),
             ("err_unsigned", stats.err_unsigned, i64),
             ("err_id_mismatch", stats.err_id_mismatch, i64),
+            ("err_id_mismatch", stats.err_id_mismatch, i64),
+            (
+                "receive_repair_request_us",
+                stats.receive_repair_request_us as i64,
+                i64
+            ),
+            (
+                "handle_repair_request_us",
+                stats.handle_repair_request_us as i64,
+                i64
+            ),
         );
 
         *stats = ServeRepairStats::default();

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -456,7 +456,7 @@ impl ServeRepair {
     ) -> Result<()> {
         //TODO cache connections
         let timeout = Duration::new(1, 0);
-        const MAX_REQUESTS_PER_ITERATION: usize = 1024;
+        const MAX_REQUESTS_PER_ITERATION: usize = 10000;
         let mut total_requests = 0;
         let root_bank = self.bank_forks.read().unwrap().root_bank();
 

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -465,6 +465,7 @@ impl ServeRepair {
             total_requests += more.len();
             if total_requests > MAX_REQUESTS_PER_ITERATION {
                 dropped_requests += more.len();
+                break;
             } else {
                 reqs_v.push(more);
             }


### PR DESCRIPTION
#### Problem

We are seeing high dropped service repair requests on testnet.

https://github.com/solana-labs/solana/pull/27959#issuecomment-1261489750

For nodes with high stake (shown in the above comments), 758K repair requests are dropped. 

The repair request handling code needs to be optimized.  From profiling it estimates to take 100 micros to handle a repair request, that is about 10K/s.

Currently, Repair service listener first buffers up to 1K request packets from the channel, then discards the excessive packets, and processes the requests at last. 

The threshold of 1K is too small and can lead to excessive packet drops. The threshold can be increased up to 10K.   
The request handling doesn't need to wait for buffering and discarding. 

#### Summary of Changes

Increase the cut off threshold to 10K.
Remove buffering, process the request as it is received, and then discard excessive packets. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
