### PR TITLE
Skips taking a bank snapshot for EAH requests

### DIFF
--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -117,6 +117,24 @@ impl AccountsPackage {
         ))
     }
 
+    /// Package up fields needed to compute an EpochAccountsHash
+    #[must_use]
+    pub fn new_for_epoch_accounts_hash(
+        package_type: AccountsPackageType,
+        bank: &Bank,
+        snapshot_storages: SnapshotStorages,
+        accounts_hash_for_testing: Option<Hash>,
+    ) -> Self {
+        assert_eq!(package_type, AccountsPackageType::EpochAccountsHash);
+        Self::_new(
+            package_type,
+            bank,
+            snapshot_storages,
+            accounts_hash_for_testing,
+            None,
+        )
+    }
+
     fn _new(
         package_type: AccountsPackageType,
         bank: &Bank,


### PR DESCRIPTION
Builds on https://github.com/solana-labs/solana/pull/28756

#### Problem

Splitting up PR https://github.com/solana-labs/solana/pull/28730.

While working on https://github.com/solana-labs/solana/issues/28722, I discovered that when handling an EAH request, ABS makes a bank snapshot then passes the package off to AHV to calculate the accounts hash.

If the EAH must be ready for the bank snapshot, but the request itself is an EAH request, then the EAH will not be available yet (since AHV hasn't processed it yet). So, chicken-and-egg problem.

#### Summary of Changes

Do not take bank snapshots for EAH requests.

This should be fine. EAH requests are *not* snapshot requests, so there is no issue skipped anything that is meant for real snapshots.