### PR TITLE
remote-node script use --force when delegating stake

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -463,6 +463,7 @@ EOF
         echo "0 Primordial stakes, staking with $internalNodesStakeLamports"
         multinode-demo/delegate-stake.sh --vote-account "$SOLANA_CONFIG_DIR"/vote-account.json \
                                          --stake-account "$SOLANA_CONFIG_DIR"/stake-account.json \
+                                         --force \
                                          "${args[@]}" "$internalNodesStakeLamports"
       else
         echo "Skipping staking with extra stakes: ${extraPrimordialStakes}"


### PR DESCRIPTION
#### Problem
remote-node script waits until we catch up to bootstrap validator before delegating stake. Because we drop votes from unstaked validators no votes will land. The sanity check does not allow staking to validators that haven't voted.

#### Summary of Changes
Use the already existing --force flag to bypass the check.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
