### PR TITLE
eliminate worthless work in store_accounts_to

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6614,12 +6614,10 @@ impl AccountsDb {
                 None => {
                     // hash any accounts where we were lazy in calculating the hash
                     let mut hash_time = Measure::start("hash_accounts");
-                    let mut stats = BankHashStats::default();
                     let len = accounts_and_meta_to_store.len();
                     let mut hashes = Vec::with_capacity(len);
                     for index in 0..accounts.len() {
                         let (pubkey, account) = (accounts.pubkey(index), accounts.account(index));
-                        stats.update(account);
                         let hash = Self::hash_account(slot, account, pubkey);
                         hashes.push(hash);
                     }


### PR DESCRIPTION
#### Problem
This is left over code from a while ago. We are updating stats that never get used.
The real stats are updated in a higher function `fn store<'a, T: ReadableAccount + Sync + ZeroLamport>(`

In looking into these stats, it was confusing they were written in 2 places. Turns out this write is ignored.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
