### PR TITLE
saturating max_concurrent_uni_streams and receive_window instead of overflow

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -81,10 +81,15 @@ pub(crate) fn configure_server(
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
     // QUIC_MAX_CONCURRENT_STREAMS doubled, which was found to improve reliability
-    const MAX_CONCURRENT_UNI_STREAMS: u32 = (QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS * 2) as u32;
+    const MAX_CONCURRENT_UNI_STREAMS: u32 =
+        (QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS.saturating_mul(2)) as u32;
     config.max_concurrent_uni_streams(MAX_CONCURRENT_UNI_STREAMS.into());
     config.stream_receive_window((PACKET_DATA_SIZE as u32).into());
-    config.receive_window((PACKET_DATA_SIZE as u32 * MAX_CONCURRENT_UNI_STREAMS).into());
+    config.receive_window(
+        (PACKET_DATA_SIZE as u32)
+            .saturating_mul(MAX_CONCURRENT_UNI_STREAMS)
+            .into(),
+    );
     let timeout = IdleTimeout::from(VarInt::from_u32(QUIC_MAX_TIMEOUT_MS));
     config.max_idle_timeout(Some(timeout));
 


### PR DESCRIPTION
#### Problem

MAX_CONCURRENT_UNI_STREAMS and receive_window could overflow.

This is found when experimenting with QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS for
unthrottled quic streams.

https://github.com/solana-labs/solana/pull/28837


#### Summary of Changes
Make the calculation saturating.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
