### PR TITLE
ci: v1.10 is EOL. stop creating backports for it

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -120,7 +120,6 @@ ubscribers')) }}"
         labels:
           - feature-gate
         branches:
-          - v1.10
           - v1.13
   - name: v1.13 non-feature-gate backport
     conditions:
@@ -131,7 +130,6 @@ ubscribers')) }}"
         assignees: *BackportAssignee
         ignore_conflicts: true
         branches:
-          - v1.10
           - v1.13
   - name: v1.14 feature-gate backport
     conditions:


### PR DESCRIPTION
#### Problem

v1.10 is EOL, but mergify is still creating backports for it

#### Summary of Changes

stop