### PR TITLE
v1.14: Fix RpcClient MemCmp filter version mapping

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -29,6 +29,7 @@ pub mod tpu_client;
 pub mod tpu_connection;
 pub mod transaction_executor;
 pub mod udp_client;
+pub mod version_req;
 
 pub mod mock_sender_for_cli {
     /// Magic `SIGNATURE` value used by `solana-cli` unit tests.

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -265,7 +265,10 @@ pub(crate) fn maybe_map_filters(
     filters: &mut [RpcFilterType],
 ) -> Result<(), String> {
     let version_reqs = VersionReq::from_strs(&["<1.11.2", "~1.13"])?;
-    if node_version.is_none() || version_reqs.matches_any(&node_version.unwrap()) {
+    let needs_mapping = node_version
+        .map(|version| version_reqs.matches_any(&version))
+        .unwrap_or(true);
+    if needs_mapping {
         for filter in filters.iter_mut() {
             if let RpcFilterType::Memcmp(memcmp) = filter {
                 match &memcmp.bytes {

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -1,5 +1,6 @@
 #![allow(deprecated)]
 use {
+    crate::version_req::VersionReq,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
     std::borrow::Cow,
@@ -263,7 +264,8 @@ pub(crate) fn maybe_map_filters(
     node_version: Option<semver::Version>,
     filters: &mut [RpcFilterType],
 ) -> Result<(), String> {
-    if node_version.is_none() || node_version.unwrap() < semver::Version::new(1, 11, 2) {
+    let version_reqs = VersionReq::from_strs(&["<1.11.2", "~1.13"])?;
+    if node_version.is_none() || version_reqs.matches_any(&node_version.unwrap()) {
         for filter in filters.iter_mut() {
             if let RpcFilterType::Memcmp(memcmp) = filter {
                 match &memcmp.bytes {

--- a/client/src/version_req.rs
+++ b/client/src/version_req.rs
@@ -1,0 +1,20 @@
+pub(crate) struct VersionReq(Vec<semver::VersionReq>);
+
+impl VersionReq {
+    pub(crate) fn from_strs<T>(versions: &[T]) -> Result<Self, String>
+    where
+        T: AsRef<str> + std::fmt::Debug,
+    {
+        let mut version_reqs = vec![];
+        for version in versions {
+            let version_req = semver::VersionReq::parse(version.as_ref())
+                .map_err(|err| format!("Could not parse version {:?}: {:?}", version, err))?;
+            version_reqs.push(version_req);
+        }
+        Ok(Self(version_reqs))
+    }
+
+    pub(crate) fn matches_any(&self, version: &semver::Version) -> bool {
+        self.0.iter().any(|r| r.matches(version))
+    }
+}


### PR DESCRIPTION
#28499 for v1.14 (lots of client re-org on master, so did manually to be careful with the rebase)
