### PR TITLE
Time out async sends to avoid slackers stuck in the queue for too long

### DIFF
--- a/tpu-client/src/connection_cache_stats.rs
+++ b/tpu-client/src/connection_cache_stats.rs
@@ -56,6 +56,10 @@ impl ConnectionCacheStats {
             client_stats.make_connection_ms.load(Ordering::Relaxed),
             Ordering::Relaxed,
         );
+        self.total_client_stats.send_timeout.fetch_add(
+            client_stats.send_timeout.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
         self.sent_packets
             .fetch_add(num_packets as u64, Ordering::Relaxed);
         self.total_batches.fetch_add(1, Ordering::Relaxed);

--- a/tpu-client/src/connection_cache_stats.rs
+++ b/tpu-client/src/connection_cache_stats.rs
@@ -188,6 +188,13 @@ impl ConnectionCacheStats {
                 self.batch_failure.swap(0, Ordering::Relaxed),
                 i64
             ),
+            (
+                "send_timeout",
+                self.total_client_stats
+                    .send_timeout
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
     }
 }

--- a/tpu-client/src/nonblocking/quic_client.rs
+++ b/tpu-client/src/nonblocking/quic_client.rs
@@ -524,6 +524,10 @@ impl QuicTpuConnection {
         self.client.stats()
     }
 
+    pub fn connection_stats(&self) -> Arc<ConnectionCacheStats> {
+        self.connection_stats.clone()
+    }
+
     pub fn new(
         endpoint: Arc<QuicLazyInitializedEndpoint>,
         addr: SocketAddr,

--- a/tpu-client/src/quic_client.rs
+++ b/tpu-client/src/quic_client.rs
@@ -117,14 +117,10 @@ async fn send_wire_transaction_async(
     .await;
     ASYNC_TASK_SEMAPHORE.release();
     match result {
-        Ok(result) => {
-            return result;
-        }
-        Err(_err) => {
-            return Err(TransportError::Custom(
-                "Timedout sending transaction".to_string(),
-            ));
-        }
+        Ok(result) => result,
+        Err(_err) => Err(TransportError::Custom(
+            "Timedout sending transaction".to_string(),
+        )),
     }
 }
 
@@ -141,14 +137,10 @@ async fn send_wire_transaction_batch_async(
     .await;
     ASYNC_TASK_SEMAPHORE.release();
     match result {
-        Ok(result) => {
-            return result;
-        }
-        Err(_err) => {
-            return Err(TransportError::Custom(
-                "Timedout sending transaction".to_string(),
-            ));
-        }
+        Ok(result) => result,
+        Err(_err) => Err(TransportError::Custom(
+            "Timedout sending transaction".to_string(),
+        )),
     }
 }
 

--- a/tpu-client/src/tpu_connection.rs
+++ b/tpu-client/src/tpu_connection.rs
@@ -21,6 +21,7 @@ pub struct ClientStats {
     pub tx_data_blocked: MovingStat,
     pub tx_acks: MovingStat,
     pub make_connection_ms: AtomicU64,
+    pub send_timeout: AtomicU64,
 }
 
 #[enum_dispatch]


### PR DESCRIPTION
#### Problem
Time out async sends to avoid slackers stuck in the queue for too long impacting future sends.

#### Summary of Changes

Use Tokio::timeout to timeout the async sends.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
