### PR TITLE
Make FIFO related validator arguments public

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1011,7 +1011,6 @@ pub fn main() {
         )
         .arg(
             Arg::with_name("rocksdb_shred_compaction")
-                .hidden(true)
                 .long("rocksdb-shred-compaction")
                 .value_name("ROCKSDB_COMPACTION_STYLE")
                 .takes_value(true)
@@ -1026,7 +1025,6 @@ pub fn main() {
         )
         .arg(
             Arg::with_name("rocksdb_fifo_shred_storage_size")
-                .hidden(true)
                 .long("rocksdb-fifo-shred-storage-size")
                 .value_name("SHRED_STORAGE_SIZE_BYTES")
                 .takes_value(true)


### PR DESCRIPTION
#### Summary of Changes
This PR makes two FIFO-related validator arguments public:
--rocksdb_shred_compaction and --rocksdb_fifo_shred_storage_size.

#### Test Plan
* There're already ~26 validators running FIFO in mainnet-beta for more than 30 days, no issues were reported so far.
* Ran a validator with FIFO for days and observed it's able to consistently catch up
  and create new roots.