### PR TITLE
Add SetAuthorityChecked instruction to bpf loader

### DIFF
--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -147,4 +147,17 @@ pub enum UpgradeableLoaderInstruction {
         /// Number of bytes to extend the program data.
         additional_bytes: u32,
     },
+
+    /// Set a new authority that is allowed to write the buffer or upgrade the
+    /// program.
+    ///
+    /// This instruction differs from SetAuthority in that the new authority is a
+    /// required signer.
+    ///
+    /// # Account references
+    ///   0. `[writable]` The Buffer or ProgramData account to change the
+    ///      authority of.
+    ///   1. `[signer]` The current authority.
+    ///   2. `[signer]` The new authority.
+    SetAuthorityChecked,
 }

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -139,6 +139,17 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
+        UpgradeableLoaderInstruction::SetAuthorityChecked => {
+            check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "setAuthority".to_string(),
+                info: json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "authority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "newAuthority": account_keys[instruction.accounts[2] as usize].to_string(),
+                }),
+            })
+        }
         UpgradeableLoaderInstruction::Close => {
             check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 3)?;
             Ok(ParsedInstructionEnum {


### PR DESCRIPTION
#### Problem

It is currently quite easy to accidentally set a program upgrade authority to a random pubkey. There should be some kind of "checked" upgrade authority instruction.

#### Summary of Changes

- Add SetAuthorityChecked to bpf loader
- TODO use SetAuthorityChecked in cli


Fixes # https://github.com/solana-labs/solana/issues/27932

TODO get feature gate (will need someone's help for this)
