### PR TITLE
bootstrap: Require known validators to have all snapshot hashes

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -653,7 +653,7 @@ fn get_rpc_nodes(
             }
         }
 
-        let know_validators_to_wait_for = if newer_cluster_snapshot_timeout
+        let known_validators_to_wait_for = if newer_cluster_snapshot_timeout
             .as_ref()
             .map(|timer: &Instant| timer.elapsed() < WAIT_FOR_ALL_KNOWN_VALIDATORS)
             .unwrap_or(true)


### PR DESCRIPTION
#### Problem

Bootstrap often does not download an incremental snapshot. See https://github.com/solana-labs/solana/issues/26180 for full context.

#### Summary of Changes

Require that we've discovered all snapshot hashes from known validators.


#### Additional Info

While testing this out against mnb, I ran a new node a bunch of times (wiped ledger each time). I saw it take 7-10 seconds before the node would get all the snapshot hashes from all the known validators. This is not too bad, especially because it can (i.e. will) save minutes/hours while catching up.

Note, this doesn't change that if a node needs to download a full snapshot first, that newer incremental snapshots could've been downloaded instead. This PR is meant to really address the majority use-case where a node shuts down to upgrade, or crashes from a panic, and needs to restart quickly. In these cases, the node already has a full snapshot and only needs an incremental snapshot; this PR will ensure bootstrap now finds and downloads an incremental snapshot. Worst case, known validators have just taken a full snapshot, and therefore there are no valid incremental snapshots. So may have to wait a minute or two for the next incremental snapshot to be taken. This should be very rare, since full snapshots are 25,000 slots by default. Worst-worst case is that a known validator is down and this check never returns true and loops until timeout is hit.

After 60 seconds, if _all_ the known validators are not reporting all snapshot hashes, then we switch over to _any_ known validator reporting all snapshot hashes. This should solve the case where a known validator is down.

This is intended to be very targeted change since I plan to backport all the way back to v1.10. Smaller changes are hopefully easier to review, and thus less risky. Subsequent PRs can address a larger change to the bootstrap process more holistically.

For scenarios where a node does not yet have a full snapshot but wants to get the newest incremental snapshot to ensure the fastest catch up time, the operator can start the validator and then stop-restart once the full snapshot has been downloaded. This will restart bootstrap and will discover new incremental snapshots.