### PR TITLE
Add ability to choose client type in GCE cluster scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -814,6 +814,7 @@ extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
 clientType=thin-client
+url=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -959,6 +960,9 @@ while [[ -n $1 ]]; do
           exit 1
           ;;
       esac
+      shift 2
+    elif [[ $1 = --url ]]; then
+      url=$2
       shift 2
     else
       usage "Unknown long option: $1"

--- a/net/net.sh
+++ b/net/net.sh
@@ -425,7 +425,7 @@ startClient() {
     startCommon "$ipAddress"
     ssh "${sshOptions[@]}" -f "$ipAddress" \
       "./solana/net/remote/remote-client.sh $deployMethod $entrypointIp \
-      $clientToRun \"$RUST_LOG\" \"$benchTpsExtraArgs\" $clientIndex"
+      $clientToRun \"$RUST_LOG\" \"$benchTpsExtraArgs\" $clientIndex $clientType"
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
     echo "^^^ +++"

--- a/net/net.sh
+++ b/net/net.sh
@@ -814,7 +814,6 @@ extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
 clientType=thin-client
-url=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -960,9 +959,6 @@ while [[ -n $1 ]]; do
           exit 1
           ;;
       esac
-      shift 2
-    elif [[ $1 = --url ]]; then
-      url=$2
       shift 2
     else
       usage "Unknown long option: $1"

--- a/net/net.sh
+++ b/net/net.sh
@@ -813,6 +813,7 @@ waitForNodeInit=true
 extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
+clientType=thin-client
 
 command=$1
 [[ -n $command ]] || usage
@@ -948,6 +949,17 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-require-tower ]]; then
       maybeSkipRequireTower="$1"
       shift 1
+    elif [[ $1 = --client-type ]]; then
+      clientType=$2
+      case "$clientType" in
+        thin-client|tpu-client|rpc-client)
+          ;;
+        *)
+          echo "Unexpected client type: \"$clientType\""
+          exit 1
+          ;;
+      esac
+      shift 2
     else
       usage "Unknown long option: $1"
     fi

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -68,15 +68,15 @@ case $clientToRun in
 solana-bench-tps)
   net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/config/bench-tps"$clientIndex".yml ./client-accounts.yml
-  
+
   args=()
-  
+
   if ${TPU_CLIENT}; then
     args+=(--use-tpu-client)
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
   fi
-  
+
   clientCommand="\
     solana-bench-tps \
       --entrypoint $entrypointIp:8001 \

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -12,8 +12,6 @@ fi
 benchTpsExtraArgs="$5"
 clientIndex="$6"
 clientType="${7:-thin-client}"
-url="${8:-""}"
-
 
 missing() {
   echo "Error: $1 not specified"
@@ -74,18 +72,12 @@ solana-bench-tps)
 
   if ${TPU_CLIENT}; then
     args+=(--use-tpu-client)
+    args+=(--url "$entrypointIp:8899")
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
+    args+=(--url "$entrypointIp:8899")
   else
     args+=(--entrypoint "$entrypointIp:8001")
-  fi
-
-  if ${TPU_CLIENT} || ${RPC_CLIENT}; then 
-    if [[ url = "" ]]; then
-       echo "URL param must be specified for tpu and rpc client"
-       exit 1
-    fi
-    args+=(--url "$url")
   fi
 
   clientCommand="\

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -11,6 +11,8 @@ if [[ -n $4 ]]; then
 fi
 benchTpsExtraArgs="$5"
 clientIndex="$6"
+clientType="${7:-thin-client}"
+
 
 missing() {
   echo "Error: $1 not specified"
@@ -41,10 +43,40 @@ skip)
   exit 1
 esac
 
+TPU_CLIENT=false
+RPC_CLIENT=false
+case "$clientType" in
+  thin-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=false
+    ;;
+  tpu-client)
+    TPU_CLIENT=true
+    RPC_CLIENT=false
+    ;;
+  rpc-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=true
+    ;;
+  *)
+    echo "Unexpected clientType: \"$clientType\""
+    exit 1
+    ;;
+esac
+
 case $clientToRun in
 solana-bench-tps)
   net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/config/bench-tps"$clientIndex".yml ./client-accounts.yml
