### PR TITLE
[docs] corrected use of confirmTransaction in examples

### DIFF
--- a/docs/src/developing/clients/javascript-api.md
+++ b/docs/src/developing/clients/javascript-api.md
@@ -184,7 +184,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 ```
 
 First, we set up the account Keypair and connection so that we have an account to make allocate on the testnet. We also create a payer Keypair and airdrop some sol so we can pay for the allocate transaction.
@@ -309,7 +309,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 let allocateTransaction = new web3.Transaction({
   feePayer: payer.publicKey,

--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -76,7 +76,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 let toAccount = web3.Keypair.generate();
 
@@ -253,7 +253,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 // Allocate Account Data
 let allocatedAccount = web3.Keypair.generate();
@@ -365,7 +365,8 @@ let airdropSignature = await connection.requestAirdrop(
   fromPublicKey.publicKey,
   web3.LAMPORTS_PER_SOL,
 );
-await connection.confirmTransaction(airdropSignature);
+
+await connection.confirmTransaction({ signature: airdropSignature });
 
 // Sign Message with Ethereum Key
 let plaintext = Buffer.from("string address");
@@ -412,7 +413,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 let type = web3.SYSTEM_INSTRUCTION_LAYOUTS.Transfer;
 let data = Buffer.alloc(type.layout.span);
@@ -532,7 +533,7 @@ let airdropSignature = await connection.requestAirdrop(
   web3.LAMPORTS_PER_SOL,
 );
 
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 // Get Minimum amount for rent exemption
 let minimumAmount = await connection.getMinimumBalanceForRentExemption(
@@ -681,7 +682,7 @@ let airdropSignature = await connection.requestAirdrop(
   fromPublicKey.publicKey,
   web3.LAMPORTS_PER_SOL,
 );
-await connection.confirmTransaction(airdropSignature);
+await connection.confirmTransaction({ signature: airdropSignature });
 
 // Create Account
 let stakeAccount = web3.Keypair.generate();

--- a/docs/src/integrations/retrying-transactions.md
+++ b/docs/src/integrations/retrying-transactions.md
@@ -255,7 +255,7 @@ const sleep = async (ms: number) => {
     LAMPORTS_PER_SOL,
   );
 
-  await connection.confirmTransaction(airdropSignature);
+  await connection.confirmTransaction({ signature: airdropSignature });
 
   const blockhashResponse = await connection.getLatestBlockhashAndContext();
   const lastValidBlockHeight = blockhashResponse.context.slot + 150;


### PR DESCRIPTION
#### Problem

The core docs use the deprecated calls for `connection.confirmTransaction`

#### Summary of Changes

Update the example code snippets to use the non-deprecated method call for `connection.confirmTransaction` using the `BlockheightBasedTransactionConfirmationStrategy`

Here is the `@solana/web3.js` docs for [`confirmTransaction`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#confirmTransaction) for reference.
