### PR TITLE
remove unused stat ancient.skipped_shrink

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2073,11 +2073,6 @@ impl ShrinkAncientStats {
                     i64
                 ),
                 (
-                    "skipped_shrink",
-                    self.shrink_stats.skipped_shrink.swap(0, Ordering::Relaxed) as i64,
-                    i64
-                ),
-                (
                     "alive_accounts",
                     self.shrink_stats.alive_accounts.swap(0, Ordering::Relaxed) as i64,
                     i64


### PR DESCRIPTION
#### Problem
A stat used by shrink is not used by ancient append vecs.

#### Summary of Changes
Don't report this stat.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
