### PR TITLE
chore: all gce performance tests use n2-standard-16

### DIFF
--- a/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
+++ b/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 100
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 2
       CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/partition-testcases/gce-5-node-3-partition.yml
+++ b/system-test/partition-testcases/gce-5-node-3-partition.yml
@@ -8,7 +8,7 @@ steps:
       TESTNET_TAG: "gce-perf-cpu-only"
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -8,7 +8,7 @@ steps:
       TESTNET_TAG: "gce-perf-cpu-only"
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -8,7 +8,7 @@ steps:
       TESTNET_TAG: "gce-perf-cpu-only"
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/partition-testcases/gce-partition-recovery.yml
+++ b/system-test/partition-testcases/gce-partition-recovery.yml
@@ -7,7 +7,7 @@ steps:
       CLOUD_PROVIDER: "gce"
       ENABLE_GPU: "false"
       NUMBER_OF_VALIDATOR_NODES: 9
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       ADDITIONAL_FLAGS: "--dedicated"
       SKIP_PERF_RESULTS: "true"

--- a/system-test/partition-testcases/gce-partition-with-offline.yml
+++ b/system-test/partition-testcases/gce-partition-with-offline.yml
@@ -8,7 +8,7 @@ steps:
       TESTNET_TAG: "gce-perf-cpu-only"
       NUMBER_OF_VALIDATOR_NODES: 4
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 25
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 25
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 50
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 50
       ENABLE_GPU: "true"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"

--- a/system-test/restart-testcases/restart_gce.yml
+++ b/system-test/restart-testcases/restart_gce.yml
@@ -6,7 +6,7 @@ steps:
       CLOUD_PROVIDER: "gce"
       ENABLE_GPU: "false"
       NUMBER_OF_VALIDATOR_NODES: 4
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       ADDITIONAL_FLAGS: "--dedicated"
       SKIP_PERF_RESULTS: "true"

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 3600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"

--- a/system-test/stability-testcases/gce-stability-5-node.yml
+++ b/system-test/stability-testcases/gce-stability-5-node.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 28800
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 0
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "false"

--- a/system-test/stake-operations-testcases/offline_stake_gce.yml
+++ b/system-test/stake-operations-testcases/offline_stake_gce.yml
@@ -8,7 +8,7 @@ steps:
       ENABLE_GPU: "false"
       TEST_DURATION_SECONDS: 30
       NUMBER_OF_VALIDATOR_NODES: 1
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n2-standard-16"
       NUMBER_OF_CLIENT_NODES: 0
       ADDITIONAL_FLAGS: "--dedicated"
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100


### PR DESCRIPTION
#### Problem

A earlier thread with Trent https://discord.com/channels/428295358100013066/1031929516383281154/1032472304472563752

The main idea is that we would like to more close user's experience

#### Summary of Changes

Use n2-standard-32 in all performance tests.

There is a test sample: https://discord.com/channels/428295358100013066/1031929516383281154/1032709168278282240
