### PR TITLE
Documentation fixes and improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ directory and viewable on the official [Solana Documentation](https://docs.solan
 
 Current design proposals may be viewed on the docs site:
 
-1. [Accepted Proposals](https://docs.solana.com/proposals/accepted-design-proposals.md).
-2. [Implemented Proposals](https://docs.solana.com/implemented-proposals/implemented-proposals.md)
+1. [Accepted Proposals](https://docs.solana.com/proposals/accepted-design-proposals)
+2. [Implemented Proposals](https://docs.solana.com/implemented-proposals/implemented-proposals)
 
 New design proposals should follow this guide on [how to submit a design proposal](./docs/src/proposals.md#submit-a-design-proposal).

--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ $ rustup install VERSION
 ```
 Note that if this is not the latest rust version on your machine, cargo commands may require an [override](https://rust-lang.github.io/rustup/overrides.html) in order to use the correct version.
 
-On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, protobuf etc.  On Ubuntu:
+On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, protobuf etc.  
 
+On Ubuntu:
 ```bash
 $ sudo apt-get update
 $ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
+```
+
+On Fedora:
+```bash
+$ sudo dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang cmake make protobuf-devel protobuf-compiler perl-core
 ```
 
 ## **2. Download the source code.**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ rustup install VERSION
 ```
 Note that if this is not the latest rust version on your machine, cargo commands may require an [override](https://rust-lang.github.io/rustup/overrides.html) in order to use the correct version.
 
-On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, protobuf etc.  
+On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, protobuf etc.
 
 On Ubuntu:
 ```bash


### PR DESCRIPTION
Hello :wave:  , this is my first contribution to the project.

#### Problem

* Some links to the existing proposals docs were broken.
* I missed the needed Linux packages (Fedora setup) in the readme for building the project. 

#### Summary of Changes

Here are the respective solutions for the commented problems:

* Fix the `CONTRIBUTING.md` proposals links 4622419734ca09540afd7733a909b3fab0f08f9e
* Add the Fedora needed dependencies in `README.md` 19c98cba3681dd192ce7c8f9db0e7586d59d2722

#### How i have verified the needed Fedora dependencies ?

1. I used the official Fedora 36 docker image as base for the tests.
```bash
$ docker run -it --rm fedora:36 bash
```
Rest of the steps are going to be executed on this container.

2. Install Git and Rust
```bash
# dnf install git
# curl https://sh.rustup.rs -sSf | sh
# source $HOME/.cargo/env
```

3. At this point, i looked to the packages for the current Ubuntu setup, and found the ones for Fedora. Just installed them.

```bash
# dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang cmake make protobuf-devel protobuf-compiler
``` 

4. Clone and try to build the project.

```bash
# cd
# git clone https://github.com/solana-labs/solana.git
# cd solana
# cargo build -j 4
```
At this point, i received the following error while compiling the project:

```bash
--- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC contains: /usr/local/lib64/perl5/5.34 /usr/local/share/perl5/5.34 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
  thread 'main' panicked at '
```
Looks like in Fedora, we need to explicitly install the `perl-core` package in order to have the `FindBin` perl module available. So we need to add this dependency to the list, being the final one:

```bash
 # dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang cmake make protobuf-devel protobuf-compiler perl-core
```
Thats it ! The project its compiling now.