### PR TITLE
Update restart guide to include the use of `solana-ledger-tool latest-optimistic-slots`

### DIFF
--- a/docs/src/running-validator/restart-cluster.md
+++ b/docs/src/running-validator/restart-cluster.md
@@ -1,13 +1,25 @@
 ## Restarting a cluster
 
-### Step 1. Identify the slot that the cluster will be restarted at
+### Step 1. Identify the latest optimistically confirmed slot for the cluster
 
-The highest optimistically confirmed slot is the best slot to start from, which
-can be found by looking for
+In Solana 1.14 or greater, run the following command to output the latest
+optimistically confirmed slot your validator observed:
+```bash
+solana-ledger-tool -l ledger latest-optimistic-slots
+```
+
+In Solana 1.13 or less, the latest optimistically confirmed can be found by looking for the more recent occurence of
 [this](https://github.com/solana-labs/solana/blob/0264147d42d506fb888f5c4c021a998e231a3e74/core/src/optimistic_confirmation_verifier.rs#L71)
-metrics datapoint. Otherwise use the last root.
+metrics datapoint.
 
 Call this slot `SLOT_X`
+
+Note that it's possible that some validators observed an optimistically
+confirmed slot that's greater than others before the outage.  Survey the other
+validators on the cluster to ensure that a greater optimistically confirmed slot
+does not exist before proceeding. If a greater slot value is found use it
+instead.
+
 
 ### Step 2. Stop the validator(s)
 


### PR DESCRIPTION
As of 1.14.x, validators don't need to grep logs to find the latest optimistically confirmed slot. 