### PR TITLE
[zk-token-sdk] Restructure proof error types

### DIFF
--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -17,7 +17,7 @@
 #![cfg(not(target_os = "solana"))]
 
 use {
-    crate::errors::ProofError,
+    crate::encryption::errors::EncryptionError,
     curve25519_dalek::{
         constants::RISTRETTO_BASEPOINT_POINT as G,
         ristretto::RistrettoPoint,
@@ -100,10 +100,10 @@ impl DiscreteLog {
     }
 
     /// Adjusts number of threads in a discrete log instance.
-    pub fn num_threads(&mut self, num_threads: usize) -> Result<(), ProofError> {
+    pub fn num_threads(&mut self, num_threads: usize) -> Result<(), EncryptionError> {
         // number of threads must be a positive power-of-two integer
         if num_threads == 0 || (num_threads & (num_threads - 1)) != 0 || num_threads > 65536 {
-            return Err(ProofError::DiscreteLogThreads);
+            return Err(EncryptionError::DiscreteLogThreads);
         }
 
         self.num_threads = num_threads;
@@ -117,9 +117,9 @@ impl DiscreteLog {
     pub fn set_compression_batch_size(
         &mut self,
         compression_batch_size: usize,
-    ) -> Result<(), ProofError> {
+    ) -> Result<(), EncryptionError> {
         if compression_batch_size >= TWO16 as usize {
-            return Err(ProofError::DiscreteLogBatchSize);
+            return Err(EncryptionError::DiscreteLogBatchSize);
         }
         self.compression_batch_size = compression_batch_size;
 

--- a/zk-token-sdk/src/encryption/errors.rs
+++ b/zk-token-sdk/src/encryption/errors.rs
@@ -1,0 +1,10 @@
+//! Errors related to the twisted ElGamal encryption scheme.
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum EncryptionError {
+    #[error("discrete log number of threads not power-of-two")]
+    DiscreteLogThreads,
+    #[error("discrete log batch size too large")]
+    DiscreteLogBatchSize,
+}

--- a/zk-token-sdk/src/encryption/mod.rs
+++ b/zk-token-sdk/src/encryption/mod.rs
@@ -13,4 +13,5 @@
 pub mod auth_encryption;
 pub mod discrete_log;
 pub mod elgamal;
+pub mod errors;
 pub mod pedersen;

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -22,18 +22,12 @@ pub enum ProofError {
     ZeroBalanceProof,
     #[error("validity proof failed to verify")]
     ValidityProof,
-    #[error(
-        "`zk_token_elgamal::pod::ElGamalCiphertext` contains invalid ElGamalCiphertext ciphertext"
-    )]
-    InconsistentCTData,
-    #[error("failed to decrypt ciphertext from transfer data")]
-    Decryption,
-    #[error("discrete log number of threads not power-of-two")]
-    DiscreteLogThreads,
-    #[error("discrete log batch size too large")]
-    DiscreteLogBatchSize,
     #[error("public-key sigma proof failed to verify")]
     PubkeySigmaProof,
+    #[error("failed to decrypt ciphertext")]
+    Decryption,
+    #[error("invalid ciphertext data")]
+    CiphertextDeserialization,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -7,6 +7,8 @@
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 
+use curve25519_dalek::traits::VartimeMultiscalarMul;
+
 #[cfg(not(target_os = "solana"))]
 use {
     crate::encryption::{

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -7,8 +7,6 @@
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 
-use curve25519_dalek::traits::VartimeMultiscalarMul;
-
 #[cfg(not(target_os = "solana"))]
 use {
     crate::encryption::{

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -98,7 +98,7 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(ct: pod::ElGamalCiphertext) -> Result<Self, Self::Error> {
-            Self::from_bytes(&ct.0).ok_or(ProofError::InconsistentCTData)
+            Self::from_bytes(&ct.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 
@@ -112,7 +112,7 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(pk: pod::ElGamalPubkey) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pk.0).ok_or(ProofError::InconsistentCTData)
+            Self::from_bytes(&pk.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 
@@ -147,7 +147,7 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(pod: pod::PedersenCommitment) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pod.0).ok_or(ProofError::InconsistentCTData)
+            Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 
@@ -171,7 +171,7 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(pod: pod::DecryptHandle) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pod.0).ok_or(ProofError::InconsistentCTData)
+            Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 
@@ -185,7 +185,7 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(ct: pod::AeCiphertext) -> Result<Self, Self::Error> {
-            Self::from_bytes(&ct.0).ok_or(ProofError::InconsistentCTData)
+            Self::from_bytes(&ct.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 


### PR DESCRIPTION
#### Problem
The errors types that are purely associated with the ElGamal encryption scheme is contained under `ProofError` that should be related to proof generation and verification.

#### Summary of Changes
Create a dedicated `EncryptionError` type and use it for errors associated with ElGamal enryption. This removes some types in the `ProofError`. This should be okay since zk tokens are not yet enabled.