### PR TITLE
Fix link to `getEpochSchedule` in `EpochSchedule` docs

### DIFF
--- a/web3.js/src/epoch-schedule.ts
+++ b/web3.js/src/epoch-schedule.ts
@@ -26,7 +26,7 @@ function nextPowerOfTwo(n: number) {
 /**
  * Epoch schedule
  * (see https://docs.solana.com/terminology#epoch)
- * Can be retrieved with the {@link connection.getEpochSchedule} method
+ * Can be retrieved with the {@link Connection.getEpochSchedule} method
  */
 export class EpochSchedule {
   /** The maximum number of slots in each epoch */


### PR DESCRIPTION
#### Problem
Generating the documentation results in the following error:
```console
> typedoc --treatWarningsAsErrors
warning Failed to resolve link to "connection.getEpochSchedule" in comment for EpochSchedule
```

And the corresponding comment is indeed broken [in the docs](https://solana-labs.github.io/solana-web3.js/classes/EpochSchedule.html)
![image](https://user-images.githubusercontent.com/25801283/201196263-ed143375-448a-48c7-bc60-fb922eacf9ad.png)

#### Summary of Changes
Fixes broken link to `Connection.getEpochSchedule`
