### PR TITLE
Explorer: add explicit dependency on tweetnacl

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -42,7 +42,8 @@
         "react-scripts": "^4.0.3",
         "react-select": "^4.3.1",
         "superstruct": "^0.15.3",
-        "swr": "^1.3.0"
+        "swr": "^1.3.0",
+        "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -25245,8 +25246,7 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "peer": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -46882,8 +46882,7 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "peer": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type": {
       "version": "1.2.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -44,7 +44,8 @@
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "superstruct": "^0.15.3",
-    "swr": "^1.3.0"
+    "swr": "^1.3.0",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
#### Problem
`tweetnacl` used to be a transitive dependency and is required for signature verification in the inspector. It should be an explicit direct dependency.

#### Summary of Changes
Add `tweetnacl` dependency to `package.json`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
