### PR TITLE
Add missing solana-program docs

### DIFF
--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -1,3 +1,5 @@
+//! Integers that serialize to variable size.
+
 #![allow(clippy::integer_arithmetic)]
 use {
     serde::{

--- a/sdk/program/src/syscalls/mod.rs
+++ b/sdk/program/src/syscalls/mod.rs
@@ -1,3 +1,7 @@
+//! Declarations of Solana program syscalls.
+//!
+//! This module is mostly empty when not compiling for BPF targets.
+
 #[cfg(target_os = "solana")]
 mod definitions;
 


### PR DESCRIPTION
#### Problem

There are a few undocumented top level items in solana-program

#### Summary of Changes

Add descriptions. Document clone_zeroed and copy_field but make them `doc(hidden)` since they are not useful to program authors.