### PR TITLE
Refactor: Rename `max_invoke_depth` to `max_invoke_stack_height`

### DIFF
--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -84,7 +84,7 @@ max_units: 1,400,000,
 log_u64_units: 100,
 create_program address units: 1500,
 invoke_units: 1000,
-max_invoke_depth: 4,
+max_invoke_stack_height: 5,
 max_instruction_trace_length: 64,
 max_call_depth: 64,
 stack_frame_size: 4096,
@@ -97,7 +97,7 @@ Then any transaction:
 - Could execute 1,400,000 BPF instructions, if it did nothing else.
 - Cannot exceed 4k of stack usage.
 - Cannot exceed a BPF call depth of 64.
-- Cannot exceed 4 levels of cross-program invocations.
+- Cannot exceed invoke stack height of 5 (4 levels of cross-program invocations).
 
 > **NOTE:** Since the compute budget is consumed incrementally as the transaction executes,
 > the total budget consumption will be a combination of the various costs of the

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -35,8 +35,11 @@ pub struct ComputeBudget {
     /// Number of compute units consumed by an invoke call (not including the cost incurred by
     /// the called program)
     pub invoke_units: u64,
-    /// Maximum cross-program invocation depth allowed
-    pub max_invoke_depth: usize,
+    /// Maximum program instruction invocation stack height. Invocation stack
+    /// height starts at 1 for transaction instructions and the stack height is
+    /// incremented each time a program invokes an instruction and decremented
+    /// when a program returns.
+    pub max_invoke_stack_height: usize,
     /// Maximum cross-program invocation and instructions per transaction
     pub max_instruction_trace_length: usize,
     /// Base number of compute units consumed to call SHA256
@@ -113,7 +116,7 @@ impl ComputeBudget {
             log_64_units: 100,
             create_program_address_units: 1500,
             invoke_units: 1000,
-            max_invoke_depth: 4,
+            max_invoke_stack_height: 5,
             max_instruction_trace_length: 64,
             sha256_base_cost: 85,
             sha256_byte_cost: 1,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -931,7 +931,7 @@ pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
     let mut transaction_context = TransactionContext::new(
         preparation.transaction_accounts,
         Some(Rent::default()),
-        compute_budget.max_invoke_depth.saturating_add(1),
+        compute_budget.max_invoke_stack_height,
         compute_budget.max_instruction_trace_length,
     );
     transaction_context.enable_cap_accounts_data_allocations_per_transaction();
@@ -967,7 +967,7 @@ pub fn mock_process_instruction(
     let mut transaction_context = TransactionContext::new(
         preparation.transaction_accounts,
         Some(Rent::default()),
-        compute_budget.max_invoke_depth.saturating_add(1),
+        compute_budget.max_invoke_stack_height,
         compute_budget.max_instruction_trace_length,
     );
     transaction_context.enable_cap_accounts_data_allocations_per_transaction();
@@ -1190,7 +1190,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(
             accounts,
             Some(Rent::default()),
-            ComputeBudget::default().max_invoke_depth,
+            ComputeBudget::default().max_invoke_stack_height,
             MAX_DEPTH,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4087,7 +4087,7 @@ impl Bank {
             } else {
                 None
             },
-            compute_budget.max_invoke_depth.saturating_add(1),
+            compute_budget.max_invoke_stack_height,
             if self
                 .feature_set
                 .is_active(&feature_set::limit_max_instruction_trace_length::id())
@@ -18296,7 +18296,7 @@ pub(crate) mod tests {
         let transaction_context = TransactionContext::new(
             loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
             Some(Rent::default()),
-            compute_budget.max_invoke_depth.saturating_add(1),
+            compute_budget.max_invoke_stack_height,
             compute_budget.max_instruction_trace_length,
         );
 


### PR DESCRIPTION
#### Problem
Instruction context now tracks "stack height" instead of depth so it's confusing that the compute budget invocation limit is still described as a depth because of the potential for off-by-one errors.

#### Summary of Changes
- Rename  `max_invoke_depth` to `max_invoke_stack_height` and remove the increment when passing this value to the transaction context.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
