### PR TITLE
Support Wasm32 build for RPC-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6044,6 +6047,7 @@ dependencies = [
  "futures 0.3.24",
  "gloo-timers",
  "indicatif",
+ "instant",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6058,7 +6058,6 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "tokio",
- "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goauth"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6030,6 +6042,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "futures 0.3.24",
+ "gloo-timers",
  "indicatif",
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6044,8 +6057,8 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-transaction-status",
  "solana-version",
- "solana-vote-program",
  "tokio",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -7938,9 +7951,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -7948,9 +7961,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -7963,9 +7976,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -7975,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote 1.0.18",
  "wasm-bindgen-macro-support",
@@ -7985,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -7998,9 +8011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -25,7 +25,12 @@ solana-sdk = { path = "../sdk", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
 thiserror = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 zstd = "0.11.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+zstd = { version = "0.11.2", default-features = false }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -21,7 +21,7 @@ solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.15.0"
 solana-program = { path = "../../sdk/program", version = "=1.15.0" }
 thiserror = "1.0"
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
+[target.'cfg(not(any(target_os = "solana", target_arch = "wasm32")))'.dependencies]
 solana-program-runtime = { path = "../../program-runtime", version = "=1.15.0" }
 solana-sdk = { path = "../../sdk", version = "=1.15.0" }
 

--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -6,7 +6,7 @@ use solana_program::declare_id;
 
 pub mod error;
 pub mod instruction;
-#[cfg(not(target_os = "solana"))]
+#[cfg(not(any(target_os = "solana", target_arch = "wasm32")))]
 pub mod processor;
 pub mod state;
 

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -14,8 +14,10 @@ bincode = "1.3.3"
 chrono = { version = "0.4.22", features = ["serde"] }
 serde = "1.0.144"
 serde_derive = "1.0.103"
-solana-program-runtime = { path = "../../program-runtime", version = "=1.15.0" }
 solana-sdk = { path = "../../sdk", version = "=1.15.0" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+solana-program-runtime = { path = "../../program-runtime", version = "=1.15.0" }
 
 [dev-dependencies]
 solana-logger = { path = "../../logger", version = "=1.15.0" }

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 pub mod config_instruction;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod config_processor;
 pub mod date_instruction;
 

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.2.4", features = ["futures"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -26,8 +26,13 @@ solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.15.0" }
 solana-version = { path = "../version", version = "=1.15.0" }
-solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.2.4", features = ["futures"] }
+wasm-bindgen-futures = "0.4.33"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.2.4", features = ["futures"] }
-wasm-bindgen-futures = "0.4.33"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -21,16 +21,22 @@ use {
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
         },
-        time::{Duration, Instant},
+        time::Duration,
     },
 };
 
 
 #[cfg(not(target_arch = "wasm32"))]
-use tokio::time::sleep;
+use {
+    std::time::Instant,
+    tokio::time::sleep,
+};
 
 #[cfg(target_arch = "wasm32")]
-use gloo_timers::future::sleep;
+use {
+    gloo_timers::future::sleep,
+    instant::Instant,
+};
 
 
 pub struct HttpSender {

--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod http_sender;
 pub mod mock_sender;
 pub mod nonblocking;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod rpc_client;
 pub mod rpc_sender;
 pub mod spinner;

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -87,7 +87,8 @@ impl MockSender {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl RpcSender for MockSender {
     fn get_transport_stats(&self) -> RpcTransportStats {
         RpcTransportStats::default()

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -58,16 +58,17 @@ use {
     std::{
         net::SocketAddr,
         str::FromStr,
-        time::{Duration, Instant},
+        time::Duration,
     },
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use tokio::{sync::RwLock, time::sleep};
+use tokio::{sync::RwLock, time::{sleep, Instant}};
 
 #[cfg(target_arch = "wasm32")]
 use {
     gloo_timers::future::sleep,
+    instant::Instant,
     std::sync::RwLock,
 };
 

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -21,7 +21,6 @@ use {
         nonblocking::{self, rpc_client::get_rpc_request_str},
         rpc_sender::*,
     },
-    serde::Serialize,
     serde_json::Value,
     solana_account_decoder::{
         parse_token::{UiTokenAccount, UiTokenAmount},
@@ -41,10 +40,9 @@ use {
         epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
-        message::{v0, Message as LegacyMessage},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, uses_durable_nonce, Transaction, VersionedTransaction},
+        transaction,
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, TransactionStatus,
@@ -53,64 +51,10 @@ use {
     std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration},
 };
 
-#[derive(Default)]
-pub struct RpcClientConfig {
-    pub commitment_config: CommitmentConfig,
-    pub confirm_transaction_initial_timeout: Option<Duration>,
-}
-
-impl RpcClientConfig {
-    pub fn with_commitment(commitment_config: CommitmentConfig) -> Self {
-        RpcClientConfig {
-            commitment_config,
-            ..Self::default()
-        }
-    }
-}
-
-/// Trait used to add support for versioned messages to RPC APIs while
-/// retaining backwards compatibility
-pub trait SerializableMessage: Serialize {}
-impl SerializableMessage for LegacyMessage {}
-impl SerializableMessage for v0::Message {}
-
-/// Trait used to add support for versioned transactions to RPC APIs while
-/// retaining backwards compatibility
-pub trait SerializableTransaction: Serialize {
-    fn get_signature(&self) -> &Signature;
-    fn get_recent_blockhash(&self) -> &Hash;
-    fn uses_durable_nonce(&self) -> bool;
-}
-impl SerializableTransaction for Transaction {
-    fn get_signature(&self) -> &Signature {
-        &self.signatures[0]
-    }
-    fn get_recent_blockhash(&self) -> &Hash {
-        &self.message.recent_blockhash
-    }
-    fn uses_durable_nonce(&self) -> bool {
-        uses_durable_nonce(self).is_some()
-    }
-}
-impl SerializableTransaction for VersionedTransaction {
-    fn get_signature(&self) -> &Signature {
-        &self.signatures[0]
-    }
-    fn get_recent_blockhash(&self) -> &Hash {
-        self.message.recent_blockhash()
-    }
-    fn uses_durable_nonce(&self) -> bool {
-        self.uses_durable_nonce()
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct GetConfirmedSignaturesForAddress2Config {
-    pub before: Option<Signature>,
-    pub until: Option<Signature>,
-    pub limit: Option<usize>,
-    pub commitment: Option<CommitmentConfig>,
-}
+pub use crate::nonblocking::rpc_client::{
+    GetConfirmedSignaturesForAddress2Config, RpcClientConfig, SerializableMessage,
+    SerializableTransaction,
+};
 
 /// A client of a remote Solana node.
 ///

--- a/rpc-client/src/rpc_sender.rs
+++ b/rpc-client/src/rpc_sender.rs
@@ -24,7 +24,8 @@ pub struct RpcTransportStats {
 /// responses from, a Solana node, and is used primarily by [`RpcClient`].
 ///
 /// [`RpcClient`]: crate::rpc_client::RpcClient
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait RpcSender {
     async fn send(
         &self,


### PR DESCRIPTION
#### Problem

Solana RPC-client does not build for wasm32. 

#### Summary of Changes

Used conditional compilation to switch dependencies for build the RPC-client for wasm32.

Related Issue: #23552
