### PR TITLE
Always verifies deserialized bank's slot and snapshot hash

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1011,6 +1011,18 @@ pub fn bank_from_snapshot_archives(
     measure_rebuild.stop();
     info!("{}", measure_rebuild);
 
+    verify_bank_against_expected_slot_hash(
+        &bank,
+        incremental_snapshot_archive_info.as_ref().map_or(
+            full_snapshot_archive_info.slot(),
+            |incremental_snapshot_archive_info| incremental_snapshot_archive_info.slot(),
+        ),
+        incremental_snapshot_archive_info.as_ref().map_or(
+            *full_snapshot_archive_info.hash(),
+            |incremental_snapshot_archive_info| *incremental_snapshot_archive_info.hash(),
+        ),
+    )?;
+
     let mut measure_verify = Measure::start("verify");
     if !bank.verify_snapshot_bank(
         test_hash_calculation,
@@ -1126,18 +1138,6 @@ pub fn bank_from_latest_snapshot_archives(
             i64
         ),
     );
-
-    verify_bank_against_expected_slot_hash(
-        &bank,
-        incremental_snapshot_archive_info.as_ref().map_or(
-            full_snapshot_archive_info.slot(),
-            |incremental_snapshot_archive_info| incremental_snapshot_archive_info.slot(),
-        ),
-        incremental_snapshot_archive_info.as_ref().map_or(
-            *full_snapshot_archive_info.hash(),
-            |incremental_snapshot_archive_info| *incremental_snapshot_archive_info.hash(),
-        ),
-    )?;
 
     Ok((
         bank,


### PR DESCRIPTION
#### Problem

`snapshot_utils::bank_from_snapshot_archives()` does not verify the deserialized bank's slot and snapshot hash against the snapshot archives it was given.

Normal validator calls `snapshot_utils::bank_from_latest_snapshot_archives()`, which *does* verify the slot and hash, so that was safe. But many tests call just the inner `bank_from_snapshot_archives()`. Including EAH tests, which is how I stumbled upon this while implementing https://github.com/solana-labs/solana/issues/28645.


#### Summary of Changes

Move the call to `verify_bank_against_expected_slot_hash()` from `bank_from_latest_snapshot_archives()` into `bank_from_snapshot_archives()`.

(Since `bank_from_latest_snapshot_archives()` calls `bank_from_snapshot_archives()`, this now ensures deserialized banks are always verified.)