### PR TITLE
Periodically limit repair to only completed slot validators

### DIFF
--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -172,16 +172,18 @@ impl ClusterSlots {
         if repair_peers.is_empty() {
             return Vec::default();
         }
+        let mut max_stake = 0;
         let stakes = {
             let validator_stakes = self.validator_stakes.read().unwrap();
             repair_peers
                 .iter()
                 .map(|peer| {
-                    validator_stakes
+                    let peer_stake = validator_stakes
                         .get(&peer.id)
                         .map(|node| node.total_stake)
-                        .unwrap_or(0)
-                        + 1
+                        .unwrap_or(0);
+                    max_stake = std::cmp::max(max_stake, peer_stake);
+                    peer_stake
                 })
                 .collect()
         };
@@ -192,9 +194,15 @@ impl ClusterSlots {
         let slot_peers = slot_peers.read().unwrap();
         repair_peers
             .iter()
-            .map(|peer| slot_peers.get(&peer.id).cloned().unwrap_or(0))
+            .map(|peer| slot_peers.get(&peer.id).is_some())
             .zip(stakes)
-            .map(|(a, b)| a + b)
+            .map(|(did_complete_slot, peer_stake)| {
+                if did_complete_slot {
+                    max_stake
+                } else {
+                    peer_stake
+                }
+            })
             .collect()
     }
 

--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -194,7 +194,7 @@ impl ClusterSlots {
         let slot_peers = slot_peers.read().unwrap();
         repair_peers
             .iter()
-            .map(|peer| slot_peers.get(&peer.id).is_some())
+            .map(|peer| slot_peers.contains_key(&peer.id))
             .zip(stakes)
             .map(|(did_complete_slot, peer_stake)| {
                 if did_complete_slot {

--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -181,7 +181,8 @@ impl ClusterSlots {
                     let peer_stake = validator_stakes
                         .get(&peer.id)
                         .map(|node| node.total_stake)
-                        .unwrap_or(0);
+                        .unwrap_or(0)
+                        + 1;
                     max_stake = std::cmp::max(max_stake, peer_stake);
                     peer_stake
                 })


### PR DESCRIPTION
#### Problem
Lowly staked validators are never picked for slot repair, even if they are the only ones that have completed a slot and the highly staked validator has not completed the slot

#### Summary of Changes
50% of the time limit repair to only completed slot validators

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
