### PR TITLE
use a tempdir in test_bucket_storage

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -381,16 +381,12 @@ impl BucketStorage {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, tempfile::tempdir};
 
     #[test]
     fn test_bucket_storage() {
-        let tmpdir1 = std::env::temp_dir().join("bucket_map_test_mt");
-        let paths: Vec<PathBuf> = [tmpdir1]
-            .iter()
-            .filter(|x| std::fs::create_dir_all(x).is_ok())
-            .cloned()
-            .collect();
+        let tmpdir = tempdir().unwrap();
+        let paths: Vec<PathBuf> = vec![tmpdir.path().to_path_buf()];
         assert!(!paths.is_empty());
 
         let mut storage =


### PR DESCRIPTION
#### Problem
The test didn't clean up it's "temp" directory. If you change users this causes the test to fail since the directory won't have correct permissions.

Ran into this when I switched from using `sol` user to my personal username on a machine. Unlikely to cause many other people issues, but easy enough to fix. 

#### Summary of Changes
Use an actual tempdir so it cleans itself up.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
