### PR TITLE
Revert "Warping calculates and sets new EAH (#28809)"

### DIFF
--- a/docs/src/proposals/epoch_accounts_hash.md
+++ b/docs/src/proposals/epoch_accounts_hash.md
@@ -214,11 +214,16 @@ slots).
 Warping introduces corner cases into EAH because many slots may be skipped,
 including the entire range of `start slot` to `stop slot`.
 
-Now, a new EAH will always be calculated based on the parent.  Thus, if the
-warp slot is `stop slot` or greater (and the parent slot is less than `stop
-slot`), the warp bank will include this newly-calculated EAH.  This is safe
-because warping cannot be used on a live cluster; only for a new cluster or
-tests/debugging.  Therefore _when_ the EAH was calculated is not germane.
+When warping from before `stop slot` to after, the new bank will include the
+existing EAH in its hash during `freeze()`.  If the bank's parent is from
+before `start slot`, then a new EAH calculation will not have been requested.
+This is safe because warping cannot be used on a live cluster; only for a new
+cluster or tests/debugging.  This means _when_ the EAH was calculated is not
+germane.
+
+When warping from before `start slot` to after, an EAH calculation will be
+requested the next time `set_root()` is called.  Therefore the EAH will be
+based on this new bank.  This is also safe and correct.
 
 For specific examples, refer to Appendix A.
 
@@ -272,60 +277,49 @@ No slots important to the EAH have been skipped, so no change in behavior.
 
 #### parent slot: `A`, warp slot: `B`
 
-An EAH calculation will be requested when the warp slot is rooted, and then
-will be included in the Bank at `slot slot 1`; behavior is unchanged.
+An EAH calculation will be requested at the warp slot, and then will be
+included in the Bank at `slot slot 1`; behavior is unchanged.
 
 
 #### parent slot: `A`, warp slot: `C` or `D`
 
 The entire EAH range has been skipped; no new EAH calculation will have been
-requested for `start slot 1`.  The warp slot will include the EAH calculated at
-the parent slot.  This is different from the normal behavior.
+requested for epoch 1.  The warp slot will include the EAH from `epoch 0`.
+This is different from the normal behavior.
 
 
 #### parent slot: `A`, warp slot: `E`
 
-Similar to `A -> C`, the warp slot will include the EAH calculated at the
-parent slot.  This behavior appears different.
-
-Then when the warp slot is rooted, a new EAH calculation will be requested,
-which will be included in `stop slot 2`.  This behavior is expected.
+Similar to `A -> B`, an EAH calculation will be requested at the warp slot, and
+then will be included in the Bank at `stop slot 2`.  Behavior appears normal.
 
 
 #### parent slot: `A`, warp slot: `F`
 
 Similar to `A -> C`, no new EAH calculation will be requested.  The warp slot
-will include the EAH calculated at the parent slot.  This is different from the
-normal behavior.
+will include the EAH from `epoch 0`.  This is different from the normal
+behavior.
 
 
 #### parent slot: `B`, warp slot: `B`
 
-A new EAH will be calculated at parent slot, which will be included in `stop
-slot 1`, _not_ the previously-calculated EAH from `start slot 1`.  This behaior
-is different.
+Similar to `A -> A`, no slots important to the EAH have been skipped, so no
+change in behavior.
 
 
 #### parent slot: `B`, warp slot: `C` or `D`
 
-The warp slot will include the EAH calculated at the parent slot, _not_ the
-previously-calculated EAH from `start slot 1`.  This is different from normal
-behavior.
+This will be observed as normal behavior; the warp slot will include the EAH
+that was calculated based on `start slot 1`.
 
 
 #### parent slot: `B`, warp slot: `E`
 
-Similar to `B -> C`, the warp slot will include the EAH calculated at the parent
-slot, _not_ the previously-calculated EAH from `start slot 1`.  This is
-different from normal behavior.
-
-And similar to `A -> E`, when the warp slot is rooted, a new EAH calculation
-will be requested, which will be included in `stop slot 2`.  This behavior is
-expected.
+Similar to `A -> B`, an EAH calculation will be requested at the warp slot, and
+then will be included in the Bank at `stop slot 2`.  Behavior appears normal.
 
 
 #### parent slot: `B`, warp slot: `F`
 
-Similar to `B -> C`, the warp slot will include the EAH calculated at the parent
-slot, _not_ the previously-calculated EAH from `start slot 1`.  This is
-different from normal behavior.
+The warp slot will include the EAH from `start slot 1`.  Behavior appears
+different.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1867,26 +1867,7 @@ impl Bank {
     /// in the past
     /// * Adjusts the new bank's tick height to avoid having to run PoH for millions of slots
     /// * Freezes the new bank, assuming that the user will `Bank::new_from_parent` from this bank
-    /// * Calculates and sets the epoch accounts hash from the parent
     pub fn warp_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
-        parent.freeze();
-        parent
-            .rc
-            .accounts
-            .accounts_db
-            .epoch_accounts_hash_manager
-            .set_in_flight(parent.slot());
-        parent.force_flush_accounts_cache();
-        let accounts_hash =
-            parent.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, true);
-        let epoch_accounts_hash = EpochAccountsHash::new(accounts_hash);
-        parent
-            .rc
-            .accounts
-            .accounts_db
-            .epoch_accounts_hash_manager
-            .set_valid(epoch_accounts_hash, parent.slot());
-
         let parent_timestamp = parent.clock().unix_timestamp;
         let mut new = Bank::new_from_parent(parent, collector_id, slot);
         new.apply_feature_activations(ApplyFeatureActivationsCaller::WarpFromParent, false);


### PR DESCRIPTION
#### Problem

PR #28809 causes CI `downstream-projects` to fail intermittently due to exceeding RPC deadline.  This is due to calculating the accounts hash when warping taking many seconds. Until the root cause of why the accounts hash calculation is taking so long is identified, the CI should be unblocked.


#### Summary of Changes

This reverts commit c1e440acb6c1b0cbbc7625adfebcef2090e4b9f6.