### PR TITLE
Backport of #28599 to v1.13

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1474,7 +1474,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
 
         #[allow(clippy::collapsible_else_if)]
         if use_fixed_nonoverlapping_check {
-            if !is_nonoverlapping(src_addr, dst_addr, n) {
+            if !is_nonoverlapping(src_addr, n, dst_addr, n) {
                 *result = Err(SyscallError::CopyOverlapping.into());
                 return;
             }
@@ -1502,7 +1502,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
         )
         .as_ptr();
         if do_check_physical_overlapping
-            && !is_nonoverlapping(src_ptr as usize, dst_ptr as usize, n as usize)
+            && !is_nonoverlapping(src_ptr as usize, n as usize, dst_ptr as usize, n as usize)
         {
             unsafe {
                 std::ptr::copy(src_ptr, dst_ptr, n as usize);

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -54,7 +54,7 @@ pub trait SyscallStubs: Sync + Send {
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
         assert!(
-            is_nonoverlapping(src as usize, dst as usize, n),
+            is_nonoverlapping(src as usize, n, dst as usize, n),
             "memcpy does not support overlapping regions"
         );
         std::ptr::copy_nonoverlapping(src, dst, n as usize);
@@ -196,18 +196,20 @@ pub(crate) fn sol_get_stack_height() -> u64 {
 
 /// Check that two regions do not overlap.
 ///
-/// Adapted from libcore, hidden to share with bpf_loader without being part of
-/// the API surface.
+/// Hidden to share with bpf_loader without being part of the API surface.
 #[doc(hidden)]
-pub fn is_nonoverlapping<N>(src: N, dst: N, count: N) -> bool
+pub fn is_nonoverlapping<N>(src: N, src_len: N, dst: N, dst_len: N) -> bool
 where
     N: Ord + std::ops::Sub<Output = N>,
     <N as std::ops::Sub>::Output: Ord,
 {
-    let diff = if src > dst { src - dst } else { dst - src };
-    // If the absolute distance between the ptrs is at least as big as the size of the buffer,
+    // If the absolute distance between the ptrs is at least as big as the size of the other,
     // they do not overlap.
-    diff >= count
+    if src > dst {
+        src - dst >= dst_len
+    } else {
+        dst - src >= src_len
+    }
 }
 
 #[cfg(test)]
@@ -216,12 +218,16 @@ mod tests {
 
     #[test]
     fn test_is_nonoverlapping() {
-        assert!(is_nonoverlapping(10, 7, 3));
-        assert!(!is_nonoverlapping(10, 8, 3));
-        assert!(!is_nonoverlapping(10, 9, 3));
-        assert!(!is_nonoverlapping(10, 10, 3));
-        assert!(!is_nonoverlapping(10, 11, 3));
-        assert!(!is_nonoverlapping(10, 12, 3));
-        assert!(is_nonoverlapping(10, 13, 3));
+        for dst in 0..8 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 8..13 {
+            assert!(!is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 13..20 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        assert!(is_nonoverlapping::<u8>(255, 3, 254, 1));
+        assert!(!is_nonoverlapping::<u8>(255, 2, 254, 3));
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -423,6 +423,10 @@ pub mod increase_tx_account_lock_limit {
     solana_sdk::declare_id!("9LZdXeKGeBV6hRLdxS1rHbHoEUsKqesCC2ZAPTPKJAbK");
 }
 
+pub mod check_syscall_outputs_do_not_overlap {
+    solana_sdk::declare_id!("3uRVPBpyEJRo1emLCrq38eLRFGcu6uKSpUXqGvU8T7SZ");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -523,6 +527,7 @@ lazy_static! {
         (sign_repair_requests::id(), "sign repair requests #26834"),
         (return_none_for_zero_lamport_accounts::id(), "return none for zero lamport accounts #27800"),
         (increase_tx_account_lock_limit::id(), "increase tx account lock limit to 128 #27241"),
+        (check_syscall_outputs_do_not_overlap::id(), "check syscall outputs do_not overlap #28600"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
Backport of #28599 to v1.13, without the tests.