### PR TITLE
Track how long background requests wait before processing

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -72,6 +72,7 @@ impl AccountsHashVerifier {
                         &accounts_package_receiver,
                     ) {
                         info!("handling accounts package: {accounts_package:?}");
+                        let enqueued_time = accounts_package.enqueued.elapsed();
 
                         let (_, measure) = measure!(Self::process_accounts_package(
                             accounts_package,
@@ -97,6 +98,7 @@ impl AccountsHashVerifier {
                                 num_re_enqueued_accounts_packages as i64,
                                 i64
                             ),
+                            ("enqueued-time-us", enqueued_time.as_micros() as i64, i64),
                             ("total-processing-time-us", measure.as_us() as i64, i64),
                         );
                     } else {
@@ -478,7 +480,7 @@ mod tests {
             sysvar::epoch_schedule::EpochSchedule,
         },
         solana_streamer::socket::SocketAddrSpace,
-        std::str::FromStr,
+        std::{str::FromStr, time::Instant},
     };
 
     fn new_test_cluster_info(contact_info: ContactInfo) -> ClusterInfo {
@@ -561,6 +563,7 @@ mod tests {
                 accounts: Arc::clone(&accounts),
                 epoch_schedule: EpochSchedule::default(),
                 rent_collector: RentCollector::default(),
+                enqueued: Instant::now(),
             };
 
             AccountsHashVerifier::process_accounts_package(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -317,6 +317,7 @@ impl BankForks {
                     snapshot_root_bank: Arc::clone(eah_bank),
                     status_cache_slot_deltas: Vec::default(),
                     request_type: SnapshotRequestType::EpochAccountsHash,
+                    enqueued: Instant::now(),
                 })
                 .expect("send epoch accounts hash request");
         }
@@ -356,6 +357,7 @@ impl BankForks {
                             snapshot_root_bank: Arc::clone(bank),
                             status_cache_slot_deltas,
                             request_type: SnapshotRequestType::Snapshot,
+                            enqueued: Instant::now(),
                         })
                     {
                         warn!(

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -18,6 +18,7 @@ use {
         fs,
         path::{Path, PathBuf},
         sync::{Arc, Mutex},
+        time::Instant,
     },
     tempfile::TempDir,
 };
@@ -46,6 +47,10 @@ pub struct AccountsPackage {
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
+
+    /// The instant this accounts package was send to the queue.
+    /// Used to track how long accounts packages wait before processing.
+    pub enqueued: Instant,
 }
 
 impl AccountsPackage {
@@ -116,6 +121,7 @@ impl AccountsPackage {
             accounts: bank.accounts(),
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
+            enqueued: Instant::now(),
         })
     }
 
@@ -139,6 +145,7 @@ impl AccountsPackage {
             accounts: Arc::new(Accounts::default_for_tests()),
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),
+            enqueued: Instant::now(),
         }
     }
 }


### PR DESCRIPTION
#### Problem

When requests are sent to the background for processing, we don't know how long they wait before they are processed.

#### Summary of Changes

Add metrics.