### PR TITLE
Ignore errors when joining background threads for EAH tests

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -211,17 +211,11 @@ impl Drop for BackgroundServices {
         info!("Stopping background services...");
         self.exit.store(true, Ordering::Relaxed);
 
-        unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }
-            .join()
-            .expect("stop ABS");
-
-        unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }
-            .join()
-            .expect("stop AHV");
-
-        unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }
-            .join()
-            .expect("stop SPS");
+        // Join the background threads, and ignore any errors.
+        // SAFETY: We do not use any of the `ManuallyDrop` fields again, so `.take()` is OK here.
+        _ = unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }.join();
+        _ = unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }.join();
+        _ = unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }.join();
 
         info!("Stopping background services... DONE");
     }


### PR DESCRIPTION
#### Problem

CI spuriously fails intermittently in EAH tests. The failure is caused in test cleanup, when background threads are being joined and throw an error [^1]. Since the test has already completed its useful bits, this error is not germane.

[^1] It appears that if the snapshot packager service has an outstanding snapshot request to service, the input files or output directory (or both) is getting cleaned up before the snapshot archive is made.

Update: [^1] may be fixed by https://github.com/solana-labs/solana/pull/28270

Here's what the error looks like:
https://buildkite.com/solana-labs/solana/builds/83273#0183abb6-af57-44eb-ae6b-c3d089995265

#### Summary of Changes

Ignore errors when joining background threads in the EAH tests.