### PR TITLE
Explorer: Support displaying closed program accounts

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -12,7 +12,6 @@ import {
 import { Slot } from "components/common/Slot";
 import { addressLabel } from "utils/tx";
 import { useCluster } from "providers/cluster";
-import { ErrorCard } from "components/common/ErrorCard";
 import { UnknownAccountCard } from "components/account/UnknownAccountCard";
 import { Downloadable } from "components/common/Downloadable";
 import { CheckingBadge, VerifiedBadge } from "components/common/VerifiedBadge";
@@ -31,9 +30,6 @@ export function UpgradeableLoaderAccountSection({
 }) {
   switch (parsedData.type) {
     case "program": {
-      if (programData === undefined) {
-        return <ErrorCard text="Invalid Upgradeable Program account" />;
-      }
       return (
         <UpgradeableProgramSection
           account={account}
@@ -71,7 +67,7 @@ export function UpgradeableProgramSection({
 }: {
   account: Account;
   programAccount: ProgramAccountInfo;
-  programData: ProgramDataAccountInfo;
+  programData: ProgramDataAccountInfo | undefined;
 }) {
   const refresh = useFetchAccountInfo();
   const { cluster } = useCluster();
@@ -81,7 +77,7 @@ export function UpgradeableProgramSection({
     <div className="card">
       <div className="card-header">
         <h3 className="card-header-title mb-0 d-flex align-items-center">
-          Program Account
+          {programData === undefined && "Closed "}Program Account
         </h3>
         <button
           className="btn btn-white btn-sm"
@@ -113,64 +109,70 @@ export function UpgradeableProgramSection({
         </tr>
         <tr>
           <td>Executable</td>
-          <td className="text-lg-end">Yes</td>
+          <td className="text-lg-end">
+            {programData !== undefined ? "Yes" : "No"}
+          </td>
         </tr>
         <tr>
-          <td>Executable Data</td>
+          <td>Executable Data{programData === undefined && " (Closed)"}</td>
           <td className="text-lg-end">
             <Address pubkey={programAccount.programData} alignRight link />
           </td>
         </tr>
-        <tr>
-          <td>Upgradeable</td>
-          <td className="text-lg-end">
-            {programData.authority !== null ? "Yes" : "No"}
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <LastVerifiedBuildLabel />
-          </td>
-          <td className="text-lg-end">
-            {loading ? (
-              <CheckingBadge />
-            ) : (
-              <>
-                {verifiableBuilds.map((b, i) => (
-                  <VerifiedBadge
-                    key={i}
-                    verifiableBuild={b}
-                    deploySlot={programData.slot}
-                  />
-                ))}
-              </>
+        {programData !== undefined && (
+          <>
+            <tr>
+              <td>Upgradeable</td>
+              <td className="text-lg-end">
+                {programData.authority !== null ? "Yes" : "No"}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <LastVerifiedBuildLabel />
+              </td>
+              <td className="text-lg-end">
+                {loading ? (
+                  <CheckingBadge />
+                ) : (
+                  <>
+                    {verifiableBuilds.map((b, i) => (
+                      <VerifiedBadge
+                        key={i}
+                        verifiableBuild={b}
+                        deploySlot={programData.slot}
+                      />
+                    ))}
+                  </>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <SecurityLabel />
+              </td>
+              <td className="text-lg-end">
+                <SecurityTXTBadge
+                  programData={programData}
+                  pubkey={account.pubkey}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>Last Deployed Slot</td>
+              <td className="text-lg-end">
+                <Slot slot={programData.slot} link />
+              </td>
+            </tr>
+            {programData.authority !== null && (
+              <tr>
+                <td>Upgrade Authority</td>
+                <td className="text-lg-end">
+                  <Address pubkey={programData.authority} alignRight link />
+                </td>
+              </tr>
             )}
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <SecurityLabel />
-          </td>
-          <td className="text-lg-end">
-            <SecurityTXTBadge
-              programData={programData}
-              pubkey={account.pubkey}
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>Last Deployed Slot</td>
-          <td className="text-lg-end">
-            <Slot slot={programData.slot} link />
-          </td>
-        </tr>
-        {programData.authority !== null && (
-          <tr>
-            <td>Upgrade Authority</td>
-            <td className="text-lg-end">
-              <Address pubkey={programData.authority} alignRight link />
-            </td>
-          </tr>
+          </>
         )}
       </TableCardBody>
     </div>

--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -197,10 +197,6 @@ async function fetchAccountInfo(
                 ) {
                   const info = create(result.data.parsed, ParsedInfo);
                   programData = create(info, ProgramDataAccount).info;
-                } else {
-                  throw new Error(
-                    `invalid program data account for program: ${pubkey.toBase58()}`
-                  );
                 }
               }
 


### PR DESCRIPTION
#### Problem
The explorer doesn't support closed program accounts, if it can't find a program data account it falls back to default account details page.

#### Summary of Changes
<img width="1208" alt="Screen Shot 2022-10-11 at 11 06 51 AM" src="https://user-images.githubusercontent.com/1076145/194987978-d328f233-49ab-47b1-9b36-53ef54d6e714.png">


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
