### PR TITLE
Add confirmation status to ConfirmedSignatureInfo web3 response

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2617,6 +2617,8 @@ export type ConfirmedSignatureInfo = {
   memo: string | null;
   /** The unix timestamp of when the transaction was processed */
   blockTime?: number | null;
+  /** cluster confirmation status, if data available. Possible responses: `processed`, `confirmed`, `finalized` */
+  confirmationStatus?: TransactionConfirmationStatus;
 };
 
 /**


### PR DESCRIPTION
#### Problem

Web3.js `ConfirmedSignatureInfo` type does not include `confirmationStatus`. This was corrected for documentation in [PR#27264](https://github.com/solana-labs/solana/pull/27964) but not added to the Connection class in web3.js.

#### Summary of Changes
Updated `/solana/web3.js/src/connection.ts` by adding `confirmationStatus` as an optional value included in `ConfirmedSignatureInfo` type:
```typescript
  /** cluster confirmation status, if data available. Possible responses: `processed`, `confirmed`, `finalized` */
  confirmationStatus?: TransactionConfirmationStatus;
```

Fixes #27569 
