### PR TITLE
test: repair tests, `space` having been added to the account response

### DIFF
--- a/web3.js/test/connection-subscriptions.test.ts
+++ b/web3.js/test/connection-subscriptions.test.ts
@@ -97,6 +97,7 @@ describe('Subscriptions', () => {
               lamports: 0,
               owner: PublicKey.default.toBase58(),
               rentEpoch: 0,
+              space: 0,
             },
           },
         });
@@ -210,6 +211,7 @@ describe('Subscriptions', () => {
                 lamports: 0,
                 owner: PublicKey.default.toBase58(),
                 rentEpoch: 0,
+                space: 0,
               },
             },
           },

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -230,6 +230,7 @@ describe('Connection', function () {
         data: ['', 'base64'],
         executable: false,
         rentEpoch: 0,
+        space: 0,
       },
       {
         owner: '11111111111111111111111111111111',
@@ -237,6 +238,7 @@ describe('Connection', function () {
         data: ['', 'base64'],
         executable: false,
         rentEpoch: 0,
+        space: 0,
       },
     ];
 
@@ -262,6 +264,7 @@ describe('Connection', function () {
         data: Buffer.from([]),
         executable: false,
         rentEpoch: 0,
+        space: 0,
       },
       {
         owner: new PublicKey('11111111111111111111111111111111'),
@@ -269,6 +272,7 @@ describe('Connection', function () {
         data: Buffer.from([]),
         executable: false,
         rentEpoch: 0,
+        space: 0,
       },
     ];
 
@@ -3935,6 +3939,7 @@ describe('Connection', function () {
           lamports: LAMPORTS_PER_SOL - 5000,
           owner: SystemProgram.programId.toBase58(),
           rentEpoch: 0,
+          space: 0,
         },
       ]);
     });


### PR DESCRIPTION
#### Problem

#28421 added a `space` param to this response.

#### Summary of Changes

* Updated the web3.js tests to expect it.