### PR TITLE
chore: add spl-instruction-padding/program to downstream ci script

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -41,6 +41,7 @@ spl() {
   (
     # Mind the order!
     PROGRAMS=(
+      instruction-padding/program
       token/program
       token/program-2022
       token/program-2022-test


### PR DESCRIPTION
#### Problem

https://buildkite.com/solana-labs/solana/builds/84345#01840d4d-81e9-42b2-92cc-c191d06f3679

we should build spl-instruction-padding in the ci script.

#### Summary of Changes

add it.
