### PR TITLE
Allow validators to reset to the slot which matches their last voted slot

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -858,36 +858,31 @@ impl HeaviestSubtreeForkChoice {
         tower
             .last_voted_slot_hash()
             .and_then(|last_voted_slot_hash| {
-                let heaviest_slot_hash_on_same_voted_fork = self.best_slot(&last_voted_slot_hash);
-                if heaviest_slot_hash_on_same_voted_fork.is_none() {
-                    if !tower.is_stray_last_vote() {
-                        // Unless last vote is stray and stale, self.bast_slot(last_voted_slot) must return
-                        // Some(_), justifying to panic! here.
-                        // Also, adjust_lockouts_after_replay() correctly makes last_voted_slot None,
-                        // if all saved votes are ancestors of replayed_root_slot. So this code shouldn't be
-                        // touched in that case as well.
-                        // In other words, except being stray, all other slots have been voted on while this
-                        // validator has been running, so we must be able to fetch best_slots for all of
-                        // them.
-                        panic!(
-                            "a bank at last_voted_slot({:?}) is a frozen bank so must have been \
-                            added to heaviest_subtree_fork_choice at time of freezing",
-                            last_voted_slot_hash,
-                        )
-                    } else {
-                        // fork_infos doesn't have corresponding data for the stale stray last vote,
-                        // meaning some inconsistency between saved tower and ledger.
-                        // (newer snapshot, or only a saved tower is moved over to new setup?)
-                        return None;
+                match self.is_candidate(&last_voted_slot_hash) {
+                    Some(true) => self.best_slot(&last_voted_slot_hash),
+                    Some(false) => None,
+                    None => {
+                        if !tower.is_stray_last_vote() {
+                            // Unless last vote is stray and stale, self.bast_slot(last_voted_slot) must return
+                            // Some(_), justifying to panic! here.
+                            // Also, adjust_lockouts_after_replay() correctly makes last_voted_slot None,
+                            // if all saved votes are ancestors of replayed_root_slot. So this code shouldn't be
+                            // touched in that case as well.
+                            // In other words, except being stray, all other slots have been voted on while this
+                            // validator has been running, so we must be able to fetch best_slots for all of
+                            // them.
+                            panic!(
+                                "a bank at last_voted_slot({:?}) is a frozen bank so must have been \
+                                        added to heaviest_subtree_fork_choice at time of freezing",
+                                last_voted_slot_hash,
+                            )
+                        } else {
+                            // fork_infos doesn't have corresponding data for the stale stray last vote,
+                            // meaning some inconsistency between saved tower and ledger.
+                            // (newer snapshot, or only a saved tower is moved over to new setup?)
+                            None
+                        }
                     }
-                }
-                let heaviest_slot_hash_on_same_voted_fork =
-                    heaviest_slot_hash_on_same_voted_fork.unwrap();
-
-                if heaviest_slot_hash_on_same_voted_fork == last_voted_slot_hash {
-                    None
-                } else {
-                    Some(heaviest_slot_hash_on_same_voted_fork)
                 }
             })
     }
@@ -2957,9 +2952,10 @@ mod test {
 
         // After marking the last vote in the tower as invalid, `heaviest_slot_on_same_voted_fork()`
         // should disregard all descendants of that invalid vote
-        assert!(heaviest_subtree_fork_choice
-            .heaviest_slot_on_same_voted_fork(&tower)
-            .is_none());
+        assert_eq!(
+            heaviest_subtree_fork_choice.heaviest_slot_on_same_voted_fork(&tower),
+            None
+        );
 
         // Adding another descendant to the invalid candidate won't
         // update the best slot, even if it contains votes

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -863,7 +863,7 @@ impl HeaviestSubtreeForkChoice {
                     Some(false) => None,
                     None => {
                         if !tower.is_stray_last_vote() {
-                            // Unless last vote is stray and stale, self.bast_slot(last_voted_slot) must return
+                            // Unless last vote is stray and stale, self.is_candidate(last_voted_slot_hash) must return
                             // Some(_), justifying to panic! here.
                             // Also, adjust_lockouts_after_replay() correctly makes last_voted_slot None,
                             // if all saved votes are ancestors of replayed_root_slot. So this code shouldn't be

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -854,19 +854,16 @@ impl HeaviestSubtreeForkChoice {
         );
     }
 
-    // If the last voted fork has an invalid ancestor, this method will return
-    // an invalid heaviest slot. This is intentional because validators should
-    // continue building on an invalid fork in case it was already confirmed the
-    // cluster and should be marked as valid.
     fn heaviest_slot_on_same_voted_fork(&self, tower: &Tower) -> Option<SlotHashKey> {
         tower
             .last_voted_slot_hash()
             .and_then(|last_voted_slot_hash| {
-                match self.best_slot(&last_voted_slot_hash) {
-                    Some(best_slot) => Some(best_slot),
+                match self.is_candidate(&last_voted_slot_hash) {
+                    Some(true) => self.best_slot(&last_voted_slot_hash),
+                    Some(false) => None,
                     None => {
                         if !tower.is_stray_last_vote() {
-                            // Unless last vote is stray and stale, self.best_slot(last_voted_slot_hash) must return
+                            // Unless last vote is stray and stale, self.is_candidate(last_voted_slot_hash) must return
                             // Some(_), justifying to panic! here.
                             // Also, adjust_lockouts_after_replay() correctly makes last_voted_slot None,
                             // if all saved votes are ancestors of replayed_root_slot. So this code shouldn't be

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2901,9 +2901,16 @@ impl ReplayStage {
         );
     }
 
-    // Given a heaviest bank, `heaviest_bank` and the next votable bank
-    // `heaviest_bank_on_same_voted_fork` as the validator's last vote, return
-    // a bank to vote on, a bank to reset to,
+    /// Given a `heaviest_bank` and a `heaviest_bank_on_same_voted_fork`, return
+    /// a bank to vote on, a bank to reset to, and a list of switch failure
+    /// reasons.
+    ///
+    /// If `heaviest_bank_on_same_voted_fork` is `None` due to that fork no
+    /// longer being valid to vote on. It's possible that a validator will not
+    /// be able to reset away from the invalid fork that they last voted on. To
+    /// resolve this scenario, validators need to wait until they can create a
+    /// switch proof for another fork or until the invalid fork to be marked
+    /// valid again because it was confirmed by the cluster.
     pub fn select_vote_and_reset_forks(
         heaviest_bank: &Arc<Bank>,
         // Should only be None if there was no previous vote

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5830,7 +5830,7 @@ pub(crate) mod tests {
             &mut vote_simulator.latest_validator_votes_for_frozen_banks,
         );
         assert!(vote_fork.is_none());
-        assert_eq!(reset_fork.unwrap(), 3);
+        assert_eq!(reset_fork, Some(3));
 
         // Now mark 2, an ancestor of 4, as duplicate
         blockstore.store_duplicate_slot(2, vec![], vec![]).unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2906,11 +2906,13 @@ impl ReplayStage {
     /// reasons.
     ///
     /// If `heaviest_bank_on_same_voted_fork` is `None` due to that fork no
-    /// longer being valid to vote on. It's possible that a validator will not
+    /// longer being valid to vote on, it's possible that a validator will not
     /// be able to reset away from the invalid fork that they last voted on. To
     /// resolve this scenario, validators need to wait until they can create a
-    /// switch proof for another fork or until the invalid fork to be marked
-    /// valid again because it was confirmed by the cluster.
+    /// switch proof for another fork or until the invalid fork is be marked
+    /// valid again if it was confirmed by the cluster.
+    /// Until this is resolved, leaders will build each of their
+    /// blocks from the last reset bank on the invalid fork.
     pub fn select_vote_and_reset_forks(
         heaviest_bank: &Arc<Bank>,
         // Should only be None if there was no previous vote

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5644,7 +5644,7 @@ pub(crate) mod tests {
         assert_eq!(vote_fork.unwrap(), 4);
         assert_eq!(reset_fork.unwrap(), 4);
 
-        // Record the vote for 5
+        // Record the vote for 5 which is not on the heaviest fork.
         tower.record_bank_vote(
             &bank_forks.read().unwrap().get(5).unwrap(),
             &Pubkey::default(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5665,7 +5665,7 @@ pub(crate) mod tests {
         // Mark 5 as duplicate
         blockstore.store_duplicate_slot(5, vec![], vec![]).unwrap();
         let mut duplicate_slots_tracker = DuplicateSlotsTracker::default();
-        let mut gossip_duplicate_confirmed_slots = GossipDuplicateConfirmedSlots::default();
+        let gossip_duplicate_confirmed_slots = GossipDuplicateConfirmedSlots::default();
         let mut epoch_slots_frozen_slots = EpochSlotsFrozenSlots::default();
         let bank5_hash = bank_forks.read().unwrap().bank_hash(5).unwrap();
         assert_ne!(bank5_hash, Hash::default());
@@ -5691,7 +5691,7 @@ pub(crate) mod tests {
         );
 
         // 4 should be the heaviest slot, but should not be votable
-        // because of lockout. 5 is no longer valid due to it being a duplicate.
+        // because of lockout. 5 is still the heaviest despite it being a duplicate.
         let (vote_fork, reset_fork) = run_compute_and_select_forks(
             &bank_forks,
             &mut progress,
@@ -5700,42 +5700,7 @@ pub(crate) mod tests {
             &mut vote_simulator.latest_validator_votes_for_frozen_banks,
         );
         assert!(vote_fork.is_none());
-        assert!(reset_fork.is_none());
-
-        // If slot 5 is marked as confirmed, it becomes the heaviest bank on same slot again
-        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
-        gossip_duplicate_confirmed_slots.insert(5, bank5_hash);
-        let duplicate_confirmed_state = DuplicateConfirmedState::new_from_state(
-            bank5_hash,
-            || progress.is_dead(5).unwrap_or(false),
-            || Some(bank5_hash),
-        );
-        check_slot_agrees_with_cluster(
-            5,
-            bank_forks.read().unwrap().root(),
-            &blockstore,
-            &mut duplicate_slots_tracker,
-            &mut epoch_slots_frozen_slots,
-            &mut vote_simulator.heaviest_subtree_fork_choice,
-            &mut duplicate_slots_to_repair,
-            &ancestor_hashes_replay_update_sender,
-            SlotStateUpdate::DuplicateConfirmed(duplicate_confirmed_state),
-        );
-        // The confirmed hash is detected in `progress`, which means
-        // it's confirmation on the replayed block. This means we have
-        // the right version of the block, so `duplicate_slots_to_repair`
-        // should be empty
-        assert!(duplicate_slots_to_repair.is_empty());
-        let (vote_fork, reset_fork) = run_compute_and_select_forks(
-            &bank_forks,
-            &mut progress,
-            &mut tower,
-            &mut vote_simulator.heaviest_subtree_fork_choice,
-            &mut vote_simulator.latest_validator_votes_for_frozen_banks,
-        );
-        // Should now pick 5 as the heaviest fork from last vote again.
-        assert!(vote_fork.is_none());
-        assert_eq!(reset_fork.unwrap(), 5);
+        assert_eq!(reset_fork, Some(5));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Validators are unable to reset back to the heaviest bank on the fork that includes their last vote if the heaviest bank's slot matches their last voted slot. If there is a heavier bank on the last voted fork than the last voted bank itself, validators can erroneously reset to an invalid slot.

#### Summary of Changes
- Allow resetting to a slot which matches the last vote slot
- Disallow resetting to a slot which is part of an invalid fork
- Fix tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
