### PR TITLE
Rename fn to Bank::update_accounts_hash_for_tests()

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -249,7 +249,7 @@ fn run_bank_forks_snapshot_n<F>(
         if slot % set_root_interval == 0 || slot == last_slot {
             // set_root should send a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
-            bank.update_accounts_hash();
+            bank.update_accounts_hash_for_tests();
             snapshot_request_handler.handle_snapshot_requests(false, false, 0, &mut None);
         }
     }
@@ -765,7 +765,7 @@ fn test_bank_forks_incremental_snapshot(
         if slot % SET_ROOT_INTERVAL == 0 {
             // set_root sends a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
-            bank.update_accounts_hash();
+            bank.update_accounts_hash_for_tests();
             snapshot_request_handler.handle_snapshot_requests(
                 false,
                 false,
@@ -1056,7 +1056,7 @@ fn test_snapshots_with_background_services(
                 .write()
                 .unwrap()
                 .set_root(slot, &abs_request_sender, None);
-            bank.update_accounts_hash();
+            bank.update_accounts_hash_for_tests();
         }
 
         // Sleep for a second when making a snapshot archive so the background services get a

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7033,7 +7033,7 @@ impl Bank {
         hash
     }
 
-    pub fn update_accounts_hash(&self) -> Hash {
+    pub fn update_accounts_hash_for_tests(&self) -> Hash {
         self.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Index, false, false)
     }
 
@@ -10349,9 +10349,9 @@ pub(crate) mod tests {
         bank.freeze();
         bank.squash();
         bank.force_flush_accounts_cache();
-        let hash = bank.update_accounts_hash();
+        let hash = bank.update_accounts_hash_for_tests();
         bank.clean_accounts_for_tests();
-        assert_eq!(bank.update_accounts_hash(), hash);
+        assert_eq!(bank.update_accounts_hash_for_tests(), hash);
 
         let bank0 = Arc::new(new_from_parent(&bank));
         let blockhash = bank.last_blockhash();
@@ -10372,9 +10372,9 @@ pub(crate) mod tests {
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank0 purge");
-        let hash = bank0.update_accounts_hash();
+        let hash = bank0.update_accounts_hash_for_tests();
         bank0.clean_accounts_for_tests();
-        assert_eq!(bank0.update_accounts_hash(), hash);
+        assert_eq!(bank0.update_accounts_hash_for_tests(), hash);
 
         assert_eq!(
             bank0.get_account(&keypair.pubkey()).unwrap().lamports(),
@@ -10400,7 +10400,7 @@ pub(crate) mod tests {
 
         bank1.freeze();
         bank1.squash();
-        bank1.update_accounts_hash();
+        bank1.update_accounts_hash_for_tests();
         assert!(bank1.verify_bank_hash(VerifyBankHash::default_for_test()));
 
         // keypair should have 0 tokens on both forks
@@ -11513,7 +11513,7 @@ pub(crate) mod tests {
         let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
-        bank2.update_accounts_hash();
+        bank2.update_accounts_hash_for_tests();
         assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
     }
 
@@ -11538,18 +11538,18 @@ pub(crate) mod tests {
 
         // Checkpointing should never modify the checkpoint's state once frozen
         let bank0_state = bank0.hash_internal_state();
-        bank2.update_accounts_hash();
+        bank2.update_accounts_hash_for_tests();
         assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
         let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
-        bank3.update_accounts_hash();
+        bank3.update_accounts_hash_for_tests();
         assert!(bank3.verify_bank_hash(VerifyBankHash::default_for_test()));
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
-        bank2.update_accounts_hash();
+        bank2.update_accounts_hash_for_tests();
         assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
         assert!(bank3.verify_bank_hash(VerifyBankHash::default_for_test()));
     }
@@ -11574,7 +11574,7 @@ pub(crate) mod tests {
         )
         .unwrap();
         bank.freeze();
-        bank.update_accounts_hash();
+        bank.update_accounts_hash_for_tests();
         assert!(bank.verify_snapshot_bank(true, false, bank.slot()));
 
         // tamper the bank after freeze!
@@ -12759,11 +12759,11 @@ pub(crate) mod tests {
         );
 
         // Re-adding builtin programs should be no-op
-        bank.update_accounts_hash();
+        bank.update_accounts_hash_for_tests();
         let old_hash = bank.get_accounts_hash();
         bank.add_builtin("mock_program1", &vote_id, mock_ix_processor);
         bank.add_builtin("mock_program2", &stake_id, mock_ix_processor);
-        bank.update_accounts_hash();
+        bank.update_accounts_hash_for_tests();
         let new_hash = bank.get_accounts_hash();
         assert_eq!(old_hash, new_hash);
         {


### PR DESCRIPTION
#### Problem

1. The Bank update-accounts-hash functions are inconsistent with the AccountsDb functions
2. Using the Index for calculating the accounts hash will be relegated to tests and debugging


#### Summary of Changes

Rename `Bank::update_accounts_hash()` to `Bank::update_accounts_hash_for_tests()`