### PR TITLE
versioned transaction compatibility for sendAndConfirmTransaction

### DIFF
--- a/web3.js/src/utils/send-and-confirm-transaction.ts
+++ b/web3.js/src/utils/send-and-confirm-transaction.ts
@@ -1,5 +1,5 @@
 import {Connection} from '../connection';
-import {Transaction} from '../transaction';
+import {Transaction, VersionedTransaction} from '../transaction';
 import type {ConfirmOptions} from '../connection';
 import type {Signer} from '../keypair';
 import type {TransactionSignature} from '../transaction';
@@ -10,14 +10,14 @@ import type {TransactionSignature} from '../transaction';
  * If `commitment` option is not specified, defaults to 'max' commitment.
  *
  * @param {Connection} connection
- * @param {Transaction} transaction
+ * @param {Transaction | VersionedTransaction} transaction
  * @param {Array<Signer>} signers
  * @param {ConfirmOptions} [options]
  * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmTransaction(
   connection: Connection,
-  transaction: Transaction,
+  transaction: Transaction | VersionedTransaction,
   signers: Array<Signer>,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {


### PR DESCRIPTION
#### Problem
`sendAndConfirmTransaction` does not have compatibility with the new Versioned Transactions.

#### Summary of Changes
type compatibility when defining transaction in `sendAndConfirmTransaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
