### PR TITLE
Update Node.js version to 16.x from deprecated 12.x

### DIFF
--- a/docs/.travis/before_install.sh
+++ b/docs/.travis/before_install.sh
@@ -1,6 +1,6 @@
 # |source| this file
 
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt install -y nodejs
 
 npm install --global docusaurus-init


### PR DESCRIPTION
#### Problem
I saw the following on the CI docs run from pushing a commit to master.

```
Error: Node.js Version "12.x" is discontinued and must be upgraded. Please set Node.js Version to 16.x in your Project Settings to use Node.js 16.
```

https://github.com/solana-labs/solana/actions/runs/3179411470/jobs/5181873768

#### Summary of Changes
Appease it
