### PR TITLE
move accounts_db::load_without_fixed_root to test mod

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4775,14 +4775,6 @@ impl AccountsDb {
             .filter(|(account, _)| !account.is_zero_lamport())
     }
 
-    pub fn load_without_fixed_root(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.load(ancestors, pubkey, LoadHint::Unspecified)
-    }
-
     fn read_index_for_accessor_or_load_slow<'a>(
         &'a self,
         ancestors: &Ancestors,
@@ -9605,6 +9597,14 @@ pub mod tests {
                 },
                 None,
             )
+        }
+
+        fn load_without_fixed_root(
+            &self,
+            ancestors: &Ancestors,
+            pubkey: &Pubkey,
+        ) -> Option<(AccountSharedData, Slot)> {
+            self.load(ancestors, pubkey, LoadHint::Unspecified)
         }
     }
 


### PR DESCRIPTION
#### Problem

#### Summary of Changes

move code only used by tests into test module.
This makes returning zero lamport accounts easier to wrangle.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
