### PR TITLE
fix: remove localeCompare from account order sorting

### DIFF
--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -420,8 +420,11 @@ export class Transaction {
         // Writable accounts always come before read-only accounts
         return x.isWritable ? -1 : 1;
       }
-      // Otherwise, sort by pubkey, stringwise.
-      return x.pubkey.toBase58().localeCompare(y.pubkey.toBase58());
+
+      const xPubKey = x.pubkey.toBase58().toLowerCase();
+      const yPubKey = y.pubkey.toBase58().toLowerCase();
+
+      return xPubKey < yPubKey ? -1 : xPubKey > yPubKey ? 1 : 0;
     });
 
     // Move fee payer to the front


### PR DESCRIPTION
#### Problem
`localeCompare` should be limited and not used when not required. For the sorting of the account metas, we don't specifically require the usage of it since those are Public Keys, and a direct comparison would work as expected.

This is prone to issues in react native, depending on the JS engine being used.

Context: [Conversation](https://github.com/solana-labs/solana/pull/21724/files#r938079723) on the #21724.

#### Summary of Changes
This fix makes the sorting of account metas work predictably independent of the JS engine used, as `localeCompare` behaves differently depending on the JS engine (v8 vs JSC, for example).
