### PR TITLE
Loop over confirm_slot until no more entries or slot completed

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1728,12 +1728,12 @@ impl ReplayStage {
         // the `check_slot_agrees_with_cluster()` called by `replay_active_banks()`
         // will break!
 
-        let mut did_process_entries = true;
+        let mut more_entries_to_process = true;
         // more entries may have been received while replaying this slot.
         // looping over this ensures that slots will be processed as fast as possible with the
         // lowest latency.
-        while did_process_entries {
-            did_process_entries = blockstore_processor::confirm_slot(
+        while more_entries_to_process {
+            more_entries_to_process = blockstore_processor::confirm_slot(
                 blockstore,
                 bank,
                 &mut w_replay_stats,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -991,7 +991,7 @@ fn confirm_full_slot(
     let skip_verification = !opts.poh_verify;
     let _ignored_prioritization_fee_cache = PrioritizationFeeCache::new(0u64);
 
-    let _did_process_entries = confirm_slot(
+    let _more_entries_to_process = confirm_slot(
         blockstore,
         bank,
         &mut confirmation_timing,


### PR DESCRIPTION
#### Problem
- while confirm_slot is running, more shreds may have been received and inserted into blockstore.
- we should process those immediately

#### Summary of Changes
- loop over confirm_slot until end of slot or no more shreds

#### Risks
- what if leader slowly feeds shreds to validators and keeps them stuck in confirm_slot? it doesn't seem like there's any concept of time in here, so perhaps we consider adding a timeout for how long we're willing to run this method for?