### PR TITLE
Rename fn to calculate_accounts_hash_from_index()

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -244,7 +244,7 @@ impl AccountsHashVerifier {
             let result_with_index = accounts_package
                 .accounts
                 .accounts_db
-                .calculate_accounts_hash(
+                .calculate_accounts_hash_from_index(
                     accounts_package.slot,
                     &CalcAccountsHashConfig {
                         use_bg_thread_pool: false,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -310,7 +310,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                 .rc
                 .accounts
                 .accounts_db
-                .calculate_accounts_hash(
+                .calculate_accounts_hash_from_index(
                     bank.slot(),
                     &CalcAccountsHashConfig {
                         use_bg_thread_pool: false,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6748,7 +6748,7 @@ impl AccountsDb {
         AccountsHash::checked_cast_for_capitalization(balances.map(|b| b as u128).sum::<u128>())
     }
 
-    pub fn calculate_accounts_hash(
+    pub fn calculate_accounts_hash_from_index(
         &self,
         max_slot: Slot,
         config: &CalcAccountsHashConfig<'_>,
@@ -6859,7 +6859,7 @@ impl AccountsDb {
         let (accumulated_hash, hash_total) = AccountsHash::calculate_hash(hashes);
         hash_time.stop();
         datapoint_info!(
-            "update_accounts_hash",
+            "calculate_accounts_hash_from_index",
             ("accounts_scan", scan.as_us(), i64),
             ("hash", hash_time.as_us(), i64),
             ("hash_total", hash_total, i64),
@@ -7244,7 +7244,7 @@ impl AccountsDb {
 
             self.calculate_accounts_hash_without_index(config, &storages, timings)
         } else {
-            self.calculate_accounts_hash(slot, config)
+            self.calculate_accounts_hash_from_index(slot, config)
         }
     }
 


### PR DESCRIPTION
#### Problem

There are many permutations of the accounts hash calculation functions, and I find that I often need to go back to the fn definitions to remember which one is which.

* `calculate_accounts_hash()`
* `calculate_accounts_hash_without_index()`
* `calculate_accounts_hash_helper()`
* `calculate_accounts_hash_helper_with_verify()`
* `update_accounts_hash()`
* `update_accounts_hash_with_index_option()`

#### Summary of Changes

Rename `calculate_accounts_hash` to `calculate_accounts_hash_from_index`

(Subsequent PR will rename the other fns; I want each PR to be small.)