### PR TITLE
Explorer: Refactor account provider data types

### DIFF
--- a/explorer/src/__tests__/parseNFTokenAccounts.ts
+++ b/explorer/src/__tests__/parseNFTokenAccounts.ts
@@ -23,8 +23,12 @@ describe("parseNFTokenAccounts", () => {
     ]);
     const nftAccount = parseNFTokenNFTAccount({
       pubkey: new PublicKey("FagABcRBhZH27JDtu6A1Jo9woXyoznP28QujLkxkN9Hj"),
-      details: { rawData: buffer, owner: new PublicKey(NFTOKEN_ADDRESS) },
-    } as any);
+      space: buffer.length,
+      lamports: 1,
+      executable: false,
+      data: { raw: buffer as Buffer },
+      owner: new PublicKey(NFTOKEN_ADDRESS),
+    });
     expect(nftAccount!.metadata_url).to.eq(
       "https://cdn.glow.app/n/88/78ef17c1-2b5a-468e-ae8f-7403856e9f00.json"
     );

--- a/explorer/src/components/account/AnchorAccountCard.tsx
+++ b/explorer/src/components/account/AnchorAccountCard.tsx
@@ -10,11 +10,8 @@ import { useAnchorProgram } from "providers/anchor";
 export function AnchorAccountCard({ account }: { account: Account }) {
   const { lamports } = account;
   const { url } = useCluster();
-  const anchorProgram = useAnchorProgram(
-    account.details?.owner.toString() || "",
-    url
-  );
-  const rawData = account?.details?.rawData;
+  const anchorProgram = useAnchorProgram(account.owner.toString(), url);
+  const rawData = account.data.raw;
   const programName = getAnchorProgramName(anchorProgram) || "Unknown Program";
 
   const { decodedAccountData, accountDef } = useMemo(() => {

--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -125,7 +125,7 @@ function OverviewCard({
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end text-uppercase">
-            <SolBalance lamports={account.lamports || 0} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
         <tr>

--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -54,11 +54,11 @@ export function TokenAccountSection({
       case "mint": {
         const info = create(tokenAccount.info, MintAccountInfo);
 
-        if (isMetaplexNFT(account.details?.data, info)) {
+        if (isMetaplexNFT(account.data.parsed, info)) {
           return (
             <NonFungibleTokenMintAccountCard
               account={account}
-              nftData={(account.details!.data as TokenProgramData).nftData!}
+              nftData={(account.data.parsed as TokenProgramData).nftData!}
               mintInfo={info}
             />
           );

--- a/explorer/src/components/account/UnknownAccountCard.tsx
+++ b/explorer/src/components/account/UnknownAccountCard.tsx
@@ -8,10 +8,8 @@ import { useCluster } from "providers/cluster";
 import { useTokenRegistry } from "providers/mints/token-registry";
 
 export function UnknownAccountCard({ account }: { account: Account }) {
-  const { details, lamports } = account;
   const { cluster } = useCluster();
   const { tokenRegistry } = useTokenRegistry();
-  if (lamports === undefined) return null;
 
   const label = addressLabel(account.pubkey.toBase58(), cluster, tokenRegistry);
   return (
@@ -36,32 +34,26 @@ export function UnknownAccountCard({ account }: { account: Account }) {
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end">
-            <SolBalance lamports={lamports} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
 
-        {details?.space !== undefined && (
-          <tr>
-            <td>Allocated Data Size</td>
-            <td className="text-lg-end">{details.space} byte(s)</td>
-          </tr>
-        )}
+        <tr>
+          <td>Allocated Data Size</td>
+          <td className="text-lg-end">{account.space} byte(s)</td>
+        </tr>
 
-        {details && (
-          <tr>
-            <td>Assigned Program Id</td>
-            <td className="text-lg-end">
-              <Address pubkey={details.owner} alignRight link />
-            </td>
-          </tr>
-        )}
+        <tr>
+          <td>Assigned Program Id</td>
+          <td className="text-lg-end">
+            <Address pubkey={account.owner} alignRight link />
+          </td>
+        </tr>
 
-        {details && (
-          <tr>
-            <td>Executable</td>
-            <td className="text-lg-end">{details.executable ? "Yes" : "No"}</td>
-          </tr>
-        )}
+        <tr>
+          <td>Executable</td>
+          <td className="text-lg-end">{account.executable ? "Yes" : "No"}</td>
+        </tr>
       </TableCardBody>
     </div>
   );

--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -104,7 +104,7 @@ export function UpgradeableProgramSection({
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end text-uppercase">
-            <SolBalance lamports={account.lamports || 0} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
         <tr>
@@ -235,22 +235,20 @@ export function UpgradeableProgramDataSection({
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end text-uppercase">
-            <SolBalance lamports={account.lamports || 0} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
-        {account.details?.space !== undefined && (
-          <tr>
-            <td>Data (Bytes)</td>
-            <td className="text-lg-end">
-              <Downloadable
-                data={programData.data[0]}
-                filename={`${account.pubkey.toString()}.bin`}
-              >
-                <span className="me-2">{account.details.space}</span>
-              </Downloadable>
-            </td>
-          </tr>
-        )}
+        <tr>
+          <td>Data Size (Bytes)</td>
+          <td className="text-lg-end">
+            <Downloadable
+              data={programData.data[0]}
+              filename={`${account.pubkey.toString()}.bin`}
+            >
+              <span className="me-2">{account.space}</span>
+            </Downloadable>
+          </td>
+        </tr>
         <tr>
           <td>Upgradeable</td>
           <td className="text-lg-end">
@@ -309,15 +307,13 @@ export function UpgradeableProgramBufferSection({
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end text-uppercase">
-            <SolBalance lamports={account.lamports || 0} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
-        {account.details?.space !== undefined && (
-          <tr>
-            <td>Data (Bytes)</td>
-            <td className="text-lg-end">{account.details.space}</td>
-          </tr>
-        )}
+        <tr>
+          <td>Data Size (Bytes)</td>
+          <td className="text-lg-end">{account.space}</td>
+        </tr>
         {programBuffer.authority !== null && (
           <tr>
             <td>Deploy Authority</td>
@@ -326,14 +322,12 @@ export function UpgradeableProgramBufferSection({
             </td>
           </tr>
         )}
-        {account.details && (
-          <tr>
-            <td>Owner</td>
-            <td className="text-lg-end">
-              <Address pubkey={account.details.owner} alignRight link />
-            </td>
-          </tr>
-        )}
+        <tr>
+          <td>Owner</td>
+          <td className="text-lg-end">
+            <Address pubkey={account.owner} alignRight link />
+          </td>
+        </tr>
       </TableCardBody>
     </div>
   );

--- a/explorer/src/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
+++ b/explorer/src/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
@@ -56,7 +56,7 @@ export function AddressLookupTableAccountSection(
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end text-uppercase">
-            <SolBalance lamports={account.lamports || 0} />
+            <SolBalance lamports={account.lamports} />
           </td>
         </tr>
         <tr>

--- a/explorer/src/components/account/nftoken/isNFTokenAccount.ts
+++ b/explorer/src/components/account/nftoken/isNFTokenAccount.ts
@@ -5,8 +5,7 @@ import { NftokenTypes } from "./nftoken-types";
 
 export function isNFTokenAccount(account: Account): boolean {
   return Boolean(
-    account.details?.owner.toBase58() === NFTOKEN_ADDRESS &&
-      account.details.rawData
+    account.owner.toBase58() === NFTOKEN_ADDRESS && account.data.raw
   );
 }
 
@@ -20,9 +19,7 @@ export const parseNFTokenNFTAccount = (
   }
 
   try {
-    const parsed = NftokenTypes.nftAccountLayout.decode(
-      account!.details!.rawData!
-    );
+    const parsed = NftokenTypes.nftAccountLayout.decode(account.data.raw!);
 
     if (!parsed) {
       return null;
@@ -36,7 +33,7 @@ export const parseNFTokenNFTAccount = (
     }
 
     return {
-      address: account!.pubkey.toBase58(),
+      address: account.pubkey.toBase58(),
       holder: new PublicKey(parsed.holder).toBase58(),
       authority: new PublicKey(parsed.authority).toBase58(),
       authority_can_update: Boolean(parsed.authority_can_update),
@@ -62,7 +59,7 @@ export const parseNFTokenCollectionAccount = (
 
   try {
     const parsed = NftokenTypes.collectionAccountLayout.decode(
-      account!.details!.rawData!
+      account.data.raw!
     );
 
     if (!parsed) {
@@ -76,7 +73,7 @@ export const parseNFTokenCollectionAccount = (
     }
 
     return {
-      address: account!.pubkey.toBase58(),
+      address: account.pubkey.toBase58(),
       authority: parsed.authority,
       authority_can_update: Boolean(parsed.authority_can_update),
       metadata_url: parsed.metadata_url?.replace(/\0/g, "") ?? null,

--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -1,16 +1,16 @@
 import { MintAccountInfo } from "validators/accounts/token";
-import { ProgramData } from "..";
+import { ParsedData } from "..";
 
 export default function isMetaplexNFT(
-  data?: ProgramData,
+  parsedData?: ParsedData,
   mintInfo?: MintAccountInfo
 ) {
   return (
-    data?.program === "spl-token" &&
-    data?.parsed.type === "mint" &&
-    data?.nftData &&
+    parsedData?.program === "spl-token" &&
+    parsedData?.parsed.type === "mint" &&
+    parsedData?.nftData &&
     mintInfo?.decimals === 0 &&
     (parseInt(mintInfo.supply) === 1 ||
-      data?.nftData?.metadata?.tokenStandard === 1)
+      parsedData?.nftData?.metadata?.tokenStandard === 1)
   );
 }

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -169,7 +169,7 @@ export function abbreviatedNumber(value: number, fixed = 1) {
 }
 
 export const pubkeyToString = (key: PublicKey | string = "") => {
-  return typeof key === "string" ? key : key?.toBase58() || "";
+  return typeof key === "string" ? key : key.toBase58();
 };
 
 export const getLast = (arr: string[]) => {


### PR DESCRIPTION
#### Problem
The account provider data type is clunky because too many fields can be undefined

#### Summary of Changes
- Initialize all account metadata fields for accounts that don't exist
- Clean up parsed vs raw data type representation
- Clean up type handling

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
