### PR TITLE
Use const generics for hash_data_cache mmap

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,6 +62,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0"
 zstd = "0.11.2"
+static_assertions = "1.1.0"
 
 [lib]
 crate-type = ["lib"]

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -118,8 +118,6 @@ impl<H, T> CacheDataFile<H, T> {
     }
 }
 
-pub(crate) type CacheHashDataFile = CacheDataFile<Header, EntryType>;
-
 /// Specialization for CacheHashDataFile
 impl CacheDataFile<Header, EntryType> {
     /// Populate 'accumulator' from entire contents of the cache file.

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -22,6 +22,7 @@ pub type SavedTypeSlice = [Vec<EntryType>];
 const CELL_SIZE: usize = std::mem::size_of::<EntryType>();
 const CELL_ALIGNMENT: usize = std::mem::align_of::<EntryType>();
 
+// NOTE: if change the layout of Headers, i.e. add or remove fields, you MUST ensure that size_of::<Header>() is equal or a multiple of CELL_ALIGNMENT
 #[repr(C)]
 pub struct Header {
     count: usize,

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -19,13 +19,15 @@ pub type EntryType = CalculateHashIntermediate;
 pub type SavedType = Vec<Vec<EntryType>>;
 pub type SavedTypeSlice = [Vec<EntryType>];
 
+const CELL_SIZE: usize = std::mem::size_of::<EntryType>();
+const CELL_ALIGNMENT: usize = std::mem::align_of::<EntryType>();
+
 #[repr(C)]
 pub struct Header {
     count: usize,
+    _align: [u8; CELL_ALIGNMENT - std::mem::size_of::<usize>()],
 }
-
 const HEADER_SIZE: usize = std::mem::size_of::<Header>();
-const CELL_SIZE: usize = std::mem::size_of::<EntryType>();
 
 pub(crate) struct CacheHashDataFile<const CELL_SIZE: usize, const HEADER_SIZE: usize> {
     mmap: MmapMut,
@@ -87,7 +89,7 @@ impl<const CELL_SIZE: usize, const HEADER_SIZE: usize> CacheHashDataFile<CELL_SI
     /// return byte offset of entry 'ix' into a slice which contains a header and at least ix elements
     fn get_element_offset_byte(&self, ix: u64) -> usize {
         let start = (ix as usize) * CELL_SIZE + HEADER_SIZE;
-        debug_assert_eq!(start % std::mem::align_of::<EntryType>(), 0);
+        debug_assert_eq!(start % CELL_ALIGNMENT, 0);
         start
     }
 

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -66,15 +66,6 @@ impl<const CELL_SIZE: usize, const HEADER_SIZE: usize> CacheHashDataFile<CELL_SI
         stats.decode_us += m2.as_us();
     }
 
-    /// get '&mut EntryType' from cache file [ix]
-    fn get_mut(&mut self, ix: u64) -> &mut EntryType {
-        let item_slice = self.get_slice_internal(ix);
-        unsafe {
-            let item = item_slice.as_ptr() as *mut EntryType;
-            &mut *item
-        }
-    }
-
     /// get '&[EntryType]' from cache file [ix..]
     fn get_slice(&self, ix: u64) -> &[EntryType] {
         let start = self.get_element_offset_byte(ix);
@@ -102,21 +93,6 @@ impl<const CELL_SIZE: usize, const HEADER_SIZE: usize> CacheHashDataFile<CELL_SI
         let start = (ix as usize) * CELL_SIZE + HEADER_SIZE;
         debug_assert_eq!(start % CELL_ALIGNMENT, 0);
         start
-    }
-
-    /// get the bytes representing cache file [ix]
-    fn get_slice_internal(&self, ix: u64) -> &[u8] {
-        let start = self.get_element_offset_byte(ix);
-        let end = start + CELL_SIZE;
-        assert!(
-            end <= self.capacity as usize,
-            "end: {}, capacity: {}, ix: {}, cell size: {}",
-            end,
-            self.capacity,
-            ix,
-            CELL_SIZE
-        );
-        &self.mmap[start..end]
     }
 
     fn get_header_mut(&mut self) -> &mut Header {

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -341,10 +341,9 @@ impl CacheHashData {
         let mut m2 = Measure::start("write_to_mmap");
         let mut i = 0;
 
-        let s = cache_file.get_slice_mut(0_u64);
-
+        let cache = cache_file.get_slice_mut(0_u64);
         for item in data.into_iter().flatten() {
-            s[i] = item.clone();
+            cache[i] = item.clone();
             i += 1;
         }
         assert_eq!(i, entries);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -92,3 +92,6 @@ extern crate serde_derive;
 
 #[macro_use]
 extern crate solana_frozen_abi_macro;
+
+#[macro_use]
+extern crate static_assertions;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
 #![feature(inherent_associated_types)]
+#![feature(associated_type_defaults)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
+#![feature(inherent_associated_types)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
#### Problem

hash_data_cache mmap header and cell sizes are always constant. We can use const generics instead of member variable. 

#### Summary of Changes

Use const generic for `CacheHashDataFile`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
