### PR TITLE
run initial hash calc in background, using background threads

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -113,6 +113,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
             false,
             false,
             true,
+            false,
         ))
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -834,6 +834,7 @@ impl Accounts {
         ignore_mismatch: bool,
         store_detailed_debug_info: bool,
         enable_rehashing: bool,
+        use_bg_thread_pool: bool,
     ) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports_new(
             slot,
@@ -845,6 +846,7 @@ impl Accounts {
             ignore_mismatch,
             store_detailed_debug_info,
             enable_rehashing,
+            use_bg_thread_pool,
         ) {
             warn!("verify_bank_hash failed: {:?}, slot: {}", err, slot);
             false

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7493,6 +7493,7 @@ impl AccountsDb {
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
         enable_rehashing: bool,
+        use_bg_thread_pool: bool,
     ) -> Result<(), BankHashVerificationError> {
         self.verify_bank_hash_and_lamports_new(
             slot,
@@ -7504,6 +7505,7 @@ impl AccountsDb {
             false,
             false,
             enable_rehashing,
+            use_bg_thread_pool,
         )
     }
 
@@ -7520,20 +7522,19 @@ impl AccountsDb {
         ignore_mismatch: bool,
         store_hash_raw_data_for_debug: bool,
         enable_rehashing: bool,
+        use_bg_thread_pool: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
         let use_index = false;
         let check_hash = false; // this will not be supported anymore
-                                // interesting to consider this
-        let is_startup = true;
         let (calculated_hash, calculated_lamports) = self
             .calculate_accounts_hash_helper_with_verify(
                 use_index,
                 test_hash_calculation,
                 slot,
                 CalcAccountsHashConfig {
-                    use_bg_thread_pool: !is_startup,
+                    use_bg_thread_pool,
                     check_hash,
                     ancestors: Some(ancestors),
                     epoch_schedule,
@@ -11819,6 +11820,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             )
             .unwrap();
     }
@@ -12223,6 +12225,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Ok(_)
         );
@@ -12237,6 +12240,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Err(MissingBankHash)
         );
@@ -12260,6 +12264,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Err(MismatchedBankHash)
         );
@@ -12289,6 +12294,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Ok(_)
         );
@@ -12311,12 +12317,13 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Ok(_)
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default(), true,),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default(), true, false,),
             Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }
@@ -12344,6 +12351,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Ok(_)
         );
@@ -12388,6 +12396,7 @@ pub mod tests {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                false,
             ),
             Err(MismatchedBankHash)
         );
@@ -13008,6 +13017,7 @@ pub mod tests {
                     &EpochSchedule::default(),
                     &RentCollector::default(),
                     true,
+                    false,
                 )
                 .unwrap();
 
@@ -13021,6 +13031,7 @@ pub mod tests {
                     &EpochSchedule::default(),
                     &RentCollector::default(),
                     true,
+                    false,
                 )
                 .unwrap();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7004,6 +7004,8 @@ impl Bank {
                             config.ignore_mismatch,
                             config.store_hash_raw_data_for_debug,
                             enable_rehashing,
+                            // true to run using bg thread pool
+                            true,
                         );
                         accounts_
                             .accounts_db
@@ -7025,6 +7027,8 @@ impl Bank {
                 config.ignore_mismatch,
                 config.store_hash_raw_data_for_debug,
                 enable_rehashing,
+                // fg is waiting for this to run, so we can use the fg thread pool
+                false,
             );
             self.set_initial_accounts_hash_verification_completed();
             result


### PR DESCRIPTION
#### Problem

perf issues on startup in 1.14
If we run the initial hash calc in the background, which was new to 1.14, we were using the foreground threads still. This starves the foreground processes.
Previously, at startup, we waited for the hash calculation to complete before beginning tx processing. Now, we run it in the background, and wait to create snapshots or vote until we have verified our full accounts state at startup in the background.

#### Summary of Changes
If we run the initial hash calc in the background, then have it use the background threads.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
