### PR TITLE
Refactor CPI, add tests and sprinkle some comments

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -285,7 +285,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             invoke_context,
         )?;
 
-        translate_accounts(
+        translate_and_update_accounts(
             instruction_accounts,
             program_indices,
             &account_info_keys,
@@ -519,7 +519,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
             invoke_context,
         )?;
 
-        translate_accounts(
+        translate_and_update_accounts(
             instruction_accounts,
             program_indices,
             &account_info_keys,
@@ -619,7 +619,9 @@ where
     Ok((account_infos, account_info_keys))
 }
 
-fn translate_accounts<'a, T, F>(
+// Finish translating accounts, build CallerAccount values and update callee
+// accounts in preparation of executing the callee.
+fn translate_and_update_accounts<'a, T, F>(
     instruction_accounts: &[InstructionAccount],
     program_indices: &[IndexOfAccount],
     account_info_keys: &[&Pubkey],

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1618,7 +1618,7 @@ mod tests {
             CallerAccount {
                 lamports: &mut self.lamports,
                 owner: &mut self.owner,
-                original_data_len: data.len() as usize,
+                original_data_len: data.len(),
                 data,
                 vm_data_addr: self.vm_addr + mem::size_of::<u64>() as u64,
                 ref_to_len_in_vm: &mut self.len,

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1226,17 +1226,7 @@ mod tests {
 
         let key = Pubkey::new_unique();
         let vm_addr = MM_INPUT_START;
-        let (_mem, region) = MockAccountInfo {
-            key,
-            is_signer: false,
-            is_writable: false,
-            lamports: account.lamports(),
-            data: account.data(),
-            owner: *account.owner(),
-            executable: account.executable(),
-            rent_epoch: account.rent_epoch(),
-        }
-        .into_region(vm_addr);
+        let (_mem, region) = MockAccountInfo::new(key, &account).into_region(vm_addr);
 
         let config = Config {
             aligned_memory_mapping: false,
@@ -1520,17 +1510,7 @@ mod tests {
             .unwrap();
 
         let vm_addr = MM_INPUT_START;
-        let (_mem, region) = MockAccountInfo {
-            key,
-            is_signer: false,
-            is_writable: false,
-            lamports: account.lamports(),
-            data: account.data(),
-            owner: *account.owner(),
-            executable: account.executable(),
-            rent_epoch: account.rent_epoch(),
-        }
-        .into_region(vm_addr);
+        let (_mem, region) = MockAccountInfo::new(key, &account).into_region(vm_addr);
 
         let config = Config {
             aligned_memory_mapping: false,
@@ -1741,9 +1721,9 @@ mod tests {
     }
 
     struct MockAccountInfo<'a> {
-        pub key: Pubkey,
-        pub is_signer: bool,
-        pub is_writable: bool,
+        key: Pubkey,
+        is_signer: bool,
+        is_writable: bool,
         lamports: u64,
         data: &'a [u8],
         owner: Pubkey,
@@ -1752,6 +1732,19 @@ mod tests {
     }
 
     impl<'a> MockAccountInfo<'a> {
+        fn new(key: Pubkey, account: &AccountSharedData) -> MockAccountInfo {
+            MockAccountInfo {
+                key,
+                is_signer: false,
+                is_writable: false,
+                lamports: account.lamports(),
+                data: account.data(),
+                owner: *account.owner(),
+                executable: account.executable(),
+                rent_epoch: account.rent_epoch(),
+            }
+        }
+
         fn into_region(self, vm_addr: u64) -> (Vec<u8>, MemoryRegion) {
             let size = mem::size_of::<AccountInfo>()
                 + mem::size_of::<Pubkey>() * 2

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -969,6 +969,14 @@ fn cpi_common<S: SyscallInvokeSigned>(
     Ok(())
 }
 
+// Update the given account after executing CPI.
+//
+// caller_account and callee_account describe to the same account. At CPI exit
+// callee_account might include changes the callee has made to the account
+// after executing.
+//
+// This method updates caller_account so the CPI caller can see the callee's
+// changes.
 fn update_caller_account(
     invoke_context: &InvokeContext,
     memory_mapping: &MemoryMapping,

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1088,7 +1088,12 @@ mod tests {
             rent::Rent,
             transaction_context::{TransactionAccount, TransactionContext},
         },
-        std::{cell::Cell, mem, ptr, slice},
+        std::{
+            cell::{Cell, RefCell},
+            mem, ptr,
+            rc::Rc,
+            slice,
+        },
     };
 
     macro_rules! mock_invoke_context {

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1105,12 +1105,12 @@ mod tests {
         let key = Pubkey::new_unique();
         let vm_addr = MM_INPUT_START;
         let (_mem, region) = MockAccountInfo {
-            key: key.clone(),
+            key,
             is_signer: false,
             is_writable: false,
             lamports: account.lamports(),
             data: account.data(),
-            owner: account.owner().clone(),
+            owner: *account.owner(),
             executable: account.executable(),
             rent_epoch: account.rent_epoch(),
         }
@@ -1171,7 +1171,7 @@ mod tests {
         let mut caller_account = mock_caller_account.caller_account();
 
         let mut callee_account = instruction_context
-            .try_borrow_instruction_account(&invoke_context.transaction_context, 0)
+            .try_borrow_instruction_account(invoke_context.transaction_context, 0)
             .unwrap();
 
         callee_account.set_lamports(42).unwrap();
@@ -1230,7 +1230,7 @@ mod tests {
         let mut caller_account = mock_caller_account.caller_account();
 
         let mut callee_account = instruction_context
-            .try_borrow_instruction_account(&invoke_context.transaction_context, 0)
+            .try_borrow_instruction_account(invoke_context.transaction_context, 0)
             .unwrap();
 
         for (new_value, expected_realloc_size) in [
@@ -1305,11 +1305,11 @@ mod tests {
         let mut mock_caller_account =
             MockCallerAccount::new(1234, *account.owner(), 0xFFFFFFFF00000000, account.data());
 
-        let mut caller_account = mock_caller_account.caller_account();
+        let caller_account = mock_caller_account.caller_account();
 
         let get_callee = || {
             instruction_context
-                .try_borrow_instruction_account(&invoke_context.transaction_context, 0)
+                .try_borrow_instruction_account(invoke_context.transaction_context, 0)
                 .unwrap()
         };
         let callee_account = get_callee();
@@ -1317,7 +1317,7 @@ mod tests {
         *caller_account.lamports = 42;
         *caller_account.owner = Pubkey::new_unique();
 
-        update_callee_account(&invoke_context, &mut caller_account, callee_account).unwrap();
+        update_callee_account(&invoke_context, &caller_account, callee_account).unwrap();
 
         let callee_account = get_callee();
         assert_eq!(callee_account.get_lamports(), 42);
@@ -1345,7 +1345,7 @@ mod tests {
 
         let get_callee = || {
             instruction_context
-                .try_borrow_instruction_account(&invoke_context.transaction_context, 0)
+                .try_borrow_instruction_account(invoke_context.transaction_context, 0)
                 .unwrap()
         };
         let callee_account = get_callee();
@@ -1353,7 +1353,7 @@ mod tests {
         let mut data = b"foo".to_vec();
         caller_account.data = &mut data;
 
-        update_callee_account(&invoke_context, &mut caller_account, callee_account).unwrap();
+        update_callee_account(&invoke_context, &caller_account, callee_account).unwrap();
 
         let callee_account = get_callee();
         assert_eq!(callee_account.get_data(), caller_account.data);
@@ -1363,7 +1363,7 @@ mod tests {
     fn test_translate_accounts_rust() {
         let transaction_accounts = one_instruction_account(b"foobar".to_vec());
         let account = transaction_accounts[1].1.clone();
-        let key = transaction_accounts[1].0.clone();
+        let key = transaction_accounts[1].0;
         let original_data_len = account.data().len();
 
         let mut invoke_context_builder =
@@ -1383,12 +1383,12 @@ mod tests {
 
         let vm_addr = MM_INPUT_START;
         let (_mem, region) = MockAccountInfo {
-            key: key.clone(),
+            key,
             is_signer: false,
             is_writable: false,
             lamports: account.lamports(),
             data: account.data(),
-            owner: account.owner().clone(),
+            owner: *account.owner(),
             executable: account.executable(),
             rent_epoch: account.rent_epoch(),
         }
@@ -1580,7 +1580,7 @@ mod tests {
                 }),
                 false,
             ),
-            (Pubkey::new_unique(), account.clone(), true),
+            (Pubkey::new_unique(), account, true),
         ]
     }
 


### PR DESCRIPTION
I've refactored CPI a bit:

- added `CallerAccount::from_account_info` and `CallerAccount::from_sol_account_info` to create caller accounts from `AccountInfo` (rust) and `SolAccountInfo` (C) respectively
- added `update_callee_account` and `update_caller_account` to sync caller <-> callee accounts at entry and exit of CPI respectively
- I've done some smaller refactorings
- added tests and some comments

I've done this so that I can more confidently land the account direct mapping branch by having tests that check that changes to accounts, data and realloc space are identical. 

The diff is large but I've split the changes in logical commits, which should be pretty easy to review one by one. I've taken care to refactor the code without changing any error paths.