### PR TITLE
Verifies EAH in SnapshotHash

### DIFF
--- a/docs/src/proposals/epoch_accounts_hash.md
+++ b/docs/src/proposals/epoch_accounts_hash.md
@@ -149,6 +149,30 @@ contain the EAH.
 Same as (4).
 
 
+#### Snapshot Verification
+
+If a snapshot archive includes an EAH, we want to verify the EAH is correct at
+load time (instead of waiting until `stop slot`, which could be far in the
+future).
+
+If the snapshot archive is for a slot within the `calculation window`†¹, then it
+*must* include an EAH.  The snapshot hash itself will now also incorporate the
+EAH.  In pseudo code:
+```pseudo
+if slot is in calculation window
+    let snapshot hash = hash(accounts hash, epoch accounts hash)
+else
+    let snapshot hash = accounts hash
+endif
+```
+Since loading from a snapshot archive already verifies the snapshot archive's
+hash against the deserialized bank, the EAH will be implicitly verified as
+well.
+
+†¹: The `calculation window` is `[start slot, stop slot)`, based on the epoch
+    of the referenced `Bank`.
+
+
 #### Corner Cases
 
 #### Minimum Slots per Epoch

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6984,7 +6984,8 @@ impl Bank {
 
     pub fn get_snapshot_hash(&self) -> SnapshotHash {
         let accounts_hash = self.get_accounts_hash();
-        SnapshotHash::new(&accounts_hash)
+        let epoch_accounts_hash = self.get_epoch_accounts_hash_to_serialize();
+        SnapshotHash::new(&accounts_hash, epoch_accounts_hash.as_ref())
     }
 
     pub fn get_thread_pool(&self) -> &ThreadPool {


### PR DESCRIPTION
#### Problem

Please refer to https://github.com/solana-labs/solana/issues/28645


#### Summary of Changes

Verify the snapshot hash from the snapshot archive matches the snapshot hash in the deserialized bank.
(Since the snapshot hash includes the EAH, this will verify the EAH in snapshots.)

Updates the EAH proposal as well. Here's [the rendered view](https://github.com/solana-labs/solana/blob/cc1904f6b72e2d78c5377b30a3b8601bc15808a8/docs/src/proposals/epoch_accounts_hash.md).

Fixes: #28645 