### PR TITLE
Fix RpcClient MemCmp filter version mapping

### DIFF
--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -265,7 +265,10 @@ pub fn maybe_map_filters(
     filters: &mut [RpcFilterType],
 ) -> Result<(), String> {
     let version_reqs = VersionReq::from_strs(&["<1.11.2", "~1.13"])?;
-    if node_version.is_none() || version_reqs.matches_any(&node_version.unwrap()) {
+    let needs_mapping = node_version
+        .map(|version| version_reqs.matches_any(&version))
+        .unwrap_or(true);
+    if needs_mapping {
         for filter in filters.iter_mut() {
             if let RpcFilterType::Memcmp(memcmp) = filter {
                 match &memcmp.bytes {

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,5 +1,6 @@
 #![allow(deprecated)]
 use {
+    crate::version_req::VersionReq,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
     std::borrow::Cow,
@@ -263,7 +264,8 @@ pub fn maybe_map_filters(
     node_version: Option<semver::Version>,
     filters: &mut [RpcFilterType],
 ) -> Result<(), String> {
-    if node_version.is_none() || node_version.unwrap() < semver::Version::new(1, 11, 2) {
+    let version_reqs = VersionReq::from_strs(&["<1.11.2", "~1.13"])?;
+    if node_version.is_none() || version_reqs.matches_any(&node_version.unwrap()) {
         for filter in filters.iter_mut() {
             if let RpcFilterType::Memcmp(memcmp) = filter {
                 match &memcmp.bytes {

--- a/rpc-client-api/src/lib.rs
+++ b/rpc-client-api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error_object;
 pub mod filter;
 pub mod request;
 pub mod response;
+pub mod version_req;
 
 #[macro_use]
 extern crate serde_derive;

--- a/rpc-client-api/src/version_req.rs
+++ b/rpc-client-api/src/version_req.rs
@@ -1,0 +1,20 @@
+pub(crate) struct VersionReq(Vec<semver::VersionReq>);
+
+impl VersionReq {
+    pub(crate) fn from_strs<T>(versions: &[T]) -> Result<Self, String>
+    where
+        T: AsRef<str> + std::fmt::Debug,
+    {
+        let mut version_reqs = vec![];
+        for version in versions {
+            let version_req = semver::VersionReq::parse(version.as_ref())
+                .map_err(|err| format!("Could not parse version {:?}: {:?}", version, err))?;
+            version_reqs.push(version_req);
+        }
+        Ok(Self(version_reqs))
+    }
+
+    pub(crate) fn matches_any(&self, version: &semver::Version) -> bool {
+        self.0.iter().any(|r| r.matches(version))
+    }
+}


### PR DESCRIPTION
#### Problem
As per #28413, using the latest master version, the command `program show --programs` presents the following error when using `--url devnet`
```
Error: RPC response error -32602: Invalid params: unknown variant `base58`, expected `binary`. 
```

This is because there was a rpc-client version check for nodes below v1.11.2 which didn't get updated when v1.10 got tied to v1.13 and v1.11 got warped to v1.14.

#### Summary of Changes
Add VersionReq struct to provide tooling to handle cases when we need to match on multiple, non-contiguous versions.
Update mapping in MemCmp filters to check for versions before `v1.11.2` and any `v1.13` patch.

Replaces #28413 as fix, but I also want to consider that change for efficiency reasons
Fixes #28265 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
