### PR TITLE
chore: fix solana-private pipeline

### DIFF
--- a/ci/buildkite-solana-private.sh
+++ b/ci/buildkite-solana-private.sh
@@ -278,8 +278,12 @@ EOF
     ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster-flakey.sh" \
     20
 
-  command_step "local-cluster-slow" \
-    ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster-slow.sh" \
+    command_step "local-cluster-slow-1" \
+    ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster-slow-1.sh" \
+    50
+
+  command_step "local-cluster-slow-2" \
+    ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster-slow-2.sh" \
     50
 }
 


### PR DESCRIPTION
#### Problem

the `local-cluster-slow` is outdated

#### Summary of Changes

use new steps local-cluster-slow-1 and local-cluster-slow-2
