### PR TITLE
[zk-token-sdk] use canonical decoding for scalars

### DIFF
--- a/zk-token-sdk/src/curve25519/edwards.rs
+++ b/zk-token-sdk/src/curve25519/edwards.rs
@@ -101,7 +101,7 @@ mod target_arch {
 
         #[cfg(not(target_os = "solana"))]
         fn multiply(scalar: &PodScalar, point: &Self) -> Option<Self> {
-            let scalar: Scalar = scalar.into();
+            let scalar: Scalar = scalar.try_into().ok()?;
             let point: EdwardsPoint = point.try_into().ok()?;
 
             let result = &scalar * &point;
@@ -114,8 +114,13 @@ mod target_arch {
         type Point = Self;
 
         fn multiscalar_multiply(scalars: &[PodScalar], points: &[Self]) -> Option<Self> {
+            let scalars = scalars
+                .iter()
+                .map(|scalar| Scalar::try_from(scalar).ok())
+                .collect::<Option<Vec<_>>>()?;
+
             EdwardsPoint::optional_multiscalar_mul(
-                scalars.iter().map(Scalar::from),
+                scalars,
                 points
                     .iter()
                     .map(|point| EdwardsPoint::try_from(point).ok()),

--- a/zk-token-sdk/src/curve25519/ristretto.rs
+++ b/zk-token-sdk/src/curve25519/ristretto.rs
@@ -101,7 +101,7 @@ mod target_arch {
 
         #[cfg(not(target_os = "solana"))]
         fn multiply(scalar: &PodScalar, point: &Self) -> Option<Self> {
-            let scalar: Scalar = scalar.into();
+            let scalar: Scalar = scalar.try_into().ok()?;
             let point: RistrettoPoint = point.try_into().ok()?;
 
             let result = &scalar * &point;
@@ -114,8 +114,13 @@ mod target_arch {
         type Point = Self;
 
         fn multiscalar_multiply(scalars: &[PodScalar], points: &[Self]) -> Option<Self> {
+            let scalars = scalars
+                .iter()
+                .map(|scalar| Scalar::try_from(scalar).ok())
+                .collect::<Option<Vec<_>>>()?;
+
             RistrettoPoint::optional_multiscalar_mul(
-                scalars.iter().map(Scalar::from),
+                scalars,
                 points
                     .iter()
                     .map(|point| RistrettoPoint::try_from(point).ok()),

--- a/zk-token-sdk/src/curve25519/scalar.rs
+++ b/zk-token-sdk/src/curve25519/scalar.rs
@@ -6,7 +6,7 @@ pub struct PodScalar(pub [u8; 32]);
 
 #[cfg(not(target_os = "solana"))]
 mod target_arch {
-    use {super::*, curve25519_dalek::scalar::Scalar};
+    use {super::*, crate::curve25519::errors::Curve25519Error, curve25519_dalek::scalar::Scalar};
 
     impl From<&Scalar> for PodScalar {
         fn from(scalar: &Scalar) -> Self {
@@ -14,9 +14,11 @@ mod target_arch {
         }
     }
 
-    impl From<&PodScalar> for Scalar {
-        fn from(pod: &PodScalar) -> Self {
-            Scalar::from_bits(pod.0)
+    impl TryFrom<&PodScalar> for Scalar {
+        type Error = Curve25519Error;
+
+        fn try_from(pod: &PodScalar) -> Result<Self, Self::Error> {
+            Scalar::from_canonical_bytes(pod.0).ok_or(Curve25519Error::PodConversion)
         }
     }
 }

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -28,6 +28,8 @@ pub enum ProofError {
     Decryption,
     #[error("invalid ciphertext data")]
     CiphertextDeserialization,
+    #[error("invalid scalar data")]
+    ScalarDeserialization,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -82,9 +82,11 @@ mod target_arch {
         }
     }
 
-    impl From<PodScalar> for Scalar {
-        fn from(pod: PodScalar) -> Self {
-            Scalar::from_bits(pod.0)
+    impl TryFrom<PodScalar> for Scalar {
+        type Error = ProofError;
+
+        fn try_from(pod: PodScalar) -> Result<Self, Self::Error> {
+            Scalar::from_canonical_bytes(pod.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 


### PR DESCRIPTION
#### Problem
Currently, convertion from `PodScalar` to `Scalar` uses `Scalar::from_bits()`. This conversion accepts scalar values that are non-canonically encoded, which is generally not a problem, but could potentially cause disagreement on the validity of a non-canonical input by different actors in a protocol.

#### Summary of Changes
Use `Scalar::from_canonical_bytes()` for pod conversions.