### PR TITLE
Correctly mark packets as forwarded

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1297,7 +1297,8 @@ impl BankingStage {
     }
 
     /// try to add filtered forwardable and valid packets to forward buffer;
-    /// returns if forward_buffer is still accepting packets, and how many packets added.
+    /// returns if forward buffer is still accepting packets, and vector of
+    /// packet indexes of those were added to forward buffer.
     fn add_filtered_packets_to_forward_buffer(
         forward_buffer: &mut ForwardPacketBatchesByAccounts,
         packets_to_process: &[Arc<ImmutableDeserializedPacket>],

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -281,6 +281,24 @@ impl UnprocessedPacketBatches {
             .get(immutable_packet.message_hash())
             .map_or(true, |p| p.forwarded)
     }
+
+    pub fn mark_accepted_packets_as_forwarded(
+        buffered_packet_batches: &mut UnprocessedPacketBatches,
+        packets_to_process: &[Arc<ImmutableDeserializedPacket>],
+        accepted_packet_indexes: &[usize],
+    ) {
+        accepted_packet_indexes
+            .iter()
+            .for_each(|accepted_packet_index| {
+                let accepted_packet = packets_to_process[*accepted_packet_index].clone();
+                if let Some(deserialized_packet) = buffered_packet_batches
+                    .message_hash_to_transaction
+                    .get_mut(accepted_packet.message_hash())
+                {
+                    deserialized_packet.forwarded = true;
+                }
+            });
+    }
 }
 
 pub fn deserialize_packets<'a>(


### PR DESCRIPTION
#### Problem
Not all packets left in banking buffer have been selected for forwarding, it is inaccurate to mark all of them as forwarded.

#### Summary of Changes
- add `mark_accepted_packets_as_forwarded()` to only mark packet accepted for forwarding as `forwarded`

Fixes #https://github.com/solana-labs/solana/issues/27738 part 1.
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
