### PR TITLE
Report transaction signature on update account (cherry pick)

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -38,12 +38,46 @@ pub struct ReplicaAccountInfo<'a> {
     pub write_version: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Information about an account being updated
+/// (extended with transaction signature doing this update)
+pub struct ReplicaAccountInfoV2<'a> {
+    /// The Pubkey for the account
+    pub pubkey: &'a [u8],
+
+    /// The lamports for the account
+    pub lamports: u64,
+
+    /// The Pubkey of the owner program account
+    pub owner: &'a [u8],
+
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: u64,
+
+    /// The data held in this account.
+    pub data: &'a [u8],
+
+    /// A global monotonically increasing atomic number, which can be used
+    /// to tell the order of the account update. For example, when an
+    /// account is updated in the same slot multiple times, the update
+    /// with higher write_version should supersede the one with lower
+    /// write_version.
+    pub write_version: u64,
+
+    /// First signature of the transaction caused this account modification
+    pub txn_signature: Option<&'a Signature>,
+}
+
 /// A wrapper to future-proof ReplicaAccountInfo handling.
 /// If there were a change to the structure of ReplicaAccountInfo,
 /// there would be new enum entry for the newer version, forcing
 /// plugin implementations to handle the change.
 pub enum ReplicaAccountInfoVersions<'a> {
     V0_0_1(&'a ReplicaAccountInfo<'a>),
+    V0_0_2(&'a ReplicaAccountInfoV2<'a>),
 }
 
 /// Information about a transaction

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -61,6 +61,7 @@ use {
         genesis_config::{ClusterType, GenesisConfig},
         hash::Hash,
         pubkey::Pubkey,
+        signature::Signature,
         timing::AtomicInterval,
     },
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
@@ -4936,11 +4937,12 @@ impl AccountsDb {
         }
     }
 
