### PR TITLE
Simplifies AHV's `test_max_hashes()`

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -535,14 +535,12 @@ mod tests {
             incremental_snapshot_archive_interval_slots: Slot::MAX,
             ..SnapshotConfig::default()
         };
-        let accounts = Arc::new(solana_runtime::accounts::Accounts::default_for_tests());
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
+            let slot = full_snapshot_archive_interval_slots + i as u64;
             let accounts_package = AccountsPackage {
-                package_type: AccountsPackageType::AccountsHashVerifier,
-                slot: full_snapshot_archive_interval_slots + i as u64,
-                block_height: full_snapshot_archive_interval_slots + i as u64,
-                accounts: Arc::clone(&accounts),
+                slot,
+                block_height: slot,
                 ..AccountsPackage::default_for_tests()
             };
 
@@ -558,7 +556,7 @@ mod tests {
                 Some(&snapshot_config),
             );
 
-            // sleep for 1ms to create a newer timestmap for gossip entry
+            // sleep for 1ms to create a newer timestamp for gossip entry
             // otherwise the timestamp won't be newer.
             std::thread::sleep(Duration::from_millis(1));
         }


### PR DESCRIPTION
#### Problem

`test_max_hahes()` in Accounts Hash Verifier is not as simple as it can be.

As part ot https://github.com/solana-labs/solana/pull/28730/, I needed to make a few changes for the tests to pass. Those changes can be done in their own PR.

#### Summary of Changes

Simplify `test_max_hashes()`