### PR TITLE
web3.js: feat: add optional Cluster to Connection

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -41,6 +41,7 @@ import {
 import {Message, MessageHeader, MessageV0, VersionedMessage} from './message';
 import {AddressLookupTableAccount} from './programs/address-lookup-table/state';
 import assert from './utils/assert';
+import {Cluster} from './utils/cluster';
 import {sleep} from './utils/sleep';
 import {toBuffer} from './utils/to-buffer';
 import {
@@ -2649,6 +2650,8 @@ export type FetchMiddleware = (
 export type ConnectionConfig = {
   /** Optional commitment level */
   commitment?: Commitment;
+  /** Optional cluster name */
+  cluster?: Cluster;
   /** Optional endpoint URL to the fullnode JSON RPC PubSub WebSocket Endpoint */
   wsEndpoint?: string;
   /** Optional HTTP headers object */
@@ -2657,9 +2660,9 @@ export type ConnectionConfig = {
   fetch?: FetchFn;
   /** Optional fetch middleware callback */
   fetchMiddleware?: FetchMiddleware;
-  /** Optional Disable retrying calls when server responds with HTTP 429 (Too Many Requests) */
+  /** Optionally disable retrying calls when server responds with HTTP 429 (Too Many Requests) */
   disableRetryOnRateLimit?: boolean;
-  /** time to allow for the server to initially process a transaction (in milliseconds) */
+  /** Optional time to allow for the server to initially process a transaction (in milliseconds) */
   confirmTransactionInitialTimeout?: number;
 };
 
@@ -2673,6 +2676,7 @@ const COMMON_HTTP_HEADERS = {
  */
 export class Connection {
   /** @internal */ _commitment?: Commitment;
+  /** @internal */ _cluster?: Cluster;
   /** @internal */ _confirmTransactionInitialTimeout?: number;
   /** @internal */ _rpcEndpoint: string;
   /** @internal */ _rpcWsEndpoint: string;
@@ -2758,6 +2762,7 @@ export class Connection {
       this._commitment = commitmentOrConfig;
     } else if (commitmentOrConfig) {
       this._commitment = commitmentOrConfig.commitment;
+      this._cluster = commitmentOrConfig.cluster;
       this._confirmTransactionInitialTimeout =
         commitmentOrConfig.confirmTransactionInitialTimeout;
       wsEndpoint = commitmentOrConfig.wsEndpoint;
@@ -2822,6 +2827,13 @@ export class Connection {
    */
   get commitment(): Commitment | undefined {
     return this._commitment;
+  }
+
+  /**
+   * The cluster the RPC endpoint uses
+   */
+  get cluster(): Cluster | undefined {
+    return this._cluster;
   }
 
   /**

--- a/web3.js/src/utils/cluster.ts
+++ b/web3.js/src/utils/cluster.ts
@@ -2,22 +2,27 @@ const endpoint = {
   http: {
     devnet: 'http://api.devnet.solana.com',
     testnet: 'http://api.testnet.solana.com',
-    'mainnet-beta': 'http://api.mainnet-beta.solana.com/',
+    'mainnet-beta': 'http://api.mainnet-beta.solana.com',
+    localnet: 'http://localhost:8899',
   },
   https: {
     devnet: 'https://api.devnet.solana.com',
     testnet: 'https://api.testnet.solana.com',
-    'mainnet-beta': 'https://api.mainnet-beta.solana.com/',
+    'mainnet-beta': 'https://api.mainnet-beta.solana.com',
+    localnet: 'https://localhost:8899',
   },
 };
 
-export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
+export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta' | 'localnet';
 
 /**
  * Retrieves the RPC API URL for the specified cluster
  */
 export function clusterApiUrl(cluster?: Cluster, tls?: boolean): string {
-  const key = tls === false ? 'http' : 'https';
+  const key =
+    tls === false || (tls == undefined && cluster === 'localnet')
+      ? 'http'
+      : 'https';
 
   if (!cluster) {
     return endpoint[key]['devnet'];


### PR DESCRIPTION
#### Problem

Connection objects are frequently passed around dapps, and to wallets and wallet adapters. The wallet or adapter lacks context on the intended cluster, which may be used to determine compatibility with it or configure it for correct operation.

The `connection.rpcEndpoint` field can only be loosely used to infer which cluster the connection is targeting, by mapping to known URLs or checking for substrings like `devnet` in the endpoint, which is messy and doesn't work well with many custom RPC endpoints that wallets and dapps use.

Connections to localnet are also allowed by major wallets (Phantom, Glow, Backpack, and others) but has no equivalent in web3.js.

#### Summary of Changes

- Expand the `Cluster` type to include `localnet`
- Add localhost endpoint URLs to `clusterApiUrl()`
- Add an optional `cluster` field to the optional config `Connection` can be instantiated with
- Add `cluster` field to `Connection` so it can be read if provided

I believe this is nonbreaking, widening the type of `Cluster` and being optional to provide.

I believe this adds no _new_ security issues. In general, wallets **should already not trust** a Connection object provided by dapps, because it may use an endpoint unknown to the wallet, or one that contains strings like `devnet` but actually targets mainnet, or its RPC can lie about the genesis hash or anything else when queried, and so on.

The endpoint _and_ cluster should be regarded as informational only, and only used by a wallet to help determine its own connection based on its own known RPCs.