### PR TITLE
Fixed flaky quic test

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1012,7 +1012,7 @@ pub mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats.clone(),
-            1,
+            100,
         )
         .unwrap();
         (t, exit, receiver, server_address, stats)


### PR DESCRIPTION
#### Problem
The quic test stream time is too small (1 ms) -- some tests might need longer time. increased to 100ms

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
