### PR TITLE
Fix client get_program_accounts_with_config calls with context

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -17,6 +17,16 @@ use {
     thiserror::Error,
 };
 
+/// Wrapper for rpc return types of methods that provide responses both with and without context.
+/// Main purpose of this is to fix methods that lack context information in their return type,
+/// without breaking backwards compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OptionalContext<T> {
+    Context(Response<T>),
+    NoContext(T),
+}
+
 pub type RpcResult<T> = client_error::Result<Response<T>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -27,6 +27,15 @@ pub enum OptionalContext<T> {
     NoContext(T),
 }
 
+impl<T> OptionalContext<T> {
+    pub fn parse_value(self) -> T {
+        match self {
+            Self::Context(response) => response.value,
+            Self::NoContext(value) => value,
+        }
+    }
+}
+
 pub type RpcResult<T> = client_error::Result<Response<T>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4420,12 +4420,14 @@ impl RpcClient {
         if let Some(filters) = config.filters {
             config.filters = Some(self.maybe_map_filters(filters).await?);
         }
-        let accounts: Vec<RpcKeyedAccount> = self
-            .send(
+
+        let accounts = self
+            .send::<OptionalContext<Vec<RpcKeyedAccount>>>(
                 RpcRequest::GetProgramAccounts,
                 json!([pubkey.to_string(), config]),
             )
-            .await?;
+            .await?
+            .parse_value();
         parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -9,7 +9,6 @@ use {
     crossbeam_channel::{unbounded, Receiver, Sender},
     jsonrpc_core::{futures::future, types::error, BoxFuture, Error, Metadata, Result},
     jsonrpc_derive::rpc,
-    serde::{Deserialize, Serialize},
     solana_account_decoder::{
         parse_token::{is_known_spl_token_id, token_amount_to_ui_amount, UiTokenAmount},
         UiAccount, UiAccountEncoding, UiDataSliceConfig, MAX_BASE58_BYTES,
@@ -120,16 +119,6 @@ fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
         context: RpcResponseContext::new(bank.slot()),
         value,
     }
-}
-
-/// Wrapper for rpc return types of methods that provide responses both with and without context.
-/// Main purpose of this is to fix methods that lack context information in their return type,
-/// without breaking backwards compatibility.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum OptionalContext<T> {
-    Context(RpcResponse<T>),
-    NoContext(T),
 }
 
 fn is_finalized(


### PR DESCRIPTION
#### Problem
As per #25869, `RpcClient::get_program_accounts_with_config()` cannot deserialize the responses from all current clusters when `with_context` is set to true. https://github.com/solana-labs/solana/pull/17399 added the `OptionalContext` wrapper to the response from the `getProgramAccounts` RPC endpoint, but didn't add any handling to client methods. This has been broken in practice since whenever that change was released to public clusters, which unfortunately means all current branches.

#### Summary of Changes
Add support for OptionalContext to `nonblocking::RpcClient::get_program_accounts_with_config()`

Fixes #25869
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
