### PR TITLE
RPC: Support versioned txs in getFeeForMessage API

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -112,7 +112,7 @@ pub fn get_fee_for_messages(
 ) -> Result<u64, CliError> {
     Ok(messages
         .iter()
-        .map(|message| rpc_client.get_fee_for_message(message))
+        .map(|message| rpc_client.get_fee_for_message(*message))
         .collect::<Result<Vec<_>, _>>()?
         .iter()
         .sum())

--- a/programs/address-lookup-table/src/error.rs
+++ b/programs/address-lookup-table/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_os = "solana"))]
-use solana_sdk::transaction::TransactionError;
+use solana_program::message::AddressLoaderError;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
@@ -22,13 +22,13 @@ pub enum AddressLookupError {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl From<AddressLookupError> for TransactionError {
+impl From<AddressLookupError> for AddressLoaderError {
     fn from(err: AddressLookupError) -> Self {
         match err {
-            AddressLookupError::LookupTableAccountNotFound => Self::AddressLookupTableNotFound,
-            AddressLookupError::InvalidAccountOwner => Self::InvalidAddressLookupTableOwner,
-            AddressLookupError::InvalidAccountData => Self::InvalidAddressLookupTableData,
-            AddressLookupError::InvalidLookupIndex => Self::InvalidAddressLookupTableIndex,
+            AddressLookupError::LookupTableAccountNotFound => Self::LookupTableAccountNotFound,
+            AddressLookupError::InvalidAccountOwner => Self::InvalidAccountOwner,
+            AddressLookupError::InvalidAccountData => Self::InvalidAccountData,
+            AddressLookupError::InvalidLookupIndex => Self::InvalidLookupIndex,
         }
     }
 }

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -41,7 +41,7 @@ use {
         epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
-        message::Message,
+        message::{v0, Message as LegacyMessage},
         pubkey::Pubkey,
         signature::Signature,
         transaction::{self, uses_durable_nonce, Transaction, VersionedTransaction},
@@ -67,6 +67,12 @@ impl RpcClientConfig {
         }
     }
 }
+
+/// Trait used to add support for versioned messages to RPC APIs while
+/// retaining backwards compatibility
+pub trait SerializableMessage: Serialize {}
+impl SerializableMessage for LegacyMessage {}
+impl SerializableMessage for v0::Message {}
 
 /// Trait used to add support for versioned transactions to RPC APIs while
 /// retaining backwards compatibility
@@ -3975,7 +3981,7 @@ impl RpcClient {
     }
 
     #[allow(deprecated)]
-    pub fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
+    pub fn get_fee_for_message(&self, message: &impl SerializableMessage) -> ClientResult<u64> {
         self.invoke((self.rpc_client.as_ref()).get_fee_for_message(message))
     }
 

--- a/sdk/program/src/message/address_loader.rs
+++ b/sdk/program/src/message/address_loader.rs
@@ -1,0 +1,56 @@
+use {
+    super::v0::{LoadedAddresses, MessageAddressTableLookup},
+    thiserror::Error,
+};
+
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum AddressLoaderError {
+    /// Address loading from lookup tables is disabled
+    #[error("Address loading from lookup tables is disabled")]
+    Disabled,
+
+    /// Failed to load slot hashes sysvar
+    #[error("Failed to load slot hashes sysvar")]
+    SlotHashesSysvarNotFound,
+
+    /// Attempted to lookup addresses from a table that does not exist
+    #[error("Attempted to lookup addresses from a table that does not exist")]
+    LookupTableAccountNotFound,
+
+    /// Attempted to lookup addresses from an account owned by the wrong program
+    #[error("Attempted to lookup addresses from an account owned by the wrong program")]
+    InvalidAccountOwner,
+
+    /// Attempted to lookup addresses from an invalid account
+    #[error("Attempted to lookup addresses from an invalid account")]
+    InvalidAccountData,
+
+    /// Address lookup contains an invalid index
+    #[error("Address lookup contains an invalid index")]
+    InvalidLookupIndex,
+}
+
+pub trait AddressLoader: Clone {
+    fn load_addresses(
+        self,
+        lookups: &[MessageAddressTableLookup],
+    ) -> Result<LoadedAddresses, AddressLoaderError>;
+}
+
+#[derive(Clone)]
+pub enum SimpleAddressLoader {
+    Disabled,
+    Enabled(LoadedAddresses),
+}
+
+impl AddressLoader for SimpleAddressLoader {
+    fn load_addresses(
+        self,
+        _lookups: &[MessageAddressTableLookup],
+    ) -> Result<LoadedAddresses, AddressLoaderError> {
+        match self {
+            Self::Disabled => Err(AddressLoaderError::Disabled),
+            Self::Enabled(loaded_addresses) => Ok(loaded_addresses),
+        }
+    }
+}

--- a/sdk/program/src/message/mod.rs
+++ b/sdk/program/src/message/mod.rs
@@ -44,10 +44,11 @@ pub mod legacy;
 #[path = ""]
 mod non_bpf_modules {
     mod account_keys;
+    mod address_loader;
     mod sanitized;
     mod versions;
 
-    pub use {account_keys::*, sanitized::*, versions::*};
+    pub use {account_keys::*, address_loader::*, sanitized::*, versions::*};
 }
 
 use compiled_keys::*;

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -106,7 +106,7 @@ impl TryFrom<legacy::Message> for SanitizedMessage {
 
 impl SanitizedMessage {
     /// Create a sanitized message from a sanitized versioned message.
-    /// If the input message uses address tables, attempt to lookup the
+    /// If the input message uses address tables, attempt to look up the
     /// address for each table index.
     pub fn try_new(
         sanitized_msg: SanitizedVersionedMessage,

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -5,7 +5,8 @@ use {
         message::{
             legacy,
             v0::{self, LoadedAddresses},
-            AccountKeys, MessageHeader,
+            AccountKeys, AddressLoader, AddressLoaderError, MessageHeader,
+            SanitizedVersionedMessage, VersionedMessage,
         },
         nonce::NONCED_TX_MARKER_IX_INDEX,
         program_utils::limited_deserialize,
@@ -81,6 +82,8 @@ pub enum SanitizeMessageError {
     ValueOutOfBounds,
     #[error("invalid value")]
     InvalidValue,
+    #[error("{0}")]
+    AddressLoaderError(#[from] AddressLoaderError),
 }
 
 impl From<SanitizeError> for SanitizeMessageError {
@@ -102,6 +105,25 @@ impl TryFrom<legacy::Message> for SanitizedMessage {
 }
 
 impl SanitizedMessage {
+    /// Create a sanitized message from a sanitized versioned message.
+    /// If the input message uses address tables, attempt to lookup the
+    /// address for each table index.
+    pub fn try_new(
+        sanitized_msg: SanitizedVersionedMessage,
+        address_loader: impl AddressLoader,
+    ) -> Result<Self, SanitizeMessageError> {
+        Ok(match sanitized_msg.message {
+            VersionedMessage::Legacy(message) => {
+                SanitizedMessage::Legacy(LegacyMessage::new(message))
+            }
+            VersionedMessage::V0(message) => {
+                let loaded_addresses =
+                    address_loader.load_addresses(&message.address_table_lookups)?;
+                SanitizedMessage::V0(v0::LoadedMessage::new(message, loaded_addresses))
+            }
+        })
+    }
+
     /// Return true if this message contains duplicate account keys
     pub fn has_duplicates(&self) -> bool {
         match self {

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        instruction::InstructionError, message::SanitizeMessageError, sanitize::SanitizeError,
+        instruction::InstructionError,
+        message::{AddressLoaderError, SanitizeMessageError},
+        sanitize::SanitizeError,
     },
     serde::Serialize,
     thiserror::Error,
@@ -156,7 +158,23 @@ impl From<SanitizeError> for TransactionError {
 }
 
 impl From<SanitizeMessageError> for TransactionError {
-    fn from(_err: SanitizeMessageError) -> Self {
-        Self::SanitizeFailure
+    fn from(err: SanitizeMessageError) -> Self {
+        match err {
+            SanitizeMessageError::AddressLoaderError(err) => Self::from(err),
+            _ => Self::SanitizeFailure,
+        }
+    }
+}
+
+impl From<AddressLoaderError> for TransactionError {
+    fn from(err: AddressLoaderError) -> Self {
+        match err {
+            AddressLoaderError::Disabled => Self::UnsupportedVersion,
+            AddressLoaderError::SlotHashesSysvarNotFound => Self::AccountNotFound,
+            AddressLoaderError::LookupTableAccountNotFound => Self::AddressLookupTableNotFound,
+            AddressLoaderError::InvalidAccountOwner => Self::InvalidAddressLookupTableOwner,
+            AddressLoaderError::InvalidAccountData => Self::InvalidAddressLookupTableData,
+            AddressLoaderError::InvalidLookupIndex => Self::InvalidAddressLookupTableIndex,
+        }
     }
 }

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -1,12 +1,13 @@
 #![cfg(feature = "full")]
 
+pub use crate::message::{AddressLoader, SimpleAddressLoader};
 use {
     super::SanitizedVersionedTransaction,
     crate::{
         hash::Hash,
         message::{
             legacy,
-            v0::{self, LoadedAddresses, MessageAddressTableLookup},
+            v0::{self, LoadedAddresses},
             LegacyMessage, SanitizedMessage, VersionedMessage,
         },
         precompiles::verify_if_precompile,
@@ -41,25 +42,6 @@ pub struct TransactionAccountLocks<'a> {
     pub readonly: Vec<&'a Pubkey>,
     /// List of writable account key locks
     pub writable: Vec<&'a Pubkey>,
-}
-
-pub trait AddressLoader: Clone {
-    fn load_addresses(self, lookups: &[MessageAddressTableLookup]) -> Result<LoadedAddresses>;
-}
-
-#[derive(Clone)]
-pub enum SimpleAddressLoader {
-    Disabled,
-    Enabled(LoadedAddresses),
-}
-
-impl AddressLoader for SimpleAddressLoader {
-    fn load_addresses(self, _lookups: &[MessageAddressTableLookup]) -> Result<LoadedAddresses> {
-        match self {
-            Self::Disabled => Err(TransactionError::AddressLookupTableNotFound),
-            Self::Enabled(loaded_addresses) => Ok(loaded_addresses),
-        }
-    }
 }
 
 /// Type that represents whether the transaction message has been precomputed or


### PR DESCRIPTION
#### Problem
The `getFeeForMessage` RPC API and the equivalent RPC client method `get_fee_for_message` both do not support versioned messages yet.

#### Summary of Changes
- Add support for versioned messages in the `getFeeForMessage` RPC API
- Add support for versioned messages through the new `SerializableMessage` trait in the `get_fee_for_message` RPC client api
- Refactor `AddressLoader` to make it usable inside `solana-program`
- Remove pre v1.9 handling in RPC client since no clusters are running v1.8 or earlier

Fixes https://github.com/solana-labs/solana/issues/28182
Fixes https://github.com/solana-labs/solana/issues/28214

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
