### PR TITLE
report ancient stats correctly in drop_or_recycle_stores

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1334,7 +1334,7 @@ pub struct AccountsDb {
     // Stats for purges called outside of clean_accounts()
     external_purge_slots_stats: PurgeStats,
 
-    shrink_stats: ShrinkStats,
+    pub(crate) shrink_stats: ShrinkStats,
 
     shrink_ancient_stats: ShrinkAncientStats,
 
@@ -1839,7 +1839,7 @@ struct ShrinkAncientStats {
 }
 
 #[derive(Debug, Default)]
-struct ShrinkStats {
+pub(crate) struct ShrinkStats {
     last_report: AtomicInterval,
     num_slots_shrunk: AtomicUsize,
     storage_read_elapsed: AtomicU64,
@@ -3871,7 +3871,12 @@ impl AccountsDb {
     /// common code from shrink and combine_ancient_slots
     /// get rid of all original store_ids in the slot
     /// returns remaining stores
-    fn remove_old_stores_shrink(&self, shrink_collect: &ShrinkCollect, slot: Slot) -> usize {
+    fn remove_old_stores_shrink(
+        &self,
+        shrink_collect: &ShrinkCollect,
+        slot: Slot,
+        stats: &ShrinkStats,
+    ) -> usize {
         // Purge old, overwritten storage entries
         let (remaining_stores, dead_storages) = self.mark_dirty_dead_stores(
             slot,
@@ -3888,7 +3893,7 @@ impl AccountsDb {
             );
         }
 
-        self.drop_or_recycle_stores(dead_storages);
+        self.drop_or_recycle_stores(dead_storages, stats);
         remaining_stores
     }
 
@@ -3974,7 +3979,7 @@ impl AccountsDb {
             self.shrink_candidate_slots.lock().unwrap().remove(&slot);
 
             let (remaining_stores, remove_old_stores_shrink) =
-                measure!(self.remove_old_stores_shrink(&shrink_collect, slot));
+                measure!(self.remove_old_stores_shrink(&shrink_collect, slot, &self.shrink_stats));
             remove_old_stores_shrink_us = remove_old_stores_shrink.as_us();
             if remaining_stores > 1 {
                 inc_new_counter_info!("accounts_db_shrink_extra_stores", 1);
@@ -4068,7 +4073,11 @@ impl AccountsDb {
         (remaining_stores, dead_storages)
     }
 
-    pub(crate) fn drop_or_recycle_stores(&self, dead_storages: Vec<Arc<AccountStorageEntry>>) {
+    pub(crate) fn drop_or_recycle_stores(
+        &self,
+        dead_storages: Vec<Arc<AccountStorageEntry>>,
+        stats: &ShrinkStats,
+    ) {
         let mut recycle_stores_write_elapsed = Measure::start("recycle_stores_write_time");
         let mut recycle_stores = self.recycle_stores.write().unwrap();
         recycle_stores_write_elapsed.stop();
@@ -4085,10 +4094,10 @@ impl AccountsDb {
             drop(dead_storages);
         }
         drop_storage_entries_elapsed.stop();
-        self.shrink_stats
+        stats
             .drop_storage_entries_elapsed
             .fetch_add(drop_storage_entries_elapsed.as_us(), Ordering::Relaxed);
-        self.shrink_stats
+        stats
             .recycle_stores_write_elapsed
             .fetch_add(recycle_stores_write_elapsed.as_us(), Ordering::Relaxed);
     }
@@ -4510,8 +4519,12 @@ impl AccountsDb {
                 dropped_roots.push(slot);
             }
 
-            let (_remaining_stores, remove_old_stores_shrink) =
-                measure!(self.remove_old_stores_shrink(&shrink_collect, slot));
+            let (_remaining_stores, remove_old_stores_shrink) = measure!(self
+                .remove_old_stores_shrink(
+                    &shrink_collect,
+                    slot,
+                    &self.shrink_ancient_stats.shrink_stats
+                ));
 
             // we should not try to shrink any of the stores from this slot anymore. All shrinking for this slot is now handled by ancient append vec code.
             self.shrink_candidate_slots.lock().unwrap().remove(&slot);

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -240,7 +240,8 @@ impl<'a> SnapshotMinimizer<'a> {
         info!("{purge_dead_slots_measure}");
 
         let (_, drop_or_recycle_stores_measure) = measure!(
-            self.accounts_db().drop_or_recycle_stores(dead_storages),
+            self.accounts_db()
+                .drop_or_recycle_stores(dead_storages, &self.accounts_db().shrink_stats),
             "drop or recycle stores"
         );
         info!("{drop_or_recycle_stores_measure}");


### PR DESCRIPTION
#### Problem
all stats from `drop_or_recycle_stores` were going to `shrink_stats`

#### Summary of Changes
correctly use `ancient_shrink_stats`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
