### PR TITLE
reworks weights for gossip pull-requests peer sampling

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1487,12 +1487,6 @@ impl ClusterInfo {
         self.append_entrypoint_to_pulls(thread_pool, &mut pulls);
         let num_requests = pulls.values().map(Vec::len).sum::<usize>() as u64;
         self.stats.new_pull_requests_count.add_relaxed(num_requests);
-        {
-            let _st = ScopedTimer::from(&self.stats.mark_pull_request);
-            for peer in pulls.keys() {
-                self.gossip.mark_pull_request_creation_time(peer.id, now);
-            }
-        }
         let self_info = CrdsData::LegacyContactInfo(self.my_contact_info());
         let self_info = CrdsValue::new_signed(self_info, &self.keypair());
         let pulls = pulls
@@ -4704,17 +4698,6 @@ RPC Enabled Nodes: 1"#;
         assert_eq!(
             (0, 0, NO_ENTRIES),
             cluster_info.handle_pull_response(&entrypoint_pubkey, data, &timeouts)
-        );
-
-        let now = timestamp();
-        for peer in peers {
-            cluster_info
-                .gossip
-                .mark_pull_request_creation_time(peer, now);
-        }
-        assert_eq!(
-            cluster_info.gossip.pull.pull_request_time().len(),
-            CRDS_UNIQUE_PUBKEY_CAPACITY
         );
     }
 

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -123,7 +123,6 @@ pub struct GossipStats {
     pub(crate) handle_batch_pull_requests_time: Counter,
     pub(crate) handle_batch_pull_responses_time: Counter,
     pub(crate) handle_batch_push_messages_time: Counter,
-    pub(crate) mark_pull_request: Counter,
     pub(crate) new_pull_requests: Counter,
     pub(crate) new_pull_requests_count: Counter,
     pub(crate) new_pull_requests_pings_count: Counter,
@@ -373,7 +372,6 @@ pub(crate) fn submit_gossip_stats(
         ),
         ("epoch_slots_lookup", stats.epoch_slots_lookup.clear(), i64),
         ("new_pull_requests", stats.new_pull_requests.clear(), i64),
-        ("mark_pull_request", stats.mark_pull_request.clear(), i64),
         (
             "gossip_pull_request_no_budget",
             stats.gossip_pull_request_no_budget.clear(),

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -565,7 +565,6 @@ fn network_run_pull(
                 bytes += serialized_size(&rsp).unwrap() as usize;
                 msgs += rsp.len();
                 if let Some(node) = network.get(&from) {
-                    node.gossip.mark_pull_request_creation_time(from, now);
                     let mut stats = ProcessPullStats::default();
                     let (vers, vers_expired_timeout, failed_inserts) = node
                         .gossip


### PR DESCRIPTION
#### Problem
Amplifying gossip peer sampling weights by the time since last pull-request has undesired consequence that a node coming back online will see a huge number of pull requests all at once.
This "time since last request" is also unnecessary to include in weights because as long as sampling probabilities are non-zero, a node will be almost surely periodically selected in the sample.

#### Summary of Changes
The commit reworks peer sampling probabilities by just using (dampened) stakes as weights.