+  
+  args=()
+  
+  if ${TPU_CLIENT}; then
+    args+=(--use-tpu-client)
+  elif ${RPC_CLIENT}; then
+    args+=(--use-rpc-client)
+  fi
+  
   clientCommand="\
     solana-bench-tps \
       --entrypoint $entrypointIp:8001 \
@@ -53,6 +85,7 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
+      ${args[@]} \
   "
   ;;
 idle)

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -12,6 +12,7 @@ fi
 benchTpsExtraArgs="$5"
 clientIndex="$6"
 clientType="${7:-thin-client}"
+url="${8:-""}"
 
 
 missing() {
@@ -75,11 +76,20 @@ solana-bench-tps)
     args+=(--use-tpu-client)
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
+  else
+    args+=(--entrypoint "$entrypointIp:8001")
+  fi
+
+  if ${TPU_CLIENT} || ${RPC_CLIENT}; then 
+    if [[ url = "" ]]; then
+       echo "URL param must be specified for tpu and rpc client"
+       exit 1
+    fi
+    args+=(--url "$url")
   fi
 
   clientCommand="\
     solana-bench-tps \
-      --entrypoint $entrypointIp:8001 \
       --duration 7500 \
       --sustained \
       --threads $threadCount \

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -85,7 +85,7 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
-      ${args[@]} \
+      ${args[*]} \
   "
   ;;
 idle)

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -30,6 +30,7 @@ extraPrimordialStakes="${21:=0}"
 tmpfsAccounts="${22:false}"
 disableQuic="${23}"
 enableUdp="${24}"
+clientType="${25:-thin-client}"
 
 set +x
 
@@ -92,6 +93,27 @@ case "$gpuMode" in
     ;;
   *)
     echo "Unexpected gpuMode: \"$gpuMode\""
+    exit 1
+    ;;
+esac
+
+TPU_CLIENT=false
+RPC_CLIENT=false
+case "$clientType" in
+  thin-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=false
+    ;;
+  tpu-client)
+    TPU_CLIENT=true
+    RPC_CLIENT=false
+    ;;
+  rpc-client)
+    TPU_CLIENT=false
+    RPC_CLIENT=true
+    ;;
+  *)
+    echo "Unexpected clientType: \"$clientType\""
     exit 1
     ;;
 esac
@@ -293,6 +315,12 @@ EOF
 
     if $enableUdp; then
       args+=(--tpu-enable-udp)
+    fi
+
+    if ${TPU_CLIENT}; then
+        args+=(--use-tpu-client)
+    elif ${RPC_CLIENT}; then
+        args+=(--use-rpc-client)
     fi
 
     if [[ $airdropsEnabled = true ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -30,7 +30,6 @@ extraPrimordialStakes="${21:=0}"
 tmpfsAccounts="${22:false}"
 disableQuic="${23}"
 enableUdp="${24}"
-clientType="${25:-thin-client}"
 
 set +x
 
@@ -93,27 +92,6 @@ case "$gpuMode" in
     ;;
   *)
     echo "Unexpected gpuMode: \"$gpuMode\""
-    exit 1
-    ;;
-esac
-
-TPU_CLIENT=false
-RPC_CLIENT=false
-case "$clientType" in
-  thin-client)
-    TPU_CLIENT=false
-    RPC_CLIENT=false
-    ;;
-  tpu-client)
-    TPU_CLIENT=true
-    RPC_CLIENT=false
-    ;;
-  rpc-client)
-    TPU_CLIENT=false
-    RPC_CLIENT=true
-    ;;
-  *)
-    echo "Unexpected clientType: \"$clientType\""
     exit 1
     ;;
 esac
@@ -315,12 +293,6 @@ EOF
 
     if $enableUdp; then
       args+=(--tpu-enable-udp)
-    fi
-
-    if ${TPU_CLIENT}; then
-        args+=(--use-tpu-client)
-    elif ${RPC_CLIENT}; then
-        args+=(--use-rpc-client)
     fi
 
     if [[ $airdropsEnabled = true ]]; then


### PR DESCRIPTION
#### Problem
Currently, there's not convenient way to choose the client type in the net scripts.

#### Summary of Changes
Add such an option

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