-    fn write_accounts_to_cache(
+    fn write_accounts_to_cache<'a>(
         &self,
         slot: Slot,
         hashes: Option<&[impl Borrow<Hash>]>,
         accounts_and_meta_to_store: &[(StoredMeta, Option<&impl ReadableAccount>)],
+        txn_signatures_iter: Box<dyn std::iter::Iterator<Item = &Option<&Signature>> + 'a>,
     ) -> Vec<AccountInfo> {
         let len = accounts_and_meta_to_store.len();
         let hashes = hashes.map(|hashes| {
@@ -4950,8 +4952,9 @@ impl AccountsDb {
 
         accounts_and_meta_to_store
             .iter()
+            .zip(txn_signatures_iter)
             .enumerate()
-            .map(|(i, (meta, account))| {
+            .map(|(i, ((meta, account), signature))| {
                 let hash = hashes.map(|hashes| hashes[i].borrow());
 
                 let account = account
@@ -4963,7 +4966,7 @@ impl AccountsDb {
                     account.lamports(),
                 );
 
-                self.notify_account_at_accounts_update(slot, meta, &account);
+                self.notify_account_at_accounts_update(slot, meta, &account, signature);
 
                 let cached_account = self.accounts_cache.store(slot, &meta.pubkey, account, hash);
                 // hash this account in the bg
@@ -4990,6 +4993,7 @@ impl AccountsDb {
         storage_finder: F,
         mut write_version_producer: P,
         is_cached_store: bool,
+        txn_signatures: Option<&'a [Option<&'a Signature>]>,
     ) -> Vec<AccountInfo> {
         let mut calc_stored_meta_time = Measure::start("calc_stored_meta");
         let slot = accounts.target_slot();
@@ -5020,7 +5024,18 @@ impl AccountsDb {
             .fetch_add(calc_stored_meta_time.as_us(), Ordering::Relaxed);
 
         if self.caching_enabled && is_cached_store {
-            self.write_accounts_to_cache(slot, hashes, &accounts_and_meta_to_store)
+            let signature_iter: Box<dyn std::iter::Iterator<Item = &Option<&Signature>>> =
+                match txn_signatures {
+                    Some(txn_signatures) => {
+                        assert_eq!(txn_signatures.len(), accounts_and_meta_to_store.len());
+                        Box::new(txn_signatures.iter())
+                    }
+                    None => {
+                        Box::new(std::iter::repeat(&None).take(accounts_and_meta_to_store.len()))
+                    }
+                };
+
+            self.write_accounts_to_cache(slot, hashes, &accounts_and_meta_to_store, signature_iter)
         } else {
             match hashes {
                 Some(hashes) => self.write_accounts_to_storage(
@@ -6331,20 +6346,26 @@ impl AccountsDb {
             .fetch_add(measure.as_us(), Ordering::Relaxed);
     }
 
-    pub fn store_cached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        self.store((slot, accounts), self.caching_enabled);
+    pub fn store_cached(
+        &self,
+        slot: Slot,
+        accounts: &[(&Pubkey, &AccountSharedData)],
+        txn_signatures: Option<&[Option<&Signature>]>,
+    ) {
+        self.store((slot, accounts), self.caching_enabled, txn_signatures);
     }
 
     /// Store the account update.
     /// only called by tests
     pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        self.store((slot, accounts), false)
+        self.store((slot, accounts), false, None);
     }
 
     fn store<'a, T: ReadableAccount + Sync + ZeroLamport>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
         is_cached_store: bool,
+        txn_signatures: Option<&'a [Option<&'a Signature>]>,
     ) {
         // If all transactions in a batch are errored,
         // it's possible to get a store with no accounts.
@@ -6374,7 +6395,7 @@ impl AccountsDb {
         }
 
         // we use default hashes for now since the same account may be stored to the cache multiple times
-        self.store_accounts_unfrozen(accounts, None, is_cached_store);
+        self.store_accounts_unfrozen(accounts, None, is_cached_store, txn_signatures);
         self.report_store_timings();
     }
 
@@ -6499,6 +6520,7 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a, T>,
         hashes: Option<&[&Hash]>,
         is_cached_store: bool,
+        txn_signatures: Option<&'a [Option<&'a Signature>]>,
     ) {
         // This path comes from a store to a non-frozen slot.
         // If a store is dead here, then a newer update for
@@ -6515,6 +6537,7 @@ impl AccountsDb {
             None::<Box<dyn Iterator<Item = u64>>>,
             is_cached_store,
             reset_accounts,
+            txn_signatures,
         );
     }
 
@@ -6537,6 +6560,7 @@ impl AccountsDb {
             write_version_producer,
             is_cached_store,
             reset_accounts,
+            None,
         )
     }
 
@@ -6548,6 +6572,7 @@ impl AccountsDb {
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
         is_cached_store: bool,
         reset_accounts: bool,
+        txn_signatures: Option<&'b [Option<&'b Signature>]>,
     ) -> StoreAccountsTiming {
         let slot = accounts.target_slot();
         let storage_finder = storage_finder
@@ -6573,6 +6598,7 @@ impl AccountsDb {
             storage_finder,
             write_version_producer,
             is_cached_store,
+            txn_signatures,
         );
         store_accounts_time.stop();
         self.stats
@@ -8478,7 +8504,7 @@ pub mod tests {
         let account0 = AccountSharedData::new(1, 0, &key);
         let ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
         if is_cached {
-            db.store_cached(unrooted_slot, &[(&key, &account0)]);
+            db.store_cached(unrooted_slot, &[(&key, &account0)], None);
         } else {
             db.store_uncached(unrooted_slot, &[(&key, &account0)]);
         }
@@ -10014,6 +10040,7 @@ pub mod tests {
             (some_slot, &[(&key, &account)][..]),
             Some(&[&Hash::default()]),
             false,
+            None,
         );
         db.add_root(some_slot);
         let check_hash = true;
@@ -10177,7 +10204,7 @@ pub mod tests {
         }
         // provide bogus account hashes
         let some_hash = Hash::new(&[0xca; HASH_BYTES]);
-        db.store_accounts_unfrozen((some_slot, accounts), Some(&[&some_hash]), false);
+        db.store_accounts_unfrozen((some_slot, accounts), Some(&[&some_hash]), false, None);
         db.add_root(some_slot);
         assert_matches!(
             db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true, false),
@@ -11319,13 +11346,13 @@ pub mod tests {
 
         let account = AccountSharedData::new(1, 16 * 4096, &Pubkey::default());
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached(0, &[(&pubkey1, &account)]);
+        accounts.store_cached(0, &[(&pubkey1, &account)], None);
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached(0, &[(&pubkey2, &account)]);
+        accounts.store_cached(0, &[(&pubkey2, &account)], None);
 
         let zero_account = AccountSharedData::new(0, 1, &Pubkey::default());
-        accounts.store_cached(1, &[(&pubkey1, &zero_account)]);
+        accounts.store_cached(1, &[(&pubkey1, &zero_account)], None);
 
         // Add root 0 and flush separately
         accounts.get_accounts_delta_hash(0);
@@ -11497,7 +11524,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached(slot, &[(&key, &account0)]);
+        db.store_cached(slot, &[(&key, &account0)], None);
 
         // Load with no ancestors and no root will return nothing
         assert!(db
@@ -11530,7 +11557,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached(slot, &[(&key, &account0)]);
+        db.store_cached(slot, &[(&key, &account0)], None);
         db.mark_slot_frozen(slot);
 
         // No root was added yet, requires an ancestor to find
@@ -11563,9 +11590,9 @@ pub mod tests {
         let unrooted_key = solana_sdk::pubkey::new_rand();
         let key5 = solana_sdk::pubkey::new_rand();
         let key6 = solana_sdk::pubkey::new_rand();
-        db.store_cached(unrooted_slot, &[(&unrooted_key, &account0)]);
-        db.store_cached(root5, &[(&key5, &account0)]);
-        db.store_cached(root6, &[(&key6, &account0)]);
+        db.store_cached(unrooted_slot, &[(&unrooted_key, &account0)], None);
+        db.store_cached(root5, &[(&key5, &account0)], None);
+        db.store_cached(root6, &[(&key6, &account0)], None);
         for slot in &[unrooted_slot, root5, root6] {
             db.mark_slot_frozen(*slot);
         }
@@ -11628,7 +11655,7 @@ pub mod tests {
         let num_slots = 2 * max_cache_slots();
         for i in 0..num_roots + num_unrooted {
             let key = Pubkey::new_unique();
-            db.store_cached(i as Slot, &[(&key, &account0)]);
+            db.store_cached(i as Slot, &[(&key, &account0)], None);
             keys.push(key);
             db.mark_slot_frozen(i as Slot);
             if i < num_roots {
@@ -11697,8 +11724,8 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached(0, &[(&account_key, &zero_lamport_account)]);
-        db.store_cached(1, &[(&account_key, &slot1_account)]);
+        db.store_cached(0, &[(&account_key, &zero_lamport_account)], None);
+        db.store_cached(1, &[(&account_key, &slot1_account)], None);
 
         db.add_root(0);
         db.add_root(1);
@@ -11720,7 +11747,7 @@ pub mod tests {
             .unwrap();
         assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
-        db.store_cached(2, &[(&account_key, &zero_lamport_account)]);
+        db.store_cached(2, &[(&account_key, &zero_lamport_account)], None);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key, LoadZeroLamports::None)
@@ -11744,8 +11771,8 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached(0, &[(&account_key, &zero_lamport_account)]);
-        db.store_cached(1, &[(&account_key, &slot1_account)]);
+        db.store_cached(0, &[(&account_key, &zero_lamport_account)], None);
+        db.store_cached(1, &[(&account_key, &slot1_account)], None);
 
         db.add_root(0);
         db.add_root(1);
@@ -11799,16 +11826,20 @@ pub mod tests {
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
         // Store into slot 0, and then flush the slot to storage
-        db.store_cached(0, &[(&zero_lamport_account_key, &slot0_account)]);
+        db.store_cached(0, &[(&zero_lamport_account_key, &slot0_account)], None);
         // Second key keeps other lamport account entry for slot 0 alive,
         // preventing clean of the zero_lamport_account in slot 1.
-        db.store_cached(0, &[(&other_account_key, &slot0_account)]);
+        db.store_cached(0, &[(&other_account_key, &slot0_account)], None);
         db.add_root(0);
         db.flush_accounts_cache(true, None);
         assert!(!db.storage.get_slot_storage_entries(0).unwrap().is_empty());
 
         // Store into slot 1, a dummy slot that will be dead and purged before flush
-        db.store_cached(1, &[(&zero_lamport_account_key, &zero_lamport_account)]);
+        db.store_cached(
+            1,
+            &[(&zero_lamport_account_key, &zero_lamport_account)],
+            None,
+        );
 
         // Store into slot 2, which makes all updates from slot 1 outdated.
         // This means slot 1 is a dead slot. Later, slot 1 will be cleaned/purged
@@ -11816,7 +11847,11 @@ pub mod tests {
         // the refcount of `zero_lamport_account_key` because cached keys do not bump
         // the refcount in the index. This means clean should *not* remove
         // `zero_lamport_account_key` from slot 2
-        db.store_cached(2, &[(&zero_lamport_account_key, &zero_lamport_account)]);
+        db.store_cached(
+            2,
+            &[(&zero_lamport_account_key, &zero_lamport_account)],
+            None,
+        );
         db.add_root(1);
         db.add_root(2);
 
@@ -11938,11 +11973,11 @@ pub mod tests {
                                 /        \
                               1            2 (root)
         */
-        db.store_cached(0, &[(&account_key, &zero_lamport_account)]);
-        db.store_cached(1, &[(&account_key, &slot1_account)]);
+        db.store_cached(0, &[(&account_key, &zero_lamport_account)], None);
+        db.store_cached(1, &[(&account_key, &slot1_account)], None);
         // Fodder for the scan so that the lock on `account_key` is not held
-        db.store_cached(1, &[(&account_key2, &slot1_account)]);
-        db.store_cached(2, &[(&account_key, &slot2_account)]);
+        db.store_cached(1, &[(&account_key2, &slot1_account)], None);
+        db.store_cached(2, &[(&account_key, &slot2_account)], None);
         db.get_accounts_delta_hash(0);
 
         let max_scan_root = 0;
@@ -12036,7 +12071,7 @@ pub mod tests {
 
         for data_size in 0..num_keys {
             let account = AccountSharedData::new(1, data_size, &Pubkey::default());
-            accounts_db.store_cached(slot, &[(&Pubkey::new_unique(), &account)]);
+            accounts_db.store_cached(slot, &[(&Pubkey::new_unique(), &account)], None);
         }
 
         accounts_db.add_root(slot);
@@ -12104,6 +12139,7 @@ pub mod tests {
                     &scan_stall_key,
                     &AccountSharedData::new(1, 0, &Pubkey::default()),
                 )],
+                None,
             );
         }
 
@@ -12115,6 +12151,7 @@ pub mod tests {
                 accounts_db.store_cached(
                     *slot,
                     &[(key, &AccountSharedData::new(1, space, &Pubkey::default()))],
+                    None,
                 );
             }
             accounts_db.add_root(*slot as Slot);
@@ -12159,6 +12196,7 @@ pub mod tests {
             accounts_db.store_cached(
                 alive_slot,
                 &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))],
+                None,
             );
             accounts_db.add_root(alive_slot);
         }
@@ -12496,8 +12534,8 @@ pub mod tests {
         let account1 = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
 
         // Store into slot 0
-        db.store_cached(0, &[(&account_key1, &account1)]);
-        db.store_cached(0, &[(&account_key2, &account1)]);
+        db.store_cached(0, &[(&account_key1, &account1)], None);
+        db.store_cached(0, &[(&account_key2, &account1)], None);
         db.add_root(0);
         if !do_intra_cache_clean {
             // If we don't want the cache doing purges before flush,
@@ -12511,7 +12549,7 @@ pub mod tests {
         }
 
         // Make account_key1 in slot 0 outdated by updating in rooted slot 1
-        db.store_cached(1, &[(&account_key1, &account1)]);
+        db.store_cached(1, &[(&account_key1, &account1)], None);
         db.add_root(1);
         // Flushes all roots
         db.flush_accounts_cache(true, None);
@@ -12535,7 +12573,7 @@ pub mod tests {
         db.shrink_candidate_slots();
 
         // Make slot 0 dead by updating the remaining key
-        db.store_cached(2, &[(&account_key2, &account1)]);
+        db.store_cached(2, &[(&account_key2, &account1)], None);
         db.add_root(2);
 
         // Flushes all roots
@@ -12764,6 +12802,7 @@ pub mod tests {
                 &pubkey,
                 &AccountSharedData::new(1, 0, AccountSharedData::default().owner()),
             )],
+            None,
         );
         db.add_root(0);
         db.flush_accounts_cache(true, None);
@@ -12782,7 +12821,7 @@ pub mod tests {
                             return;
                         }
                         account.set_lamports(slot + 1);
-                        db.store_cached(slot, &[(&pubkey, &account)]);
+                        db.store_cached(slot, &[(&pubkey, &account)], None);
                         db.add_root(slot);
                         sleep(Duration::from_millis(RACY_SLEEP_MS));
                         db.flush_accounts_cache(true, None);
@@ -12950,7 +12989,7 @@ pub mod tests {
         let num_trials = 10;
         for _ in 0..num_trials {
             let pubkey = Pubkey::new_unique();
-            db.store_cached(slot, &[(&pubkey, &account)]);
+            db.store_cached(slot, &[(&pubkey, &account)], None);
             // Wait for both threads to finish
             flush_trial_start_sender.send(()).unwrap();
             remove_trial_start_sender.send(()).unwrap();
@@ -13041,7 +13080,7 @@ pub mod tests {
             let slot_to_pubkey_map: HashMap<Slot, Pubkey> = (0..num_cached_slots)
                 .map(|slot| {
                     let pubkey = Pubkey::new_unique();
-                    db.store_cached(slot, &[(&pubkey, &account)]);
+                    db.store_cached(slot, &[(&pubkey, &account)], None);
                     (slot, pubkey)
                 })
                 .collect();
@@ -13473,19 +13512,19 @@ pub mod tests {
 
         let slot1 = 1;
         let account = AccountSharedData::new(111, space, &owner);
-        accounts_db.store_cached(slot1, &[(&pubkey, &account)]);
+        accounts_db.store_cached(slot1, &[(&pubkey, &account)], None);
         accounts_db.get_accounts_delta_hash(slot1);
         accounts_db.add_root(slot1);
 
         let slot2 = 2;
         let account = AccountSharedData::new(222, space, &owner);
-        accounts_db.store_cached(slot2, &[(&pubkey, &account)]);
+        accounts_db.store_cached(slot2, &[(&pubkey, &account)], None);
         accounts_db.get_accounts_delta_hash(slot2);
         accounts_db.add_root(slot2);
 
         let slot3 = 3;
         let account = AccountSharedData::new(0, space, &owner);
-        accounts_db.store_cached(slot3, &[(&pubkey, &account)]);
+        accounts_db.store_cached(slot3, &[(&pubkey, &account)], None);
         accounts_db.get_accounts_delta_hash(slot3);
         accounts_db.add_root(slot3);
 

--- a/runtime/src/accounts_update_notifier_interface.rs
+++ b/runtime/src/accounts_update_notifier_interface.rs
@@ -1,12 +1,18 @@
 use {
     crate::append_vec::{StoredAccountMeta, StoredMeta},
-    solana_sdk::{account::AccountSharedData, clock::Slot},
+    solana_sdk::{account::AccountSharedData, clock::Slot, signature::Signature},
     std::sync::{Arc, RwLock},
 };
 
 pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
     /// Notified when an account is updated at runtime, due to transaction activities
-    fn notify_account_update(&self, slot: Slot, meta: &StoredMeta, account: &AccountSharedData);
+    fn notify_account_update(
+        &self,
+        slot: Slot,
+        meta: &StoredMeta,
+        account: &AccountSharedData,
+        txn_signature: &Option<&Signature>,
+    );
 
     /// Notified when the AccountsDb is initialized at start when restored
     /// from a snapshot.


### PR DESCRIPTION
**There's no direct linkage between account-update events and transaction-events**
Issue is linked with geyser plugin interface
Currently, there's no straightforward way to determine what notify_transaction call is related to particular update_account call. So, there's no simple way to determine what transaction caused what changes in accounts. This issue is especially valuable in case when several transactions modifies single account in the same slot.
**NOTE**: This PR is cherrypicked from https://github.com/solana-labs/solana/pull/25726 + some minor changes added for compatibility with Solana v1.13

**Add txn_signature field to ReplicaTransactionInfo structure**
This additional field will contain the signature of transaction which caused this account update event. This modification is not bringing significant overhead because all necessary information for such linkage already available inside Accounts::collect_accounts_to_store method
