### PR TITLE
Rename variant to CalcAccountsHashDataSource::IndexForTests

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -298,7 +298,11 @@ impl SnapshotRequestHandler {
             // We have to use the index version here.
             // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality.
             // This comment is out of date and can be re-evaluated.
-            snapshot_root_bank.update_accounts_hash(CalcAccountsHashDataSource::Index, false, false)
+            snapshot_root_bank.update_accounts_hash(
+                CalcAccountsHashDataSource::IndexForTests,
+                false,
+                false,
+            )
         } else {
             Hash::default()
         };

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6967,7 +6967,7 @@ impl AccountsDb {
         is_startup: bool,
     ) -> (Hash, u64) {
         self.update_accounts_hash(
-            CalcAccountsHashDataSource::Index,
+            CalcAccountsHashDataSource::IndexForTests,
             debug_verify,
             slot,
             ancestors,
@@ -7305,7 +7305,7 @@ impl AccountsDb {
 
                 self.calculate_accounts_hash_from_storages(config, &storages, timings)
             }
-            CalcAccountsHashDataSource::Index => {
+            CalcAccountsHashDataSource::IndexForTests => {
                 self.calculate_accounts_hash_from_index(slot, config)
             }
         }
@@ -7324,8 +7324,8 @@ impl AccountsDb {
         if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
             let data_source_other = match data_source {
-                CalcAccountsHashDataSource::Index => CalcAccountsHashDataSource::Storages,
-                CalcAccountsHashDataSource::Storages => CalcAccountsHashDataSource::Index,
+                CalcAccountsHashDataSource::IndexForTests => CalcAccountsHashDataSource::Storages,
+                CalcAccountsHashDataSource::Storages => CalcAccountsHashDataSource::IndexForTests,
             };
             let (hash_other, total_lamports_other) =
                 self.calculate_accounts_hash(data_source_other, slot, &config)?;
@@ -9456,9 +9456,12 @@ impl AccountsDb {
 }
 
 /// Specify the source of the accounts data when calculating the accounts hash
+///
+/// Using the Index is meant for tests and debugging; not intended during normal validator
+/// operation.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CalcAccountsHashDataSource {
-    Index,
+    IndexForTests,
     Storages,
 }
 
@@ -12497,7 +12500,7 @@ pub mod tests {
         db.add_root(some_slot);
         let check_hash = true;
         for data_source in [
-            CalcAccountsHashDataSource::Index,
+            CalcAccountsHashDataSource::IndexForTests,
             CalcAccountsHashDataSource::Storages,
         ] {
             assert!(db
@@ -12565,7 +12568,7 @@ pub mod tests {
             )
             .unwrap(),
             db.calculate_accounts_hash(
-                CalcAccountsHashDataSource::Index,
+                CalcAccountsHashDataSource::IndexForTests,
                 some_slot,
                 &CalcAccountsHashConfig {
                     use_bg_thread_pool: true, // is_startup used to be false

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7034,7 +7034,7 @@ impl Bank {
     }
 
     pub fn update_accounts_hash_for_tests(&self) -> Hash {
-        self.update_accounts_hash(CalcAccountsHashDataSource::Index, false, false)
+        self.update_accounts_hash(CalcAccountsHashDataSource::IndexForTests, false, false)
     }
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash


### PR DESCRIPTION
#### Problem

The Index option when calculating the accounts hash should not be used by normal validators; just tests and debugging. There is no indication of this on the `CalcAccountsHashDataSource` variant.


#### Summary of Changes

Renames variant to CalcAccountsHashDataSource::IndexForTests


Fixes #28606