### PR TITLE
Fixed warnings caused by redefined macros.  Also fixed sol_memcpy to …

### DIFF
--- a/sdk/bpf/c/inc/sol/constants.h
+++ b/sdk/bpf/c/inc/sol/constants.h
@@ -1,0 +1,18 @@
+#pragma once
+/**
+ * @brief Solana constants
+ */
+
+/**
+ * The Solana runtime provides a memory region that is available to programs at
+ * a fixed virtual address and length. The builtin functions `sol_calloc` and
+ * `sol_free` call into the Solana runtime to allocate from this memory region
+ * for heap operations.  Because the memory region is directly available to
+ * programs another option is a program can implement their own heap directly on
+ * top of that region.  If a program chooses to implement their own heap they
+ * should not call the builtin heap functions because they will conflict.
+ * `HEAP_START_ADDRESS` and `HEAP_LENGTH` specify the memory region's start
+ * virtual address and length.
+ */
+#define HEAP_START_ADDRESS (uint64_t)0x300000000
+#define HEAP_LENGTH (uint64_t)(32 * 1024)

--- a/sdk/bpf/c/inc/sol/entrypoint.h
+++ b/sdk/bpf/c/inc/sol/entrypoint.h
@@ -3,6 +3,7 @@
  * @brief Solana program entrypoint
  */
 
+#include <sol/constants.h>
 #include <sol/types.h>
 #include <sol/pubkey.h>
 
@@ -24,20 +25,6 @@ typedef struct {
   bool is_writable;    /** Is the account writable? */
   bool executable;     /** This account's data contains a loaded program (and is now read-only) */
 } SolAccountInfo;
-
-/**
- * The Solana runtime provides a memory region that is available to programs at
- * a fixed virtual address and length. The builtin functions `sol_calloc` and
- * `sol_free` call into the Solana runtime to allocate from this memory region
- * for heap operations.  Because the memory region is directly available to
- * programs another option is a program can implement their own heap directly on
- * top of that region.  If a program chooses to implement their own heap they
- * should not call the builtin heap functions because they will conflict.
- * `HEAP_START_ADDRESS` and `HEAP_LENGTH` specify the memory region's start
- * virtual address and length.
- */
-#define HEAP_START_ADDRESS (uint64_t)0x300000000
-#define HEAP_LENGTH (uint64_t)(32 * 1024)
 
 /**
  * Structure that the program's entrypoint input data is deserialized into.

--- a/sdk/bpf/c/inc/sol/string.h
+++ b/sdk/bpf/c/inc/sol/string.h
@@ -3,6 +3,7 @@
  * @brief Solana string and memory system calls and utilities
  */
 
+#include <sol/constants.h>
 #include <sol/types.h>
 
 #ifdef __cplusplus
@@ -12,10 +13,11 @@ extern "C" {
 /**
  * Copies memory
  */
-static void sol_memcpy(void *dst, const void *src, int len) {
+static void *sol_memcpy(void *dst, const void *src, int len) {
   for (int i = 0; i < len; i++) {
     *((uint8_t *)dst + i) = *((const uint8_t *)src + i);
   }
+  return dst;
 }
 
 /**
@@ -55,15 +57,6 @@ static size_t sol_strlen(const char *s) {
   }
   return len;
 }
-
-/**
- * Start address of the memory region used for program heap.
- */
-#define HEAP_START_ADDRESS (0x300000000)
-/**
- * Length of the heap memory region used for program heap.
- */
-#define HEAP_LENGTH (32 * 1024)
 
 /**
  * Alloc zero-initialized memory

--- a/sdk/sbf/c/inc/sol/constants.h
+++ b/sdk/sbf/c/inc/sol/constants.h
@@ -1,0 +1,18 @@
+#pragma once
+/**
+ * @brief Solana constants
+ */
+
+/**
+ * The Solana runtime provides a memory region that is available to programs at
+ * a fixed virtual address and length. The builtin functions `sol_calloc` and
+ * `sol_free` call into the Solana runtime to allocate from this memory region
+ * for heap operations.  Because the memory region is directly available to
+ * programs another option is a program can implement their own heap directly on
+ * top of that region.  If a program chooses to implement their own heap they
+ * should not call the builtin heap functions because they will conflict.
+ * `HEAP_START_ADDRESS` and `HEAP_LENGTH` specify the memory region's start
+ * virtual address and length.
+ */
+#define HEAP_START_ADDRESS (uint64_t)0x300000000
+#define HEAP_LENGTH (uint64_t)(32 * 1024)

--- a/sdk/sbf/c/inc/sol/entrypoint.h
+++ b/sdk/sbf/c/inc/sol/entrypoint.h
@@ -3,6 +3,7 @@
  * @brief Solana program entrypoint
  */
 
+#include <sol/constants.h>
 #include <sol/types.h>
 #include <sol/pubkey.h>
 
@@ -24,20 +25,6 @@ typedef struct {
   bool is_writable;    /** Is the account writable? */
   bool executable;     /** This account's data contains a loaded program (and is now read-only) */
 } SolAccountInfo;
-
-/**
- * The Solana runtime provides a memory region that is available to programs at
- * a fixed virtual address and length. The builtin functions `sol_calloc` and
- * `sol_free` call into the Solana runtime to allocate from this memory region
- * for heap operations.  Because the memory region is directly available to
- * programs another option is a program can implement their own heap directly on
- * top of that region.  If a program chooses to implement their own heap they
- * should not call the builtin heap functions because they will conflict.
- * `HEAP_START_ADDRESS` and `HEAP_LENGTH` specify the memory region's start
- * virtual address and length.
- */
-#define HEAP_START_ADDRESS (uint64_t)0x300000000
-#define HEAP_LENGTH (uint64_t)(32 * 1024)
 
 /**
  * Structure that the program's entrypoint input data is deserialized into.

--- a/sdk/sbf/c/inc/sol/string.h
+++ b/sdk/sbf/c/inc/sol/string.h
@@ -3,6 +3,7 @@
  * @brief Solana string and memory system calls and utilities
  */
 
+#include <sol/constants.h>
 #include <sol/types.h>
 
 #ifdef __cplusplus
@@ -12,10 +13,11 @@ extern "C" {
 /**
  * Copies memory
  */
-static void sol_memcpy(void *dst, const void *src, int len) {
+static void *sol_memcpy(void *dst, const void *src, int len) {
   for (int i = 0; i < len; i++) {
     *((uint8_t *)dst + i) = *((const uint8_t *)src + i);
   }
+  return dst;
 }
 
 /**
@@ -55,15 +57,6 @@ static size_t sol_strlen(const char *s) {
   }
   return len;
 }
-
-/**
- * Start address of the memory region used for program heap.
- */
-#define HEAP_START_ADDRESS (0x300000000)
-/**
- * Length of the heap memory region used for program heap.
- */
-#define HEAP_LENGTH (32 * 1024)
 
 /**
  * Alloc zero-initialized memory


### PR DESCRIPTION
…have

the same signature as memcpy.

#### Problem

Solana C SDK has redefined macros which cause compiler warnings.  Also it uses a nonstandard signature for sol_memcpy (assuming that it is supposed to have the same signature as standard memcpy).


#### Summary of Changes

Fixed those minor issues.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
