### PR TITLE
Use fewer ports in connection cache

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -813,6 +813,7 @@ waitForNodeInit=true
 extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
+clientType=thin-client
 
 command=$1
 [[ -n $command ]] || usage
@@ -948,6 +949,17 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-require-tower ]]; then
       maybeSkipRequireTower="$1"
       shift 1
+    elif [[ $1 = --client-type ]]; then
+      clientType=$2
+      case "$clientType" in
+        thin-client|tpu-client|rpc-client)
+          ;;
+        *)
+          echo "Unexpected client type: \"$clientType\""
+          exit 1
+          ;;
+      esac
+      shift 2
     else
       usage "Unknown long option: $1"
     fi

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -317,10 +317,10 @@ EOF
       args+=(--tpu-enable-udp)
     fi
     
-    if ${TPU_CLIENT} then
-        args+=(--tpu_client)
-    elif ${RPC_CLIENT} then
-        args+=(--rpc_client)
+    if ${TPU_CLIENT}; then
+        args+=(--use-tpu-client)
+    elif ${RPC_CLIENT}; then
+        args+=(--use-rpc-client)
     fi
 
     if [[ $airdropsEnabled = true ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -30,6 +30,7 @@ extraPrimordialStakes="${21:=0}"
 tmpfsAccounts="${22:false}"
 disableQuic="${23}"
 enableUdp="${24}"
+clientType="${25:-thin-client}"
 
 set +x
 
@@ -92,6 +93,27 @@ case "$gpuMode" in
     ;;
   *)
     echo "Unexpected gpuMode: \"$gpuMode\""
+    exit 1
+    ;;
+esac
+
+TPU_CLIENT=false
+RPC_CLIENT=false
+case "$clientType" in
+  thin-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=false
+    ;;
+  tpu-client)
+    TPU_CLIENT=true
+    RPC_CLIENT=false
+    ;;
+  rpc-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=true
+    ;;
+  *)
+    echo "Unexpected clientType: \"$clientType\""
     exit 1
     ;;
 esac
@@ -293,6 +315,12 @@ EOF
 
     if $enableUdp; then
       args+=(--tpu-enable-udp)
+    fi
+    
+    if ${TPU_CLIENT} then
+        args+=(--tpu-client)
+    elif ${RPC_CLIENT} then
+        args+=(--rpc-client)
     fi
 
     if [[ $airdropsEnabled = true ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -316,7 +316,7 @@ EOF
     if $enableUdp; then
       args+=(--tpu-enable-udp)
     fi
-    
+
     if ${TPU_CLIENT}; then
         args+=(--use-tpu-client)
     elif ${RPC_CLIENT}; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -318,9 +318,9 @@ EOF
     fi
     
     if ${TPU_CLIENT} then
-        args+=(--tpu-client)
+        args+=(--tpu_client)
     elif ${RPC_CLIENT} then
-        args+=(--rpc-client)
+        args+=(--rpc_client)
     fi
 
     if [[ $airdropsEnabled = true ]]; then


### PR DESCRIPTION
#### Problem
See #28460 some users are seeing a large number of ports being bound (up to half the VALIDATOR_PORT_RANGE space), which may not be preferred.

#### Summary of Changes
Use a single endpoint for all the connections.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
