### PR TITLE
clean_dead_slots_from_accounts_index unrefs correctly (backport #2746…

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6237,7 +6237,7 @@ impl AccountsDb {
         let mut accounts_index_root_stats = AccountsIndexRootsStats::default();
         let mut measure = Measure::start("unref_from_storage");
         if let Some(purged_stored_account_slots) = purged_stored_account_slots {
-            let len = purged_stored_account_slots.len();
+            let len = purged_slot_pubkeys.len();
             // we could build a higher level function in accounts_index to group by bin
             const BATCH_SIZE: usize = 10_000;
             let batches = 1 + (len / BATCH_SIZE);


### PR DESCRIPTION
…1) (backport #27467)

#### Problem
See #27650

This fixes a longstanding bug that causes clean to not throw away old append vecs correctly. So, we accumulate them. This leads to oom.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
