### PR TITLE
Explorer: Token Decimal Fix

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -209,7 +209,7 @@ function FungibleTokenMintAccountCard({
               {normalizeTokenAmount(info.supply, info.decimals).toLocaleString(
                 "en-US",
                 {
-                  minimumFractionDigits: info.decimals,
+                  maximumFractionDigits: 20,
                 }
               )}
             </td>


### PR DESCRIPTION
#### Problem
Since the maximum is 20 as per the default spec (https://tc39.es/ecma402/#sec-defaultnumberoption), we should explicitly declare it.

#### Summary of Changes
TokenAccountSection failsafe to a maximum of 20!

Fixes #
https://github.com/solana-labs/solana/issues/25756
<!-- Don't forget to add the "feature-gate" label -->
