### PR TITLE
Requires EAH state cannot be Invalid

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -635,6 +635,7 @@ mod tests {
         super::*,
         crate::{
             bank::tests::update_vote_account_timestamp,
+            epoch_accounts_hash::EpochAccountsHash,
             genesis_utils::{
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
@@ -746,8 +747,8 @@ mod tests {
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
 
         // Spin up a thread to be a fake Accounts Background Service.  Need to intercept and handle
-        // (i.e. skip/make invalid) all EpochAccountsHash requests so future rooted banks do not hang
-        // in Bank::freeze() waiting for an in-flight EAH calculation to complete.
+        // all EpochAccountsHash requests so future rooted banks do not hang in Bank::freeze()
+        // waiting for an in-flight EAH calculation to complete.
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
         let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let bg_exit = Arc::new(AtomicBool::new(false));
@@ -767,7 +768,10 @@ mod tests {
                                 .accounts
                                 .accounts_db
                                 .epoch_accounts_hash_manager
-                                .set_invalid_for_tests();
+                                .set_valid(
+                                    EpochAccountsHash::new(Hash::new_unique()),
+                                    snapshot_request.snapshot_root_bank.slot(),
+                                )
                         });
                     std::thread::sleep(Duration::from_millis(100));
                 }

--- a/runtime/src/epoch_accounts_hash/manager.rs
+++ b/runtime/src/epoch_accounts_hash/manager.rs
@@ -1,6 +1,6 @@
 use {
     super::EpochAccountsHash,
-    solana_sdk::{clock::Slot, hash::Hash},
+    solana_sdk::clock::Slot,
     std::sync::{Condvar, Mutex},
 };
 
@@ -68,8 +68,8 @@ impl Manager {
         loop {
             match &*state {
                 State::Valid(epoch_accounts_hash, _slot) => break *epoch_accounts_hash,
-                State::Invalid => break SENTINEL_EPOCH_ACCOUNTS_HASH,
                 State::InFlight(_slot) => state = self.cvar.wait(state).unwrap(),
+                State::Invalid => panic!("The epoch accounts hash cannot be awaited when Invalid!"),
             }
         }
     }
@@ -84,23 +84,15 @@ impl Manager {
             _ => None,
         }
     }
-
-    /// **FOR TESTS ONLY**
-    /// Set the state to Invalid
-    /// This is needed by tests that do not fully startup all the accounts background services.
-    /// **FOR TESTS ONLY**
-    pub fn set_invalid_for_tests(&self) {
-        *self.state.lock().unwrap() = State::Invalid;
-    }
 }
 
 /// The EpochAccountsHash is calculated in the background via AccountsBackgroundService.  This enum
-/// is used to track the state of that calculation, and queried when saving the EAH into a Bank.
+/// is used to track the state of that calculation, and queried when saving the EAH into a Bank or
+/// Snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
-    /// On startup from genesis/slot0, the initial state of the EAH is invalid since one has not
-    /// yet been requested.  This state should only really occur for tests and new clusters; not
-    /// for established running clusters.
+    /// The initial state of the EAH.  This can occur when loading from a snapshot that does not
+    /// include an EAH, or when starting from genesis (before an EAH calculation is requested).
     Invalid,
     /// An EAH calculation has been requested (for `Slot`) and is in flight.  The Bank that should
     /// save the EAH must wait until the calculation has completed.
@@ -109,19 +101,9 @@ enum State {
     Valid(EpochAccountsHash, Slot),
 }
 
-/// Sentinel epoch accounts hash value; used when getting an Invalid EAH
-///
-/// Displays as "Sentine1EpochAccountsHash111111111111111111"
-const SENTINEL_EPOCH_ACCOUNTS_HASH: EpochAccountsHash =
-    EpochAccountsHash::new(Hash::new_from_array([
-        0x06, 0x92, 0x40, 0x3b, 0xee, 0xea, 0x7e, 0xe2, 0x7d, 0xf4, 0x90, 0x7f, 0xbd, 0x9e, 0xd0,
-        0xd2, 0x1c, 0x2b, 0x66, 0x9a, 0xc4, 0xda, 0xce, 0xd7, 0x23, 0x41, 0x69, 0xab, 0xb7, 0x80,
-        0x00, 0x00,
-    ]));
-
 #[cfg(test)]
 mod tests {
-    use {super::*, std::time::Duration};
+    use {super::*, solana_sdk::hash::Hash, std::time::Duration};
 
     #[test]
     fn test_new_valid() {
@@ -138,10 +120,6 @@ mod tests {
     fn test_new_invalid() {
         let manager = Manager::new_invalid();
         assert!(manager.try_get_epoch_accounts_hash().is_none());
-        assert_eq!(
-            manager.wait_get_epoch_accounts_hash(),
-            SENTINEL_EPOCH_ACCOUNTS_HASH,
-        );
     }
 
     #[test]
@@ -163,15 +141,6 @@ mod tests {
 
     #[test]
     fn test_wait_epoch_accounts_hash() {
-        // Test: State is Invalid, no need to wait
-        {
-            let manager = Manager::new_invalid();
-            assert_eq!(
-                manager.wait_get_epoch_accounts_hash(),
-                SENTINEL_EPOCH_ACCOUNTS_HASH,
-            );
-        }
-
         // Test: State is Valid, no need to wait
         {
             let epoch_accounts_hash = EpochAccountsHash::new(Hash::new_unique());
@@ -195,5 +164,13 @@ mod tests {
                 assert!(manager.try_get_epoch_accounts_hash().is_some());
             });
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_wait_epoch_accounts_hash_invalid() {
+        // Test: State is Invalid, should panic
+        let manager = Manager::new_invalid();
+        let _epoch_accounts_hash = manager.wait_get_epoch_accounts_hash();
     }
 }

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -3,12 +3,14 @@ use {
     solana_runtime::{
         bank::Bank,
         bank_client::BankClient,
+        epoch_accounts_hash::EpochAccountsHash,
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
     },
     solana_sdk::{
         account::from_account,
         account_utils::StateMut,
         client::SyncClient,
+        hash::Hash,
         message::Message,
         pubkey::Pubkey,
         rent::Rent,
@@ -282,6 +284,13 @@ fn test_stake_account_lifetime() {
     let bank = Bank::new_for_tests(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let mut bank = Arc::new(bank);
+    // Need to set the EAH to Valid so that `Bank::new_from_parent()` doesn't panic during freeze
+    // when parent is in the EAH calculation window.
+    bank.rc
+        .accounts
+        .accounts_db
+        .epoch_accounts_hash_manager
+        .set_valid(EpochAccountsHash::new(Hash::new_unique()), bank.slot());
     let bank_client = BankClient::new_shared(&bank);
 
     let (vote_balance, stake_rent_exempt_reserve, stake_minimum_delegation) = {


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/28804


#### Summary of Changes

Enforce that the `Invalid` EAH state can never be hit.


Fixes #28804