### PR TITLE
Rename fn to Bank::update_accounts_hash()

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -296,12 +296,9 @@ impl SnapshotRequestHandler {
 
         let previous_hash = if test_hash_calculation {
             // We have to use the index version here.
-            // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality. This comment is out of date and can be re-evaluated.
-            snapshot_root_bank.update_accounts_hash_with_index_option(
-                CalcAccountsHashDataSource::Index,
-                false,
-                false,
-            )
+            // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality.
+            // This comment is out of date and can be re-evaluated.
+            snapshot_root_bank.update_accounts_hash(CalcAccountsHashDataSource::Index, false, false)
         } else {
             Hash::default()
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6983,7 +6983,7 @@ impl Bank {
             .load_account_into_read_cache(&self.ancestors, key);
     }
 
-    pub fn update_accounts_hash_with_index_option(
+    pub fn update_accounts_hash(
         &self,
         data_source: CalcAccountsHashDataSource,
         mut debug_verify: bool,
@@ -7034,7 +7034,7 @@ impl Bank {
     }
 
     pub fn update_accounts_hash_for_tests(&self) -> Hash {
-        self.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Index, false, false)
+        self.update_accounts_hash(CalcAccountsHashDataSource::Index, false, false)
     }
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2172,7 +2172,7 @@ pub fn bank_to_full_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(bank.slot()));
-    bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
+    bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
@@ -2219,7 +2219,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(full_snapshot_slot));
-    bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
+    bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;


### PR DESCRIPTION
#### Problem

1. The Bank update-accounts-hash functions are inconsistent with the AccountsDb functions
2. Using the Index for calculating the accounts hash will be relegated to tests and debugging


#### Summary of Changes

Rename `Bank::update_accounts_hash_with_index_option()` to `Bank::update_accounts_hash()`