### PR TITLE
Remove Default impls for TpuConnectionCache and ConnectionPool clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5963,6 +5963,7 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-streamer",
  "solana-tpu-client",
+ "thiserror",
 ]
 
 [[package]]
@@ -6654,6 +6655,7 @@ version = "1.15.0"
 dependencies = [
  "solana-net-utils",
  "solana-tpu-client",
+ "thiserror",
 ]
 
 [[package]]

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -14,6 +14,7 @@ solana-metrics = { path = "../metrics", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-streamer = { path = "../streamer", version = "=1.15.0" }
 solana-tpu-client = { path = "../tpu-client", version = "=1.15.0" }
+thiserror = "1.0"
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.15.0" }

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -90,12 +90,6 @@ pub struct QuicConfig {
     maybe_client_pubkey: Option<Pubkey>,
 }
 
-impl Default for QuicConfig {
-    fn default() -> Self {
-        Self::new().expect("Failed to initialize QUIC client certificates")
-    }
-}
-
 impl NewTpuConfig for QuicConfig {
     type ClientError = QuicClientError;
 

--- a/tpu-client/src/tpu_connection_cache.rs
+++ b/tpu-client/src/tpu_connection_cache.rs
@@ -270,7 +270,7 @@ pub trait NewTpuConfig {
 
 pub trait ConnectionPool {
     type PoolTpuConnection: BaseTpuConnection;
-    type TpuConfig: Default + NewTpuConfig;
+    type TpuConfig: NewTpuConfig;
     const PORT_OFFSET: u16 = 0;
 
     /// Create a new connection pool based on protocol-specific configuration

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2021"
 [dependencies]
 solana-net-utils = { path = "../net-utils", version = "=1.15.0" }
 solana-tpu-client = { path = "../tpu-client", version = "=1.15.0" }
+thiserror = "1.0"

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -10,7 +10,9 @@ use {
     },
     solana_tpu_client::{
         connection_cache_stats::ConnectionCacheStats,
-        tpu_connection_cache::{BaseTpuConnection, ConnectionPool, ConnectionPoolError},
+        tpu_connection_cache::{
+            BaseTpuConnection, ConnectionPool, ConnectionPoolError, NewTpuConfig,
+        },
     },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -75,8 +77,10 @@ impl Default for UdpConfig {
     }
 }
 
-impl UdpConfig {
-    pub fn new() -> Result<Self, UdpClientError> {
+impl NewTpuConfig for UdpConfig {
+    type ClientError = UdpClientError;
+
+    fn new() -> Result<Self, UdpClientError> {
         let socket = solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
             .map_err(Into::<UdpClientError>::into)?;
         Ok(Self {

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -71,12 +71,6 @@ pub struct UdpConfig {
     tpu_udp_socket: Arc<UdpSocket>,
 }
 
-impl Default for UdpConfig {
-    fn default() -> Self {
-        Self::new().expect("Unable to bind to UDP socket")
-    }
-}
-
 impl NewTpuConfig for UdpConfig {
     type ClientError = UdpClientError;
 


### PR DESCRIPTION
#### Problem
Currently, Tpu connection actions like creating a self-sign tls cert chain (Quic) or binding to a socket (Udp) are done in default implementations, which cannot be fallible, and success asserted. This means we cannot handle any errors sensibly.

#### Summary of Changes
- Replace TpuConfig Default impl with FallibleCtor trait
- Add Quic/UdpClientError enums
- Make TpuConnectionCache::new() fallible, and add new_with_config() helper fn as infallible alternative


Toward #28401
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
