### PR TITLE
ci: move `stable-sbf` job to `solana` queue

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -183,7 +183,7 @@ all_test_steps() {
     timeout_in_minutes: 35
     artifact_paths: "sbf-dumps.tar.bz2"
     agents:
-      queue: "gcp"
+      queue: "solana"
 EOF
   else
     annotate --style info \

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -2,6 +2,8 @@
 set -e
 cd "$(dirname "$0")/.."
 
+# kick the ci job
+
 cargo="$(readlink -f "./cargo")"
 
 source ci/_


### PR DESCRIPTION
#### Problem

`stable-sbf` ci job is still targeting the `gcp` buildkite queue, which was recently decommissioned

#### Summary of Changes

move it to the `solana` buildkite queue