### PR TITLE
separate account locks validation from creating the locks

### DIFF
--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -199,13 +199,8 @@ impl SanitizedTransaction {
         &self,
         tx_account_lock_limit: usize,
     ) -> Result<TransactionAccountLocks> {
-        if self.message.has_duplicates() {
-            Err(TransactionError::AccountLoadedTwice)
-        } else if self.message.account_keys().len() > tx_account_lock_limit {
-            Err(TransactionError::TooManyAccountLocks)
-        } else {
-            Ok(self.get_account_locks_unchecked())
-        }
+        Self::validate_account_locks(self.message(), tx_account_lock_limit)?;
+        Ok(self.get_account_locks_unchecked())
     }
 
     /// Return the list of accounts that must be locked during processing this transaction.
@@ -280,5 +275,19 @@ impl SanitizedTransaction {
             .map_err(|_| TransactionError::InvalidAccountIndex)?;
         }
         Ok(())
+    }
+
+    /// Validate a transaction message against locked accounts
+    fn validate_account_locks(
+        message: &SanitizedMessage,
+        tx_account_lock_limit: usize,
+    ) -> Result<()> {
+        if message.has_duplicates() {
+            Err(TransactionError::AccountLoadedTwice)
+        } else if message.account_keys().len() > tx_account_lock_limit {
+            Err(TransactionError::TooManyAccountLocks)
+        } else {
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
#### Problem
We want to move this check into sanitization, creating a simple preliminary PR to just separate this valdiation from current function.

#### Summary of Changes
Separate checks if we can lock accounts for tx (duplicate and count checks) from getting the locks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
