### PR TITLE
feat: expose makeWebsocketUrl

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2768,7 +2768,14 @@ export class Connection {
     }
 
     this._rpcEndpoint = assertEndpointUrl(endpoint);
-    this._rpcWsEndpoint = wsEndpoint || makeWebsocketUrl(endpoint);
+    if (wsEndpoint) {
+      this._rpcWsEndpoint = wsEndpoint;
+    } else {
+      this._rpcWsEndpoint = makeWebsocketUrl(endpoint);
+      console.warn(
+        `No websocket endpoint specified, created one automatically: ${this._rpcWsEndpoint}`,
+      );
+    }
 
     this._rpcClient = createRpcClient(
       endpoint,

--- a/web3.js/src/utils/index.ts
+++ b/web3.js/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './borsh-schema';
 export * from './cluster';
 export type {Ed25519Keypair} from './ed25519';
+export * from './makeWebsocketUrl';
 export * from './send-and-confirm-raw-transaction';
 export * from './send-and-confirm-transaction';


### PR DESCRIPTION
#### Problem

Recently we ran into the issue where we specified an RPC endpoint when creating a connection, but did not specify a websocket endpoint.  The problem was that our RPC endpoint had a port on the end of it and when the `makeWebsocketUrl` was called to create a websocket endpoint by default it simply added 1 to the RPC endpoint port.  In our case this was not the correct port for our websocket connection and it was causing a lot of timeouts.  I was able to remedy the problem by taking our port number off our endpoint.  FWIW, here's a [link to the PR](https://github.com/solana-labs/solana-web3.js/commit/4f2d052e82422d64ab7d2819575418bd0932d14e) that broke this logic for us.

#### Summary of Changes

I would like to expose this function so we can leverage it in our code when specifying connections so we don't need to have environment variables for RPC & websocket endpoints.  I also added a `console.warn` statement when the websocket endpoint is auto-created so it makes it more clear to the user that it's being specified and what is being specified.
