### PR TITLE
fix: wrap _rpcWebSocketGeneration around when about to overflow

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -5084,7 +5084,8 @@ export class Connection {
    */
   _wsOnClose(code: number) {
     this._rpcWebSocketConnected = false;
-    this._rpcWebSocketGeneration++;
+    this._rpcWebSocketGeneration =
+      (this._rpcWebSocketGeneration + 1) % Number.MAX_SAFE_INTEGER;
     if (this._rpcWebSocketIdleTimeout) {
       clearTimeout(this._rpcWebSocketIdleTimeout);
       this._rpcWebSocketIdleTimeout = null;


### PR DESCRIPTION
#### Problem

It's _conceivable_ that someone could open up so many WebSocket connections (ie. in a long running Node process) so as to exhaust this index. JavaScript integers, after all, have a maximum value of `Number.MAX_SAFE_INTEGER`.

Upon hearing a report of someone with a script that works from Saturday to Thursday but then crashes with the dreaded infinite recursion bug (see #26198) I immediately thought that this index might be overflowing, essentially _pinning_ it to a constant value from `Number.MAX_SAFE_INTEGER + 1` onward.

#### Summary of Changes

Wrap the index back around to 0 after hitting `Number.MAX_SAFE_INTEGER`.

Addresses #26198. Closes #28426.