### PR TITLE
exit early deep in bank freeze, avoiding some unnecessary work

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7646,6 +7646,10 @@ impl AccountsDb {
         skipped_rewrites: &Rewrites,
     ) {
         let mut skipped_rewrites = skipped_rewrites.read().unwrap().clone();
+        if skipped_rewrites.is_empty() {
+            // if there are no skipped rewrites, then there is nothing futher to do
+            return;
+        }
         hashes.iter().for_each(|(key, _)| {
             skipped_rewrites.remove(key);
         });


### PR DESCRIPTION
#### Problem
We're wasting time down deep in `Bank::freeze` inside `AccountsDb::extend_hashes_with_skipped_rewrites()`

#### Summary of Changes
remove unnecessary iteration of all entries to hash at bank freeze if we have no skipped rewrites.
skipped rewrites only occur as a result of a cli option at the moment. As soon as the way forward is cleared, this will occur behind a feature flag.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
