### PR TITLE
Remove Blockstore manual compaction code

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -81,8 +81,6 @@ pub struct TvuConfig {
     pub max_ledger_shreds: Option<u64>,
     pub shred_version: u16,
     pub repair_validators: Option<HashSet<Pubkey>>,
-    pub rocksdb_compaction_interval: Option<u64>,
-    pub rocksdb_max_compaction_jitter: Option<u64>,
     pub wait_for_vote_to_start_leader: bool,
     pub replay_slots_concurrently: bool,
 }
@@ -300,8 +298,6 @@ impl Tvu {
                 blockstore.clone(),
                 max_ledger_shreds,
                 exit,
-                tvu_config.rocksdb_compaction_interval,
-                tvu_config.rocksdb_max_compaction_jitter,
             )
         });
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -142,9 +142,6 @@ pub struct ValidatorConfig {
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub halt_on_known_validators_accounts_hash_mismatch: bool,
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
-    pub no_rocksdb_compaction: bool,
-    pub rocksdb_compaction_interval: Option<u64>,
-    pub rocksdb_max_compaction_jitter: Option<u64>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,
@@ -207,9 +204,6 @@ impl Default for ValidatorConfig {
             gossip_validators: None,
             halt_on_known_validators_accounts_hash_mismatch: false,
             accounts_hash_fault_injection_slots: 0,
-            no_rocksdb_compaction: false,
-            rocksdb_compaction_interval: None,
-            rocksdb_max_compaction_jitter: None,
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             wal_recovery_mode: None,
@@ -981,8 +975,6 @@ impl Validator {
                 max_ledger_shreds: config.max_ledger_shreds,
                 shred_version: node.info.shred_version,
                 repair_validators: config.repair_validators.clone(),
-                rocksdb_compaction_interval: config.rocksdb_compaction_interval,
-                rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
                 wait_for_vote_to_start_leader,
                 replay_slots_concurrently: config.replay_slots_concurrently,
             },
@@ -1414,7 +1406,6 @@ fn load_blockstore(
         },
     )
     .expect("Failed to open ledger database");
-    blockstore.set_no_compaction(config.no_rocksdb_compaction);
     blockstore.shred_timing_point_sender = poh_timing_point_sender;
     // following boot sequence (esp BankForks) could set root. so stash the original value
     // of blockstore root away here as soon as possible.

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -38,8 +38,6 @@ mod tests {
     const DEFAULT_STOP_SIZE_CF_DATA_BYTES: u64 = 0;
     const DEFAULT_SHRED_DATA_CF_SIZE_BYTES: u64 = 125 * 1024 * 1024 * 1024;
 
-    const ROCKSDB_FLUSH_GRACE_PERIOD_SECS: u64 = 20;
-
     #[derive(Debug)]
     struct BenchmarkConfig {
         benchmark_slots: u64,
@@ -51,9 +49,6 @@ mod tests {
         stop_size_cf_data_bytes: u64,
         pre_generate_data: bool,
         cleanup_blockstore: bool,
-        assert_compaction: bool,
-        compaction_interval: Option<u64>,
-        no_compaction: bool,
         num_writers: u64,
         cleanup_service: bool,
         fifo_compaction: bool,
@@ -187,19 +182,10 @@ mod tests {
     ///   under the storage limitation.
     /// - `CLEANUP_BLOCKSTORE`: if true, the ledger store created in the current
     ///   benchmark run will be deleted.  Default: true.
-    /// - `NO_COMPACTION`: whether to stop rocksdb's background compaction
-    ///   completely.  Default: false.
     ///
     /// Cleanup-service related settings:
     /// - `MAX_LEDGER_SHREDS`: when the clean-up service is on, the service will
     ///   clean up the ledger store when the number of shreds exceeds this value.
-    /// - `COMPACTION_INTERVAL`: if set, the clean-up service will compact all
-    ///   slots that are older than the specified interval.  The interval is
-    ///   measured by slots.
-    ///   Default: the number of slots per day (`TICKS_PER_DAY` / `DEFAULT_TICKS_PER_SLOT`)
-    /// - `ASSERT_COMPACTION`: if true, then the benchmark will perform a sanity check
-    ///   on whether clean-up service triggers the expected compaction at the end of
-    ///   the benchmark run.  Default: false.
     /// - `CLEANUP_SERVICE`: whether to enable the background cleanup service.
     ///   If set to false, the ledger store in the benchmark will be purely relied
     ///   on RocksDB's compaction.  Default: true.
@@ -220,13 +206,6 @@ mod tests {
             read_env("STOP_SIZE_CF_DATA_BYTES", DEFAULT_STOP_SIZE_CF_DATA_BYTES);
         let pre_generate_data = read_env("PRE_GENERATE_DATA", false);
         let cleanup_blockstore = read_env("CLEANUP_BLOCKSTORE", true);
-        // set default to `true` once compaction is merged
-        let assert_compaction = read_env("ASSERT_COMPACTION", false);
-        let compaction_interval = match read_env("COMPACTION_INTERVAL", 0) {
-            maybe_zero if maybe_zero == 0 => None,
-            non_zero => Some(non_zero),
-        };
-        let no_compaction = read_env("NO_COMPACTION", false);
         let num_writers = read_env("NUM_WRITERS", 1);
         // A flag indicating whether to have a background clean-up service.
         // If set to false, the ledger store will purely rely on RocksDB's
@@ -246,9 +225,6 @@ mod tests {
             stop_size_cf_data_bytes,
             pre_generate_data,
             cleanup_blockstore,
-            assert_compaction,
-            compaction_interval,
-            no_compaction,
             num_writers,
             cleanup_service,
             fifo_compaction,
@@ -331,7 +307,7 @@ mod tests {
         false
     }
 
-    /// The ledger cleanup compaction test which can also be used as a benchmark
+    /// The ledger cleanup  test which can also be used as a benchmark
     /// measuring shred insertion performance of the blockstore.
     ///
     /// The benchmark is controlled by several environmental arguments.
@@ -339,15 +315,15 @@ mod tests {
     ///
     /// Example command:
     /// BENCHMARK_SLOTS=1000000 BATCH_SIZE=1 SHREDS_PER_SLOT=25 NUM_WRITERS=8 \
-    /// PRE_GENERATE_DATA=false cargo test --release tests::test_ledger_cleanup_compaction \
+    /// PRE_GENERATE_DATA=false cargo test --release tests::test_ledger_cleanup \
     /// -- --exact --nocapture
     #[test]
-    fn test_ledger_cleanup_compaction() {
+    fn test_ledger_cleanup() {
         solana_logger::setup_with("error,ledger_cleanup::tests=info");
 
         let ledger_path = get_tmp_ledger_path!();
         let config = get_benchmark_config();
-        let mut blockstore = Blockstore::open_with_options(
+        let blockstore = Blockstore::open_with_options(
             &ledger_path,
             if config.fifo_compaction {
                 BlockstoreOptions {
@@ -367,9 +343,6 @@ mod tests {
             },
         )
         .unwrap();
-        if config.no_compaction {
-            blockstore.set_no_compaction(true);
-        }
         let blockstore = Arc::new(blockstore);
 
         info!("Benchmark configuration: {:#?}", config);
@@ -383,7 +356,6 @@ mod tests {
         let stop_size_iterations = config.stop_size_iterations;
         let stop_size_cf_data_bytes = config.stop_size_cf_data_bytes;
         let pre_generate_data = config.pre_generate_data;
-        let compaction_interval = config.compaction_interval;
         let num_writers = config.num_writers;
         let cleanup_service = config.cleanup_service;
 
@@ -399,8 +371,6 @@ mod tests {
                 blockstore.clone(),
                 max_ledger_shreds,
                 &exit,
-                compaction_interval,
-                None,
             ))
         } else {
             None
@@ -619,23 +589,6 @@ mod tests {
             insert_timer,
             num_shreds_total as f32 / insert_timer.as_s(),
         );
-        let u1 = storage_previous;
-
-        // Poll on some compaction happening
-        info!("Begin polling for compaction ...");
-        let start_poll = Instant::now();
-        while blockstore.storage_size().unwrap_or(0) >= u1 {
-            if start_poll.elapsed().as_secs() > ROCKSDB_FLUSH_GRACE_PERIOD_SECS {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(200));
-        }
-        info!(
-            "Done polling for compaction after {}s",
-            start_poll.elapsed().as_secs_f32()
-        );
-
-        let u2 = storage_previous;
 
         exit.store(true, Ordering::SeqCst);
         if cleanup_service {
@@ -645,74 +598,9 @@ mod tests {
         exit_cpu.store(true, Ordering::SeqCst);
         sys.join().unwrap();
 
-        if config.assert_compaction {
-            assert!(u2 < u1, "expected compaction! pre={},post={}", u1, u2);
-        }
-
         if config.cleanup_blockstore {
             drop(blockstore);
             Blockstore::destroy(&ledger_path).expect("Expected successful database destruction");
         }
-    }
-
-    #[test]
-    fn test_compaction() {
-        let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
-
-        let n = 10_000;
-        let batch_size_slots = 100;
-        let num_batches = n / batch_size_slots;
-        let max_ledger_shreds = 100;
-
-        for i in 0..num_batches {
-            let start_slot = i * batch_size_slots;
-            let (shreds, _) = make_many_slot_shreds(start_slot, batch_size_slots, 1);
-            blockstore.insert_shreds(shreds, None, false).unwrap();
-        }
-
-        let u1 = blockstore.storage_size().unwrap() as f64;
-
-        // send signal to cleanup slots
-        let (sender, receiver) = unbounded();
-        sender.send(n).unwrap();
-        let mut last_purge_slot = 0;
-        let highest_compact_slot = Arc::new(AtomicU64::new(0));
-        LedgerCleanupService::cleanup_ledger(
-            &receiver,
-            &blockstore,
-            max_ledger_shreds,
-            &mut last_purge_slot,
-            10,
-            &highest_compact_slot,
-        )
-        .unwrap();
-
-        let mut compaction_jitter = 0;
-        let mut last_compaction_slot = 0;
-        LedgerCleanupService::compact_ledger(
-            &blockstore,
-            &mut last_compaction_slot,
-            10,
-            &highest_compact_slot,
-            &mut compaction_jitter,
-            None,
-        );
-
-        thread::sleep(Duration::from_secs(2));
-
-        let u2 = blockstore.storage_size().unwrap() as f64;
-
-        assert!(u2 < u1, "insufficient compaction! pre={},post={}", u1, u2,);
-
-        // check that early slots don't exist
-        let max_slot = n - max_ledger_shreds - 1;
-        blockstore
-            .slot_meta_iterator(0)
-            .unwrap()
-            .for_each(|(slot, _)| assert!(slot > max_slot));
-
-        drop(blockstore);
-        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
 }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -31,9 +31,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         halt_on_known_validators_accounts_hash_mismatch: config
             .halt_on_known_validators_accounts_hash_mismatch,
         accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
-        no_rocksdb_compaction: config.no_rocksdb_compaction,
-        rocksdb_compaction_interval: config.rocksdb_compaction_interval,
-        rocksdb_max_compaction_jitter: config.rocksdb_max_compaction_jitter,
         accounts_hash_interval_slots: config.accounts_hash_interval_slots,
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         wal_recovery_mode: config.wal_recovery_mode.clone(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -818,7 +818,6 @@ impl TestValidator {
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,
             validator_exit: config.validator_exit.clone(),
-            rocksdb_compaction_interval: Some(100), // Compact every 100 slots
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
             staked_nodes_overrides: config.staked_nodes_overrides.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1189,13 +1189,6 @@ pub fn main() {
                       [default: all validators]")
         )
         .arg(
-            Arg::with_name("rocksdb_compaction_interval")
-                .long("rocksdb-compaction-interval-slots")
-                .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")
-                .takes_value(true)
-                .help("Number of slots between compacting ledger"),
-        )
-        .arg(
             Arg::with_name("tpu_coalesce_ms")
                 .long("tpu-coalesce-ms")
                 .value_name("MILLISECS")
@@ -1241,13 +1234,6 @@ pub fn main() {
                             as valid for other peers in network. The stake amount is used for calculating
                             number of QUIC streams permitted from the peer and vote packet sender stage.
                             Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}"),
-        )
-        .arg(
-            Arg::with_name("rocksdb_max_compaction_jitter")
-                .long("rocksdb-max-compaction-jitter-slots")
-                .value_name("ROCKSDB_MAX_COMPACTION_JITTER_SLOTS")
-                .takes_value(true)
-                .help("Introduce jitter into the compaction to offset compaction operation"),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -2308,10 +2294,6 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
-    let no_rocksdb_compaction = true;
-    let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
-    let rocksdb_max_compaction_jitter =
-        value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();
     let tpu_coalesce_ms =
         value_t!(matches, "tpu_coalesce_ms", u64).unwrap_or(DEFAULT_TPU_COALESCE_MS);
     let wal_recovery_mode = matches
@@ -2661,9 +2643,6 @@ pub fn main() {
         known_validators,
         repair_validators,
         gossip_validators,
-        no_rocksdb_compaction,
-        rocksdb_compaction_interval,
-        rocksdb_max_compaction_jitter,
         wal_recovery_mode,
         poh_verify: !matches.is_present("skip_poh_verify"),
         debug_keys,
@@ -3294,6 +3273,18 @@ fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
             .hidden(true)
             .takes_value(false)
             .help("Disable manual compaction of the ledger database (this is ignored)."),
+        Arg::with_name("rocksdb_compaction_interval")
+            .long("rocksdb-compaction-interval-slots")
+            .hidden(true)
+            .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")
+            .takes_value(true)
+            .help("Number of slots between compacting ledger"),
+        Arg::with_name("rocksdb_max_compaction_jitter")
+            .long("rocksdb-max-compaction-jitter-slots")
+            .hidden(true)
+            .value_name("ROCKSDB_MAX_COMPACTION_JITTER_SLOTS")
+            .takes_value(true)
+            .help("Introduce jitter into the compaction to offset compaction operation"),
     ]
 }
 
@@ -3328,6 +3319,8 @@ lazy_static! {
             "Vote account sanity checks are no longer performed by default.",
         ),
         ("no_rocksdb_compaction", ""),
+        ("rocksdb_compaction_interval", ""),
+        ("rocksdb_max_compaction_jitter", ""),
     ];
 }
 


### PR DESCRIPTION
#### Problem
The manual Blockstore compaction that was being initiated from LedgerCleanupService has been disabled for quite some time in favor of several optimizations.

#### Summary of Changes
Rip out the dead code (and eliminate one thread)

I was poking around LedgerCleanupService following an idea I discussed with Yueh-Hsuan, and then was reminded of the dead code in there. So, I decided to pick up some of the cleanup from https://github.com/solana-labs/solana/pull/27529. However, that PR modified compaction and purge routines. I thought it'd be more manageable to handle one item per PR, so here is just the compaction stuff. The compaction removal is more straightforward than the purge change as well, so this should be a less complex review.
