### PR TITLE
Make Blockstore::get_entries_in_data_block() use multi_get()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2889,53 +2889,51 @@ impl Blockstore {
         end_index: u32,
         slot_meta: Option<&SlotMeta>,
     ) -> Result<Vec<Entry>> {
-        let data_shred_cf = self.db.column::<cf::ShredData>();
-
-        // Short circuit on first error
-        let data_shreds: Result<Vec<Shred>> = (start_index..=end_index)
-            .map(|i| {
-                data_shred_cf
-                    .get_bytes((slot, u64::from(i)))
-                    .and_then(|serialized_shred| {
-                        if serialized_shred.is_none() {
-                            if let Some(slot_meta) = slot_meta {
-                                if slot > self.lowest_cleanup_slot() {
-                                    panic!(
-                                        "Shred with
-                                        slot: {},
-                                        index: {},
-                                        consumed: {},
-                                        completed_indexes: {:?}
-                                        must exist if shred index was included in a range: {} {}",
-                                        slot,
-                                        i,
-                                        slot_meta.consumed,
-                                        slot_meta.completed_data_indexes,
-                                        start_index,
-                                        end_index
-                                    );
-                                }
-                            }
-                            return Err(BlockstoreError::InvalidShredData(Box::new(
-                                bincode::ErrorKind::Custom(format!(
-                                    "Missing shred for slot {}, index {}",
-                                    slot, i
-                                )),
-                            )));
-                        }
-
-                        Shred::new_from_serialized_shred(serialized_shred.unwrap()).map_err(|err| {
-                            BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                                format!(
-                                    "Could not reconstruct shred from shred payload: {:?}",
-                                    err
-                                ),
-                            )))
-                        })
-                    })
-            })
+        let keys: Vec<(Slot, u64)> = (start_index..=end_index)
+            .map(|index| (slot, u64::from(index)))
             .collect();
 
+        let data_shreds: Result<Vec<Option<Vec<u8>>>> = self
+            .data_shred_cf
+            .multi_get_bytes(keys)
+            .into_iter()
+            .collect();
+        let data_shreds = data_shreds?;
+
+        let data_shreds: Result<Vec<Shred>> =
+            data_shreds
+                .into_iter()
+                .enumerate()
+                .map(|(idx, shred_bytes)| {
+                    if shred_bytes.is_none() {
+                        if let Some(slot_meta) = slot_meta {
+                            if slot > self.lowest_cleanup_slot() {
+                                panic!(
+                                    "Shred with slot: {}, index: {}, consumed: {}, completed_indexes: {:?} \
+                                    must exist if shred index was included in a range: {} {}",
+                                    slot,
+                                    idx,
+                                    slot_meta.consumed,
+                                    slot_meta.completed_data_indexes,
+                                    start_index,
+                                    end_index
+                                );
+                            }
+                        }
+                        return Err(BlockstoreError::InvalidShredData(Box::new(
+                            bincode::ErrorKind::Custom(format!(
+                                "Missing shred for slot {}, index {}",
+                                slot, idx
+                            )),
+                        )));
+                    }
+                    Shred::new_from_serialized_shred(shred_bytes.unwrap()).map_err(|err| {
+                        BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
+                            format!("Could not reconstruct shred from shred payload: {:?}", err),
+                        )))
+                    })
+                })
+                .collect();
         let data_shreds = data_shreds?;
         let last_shred = data_shreds.last().unwrap();
         assert!(last_shred.data_complete() || last_shred.last_in_slot());


### PR DESCRIPTION
#### Problem
`Blockstore::get_entries_in_data_block()` pulls individual shreds out of the blockstore in a loop. This type of behavior is well suited to use `multi_get()`

#### Summary of Changes
Refactor to use `multi_get_bytes()` to get the gains of a batched read vs multiple individual reads.

Note that this now performs all of the I/O before doing the correctness checks (check for missing shred and `Shred` creation). I think this is a fine tradeoff to make in the name of optimizing the non-error code-path.

I'll try to get some runtime on comparable nodes with this change. For normal replay, I don't expect massive savings since those reads should be hitting memtables (ie recently inserted). However, this should drop fetch time when we're catching up at startup, and for RPC nodes who are serving queries on past slots.

Depends on https://github.com/solana-labs/solana/pull/28244, so only look at the second commit for viewing this diff.