### PR TITLE
Explorer: Fix transaction inspector simulation

### DIFF
--- a/explorer/src/pages/inspector/SimulatorCard.tsx
+++ b/explorer/src/pages/inspector/SimulatorCard.tsx
@@ -100,7 +100,8 @@ function useSimulator(message: VersionedMessage) {
       try {
         // Simulate without signers to skip signer verification
         const resp = await connection.simulateTransaction(
-          new VersionedTransaction(message)
+          new VersionedTransaction(message),
+          { replaceRecentBlockhash: true }
         );
         if (resp.value.logs === null) {
           throw new Error("Expected to receive logs from simulation");


### PR DESCRIPTION
#### Problem
The `simulateTransaction` method in web3.js used to have a side effect of replacing a simulated message's recent blockhash but that was removed when versioned transaction support was added. The explorer relied on that side effect to work properly during tx simulation.

#### Summary of Changes
- Explicitly call `simulateTransaction` with the `replaceRecentBlockhash` option

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
