### PR TITLE
Explorer: Support additional bpf upgradeable loader instructions

### DIFF
--- a/explorer/src/components/instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard.tsx
+++ b/explorer/src/components/instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard.tsx
@@ -13,7 +13,9 @@ import { ParsedInfo } from "validators";
 import { InstructionCard } from "../InstructionCard";
 import { UnknownDetailsCard } from "../UnknownDetailsCard";
 import {
+  CloseInfo,
   DeployWithMaxDataLenInfo,
+  ExtendProgramInfo,
   InitializeBufferInfo,
   SetAuthorityInfo,
   UpgradeInfo,
@@ -33,14 +35,15 @@ export function BpfUpgradeableLoaderDetailsCard(props: DetailsProps) {
   try {
     const parsed = create(props.ix.parsed, ParsedInfo);
     switch (parsed.type) {
+      case "initializeBuffer": {
+        return renderDetails<InitializeBufferInfo>(
+          props,
+          parsed,
+          InitializeBufferInfo
+        );
+      }
       case "write": {
         return renderDetails<WriteInfo>(props, parsed, WriteInfo);
-      }
-      case "upgrade": {
-        return renderDetails<UpgradeInfo>(props, parsed, UpgradeInfo);
-      }
-      case "setAuthority": {
-        return renderDetails<SetAuthorityInfo>(props, parsed, SetAuthorityInfo);
       }
       case "deployWithMaxDataLen": {
         return renderDetails<DeployWithMaxDataLenInfo>(
@@ -49,11 +52,20 @@ export function BpfUpgradeableLoaderDetailsCard(props: DetailsProps) {
           DeployWithMaxDataLenInfo
         );
       }
-      case "initializeBuffer": {
-        return renderDetails<InitializeBufferInfo>(
+      case "upgrade": {
+        return renderDetails<UpgradeInfo>(props, parsed, UpgradeInfo);
+      }
+      case "setAuthority": {
+        return renderDetails<SetAuthorityInfo>(props, parsed, SetAuthorityInfo);
+      }
+      case "close": {
+        return renderDetails<CloseInfo>(props, parsed, CloseInfo);
+      }
+      case "extendProgram": {
+        return renderDetails<ExtendProgramInfo>(
           props,
           parsed,
-          InitializeBufferInfo
+          ExtendProgramInfo
         );
       }
       default:

--- a/explorer/src/components/instruction/bpf-upgradeable-loader/types.ts
+++ b/explorer/src/components/instruction/bpf-upgradeable-loader/types.ts
@@ -1,19 +1,32 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-import { enums, nullable, number, type, string, Infer } from "superstruct";
+import { enums, number, type, string, Infer, optional } from "superstruct";
 import { PublicKeyFromString } from "validators/pubkey";
-
-export type WriteInfo = Infer<typeof WriteInfo>;
-export const WriteInfo = type({
-  account: PublicKeyFromString,
-  authority: PublicKeyFromString,
-  bytes: string(),
-  offset: number(),
-});
 
 export type InitializeBufferInfo = Infer<typeof InitializeBufferInfo>;
 export const InitializeBufferInfo = type({
   account: PublicKeyFromString,
+  authority: PublicKeyFromString,
+});
+
+export type WriteInfo = Infer<typeof WriteInfo>;
+export const WriteInfo = type({
+  offset: number(),
+  bytes: string(),
+  account: PublicKeyFromString,
+  authority: PublicKeyFromString,
+});
+
+export type DeployWithMaxDataLenInfo = Infer<typeof DeployWithMaxDataLenInfo>;
+export const DeployWithMaxDataLenInfo = type({
+  maxDataLen: number(),
+  payerAccount: PublicKeyFromString,
+  programDataAccount: PublicKeyFromString,
+  programAccount: PublicKeyFromString,
+  bufferAccount: PublicKeyFromString,
+  rentSysvar: PublicKeyFromString,
+  clockSysvar: PublicKeyFromString,
+  systemProgram: PublicKeyFromString,
   authority: PublicKeyFromString,
 });
 
@@ -23,29 +36,33 @@ export const UpgradeInfo = type({
   programAccount: PublicKeyFromString,
   bufferAccount: PublicKeyFromString,
   spillAccount: PublicKeyFromString,
-  authority: PublicKeyFromString,
   rentSysvar: PublicKeyFromString,
   clockSysvar: PublicKeyFromString,
+  authority: PublicKeyFromString,
 });
 
 export type SetAuthorityInfo = Infer<typeof SetAuthorityInfo>;
 export const SetAuthorityInfo = type({
   account: PublicKeyFromString,
   authority: PublicKeyFromString,
-  newAuthority: nullable(PublicKeyFromString),
+  newAuthority: optional(PublicKeyFromString),
 });
 
-export type DeployWithMaxDataLenInfo = Infer<typeof DeployWithMaxDataLenInfo>;
-export const DeployWithMaxDataLenInfo = type({
+export type CloseInfo = Infer<typeof CloseInfo>;
+export const CloseInfo = type({
+  account: PublicKeyFromString,
+  recipient: PublicKeyFromString,
+  authority: PublicKeyFromString,
+  programAccount: optional(PublicKeyFromString),
+});
+
+export type ExtendProgramInfo = Infer<typeof ExtendProgramInfo>;
+export const ExtendProgramInfo = type({
+  additionalBytes: number(),
   programDataAccount: PublicKeyFromString,
   programAccount: PublicKeyFromString,
-  payerAccount: PublicKeyFromString,
-  bufferAccount: PublicKeyFromString,
-  authority: PublicKeyFromString,
-  rentSysvar: PublicKeyFromString,
-  clockSysvar: PublicKeyFromString,
-  systemProgram: PublicKeyFromString,
-  maxDataLen: number(),
+  systemProgram: optional(PublicKeyFromString),
+  payerAccount: optional(PublicKeyFromString),
 });
 
 export type UpgradeableBpfLoaderInstructionType = Infer<
@@ -53,8 +70,10 @@ export type UpgradeableBpfLoaderInstructionType = Infer<
 >;
 export const UpgradeableBpfLoaderInstructionType = enums([
   "initializeBuffer",
-  "deployWithMaxDataLen",
-  "setAuthority",
   "write",
-  "finalize",
+  "deployWithMaxDataLen",
+  "upgrade",
+  "setAuthority",
+  "close",
+  "extendProgram",
 ]);


### PR DESCRIPTION
#### Problem
The `ExtendProgram` and `Close` instructions aren't supported by the explorer yet
