### PR TITLE
report additional transaction errors to metrics

### DIFF
--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -109,6 +109,11 @@ struct LeaderSlotPacketCountMetrics {
     // `self.retrayble_errored_transaction_count`.
     account_lock_throttled_transactions_count: u64,
 
+    // total number of transactions that were excluded from the block because their write
+    // account locks exceed the limit.
+    // These transactions are not retried.
+    account_locks_limit_throttled_transactions_count: u64,
+
     // total number of transactions that were excluded from the block because they were too expensive
     // according to the cost model. These transactions are added back to the buffered queue and are
     // already counted in `self.retrayble_errored_transaction_count`.
@@ -205,6 +210,11 @@ impl LeaderSlotPacketCountMetrics {
             (
                 "account_lock_throttled_transactions_count",
                 self.account_lock_throttled_transactions_count as i64,
+                i64
+            ),
+            (
+                "account_locks_limit_throttled_transactions_count",
+                self.account_locks_limit_throttled_transactions_count as i64,
                 i64
             ),
             (
@@ -457,6 +467,13 @@ impl LeaderSlotMetricsTracker {
                     .packet_count_metrics
                     .account_lock_throttled_transactions_count,
                 error_counters.account_in_use as u64
+            );
+
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .account_locks_limit_throttled_transactions_count,
+                error_counters.too_many_account_locks as u64
             );
 
             saturating_add_assign!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4542,14 +4542,32 @@ impl Bank {
             .iter()
             .enumerate()
             .filter_map(|(index, res)| match res {
+                // following are retryable errors
                 Err(TransactionError::AccountInUse) => {
                     error_counters.account_in_use += 1;
                     Some(index)
                 }
-                Err(TransactionError::WouldExceedMaxBlockCostLimit)
-                | Err(TransactionError::WouldExceedMaxVoteCostLimit)
-                | Err(TransactionError::WouldExceedMaxAccountCostLimit)
-                | Err(TransactionError::WouldExceedAccountDataBlockLimit) => Some(index),
+                Err(TransactionError::WouldExceedMaxBlockCostLimit) => {
+                    error_counters.would_exceed_max_block_cost_limit += 1;
+                    Some(index)
+                }
+                Err(TransactionError::WouldExceedMaxVoteCostLimit) => {
+                    error_counters.would_exceed_max_vote_cost_limit += 1;
+                    Some(index)
+                }
+                Err(TransactionError::WouldExceedMaxAccountCostLimit) => {
+                    error_counters.would_exceed_max_account_cost_limit += 1;
+                    Some(index)
+                }
+                Err(TransactionError::WouldExceedAccountDataBlockLimit) => {
+                    error_counters.would_exceed_account_data_block_limit += 1;
+                    Some(index)
+                }
+                // following are non-retryable errors
+                Err(TransactionError::TooManyAccountLocks) => {
+                    error_counters.too_many_account_locks += 1;
+                    None
+                }
                 Err(_) => None,
                 Ok(_) => None,
             })

--- a/runtime/src/transaction_error_metrics.rs
+++ b/runtime/src/transaction_error_metrics.rs
@@ -4,6 +4,7 @@ use solana_sdk::{clock::Slot, saturating_add_assign};
 pub struct TransactionErrorMetrics {
     pub total: usize,
     pub account_in_use: usize,
+    pub too_many_account_locks: usize,
     pub account_loaded_twice: usize,
     pub account_not_found: usize,
     pub blockhash_not_found: usize,
@@ -18,6 +19,10 @@ pub struct TransactionErrorMetrics {
     pub not_allowed_during_cluster_maintenance: usize,
     pub invalid_writable_account: usize,
     pub invalid_rent_paying_account: usize,
+    pub would_exceed_max_block_cost_limit: usize,
+    pub would_exceed_max_account_cost_limit: usize,
+    pub would_exceed_max_vote_cost_limit: usize,
+    pub would_exceed_account_data_block_limit: usize,
 }
 
 impl TransactionErrorMetrics {
@@ -28,6 +33,7 @@ impl TransactionErrorMetrics {
     pub fn accumulate(&mut self, other: &TransactionErrorMetrics) {
         saturating_add_assign!(self.total, other.total);
         saturating_add_assign!(self.account_in_use, other.account_in_use);
+        saturating_add_assign!(self.too_many_account_locks, other.too_many_account_locks);
         saturating_add_assign!(self.account_loaded_twice, other.account_loaded_twice);
         saturating_add_assign!(self.account_not_found, other.account_not_found);
         saturating_add_assign!(self.blockhash_not_found, other.blockhash_not_found);
@@ -54,6 +60,22 @@ impl TransactionErrorMetrics {
             self.invalid_rent_paying_account,
             other.invalid_rent_paying_account
         );
+        saturating_add_assign!(
+            self.would_exceed_max_block_cost_limit,
+            other.would_exceed_max_block_cost_limit
+        );
+        saturating_add_assign!(
+            self.would_exceed_max_account_cost_limit,
+            other.would_exceed_max_account_cost_limit
+        );
+        saturating_add_assign!(
+            self.would_exceed_max_vote_cost_limit,
+            other.would_exceed_max_vote_cost_limit
+        );
+        saturating_add_assign!(
+            self.would_exceed_account_data_block_limit,
+            other.would_exceed_account_data_block_limit
+        );
     }
 
     pub fn report(&self, id: u32, slot: Slot) {
@@ -63,6 +85,11 @@ impl TransactionErrorMetrics {
             ("slot", slot as i64, i64),
             ("total", self.total as i64, i64),
             ("account_in_use", self.account_in_use as i64, i64),
+            (
+                "too_many_account_locks",
+                self.too_many_account_locks as i64,
+                i64
+            ),
             (
                 "account_loaded_twice",
                 self.account_loaded_twice as i64,
@@ -103,6 +130,26 @@ impl TransactionErrorMetrics {
             (
                 "invalid_rent_paying_account",
                 self.invalid_rent_paying_account as i64,
+                i64
+            ),
+            (
+                "would_exceed_max_block_cost_limit",
+                self.would_exceed_max_block_cost_limit as i64,
+                i64
+            ),
+            (
+                "would_exceed_max_account_cost_limit",
+                self.would_exceed_max_account_cost_limit as i64,
+                i64
+            ),
+            (
+                "would_exceed_max_vote_cost_limit",
+                self.would_exceed_max_vote_cost_limit as i64,
+                i64
+            ),
+            (
+                "would_exceed_account_data_block_limit",
+                self.would_exceed_account_data_block_limit as i64,
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem
Some of transaction errors are not reported to metrics. 

#### Summary of Changes
- reports TooManyAccountLocks and 4 WouldExceed*Limit errors

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
