### PR TITLE
fix verify_vote in cluster_info_vote_listener

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -358,7 +358,12 @@ impl ClusterInfoVoteListener {
                     .epoch_authorized_voters()
                     .get(&vote_account_key)?;
                 let mut keys = tx.message.account_keys.iter().enumerate();
-                if !keys.any(|(i, key)| tx.message.is_signer(i) && key == authorized_voter) {
+                // When the authorized_voter and authorized_vote_withdrawer
+                // keypairs are different, the vote message will be signed by
+                // auth_vote_withdrawer keypair, not authorized_voter keypair.
+                // Therefore, we should only check that the authorized_voter
+                // account exist.
+                if !keys.any(|(_i, key)| key == authorized_voter) {
                     return None;
                 }
                 let verified_vote_metadata = VerifiedVoteMetadata {


### PR DESCRIPTION
#### Problem

We will miss votes from voting account that use different authorized
withdrawer account from vote account on gossip.

#### Summary of Changes

Don't check the vote instruction are signed by vote account on gossip.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
