### PR TITLE
Gmg/rpc request estimated instruction costs master

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -440,6 +440,9 @@ pub enum CliCommand {
     },
     // Address lookup table commands
     AddressLookupTable(AddressLookupTableCliCommand),
+    GetEstimatedInstructionCost {
+        program_id : Option<String>,
+    },
 }
 
 #[derive(Debug, PartialEq)]
@@ -821,6 +824,7 @@ pub fn parse_command(
             })
         }
         ("transfer", Some(matches)) => parse_transfer(matches, default_signer, wallet_manager),
+        ("estimated-instruction-costs", Some(matches)) => parse_estimated_instruction_costs(matches, default_signer, wallet_manager),
         //
         ("", None) => {
             eprintln!("{}", matches.usage());
@@ -1638,7 +1642,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Address Lookup Table Commands
         CliCommand::AddressLookupTable(subcommand) => {
             process_address_lookup_table_subcommand(rpc_client, config, subcommand)
-        }
+        },
+        // Get estimated instrution costs
+        CliCommand::GetEstimatedInstructionCost { program_id } => {
+            get_estimated_instruction_costs(rpc_client, program_id)
+        },
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -762,6 +762,11 @@ impl Validator {
         // block min prioritization fee cache should be readable by RPC, and writable by validator
         // (for now, by replay stage)
         let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::default());
+        let mut cost_model = CostModel::default();
+        // initialize cost model with built-in instruction costs only
+        cost_model.initialize_cost_table(&[]);
+        let cost_model = Arc::new(RwLock::new(cost_model));
+
 
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let (
@@ -811,6 +816,7 @@ impl Validator {
                 connection_cache.clone(),
                 max_complete_transaction_status_slot,
                 prioritization_fee_cache.clone(),
+                cost_model.clone(),
             )?;
 
             (
@@ -923,11 +929,6 @@ impl Validator {
         );
 
         let vote_tracker = Arc::<VoteTracker>::default();
-        let mut cost_model = CostModel::default();
-        // initialize cost model with built-in instruction costs only
-        cost_model.initialize_cost_table(&[]);
-        let cost_model = Arc::new(RwLock::new(cost_model));
-
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
         let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -113,6 +113,8 @@ pub enum RpcRequest {
     SendTransaction,
     SimulateTransaction,
     SignVote,
+    GetEstimatedInstructionCosts,
+    GetEstimatedInstructionCost,
 }
 
 #[allow(deprecated)]
@@ -188,6 +190,8 @@ impl fmt::Display for RpcRequest {
             RpcRequest::SendTransaction => "sendTransaction",
             RpcRequest::SimulateTransaction => "simulateTransaction",
             RpcRequest::SignVote => "signVote",
+            RpcRequest::GetEstimatedInstructionCosts => "getEstimatedInstructionCosts",
+            RpcRequest::GetEstimatedInstructionCost => "getEstimatedInstructionCost",
         };
 
         write!(f, "{}", method)

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -191,6 +191,14 @@ pub struct SlotTransactionStats {
     pub max_transactions_per_entry: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcExecuteCostInfo{
+    pub program_id: String,
+    pub cost: u64,
+    pub occurence: u64,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum SlotUpdate {

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -5316,6 +5316,18 @@ impl RpcClient {
         .into())
     }
 
+    #[allow(deprecated)]
+    pub async fn get_estimated_instruction_costs(&self) -> ClientResult<Vec<RpcExecuteCostInfo>> {
+        let result = self.send::<Response<Vec<RpcExecuteCostInfo>>>(RpcRequest::GetEstimatedInstructionCosts, json!([])).await?;
+        Ok(result.value)
+    }
+
+    #[allow(deprecated)]
+    pub async fn get_estimated_instruction_cost(&self, program_id : Pubkey) -> ClientResult<RpcExecuteCostInfo> {
+        let result = self.send::<Response<RpcExecuteCostInfo>>(RpcRequest::GetEstimatedInstructionCost, json!([program_id.to_string()])).await?;
+        Ok(result.value)
+    }
+
     pub async fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
     where
         T: serde::de::DeserializeOwned,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3993,6 +3993,14 @@ impl RpcClient {
         (self.rpc_client.as_ref()).get_transport_stats()
     }
 
+    pub fn get_estimated_instruction_costs(&self) -> ClientResult<Vec<RpcExecuteCostInfo>> {
+        self.invoke(self.rpc_client.get_estimated_instruction_costs())
+    }
+
+    pub fn get_estimated_instruction_cost(&self, program_id : Pubkey) -> ClientResult<RpcExecuteCostInfo> {
+        self.invoke(self.rpc_client.get_estimated_instruction_cost(program_id))
+    }
+
     fn invoke<T, F: std::future::Future<Output = ClientResult<T>>>(&self, f: F) -> ClientResult<T> {
         // `block_on()` panics if called within an asynchronous execution context. Whereas
         // `block_in_place()` only panics if called from a current_thread runtime, which is the

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -1,5 +1,7 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
+use solana_runtime::cost_model::CostModel;
+
 use {
     crate::{
         cluster_tpu_info::ClusterTpuInfo,
@@ -358,6 +360,7 @@ impl JsonRpcService {
         connection_cache: Arc<ConnectionCache>,
         current_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+        cost_model: Arc<RwLock<CostModel>>,
     ) -> Result<Self, String> {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -467,6 +470,7 @@ impl JsonRpcService {
             leader_schedule_cache,
             current_transaction_status_slot,
             prioritization_fee_cache,
+            cost_model,
         );
 
         let leader_info =
@@ -650,6 +654,7 @@ mod tests {
             connection_cache,
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
+            Arc::new(RwLock::new(CostModel::new())),
         )
         .expect("assume successful JsonRpcService start");
         let thread = rpc_service.thread_hdl.thread();

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -4,6 +4,8 @@
 //!
 //! The main function is `calculate_cost` which returns &TransactionCost.
 //!
+
+use crate::execute_cost_table::UiExecuteCostTable;
 use {
     crate::{block_cost_limits::*, execute_cost_table::ExecuteCostTable},
     log::*,
@@ -234,6 +236,14 @@ impl CostModel {
                 Self::calculate_account_data_size_on_instruction(program_id, instruction)
             })
             .sum()
+    }
+
+    pub fn get_ui_data(&self) -> UiExecuteCostTable {
+        self.instruction_execution_cost_table.get_ui_data()
+    }
+
+    pub fn get_ui_data_for_program(&self, program_id: Pubkey) -> Option<(u64, usize, u128)> {
+        self.instruction_execution_cost_table.get_ui_data_for_program(program_id)
     }
 }
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/28269

Currently each solana RPC node maintains its own table for instruction cost. This table is not available and can be only see by adding logs and running a validator.

For purposes of checking the estimated instruction cost for program I have made this info available by rpc and solana cli.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
