### PR TITLE
rename and change capacity on unprocessed transaction storage - max_receive_size

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1943,7 +1943,7 @@ impl BankingStage {
             failed_sigverify_count,
         } = packet_deserializer.handle_received_packets(
             recv_timeout,
-            unprocessed_transaction_storage.capacity() - unprocessed_transaction_storage.len(),
+            unprocessed_transaction_storage.max_receive_size(),
         )?;
         let packet_count = deserialized_packets.len();
         debug!(

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -23,7 +23,8 @@ use {
 };
 
 pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 128;
-const MAX_STAKED_VALIDATORS: usize = 10_000;
+/// Maximum numer of votes a single receive call will accept
+const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 
 #[derive(Debug)]
 pub enum UnprocessedTransactionStorage {
@@ -153,10 +154,13 @@ impl UnprocessedTransactionStorage {
         }
     }
 
-    pub fn capacity(&self) -> usize {
+    /// Returns the maximum number of packets a receive should accept
+    pub fn max_receive_size(&self) -> usize {
         match self {
-            Self::VoteStorage(vote_storage) => vote_storage.capacity(),
-            Self::LocalTransactionStorage(transaction_storage) => transaction_storage.capacity(),
+            Self::VoteStorage(vote_storage) => vote_storage.max_receive_size(),
+            Self::LocalTransactionStorage(transaction_storage) => {
+                transaction_storage.max_receive_size()
+            }
         }
     }
 
@@ -258,8 +262,8 @@ impl VoteStorage {
         self.latest_unprocessed_votes.len()
     }
 
-    fn capacity(&self) -> usize {
-        MAX_STAKED_VALIDATORS
+    fn max_receive_size(&self) -> usize {
+        MAX_NUM_VOTES_RECEIVE
     }
 
     fn forward_option(&self) -> ForwardOption {
@@ -357,8 +361,8 @@ impl ThreadLocalUnprocessedPackets {
         self.unprocessed_packet_batches.len()
     }
 
-    fn capacity(&self) -> usize {
-        self.unprocessed_packet_batches.capacity()
+    fn max_receive_size(&self) -> usize {
+        self.unprocessed_packet_batches.capacity() - self.unprocessed_packet_batches.len()
     }
 
     #[cfg(test)]


### PR DESCRIPTION
#### Problem
VoteStorage doesn't actually have a max capacity.

#### Summary of Changes
Change capacity fn on unprocessed transaction storage - we only use it to get the maximum number of packets to accept in a receive call.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
