### PR TITLE
program-test: Add working `get_stack_height` stub call

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -395,6 +395,11 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             .set_return_data(caller, data.to_vec())
             .unwrap();
     }
+
+    fn sol_get_stack_height(&self) -> u64 {
+        let invoke_context = get_invoke_context();
+        invoke_context.get_stack_height().try_into().unwrap()
+    }
 }
 
 pub fn find_file(filename: &str) -> Option<PathBuf> {


### PR DESCRIPTION
#### Problem

When working in "native mode" in program-test, the syscall to `sol_get_stack_height` defaults to 0, as noticed during https://github.com/solana-labs/solana-program-library/pull/3712

#### Summary of Changes

We have the information, so implement the real thing from the invoke context.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

cc @2501babe 