### PR TITLE
Refactor - create_executor() to be usable outside of bpf_loader

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2083,7 +2083,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
     let mut transaction_context = TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
-    let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+    let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program
     let executable = Executable::<ThisInstructionMeter>::from_elf(
@@ -2092,7 +2092,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
             reject_broken_elfs: true,
             ..Config::default()
         },
-        register_syscalls(&mut invoke_context, true).unwrap(),
+        register_syscalls(&invoke_context.feature_set, true).unwrap(),
     )
     .map_err(|err| format!("ELF error: {}", err))?;
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -156,8 +156,10 @@ pub fn create_executor(
         && invoke_context
             .feature_set
             .is_active(&disable_deploy_of_alloc_free_syscall::id());
-    let register_syscall_result =
-        syscalls::register_syscalls(invoke_context, disable_deploy_of_alloc_free_syscall);
+    let register_syscall_result = syscalls::register_syscalls(
+        &invoke_context.feature_set,
+        disable_deploy_of_alloc_free_syscall,
+    );
     register_syscalls_time.stop();
     invoke_context.timings.create_executor_register_syscalls_us = invoke_context
         .timings

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -28,6 +28,7 @@ use {
         account_info::AccountInfo,
         blake3, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, SUCCESS},
+        feature_set::FeatureSet,
         feature_set::{
             self, blake3_syscall_enabled, check_physical_overlapping, curve25519_syscall_enabled,
             disable_cpi_setting_executable_and_rent_epoch, disable_fees_sysvar,
@@ -151,18 +152,12 @@ macro_rules! register_feature_gated_syscall {
 }
 
 pub fn register_syscalls(
-    invoke_context: &mut InvokeContext,
+    feature_set: &FeatureSet,
     disable_deploy_of_alloc_free_syscall: bool,
 ) -> Result<SyscallRegistry, EbpfError> {
-    let blake3_syscall_enabled = invoke_context
-        .feature_set
-        .is_active(&blake3_syscall_enabled::id());
-    let curve25519_syscall_enabled = invoke_context
-        .feature_set
-        .is_active(&curve25519_syscall_enabled::id());
-    let disable_fees_sysvar = invoke_context
-        .feature_set
-        .is_active(&disable_fees_sysvar::id());
+    let blake3_syscall_enabled = feature_set.is_active(&blake3_syscall_enabled::id());
+    let curve25519_syscall_enabled = feature_set.is_active(&curve25519_syscall_enabled::id());
+    let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
     let is_abi_v2 = false;
 
     let mut syscall_registry = SyscallRegistry::default();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -110,7 +110,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
         let executable = Executable::<ThisInstructionMeter>::from_elf(
             &elf,
             Config::default(),
-            register_syscalls(invoke_context, true).unwrap(),
+            register_syscalls(&invoke_context.feature_set, true).unwrap(),
         )
         .unwrap();
 
@@ -238,7 +238,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
         let executable = Executable::<ThisInstructionMeter>::from_elf(
             &elf,
             Config::default(),
-            register_syscalls(invoke_context, true).unwrap(),
+            register_syscalls(&invoke_context.feature_set, true).unwrap(),
         )
         .unwrap();
 
@@ -285,7 +285,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         let executable = Executable::<ThisInstructionMeter>::from_elf(
             &elf,
             Config::default(),
-            register_syscalls(invoke_context, true).unwrap(),
+            register_syscalls(&invoke_context.feature_set, true).unwrap(),
         )
         .unwrap();
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -234,7 +234,11 @@ fn run_program(name: &str) -> u64 {
         let executable = Executable::<ThisInstructionMeter>::from_elf(
             &data,
             config,
-            register_syscalls(invoke_context, true /* no sol_alloc_free */).unwrap(),
+            register_syscalls(
+                &invoke_context.feature_set,
+                true, /* no sol_alloc_free */
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -252,7 +252,7 @@ native machine code before execting it in the virtual machine.",
     file.seek(SeekFrom::Start(0)).unwrap();
     let mut contents = Vec::new();
     file.read_to_end(&mut contents).unwrap();
-    let syscall_registry = register_syscalls(&mut invoke_context, true).unwrap();
+    let syscall_registry = register_syscalls(&invoke_context.feature_set, true).unwrap();
     let executable = if magic == [0x7f, 0x45, 0x4c, 0x46] {
         Executable::<ThisInstructionMeter>::from_elf(&contents, config, syscall_registry)
             .map_err(|err| format!("Executable constructor failed: {:?}", err))


### PR DESCRIPTION
#### Problem
`create_executor()`s interfaces make it hard to use from other crates such as the runtime.
This PR introduces `create_executor_from_account()` which allows the bank to crate executors form accounts it loaded.

#### Summary of Changes
- Moves `disable_deploy_of_alloc_free_syscall` parameter inside `create_executor()`.
- Lets `register_syscalls()` take `&FeatureSet` only instead of the entire `InvokeContext`.
- Uses `ic_logger_msg!()` instead of `ic_msg!()` inside `create_executor()`.
- Inlines `map_ebpf_error()`.
- Adds `register_syscalls_us` to `executor_metrics::CreateMetrics`.
- Moves timings accumulation into `executor_metrics::CreateMetrics::submit_datapoint()`.
- Moves `&invoke_context.feature_set` into a variable.
- Lets `create_executor()` return `executor_metrics::CreateMetrics` via a mutable parameter.
- Dissolves `invoke_context` parameter in `create_executor()`.
- Pulls assignment of `create_executor_metrics.program_id` outside of `create_executor()`.
- Makes `create_executor()` take a byte slice instead of a `BorrowedAccount`.
- Adds `create_executor_from_account()`.
