### PR TITLE
Rename BankHashInfo field to accounts_hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1154,7 +1154,7 @@ impl BankHashStats {
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
 pub struct BankHashInfo {
     pub hash: Hash,
-    pub snapshot_hash: Hash,
+    pub accounts_hash: Hash,
     pub stats: BankHashStats,
 }
 
@@ -4879,7 +4879,7 @@ impl AccountsDb {
 
         let new_hash_info = BankHashInfo {
             hash: Hash::default(),
-            snapshot_hash: Hash::default(),
+            accounts_hash: Hash::default(),
             stats: BankHashStats::default(),
         };
         bank_hashes.insert(slot, new_hash_info);
@@ -6956,7 +6956,7 @@ impl AccountsDb {
     pub fn get_accounts_hash(&self, slot: Slot) -> Hash {
         let bank_hashes = self.bank_hashes.read().unwrap();
         let bank_hash_info = bank_hashes.get(&slot).unwrap();
-        bank_hash_info.snapshot_hash
+        bank_hash_info.accounts_hash
     }
 
     pub fn update_accounts_hash_for_tests(
@@ -7376,7 +7376,7 @@ impl AccountsDb {
     pub(crate) fn set_accounts_hash(&self, slot: Slot, hash: Hash) {
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
-        bank_hash_info.snapshot_hash = hash;
+        bank_hash_info.accounts_hash = hash;
     }
 
     /// scan 'storage', return a vec of 'CacheHashDataFile', one per pass
@@ -7677,12 +7677,12 @@ impl AccountsDb {
         } else {
             let bank_hashes = self.bank_hashes.read().unwrap();
             if let Some(found_hash_info) = bank_hashes.get(&slot) {
-                if calculated_hash == found_hash_info.snapshot_hash {
+                if calculated_hash == found_hash_info.accounts_hash {
                     Ok(())
                 } else {
                     warn!(
                         "mismatched bank hash for slot {}: {} (calculated) != {} (expected)",
-                        slot, calculated_hash, found_hash_info.snapshot_hash
+                        slot, calculated_hash, found_hash_info.accounts_hash
                     );
                     Err(MismatchedBankHash)
                 }
@@ -12609,7 +12609,7 @@ pub mod tests {
         let some_bank_hash = Hash::new(&[0xca; HASH_BYTES]);
         let bank_hash_info = BankHashInfo {
             hash: some_bank_hash,
-            snapshot_hash: Hash::new(&[0xca; HASH_BYTES]),
+            accounts_hash: Hash::new(&[0xca; HASH_BYTES]),
             stats: BankHashStats::default(),
         };
         db.bank_hashes

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -355,7 +355,7 @@ impl<'a> TypeContext<'a> for Context {
     {
         let (bank_fields, mut accounts_db_fields) =
             Self::deserialize_bank_fields(stream_reader).unwrap();
-        accounts_db_fields.3.snapshot_hash = *accounts_hash;
+        accounts_db_fields.3.accounts_hash = *accounts_hash;
         let mut rhs = bank_fields;
         let blockhash_queue = RwLock::new(std::mem::take(&mut rhs.blockhash_queue));
         let hard_forks = RwLock::new(std::mem::take(&mut rhs.hard_forks));

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -692,7 +692,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "7SZNRErAktC7sRcpChrcHfsr9Uw7XXoSzNbYzoNtoQCr")]
+    #[frozen_abi(digest = "C4asU4c7Qbd31QQDScqRPnT3iLCYc4qaGqeUQEGP7cTw")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem

Soon, snapshots will hash in the EAH for added verification. This will change the meaning of the snapshot hash; specifically, the snapshot hash will *not* automatically mean the accounts hash.

`BankHashInfo` has a field `snapshot_hash`, which is referred to (and used as) `accounts_hash` everywhere else. This will be confusing if this field is always the accounts hash, and not the real snapshot hash.


#### Summary of Changes

Rename BankHashInfo::snapshot_hash to accounts_hash.