### PR TITLE
Fix clippy warnings on Windows

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -455,7 +455,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                     break;
                 }
             }
-            source.replace("\\", "/")
+            source.replace('\\', "/")
         }
         #[cfg(not(target_family = "windows"))]
         {

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -455,7 +455,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                     break;
                 }
             }
-            source.replace("\\", "/")
+            source.replace('\\', "/")
         }
         #[cfg(not(target_family = "windows"))]
         {


### PR DESCRIPTION
#### Problem

When running cilppy linter on Windows, clippy warns about using string for single character for such lines:
```
source.replace("\\", "/")
```

#### Summary of Changes

Fixes #
Both lines were changed to this:
```
source.replace('\\', "/")
```