### PR TITLE
Don't try to deserialize WebSocket ping messages

### DIFF
--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -244,15 +244,18 @@ where
 
     fn read_message(
         writable_socket: &Arc<RwLock<WebSocket<MaybeTlsStream<TcpStream>>>>,
-    ) -> Result<T, PubsubClientError> {
+    ) -> Result<Option<T>, PubsubClientError> {
         let message = writable_socket.write().unwrap().read_message()?;
+        if let Message::Ping(_) = message {
+            return Ok(None)
+        }
         let message_text = &message.into_text().unwrap();
         let json_msg: Map<String, Value> = serde_json::from_str(message_text)?;
 
         if let Some(Object(params)) = json_msg.get("params") {
             if let Some(result) = params.get("result") {
                 let x: T = serde_json::from_value::<T>(result.clone()).unwrap();
-                return Ok(x);
+                return Ok(Some(x));
             }
         }
 
@@ -842,7 +845,10 @@ impl PubsubClient {
             }
 
             match PubsubClientSubscription::read_message(socket) {
-                Ok(message) => handler(message),
+                Ok(Some(message)) => handler(message),
+                Ok(None) => {
+                    // Nothing useful, means we received a ping request
+                },
                 Err(err) => {
                     info!("receive error: {:?}", err);
                     break;

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -247,7 +247,7 @@ where
     ) -> Result<Option<T>, PubsubClientError> {
         let message = writable_socket.write().unwrap().read_message()?;
         if message.is_ping() {
-            return Ok(None)
+            return Ok(None);
         }
         let message_text = &message.into_text().unwrap();
         let json_msg: Map<String, Value> = serde_json::from_str(message_text)?;
@@ -848,7 +848,7 @@ impl PubsubClient {
                 Ok(Some(message)) => handler(message),
                 Ok(None) => {
                     // Nothing useful, means we received a ping message
-                },
+                }
                 Err(err) => {
                     info!("receive error: {:?}", err);
                     break;

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -847,7 +847,7 @@ impl PubsubClient {
             match PubsubClientSubscription::read_message(socket) {
                 Ok(Some(message)) => handler(message),
                 Ok(None) => {
-                    // Nothing useful, means we received a ping request
+                    // Nothing useful, means we received a ping message
                 },
                 Err(err) => {
                     info!("receive error: {:?}", err);

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -246,7 +246,7 @@ where
         writable_socket: &Arc<RwLock<WebSocket<MaybeTlsStream<TcpStream>>>>,
     ) -> Result<Option<T>, PubsubClientError> {
         let message = writable_socket.write().unwrap().read_message()?;
-        if let Message::Ping(_) = message {
+        if message.is_ping() {
             return Ok(None)
         }
         let message_text = &message.into_text().unwrap();


### PR DESCRIPTION
#### Problem

Some RPC nodes are sending WebSocket messages with the `PING` opcode which makes client fail on JSON deserialization attempt and stop iteration over incoming messages. Example of such node – `wss://solana-api.projectserum.com`, it's mentioned in the official docs here: https://docs.solana.com/ru/cluster/rpc-endpoints#mainnet-beta

#### Summary of Changes

Ignore WebSocket message with the `PING` opcode. Don't worry about server – Tungstenite will handle such messages for us and respond with corresponding `PONG` reply.

Fixes #26343