### PR TITLE
The `signature` of a transaction should not be required for `sendAndConfirmRawTransaction`

### DIFF
--- a/web3.js/src/utils/send-and-confirm-raw-transaction.ts
+++ b/web3.js/src/utils/send-and-confirm-raw-transaction.ts
@@ -41,7 +41,7 @@ export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
   confirmationStrategyOrConfirmOptions:
-    | BlockheightBasedTransactionConfirmationStrategy
+    | Omit<BlockheightBasedTransactionConfirmationStrategy, 'signature'>
     | ConfirmOptions
     | undefined,
   maybeConfirmOptions?: ConfirmOptions,
@@ -78,7 +78,10 @@ export async function sendAndConfirmRawTransaction(
 
   const commitment = options && options.commitment;
   const confirmationPromise = confirmationStrategy
-    ? connection.confirmTransaction(confirmationStrategy, commitment)
+    ? connection.confirmTransaction(
+        {...confirmationStrategy, signature},
+        commitment,
+      )
     : connection.confirmTransaction(signature, commitment);
   const status = (await confirmationPromise).value;
 


### PR DESCRIPTION
#### Problem
`sendAndConfirmRawTransaction` requires passing the `signature` of the transaction for confirmation, but since we haven't sent the transaction yet we don't have a valid transaction signature to confirm! See [this Typescript playground](https://www.typescriptlang.org/play?ssl=7&ssc=109&pln=1&pc=1#code/JYWwDg9gTgLgBAbzgZwKYDsAmBBLBhCdAM2ChACUBDAdwBUpL1lKBjGYQgGjgPXVTYd03eo2aCucFgBsArshioo2MMACqUaXAC+cIlAgg4AcgACyCNMaUA9NVQAjAMwA6AFbJjAbgBQPloQKUoT8EuhwALxw-NQ8IQLshAAUMvKKyqoa0knGIJTAfKgwALQORZTGAJSVvgFM8DAMTKyJ4VExcKLNYUk1-oHwSA7SECwA1gAWlMgT3FYKAGqU0sCYAEIj4wASqMAA5hPwulE0+fB1oa0ue0UAMpSKChujk9MTvb4+p8DwaFi4mF4JDIVDoTXErRS8TC3EaYhaQhcaCgwGWwAAXqhetwhptXjM5tMYEsVus8Tt9ocdJU-EA) that exemplifies the issue.

`sendAndConfirmRawTransaction`'s third parameter is `confirmationStrategyOrConfirmOptions`, where `confirmationStrategy` is https://github.com/solana-labs/solana/blob/8036f6f3046b18795e6b7fab834b405c32295c1d/web3.js/src/connection.ts#L308-L310

this makes sense in the context of "confirming" a transaction, but not in the context of sending the transaction. in the case that `{ lastValidBlockHeight, blockhash }` is passed to `sendAndConfirmRawTransaction`, the signature of the sent transaction isn't actually being passed to `connection.confirmTransaction`: https://github.com/solana-labs/solana/blob/8036f6f3046b18795e6b7fab834b405c32295c1d/web3.js/src/utils/send-and-confirm-raw-transaction.ts#L74-L82

#### Summary of Changes

- Omits the requirement to pass `signature` to the `confirmationStrategy` for `sendAndConfirmRawTransaction`
- Passes the transaction signature from the sent transaction to wait for it to be confirmed

**Should result in the following to be valid:**
```TypeScript
const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
await sendAndConfirmRawTransaction(connection, transaction.serialize(), { blockhash, lastValidBlockHeight })
```
