### PR TITLE
reduce memory usage report freq to 1 per 5s

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -26,9 +26,9 @@ const MS_PER_M: u64 = MS_PER_S * 60;
 const MS_PER_H: u64 = MS_PER_M * 60;
 const SAMPLE_INTERVAL_UDP_MS: u64 = 2 * MS_PER_S;
 const SAMPLE_INTERVAL_OS_NETWORK_LIMITS_MS: u64 = MS_PER_H;
-const SAMPLE_INTERVAL_MEM_MS: u64 = MS_PER_S;
+const SAMPLE_INTERVAL_MEM_MS: u64 = 5 * MS_PER_S;
 const SAMPLE_INTERVAL_CPU_MS: u64 = 10 * MS_PER_S;
-const SAMPLE_INTERVAL_DISK_MS: u64 = MS_PER_S;
+const SAMPLE_INTERVAL_DISK_MS: u64 = 5 * MS_PER_S;
 const SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
#### Problem

In dashboard, the memory usage are aggreated for 1 minute interval. Reporting
it at one point per second is too much. 


#### Summary of Changes

Reduce the memory usage reporting frequency to 1 point per 5 seconds.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
