### PR TITLE
Fix blockstore_processor::load_frozen_forks() halt_at_slot behavior II

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1360,6 +1360,7 @@ fn process_next_slots(
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     pending_slots: &mut Vec<(SlotMeta, Bank, Hash)>,
+    halt_at_slot: Option<Slot>,
 ) -> result::Result<(), BlockstoreProcessorError> {
     if meta.next_slots.is_empty() {
         return Ok(());
@@ -1367,6 +1368,13 @@ fn process_next_slots(
 
     // This is a fork point if there are multiple children, create a new child bank for each fork
     for next_slot in &meta.next_slots {
+        let skip_next_slot = halt_at_slot
+            .map(|halt_at_slot| *next_slot > halt_at_slot)
+            .unwrap_or(false);
+        if skip_next_slot {
+            continue;
+        }
+
         let next_meta = blockstore
             .meta(*next_slot)
             .map_err(|err| {
@@ -1438,6 +1446,7 @@ fn load_frozen_forks(
         blockstore,
         leader_schedule_cache,
         &mut pending_slots,
+        opts.halt_at_slot,
     )?;
 
     let on_halt_store_hash_raw_data_for_debug = opts.on_halt_store_hash_raw_data_for_debug;
@@ -1604,6 +1613,7 @@ fn load_frozen_forks(
                 blockstore,
                 leader_schedule_cache,
                 &mut pending_slots,
+                opts.halt_at_slot,
             )?;
         }
     } else if on_halt_store_hash_raw_data_for_debug {


### PR DESCRIPTION
#### Problem
PR #28317 previously attempted to fix a case where blockstore processing would create children banks for slots past the halt_at_slot.

However, the previous fix didn't handle the case where a slot could be strictly less than the halt_at_slot, but have children that were greater than the halt_at_slot. For example, this could happen if the child of slot S is S+n where n > 1.

The result is that we were corrupting the same state like the other issue
```
[2022-10-12T01:57:50.035632651Z ERROR solana_runtime::accounts_db] set_hash: already exists; multiple forks with shared slot 154881268 as child (parent: 154881259)!?
```
The above log came from a case where halt_at_slot would have been *263, but we still created a bank for *268 as part of `load_frozen_forks()`
```
// Replay existing ledger
[2022-10-12T01:23:54.735223569Z INFO  solana_ledger::blockstore_processor] Processing ledger from slot 154878090...
[2022-10-12T01:23:54.737688847Z INFO  solana_ledger::blockstore_processor] ledger holds data through slot 154881263

// Create a bank past halt_at_slot (unexpected behavior)
[2022-10-12T01:43:14.045037362Z INFO  solana_metrics::metrics] datapoint: bank-new_from_parent-heights slot=154881268i block_height=139893750i parent_slot=154881259 ...

// Existing ledger replay done
[2022-10-12T01:43:15.185534712Z INFO  solana_ledger::blockstore_processor] ledger processed in 19 minutes, 20 seconds, 450 ms, 45 µs and 184 ns. root slot is 154881223, 41 banks: 154881223, 154881224, 154881225, 154881226, 154881227, 154881228, 154881229, 154881230, 154881231, 154881232, 154881233, 154881234, 154881235, 154881236, 154881237, 154881238, 154881239, 154881240, 154881241, 154881242, 154881243, 154881244, 154881245, 154881246, 154881247, 154881248, 154881249, 154881250, 154881251, 154881252, 154881253, 154881254, 154881255, 154881256, 154881257, 154881258, 154881259, 154881260, 154881261, 154881262, 154881263

// Reply stage now running

// This is a sub-function of creating a new bank, we're in a bad state
[2022-10-12T01:43:15.190913791Z ERROR solana_runtime::accounts_db] set_hash: already exists; multiple forks with shared slot 154881268 as child (parent: 154881259)!?

// Created the bank a second time, but things not good
[2022-10-12T01:43:15.193827380Z INFO  solana_metrics::metrics] datapoint: bank-new_from_parent-heights slot=154881268i block_height=139893750i parent_slot=154881259i ...
```

#### Summary of Changes
Thus, this change covers our processing logic to cover this second case as well.

