### PR TITLE
Do not take bank snapshots for EAH requests

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -283,7 +283,7 @@ impl SnapshotRequestHandler {
         let SnapshotRequest {
             snapshot_root_bank,
             status_cache_slot_deltas,
-            request_type: _,
+            request_type,
             enqueued: _,
         } = snapshot_request;
 
@@ -374,37 +374,52 @@ impl SnapshotRequestHandler {
 
         // Snapshot the bank and send over an accounts package
         let mut snapshot_time = Measure::start("snapshot_time");
-        let result = snapshot_utils::snapshot_bank(
-            &snapshot_root_bank,
-            status_cache_slot_deltas,
-            &self.accounts_package_sender,
-            &self.snapshot_config.bank_snapshots_dir,
-            &self.snapshot_config.full_snapshot_archives_dir,
-            &self.snapshot_config.incremental_snapshot_archives_dir,
-            self.snapshot_config.snapshot_version,
-            self.snapshot_config.archive_format,
-            hash_for_testing,
-            accounts_package_type,
-        );
-        if let Err(e) = result {
-            warn!(
-                "Error taking bank snapshot. slot: {}, accounts package type: {:?}, err: {:?}",
-                snapshot_root_bank.slot(),
-                accounts_package_type,
-                e,
-            );
-
-            if Self::is_snapshot_error_fatal(&e) {
-                return Err(e);
+        let snapshot_storages = snapshot_utils::get_snapshot_storages(&snapshot_root_bank);
+        let accounts_package = match request_type {
+            SnapshotRequestType::Snapshot => {
+                let bank_snapshot_info = snapshot_utils::add_bank_snapshot(
+                    &self.snapshot_config.bank_snapshots_dir,
+                    &snapshot_root_bank,
+                    &snapshot_storages,
+                    self.snapshot_config.snapshot_version,
+                )
+                .expect("snapshot bank");
+                AccountsPackage::new_for_snapshot(
+                    accounts_package_type,
+                    &snapshot_root_bank,
+                    &bank_snapshot_info,
+                    &self.snapshot_config.bank_snapshots_dir,
+                    status_cache_slot_deltas,
+                    &self.snapshot_config.full_snapshot_archives_dir,
+                    &self.snapshot_config.incremental_snapshot_archives_dir,
+                    snapshot_storages,
+                    self.snapshot_config.archive_format,
+                    self.snapshot_config.snapshot_version,
+                    hash_for_testing,
+                )
+                .expect("new accounts package for snapshot")
             }
-        }
+            SnapshotRequestType::EpochAccountsHash => {
+                // skip the bank snapshot, just make an accounts package to send to AHV
+                AccountsPackage::new_for_epoch_accounts_hash(
+                    accounts_package_type,
+                    &snapshot_root_bank,
+                    snapshot_storages,
+                    hash_for_testing,
+                )
+            }
+        };
+        self.accounts_package_sender
+            .send(accounts_package)
+            .expect("send accounts package");
         snapshot_time.stop();
-        info!("Took bank snapshot. accounts package type: {:?}, slot: {}, accounts hash: {}, bank hash: {}",
-              accounts_package_type,
-              snapshot_root_bank.slot(),
-              snapshot_root_bank.get_accounts_hash(),
-              snapshot_root_bank.hash(),
-              );
+
+        info!(
+            "Took bank snapshot. accounts package type: {:?}, slot: {}, bank hash: {}",
+            accounts_package_type,
+            snapshot_root_bank.slot(),
+            snapshot_root_bank.hash(),
+        );
 
         // Cleanup outdated snapshots
         let mut purge_old_snapshots_time = Measure::start("purge_old_snapshots_time");
@@ -431,31 +446,6 @@ impl SnapshotRequestHandler {
             ("non_snapshot_time_us", non_snapshot_time_us, i64),
         );
         Ok(snapshot_root_bank.block_height())
-    }
-
-    /// Check if a SnapshotError should be treated as 'fatal' by SnapshotRequestHandler, and
-    /// `handle_snapshot_requests()` in particular.  Fatal errors will cause the node to shutdown.
-    /// Non-fatal errors are logged and then swallowed.
-    ///
-    /// All `SnapshotError`s are enumerated, and there is **NO** default case.  This way, if
-    /// a new error is added to SnapshotError, a conscious decision must be made on how it should
-    /// be handled.
-    fn is_snapshot_error_fatal(err: &SnapshotError) -> bool {
-        match err {
-            SnapshotError::Io(..) => true,
-            SnapshotError::Serialize(..) => true,
-            SnapshotError::ArchiveGenerationFailure(..) => true,
-            SnapshotError::StoragePathSymlinkInvalid => true,
-            SnapshotError::UnpackError(..) => true,
-            SnapshotError::IoWithSource(..) => true,
-            SnapshotError::PathToFileNameError(..) => true,
-            SnapshotError::FileNameToStrError(..) => true,
-            SnapshotError::ParseSnapshotArchiveFileNameError(..) => true,
-            SnapshotError::MismatchedBaseSlot(..) => true,
-            SnapshotError::NoSnapshotArchives => true,
-            SnapshotError::MismatchedSlotHash(..) => true,
-            SnapshotError::VerifySlotDeltas(..) => true,
-        }
     }
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -747,12 +747,18 @@ where
 }
 
 /// Serialize a bank to a snapshot
+///
+/// **DEVELOPER NOTE** Any error that is returned from this function may bring down the node!  This
+/// function is called from AccountsBackgroundService to handle snapshot requests.  Since taking a
+/// snapshot is not permitted to fail, any errors returned here will trigger the node to shutdown.
+/// So, be careful whenever adding new code that may return errors.
 pub fn add_bank_snapshot<P: AsRef<Path>>(
     bank_snapshots_dir: P,
     bank: &Bank,
     snapshot_storages: &[SnapshotStorage],
     snapshot_version: SnapshotVersion,
 ) -> Result<BankSnapshotInfo> {
+    let mut add_snapshot_time = Measure::start("add-snapshot-ms");
     let slot = bank.slot();
     // bank_snapshots_dir/slot
     let bank_snapshots_dir = get_bank_snapshots_dir(bank_snapshots_dir, slot);
@@ -779,6 +785,7 @@ pub fn add_bank_snapshot<P: AsRef<Path>>(
     let consumed_size =
         serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer)?;
     bank_serialize.stop();
+    add_snapshot_time.stop();
 
     // Monitor sizes because they're capped to MAX_SNAPSHOT_DATA_FILE_SIZE
     datapoint_info!(
@@ -788,6 +795,7 @@ pub fn add_bank_snapshot<P: AsRef<Path>>(
     );
 
     inc_new_counter_info!("bank-serialize-ms", bank_serialize.as_ms() as usize);
+    inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
 
     info!(
         "{} for slot {} at {}",
@@ -2076,62 +2084,8 @@ pub fn purge_old_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) {
     do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
 }
 
-/// Gather the necessary elements for a snapshot of the given `root_bank`.
-///
-/// **DEVELOPER NOTE** Any error that is returned from this function may bring down the node!  This
-/// function is called from AccountsBackgroundService to handle snapshot requests.  Since taking a
-/// snapshot is not permitted to fail, any errors returned here will trigger the node to shutdown.
-/// So, be careful whenever adding new code that may return errors.
-#[allow(clippy::too_many_arguments)]
-pub fn snapshot_bank(
-    root_bank: &Bank,
-    status_cache_slot_deltas: Vec<BankSlotDelta>,
-    accounts_package_sender: &Sender<AccountsPackage>,
-    bank_snapshots_dir: impl AsRef<Path>,
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-    snapshot_version: SnapshotVersion,
-    archive_format: ArchiveFormat,
-    hash_for_testing: Option<Hash>,
-    accounts_package_type: AccountsPackageType,
-) -> Result<()> {
-    let snapshot_storages = get_snapshot_storages(root_bank);
-
-    let mut add_snapshot_time = Measure::start("add-snapshot-ms");
-    let bank_snapshot_info = add_bank_snapshot(
-        &bank_snapshots_dir,
-        root_bank,
-        &snapshot_storages,
-        snapshot_version,
-    )?;
-    add_snapshot_time.stop();
-    inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
-
-    let accounts_package = AccountsPackage::new(
-        accounts_package_type,
-        root_bank,
-        &bank_snapshot_info,
-        bank_snapshots_dir,
-        status_cache_slot_deltas,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
-        snapshot_storages,
-        archive_format,
-        snapshot_version,
-        hash_for_testing,
-    )
-    .expect("failed to hard link bank snapshot into a tmpdir");
-
-    // Submit the accounts package
-    accounts_package_sender
-        .send(accounts_package)
-        .expect("send accounts package");
-
-    Ok(())
-}
-
 /// Get the snapshot storages for this bank
-fn get_snapshot_storages(bank: &Bank) -> SnapshotStorages {
+pub fn get_snapshot_storages(bank: &Bank) -> SnapshotStorages {
     let mut measure_snapshot_storages = Measure::start("snapshot-storages");
     let snapshot_storages = bank.get_snapshot_storages(None);
     measure_snapshot_storages.stop();
@@ -2256,7 +2210,7 @@ pub fn package_and_archive_full_snapshot(
     maximum_incremental_snapshot_archives_to_retain: usize,
 ) -> Result<FullSnapshotArchiveInfo> {
     let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let accounts_package = AccountsPackage::new(
+    let accounts_package = AccountsPackage::new_for_snapshot(
         AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
         bank,
         bank_snapshot_info,
@@ -2271,7 +2225,12 @@ pub fn package_and_archive_full_snapshot(
     )?;
 
     crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-        accounts_package.snapshot_links.path(),
+        accounts_package
+            .snapshot_info
+            .as_ref()
+            .unwrap()
+            .snapshot_links
+            .path(),
         accounts_package.slot,
         &bank.get_accounts_hash(),
         None,
@@ -2307,7 +2266,7 @@ pub fn package_and_archive_incremental_snapshot(
     maximum_incremental_snapshot_archives_to_retain: usize,
 ) -> Result<IncrementalSnapshotArchiveInfo> {
     let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let accounts_package = AccountsPackage::new(
+    let accounts_package = AccountsPackage::new_for_snapshot(
         AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(
             incremental_snapshot_base_slot,
         )),
@@ -2324,7 +2283,12 @@ pub fn package_and_archive_incremental_snapshot(
     )?;
 
     crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-        accounts_package.snapshot_links.path(),
+        accounts_package
+            .snapshot_info
+            .as_ref()
+            .unwrap()
+            .snapshot_links
+            .path(),
         accounts_package.slot,
         &bank.get_accounts_hash(),
         None,


### PR DESCRIPTION
#### Problem

While working on https://github.com/solana-labs/solana/issues/28722, I discovered that an when handling an EAH request, ABS makes a bank snapshot then passes the package off to AHV to calculate the accounts hash.

If the EAH must be ready for the bank snapshot, but the request itself is an EAH request, then the EAH will not be available yet (since AHV hasn't processed it yet). So, chicken-and-egg problem.

#### Summary of Changes

Do not take bank snapshots for EAH requests.

This should be fine. EAH requests are *not* snapshot requests, so there is no issue skipped anything that is meant for real snapshots.

NOTE: This PR is pretty large. I likely will break it up into a few pieces.