### PR TITLE
Log accounts info from Bank on hash mismatch

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1371,6 +1371,7 @@ impl ReplayStage {
                     let bank = w_bank_forks
                         .remove(*slot)
                         .expect("BankForks should not have been purged yet");
+                    bank.write_stored_accounts_to_file_for_debugging();
                     ((*slot, bank.bank_id()), bank)
                 })
                 .unzip()


### PR DESCRIPTION
#### Problem
When we get a hash mismatch during runtime, it can be hard to tell what went wrong. More so, sometimes the failures aren't reproducible which makes trying to diagnose the underlying problem very difficult.

#### Summary of Changes
Upon detecting a mismatched hash against the cluster, dump some info about that bank to a file. This file could then later be compared to a file generated by ledger-tool
