### PR TITLE
Resolve PagerDuty incident on All Clear instead of triggering new incident

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5667,6 +5667,7 @@ dependencies = [
  "log",
  "reqwest",
  "serde_json",
+ "solana-sdk 1.15.0",
 ]
 
 [[package]]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 log = "0.4.17"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = "1.0"
+solana-sdk = { path = "../sdk", version = "=1.15.0" }
 
 [lib]
 name = "solana_notifier"


### PR DESCRIPTION
#### Problem
On the initial PagerDuty implementation when watchtower sends an All Clear message it triggers a new PagerDuty incident, instead of resolving the existing one

#### Summary of Changes
Create a dedup key for PagerDuty alerts to group initial trigger and resolution together

Without this it was triggering a new incident on the All Clear message

Renames the NotificationType enum to NotificationChannel and creates a new NotificationType enum to hold the actions Trigger and Resolve

Generates a random hash to use as a dedup key and resets it after the failure is resolved so next failure triggers a new incident.

- Tested with balance check alert multiple times, including multiple separate incidents/alerts to ensure the dedup_key is being correctly rotated
- Tested Slack and Telegram alerts as well to ensure they're not affected