### PR TITLE
use write cache by default in some tests

### DIFF
--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -63,6 +63,7 @@ fn test_bench_tps_local_cluster(config: Config) {
             cluster_lamports: 200_000_000,
             validator_configs: make_identical_validator_configs(
                 &ValidatorConfig {
+                    accounts_db_caching_enabled: true,
                     rpc_config: JsonRpcConfig {
                         faucet_addr: Some(faucet_addr),
                         ..JsonRpcConfig::default_for_test()

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -101,7 +101,7 @@ impl SnapshotTestConfig {
             Arc::<RuntimeConfig>::default(),
             vec![accounts_dir.path().to_path_buf()],
             AccountSecondaryIndexes::default(),
-            false,
+            true,
             accounts_db::AccountShrinkThreshold::default(),
         );
         bank0.freeze();
@@ -252,7 +252,7 @@ fn run_bank_forks_snapshot_n<F>(
             // set_root should send a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
             bank.update_accounts_hash_for_tests();
-            snapshot_request_handler.handle_snapshot_requests(false, false, 0, &mut None);
+            snapshot_request_handler.handle_snapshot_requests(true, false, 0, &mut None);
         }
     }
 
@@ -784,7 +784,7 @@ fn test_bank_forks_incremental_snapshot(
             bank_forks.set_root(bank.slot(), &request_sender, None);
             bank.update_accounts_hash_for_tests();
             snapshot_request_handler.handle_snapshot_requests(
-                false,
+                true,
                 false,
                 0,
                 &mut last_full_snapshot_slot,
@@ -1041,7 +1041,7 @@ fn test_snapshots_with_background_services(
         bank_forks.clone(),
         &exit,
         abs_request_handler,
-        false,
+        true,
         false,
         None,
     );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4791,6 +4791,7 @@ pub mod tests {
             let (bank_forks, mint_keypair, leader_vote_keypair) =
                 new_bank_forks_with_config(BankTestConfig {
                     secondary_indexes: config.account_indexes.clone(),
+                    accounts_db_caching_enabled: true,
                 });
 
             let ledger_path = get_tmp_ledger_path!();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1150,6 +1150,14 @@ pub struct NewBankOptions {
 #[derive(Debug, Default)]
 pub struct BankTestConfig {
     pub secondary_indexes: AccountSecondaryIndexes,
+    pub accounts_db_caching_enabled: bool,
+}
+
+pub fn bank_test_config_caching_enabled() -> BankTestConfig {
+    BankTestConfig {
+        accounts_db_caching_enabled: true,
+        ..BankTestConfig::default()
+    }
 }
 
 #[derive(Debug)]
@@ -1224,7 +1232,7 @@ impl Bank {
         Self::new_with_config_for_tests(
             genesis_config,
             test_config.secondary_indexes,
-            false,
+            test_config.accounts_db_caching_enabled,
             AccountShrinkThreshold::default(),
         )
     }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -152,7 +152,7 @@ impl Default for TestValidatorGenesis {
             max_ledger_shreds: Option::<u64>::default(),
             max_genesis_archive_unpacked_size: Option::<u64>::default(),
             geyser_plugin_config_files: Option::<Vec<PathBuf>>::default(),
-            accounts_db_caching_enabled: bool::default(),
+            accounts_db_caching_enabled: true,
             deactivate_feature_set: HashSet::<Pubkey>::default(),
             compute_unit_limit: Option::<u64>::default(),
             log_messages_bytes_limit: Option::<usize>::default(),


### PR DESCRIPTION
#### Problem
goal is to enable write cache always, since it is always enabled in the validator.
This lets us get rid of `write_version` and the concept of multiple append vecs per slot.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
