### PR TITLE
Removes EAH string from datapoint metric

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6747,11 +6747,6 @@ impl Bank {
         datapoint_info!(
             "bank-wait_get_epoch_accounts_hash",
             ("slot", self.slot() as i64, i64),
-            (
-                "epoch_accounts_hash",
-                epoch_accounts_hash.as_ref().to_string(),
-                String
-            ),
             ("waiting-time-us", measure.as_us() as i64, i64),
         );
         epoch_accounts_hash


### PR DESCRIPTION
#### Problem

Submitting long strings to metrics is not great; it is expensive to both store and query.

In this case, the actual epoch accounts hash is not useful, so no need to submit it.


#### Summary of Changes

Remove the EAH datapoint.