### PR TITLE
chore: bump serde_yaml from 0.8.26 to 0.9.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,7 +3230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c53a5ade47760e8cc4986bdc5e72daeffaaaee64cbc374f9cfe0a00c1cd87b1f"
 dependencies = [
  "serde",
- "serde_yaml",
+ "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -4279,6 +4279,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+dependencies = [
+ "indexmap",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4678,7 +4691,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.13",
  "serial_test",
  "solana-clap-utils",
  "solana-cli-config",
@@ -4907,7 +4920,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "serde_yaml",
+ "serde_yaml 0.9.13",
  "solana-clap-utils",
  "solana-sdk 1.15.0",
  "url 2.2.2",
@@ -5267,7 +5280,7 @@ dependencies = [
  "clap 2.33.3",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.13",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-entry",
@@ -5386,7 +5399,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.14",
  "serde",
- "serde_yaml",
+ "serde_yaml 0.9.13",
  "solana-clap-utils",
  "solana-config-program",
  "solana-logger 1.15.0",
@@ -6642,7 +6655,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.13",
  "signal-hook",
  "solana-clap-utils",
  "solana-cli-config",
@@ -7774,6 +7787,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "untrusted"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde_json = "1.0.83"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-client = { path = "../client", version = "=1.15.0" }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -189,6 +189,7 @@ fn main() {
         let serialized = serde_yaml::to_string(&accounts).unwrap();
         let path = Path::new(&client_ids_and_stake_file);
         let mut file = File::create(path).unwrap();
+        file.write_all(b"---\n").unwrap();
         file.write_all(&serialized.into_bytes()).unwrap();
         return;
     }

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -14,7 +14,7 @@ dirs-next = "2.0.0"
 lazy_static = "1.4.0"
 serde = "1.0.144"
 serde_derive = "1.0.103"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 url = "2.2.2"

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -112,6 +112,7 @@ where
         create_dir_all(outdir)?;
     }
     let mut file = File::create(config_file)?;
+    file.write_all(b"---\n")?;
     file.write_all(&serialized.into_bytes())?;
 
     Ok(())

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.13.0"
 clap = "2.33.1"
 serde = "1.0.144"
 serde_json = "1.0.83"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-entry = { path = "../entry", version = "=1.15.0" }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -683,6 +683,7 @@ mod tests {
         let serialized = serde_yaml::to_string(&genesis_accounts).unwrap();
         let path = Path::new("test_append_primordial_accounts_to_genesis.yml");
         let mut file = File::create(path).unwrap();
+        file.write_all(b"---\n").unwrap();
         file.write_all(&serialized.into_bytes()).unwrap();
 
         load_genesis_accounts(
@@ -756,6 +757,7 @@ mod tests {
         let serialized = serde_yaml::to_string(&genesis_accounts1).unwrap();
         let path = Path::new("test_append_primordial_accounts_to_genesis.yml");
         let mut file = File::create(path).unwrap();
+        file.write_all(b"---\n").unwrap();
         file.write_all(&serialized.into_bytes()).unwrap();
 
         load_genesis_accounts(
@@ -839,6 +841,7 @@ mod tests {
         let serialized = serde_yaml::to_string(&genesis_accounts2).unwrap();
         let path = Path::new("test_append_primordial_accounts_to_genesis.yml");
         let mut file = File::create(path).unwrap();
+        file.write_all(b"---\n").unwrap();
         file.write_all(&serialized.into_bytes()).unwrap();
 
         load_genesis_accounts(

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -25,7 +25,7 @@ nix = "0.25.0"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.14"
 serde = { version = "1.0.144", features = ["derive"] }
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-config-program = { path = "../programs/config", version = "=1.15.0" }
 solana-logger = { path = "../logger", version = "=1.15.0" }

--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -63,6 +63,7 @@ impl Config {
             create_dir_all(outdir)?;
         }
         let mut file = File::create(config_file)?;
+        file.write_all(b"---\n")?;
         file.write_all(&serialized.into_bytes())?;
 
         Ok(())

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2309,12 +2309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,14 +3866,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6924,6 +6919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7320,15 +7321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.144"
 serde_json = "1.0.83"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.15.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.15.0" }
 solana-core = { path = "../core", version = "=1.15.0" }


### PR DESCRIPTION
#### Problem
Earlier attempt to bump serde_yaml broke gce testnets with bench-tps clients because of the breaking change in[ v0.9.0](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0) to remove leading `---\n` strings and [this assumption](https://github.com/solana-labs/solana/blob/f627b7d8267e74a7a905178731ffb185fc0e92f5/net/remote/remote-node.sh#L196)

cc @behzadnouri 

#### Summary of Changes
In addition to performing the serde_yaml bump to v0.9.13, manually prepend `---\n` to all yaml files we write.
Confirmed that v0.9.13 reads existing v0.8 format yaml files correctly.

Dependabot notes duplicated:

* chore: bump serde_yaml from 0.8.26 to 0.9.13

Bumps [serde_yaml](https://github.com/dtolnay/serde-yaml) from 0.8.26 to 0.9.13.
- [Release notes](https://github.com/dtolnay/serde-yaml/releases)
- [Commits](https://github.com/dtolnay/serde-yaml/compare/0.8.26...0.9.13)

---
updated-dependencies:
- dependency-name: serde_yaml dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>

* [auto-commit] Update all Cargo lock files

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: dependabot-buildkite <dependabot-buildkite@noreply.solana.com>
