### PR TITLE
use ref for snapshot_storages.iter_range

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6896,7 +6896,7 @@ impl AccountsDb {
 
         let range = snapshot_storages.range();
         let ancient_slots = snapshot_storages
-            .iter_range(range.start..one_epoch_old_slot)
+            .iter_range(&(range.start..one_epoch_old_slot))
             .filter_map(|(slot, storages)| storages.map(|_| slot))
             .collect::<Vec<_>>();
         let ancient_slot_count = ancient_slots.len() as Slot;
@@ -6974,6 +6974,7 @@ impl AccountsDb {
                 if start == end_exclusive {
                     return scanner.scanning_complete();
                 }
+                let range_this_chunk = start..end_exclusive;
 
                 let should_cache_hash_data = CalcAccountsHashConfig::get_should_cache_hash_data()
                     || config.store_detailed_debug_info_on_failure;
@@ -7004,7 +7005,7 @@ impl AccountsDb {
                     let mut load_from_cache = true;
                     let mut hasher = std::collections::hash_map::DefaultHasher::new(); // wrong one?
 
-                    for (slot, sub_storages) in snapshot_storages.iter_range(start..end_exclusive) {
+                    for (slot, sub_storages) in snapshot_storages.iter_range(&range_this_chunk) {
                         if bin_range.start == 0 && slot < one_epoch_old {
                             self.update_old_slot_stats(stats, sub_storages);
                         }
@@ -7049,7 +7050,11 @@ impl AccountsDb {
                         let hash = hasher.finish();
                         let file_name = format!(
                             "{}.{}.{}.{}.{}",
-                            start, end_exclusive, bin_range.start, bin_range.end, hash
+                            range_this_chunk.start,
+                            range_this_chunk.end,
+                            bin_range.start,
+                            bin_range.end,
+                            hash
                         );
                         let mut retval = scanner.get_accum();
                         if eligible_for_caching
@@ -7072,7 +7077,7 @@ impl AccountsDb {
                         String::default()
                     }
                 } else {
-                    for (slot, sub_storages) in snapshot_storages.iter_range(start..end_exclusive) {
+                    for (slot, sub_storages) in snapshot_storages.iter_range(&range_this_chunk) {
                         if bin_range.start == 0 && slot < one_epoch_old {
                             self.update_old_slot_stats(stats, sub_storages);
                         }
@@ -7080,7 +7085,7 @@ impl AccountsDb {
                     String::default()
                 };
 
-                for (slot, sub_storages) in snapshot_storages.iter_range(start..end_exclusive) {
+                for (slot, sub_storages) in snapshot_storages.iter_range(&range_this_chunk) {
                     scanner.set_slot(slot);
                     if let Some(sub_storages) = sub_storages {
                         Self::scan_multiple_account_storages_one_slot(sub_storages, &mut scanner);
@@ -7122,7 +7127,7 @@ impl AccountsDb {
         let acceptable_straggler_slot_count = 100; // do nothing special for these old stores which will likely get cleaned up shortly
         let sub = slots_per_epoch + acceptable_straggler_slot_count;
         let in_epoch_range_start = max.saturating_sub(sub);
-        for (slot, storages) in storages.iter_range(..in_epoch_range_start) {
+        for (slot, storages) in storages.iter_range(&(..in_epoch_range_start)) {
             if let Some(storages) = storages {
                 storages.iter().for_each(|store| {
                     if !is_ancient(&store.accounts) {

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -28,7 +28,7 @@ impl<'a> SortedStorages<'a> {
     }
 
     /// primary method of retrieving (Slot, SnapshotStorage)
-    pub fn iter_range<R>(&'a self, range: R) -> SortedStoragesIter<'a>
+    pub fn iter_range<R>(&'a self, range: &R) -> SortedStoragesIter<'a>
     where
         R: RangeBounds<Slot>,
     {
@@ -175,7 +175,7 @@ impl<'a> Iterator for SortedStoragesIter<'a> {
 impl<'a> SortedStoragesIter<'a> {
     pub fn new<R: RangeBounds<Slot>>(
         storages: &'a SortedStorages<'a>,
-        range: R,
+        range: &R,
     ) -> SortedStoragesIter<'a> {
         let storage_range = storages.range();
         let next_slot = match range.start_bound() {
@@ -246,19 +246,19 @@ pub mod tests {
         };
         assert_eq!(
             (0..5).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..5).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..5)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (1..5).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(1..5).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(1..5)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (0..0).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (0..0).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(1..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(1..)).map(check).collect::<Vec<_>>()
         );
 
         // only item is slot 3
@@ -278,7 +278,7 @@ pub mod tests {
                 assert_eq!(
                     (start..end).into_iter().collect::<Vec<_>>(),
                     storages
-                        .iter_range(start..end)
+                        .iter_range(&(start..end))
                         .map(check)
                         .collect::<Vec<_>>()
                 );
@@ -286,15 +286,15 @@ pub mod tests {
         }
         assert_eq!(
             (3..5).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..5).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..5)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (1..=3).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(1..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(1..)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (3..=3).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..)).map(check).collect::<Vec<_>>()
         );
 
         // items in slots 2 and 4
@@ -318,7 +318,7 @@ pub mod tests {
                 assert_eq!(
                     (start..end).into_iter().collect::<Vec<_>>(),
                     storages
-                        .iter_range(start..end)
+                        .iter_range(&(start..end))
                         .map(check)
                         .collect::<Vec<_>>()
                 );
@@ -326,15 +326,15 @@ pub mod tests {
         }
         assert_eq!(
             (2..5).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..5).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..5)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (1..=4).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(1..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(1..)).map(check).collect::<Vec<_>>()
         );
         assert_eq!(
             (2..=4).into_iter().collect::<Vec<_>>(),
-            storages.iter_range(..).map(check).collect::<Vec<_>>()
+            storages.iter_range(&(..)).map(check).collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
#### Problem

cleanup/simplify accounts hash chunking code

#### Summary of Changes
take &Range instead of Range
This avoids making copies of ranges.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
