### PR TITLE
[zk-token-sdk] divide fee encryption into two ciphertexts

### DIFF
--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -11,8 +11,6 @@ pub enum ProofError {
     #[error("proof generation failed")]
     Generation,
     #[error("proof failed to verify")]
-    Verification,
-    #[error("range proof failed to verify")]
     RangeProof,
     #[error("equality proof failed to verify")]
     EqualityProof,
@@ -30,6 +28,10 @@ pub enum ProofError {
     CiphertextDeserialization,
     #[error("invalid scalar data")]
     ScalarDeserialization,
+    #[error("invalid public key data")]
+    PubkeyDeserialization,
+    #[error("ciphertext does not exist in proof data")]
+    MissingCiphertext,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -32,6 +32,8 @@ pub enum ProofError {
     PubkeyDeserialization,
     #[error("ciphertext does not exist in proof data")]
     MissingCiphertext,
+    #[error("transfer amount split failed")]
+    TransferSplit,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -61,7 +61,7 @@ pub fn split_u64(
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> u64 {
     // TODO: check bit_length
-    amount_lo + amount_hi << bit_length
+    amount_lo + (amount_hi << bit_length)
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -15,7 +15,6 @@ use {
         errors::ProofError,
     },
     curve25519_dalek::scalar::Scalar,
-    subtle::ConstantTimeEq,
 };
 pub use {
     close_account::CloseAccountData, pubkey_validity::PubkeyValidityData, transfer::TransferData,
@@ -41,28 +40,23 @@ pub enum Role {
 ///  - the `bit_length` low bits of `amount` interpretted as u64
 ///  - the (64 - `bit_length`) high bits of `amount` interpretted as u64
 #[cfg(not(target_os = "solana"))]
-pub fn split_u64(
-    amount: u64,
-    lo_bit_length: usize,
-    hi_bit_length: usize,
-) -> Result<(u64, u64), ProofError> {
-    assert!(lo_bit_length <= 64);
-    assert!(hi_bit_length <= 64);
-
-    if !bool::from((amount >> (lo_bit_length + hi_bit_length)).ct_eq(&0u64)) {
-        return Err(ProofError::TransferAmount);
+pub fn split_u64(amount: u64, bit_length: usize) -> (u64, u64) {
+    if bit_length == 64 {
+        (amount, 0)
+    } else {
+        let lo = amount << (64 - bit_length) >> (64 - bit_length);
+        let hi = amount >> bit_length;
+        (lo, hi)
     }
-
-    let lo = amount << (64 - lo_bit_length) >> (64 - lo_bit_length);
-    let hi = amount >> lo_bit_length;
-
-    Ok((lo, hi))
 }
 
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> u64 {
-    // TODO: check bit_length
-    amount_lo + (amount_hi << bit_length)
+    if bit_length == 64 {
+        amount_lo
+    } else {
+        amount_lo + (amount_hi << bit_length)
+    }
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -59,6 +59,12 @@ pub fn split_u64(
 }
 
 #[cfg(not(target_os = "solana"))]
+pub fn combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> u64 {
+    // TODO: check bit_length
+    amount_lo + amount_hi << bit_length
+}
+
+#[cfg(not(target_os = "solana"))]
 fn combine_lo_hi_ciphertexts(
     ciphertext_lo: &ElGamalCiphertext,
     ciphertext_hi: &ElGamalCiphertext,

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -32,8 +32,9 @@ pub trait Verifiable {
 #[derive(Debug, Copy, Clone)]
 pub enum Role {
     Source,
-    Dest,
+    Destination,
     Auditor,
+    WithdrawWithheldAuthority,
 }
 
 /// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -68,11 +68,7 @@ impl TransferData {
         (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
     ) -> Result<Self, ProofError> {
         // split and encrypt transfer amount
-        let (amount_lo, amount_hi) = split_u64(
-            transfer_amount,
-            TRANSFER_AMOUNT_LO_BITS,
-            TRANSFER_AMOUNT_HI_BITS,
-        )?;
+        let (amount_lo, amount_hi) = split_u64(transfer_amount, TRANSFER_AMOUNT_LO_BITS);
 
         let (ciphertext_lo, opening_lo) = TransferAmountEncryption::new(
             amount_lo,
@@ -584,26 +580,7 @@ mod test {
 
         assert!(transfer_data.verify().is_ok());
 
-        // Case 4: transfer amount too big
-
-        // create source account spendable ciphertext
-        let spendable_balance: u64 = u64::max_value();
-        let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
-
-        // transfer amount
-        let transfer_amount: u64 = 1u64 << (TRANSFER_AMOUNT_LO_BITS + TRANSFER_AMOUNT_HI_BITS);
-
-        // create transfer data
-        let transfer_data = TransferData::new(
-            transfer_amount,
-            (spendable_balance, &spendable_ciphertext),
-            &source_keypair,
-            (&dest_pk, &auditor_pk),
-        );
-
-        assert!(transfer_data.is_err());
-
-        // Case 5: invalid destination or auditor pubkey
+        // Case 4: invalid destination or auditor pubkey
         let spendable_balance: u64 = 0;
         let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
 

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -529,8 +529,8 @@ impl TransferWithFeeProof {
         let range_proof = RangeProof::new(
             vec![
                 source_new_balance,
-                transfer_amount_lo as u64,
-                transfer_amount_hi as u64,
+                transfer_amount_lo,
+                transfer_amount_hi,
                 delta_fee,
                 MAX_FEE_BASIS_POINTS - delta_fee,
                 fee_amount_lo,

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -18,9 +18,8 @@ use {
         },
         range_proof::RangeProof,
         sigma_proofs::{
-            equality_proof::CtxtCommEqualityProof,
-            fee_proof::FeeSigmaProof,
-            validity_proof::{AggregatedValidityProof, ValidityProof},
+            equality_proof::CtxtCommEqualityProof, fee_proof::FeeSigmaProof,
+            validity_proof::AggregatedValidityProof,
         },
         transcript::TranscriptProtocol,
     },

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -97,11 +97,7 @@ impl TransferWithFeeData {
         withdraw_withheld_authority_pubkey: &ElGamalPubkey,
     ) -> Result<Self, ProofError> {
         // split and encrypt transfer amount
-        let (amount_lo, amount_hi) = split_u64(
-            transfer_amount,
-            TRANSFER_AMOUNT_LO_BITS,
-            TRANSFER_AMOUNT_HI_BITS,
-        )?;
+        let (amount_lo, amount_hi) = split_u64(transfer_amount, TRANSFER_AMOUNT_LO_BITS);
 
         let (ciphertext_lo, opening_lo) = TransferAmountEncryption::new(
             amount_lo,
@@ -150,8 +146,7 @@ impl TransferWithFeeData {
             u64::conditional_select(&fee_parameters.maximum_fee, &fee_amount, below_max);
 
         // split and encrypt fee
-        let (fee_to_encrypt_lo, fee_to_encrypt_hi) =
-            split_u64(fee_to_encrypt, FEE_AMOUNT_LO_BITS, FEE_AMOUNT_HI_BITS)?;
+        let (fee_to_encrypt_lo, fee_to_encrypt_hi) = split_u64(fee_to_encrypt, FEE_AMOUNT_LO_BITS);
 
         let (fee_ciphertext_lo, opening_fee_lo) = FeeEncryption::new(
             fee_to_encrypt_lo,
@@ -940,29 +935,7 @@ mod test {
 
         assert!(fee_data.verify().is_ok());
 
-        // Case 4: transfer amount too big
-        let spendable_balance: u64 = u64::max_value();
-        let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
-
-        let transfer_amount: u64 = 1u64 << (TRANSFER_AMOUNT_LO_BITS + TRANSFER_AMOUNT_HI_BITS);
-
-        let fee_parameters = FeeParameters {
-            fee_rate_basis_points: 400,
-            maximum_fee: 3,
-        };
-
-        let fee_data = TransferWithFeeData::new(
-            transfer_amount,
-            (spendable_balance, &spendable_ciphertext),
-            &source_keypair,
-            (&destination_pubkey, &auditor_pubkey),
-            fee_parameters,
-            &withdraw_withheld_authority_pubkey,
-        );
-
-        assert!(fee_data.is_err());
-
-        // Case 5: invalid destination, auditor, or withdraw authority pubkeys
+        // Case 4: invalid destination, auditor, or withdraw authority pubkeys
         let spendable_balance: u64 = 120;
         let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
 

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -201,7 +201,7 @@ mod tests {
     fn test_transfer_arithmetic() {
         // transfer amount
         let transfer_amount: u64 = 55;
-        let (amount_lo, amount_hi) = split_u64(transfer_amount, 16, 32).unwrap();
+        let (amount_lo, amount_hi) = split_u64(transfer_amount, 16);
 
         // generate public keys
         let source_pk = ElGamalKeypair::new_rand().public;


### PR DESCRIPTION
#### Problem
The transfer fees for confidential transfers are encrypted as one single ciphertext, which prevents it from being added on to the destination token account's pending balance.

#### Summary of Changes
Divide the transfer fee and encrypt it as two separate ciphertexts. Update the zk proofs accordingly.