### PR TITLE
remove slot# from account hash

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, LoadHint, LoadedAccount, ScanStorageResult,
+            BankHashInfo, IncludeSlotInHash, LoadHint, LoadedAccount, ScanStorageResult,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
@@ -1201,7 +1201,7 @@ impl Accounts {
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
         preserve_rent_epoch_for_rent_exempt_accounts: bool,
-        include_slot_in_hash: bool,
+        include_slot_in_hash: IncludeSlotInHash,
     ) {
         let (accounts_to_store, txn_signatures) = self.collect_accounts_to_store(
             txs,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1201,6 +1201,7 @@ impl Accounts {
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
         preserve_rent_epoch_for_rent_exempt_accounts: bool,
+        include_slot_in_hash: bool,
     ) {
         let (accounts_to_store, txn_signatures) = self.collect_accounts_to_store(
             txs,
@@ -1211,8 +1212,10 @@ impl Accounts {
             lamports_per_signature,
             preserve_rent_epoch_for_rent_exempt_accounts,
         );
-        self.accounts_db
-            .store_cached((slot, &accounts_to_store[..]), Some(&txn_signatures));
+        self.accounts_db.store_cached(
+            (slot, &accounts_to_store[..], include_slot_in_hash),
+            Some(&txn_signatures),
+        );
     }
 
     pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport>(

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,4 +1,5 @@
 use {
+    crate::accounts_db::IncludeSlotInHash,
     dashmap::DashMap,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -71,7 +72,7 @@ impl SlotCacheInner {
         account: AccountSharedData,
         hash: Option<impl Borrow<Hash>>,
         slot: Slot,
-        include_slot_in_hash: bool,
+        include_slot_in_hash: IncludeSlotInHash,
     ) -> CachedAccount {
         let data_len = account.data().len() as u64;
         let item = Arc::new(CachedAccountInner {
@@ -146,7 +147,8 @@ pub struct CachedAccountInner {
     slot: Slot,
     pubkey: Pubkey,
     /// temporarily here during feature activation
-    pub include_slot_in_hash: bool,
+    /// since we calculate the hash later, or in the background, we need knowledge of whether this slot uses the slot in the hash or not
+    pub include_slot_in_hash: IncludeSlotInHash,
 }
 
 impl CachedAccountInner {
@@ -232,7 +234,7 @@ impl AccountsCache {
         pubkey: &Pubkey,
         account: AccountSharedData,
         hash: Option<impl Borrow<Hash>>,
-        include_slot_in_hash: bool,
+        include_slot_in_hash: IncludeSlotInHash,
     ) -> CachedAccount {
         let slot_cache = self.slot_cache(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -333,7 +333,7 @@ impl AccountsCache {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
+    use {super::*, crate::accounts_db::INCLUDE_SLOT_IN_HASH_TESTS};
 
     #[test]
     fn test_remove_slots_le() {
@@ -346,6 +346,7 @@ pub mod tests {
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
             Some(&Hash::default()),
+            INCLUDE_SLOT_IN_HASH_TESTS,
         );
         // If the cache is told the size limit is 0, it should return the one slot
         let removed = cache.remove_slots_le(0);
@@ -364,6 +365,7 @@ pub mod tests {
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
             Some(&Hash::default()),
+            INCLUDE_SLOT_IN_HASH_TESTS,
         );
 
         // If the cache is told the size limit is 0, it should return nothing, because there's no

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -12354,6 +12354,8 @@ pub mod tests {
         assert_eq!(bank_hash.stats.num_executable_accounts, 1);
     }
 
+    // this test tests check_hash=true, which is unsupported behavior at the moment. It cannot be enabled by anything but these tests.
+    #[ignore]
     #[test]
     fn test_calculate_accounts_hash_check_hash_mismatch() {
         solana_logger::setup();
@@ -12412,6 +12414,8 @@ pub mod tests {
         }
     }
 
+    // this test tests check_hash=true, which is unsupported behavior at the moment. It cannot be enabled by anything but these tests.
+    #[ignore]
     #[test]
     fn test_calculate_accounts_hash_check_hash() {
         solana_logger::setup();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5977,7 +5977,8 @@ impl AccountsDb {
 
         hasher.update(&lamports.to_le_bytes());
 
-        hasher.update(&slot.to_le_bytes());
+        // upon feature activation, remove slot# from account hash
+        // hasher.update(&slot.to_le_bytes());
 
         hasher.update(&rent_epoch.to_le_bytes());
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5321,7 +5321,7 @@ impl Bank {
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         if self
             .feature_set
-            .is_active(&feature_set::account_hash_ignore_slot::ID)
+            .is_active(&feature_set::account_hash_ignore_slot::id())
         {
             IncludeSlotInHash::RemoveSlot
         } else {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1154,7 +1154,8 @@ impl StakeReward {
 }
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
-impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward]) {
+/// last bool is include_slot_in_hash
+impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward], bool) {
     fn pubkey(&self, index: usize) -> &Pubkey {
         &self.1[index].stake_pubkey
     }
@@ -1173,6 +1174,9 @@ impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward]) {
     }
     fn contains_multiple_slots(&self) -> bool {
         false
+    }
+    fn include_slot_in_hash(&self) -> bool {
+        self.2
     }
 }
 
@@ -2957,7 +2961,7 @@ impl Bank {
         // store stake account even if stakers_reward is 0
         // because credits observed has changed
         let mut m = Measure::start("store_stake_account");
-        self.store_accounts((self.slot(), stake_rewards));
+        self.store_accounts((self.slot(), stake_rewards, self.include_slot_in_hash()));
         m.stop();
         metrics
             .store_stake_accounts_us
@@ -4801,6 +4805,7 @@ impl Bank {
             &durable_nonce,
             lamports_per_signature,
             self.preserve_rent_epoch_for_rent_exempt_accounts(),
+            self.include_slot_in_hash(),
         );
         let rent_debits = self.collect_rent(&execution_results, loaded_txs);
 
@@ -5262,7 +5267,8 @@ impl Bank {
                 let (hash, measure) = measure!(crate::accounts_db::AccountsDb::hash_account(
                     self.slot(),
                     account,
-                    pubkey
+                    pubkey,
+                    self.include_slot_in_hash(),
                 ));
                 time_hashing_skipped_rewrites_us += measure.as_us();
                 rewrites_skipped.push((*pubkey, hash));
@@ -5293,7 +5299,11 @@ impl Bank {
         if !accounts_to_store.is_empty() {
             // TODO: Maybe do not call `store_accounts()` here.  Instead return `accounts_to_store`
             // and have `collect_rent_in_partition()` perform all the stores.
-            let (_, measure) = measure!(self.store_accounts((self.slot(), &accounts_to_store[..])));
+            let (_, measure) = measure!(self.store_accounts((
+                self.slot(),
+                &accounts_to_store[..],
+                self.include_slot_in_hash()
+            )));
             time_storing_accounts_us += measure.as_us();
         }
 
@@ -5306,6 +5316,13 @@ impl Bank {
             time_storing_accounts_us,
             num_accounts: accounts.len(),
         }
+    }
+
+    /// true if we should include the slot in account hash
+    fn include_slot_in_hash(&self) -> bool {
+        !self
+            .feature_set
+            .is_active(&feature_set::account_hash_ignore_slot::ID)
     }
 
     /// convert 'partition' to a pubkey range and 'collect_rent_in_range'
@@ -6169,7 +6186,11 @@ impl Bank {
         pubkey: &Pubkey,
         account: &T,
     ) {
-        self.store_accounts((self.slot(), &[(pubkey, account)][..]))
+        self.store_accounts((
+            self.slot(),
+            &[(pubkey, account)][..],
+            self.include_slot_in_hash(),
+        ))
     }
 
     pub fn store_accounts<'a, T: ReadableAccount + Sync + ZeroLamport>(

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -368,9 +368,9 @@ impl<'a> SnapshotMinimizer<'a> {
             }
 
             let (new_storage, _time) = self.accounts_db().get_store_for_shrink(slot, aligned_total);
-
+            let include_slot_in_hash = true; // todo
             self.accounts_db().store_accounts_frozen(
-                (slot, &accounts[..]),
+                (slot, &accounts[..], include_slot_in_hash),
                 Some(&hashes),
                 Some(&new_storage),
                 Some(Box::new(write_versions.into_iter())),

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -368,9 +368,12 @@ impl<'a> SnapshotMinimizer<'a> {
             }
 
             let (new_storage, _time) = self.accounts_db().get_store_for_shrink(slot, aligned_total);
-            let include_slot_in_hash = true; // this is irrelevant. We are rewriting existing storages, so hash will always exist
             self.accounts_db().store_accounts_frozen(
-                (slot, &accounts[..], include_slot_in_hash),
+                (
+                    slot,
+                    &accounts[..],
+                    crate::accounts_db::INCLUDE_SLOT_IN_HASH_IRRELEVANT_SHRINK,
+                ),
                 Some(&hashes),
                 Some(&new_storage),
                 Some(Box::new(write_versions.into_iter())),

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -372,7 +372,7 @@ impl<'a> SnapshotMinimizer<'a> {
                 (
                     slot,
                     &accounts[..],
-                    crate::accounts_db::INCLUDE_SLOT_IN_HASH_IRRELEVANT_SHRINK,
+                    crate::accounts_db::INCLUDE_SLOT_IN_HASH_IRRELEVANT_APPEND_VEC_OPERATION,
                 ),
                 Some(&hashes),
                 Some(&new_storage),

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -368,7 +368,7 @@ impl<'a> SnapshotMinimizer<'a> {
             }
 
             let (new_storage, _time) = self.accounts_db().get_store_for_shrink(slot, aligned_total);
-            let include_slot_in_hash = true; // todo
+            let include_slot_in_hash = true; // this is irrelevant. We are rewriting existing storages, so hash will always exist
             self.accounts_db().store_accounts_frozen(
                 (slot, &accounts[..], include_slot_in_hash),
                 Some(&hashes),

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -39,7 +39,7 @@ pub struct StorableAccountsMovingSlots<'a, T: ReadableAccount + Sync> {
     /// slot where accounts are currently stored
     pub old_slot: Slot,
     /// true if hashing an account should include the slot
-    /// temporarily here until feature activation
+    /// This is temporarily here until feature activation.
     pub include_slot_in_hash: bool,
 }
 

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -3,7 +3,7 @@ use {
     rand::{thread_rng, Rng},
     rayon::prelude::*,
     solana_runtime::{
-        accounts_db::{AccountsDb, LoadHint},
+        accounts_db::{AccountsDb, LoadHint, INCLUDE_SLOT_IN_HASH_TESTS},
         ancestors::Ancestors,
     },
     solana_sdk::{
@@ -128,7 +128,7 @@ fn test_bad_bank_hash() {
             assert_eq!(
                 db.load_account_hash(&ancestors, key, None, LoadHint::Unspecified)
                     .unwrap(),
-                AccountsDb::hash_account(some_slot, *account, key)
+                AccountsDb::hash_account(some_slot, *account, key, INCLUDE_SLOT_IN_HASH_TESTS)
             );
         }
         existing.clear();

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -490,6 +490,10 @@ pub mod disable_cpi_setting_executable_and_rent_epoch {
     solana_sdk::declare_id!("B9cdB55u4jQsDNsdTK525yE9dmSc5Ga7YBaBrDFvEhM9");
 }
 
+pub mod account_hash_ignore_slot {
+    solana_sdk::declare_id!("SVn36yVApPLYsa8koK3qUcy14zXDnqkNYWyUh1f4oK1");
+}
+
 pub mod relax_authority_signer_check_for_lookup_table_creation {
     solana_sdk::declare_id!("FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap");
 }
@@ -632,6 +636,7 @@ lazy_static! {
         (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
         (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),
         (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
+        (account_hash_ignore_slot::id(), "ignore slot when calculating an account hash #28420"),
         (prevent_crediting_accounts_that_end_rent_paying::id(), "prevent crediting rent paying accounts #26606"),
         (cap_bpf_program_instruction_accounts::id(), "enforce max number of accounts per bpf program instruction #26628"),
         (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),


### PR DESCRIPTION
#### Problem
#28404

To facilitate eliminating rewrites during rent collection, we need a feature to stop using the slot an account was written in its hash calculation.

#### Summary of Changes

Implement a feature (#28420) to change the account hash calculation.

Fixes #
Feature Gate Issue: #28420
