### PR TITLE
add scan statistics in hash calc for ancient append vecs

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -104,6 +104,9 @@ pub struct HashStats {
     pub append_vec_sizes_older_than_epoch: AtomicUsize,
     /// # ancient append vecs encountered
     pub ancient_append_vecs: AtomicUsize,
+    pub longest_ancient_scan_us: AtomicU64,
+    pub sum_ancient_scans_us: AtomicU64,
+    pub count_ancient_scans: AtomicU64,
 }
 impl HashStats {
     pub fn calc_storage_size_quartiles(&mut self, storages: &SnapshotStorages) {
@@ -229,6 +232,21 @@ impl HashStats {
             (
                 "ancient_append_vecs",
                 self.ancient_append_vecs.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "longest_ancient_scan_us",
+                self.longest_ancient_scan_us.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "sum_ancient_scans_us",
+                self.sum_ancient_scans_us.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "count_ancient_scans",
+                self.count_ancient_scans.load(Ordering::Relaxed) as i64,
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
the larger ancient append vecs get, the longer scanning them for accounts hash is taking.
Metrics for this will be important.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
