### PR TITLE
Revert "log adding root every 10s (#28280)"

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1193,8 +1193,6 @@ pub struct AccountsDb {
     /// debug feature to scan every append vec and verify refcounts are equal
     exhaustively_verify_refcounts: bool,
 
-    last_add_root_log: AtomicInterval,
-
     /// the full accounts hash calculation as of a predetermined block height 'N'
     /// to be included in the bank hash at a predetermined block height 'M'
     /// The cadence is once per epoch, all nodes calculate a full accounts hash as of a known slot calculated using 'N'
@@ -2177,7 +2175,6 @@ impl AccountsDb {
             num_hash_scan_passes,
             log_dead_slots: AtomicBool::new(true),
             exhaustively_verify_refcounts: false,
-            last_add_root_log: AtomicInterval::default(),
             epoch_accounts_hash_manager: EpochAccountsHashManager::new_invalid(),
         }
     }
@@ -8511,10 +8508,6 @@ impl AccountsDb {
             }
         }
         store_time.stop();
-
-        if self.last_add_root_log.should_update(10_000) {
-            datapoint_info!("add_root", ("root", slot, i64));
-        }
 
         AccountsAddRootTiming {
             index_us: index_time.as_us(),


### PR DESCRIPTION
#### Problem
We get similar coverage from the slot field of bank-forks_set_root; additionally, we can see banks with bank-new_from_parent-heights.

#### Summary of Changes
This reverts commit 16853acf354ea855fbf1aa632304ff58689fba58.

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/5400107/194943363-1e087518-0803-4d6b-a676-e1a6ad72750d.png">

`bank-forks_set_root` slot field and `add_root` root are in lock step as you can see; I included the bank-new_from_parent-heights so that you can see that the validator is spinning at this point (the node in this graph had consensus failure for orange flatline)