### PR TITLE
Relax sanity checks in stake cli for new vote accounts

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2553,9 +2553,7 @@ pub fn process_delegate_stake(
         })?;
 
         let sanity_check_result = match vote_state.root_slot {
-            None => Err(CliError::BadParameter(
-                "Unable to delegate. Vote account has no root slot".to_string(),
-            )),
+            None => Ok(()), // New vote account no need to sanity check
             Some(root_slot) => {
                 let min_root_slot = rpc_client
                     .get_slot()?


### PR DESCRIPTION
#### Problem
Namely do not check if root is within delinquent validator slot distance
of the cluster root if the vote account has no root. With the recent
vote optimizations we drop votes from accounts with no stake, so it is
impossible for a new account to satisfy this check.


#### Summary of Changes
If a validator does not have root slot do not perform the sanity check

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
