### PR TITLE
Use Storages to update accounts hash in bank_to_snapshot_archive()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
         accounts_db::{
-            AccountShrinkThreshold, AccountsDbConfig, SnapshotStorage, SnapshotStorages,
+            AccountShrinkThreshold, AccountsDbConfig, CalcAccountsHashDataSource, SnapshotStorage,
+            SnapshotStorages,
         },
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -2171,7 +2172,7 @@ pub fn bank_to_full_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(bank.slot()));
-    bank.update_accounts_hash();
+    bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
@@ -2218,7 +2219,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(full_snapshot_slot));
-    bank.update_accounts_hash();
+    bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;


### PR DESCRIPTION
#### Problem

Using the index for calculating the accounts hash should only be for tests/debugging. The `bank_to_snapshot_archive()` functions were using the Index, but can use Storages instead.

Related: https://github.com/solana-labs/solana/issues/28606

This will allow removing the Index option later; or containing it to tests-only.


#### Summary of Changes

Use Storages instead of Index in `bank_to_snapshot_archive()` functions.