### PR TITLE
stop testing rent_epoch in sbf programs

### DIFF
--- a/programs/sbf/c/src/invoked/invoked.c
+++ b/programs/sbf/c/src/invoked/invoked.c
@@ -45,7 +45,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(accounts[ARGUMENT_INDEX].data_len == 100);
     sol_assert(accounts[ARGUMENT_INDEX].is_signer);
     sol_assert(accounts[ARGUMENT_INDEX].is_writable);
-    sol_assert(accounts[ARGUMENT_INDEX].rent_epoch == 0);
     sol_assert(!accounts[ARGUMENT_INDEX].executable);
     for (int i = 0; i < accounts[ARGUMENT_INDEX].data_len; i++) {
       sol_assert(accounts[ARGUMENT_INDEX].data[i] == i);
@@ -57,7 +56,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(accounts[INVOKED_ARGUMENT_INDEX].data_len == 10);
     sol_assert(accounts[INVOKED_ARGUMENT_INDEX].is_signer);
     sol_assert(accounts[INVOKED_ARGUMENT_INDEX].is_writable);
-    sol_assert(accounts[INVOKED_ARGUMENT_INDEX].rent_epoch == 0);
     sol_assert(!accounts[INVOKED_ARGUMENT_INDEX].executable);
 
     sol_assert(
@@ -66,7 +64,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
                                   &sbf_loader_id));
     sol_assert(!accounts[INVOKED_PROGRAM_INDEX].is_signer);
     sol_assert(!accounts[INVOKED_PROGRAM_INDEX].is_writable);
-    sol_assert(accounts[INVOKED_PROGRAM_INDEX].rent_epoch == 0);
     sol_assert(accounts[INVOKED_PROGRAM_INDEX].executable);
 
     sol_assert(SolPubkey_same(accounts[INVOKED_PROGRAM_INDEX].key,

--- a/programs/sbf/rust/invoked/src/processor.rs
+++ b/programs/sbf/rust/invoked/src/processor.rs
@@ -48,7 +48,6 @@ fn process_instruction(
             assert_eq!(accounts[ARGUMENT_INDEX].data_len(), 100);
             assert!(accounts[ARGUMENT_INDEX].is_signer);
             assert!(accounts[ARGUMENT_INDEX].is_writable);
-            assert_eq!(accounts[ARGUMENT_INDEX].rent_epoch, 0);
             assert!(!accounts[ARGUMENT_INDEX].executable);
             {
                 let data = accounts[ARGUMENT_INDEX].try_borrow_data()?;
@@ -65,14 +64,12 @@ fn process_instruction(
             assert_eq!(accounts[INVOKED_ARGUMENT_INDEX].data_len(), 10);
             assert!(accounts[INVOKED_ARGUMENT_INDEX].is_signer);
             assert!(accounts[INVOKED_ARGUMENT_INDEX].is_writable);
-            assert_eq!(accounts[INVOKED_ARGUMENT_INDEX].rent_epoch, 0);
             assert!(!accounts[INVOKED_ARGUMENT_INDEX].executable);
 
             assert_eq!(accounts[INVOKED_PROGRAM_INDEX].key, program_id);
             assert_eq!(accounts[INVOKED_PROGRAM_INDEX].owner, &bpf_loader::id());
             assert!(!accounts[INVOKED_PROGRAM_INDEX].is_signer);
             assert!(!accounts[INVOKED_PROGRAM_INDEX].is_writable);
-            assert_eq!(accounts[INVOKED_PROGRAM_INDEX].rent_epoch, 0);
             assert!(accounts[INVOKED_PROGRAM_INDEX].executable);
 
             assert_eq!(


### PR DESCRIPTION
#### Problem

I'm trying to get rid of `rent_epoch`
In the meantime, it will soon have a fixed value for all rent_exempt accounts.
see: #28690

#### Summary of Changes

Stop testing it in sbf program tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
