### PR TITLE
ci: Remove unneeded ignores in audit

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -8,26 +8,9 @@ src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
 cargo_audit_ignores=(
-  # `net2` crate has been deprecated; use `socket2` instead
-  #
-  # Blocked on https://github.com/paritytech/jsonrpc/issues/575
-  --ignore RUSTSEC-2020-0016
-
-  # stdweb is unmaintained
-  #
-  # Blocked on multiple upstream crates removing their `stdweb` dependency.
-  --ignore RUSTSEC-2020-0056
-
   # Potential segfault in the time crate
   #
-  # Blocked on multiple crates updating `time` to >= 0.2.23
+  # Blocked on chrono updating `time` to >= 0.2.23
   --ignore RUSTSEC-2020-0071
-
-  # chrono: Potential segfault in `localtime_r` invocations
-  #
-  # Blocked due to no safe upgrade
-  # https://github.com/chronotope/chrono/issues/499
-  --ignore RUSTSEC-2020-0159
-
 )
 scripts/cargo-for-all-lock-files.sh stable audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

A few RUSTSEC advisories have been ignored over the years, but the crates have since upgraded for the most part!

#### Summary of Changes

Remove ignores that aren't needed anymore.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
