### PR TITLE
chore: use >> $GITHUB_OUTPUT instead of ::set-output

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
         id: check
         run: |
           source ci/env.sh
-          echo "::set-output name=tag::$CI_TAG"
+          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"
-          echo "::set-output name=channel::$CHANNEL"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
 
       - name: Get specific changed files
         id: changed-files-specific
@@ -43,7 +43,7 @@ jobs:
           echo "tag: ${{ steps.check.outputs.tag }}"
           echo "channel: ${{ steps.check.outputs.channel }}"
           echo "any changes: ${{ steps.changed-files-specific.outputs.any_changed }}"
-          echo "::set-output name=need_to_build::${{
+          echo "need_to_build=${{
             steps.check.outputs.tag != ''
             ||
             (
@@ -51,7 +51,7 @@ jobs:
               &&
               steps.changed-files-specific.outputs.any_changed != ''
             )
-          }}"
+          }}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Setup Node

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -52,9 +52,9 @@ jobs:
           choco install protoc
           export PROTOC="C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe"
           source /tmp/env.sh
-          echo "::set-output name=tag::$CI_TAG"
+          echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"
-          echo "::set-output name=channel::$CHANNEL"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files


### PR DESCRIPTION
#### Problem

[GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

#### Summary of Changes

replace all ::set-output with >> $GITHUB_OUTPUT
