### PR TITLE
Enforce stream receive timeout

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -30,6 +30,7 @@ use {
     },
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
     solana_streamer::{
+        nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
         quic::{spawn_server, StreamStats, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
         streamer::StakedNodes,
     },
@@ -169,6 +170,7 @@ impl Tpu {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats.clone(),
+            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
         )
         .unwrap();
 
@@ -183,6 +185,7 @@ impl Tpu {
             MAX_STAKED_CONNECTIONS.saturating_add(MAX_UNSTAKED_CONNECTIONS),
             0, // Prevent unstaked nodes from forwarding transactions
             stats,
+            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
         )
         .unwrap();
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -41,7 +41,7 @@ use {
 };
 
 const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: f64 = 100_000f64;
-const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 100;
+const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 1000;
 
 pub const ALPN_TPU_PROTOCOL_ID: &[u8] = b"solana-tpu";
 
@@ -560,6 +560,7 @@ async fn handle_connection(
                                     stats
                                         .total_stream_read_timeouts
                                         .fetch_add(1, Ordering::Relaxed);
+                                    break;
                                 }
                             }
                             stats.total_streams.fetch_sub(1, Ordering::Relaxed);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -400,6 +400,7 @@ fn compute_recieve_window(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn setup_connection(
     connecting: Connecting,
     unstaked_connection_table: Arc<Mutex<ConnectionTable>>,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -41,7 +41,7 @@ use {
 };
 
 const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: f64 = 100_000f64;
-const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 1000;
+const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 100;
 pub const DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS: u64 = 10000;
 
 pub const ALPN_TPU_PROTOCOL_ID: &[u8] = b"solana-tpu";
@@ -1137,7 +1137,7 @@ pub mod test {
                 total_packets += packets.len();
                 all_packets.push(packets)
             }
-            if total_packets > num_expected_packets {
+            if total_packets >= num_expected_packets {
                 break;
             }
         }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -540,11 +540,9 @@ async fn handle_connection(
         )
         .await
         {
-            info!("Got a stream {:?}", stream);
             match stream {
                 Some(stream_result) => match stream_result {
                     Ok(mut stream) => {
-                        info!("Indeed we have a stream {:?}", stream);
                         stats.total_streams.fetch_add(1, Ordering::Relaxed);
                         stats.total_new_streams.fetch_add(1, Ordering::Relaxed);
                         let stream_exit = stream_exit.clone();

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -42,6 +42,7 @@ use {
 
 const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: f64 = 100_000f64;
 const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 1000;
+const WAIT_FOR_CHUNK_TIMEOUT_MS: u64 = 10000;
 
 pub const ALPN_TPU_PROTOCOL_ID: &[u8] = b"solana-tpu";
 
@@ -538,7 +539,7 @@ async fn handle_connection(
                             let mut maybe_batch = None;
                             while !stream_exit.load(Ordering::Relaxed) {
                                 if let Ok(chunk) = tokio::time::timeout(
-                                    Duration::from_millis(WAIT_FOR_STREAM_TIMEOUT_MS),
+                                    Duration::from_millis(WAIT_FOR_CHUNK_TIMEOUT_MS),
                                     stream.read_chunk(PACKET_DATA_SIZE, false),
                                 )
                                 .await

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -147,7 +147,6 @@ pub struct StreamStats {
 
 impl StreamStats {
     pub fn report(&self) {
-        info!("Reporting stats");
         datapoint_info!(
             "quic-connections",
             (
@@ -370,7 +369,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats,
-            2,
+            100,
         )
         .unwrap();
         (t, exit, receiver, server_address)
@@ -426,7 +425,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats,
-            2,
+            100,
         )
         .unwrap();
 
@@ -469,7 +468,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             0, // Do not allow any connection from unstaked clients/nodes
             stats,
-            2,
+            100,
         )
         .unwrap();
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -147,6 +147,7 @@ pub struct StreamStats {
 
 impl StreamStats {
     pub fn report(&self) {
+        info!("Reporting stats");
         datapoint_info!(
             "quic-connections",
             (
@@ -307,6 +308,7 @@ pub fn spawn_server(
     max_staked_connections: usize,
     max_unstaked_connections: usize,
     stats: Arc<StreamStats>,
+    wait_for_chunk_timeout_ms: u64,
 ) -> Result<thread::JoinHandle<()>, QuicServerError> {
     let runtime = rt();
     let task = {
@@ -322,6 +324,7 @@ pub fn spawn_server(
             max_staked_connections,
             max_unstaked_connections,
             stats,
+            wait_for_chunk_timeout_ms,
         )
     }?;
     let handle = thread::Builder::new()
@@ -367,6 +370,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats,
+            2,
         )
         .unwrap();
         (t, exit, receiver, server_address)
@@ -422,6 +426,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats,
+            2,
         )
         .unwrap();
 
@@ -464,6 +469,7 @@ mod test {
             MAX_STAKED_CONNECTIONS,
             0, // Do not allow any connection from unstaked clients/nodes
             stats,
+            2,
         )
         .unwrap();
 

--- a/tpu-client/tests/quic_client.rs
+++ b/tpu-client/tests/quic_client.rs
@@ -78,7 +78,7 @@ mod tests {
             10,
             10,
             stats,
-            10,
+            100,
         )
         .unwrap();
 
@@ -124,7 +124,7 @@ mod tests {
             10,
             10,
             stats,
-            10,
+            100,
         )
         .unwrap();
 

--- a/tpu-client/tests/quic_client.rs
+++ b/tpu-client/tests/quic_client.rs
@@ -78,7 +78,7 @@ mod tests {
             10,
             10,
             stats,
-            100,
+            1000,
         )
         .unwrap();
 
@@ -124,7 +124,7 @@ mod tests {
             10,
             10,
             stats,
-            100,
+            1000,
         )
         .unwrap();
 

--- a/tpu-client/tests/quic_client.rs
+++ b/tpu-client/tests/quic_client.rs
@@ -78,6 +78,7 @@ mod tests {
             10,
             10,
             stats,
+            10,
         )
         .unwrap();
 
@@ -123,6 +124,7 @@ mod tests {
             10,
             10,
             stats,
+            10,
         )
         .unwrap();
 


### PR DESCRIPTION
#### Problem

In the quic server handle_connection, when we timed out in receiving the chunks, we loop forever to wait for the chunk. If the client never provide another chunk, the server can hopelessly wait for that chunk and wasting server resources. Instead WAIT_FOR_CHUNK_TIMEOUT_MS is introduced to bound this to 10 seconds at maximum. The stream will be dropped if it times out.



#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
