### PR TITLE
chore: bump cargo-ndk to v2.12.2

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -53,7 +53,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Install cargo-ndk
         if: ${{ matrix.platform == 'android' }}
-        run: cargo install cargo-ndk@2.11.0
+        run: cargo install cargo-ndk@2.12.2
       - name: Install NDK 21
         if: ${{ matrix.platform == 'android' }}
         run: |


### PR DESCRIPTION
#### Problem

They fixed the ring crates building issue. `https://github.com/bbqsrc/cargo-ndk/issues/76`
We don't need to stuck in the old version anymore. Bump it to the latest.

#### Summary of Changes

bump cargo-ndk to 2.12.2

Close #28153
