### PR TITLE
Removes `snapshot_bank()` wrapper fn

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -408,19 +408,29 @@ fn test_concurrent_snapshot_packaging(
             }
         };
 
-        snapshot_utils::snapshot_bank(
-            &bank,
-            vec![],
-            accounts_package_sender,
+        let snapshot_storages = bank.get_snapshot_storages(None);
+        let bank_snapshot_info = snapshot_utils::add_bank_snapshot(
             bank_snapshots_dir,
-            full_snapshot_archives_dir,
-            incremental_snapshot_archives_dir,
+            &bank,
+            &snapshot_storages,
             snapshot_config.snapshot_version,
-            snapshot_config.archive_format,
-            None,
-            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
         )
         .unwrap();
+        let accounts_package = AccountsPackage::new(
+            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
+            &bank,
+            &bank_snapshot_info,
+            bank_snapshots_dir,
+            vec![],
+            full_snapshot_archives_dir,
+            incremental_snapshot_archives_dir,
+            snapshot_storages,
+            snapshot_config.archive_format,
+            snapshot_config.snapshot_version,
+            None,
+        )
+        .unwrap();
+        accounts_package_sender.send(accounts_package).unwrap();
 
         bank_forks.insert(bank);
         if slot == saved_slot as u64 {


### PR DESCRIPTION
Builds on https://github.com/solana-labs/solana/pull/28752

#### Problem

Splitting up PR https://github.com/solana-labs/solana/pull/28730.

The `snapshot_bank()` wrapper function makes it less straight-forward to skip taking a bank snapshot.

#### Summary of Changes

To support #28722 and PR #28730, we want to make it straight-forward to skip a bank snapshot. Remove the `snapshot_bank()` function, and inline its contents at call sites.