### PR TITLE
[zk-token-sdk] Fix ElGamal key derivation

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -71,14 +71,10 @@ impl ElGamal {
     #[cfg(not(target_os = "solana"))]
     #[allow(non_snake_case)]
     fn keygen_with_scalar(s: &Scalar) -> ElGamalKeypair {
-        assert!(s != &Scalar::zero());
+        let secret = ElGamalSecretKey(*s);
+        let public = ElGamalPubkey::new(&secret);
 
-        let P = s.invert() * &(*H);
-
-        ElGamalKeypair {
-            public: ElGamalPubkey(P),
-            secret: ElGamalSecretKey(*s),
-        }
+        ElGamalKeypair { public, secret }
     }
 
     /// On input an ElGamal public key and an amount to be encrypted, the function returns a
@@ -267,7 +263,10 @@ impl ElGamalPubkey {
     /// Derives the `ElGamalPubkey` that uniquely corresponds to an `ElGamalSecretKey`.
     #[allow(non_snake_case)]
     pub fn new(secret: &ElGamalSecretKey) -> Self {
-        ElGamalPubkey(&secret.0 * &(*H))
+        let s = &secret.0;
+        assert!(s != &Scalar::zero());
+
+        ElGamalPubkey(s.invert() * &(*H))
     }
 
     pub fn get_point(&self) -> &RistrettoPoint {

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -137,10 +137,23 @@ impl PubkeySigmaProof {
 #[cfg(test)]
 mod test {
     use super::*;
+    use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 
     #[test]
     fn test_pubkey_proof_correctness() {
+        // random ElGamal keypair
         let keypair = ElGamalKeypair::new_rand();
+
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
+
+        let proof = PubkeySigmaProof::new(&keypair, &mut prover_transcript);
+        assert!(proof
+            .verify(&keypair.public, &mut verifier_transcript)
+            .is_ok());
+
+        // derived ElGamal keypair
+        let keypair = ElGamalKeypair::new(&Keypair::new(), &Pubkey::default()).unwrap();
 
         let mut prover_transcript = Transcript::new(b"test");
         let mut verifier_transcript = Transcript::new(b"test");

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -136,8 +136,10 @@ impl PubkeySigmaProof {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use solana_sdk::{pubkey::Pubkey, signature::Keypair};
+    use {
+        super::*,
+        solana_sdk::{pubkey::Pubkey, signature::Keypair},
+    };
 
     #[test]
     fn test_pubkey_proof_correctness() {


### PR DESCRIPTION
#### Problem
The inversion method in the ElGamal pubkey derivation was removed when I was adding additional comments and cleaning up the code.

#### Summary of Changes
- Add the inversion method again
- Augment the tests so that these type of misses can be caught in the future