### PR TITLE
feat: add dataSlice param to account fetching config

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -470,6 +470,8 @@ export type GetAccountInfoConfig = {
   commitment?: Commitment;
   /** The minimum slot that the request can be evaluated at */
   minContextSlot?: number;
+  /** Optional data slice to limit the returned account data */
+  dataSlice?: DataSlice;
 };
 
 /**
@@ -2396,6 +2398,8 @@ export type GetMultipleAccountsConfig = {
   commitment?: Commitment;
   /** The minimum slot that the request can be evaluated at */
   minContextSlot?: number;
+  /** Optional data slice to limit the returned account data */
+  dataSlice?: DataSlice;
 };
 
 /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -4505,8 +4505,9 @@ describe('Connection', function () {
         const transferToKey = lookupTableAddresses[0];
         const transferToAccount = await connection.getAccountInfo(
           transferToKey,
-          'confirmed',
+          {commitment: 'confirmed', dataSlice: {length: 0, offset: 0}},
         );
+        expect(transferToAccount?.data.length).to.be.eq(0);
         expect(transferToAccount?.lamports).to.be.eq(LAMPORTS_PER_SOL);
       });
 


### PR DESCRIPTION
#### Problem
The `GetAccountInfoConfig` and `GetMultipleAccountsConfig` types don't support the `dataSlice` config yet
