### PR TITLE
Shrink storages before creating one-off snapshot archives

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2172,6 +2172,7 @@ pub fn bank_to_full_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(bank.slot()));
+    bank.shrink_candidate_slots();
     bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
@@ -2219,6 +2220,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(full_snapshot_slot));
+    bank.shrink_candidate_slots();
     bank.update_accounts_hash_with_index_option(CalcAccountsHashDataSource::Storages, false, false);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 


### PR DESCRIPTION
#### Problem

When creating one-off snapshot archives (like for `solana-ledger-tool create-snapshot`), the storages it incudes are not shrunk first, thus could be bigger than necessary.

If this new snapshot is used locally, the shrink will also be skipped on load. So shrinking will be delayed until ABS runs. In the normal snapshot code path, `shrink` occurs before getting the storages.


#### Summary of Changes

Call `shrink` before getting the storages, when taking a one-off snapshot archive.


#### TODO

1. gather metrics for runtime and size when creating snapshots with ledger-tool against mnb
2. gather metrics for runtime on booting from the snapshot in (1)