### PR TITLE
web3.js: add getSignatureStatuses to confirm transaction

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3408,7 +3408,10 @@ export class Connection {
           subscriptionCommitment,
         );
 
-        this.getSignatureStatuses([rawSignature]).then(signatureStatuses => {
+        (async () => {
+          const signatureStatuses = await this.getSignatureStatuses([
+            rawSignature,
+          ]);
           const result = signatureStatuses && signatureStatuses.value[0];
           if (result?.err) {
             reject(result.err);
@@ -3421,7 +3424,7 @@ export class Connection {
             done = true;
             resolve({__type: TransactionStatus.PROCESSED, response});
           }
-        });
+        })();
       } catch (err) {
         reject(err);
       }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3436,6 +3436,9 @@ export class Connection {
                   done = true;
                   resolve({__type: TransactionStatus.PROCESSED, response});
                 }
+                if (intervalId) {
+                  clearInterval(intervalId);
+                }
               })();
             }
           }, 100);

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3424,7 +3424,7 @@ export class Connection {
         try {
           while (!done) {
             //we want to ignore sleep for the first call to resolve
-            //immediately if tx was confirmed before whole function run
+            //immediately if tx was confirmed before
             if (retryCount > 0) {
               await sleep(signatureStatusesPoolInterval);
             }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3389,7 +3389,7 @@ export class Connection {
     let subscriptionId;
     let done = false;
 
-    const signaturePromise = new Promise<{
+    const confirmationPromise = new Promise<{
       __type: TransactionStatus.PROCESSED;
       response: RpcResponseAndContext<SignatureResult>;
     }>((resolve, reject) => {
@@ -3479,7 +3479,7 @@ export class Connection {
 
     let result: RpcResponseAndContext<SignatureResult>;
     try {
-      const outcome = await Promise.race([signaturePromise, expiryPromise]);
+      const outcome = await Promise.race([confirmationPromise, expiryPromise]);
       switch (outcome.__type) {
         case TransactionStatus.BLOCKHEIGHT_EXCEEDED:
           throw new TransactionExpiredBlockheightExceededError(rawSignature);

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3415,7 +3415,7 @@ export class Connection {
       }
     });
 
-    const statusPromise = new Promise<{
+    const signatureStatusPoolPromise = new Promise<{
       __type: TransactionStatus.PROCESSED;
       response: RpcResponseAndContext<SignatureResult>;
     }>((resolve, reject) => {
@@ -3505,7 +3505,7 @@ export class Connection {
     try {
       const outcome = await Promise.race([
         signaturePromise,
-        statusPromise,
+        signatureStatusPoolPromise,
         expiryPromise,
       ]);
       switch (outcome.__type) {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -998,6 +998,13 @@ describe('Connection', function () {
           params: [mockSignature, {commitment: 'finalized'}],
           result: new Promise(() => {}),
         });
+
+        await mockRpcResponse({
+          method: 'getSignatureStatuses',
+          params: [[mockSignature]],
+          value: [null],
+          withContext: true,
+        });
         const timeoutPromise = connection.confirmTransaction(mockSignature);
 
         // Advance the clock past all waiting timers, notably the expiry timer.
@@ -1016,6 +1023,13 @@ describe('Connection', function () {
           method: 'signatureSubscribe',
           params: [mockSignature, {commitment: 'finalized'}],
           result: new Promise(() => {}), // Never resolve this = never get a response.
+        });
+
+        await mockRpcResponse({
+          method: 'getSignatureStatuses',
+          params: [[mockSignature]],
+          value: [null],
+          withContext: true,
         });
 
         const lastValidBlockHeight = 3;

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -91,7 +91,7 @@ const verifySignatureStatus = (
   return status;
 };
 
-describe.only('Connection', function () {
+describe('Connection', function () {
   let connection: Connection;
   beforeEach(() => {
     connection = new Connection(url);

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -91,7 +91,7 @@ const verifySignatureStatus = (
   return status;
 };
 
-describe('Connection', function () {
+describe.only('Connection', function () {
   let connection: Connection;
   beforeEach(() => {
     connection = new Connection(url);

--- a/web3.js/test/mocks/rpc-websockets.ts
+++ b/web3.js/test/mocks/rpc-websockets.ts
@@ -7,6 +7,7 @@ import {Connection} from '../../src';
 type RpcRequest = {
   method: string;
   params?: Array<any>;
+  subscriptionEstablishmentPromise?: Promise<void>;
 };
 
 type RpcResponse = {
@@ -24,13 +25,15 @@ export const mockRpcMessage = ({
   method,
   params,
   result,
+  subscriptionEstablishmentPromise,
 }: {
   method: string;
   params: Array<any>;
   result: any | Promise<any>;
+  subscriptionEstablishmentPromise?: Promise<void>;
 }) => {
   mockRpcSocket.push([
-    {method, params},
+    {method, params, subscriptionEstablishmentPromise},
     {
       context: {slot: 11},
       value: result,
@@ -107,6 +110,10 @@ class MockClient {
       expect(params[0]).to.be.a('number');
     } else {
       expect(params).to.eql(mockRequest.params);
+    }
+
+    if (mockRequest.subscriptionEstablishmentPromise) {
+      await mockRequest.subscriptionEstablishmentPromise;
     }
 
     let id = ++this.subscriptionCounter;


### PR DESCRIPTION
#### Problem

If you call confirmTransaction for a signature that has already been processed, the signatureSubscribe subscription will never fire a notification. This will certainly mean that confirmTransaction() will throw an expiry error for a transaction that is, in actual fact, confirmed.

https://github.com/solana-labs/solana/issues/25955

#### Summary of Changes

add getSignatureStatuses 
