### PR TITLE
Check for newer incremental snapshot before downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,7 +5106,9 @@ dependencies = [
  "console",
  "indicatif",
  "log",
+ "regex",
  "reqwest",
+ "solana-rpc",
  "solana-runtime",
  "solana-sdk 1.15.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,7 +5106,6 @@ dependencies = [
  "console",
  "indicatif",
  "log",
- "regex",
  "reqwest",
  "solana-rpc",
  "solana-runtime",

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 console = "0.15.0"
 indicatif = "0.17.1"
 log = "0.4.17"
-regex = "1.6.0"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-rpc = { path = "../rpc", version = "=1.15.0" }
 solana-runtime = { path = "../runtime", version = "=1.15.0" }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -13,7 +13,9 @@ edition = "2021"
 console = "0.15.0"
 indicatif = "0.17.1"
 log = "0.4.17"
+regex = "1.6.0"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+solana-rpc = { path = "../rpc", version = "=1.15.0" }
 solana-runtime = { path = "../runtime", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -346,7 +346,7 @@ pub fn check_for_newer_incremental_snapshot(
     let incremental_snapshot_url = String::from_str(response.url().path()).ok()?;
     let (full_slot, recent_inc_slot, recent_inc_hash, _format) =
         snapshot_utils::parse_incremental_snapshot_archive_filename(
-            &incremental_snapshot_url.as_str(),
+            incremental_snapshot_url.as_str(),
         )
         .ok()?;
 

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -3,7 +3,6 @@ use {
     console::Emoji,
     indicatif::{ProgressBar, ProgressStyle},
     log::*,
-    regex::Regex,
     solana_rpc::rpc_service::INCREMENTAL_SNAPSHOT_REQUEST_PATH,
     solana_runtime::{
         snapshot_package::SnapshotType,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -362,7 +362,7 @@ pub fn check_for_newer_incremental_snapshot(
     // Expected URL format: /incremental-snapshot-<full slot>-<incremental slot>-<incremental slot hash>.tar.zst
     // eg: "/incremental-snapshot-152074294-152089382-BqBphVi1gnim96v6xXim7xq1L2PDFX3aDjd1Nn7SbRFM.tar.zst"
     let re = Regex::new(r"incremental-snapshot-([0-9]*)-([0-9]*)-(\w*)\.").unwrap();
-    let captures = re.captures(&incremental_snapshot_url.as_str());
+    let captures = re.captures(incremental_snapshot_url.as_str());
     let captures = match captures {
         Some(c) => c,
         None => {
@@ -405,8 +405,8 @@ pub fn check_for_newer_incremental_snapshot(
     };
 
     if full_snapshot_slot == full_slot && recent_inc_slot > incremental_snapshot_slot {
-        return Some((recent_inc_slot, recent_inc_hash));
+        Some((recent_inc_slot, recent_inc_hash))
     } else {
-        return None;
+        None
     }
 }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4746,7 +4746,6 @@ dependencies = [
  "console",
  "indicatif",
  "log",
- "regex",
  "reqwest",
  "solana-rpc",
  "solana-runtime",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4746,7 +4746,9 @@ dependencies = [
  "console",
  "indicatif",
  "log",
+ "regex",
  "reqwest",
+ "solana-rpc",
  "solana-runtime",
  "solana-sdk 1.15.0",
 ]

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -55,7 +55,7 @@ use {
 };
 
 const FULL_SNAPSHOT_REQUEST_PATH: &str = "/snapshot.tar.bz2";
-const INCREMENTAL_SNAPSHOT_REQUEST_PATH: &str = "/incremental-snapshot.tar.bz2";
+pub const INCREMENTAL_SNAPSHOT_REQUEST_PATH: &str = "/incremental-snapshot.tar.bz2";
 const LARGEST_ACCOUNTS_CACHE_DURATION: u64 = 60 * 60 * 2;
 
 pub struct JsonRpcService {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1422,7 +1422,7 @@ pub(crate) fn parse_full_snapshot_archive_filename(
 }
 
 /// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and Archive Format
-pub(crate) fn parse_incremental_snapshot_archive_filename(
+pub fn parse_incremental_snapshot_archive_filename(
     archive_filename: &str,
 ) -> Result<(Slot, Slot, Hash, ArchiveFormat)> {
     lazy_static! {

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1126,7 +1126,7 @@ fn download_snapshots(
             None => 0,
         },
     ) {
-        Some(nis) => Some(nis),
+        Some(newer_incremental_snapshot) => Some(newer_incremental_snapshot),
         None => incremental_snapshot_hash,
     };
 


### PR DESCRIPTION
#### Problem
When a validator downloads snapshots on startup it follows these steps:
1) gets the latest full and incremental snapshot slots & hashes
2) downloads the full snapshot
3) downloads the incremental snapshot.

Step 2 can take a few minutes (eg on my dev machine it takes 10-20 minutes to download the 34GB mainnet-beta snapshot). With default configs (incremental snapshots every 100 slots, retain 4 snapshots) each incremental snapshot persists for about 8 minutes. By the time we get to step 3 the incremental snapshot has been deleted and we get a 404.

Without an incremental snapshot the node attempts to start from the full snapshot which may be very outdated. 

#### Summary of Changes
After downloading the full snapshot get the slot and hash of the latest incremental snapshot before attempting the incremental snapshot download.

