### PR TITLE
Report total_transactions in replay-slot-stats

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -39,6 +39,7 @@ impl ReplaySlotStats {
     pub fn report_stats(
         &self,
         slot: Slot,
+        num_txs: usize,
         num_entries: usize,
         num_shreds: u64,
         bank_complete_time_us: u64,
@@ -71,6 +72,7 @@ impl ReplaySlotStats {
                     i64
                 ),
                 ("bank_complete_time_us", bank_complete_time_us, i64),
+                ("total_transactions", num_txs as i64, i64),
                 ("total_entries", num_entries as i64, i64),
                 ("total_shreds", num_shreds as i64, i64),
                 // Everything inside the `eager!` block will be eagerly expanded before

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2564,6 +2564,7 @@ impl ReplayStage {
 
                 r_replay_stats.report_stats(
                     bank.slot(),
+                    r_replay_progress.num_txs,
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),


### PR DESCRIPTION
#### Problem
We have transactions counted in replay-slot-end-to-end-stats, but that metric is broken down to report things per thread. Given that this will be machine dependent based on what all is available when replaying segments of the slot and the rebatching that occurs, this number won't be consistent between nodes.

#### Summary of Changes
So, report total_transactions for the entire slot (all threads) in replay-slot-stats.