### PR TITLE
chore: use cargo-ndk@2.11.0

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -53,7 +53,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Install cargo-ndk
         if: ${{ matrix.platform == 'android' }}
-        run: cargo install cargo-ndk
+        run: cargo install cargo-ndk@2.11.0
       - name: Install NDK 21
         if: ${{ matrix.platform == 'android' }}
         run: |


### PR DESCRIPTION
#### Problem

seems the latest cargo-ndk killed us due to this commit
https://github.com/bbqsrc/cargo-ndk/commit/e5896937b4feb762b64be77d8efcb700ee836642

#### Summary of Changes

use cargo-ndk@2.11.0 for a while
