### PR TITLE
lock 1.13 cargo-install-all.sh to token-cli 2.0.17

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -133,7 +133,7 @@ mkdir -p "$installDir/bin"
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
+    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir" --version 2.0.17
   fi
 )
 


### PR DESCRIPTION
#### Problem
we are preparing a new release of the token-cli based on solana 1.14, which is incompatible with 1.10 and 1.13 because of the upgrade from rust 1.59 to rust 1.60

#### Summary of Changes
lock the 1.10 and 1.13 branches to token-cli version 2.0.17, which builds on rust 1.59