### PR TITLE
RPC: Improve unsupported transaction error message

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -195,7 +195,12 @@ impl From<RpcCustomError> for Error {
             },
             RpcCustomError::UnsupportedTransactionVersion(version) => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION),
-                message: format!("Transaction version ({}) is not supported", version),
+                message: format!(
+                    "Transaction version ({0}) is not supported by the requesting client. \
+                    Please try the request again with the following configuration parameter: \
+                    \"maxSupportedTransactionVersion\": {0}",
+                    version
+                ),
                 data: None,
             },
             RpcCustomError::MinContextSlotNotReached { context_slot } => Self {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6753,7 +6753,11 @@ pub mod tests {
         let response = parse_failure_response(rpc.handle_request_sync(request));
         let expected = (
             JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
-            String::from("Transaction version (0) is not supported"),
+            String::from(
+                "Transaction version (0) is not supported by the requesting client. \
+                Please try the request again with the following configuration parameter: \
+                \"maxSupportedTransactionVersion\": 0",
+            ),
         );
         assert_eq!(response, expected);
     }


### PR DESCRIPTION
#### Problem
The `Transaction version ({0}) is not supported` error message is not very clear or actionable. It appears to be an error that the RPC API server needs to fix rather than the client.

#### Summary of Changes
Make it clear that the requestor needs to pass a param if they request an unsupported transaction version and receive an error

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
