### PR TITLE
Feature/account_locks_filter_during_deserialization

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -458,7 +458,15 @@ impl BankingStage {
                     _ => (verified_receiver.clone(), ForwardOption::ForwardTransaction),
                 };
 
-                let mut packet_deserializer = PacketDeserializer::new(verified_receiver);
+                let runtime_config_tx_account_lock_limit = bank_forks
+                    .read()
+                    .unwrap()
+                    .root_bank()
+                    .get_runtime_config_transaction_account_lock_limit();
+                let mut packet_deserializer = PacketDeserializer::new(
+                    verified_receiver,
+                    runtime_config_tx_account_lock_limit,
+                );
                 let poh_recorder = poh_recorder.clone();
                 let cluster_info = cluster_info.clone();
                 let mut recv_start = Instant::now();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3918,6 +3918,11 @@ impl Bank {
         }
     }
 
+    /// Get the runtime configuration transaction account limit
+    pub fn get_runtime_config_transaction_account_lock_limit(&self) -> Option<usize> {
+        self.runtime_config.transaction_account_lock_limit
+    }
+
     /// Prepare a transaction batch from a list of legacy transactions. Used for tests only.
     pub fn prepare_batch_for_tests(&self, txs: Vec<Transaction>) -> TransactionBatch {
         let transaction_account_lock_limit = self.get_transaction_account_lock_limit();


### PR DESCRIPTION
#### Problem
We can filter transactions exceeding account lock limits during deserialization.

#### Summary of Changes
Check immutable deserialized packet, during deserialization, to see if it exceeds account lock limits.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
