### PR TITLE
Use VecDeque as a queue instead of Vec

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3788,9 +3788,10 @@ fn traverse_children_mut<F>(
 where
     F: Fn(&mut SlotMeta) -> bool,
 {
-    let mut next_slots: Vec<(u64, Rc<RefCell<SlotMeta>>)> = vec![(slot, slot_meta.clone())];
+    let mut next_slots: VecDeque<(u64, Rc<RefCell<SlotMeta>>)> =
+        vec![(slot, slot_meta.clone())].into();
     while !next_slots.is_empty() {
-        let (_, current_slot) = next_slots.pop().unwrap();
+        let (_, current_slot) = next_slots.pop_front().unwrap();
         // Check whether we should explore the children of this slot
         if slot_function(&mut current_slot.borrow_mut()) {
             let current_slot = &RefCell::borrow(&*current_slot);
@@ -3801,7 +3802,7 @@ where
                     passed_visisted_slots,
                     *next_slot_index,
                 )?;
-                next_slots.push((*next_slot_index, next_slot));
+                next_slots.push_back((*next_slot_index, next_slot));
             }
         }
     }


### PR DESCRIPTION
#### Problem
`traverse_children_mut()` searches through blocks by pushing block's children onto a queue. Popping from the front of a `Vec` of `n` items requires the remaining `n-1` items to be shifted to fill the first `n-1` positions. `VecDeque` is a ring buffer, and as such, saves the memcpy when popping from the front.

For what it is worth, this change will probably have negligible impact. The `next_slots` queue should never really get that large; in the absence of forking, this queue would just be a single element, with a parent getting popped off and then replaced by its' child. With normal forking (ie current epoch boundary issue), we are typically looking at on the order of 10 forks. Regardless, `VecDeque` is the right structure here. 

#### Summary of Changes
Use `VecDeque` instead of `Vec`.
