### PR TITLE
ci: remove stale clippy allows

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -69,18 +69,7 @@ fi
 
  _ ci/order-crates-for-publishing.py
 
-nightly_clippy_allows=(
-  # This lint occurs all over the code base
-  "--allow=clippy::significant_drop_in_scrutinee"
-
-  # The prost crate, used by solana-storage-proto, generates Rust source that
-  # triggers this lint. Need to resolve upstream in prost
-  "--allow=clippy::derive_partial_eq_without_eq"
-
-  # This link seems to incorrectly trigger in
-  # `programs/bpf_loader/src/syscalls/{lib,cpi}.rs`
-  "--allow=clippy::explicit_auto_deref"
-)
+nightly_clippy_allows=()
 
 # -Z... is needed because of clippy bug: https://github.com/rust-lang/rust-clippy/issues/4612
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -29,7 +29,7 @@ pub trait Executor: Debug + Send + Sync {
 
 /// Relation between a TransactionExecutorCacheEntry and its matching BankExecutorCacheEntry
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TxBankExecutorCacheDiff {
     /// The TransactionExecutorCacheEntry did not change and is the same as the BankExecutorCacheEntry.
     None,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -690,9 +690,9 @@ fn process_loader_upgradeable_instruction(
             let instruction_context = transaction_context.get_current_instruction_context()?;
             let caller_program_id =
                 instruction_context.get_last_program_key(transaction_context)?;
-            let signers = [&[new_program_id.as_ref(), &[bump_seed]]]
+            let signers = [[new_program_id.as_ref(), &[bump_seed]]]
                 .iter()
-                .map(|seeds| Pubkey::create_program_address(*seeds, caller_program_id))
+                .map(|seeds| Pubkey::create_program_address(seeds, caller_program_id))
                 .collect::<Result<Vec<Pubkey>, solana_sdk::pubkey::PubkeyError>>()?;
             invoke_context.native_invoke(instruction, signers.as_slice())?;
 


### PR DESCRIPTION
#### Problem

we're allowing a few clippy lints that are resolved/resolvable now.  one of which was introduced for the sake of a dependency and allowed warnings into the monorepo

#### Summary of Changes

* drop the allows
* fix recently introduced warning `derive_partial_eq_without_eq`
* fix outstanding warning `explicit_auto_deref`