### PR TITLE
remove per-account slot in ancient append vecs

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9934,7 +9934,14 @@ pub mod tests {
             self.1.len()
         }
         fn contains_multiple_slots(&self) -> bool {
-            false
+            let len = self.len();
+            if len > 0 {
+                let slot = self.slot(0);
+                // true if any item has a different slot than the first item
+                (1..len).any(|i| slot != self.slot(i))
+            } else {
+                false
+            }
         }
         fn include_slot_in_hash(&self) -> IncludeSlotInHash {
             INCLUDE_SLOT_IN_HASH_TESTS

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -226,16 +226,17 @@ impl CurrentAncientAppendVec {
     fn store_ancient_accounts(
         &self,
         db: &AccountsDb,
-        accounts: &AccountsToStore,
+        accounts_to_store: &AccountsToStore,
         storage_selector: StorageSelector,
     ) -> StoreAccountsTiming {
-        let (accounts, hashes) = accounts.get(storage_selector);
+        let (accounts, hashes) = accounts_to_store.get(storage_selector);
 
         db.store_accounts_frozen(
             (
                 self.slot(),
                 accounts,
                 INCLUDE_SLOT_IN_HASH_IRRELEVANT_APPEND_VEC_OPERATION,
+                accounts_to_store.slot,
             ),
             Some(hashes),
             Some(self.append_vec()),
@@ -4360,14 +4361,14 @@ impl AccountsDb {
     /// returns the pubkeys that are in 'accounts' that are already in 'existing_ancient_pubkeys'
     /// Also updated 'existing_ancient_pubkeys' to include all pubkeys in 'accounts' since they will soon be written into the ancient slot.
     fn get_keys_to_unref_ancient<'a>(
-        accounts: &'a [(&StoredAccountMeta<'_>, Slot)],
+        accounts: &'a [&StoredAccountMeta<'_>],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) -> HashSet<&'a Pubkey> {
         let mut unref = HashSet::<&Pubkey>::default();
         // for each key that we're about to add that already exists in this storage, we need to unref. The account was in a different storage.
         // Now it is being put into an ancient storage again, but it is already there, so maintain max of 1 ref per storage in the accounts index.
         // The slot that currently references the account is going away, so unref to maintain # slots that reference the pubkey = refcount.
-        accounts.iter().for_each(|(account, _)| {
+        accounts.iter().for_each(|account| {
             let key = account.pubkey();
             if !existing_ancient_pubkeys.insert(*key) {
                 // this key exists BOTH in 'accounts' and already in the ancient append vec, so we need to unref it
@@ -4382,7 +4383,7 @@ impl AccountsDb {
     /// As a side effect, on exit, 'existing_ancient_pubkeys' will now contain all pubkeys in 'accounts'.
     fn unref_accounts_already_in_storage(
         &self,
-        accounts: &[(&StoredAccountMeta<'_>, Slot)],
+        accounts: &[&StoredAccountMeta<'_>],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) {
         let unref = Self::get_keys_to_unref_ancient(accounts, existing_ancient_pubkeys);
@@ -9933,14 +9934,7 @@ pub mod tests {
             self.1.len()
         }
         fn contains_multiple_slots(&self) -> bool {
-            let len = self.len();
-            if len > 0 {
-                let slot = self.slot(0);
-                // true if any item has a different slot than the first item
-                (1..len).any(|i| slot != self.slot(i))
-            } else {
-                false
-            }
+            false
         }
         fn include_slot_in_hash(&self) -> IncludeSlotInHash {
             INCLUDE_SLOT_IN_HASH_TESTS
@@ -10106,9 +10100,8 @@ pub mod tests {
             stored_size,
             hash: &hash,
         };
-        let slot0 = 0;
         let mut existing_ancient_pubkeys = HashSet::default();
-        let accounts = [(&stored_account, slot0)];
+        let accounts = [&stored_account];
         // pubkey NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
         let unrefs =
             AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
@@ -10126,7 +10119,7 @@ pub mod tests {
         );
         assert_eq!(unrefs.iter().cloned().collect::<Vec<_>>(), vec![&pubkey]);
         // pubkey2 NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
-        let accounts = [(&stored_account2, slot0)];
+        let accounts = [&stored_account2];
         let unrefs =
             AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
         assert!(unrefs.is_empty());
@@ -10149,7 +10142,7 @@ pub mod tests {
         );
         assert_eq!(unrefs.iter().cloned().collect::<Vec<_>>(), vec![&pubkey2]);
         // pubkey3/4 NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
-        let accounts = [(&stored_account3, slot0), (&stored_account4, slot0)];
+        let accounts = [&stored_account3, &stored_account4];
         let unrefs =
             AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
         assert!(unrefs.is_empty());

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -128,7 +128,7 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
     }
 }
 
-/// this tuple contains slot info PER account
+/// this tuple contains a single different source slot that applies to all accounts
 impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
     for (
         Slot,
@@ -144,7 +144,7 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
         self.1[index]
     }
     fn slot(&self, _index: usize) -> Slot {
-        // note that this could be different than 'target_slot()' PER account
+        // same other slot for all accounts
         self.3
     }
     fn target_slot(&self) -> Slot {
@@ -154,14 +154,7 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
         self.1.len()
     }
     fn contains_multiple_slots(&self) -> bool {
-        let len = self.len();
-        if len > 0 {
-            let slot = self.slot(0);
-            // true if any item has a different slot than the first item
-            (1..len).any(|i| slot != self.slot(i))
-        } else {
-            false
-        }
+        false
     }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.2


### PR DESCRIPTION
#### Problem
The plan was to be able to specify a target slot for a store of accounts as well as a source slot per account. This allows us to update the index correctly when moving between slots during ancient append vec work. However, we don't need per-account slot, we just need a single source slot shared by all accounts that are moving.

#### Summary of Changes
Remove the variations that allowed a per-account slot and use a single source slot for all accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
