### PR TITLE
Separate deprecated arguments out to reduce clutter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,6 +6639,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-ipc-server",
  "jsonrpc-server-utils",
+ "lazy_static",
  "libc",
  "log",
  "num_cpus",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5853,6 +5853,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-ipc-server",
  "jsonrpc-server-utils",
+ "lazy_static",
  "libc",
  "log",
  "num_cpus",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -23,6 +23,7 @@ jsonrpc-core-client = { version = "18.0.0", features = ["ipc"] }
 jsonrpc-derive = "18.0.0"
 jsonrpc-ipc-server = "18.0.0"
 jsonrpc-server-utils = "18.0.0"
+lazy_static = "1.4.0"
 log = "0.4.17"
 num_cpus = "1.13.1"
 rand = "0.7.0"

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,6 +7,7 @@ use {
         AppSettings, Arg, ArgMatches, SubCommand,
     },
     console::style,
+    lazy_static::lazy_static,
     log::*,
     rand::{seq::SliceRandom, thread_rng},
     solana_clap_utils::{
@@ -595,15 +596,6 @@ pub fn main() {
                 .help("Launch validator without voting"),
         )
         .arg(
-            Arg::with_name("no_check_vote_account")
-                .long("no-check-vote-account")
-                .takes_value(false)
-                .conflicts_with("no_voting")
-                .requires("entrypoint")
-                .hidden(true)
-                .help("Skip the RPC vote account sanity check")
-        )
-        .arg(
             Arg::with_name("check_vote_account")
                 .long("check-vote-account")
                 .takes_value(true)
@@ -638,13 +630,6 @@ pub fn main() {
                 .takes_value(true)
                 .validator(solana_validator::port_validator)
                 .help("Enable JSON RPC on this port, and the next port for the RPC websocket"),
-        )
-        .arg(
-            Arg::with_name("minimal_rpc_api")
-                .long("--minimal-rpc-api")
-                .takes_value(false)
-                .hidden(true)
-                .help("Only expose the RPC methods required to serve snapshots to other nodes"),
         )
         .arg(
             Arg::with_name("full_rpc_api")
@@ -693,16 +678,6 @@ pub fn main() {
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
                 .help("Upload new confirmed blocks into a BigTable instance"),
-        )
-        .arg(
-            Arg::with_name("enable_cpi_and_log_storage")
-                .long("enable-cpi-and-log-storage")
-                .requires("enable_rpc_transaction_history")
-                .takes_value(false)
-                .hidden(true)
-                .help("Deprecated, please use \"enable-extended-tx-metadata-storage\". \
-                       Include CPI inner instructions, logs and return data in \
-                       the historical transaction info stored"),
         )
         .arg(
             Arg::with_name("enable_extended_tx_metadata_storage")
@@ -886,18 +861,6 @@ pub fn main() {
                        slots behind the highest snapshot available for \
                        download from other validators"),
         )
-        .arg(
-            Arg::with_name("incremental_snapshots")
-                .long("incremental-snapshots")
-                .takes_value(false)
-                .hidden(true)
-                .conflicts_with("no_incremental_snapshots")
-                .help("Enable incremental snapshots")
-                .long_help("Enable incremental snapshots by setting this flag. \
-                   When enabled, --snapshot-interval-slots will set the \
-                   incremental snapshot interval. To set the full snapshot \
-                   interval, use --full-snapshot-interval-slots.")
-         )
         .arg(
             Arg::with_name("no_incremental_snapshots")
                 .long("no-incremental-snapshots")
@@ -1228,12 +1191,6 @@ pub fn main() {
                       [default: all validators]")
         )
         .arg(
-            Arg::with_name("no_rocksdb_compaction")
-                .long("no-rocksdb-compaction")
-                .takes_value(false)
-                .help("Disable manual compaction of the ledger database (this is ignored).")
-        )
-        .arg(
             Arg::with_name("rocksdb_compaction_interval")
                 .long("rocksdb-compaction-interval-slots")
                 .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")
@@ -1267,17 +1224,6 @@ pub fn main() {
                 .long("tpu-enable-udp")
                 .takes_value(false)
                 .help("Enable UDP for receiving/sending transactions."),
-        )
-        .arg(
-            Arg::with_name("disable_quic_servers")
-                .long("disable-quic-servers")
-                .takes_value(false)
-                .hidden(true)
-        )
-        .arg(
-            Arg::with_name("enable_quic_servers")
-                .hidden(true)
-                .long("enable-quic-servers")
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")
@@ -1633,14 +1579,6 @@ pub fn main() {
                 .help("Disable the just-in-time compiler and instead use the interpreter for BPF"),
         )
         .arg(
-            // legacy nop argument
-            Arg::with_name("bpf_jit")
-                .long("bpf-jit")
-                .hidden(true)
-                .takes_value(false)
-                .conflicts_with("no_bpf_jit")
-        )
-        .arg(
             Arg::with_name("poh_pinned_cpu_core")
                 .hidden(true)
                 .long("experimental-poh-pinned-cpu-core")
@@ -1806,28 +1744,6 @@ pub fn main() {
                       AccountsHashVerifier. This has a computational cost."),
         )
         .arg(
-            Arg::with_name("accounts_db_index_hashing")
-                .long("accounts-db-index-hashing")
-                .help("Enables the use of the index in hash calculation in \
-                       AccountsHashVerifier/Accounts Background Service.")
-                .hidden(true),
-        )
-        .arg(
-            Arg::with_name("no_accounts_db_index_hashing")
-                .long("no-accounts-db-index-hashing")
-                .help("This is obsolete. See --accounts-db-index-hashing. \
-                       Disables the use of the index in hash calculation in \
-                       AccountsHashVerifier/Accounts Background Service.")
-                .hidden(true),
-        )
-        .arg(
-            // legacy nop argument
-            Arg::with_name("accounts_db_caching_enabled")
-                .long("accounts-db-caching-enabled")
-                .conflicts_with("no_accounts_db_caching")
-                .hidden(true)
-        )
-        .arg(
             Arg::with_name("accounts_shrink_optimize_total_space")
                 .long("accounts-shrink-optimize-total-space")
                 .takes_value(true)
@@ -1877,6 +1793,7 @@ pub fn main() {
                 .long("replay-slots-concurrently")
                 .help("Allow concurrent replay of slots on different forks")
         )
+        .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
         .subcommand(
             SubCommand::with_name("exit")
@@ -2055,6 +1972,7 @@ pub fn main() {
                          then this not a good time for a restart")
         )
         .get_matches();
+    warn_for_deprecated_arguments(&matches);
 
     let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
@@ -2375,9 +2293,6 @@ pub fn main() {
 
     let init_complete_file = matches.value_of("init_complete_file");
 
-    if matches.is_present("no_check_vote_account") {
-        info!("vote account sanity checks are no longer performed by default. --no-check-vote-account is deprecated and can be removed from the command line");
-    }
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: matches.is_present("no_genesis_fetch"),
         no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
@@ -2621,25 +2536,6 @@ pub fn main() {
         None
     };
 
-    if matches.is_present("minimal_rpc_api") {
-        warn!("--minimal-rpc-api is now the default behavior. This flag is deprecated and can be removed from the launch args");
-    }
-
-    if matches.is_present("enable_cpi_and_log_storage") {
-        warn!(
-            "--enable-cpi-and-log-storage is deprecated. Please update the \
-            launch args to use --enable-extended-tx-metadata-storage and remove \
-            --enable-cpi-and-log-storage"
-        );
-    }
-
-    if matches.is_present("enable_quic_servers") {
-        warn!("--enable-quic-servers is now the default behavior. This flag is deprecated and can be removed from the launch args");
-    }
-    if matches.is_present("disable_quic_servers") {
-        warn!("--disable-quic-servers is deprecated. The quic server cannot be disabled.");
-    }
-
     let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
         || matches.is_present("enable_bigtable_ledger_upload")
     {
@@ -2659,12 +2555,6 @@ pub fn main() {
         None
     };
 
-    if matches.is_present("accounts_db_index_hashing") {
-        info!("The accounts hash is only calculated without using the index. --accounts-db-index-hashing is deprecated and can be removed from the command line");
-    }
-    if matches.is_present("no_accounts_db_index_hashing") {
-        info!("The accounts hash is only calculated without using the index. --no-accounts-db-index-hashing is deprecated and can be removed from the command line");
-    }
     let rpc_send_retry_rate_ms = value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64);
     let rpc_send_batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
     let rpc_send_batch_send_rate_ms =
@@ -3012,9 +2902,6 @@ pub fn main() {
 
         exit(1);
     }
-    if matches.is_present("incremental_snapshots") {
-        warn!("--incremental-snapshots is now the default behavior. This flag is deprecated and can be removed from the launch args")
-    }
 
     if matches.is_present("limit_ledger_size") {
         let limit_ledger_size = match matches.value_of("limit_ledger_size") {
@@ -3332,5 +3219,127 @@ fn process_account_indexes(matches: &ArgMatches) -> AccountSecondaryIndexes {
     AccountSecondaryIndexes {
         keys,
         indexes: account_indexes,
+    }
+}
+
+// Helper to add arguments that are no longer used but are being kept around to
+// avoid breaking validator startup commands
+fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
+    vec![
+        Arg::with_name("accounts_db_caching_enabled")
+            .long("accounts-db-caching-enabled")
+            .conflicts_with("no_accounts_db_caching")
+            .hidden(true),
+        Arg::with_name("accounts_db_index_hashing")
+            .long("accounts-db-index-hashing")
+            .help(
+                "Enables the use of the index in hash calculation in \
+                   AccountsHashVerifier/Accounts Background Service.",
+            )
+            .hidden(true),
+        Arg::with_name("no_accounts_db_index_hashing")
+            .long("no-accounts-db-index-hashing")
+            .help(
+                "This is obsolete. See --accounts-db-index-hashing. \
+                   Disables the use of the index in hash calculation in \
+                   AccountsHashVerifier/Accounts Background Service.",
+            )
+            .hidden(true),
+        Arg::with_name("bpf_jit")
+            .long("bpf-jit")
+            .hidden(true)
+            .takes_value(false)
+            .conflicts_with("no_bpf_jit"),
+        Arg::with_name("disable_quic_servers")
+            .long("disable-quic-servers")
+            .takes_value(false)
+            .hidden(true),
+        Arg::with_name("enable_quic_servers")
+            .hidden(true)
+            .long("enable-quic-servers"),
+        Arg::with_name("enable_cpi_and_log_storage")
+            .long("enable-cpi-and-log-storage")
+            .requires("enable_rpc_transaction_history")
+            .takes_value(false)
+            .hidden(true)
+            .help(
+                "Deprecated, please use \"enable-extended-tx-metadata-storage\". \
+                   Include CPI inner instructions, logs and return data in \
+                   the historical transaction info stored",
+            ),
+        Arg::with_name("incremental_snapshots")
+            .long("incremental-snapshots")
+            .takes_value(false)
+            .hidden(true)
+            .conflicts_with("no_incremental_snapshots")
+            .help("Enable incremental snapshots")
+            .long_help(
+                "Enable incremental snapshots by setting this flag. \
+                   When enabled, --snapshot-interval-slots will set the \
+                   incremental snapshot interval. To set the full snapshot \
+                   interval, use --full-snapshot-interval-slots.",
+            ),
+        Arg::with_name("minimal_rpc_api")
+            .long("--minimal-rpc-api")
+            .takes_value(false)
+            .hidden(true)
+            .help("Only expose the RPC methods required to serve snapshots to other nodes"),
+        Arg::with_name("no_check_vote_account")
+            .long("no-check-vote-account")
+            .takes_value(false)
+            .conflicts_with("no_voting")
+            .requires("entrypoint")
+            .hidden(true)
+            .help("Skip the RPC vote account sanity check"),
+        Arg::with_name("no_rocksdb_compaction")
+            .long("no-rocksdb-compaction")
+            .hidden(true)
+            .takes_value(false)
+            .help("Disable manual compaction of the ledger database (this is ignored)."),
+    ]
+}
+
+lazy_static! {
+    static ref DEPRECATED_ARGS_AND_HELP: Vec<(&'static str, &'static str)> = vec![
+        ("accounts_db_caching_enabled", ""),
+        (
+            "accounts_db_index_hashing",
+            "The accounts hash is only calculated without using the index.",
+        ),
+        (
+            "no_accounts_db_index_hashing",
+            "The accounts hash is only calculated without using the index.",
+        ),
+        ("bpf_jit", ""),
+        (
+            "disable_quic_servers",
+            "The quic server cannot be disabled.",
+        ),
+        (
+            "enable_quic_servers",
+            "The quic server is now enabled by default.",
+        ),
+        (
+            "enable_cpi_and_log_storage",
+            "Please use --enable-extended-tx-metadata-storage instead.",
+        ),
+        ("incremental_snapshots", ""),
+        ("minimal_rpc_api", ""),
+        (
+            "no_check_vote_account",
+            "Vote account sanity checks are no longer performed by default.",
+        ),
+        ("no_rocksdb_compaction", ""),
+    ];
+}
+
+fn warn_for_deprecated_arguments(matches: &ArgMatches) {
+    for (arg, help) in DEPRECATED_ARGS_AND_HELP.iter() {
+        if matches.is_present(arg) {
+            warn!(
+                "{}",
+                format!("--{} is deprecated. {}", arg, help).replace('_', "-")
+            );
+        }
     }
 }


### PR DESCRIPTION
#### Problem
We keep deprecated arguments around to avoid breaking compatibility; however, they add clutter to the code.

#### Summary of Changes
 Move all of the deprecated arguments and warnings for using the deprecated warnings into their own functions to keep main function more readable.

Here is a run with all of these arguments specified and the subsequent warnings to prove I didn't screw up the copy/paste:
```
target/debug/solana-validator \
--identity keypair.json \
--dynamic-port-range 8002-8032 \
--gossip-port 8001 \
--ledger ./ \
--limit-ledger-size \
--log ./ \
--rpc-port 8899 \
--expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
--wal-recovery-mode skip_any_corrupted_record \
--accounts-index-memory-limit-mb 5000 \
--trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
--halt-on-trusted-validators-accounts-hash-mismatch \
--no-untrusted-rpc \
--expected-shred-version 11762 \
--entrypoint mainnet-beta.solana.com:8001 \
--no-genesis-fetch \
--no-snapshot-fetch \
--accounts-db-caching-enabled \
--accounts-db-index-hashing \
--no-accounts-db-index-hashing \
--bpf-jit \
--disable-quic-servers \
--enable-quic-servers \
--enable-cpi-and-log-storage \
--incremental-snapshots \
--minimal-rpc-api \
--no-check-vote-account \
--no-rocksdb-compaction \
--enable-rpc-transaction-history
[2022-10-06T07:13:58.809624000Z WARN  solana_validator] --accounts-db-caching-enabled is now deprecated. 
[2022-10-06T07:13:58.809678000Z WARN  solana_validator] --accounts-db-index-hashing is now deprecated. The accounts hash is only calculated without using the index.
[2022-10-06T07:13:58.809703000Z WARN  solana_validator] --no-accounts-db-index-hashing is now deprecated. The accounts hash is only calculated without using the index.
[2022-10-06T07:13:58.809720000Z WARN  solana_validator] --bpf-jit is now deprecated. 
[2022-10-06T07:13:58.809737000Z WARN  solana_validator] --disable-quic-servers is now deprecated. The quic server cannot be disabled.
[2022-10-06T07:13:58.809755000Z WARN  solana_validator] --enable-quic-servers is now deprecated. The quic server is now enabled by default.
[2022-10-06T07:13:58.809776000Z WARN  solana_validator] --enable-cpi-and-log-storage is now deprecated. Please use --enable-extended-tx-metadata-storage instead.
[2022-10-06T07:13:58.809794000Z WARN  solana_validator] --incremental-snapshots is now deprecated. 
[2022-10-06T07:13:58.809810000Z WARN  solana_validator] --minimal-rpc-api is now deprecated. 
[2022-10-06T07:13:58.809827000Z WARN  solana_validator] --no-check-vote-account is now deprecated. Vote account sanity checks are no longer performed by default.
[2022-10-06T07:13:58.809845000Z WARN  solana_validator] --no-rocksdb-compaction is now deprecated. 
```
