### PR TITLE
Revert #27444

### DIFF
--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -99,8 +99,6 @@ pub struct ComputeBudget {
     pub heap_cost: u64,
     /// Memory operation syscall base cost
     pub mem_op_base_cost: u64,
-    /// Number of compute units consumed per AccountPropertyUpdate
-    pub account_property_update_cost: u64,
 }
 
 impl Default for ComputeBudget {
@@ -144,7 +142,6 @@ impl ComputeBudget {
             heap_size: None,
             heap_cost: 8,
             mem_op_base_cost: 10,
-            account_property_update_cost: 10,
         }
     }
 

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -743,34 +743,6 @@ pub fn get_stack_height() -> usize {
     }
 }
 
-/// Used to specify which properties of which accounts to update
-/// when calling the `sol_set_account_properties` syscall.
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct AccountPropertyUpdate<'a> {
-    /// Index of the account to update
-    pub instruction_account_index: u16,
-    /// Index of the property to update
-    pub attribute: u16,
-    /// Value to set, encoding depends on the attribute
-    pub value: u64,
-    /// Holds the lifetime parameter in case that the value is a pointer
-    pub _marker: std::marker::PhantomData<&'a ()>,
-}
-
-/// Sets properties of accounts according to the given list of updates
-pub fn set_account_properties(updates: &[AccountPropertyUpdate]) {
-    #[cfg(target_os = "solana")]
-    unsafe {
-        crate::syscalls::sol_set_account_properties(updates.as_ptr(), updates.len() as u64);
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    {
-        crate::program_stubs::sol_set_account_properties(updates);
-    }
-}
-
 #[test]
 fn test_account_meta_layout() {
     #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -4,11 +4,8 @@
 
 use {
     crate::{
-        account_info::AccountInfo,
-        entrypoint::ProgramResult,
-        instruction::{AccountPropertyUpdate, Instruction},
-        program_error::UNSUPPORTED_SYSVAR,
-        pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+        program_error::UNSUPPORTED_SYSVAR, pubkey::Pubkey,
     },
     itertools::Itertools,
     std::sync::{Arc, RwLock},
@@ -100,7 +97,6 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_stack_height(&self) -> u64 {
         0
     }
-    fn sol_set_account_properties(&self, _updates: &[AccountPropertyUpdate]) {}
 }
 
 struct DefaultSyscallStubs {}
@@ -196,13 +192,6 @@ pub(crate) fn sol_get_processed_sibling_instruction(index: usize) -> Option<Inst
 
 pub(crate) fn sol_get_stack_height() -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_stack_height()
-}
-
-pub(crate) fn sol_set_account_properties(updates: &[AccountPropertyUpdate]) {
-    SYSCALL_STUBS
-        .read()
-        .unwrap()
-        .sol_set_account_properties(updates)
 }
 
 /// Check that two regions do not overlap.

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    instruction::{AccountMeta, AccountPropertyUpdate, ProcessedSiblingInstruction},
+    instruction::{AccountMeta, ProcessedSiblingInstruction},
     pubkey::Pubkey,
 };
 
@@ -61,7 +61,6 @@ define_syscall!(fn sol_get_return_data(data: *mut u8, length: u64, program_id: *
 define_syscall!(fn sol_log_data(data: *const u8, data_len: u64));
 define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut ProcessedSiblingInstruction, program_id: *mut Pubkey, data: *mut u8, accounts: *mut AccountMeta) -> u64);
 define_syscall!(fn sol_get_stack_height() -> u64);
-define_syscall!(fn sol_set_account_properties(updates_addr: *const AccountPropertyUpdate, updates_count: u64));
 define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
 define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -1,8 +1,6 @@
 //! Data shared between program runtime and built-in programs as well as SBF programs
 #![deny(clippy::indexing_slicing)]
 
-#[cfg(target_os = "solana")]
-use crate::instruction::AccountPropertyUpdate;
 #[cfg(not(target_os = "solana"))]
 use crate::{
     account::WritableAccount,
@@ -752,16 +750,6 @@ impl<'a> BorrowedAccount<'a> {
         Ok(())
     }
 
-    #[cfg(target_os = "solana")]
-    pub fn set_owner<'b>(&mut self, pubkey: &'b [u8]) -> AccountPropertyUpdate<'b> {
-        AccountPropertyUpdate {
-            instruction_account_index: self.index_in_instruction as u16,
-            attribute: TransactionContextAttribute::TransactionAccountOwner as u16,
-            value: pubkey.as_ptr() as u64,
-            _marker: std::marker::PhantomData::default(),
-        }
-    }
-
     /// Returns the number of lamports of this account (transaction wide)
     #[inline]
     pub fn get_lamports(&self) -> u64 {
@@ -795,16 +783,6 @@ impl<'a> BorrowedAccount<'a> {
         }
         self.account.set_lamports(lamports);
         Ok(())
-    }
-
-    #[cfg(target_os = "solana")]
-    pub fn set_lamports(&mut self, lamports: u64) -> AccountPropertyUpdate<'static> {
-        AccountPropertyUpdate {
-            instruction_account_index: self.index_in_instruction as u16,
-            attribute: TransactionContextAttribute::TransactionAccountLamports as u16,
-            value: lamports,
-            _marker: std::marker::PhantomData::default(),
-        }
     }
 
     /// Adds lamports to this account (transaction wide)
