### PR TITLE
Warping works with Epoch Accounts Hash

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -674,6 +674,7 @@ impl Validator {
             ledger_path,
             &bank_forks,
             &leader_schedule_cache,
+            &accounts_background_request_sender,
         )?;
 
         if config.process_ledger_before_services {
@@ -1675,6 +1676,7 @@ fn maybe_warp_slot(
     ledger_path: &Path,
     bank_forks: &RwLock<BankForks>,
     leader_schedule_cache: &LeaderScheduleCache,
+    accounts_background_request_sender: &AbsRequestSender,
 ) -> Result<(), String> {
     if let Some(warp_slot) = config.warp_slot {
         let snapshot_config = match config.snapshot_config.as_ref() {
@@ -1705,7 +1707,7 @@ fn maybe_warp_slot(
         ));
         bank_forks.set_root(
             warp_slot,
-            &solana_runtime::accounts_background_service::AbsRequestSender::default(),
+            accounts_background_request_sender,
             Some(warp_slot),
         );
         leader_schedule_cache.set_root(&bank_forks.root_bank());

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -296,12 +296,6 @@ impl BankForks {
                 "sending epoch accounts hash request, slot: {}",
                 eah_bank.slot()
             );
-            eah_bank
-                .rc
-                .accounts
-                .accounts_db
-                .epoch_accounts_hash_manager
-                .set_in_flight(eah_bank.slot());
 
             self.last_accounts_hash_slot = eah_bank.slot();
             let squash_timing = eah_bank.squash();
@@ -312,6 +306,12 @@ impl BankForks {
             total_squash_cache_ms += squash_timing.squash_cache_ms as i64;
             is_root_bank_squashed = eah_bank.slot() == root;
 
+            eah_bank
+                .rc
+                .accounts
+                .accounts_db
+                .epoch_accounts_hash_manager
+                .set_in_flight(eah_bank.slot());
             accounts_background_request_sender
                 .send_snapshot_request(SnapshotRequest {
                     snapshot_root_bank: Arc::clone(eah_bank),


### PR DESCRIPTION
#### Problem

Warping could cause issues due to Epoch Accounts Hash. If `set_root()` was called after warping, and both the EAH start and stop slots were skipped, then the bank would be frozen in `set_root()` and would hang waiting for the EAH calculation to complete, but the EAH calculation request had not been sent yet. Looping forever, and sadness, ensue.

#### Summary of Changes

* In `set_root()`, move `set_in_flight()` to _after_ `Bank::freeze()`
* Use real ABS request sender in `validator.rs` when warping. This ensures any EAH request triggered there (currently only due to solana-test-validator) is handled properly, and does not hang.
* Add tests