### PR TITLE
feat: add getParsedBlock method to Connection

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1144,6 +1144,40 @@ export type BlockResponse = {
 };
 
 /**
+ * A block with parsed transactions
+ */
+export type ParsedBlockResponse = {
+  /** Blockhash of this block */
+  blockhash: Blockhash;
+  /** Blockhash of this block's parent */
+  previousBlockhash: Blockhash;
+  /** Slot index of this block's parent */
+  parentSlot: number;
+  /** Vector of transactions with status meta and original message */
+  transactions: Array<{
+    /** The details of the transaction */
+    transaction: ParsedTransaction;
+    /** Metadata produced from the transaction */
+    meta: ParsedTransactionMeta | null;
+    /** The transaction version */
+    version?: TransactionVersion;
+  }>;
+  /** Vector of block rewards */
+  rewards?: Array<{
+    /** Public key of reward recipient */
+    pubkey: string;
+    /** Reward value in lamports */
+    lamports: number;
+    /** Account balance after reward is applied */
+    postBalance: number | null;
+    /** Type of reward received */
+    rewardType: string | null;
+  }>;
+  /** The unix timestamp of when the block was processed */
+  blockTime: number | null;
+};
+
+/**
  * A processed block fetched from the RPC API
  */
 export type VersionedBlockResponse = {
@@ -2062,6 +2096,38 @@ const GetBlockRpcResult = jsonRpcResult(
         pick({
           transaction: ConfirmedTransactionResult,
           meta: nullable(ConfirmedTransactionMetaResult),
+          version: optional(TransactionVersionStruct),
+        }),
+      ),
+      rewards: optional(
+        array(
+          pick({
+            pubkey: string(),
+            lamports: number(),
+            postBalance: nullable(number()),
+            rewardType: nullable(string()),
+          }),
+        ),
+      ),
+      blockTime: nullable(number()),
+      blockHeight: nullable(number()),
+    }),
+  ),
+);
+
+/**
+ * Expected parsed JSON RPC response for the "getBlock" message
+ */
+const GetParsedBlockRpcResult = jsonRpcResult(
+  nullable(
+    pick({
+      blockhash: string(),
+      previousBlockhash: string(),
+      parentSlot: number(),
+      transactions: array(
+        pick({
+          transaction: ParsedConfirmedTransactionResult,
+          meta: nullable(ParsedConfirmedTransactionMetaResult),
           version: optional(TransactionVersionStruct),
         }),
       ),
@@ -3876,6 +3942,28 @@ export class Connection {
         version,
       })),
     };
+  }
+
+  /**
+   * Fetch parsed transaction details for a confirmed or finalized block
+   */
+  async getParsedBlock(
+    slot: number,
+    rawConfig?: GetVersionedBlockConfig,
+  ): Promise<ParsedBlockResponse | null> {
+    const {commitment, config} = extractCommitmentFromConfig(rawConfig);
+    const args = this._buildArgsAtLeastConfirmed(
+      [slot],
+      commitment as Finality,
+      'jsonParsed',
+      config,
+    );
+    const unsafeRes = await this._rpcRequest('getBlock', args);
+    const res = create(unsafeRes, GetParsedBlockRpcResult);
+    if ('error' in res) {
+      throw new SolanaJSONRPCError(res.error, 'failed to get block');
+    }
+    return res.result;
   }
 
   /*

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1175,6 +1175,8 @@ export type ParsedBlockResponse = {
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
+  /** The number of blocks beneath this block */
+  blockHeight: number | null;
 };
 
 /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -4621,6 +4621,24 @@ describe('Connection', function () {
         }
         expect(foundTx).to.be.true;
       });
+
+      it('getParsedBlock', async () => {
+        const block = await connection.getParsedBlock(transactionSlot, {
+          maxSupportedTransactionVersion: 0,
+          commitment: 'confirmed',
+        });
+        expect(block).to.not.be.null;
+        if (block === null) throw new Error(); // unreachable
+
+        let foundTx = false;
+        for (const tx of block.transactions) {
+          if (tx.transaction.signatures[0] === signature) {
+            foundTx = true;
+            expect(tx.version).to.eq(0);
+          }
+        }
+        expect(foundTx).to.be.true;
+      });
     }).timeout(5 * 1000);
   }
 });


### PR DESCRIPTION
#### Problem
No way to fetch a `jsonParsed` encoded block with web3.js

#### Summary of Changes
- Added `Connection.getParsedBlock` method

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
