### PR TITLE
Lowers test's account data size to avoid hitting MaxLoadedAccountsDataSizeExceed

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19797,7 +19797,7 @@ pub(crate) mod tests {
             let account_balance = LAMPORTS_PER_SOL;
             let account_size = rng.gen_range(
                 1,
-                MAX_PERMITTED_DATA_LENGTH as usize - MAX_PERMITTED_DATA_INCREASE,
+                (MAX_PERMITTED_DATA_LENGTH / 4) as usize - MAX_PERMITTED_DATA_INCREASE,
             );
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);
@@ -19827,8 +19827,9 @@ pub(crate) mod tests {
         {
             let account_pubkey = Pubkey::new_unique();
             let account_balance = LAMPORTS_PER_SOL;
-            let account_size =
-                rng.gen_range(MAX_PERMITTED_DATA_LENGTH / 2, MAX_PERMITTED_DATA_LENGTH) as usize;
+            let account_size = rng
+                .gen_range(MAX_PERMITTED_DATA_LENGTH / 8, MAX_PERMITTED_DATA_LENGTH / 4)
+                as usize;
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);
             bank.store_account(&account_pubkey, &account_data);


### PR DESCRIPTION
#### Problem

@jeffwashington informed me that https://github.com/solana-labs/solana/pull/28690/ was failing in CI due to an error in `test_accounts_data_size_and_resize_transactions()`:
https://buildkite.com/solana-labs/solana/builds/85042#01847837-100f-41b7-af5a-fe94c67358f6

Running locally, I observed this test failing intermittently will this error:
```
[2022-11-15T14:29:15.554837000Z DEBUG solana_runtime::bank] tx error: MaxLoadedAccountsDataSizeExceeded SanitizedTransaction { message: Legacy(LegacyMessage { message: Message { header: MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 1 }, account_keys: [J6MEcxb4f4oeePxv1RvzCyzhfXpi8SkJUAMfEWCLNSRh, 11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP, 7QmP1NzaR3SfDfKZBZ28LM6Wt4ii19AAFM2jMWcZJDg1, 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM], recent_blockhash: FpCi9pXxubub4F7qpceqpiPf8xPvkSvw6Rt8jELWAm3Q, instructions: [CompiledInstruction { program_id_index: 3, accounts: [2, 1], data: [0, 0, 0, 0, 89, 160, 64, 0, 0, 0, 0, 0, 0, 232, 118, 72, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }] }, is_writable_account_cache: [true, true, true, false] }), message_hash: 9yxLvvz7xaQMm8cs5b3jGXsEm6xjZdn7MaEVbemmbssr, is_simple_vote_tx: false, signatures: [3tBZnNkr3Z7Rdk5dXxv1WWDvUkdzwWRYnqi5VG5wBKyRg8YiT1y2hmnAj7JNZghCEdH9hy1VMraRpawpNiazpDgv] }
```

This test grows and shrinks accounts to ensure their data size is tracked correctly by the bank. The initial data size _and_ the grow/shrink size are randomly generated, which explains _how_ this test could fail intermittently.

Zooming in, we see the error is `MaxLoadedAccountsDataSizeExceeded`, which is new as of https://github.com/solana-labs/solana/pull/27840.

So `test_accounts_data_size_and_resize_transactions()` fails when the account size triggers `MaxLoadedAccountsDataSizeExceeded`.


#### Summary of Changes

Lower the bounds for the accounts size to ensure `MaxLoadedAccountsDataSizeExceeded` is not hit.