### PR TITLE
Ignore errors when joining background threads in snapshot tests

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1113,10 +1113,10 @@ fn test_snapshots_with_background_services(
             .as_ref()
     );
 
-    // Stop the background services
+    // Stop the background services, ignore any errors
     info!("Shutting down background services...");
     exit.store(true, Ordering::Relaxed);
-    accounts_background_service.join().unwrap();
-    accounts_hash_verifier.join().unwrap();
-    snapshot_packager_service.join().unwrap();
+    _ = accounts_background_service.join();
+    _ = accounts_hash_verifier.join();
+    _ = snapshot_packager_service.join();
 }


### PR DESCRIPTION
#### Problem

The `test_snapshots_with_background_services` tests spuriously fail. This happens when the test is done and then joins the background services threads. If cleaning up rugs files that a background service was using, then it'll panic. For these tests, that's fine and does not impact the correctness of the tests (or non-test code).

#### Summary of Changes

Ignore errors when joining background threads