### PR TITLE
Fix blockstore_processor::load_frozen_forks() halt_at_slot behavior

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1440,9 +1440,8 @@ fn load_frozen_forks(
         &mut pending_slots,
     )?;
 
-    let halt_at_slot = opts.halt_at_slot.unwrap_or(std::u64::MAX);
     let on_halt_store_hash_raw_data_for_debug = opts.on_halt_store_hash_raw_data_for_debug;
-    if bank_forks.read().unwrap().root() != halt_at_slot {
+    if Some(bank_forks.read().unwrap().root()) != opts.halt_at_slot {
         let mut set_root_us = 0;
         let mut root_retain_us = 0;
         let mut process_single_slot_us = 0;
@@ -1588,6 +1587,17 @@ fn load_frozen_forks(
                 slot,
             );
 
+            let done_processing = opts
+                .halt_at_slot
+                .map(|halt_at_slot| slot >= halt_at_slot)
+                .unwrap_or(false);
+            if done_processing {
+                if opts.run_final_accounts_hash_calc {
+                    run_final_hash_calc(&bank, on_halt_store_hash_raw_data_for_debug);
+                }
+                break;
+            }
+
             process_next_slots(
                 &bank,
                 &meta,
@@ -1595,13 +1605,6 @@ fn load_frozen_forks(
                 leader_schedule_cache,
                 &mut pending_slots,
             )?;
-
-            if slot >= halt_at_slot {
-                if opts.run_final_accounts_hash_calc {
-                    run_final_hash_calc(&bank, on_halt_store_hash_raw_data_for_debug);
-                }
-                break;
-            }
         }
     } else if on_halt_store_hash_raw_data_for_debug {
         run_final_hash_calc(


### PR DESCRIPTION
#### Problem
load_frozen_forks() finds new slots to process by creating new Banks for the children of the current slot in process_next_slots(). Prior to this change, we would then immediately check if we had reached the halt_at_slot and correctly halt processing when appropriate. As such, it would be possible for Banks to be created for slots beyond the halt_at_slot.

While a potential child slot that is past halt_at_slot wouldn't be replayed, the Bank being created still alters some universal state in AccountsDb. Ie
```
[... ERROR solana_runtime::accounts_db] set_hash: already exists; multiple forks with shared slot <CHILD> as child (parent: <PARENT>)!?
```

`halt_at_slot` is specified in normal operation; we capture the largest slot available during startup and say we'll go no further than that in `load_frozen_forks()`
https://github.com/solana-labs/solana/blob/d500391006475e16d870f81647096799a6a2fa4b/core/src/validator.rs#L1421-L1423

#### Summary of Changes
So, this change moves the halt_at_slot check before we create children Banks in process_next_slots().

Fixes #28236 , see that issue for some log lines that led me to discovering this
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
