### PR TITLE
expect only 1 store per slot

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3881,6 +3881,8 @@ impl AccountsDb {
             .bytes_written
             .fetch_add(aligned_total, Ordering::Relaxed);
 
+        assert_eq!(store_ids.len(), 1);
+
         ShrinkCollect {
             store_ids,
             original_bytes,


### PR DESCRIPTION
#### Problem
Shrinking and ancient append vecs can be more efficient if we assume only a single store per slot.

#### Summary of Changes
Assert that when we shrink, we only ever have 1 append vec per slot. This will be true for validators that are using the write cache. The write cache can no longer be disabled due to a recent commit. All laggard tests that don't use the write cache are being addressed. All the tests that triggered this assert have already been adapted to use the write cache.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
