### PR TITLE
Explorer: Disable cluster url replacement on localhost

### DIFF
--- a/explorer/src/providers/cluster.tsx
+++ b/explorer/src/providers/cluster.tsx
@@ -61,13 +61,21 @@ export const TESTNET_URL = clusterApiUrl("testnet");
 export const DEVNET_URL = clusterApiUrl("devnet");
 
 export function clusterUrl(cluster: Cluster, customUrl: string): string {
+  const modifyUrl = (url: string): string => {
+    if (window.location.hostname === "localhost") {
+      return url;
+    } else {
+      return url.replace("api", "explorer-api");
+    }
+  };
+
   switch (cluster) {
     case Cluster.Devnet:
-      return DEVNET_URL.replace("api", "explorer-api");
+      return modifyUrl(DEVNET_URL);
     case Cluster.MainnetBeta:
-      return MAINNET_BETA_URL.replace("api", "explorer-api");
+      return modifyUrl(MAINNET_BETA_URL);
     case Cluster.Testnet:
-      return TESTNET_URL.replace("api", "explorer-api");
+      return modifyUrl(TESTNET_URL);
     case Cluster.Custom:
       return customUrl;
   }


### PR DESCRIPTION
#### Problem
The explorer RPC API is restricted to solana.com domains and needs to be manually overridden when running the explorer locally.

#### Summary of Changes
- Don't use the explorer RPC API for localhost env

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
