### PR TITLE
Rename fn to calculate_accounts_hash_from_storages()

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -159,6 +159,6 @@ fn main() {
         info!("update_accounts_hash(us),{}", x);
     }
     for x in elapsed_store {
-        info!("calculate_accounts_hash_without_index(us),{}", x);
+        info!("calculate_accounts_hash_from_storages(us),{}", x);
     }
 }

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -223,7 +223,7 @@ impl AccountsHashVerifier {
         let (accounts_hash, lamports) = accounts_package
             .accounts
             .accounts_db
-            .calculate_accounts_hash_without_index(
+            .calculate_accounts_hash_from_storages(
                 &CalcAccountsHashConfig {
                     use_bg_thread_pool: true,
                     check_hash: false,
@@ -263,7 +263,7 @@ impl AccountsHashVerifier {
             let _ = accounts_package
                 .accounts
                 .accounts_db
-                .calculate_accounts_hash_without_index(
+                .calculate_accounts_hash_from_storages(
                     &CalcAccountsHashConfig {
                         use_bg_thread_pool: false,
                         check_hash: false,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2679,7 +2679,7 @@ impl AccountsDb {
             std::cmp::max(*accounts_hash_complete_one_epoch_old, one_epoch_old_slot);
         let accounts_hash_complete_one_epoch_old = *accounts_hash_complete_one_epoch_old;
 
-        // now that calculate_accounts_hash_without_index is complete, we can remove old historical roots
+        // now that accounts hash calculation is complete, we can remove old historical roots
         self.remove_old_historical_roots(accounts_hash_complete_one_epoch_old);
     }
 
@@ -7242,7 +7242,7 @@ impl AccountsDb {
             };
             timings.calc_storage_size_quartiles(&combined_maps);
 
-            self.calculate_accounts_hash_without_index(config, &storages, timings)
+            self.calculate_accounts_hash_from_storages(config, &storages, timings)
         } else {
             self.calculate_accounts_hash(slot, config)
         }
@@ -7425,7 +7425,7 @@ impl AccountsDb {
 
     // modeled after get_accounts_delta_hash
     // intended to be faster than calculate_accounts_hash
-    pub fn calculate_accounts_hash_without_index(
+    pub fn calculate_accounts_hash_from_storages(
         &self,
         config: &CalcAccountsHashConfig<'_>,
         storages: &SortedStorages<'_>,
@@ -7495,7 +7495,7 @@ impl AccountsDb {
             }
 
             info!(
-                "calculate_accounts_hash_without_index: slot: {} {:?}",
+                "calculate_accounts_hash_from_storages: slot: {} {:?}",
                 storages.max_slot_inclusive(),
                 final_result
             );
@@ -10149,13 +10149,13 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accountsdb_calculate_accounts_hash_without_index_simple() {
+    fn test_accountsdb_calculate_accounts_hash_from_storages_simple() {
         solana_logger::setup();
 
         let (storages, _size, _slot_expected) = sample_storage();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let result = db
-            .calculate_accounts_hash_without_index(
+            .calculate_accounts_hash_from_storages(
                 &CalcAccountsHashConfig::default(),
                 &get_storage_refs(&storages),
                 HashStats::default(),
@@ -10166,7 +10166,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accountsdb_calculate_accounts_hash_without_index() {
+    fn test_accountsdb_calculate_accounts_hash_from_storages() {
         solana_logger::setup();
 
         let (storages, raw_expected) = sample_storages_and_accounts();
@@ -10177,7 +10177,7 @@ pub mod tests {
         let sum = raw_expected.iter().map(|item| item.lamports).sum();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let result = db
-            .calculate_accounts_hash_without_index(
+            .calculate_accounts_hash_from_storages(
                 &CalcAccountsHashConfig::default(),
                 &get_storage_refs(&storages),
                 HashStats::default(),

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -145,7 +145,7 @@ impl HashStats {
             + self.collect_snapshots_us
             + self.storage_sort_us;
         datapoint_info!(
-            "calculate_accounts_hash_without_index",
+            "calculate_accounts_hash_from_storages",
             ("mark_time_us", self.mark_time_us, i64),
             ("accounts_scan_us", self.scan_time_total_us, i64),
             ("eliminate_zeros_us", self.zeros_time_total_us, i64),


### PR DESCRIPTION
#### Problem

There are many permutations of the accounts hash calculation functions, and I find that I often need to go back to the fn definitions to remember which one is which.

* `calculate_accounts_hash()`
* `calculate_accounts_hash_without_index()`
* `calculate_accounts_hash_helper()`
* `calculate_accounts_hash_helper_with_verify()`
* `update_accounts_hash()`
* `update_accounts_hash_with_index_option()`

#### Summary of Changes

Rename `calculate_accounts_hash_without_index` to `calculate_accounts_hash_from_storages`

(Subsequent PR will rename the other fns; I want each PR to be small.)