### PR TITLE
Snapshots wait for EAH calculations to complete

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -466,7 +466,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
             assert_eq!(&deserialized_bank, bank.as_ref());
             assert_eq!(
                 deserialized_bank.epoch_accounts_hash(),
-                bank.epoch_accounts_hash(),
+                bank.get_epoch_accounts_hash_to_serialize(),
             );
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -37,6 +37,7 @@ use {
     },
     solana_sdk::{
         clock::Slot,
+        epoch_schedule::EpochSchedule,
         genesis_config::{
             ClusterType::{self, Development, Devnet, MainnetBeta, Testnet},
             GenesisConfig,
@@ -94,6 +95,8 @@ impl SnapshotTestConfig {
             &solana_sdk::pubkey::new_rand(), // validator_pubkey
             1,                               // validator_stake_lamports
         );
+        // NOTE: Must set `warmup == false` until EAH can handle short epochs
+        genesis_config_info.genesis_config.epoch_schedule = EpochSchedule::without_warmup();
         genesis_config_info.genesis_config.cluster_type = cluster_type;
         let bank0 = Bank::new_with_paths_for_tests(
             &genesis_config_info.genesis_config,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7697,10 +7697,28 @@ impl Bank {
         total_accounts_stats
     }
 
-    /// if we were to serialize THIS bank, what value should be saved for the prior accounts hash?
-    /// This depends on the proximity to the time to take the snapshot and the time to use the snapshot.
-    pub(crate) fn get_epoch_accounts_hash_to_serialize(&self) -> Option<Hash> {
-        self.epoch_accounts_hash().map(|hash| *hash.as_ref())
+    /// Get the EAH that will be used by snapshots
+    ///
+    /// Since snapshots are taken on roots, if the bank is in the EAH calculation window then an
+    /// EAH *must* be included.  This means if an EAH calculation is currently in-flight we will
+    /// wait for it to complete.
+    pub fn get_epoch_accounts_hash_to_serialize(&self) -> Option<EpochAccountsHash> {
+        let (epoch_accounts_hash, measure) = measure!(
+            epoch_accounts_hash::is_in_calculation_window(self).then(|| {
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .epoch_accounts_hash_manager
+                    .wait_get_epoch_accounts_hash()
+            })
+        );
+
+        datapoint_info!(
+            "bank-get_epoch_accounts_hash_to_serialize",
+            ("slot", self.slot(), i64),
+            ("waiting-time-us", measure.as_us(), i64),
+        );
+        epoch_accounts_hash
     }
 
     /// Convenience fn to get the Epoch Accounts Hash

--- a/runtime/src/epoch_accounts_hash/utils.rs
+++ b/runtime/src/epoch_accounts_hash/utils.rs
@@ -38,6 +38,15 @@ pub fn calculation_stop(bank: &Bank) -> Slot {
     calculation_info(bank).calculation_stop
 }
 
+/// Is this bank in the calculation window?
+#[must_use]
+#[inline]
+pub fn is_in_calculation_window(bank: &Bank) -> bool {
+    let bank_slot = bank.slot();
+    let info = calculation_info(bank);
+    bank_slot >= info.calculation_start && bank_slot < info.calculation_stop
+}
+
 /// For the epoch that `bank` is in, get all the EAH calculation information
 pub fn calculation_info(bank: &Bank) -> CalculationInfo {
     let epoch = bank.epoch();

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -214,7 +214,8 @@ impl<'a> TypeContext<'a> for Context {
             None::<BankIncrementalSnapshotPersistence>,
             serializable_bank
                 .bank
-                .get_epoch_accounts_hash_to_serialize(),
+                .get_epoch_accounts_hash_to_serialize()
+                .map(|epoch_accounts_hash| *epoch_accounts_hash.as_ref()),
         )
             .serialize(serializer)
     }


### PR DESCRIPTION
#### Problem

Please refer to https://github.com/solana-labs/solana/issues/28722.


#### Summary of Changes

When snapshotting a bank in the calculation window, wait for in-flight EAH calculations to complete first, before grabbing the EAH value to serialize.

Fixes #28722
