### PR TITLE
Fix 2 clippy warnings with temporary references

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -400,7 +400,7 @@ fn add_to_path(new_path: &str) -> bool {
         return false;
     };
 
-    if !old_path.contains(&new_path) {
+    if !old_path.contains(new_path) {
         let mut new_path = new_path.to_string();
         if !old_path.is_empty() {
             new_path.push(';');

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -699,7 +699,7 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
             #[cfg(windows)]
             let output = spawn(
                 &llvm_bin.join("llvm-objcopy"),
-                &[
+                [
                     "--strip-all".as_ref(),
                     program_unstripped_so.as_os_str(),
                     program_so.as_os_str(),


### PR DESCRIPTION
#### Problem

After upgrading to Rust 1.65 clippy prints two new warnings:

```
warning: the borrowed expression implements the required traits
   --> sdk\cargo-build-sbf\src/main.rs:702:17
    |
702 | /                 &[
703 | |                     "--strip-all".as_ref(),
704 | |                     program_unstripped_so.as_os_str(),
705 | |                     program_so.as_os_str(),
706 | |                 ],
    | |_________________^
    |
    = note: #[warn(clippy::needless_borrow)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
help: change this to
    |
702 ~                 [
703 +                     "--strip-all".as_ref(),
704 +                     program_unstripped_so.as_os_str(),
705 +                     program_so.as_os_str(),
706 ~                 ],
    |

warning: the borrowed expression implements the required traits
   --> install\src\command.rs:403:27
    |
403 |     if !old_path.contains(&new_path) {
    |                           ^^^^^^^^^ help: change this to: new_path
    |
    = note: #[warn(clippy::needless_borrow)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

#### Summary of Changes

Removed excessive references before arguments.
