### PR TITLE
Fix call to calculate_accounts_hash()

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -293,7 +293,6 @@ fn test_epoch_accounts_hash() {
                         use_bg_thread_pool: false,
                         check_hash: false,
                         ancestors: Some(&bank.ancestors),
-                        use_write_cache: true,
                         epoch_schedule: bank.epoch_schedule(),
                         rent_collector: bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,


### PR DESCRIPTION
#### Problem

I broke the build due to interleaving PRs.

#### Summary of Changes

Remove the `use_write_cache` param from `calculate_accounts_hash()` call.