### PR TITLE
fix account resize test by requesting max tx data size

### DIFF
--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -25,7 +25,7 @@ pub enum LoadedAccountsDataLimitType {
 
 /// Get default value of `ComputeBudget::accounts_data_size_limit` if not set specifically. It
 /// sets to 10MB initially, may be changed with feature gate.
-const DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 10_000_000;
+const DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 10 * 1024 * 1024;
 pub fn get_default_loaded_accounts_data_limit(limit_type: &LoadedAccountsDataLimitType) -> u32 {
     match limit_type {
         LoadedAccountsDataLimitType::V0 => DEFAULT_LOADED_ACCOUNTS_DATA_LIMIT,
@@ -34,7 +34,7 @@ pub fn get_default_loaded_accounts_data_limit(limit_type: &LoadedAccountsDataLim
 /// Get max value of `ComputeBudget::accounts_data_size_limit`, it caps value user
 /// sets via `ComputeBudgetInstruction::set_compute_unit_limit`. It is set to 100MB
 /// initially, can be changed with feature gate.
-const MAX_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 100_000_000;
+const MAX_LOADED_ACCOUNTS_DATA_LIMIT: u32 = 100 * 1024 * 1024;
 pub fn get_max_loaded_accounts_data_limit(limit_type: &LoadedAccountsDataLimitType) -> u32 {
     match limit_type {
         LoadedAccountsDataLimitType::V0 => MAX_LOADED_ACCOUNTS_DATA_LIMIT,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19806,8 +19806,16 @@ pub(crate) mod tests {
 
         // get builtin program account data size, will beused to request max data size for
         // transaction.
-        let mock_account_data_size = bank.get_account_with_fixed_root(&mock_program_id).unwrap().data().len();
-        let compute_budget_account_data_size = bank.get_account_with_fixed_root(&solana_sdk::compute_budget::id()).unwrap().data().len();
+        let mock_account_data_size = bank
+            .get_account_with_fixed_root(&mock_program_id)
+            .unwrap()
+            .data()
+            .len();
+        let compute_budget_account_data_size = bank
+            .get_account_with_fixed_root(&solana_sdk::compute_budget::id())
+            .unwrap()
+            .data()
+            .len();
 
         let recent_blockhash = bank.last_blockhash();
 
@@ -19856,7 +19864,7 @@ pub(crate) mod tests {
         {
             let account_pubkey = Pubkey::new_unique();
             let account_balance = LAMPORTS_PER_SOL;
-            let account_size = 
+            let account_size =
                 rng.gen_range(MAX_PERMITTED_DATA_LENGTH / 2, MAX_PERMITTED_DATA_LENGTH) as usize;
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19479,7 +19479,6 @@ pub(crate) mod tests {
         new_balance: u64,
         mock_program_id: Pubkey,
         recent_blockhash: Hash,
-        tx_data_size_limit: u32,
     ) -> Transaction {
         let account_metas = vec![
             AccountMeta::new(funder.pubkey(), false),
@@ -19493,7 +19492,7 @@ pub(crate) mod tests {
         Transaction::new_signed_with_payer(
             &[
                 instruction,
-                ComputeBudgetInstruction::set_accounts_data_size_limit(tx_data_size_limit),
+                ComputeBudgetInstruction::set_accounts_data_size_limit(u32::MAX),
             ],
             Some(&payer.pubkey()),
             &[payer],
@@ -19554,7 +19553,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_small - 1,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let expected_err = {
             let account_index = tx
@@ -19580,7 +19578,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_large,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let result = bank.process_transaction(&tx);
         assert!(result.is_ok());
@@ -19598,7 +19595,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_small - 1,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let expected_err = {
             let account_index = tx
@@ -19624,7 +19620,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_small,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let result = bank.process_transaction(&tx);
         assert!(result.is_ok());
@@ -19642,7 +19637,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_large - 1,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let expected_err = {
             let account_index = tx
@@ -19668,7 +19662,6 @@ pub(crate) mod tests {
             rent_exempt_minimum_large,
             mock_program_id,
             recent_blockhash,
-            u32::MAX,
         );
         let result = bank.process_transaction(&tx);
         assert!(result.is_ok());
@@ -19790,7 +19783,6 @@ pub(crate) mod tests {
     /// Ensure that accounts data size is updated correctly on resize transactions
     #[test]
     fn test_accounts_data_size_and_resize_transactions() {
-        solana_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -19803,19 +19795,6 @@ pub(crate) mod tests {
             &mock_program_id,
             mock_realloc_process_instruction,
         );
-
-        // get builtin program account data size, will beused to request max data size for
-        // transaction.
-        let mock_account_data_size = bank
-            .get_account_with_fixed_root(&mock_program_id)
-            .unwrap()
-            .data()
-            .len();
-        let compute_budget_account_data_size = bank
-            .get_account_with_fixed_root(&solana_sdk::compute_budget::id())
-            .unwrap()
-            .data()
-            .len();
 
         let recent_blockhash = bank.last_blockhash();
 
@@ -19849,7 +19828,6 @@ pub(crate) mod tests {
                 account_balance,
                 mock_program_id,
                 recent_blockhash,
-                (account_size + mock_account_data_size + compute_budget_account_data_size) as u32,
             );
             let result = bank.process_transaction(&transaction);
             assert!(result.is_ok());
@@ -19880,7 +19858,6 @@ pub(crate) mod tests {
                 account_balance,
                 mock_program_id,
                 recent_blockhash,
-                (account_size + mock_account_data_size + compute_budget_account_data_size) as u32,
             );
             let result = bank.process_transaction(&transaction);
             assert!(result.is_ok());


### PR DESCRIPTION
#### Problem
`test_accounts_data_size_and_resize_transactions():` generate random account data size without compute_budget instruction to set tx's max data size. When the randomly generated account size exceeds default 10M limit, transaction will fail due to `MaxLoadedAccountsDataSizeExceeded`

#### Summary of Changes
- add compute_budget instruction to set correct tx max data size limit

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
