### PR TITLE
Explorer: Display block utc timestamp in account history

### DIFF
--- a/explorer/src/components/account/history/TransactionHistoryCard.tsx
+++ b/explorer/src/components/account/history/TransactionHistoryCard.tsx
@@ -15,6 +15,7 @@ import {
 import { FetchStatus } from "providers/cache";
 import { LoadingCard } from "components/common/LoadingCard";
 import { ErrorCard } from "components/common/ErrorCard";
+import { displayTimestampUtc } from "utils/date";
 
 export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
   const address = pubkey.toBase58();
@@ -56,7 +57,7 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
       return (
         <tr key={signature}>
           <td>
-            <Signature signature={signature} link truncate />
+            <Signature signature={signature} link truncateChars={60} />
           </td>
 
           <td className="w-1">
@@ -64,9 +65,16 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
           </td>
 
           {hasTimestamps && (
-            <td className="text-muted">
-              {blockTime ? <Moment date={blockTime * 1000} fromNow /> : "---"}
-            </td>
+            <>
+              <td className="text-muted">
+                {blockTime ? <Moment date={blockTime * 1000} fromNow /> : "---"}
+              </td>
+              <td className="text-muted">
+                {blockTime
+                  ? displayTimestampUtc(blockTime * 1000, true)
+                  : "---"}
+              </td>
+            </>
           )}
 
           <td>
@@ -90,8 +98,13 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
           <thead>
             <tr>
               <th className="text-muted w-1">Transaction Signature</th>
-              <th className="text-muted w-1">Slot</th>
-              {hasTimestamps && <th className="text-muted w-1">Age</th>}
+              <th className="text-muted w-1">Block</th>
+              {hasTimestamps && (
+                <>
+                  <th className="text-muted w-1">Age</th>
+                  <th className="text-muted w-1">Timestamp</th>
+                </>
+              )}
               <th className="text-muted">Result</th>
             </tr>
           </thead>


### PR DESCRIPTION
#### Problem
Have to click through tx signatures to get the UTC timestamp of transactions. They should be visible in the history table

#### Summary of Changes

Before
<img width="984" alt="Screen Shot 2022-10-06 at 1 57 28 PM" src="https://user-images.githubusercontent.com/1076145/194225584-a8277c09-52df-4f48-80c1-bb49695606fc.png">

After
<img width="995" alt="Screen Shot 2022-10-06 at 1 57 20 PM" src="https://user-images.githubusercontent.com/1076145/194225592-a3d71cdc-221f-4101-8ab2-de7612aa7709.png">

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
