### PR TITLE
Uses SnapshotHash type in snapshot archive fields

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -94,7 +94,7 @@ impl SnapshotPackagerService {
                     if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
                         snapshot_gossip_manager.push_snapshot_hash(
                             snapshot_package.snapshot_type,
-                            (snapshot_package.slot(), *snapshot_package.hash()),
+                            (snapshot_package.slot(), snapshot_package.hash().0),
                         );
                     }
                 }
@@ -225,6 +225,7 @@ mod tests {
             accounts_db::AccountStorageEntry,
             bank::BankSlotDelta,
             snapshot_archive_info::SnapshotArchiveInfo,
+            snapshot_hash::SnapshotHash,
             snapshot_package::{SnapshotPackage, SnapshotType},
             snapshot_utils::{
                 self, ArchiveFormat, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILENAME,
@@ -309,7 +310,7 @@ mod tests {
 
         // Create a packageable snapshot
         let slot = 42;
-        let hash = Hash::default();
+        let hash = SnapshotHash(Hash::default());
         let archive_format = ArchiveFormat::TarBzip2;
         let output_tar_path = snapshot_utils::build_full_snapshot_archive_path(
             &full_snapshot_archives_dir,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -24,6 +24,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_config::SnapshotConfig,
+        snapshot_hash::SnapshotHash,
         snapshot_package::{
             AccountsPackage, AccountsPackageType, PendingSnapshotPackage, SnapshotPackage,
             SnapshotType,
@@ -149,7 +150,7 @@ fn restore_from_snapshot(
     let full_snapshot_archive_path = snapshot_utils::build_full_snapshot_archive_path(
         full_snapshot_archives_dir,
         old_last_bank.slot(),
-        &old_last_bank.get_accounts_hash(),
+        &old_last_bank.get_snapshot_hash(),
         ArchiveFormat::TarBzip2,
     );
     let full_snapshot_archive_info =
@@ -467,7 +468,7 @@ fn test_concurrent_snapshot_packaging(
                 slot,
                 // this needs to match the hash value that we reserialize with later. It is complicated, so just use default.
                 // This hash value is just used to build the file name. Since this is mocked up test code, it is sufficient to pass default here.
-                &Hash::default(),
+                &SnapshotHash(Hash::default()),
                 ArchiveFormat::TarBzip2,
             ));
         }

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -4,10 +4,11 @@ use {
     indicatif::{ProgressBar, ProgressStyle},
     log::*,
     solana_runtime::{
+        snapshot_hash::SnapshotHash,
         snapshot_package::SnapshotType,
         snapshot_utils::{self, ArchiveFormat},
     },
-    solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE, hash::Hash},
+    solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE},
     std::{
         fs::{self, File},
         io::{self, Read},
@@ -260,7 +261,7 @@ pub fn download_snapshot_archive<'a, 'b>(
     rpc_addr: &SocketAddr,
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
-    desired_snapshot_hash: (Slot, Hash),
+    desired_snapshot_hash: (Slot, SnapshotHash),
     snapshot_type: SnapshotType,
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -231,7 +231,7 @@ fn bank_forks_from_snapshot(
     let full_snapshot_hash = FullSnapshotHash {
         hash: (
             full_snapshot_archive_info.slot(),
-            *full_snapshot_archive_info.hash(),
+            full_snapshot_archive_info.hash().0,
         ),
     };
     let starting_incremental_snapshot_hash =
@@ -240,7 +240,7 @@ fn bank_forks_from_snapshot(
                 base: full_snapshot_hash.hash,
                 hash: (
                     incremental_snapshot_archive_info.slot(),
-                    *incremental_snapshot_archive_info.hash(),
+                    incremental_snapshot_archive_info.hash().0,
                 ),
             }
         });

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,6 +60,7 @@ use {
         message_processor::MessageProcessor,
         rent_collector::{CollectedInfo, RentCollector},
         runtime_config::RuntimeConfig,
+        snapshot_hash::SnapshotHash,
         stake_account::{self, StakeAccount},
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
@@ -6970,6 +6971,11 @@ impl Bank {
 
     pub fn get_accounts_hash(&self) -> Hash {
         self.rc.accounts.accounts_db.get_accounts_hash(self.slot)
+    }
+
+    pub fn get_snapshot_hash(&self) -> SnapshotHash {
+        let accounts_hash = self.get_accounts_hash();
+        SnapshotHash::new(&accounts_hash)
     }
 
     pub fn get_thread_pool(&self) -> &ThreadPool {

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -1,8 +1,11 @@
 //! Information about snapshot archives
 
 use {
-    crate::snapshot_utils::{self, ArchiveFormat, Result},
-    solana_sdk::{clock::Slot, hash::Hash},
+    crate::{
+        snapshot_hash::SnapshotHash,
+        snapshot_utils::{self, ArchiveFormat, Result},
+    },
+    solana_sdk::clock::Slot,
     std::{cmp::Ordering, path::PathBuf},
 };
 
@@ -18,7 +21,7 @@ pub trait SnapshotArchiveInfoGetter {
         self.snapshot_archive_info().slot
     }
 
-    fn hash(&self) -> &Hash {
+    fn hash(&self) -> &SnapshotHash {
         &self.snapshot_archive_info().hash
     }
 
@@ -45,8 +48,8 @@ pub struct SnapshotArchiveInfo {
     /// Slot that the snapshot was made
     pub slot: Slot,
 
-    /// Hash of the accounts at this slot
-    pub hash: Hash,
+    /// Hash for the snapshot
+    pub hash: SnapshotHash,
 
     /// Archive format for the snapshot file
     pub archive_format: ArchiveFormat,

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -42,3 +42,17 @@ pub struct IncrementalSnapshotHashes {
     pub base: (Slot, Hash),
     pub hashes: Vec<(Slot, Hash)>,
 }
+
+/// The hash used for snapshot archives
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct SnapshotHash(pub Hash);
+
+impl SnapshotHash {
+    /// Make a snapshot hash from an accounts hash
+    ///
+    /// Will soon also incorporate the epoch accounts hash
+    #[must_use]
+    pub fn new(accounts_hash: &Hash) -> Self {
+        Self(*accounts_hash)
+    }
+}

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -5,6 +5,7 @@ use {
         bank::{Bank, BankSlotDelta},
         rent_collector::RentCollector,
         snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
+        snapshot_hash::SnapshotHash,
         snapshot_utils::{
             self, ArchiveFormat, BankSnapshotInfo, Result, SnapshotVersion,
             TMP_BANK_SNAPSHOT_PREFIX,
@@ -182,6 +183,7 @@ pub struct SnapshotPackage {
 
 impl SnapshotPackage {
     pub fn new(accounts_package: AccountsPackage, accounts_hash: Hash) -> Self {
+        let snapshot_hash = SnapshotHash::new(&accounts_hash);
         let mut snapshot_storages = accounts_package.snapshot_storages;
         let (snapshot_type, snapshot_archive_path) = match accounts_package.package_type {
             AccountsPackageType::Snapshot(snapshot_type) => match snapshot_type {
@@ -190,7 +192,7 @@ impl SnapshotPackage {
                     snapshot_utils::build_full_snapshot_archive_path(
                         accounts_package.full_snapshot_archives_dir,
                         accounts_package.slot,
-                        &accounts_hash,
+                        &snapshot_hash,
                         accounts_package.archive_format,
                     ),
                 ),
@@ -213,7 +215,7 @@ impl SnapshotPackage {
                             accounts_package.incremental_snapshot_archives_dir,
                             incremental_snapshot_base_slot,
                             accounts_package.slot,
-                            &accounts_hash,
+                            &snapshot_hash,
                             accounts_package.archive_format,
                         ),
                     )
@@ -228,7 +230,7 @@ impl SnapshotPackage {
             snapshot_archive_info: SnapshotArchiveInfo {
                 path: snapshot_archive_path,
                 slot: accounts_package.slot,
-                hash: accounts_hash,
+                hash: snapshot_hash,
                 archive_format: accounts_package.archive_format,
             },
             block_height: accounts_package.block_height,


### PR DESCRIPTION
#### Problem

The hash used in various snapshot archive fields and parameters is a generic `Hash`. This makes it possible to accidentally use the wrong hash in those snapshot functions/structs. 

In preparation for including the EAH in the snapshot hash (https://github.com/solana-labs/solana/issues/28645), promoting the snapshot hash to its own type will (1) make the EAH support easier, since shared code can live in one place, and (2) make it hard to forget/miss a spot that does use the snapshot hash _without_ the new type.


#### Summary of Changes

Create a new type, `SnapshotHash`, that is used in structs/functions dealing with snapshot archives.

Note: This purposely does *not* change the types that interact with gossip/CRDS (which are `(Slot, Hash)`); that can be implemented in a subsequent PR.