### PR TITLE
Renaming the Bonfida Pool -> Serum Pool

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -49,7 +49,6 @@ export enum PROGRAM_NAMES {
 
   // other
   ACUMEN = "Acumen Program",
-  BONFIDA_POOL = "Bonfida Pool Program",
   BREAK_SOLANA = "Break Solana Program",
   CHAINLINK_ORACLE = "Chainlink OCR2 Oracle Program",
   CHAINLINK_STORE = "Chainlink Store Program",
@@ -87,6 +86,7 @@ export enum PROGRAM_NAMES {
   SERUM_2 = "Serum Dex Program v2",
   SERUM_3 = "Serum Dex Program v3",
   SERUM_SWAP = "Serum Swap Program",
+  SERUM_POOL = "Serum Pool",
   SOLEND = "Solend Program",
   SOLIDO = "Lido for Solana Program",
   STEP_SWAP = "Step Finance Swap Program",
@@ -204,7 +204,7 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     deployments: [Cluster.MainnetBeta],
   },
   WvmTNLpGMVbwJVYztYL4Hnsy82cJhQorxjnnXcRm3b6: {
-    name: PROGRAM_NAMES.BONFIDA_POOL,
+    name: PROGRAM_NAMES.SERUM_POOL,
     deployments: [Cluster.MainnetBeta],
   },
   BrEAK7zGZ6dM71zUDACDqJnekihmwF15noTddWTsknjC: {


### PR DESCRIPTION
This program is owned by Serum, not by Bonfida

#### Problem
This program was mislabeled as `Bonfida Pool`, but is actually owned by Serum: https://github.com/project-serum/serum-dex/tree/master/pool

#### Summary of Changes
- Remove the `Bonfida Pool`
- Add `Serum Pool`, update labels