### PR TITLE
Use LoadZeroLamports in accounts_db

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, LoadHint, LoadedAccount, ScanStorageResult,
+            BankHashInfo, LoadHint, LoadZeroLamports, LoadedAccount, ScanStorageResult,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
@@ -653,7 +653,9 @@ impl Accounts {
         pubkey: &Pubkey,
         load_hint: LoadHint,
     ) -> Option<(AccountSharedData, Slot)> {
-        let (account, slot) = self.accounts_db.load(ancestors, pubkey, load_hint)?;
+        let (account, slot) =
+            self.accounts_db
+                .load(ancestors, pubkey, load_hint, LoadZeroLamports::None)?;
         Self::filter_zero_lamport_account(account, slot)
     }
 


### PR DESCRIPTION
#### Problem
A feature was activated to cause most load apis to return None when loading an account with zero lamports.
Some tests currently rely on returning Some(zero lamport account) instead of None.

#### Summary of Changes

Re-introduce `LoadZeroLamports` enum.
Pass the correct values from a handful of places.

An alternative is:
#28242
Earlier work:
#27943

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