@@ -892,16 +870,6 @@ impl<'a> BorrowedAccount<'a> {
         Ok(())
     }
 
-    #[cfg(target_os = "solana")]
-    pub fn set_data_length(&mut self, new_length: usize) -> AccountPropertyUpdate<'static> {
-        AccountPropertyUpdate {
-            instruction_account_index: self.index_in_instruction as u16,
-            attribute: TransactionContextAttribute::TransactionAccountData as u16,
-            value: new_length as u64,
-            _marker: std::marker::PhantomData::default(),
-        }
-    }
-
     /// Appends all elements in a slice to the account
     #[cfg(not(target_os = "solana"))]
     pub fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
@@ -974,16 +942,6 @@ impl<'a> BorrowedAccount<'a> {
         }
         self.account.set_executable(is_executable);
         Ok(())
-    }
-
-    #[cfg(target_os = "solana")]
-    pub fn set_executable(&mut self, is_executable: bool) -> AccountPropertyUpdate<'static> {
-        AccountPropertyUpdate {
-            instruction_account_index: self.index_in_instruction as u16,
-            attribute: TransactionContextAttribute::TransactionAccountIsExecutable as u16,
-            value: is_executable as u64,
-            _marker: std::marker::PhantomData::default(),
-        }
     }
 
     /// Returns the rent epoch of this account (transaction wide)

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -22,59 +22,6 @@ use {
     },
 };
 
-/// For addressing (nested) properties of the TransactionContext
-#[repr(u16)]
-pub enum TransactionContextAttribute {
-    /// TransactionContext -> &[u8]
-    ReturnData,
-    /// TransactionContext -> u128
-    AccountsResizeDelta,
-    /// TransactionContext -> u16
-    TransactionAccountCount,
-    /// TransactionContext -> &[TransactionAccount] -> Pubkey
-    TransactionAccountKey,
-    /// TransactionContext -> &[TransactionAccount] -> Pubkey
-    TransactionAccountOwner,
-    /// TransactionContext -> &[TransactionAccount] -> u64
-    TransactionAccountLamports,
-    /// TransactionContext -> &[TransactionAccount] -> &[u8]
-    TransactionAccountData,
-    /// TransactionContext -> &[TransactionAccount] -> bool
-    TransactionAccountIsExecutable,
-    /// TransactionContext -> &[TransactionAccount] -> u64
-    TransactionAccountRentEpoch,
-    /// TransactionContext -> &[TransactionAccount] -> bool
-    TransactionAccountTouchedFlag,
-    /// TransactionContext -> u8
-    InstructionStackHeight,
-    /// TransactionContext -> u8
-    InstructionStackCapacity,
-    /// TransactionContext -> &[u8]
-    InstructionStackEntry,
-    /// TransactionContext -> u16
-    InstructionTraceLength,
-    /// TransactionContext -> u16
-    InstructionTraceCapacity,
-    /// TransactionContext -> &[InstructionContext] -> u8
-    InstructionTraceNestingLevel,
-    /// TransactionContext -> &[InstructionContext] -> u128
-    InstructionTraceLamportSum,
-    /// TransactionContext -> &[InstructionContext] -> &[u8]
-    InstructionTraceInstructionData,
-    /// TransactionContext -> &[InstructionContext] -> &[u16]
-    InstructionTraceProgramAccount,
-    /// TransactionContext -> &[InstructionContext] -> &[InstructionAccount] -> u16
-    InstructionAccountIndexInTransaction,
-    /// TransactionContext -> &[InstructionContext] -> &[InstructionAccount] -> u16
-    InstructionAccountIndexInCaller,
-    /// TransactionContext -> &[InstructionContext] -> &[InstructionAccount] -> u16
-    InstructionAccountIndexInCallee,
-    /// TransactionContext -> &[InstructionContext] -> &[InstructionAccount] -> bool
-    InstructionAccountIsSigner,
-    /// TransactionContext -> &[InstructionContext] -> &[InstructionAccount] -> bool
-    InstructionAccountIsWritable,
-}
-
 /// Index of an account inside of the TransactionContext or an InstructionContext.
 pub type IndexOfAccount = u16;
 


### PR DESCRIPTION
#### Problem
Using type inference in the VM might allow us to avoid memory address translation in ABIv2 all together. Thus, the syscall would become useless.

#### Summary of Changes
Removes `SyscallSetAccountProperties`, `AccountPropertyUpdate` and `TransactionContextAttribute`.