### PR TITLE
experiments to collect repair peers shred distribution data

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -117,6 +117,23 @@ impl ShredFetchStage {
             }
 
             packet_batch.iter_mut().for_each(|packet| {
+                if repair_context.is_some() {
+                    stats.repair_peers.insert(packet.meta.socket_addr());
+                    let staked = repair_context
+                        .as_ref()
+                        .map(|(_, cluster_info)| {
+                            cluster_info
+                                .staked_repair_sockets
+                                .lock()
+                                .unwrap()
+                                .contains(&packet.meta.socket_addr())
+                        })
+                        .unwrap_or_default();
+                    if staked {
+                        stats.staked_repair_shreds += 1;
+                        stats.staked_repair_peers.insert(packet.meta.socket_addr());
+                    }
+                }
                 Self::process_packet(
                     packet,
                     &mut shreds_received,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -168,6 +168,7 @@ pub struct ClusterInfo {
     instance: RwLock<NodeInstance>,
     contact_info_path: PathBuf,
     socket_addr_space: SocketAddrSpace,
+    pub staked_repair_sockets: Mutex<HashSet<SocketAddr>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, AbiExample)]
@@ -420,6 +421,7 @@ impl ClusterInfo {
             contact_info_path: PathBuf::default(),
             contact_save_interval: 0, // disabled
             socket_addr_space,
+            staked_repair_sockets: Mutex::new(HashSet::default()),
         };
         me.insert_self();
         me.push_self(&HashMap::new(), None);
@@ -449,6 +451,7 @@ impl ClusterInfo {
             instance: RwLock::new(NodeInstance::new(&mut thread_rng(), *new_id, timestamp())),
             contact_info_path: PathBuf::default(),
             contact_save_interval: 0, // disabled
+            staked_repair_sockets: Mutex::new(self.staked_repair_sockets.lock().unwrap().clone()),
             ..*self
         }
     }

--- a/ledger/src/shred_stats.rs
+++ b/ledger/src/shred_stats.rs
@@ -1,6 +1,8 @@
 use {
     solana_sdk::clock::Slot,
     std::{
+        collections::HashSet,
+        net::SocketAddr,
         ops::AddAssign,
         time::{Duration, Instant},
     },
@@ -36,6 +38,9 @@ pub struct ShredFetchStats {
     pub slot_out_of_range: usize,
     pub(crate) bad_shred_type: usize,
     since: Option<Instant>,
+    pub repair_peers: HashSet<SocketAddr>,
+    pub staked_repair_peers: HashSet<SocketAddr>,
+    pub staked_repair_shreds: usize,
 }
 
 impl ProcessShredsStats {
@@ -107,6 +112,9 @@ impl ShredFetchStats {
             ("index_out_of_bounds", self.index_out_of_bounds, i64),
             ("slot_out_of_range", self.slot_out_of_range, i64),
             ("duplicate_shred", self.duplicate_shred, i64),
+            ("repair_peers", self.repair_peers.len(), i64),
+            ("staked_repair_peers", self.staked_repair_peers.len(), i64),
+            ("staked_repair_shreds", self.staked_repair_shreds, i64),
         );
         *self = Self {
             since: Some(Instant::now()),


### PR DESCRIPTION
This is a placeholder for comparison of different repair request distribution strategies.

Compare repair distribution with various strategies. Measure peer distribution of outgoing repair requests and incoming repair shreds.

Some new temporary metrics were added:

repair_service-my_requests (egress):
repair_total: total number of outgoing repair requests
repair-staked-request-count: number of outgoing requests to staked nodes
repair-peers-staked: number of staked repair peers targeted for repair requests
repair-peers-unstaked: number of unstaked repair peers targeted for repair requests

shred_fetch_repair (ingress):
shred_count: total incoming repair response packets
staked_repair_shreds: total number of incoming repair response packets from staked nodes
repair_peers: total number of nodes sending repair responses
staked_repair_peers: total number of staked nodes sending repair responses


Numbers collected from mainnet-beta using _unstaked_ node.


Existing distribution:
![Screen Shot 2022-10-12 at 9 42 07 PM](https://user-images.githubusercontent.com/1054614/195505379-bf47cf4f-7b1c-470d-bb34-d0018a7a1cd9.png)
![Screen Shot 2022-10-12 at 9 46 06 PM](https://user-images.githubusercontent.com/1054614/195505490-f2816d5c-4e69-43b2-83d0-97e2c24a8ad9.png)


Stake weights normalized with `ln(stake)`:
![Screen Shot 2022-10-12 at 9 42 58 PM](https://user-images.githubusercontent.com/1054614/195505521-9736bc45-21c0-4a8e-8072-adc0e265aecd.png)
![Screen Shot 2022-10-12 at 9 46 50 PM](https://user-images.githubusercontent.com/1054614/195505527-b53ba7ed-0c3f-41a2-8c51-f0d182a00f64.png)


Stake weights normalized with `ln(ln(stake))`:
![Screen Shot 2022-10-12 at 9 43 42 PM](https://user-images.githubusercontent.com/1054614/195505549-508c309f-f58f-4977-bc27-b12fda75e44e.png)
![Screen Shot 2022-10-12 at 9 47 31 PM](https://user-images.githubusercontent.com/1054614/195505552-89c60fac-3136-48c0-b8a6-a26c8e4f22d7.png)


Stake disregarded in random selection:
![Screen Shot 2022-10-12 at 9 44 29 PM](https://user-images.githubusercontent.com/1054614/195505568-2850414d-817d-41bd-8690-0ae8fa1102f5.png)
![Screen Shot 2022-10-12 at 9 48 21 PM](https://user-images.githubusercontent.com/1054614/195505570-758b5611-3ec8-4a98-94e4-9578f6a0bcc8.png)


Only unstaked nodes:
![Screen Shot 2022-10-13 at 12 01 02 AM](https://user-images.githubusercontent.com/1054614/195525201-b8dcd8f6-3237-4529-8da7-69f8f550851d.png)
![Screen Shot 2022-10-13 at 12 01 50 AM](https://user-images.githubusercontent.com/1054614/195525210-a327cff6-5558-4d58-b6d3-60ed4a69b91d.png)


Comparing response rate for only staked vs only unstaked peers:
`repair_service-my_requests.repair-staked-request-count / shred_fetch_repair.staked_repair_shreds == ~.331`

`(repair_service-my_requests.repair_total - repair_service-my_requests.repair-staked-request-count) / (shred_fetch_repair.shed_count - shred_fetch_repair.staked_repair_shreds) == ~.281`

#### Problem


#### Summary of Changes




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
