### PR TITLE
benches/bpf_loader: make account writable in bench_instruction_count_…

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -998,27 +998,26 @@ pub fn prepare_mock_invoke_context(
 pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
     loader_id: Pubkey,
     account_size: usize,
+    is_writable: bool,
     mut callback: F,
 ) -> R {
     let program_indices = vec![0, 1];
+    let program_key = Pubkey::new_unique();
     let transaction_accounts = vec![
         (
             loader_id,
             AccountSharedData::new(0, 0, &native_loader::id()),
         ),
+        (program_key, AccountSharedData::new(1, 0, &loader_id)),
         (
             Pubkey::new_unique(),
-            AccountSharedData::new(1, 0, &loader_id),
-        ),
-        (
-            Pubkey::new_unique(),
-            AccountSharedData::new(2, account_size, &Pubkey::new_unique()),
+            AccountSharedData::new(2, account_size, &program_key),
         ),
     ];
     let instruction_accounts = vec![AccountMeta {
         pubkey: transaction_accounts.get(2).unwrap().0,
         is_signer: false,
-        is_writable: false,
+        is_writable,
     }];
     let preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -31,6 +31,7 @@ use {
         instruction::{AccountMeta, Instruction},
         message::Message,
         pubkey::Pubkey,
+        rent::Rent,
         signature::{Keypair, Signer},
     },
     std::{env, fs::File, io::Read, mem, path::PathBuf, sync::Arc},
@@ -100,7 +101,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     inner_iter.write_u64::<LittleEndian>(0).unwrap();
     let elf = load_elf("bench_alu").unwrap();
     let loader_id = bpf_loader::id();
-    with_mock_invoke_context(loader_id, 10000001, |invoke_context| {
+    with_mock_invoke_context(loader_id, 10000001, false, |invoke_context| {
         invoke_context
             .get_compute_meter()
             .borrow_mut()
@@ -216,7 +217,7 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
 fn bench_create_vm(bencher: &mut Bencher) {
     let elf = load_elf("noop").unwrap();
     let loader_id = bpf_loader::id();
-    with_mock_invoke_context(loader_id, 10000001, |invoke_context| {
+    with_mock_invoke_context(loader_id, 10000001, false, |invoke_context| {
         const BUDGET: u64 = 200_000;
         invoke_context
             .get_compute_meter()
@@ -264,7 +265,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
 fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     let elf = load_elf("tuner").unwrap();
     let loader_id = bpf_loader::id();
-    with_mock_invoke_context(loader_id, 10000001, |invoke_context| {
+    with_mock_invoke_context(loader_id, 10000001, true, |invoke_context| {
         const BUDGET: u64 = 200_000;
         invoke_context
             .get_compute_meter()

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -223,7 +223,7 @@ fn run_program(name: &str) -> u64 {
     let mut data = vec![];
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
-    with_mock_invoke_context(loader_id, 0, |invoke_context| {
+    with_mock_invoke_context(loader_id, 0, false, |invoke_context| {
         let (parameter_bytes, account_lengths) = serialize_parameters(
             invoke_context.transaction_context,
             invoke_context


### PR DESCRIPTION
The tuner program writes to its input account https://github.com/solana-labs/solana/blob/3f9e6a600bb503e047878dc1b4a17b954e9bcc10/programs/bpf/c/src/tuner/tuner.c#L25

This fixes the benchmark when the early account verify feature is on.