### PR TITLE
after replay at validator startup don't verify hash calc

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2769,6 +2769,8 @@ fn main() {
                     poh_verify: !arg_matches.is_present("skip_poh_verify"),
                     on_halt_store_hash_raw_data_for_debug: arg_matches
                         .is_present("halt_at_slot_store_hash_raw_data"),
+                    // ledger tool verify always runs the accounts hash calc at the end of processing the blockstore
+                    run_final_accounts_hash_calc: true,
                     halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                     debug_keys,
                     accounts_db_caching_enabled: !arg_matches.is_present("no_accounts_db_caching"),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -716,6 +716,9 @@ pub struct ProcessOptions {
     pub shrink_ratio: AccountShrinkThreshold,
     pub runtime_config: RuntimeConfig,
     pub on_halt_store_hash_raw_data_for_debug: bool,
+    /// true if after processing the contents of the blockstore at startup, we should run an accounts hash calc
+    /// This is useful for debugging.
+    pub run_final_accounts_hash_calc: bool,
 }
 
 pub fn test_process_blockstore(
@@ -1529,7 +1532,9 @@ fn load_frozen_forks(
             )?;
 
             if slot >= halt_at_slot {
-                run_final_hash_calc(&bank, on_halt_store_hash_raw_data_for_debug);
+                if opts.run_final_accounts_hash_calc {
+                    run_final_hash_calc(&bank, on_halt_store_hash_raw_data_for_debug);
+                }
                 break;
             }
         }


### PR DESCRIPTION
#### Problem

When ledger-tool runs, it runs a final hash calc at the end to verify capitalization if halt-at-slot is passed.
This inadvertently ran during validator startup if there was a ledger when the validator was started.
This extra hash calc is only for debugging and should not be running on validator startup.

#### Summary of Changes
only run this hash calc from ledger-tool verify

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
