### PR TITLE
Make RocksFifo storage size API expose an Option<u64>

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -33,7 +33,6 @@ use {
         blockstore_options::{
             AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
             ShredStorageType, BLOCKSTORE_DIRECTORY_ROCKS_FIFO,
-            MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
         },
         blockstore_processor::{self, BlockstoreProcessorError, ProcessOptions},
         shred::Shred,
@@ -875,9 +874,9 @@ fn open_blockstore_with_temporary_primary_access(
 fn get_shred_storage_type(ledger_path: &Path, warn_message: &str) -> ShredStorageType {
     // TODO: the following shred_storage_type inference must be updated once
     // the rocksdb options can be constructed via load_options_file() as the
-    // temporary use of MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES could
-    // affect the persisted rocksdb options file.
-    match ShredStorageType::from_ledger_path(ledger_path, MAX_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES) {
+    // value picked by passing None for `max_shred_storage_size` could affect
+    // the persisted rocksdb options file.
+    match ShredStorageType::from_ledger_path(ledger_path, None) {
         Some(s) => s,
         None => {
             warn!("{}", warn_message);

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -87,7 +87,6 @@ fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {
 }
 
 fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str) {
-    const TEST_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = std::u64::MAX;
     let genesis_config = create_genesis_config(100).genesis_config;
 
     let (ledger_path, _blockhash) = match src_shred_compaction {
@@ -101,10 +100,9 @@ fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str)
 
     let target_ledger_path = get_tmp_ledger_path_auto_delete!();
     if dst_shred_compaction == "fifo" {
-        let rocksdb_fifo_path = target_ledger_path.path().join(
-            ShredStorageType::rocks_fifo(TEST_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES)
-                .blockstore_directory(),
-        );
+        let rocksdb_fifo_path = target_ledger_path
+            .path()
+            .join(ShredStorageType::rocks_fifo(None).blockstore_directory());
         fs::create_dir_all(rocksdb_fifo_path).unwrap();
     }
     let target_ledger_path = target_ledger_path.path().to_str().unwrap();


### PR DESCRIPTION
#### Problem
A fifo rocksdb instance must be opened with max size parameter on the fifo columns. To support this, we previously plumbed a constant up to callers that provided a default if unbounded growth desired.

#### Summary of Changes
This change attempts to be more rusty by exposing an option for this value, and converting the option to a constant at the lowest level possible.