### PR TITLE
Rename fn to update_accounts_hash()

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -125,7 +125,7 @@ fn main() {
                 .update_accounts_hash_for_tests(0, &ancestors, false, false);
             time.stop();
             let mut time_store = Measure::start("hash using store");
-            let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
+            let results_store = accounts.accounts_db.update_accounts_hash(
                 false,
                 false,
                 solana_sdk::clock::Slot::default(),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -795,7 +795,7 @@ impl Accounts {
             .verify_accounts_hash_in_bg
             .wait_for_complete();
         self.accounts_db
-            .update_accounts_hash_with_index_option(
+            .update_accounts_hash(
                 use_index,
                 debug_verify,
                 slot,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6927,7 +6927,7 @@ impl AccountsDb {
         debug_verify: bool,
         is_startup: bool,
     ) -> (Hash, u64) {
-        self.update_accounts_hash_with_index_option(
+        self.update_accounts_hash(
             true,
             debug_verify,
             slot,
@@ -7292,7 +7292,7 @@ impl AccountsDb {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn update_accounts_hash_with_index_option(
+    pub fn update_accounts_hash(
         &self,
         use_index: bool,
         debug_verify: bool,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6970,20 +6970,16 @@ impl Bank {
         mut debug_verify: bool,
         is_startup: bool,
     ) -> Hash {
-        let (hash, total_lamports) = self
-            .rc
-            .accounts
-            .accounts_db
-            .update_accounts_hash_with_index_option(
-                use_index,
-                debug_verify,
-                self.slot(),
-                &self.ancestors,
-                Some(self.capitalization()),
-                self.epoch_schedule(),
-                &self.rent_collector,
-                is_startup,
-            );
+        let (hash, total_lamports) = self.rc.accounts.accounts_db.update_accounts_hash(
+            use_index,
+            debug_verify,
+            self.slot(),
+            &self.ancestors,
+            Some(self.capitalization()),
+            self.epoch_schedule(),
+            &self.rent_collector,
+            is_startup,
+        );
         if total_lamports != self.capitalization() {
             datapoint_info!(
                 "capitalization_mismatch",
@@ -6996,19 +6992,16 @@ impl Bank {
                 // cap mismatch detected. It has been logged to metrics above.
                 // Run both versions of the calculation to attempt to get more info.
                 debug_verify = true;
-                self.rc
-                    .accounts
-                    .accounts_db
-                    .update_accounts_hash_with_index_option(
-                        use_index,
-                        debug_verify,
-                        self.slot(),
-                        &self.ancestors,
-                        Some(self.capitalization()),
-                        self.epoch_schedule(),
-                        &self.rent_collector,
-                        is_startup,
-                    );
+                self.rc.accounts.accounts_db.update_accounts_hash(
+                    use_index,
+                    debug_verify,
+                    self.slot(),
+                    &self.ancestors,
+                    Some(self.capitalization()),
+                    self.epoch_schedule(),
+                    &self.rent_collector,
+                    is_startup,
+                );
             }
 
             panic!(


### PR DESCRIPTION
#### Problem

There are many permutations of the accounts hash calculation functions, and I find that I often need to go back to the fn definitions to remember which one is which.

* `calculate_accounts_hash()`
* `calculate_accounts_hash_without_index()`
* `calculate_accounts_hash_helper()`
* `calculate_accounts_hash_helper_with_verify()`
* `update_accounts_hash()`
* `update_accounts_hash_with_index_option()`

#### Summary of Changes

Rename `update_accounts_hash_with_index_option` to `update_accounts_hash`

(Subsequent PR will rename the other fns; I want each PR to be small.)