### PR TITLE
remove duplicate pubkey when shrinking or combining ancient

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -136,6 +136,10 @@ impl<'a> StoredAccountMeta<'a> {
         let executable_byte: &u8 = unsafe { &*(executable_bool as *const bool as *const u8) };
         executable_byte
     }
+
+    pub fn pubkey(&self) -> &Pubkey {
+        &self.meta.pubkey
+    }
 }
 
 pub struct AppendVecAccountsIter<'a> {


### PR DESCRIPTION
#### Problem

pubkey is already available in `StoredAccountMeta`.
Including in the tuple when we store just causes us to add duplicate information.


#### Summary of Changes
Remove pubkey from the tuple and get the pubkey from StoredAccountMeta.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
