### PR TITLE
show freeze authority for NFTs

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -363,6 +363,14 @@ function NonFungibleTokenMintAccountCard({
             </td>
           </tr>
         )}
+        {mintInfo.freezeAuthority && (
+          <tr>
+            <td>Freeze Authority</td>
+            <td className="text-lg-end">
+              <Address pubkey={mintInfo.freezeAuthority} alignRight link />
+            </td>
+          </tr>
+        )}
         <tr>
           <td>Update Authority</td>
           <td className="text-lg-end">


### PR DESCRIPTION
#### Problem
No freeze authority was being displayed for NFTs

#### Summary of Changes

Display Freeze Authority for NFTs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
