### PR TITLE
Renames BankHashInfo field to accounts_delta_hash

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1196,20 +1196,20 @@ impl Accounts {
     }
 
     pub fn bank_hash_at(&self, slot: Slot, rewrites: &Rewrites) -> Hash {
-        self.bank_hash_info_at(slot, rewrites).hash
+        self.bank_hash_info_at(slot, rewrites).accounts_delta_hash
     }
 
     pub fn bank_hash_info_at(&self, slot: Slot, rewrites: &Rewrites) -> BankHashInfo {
-        let delta_hash = self
+        let accounts_delta_hash = self
             .accounts_db
             .get_accounts_delta_hash_with_rewrites(slot, rewrites);
         let bank_hashes = self.accounts_db.bank_hashes.read().unwrap();
-        let mut hash_info = bank_hashes
+        let mut bank_hash_info = bank_hashes
             .get(&slot)
             .expect("No bank hash was found for this bank, that should not be possible")
             .clone();
-        hash_info.hash = delta_hash;
-        hash_info
+        bank_hash_info.accounts_delta_hash = accounts_delta_hash;
+        bank_hash_info
     }
 
     /// This function will prevent multiple threads from modifying the same account state at the

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1150,7 +1150,7 @@ impl BankHashStats {
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
 pub struct BankHashInfo {
-    pub hash: Hash,
+    pub accounts_delta_hash: Hash,
     pub accounts_hash: Hash,
     pub stats: BankHashStats,
 }
@@ -4963,7 +4963,7 @@ impl AccountsDb {
         }
 
         let new_hash_info = BankHashInfo {
-            hash: Hash::default(),
+            accounts_delta_hash: Hash::default(),
             accounts_hash: Hash::default(),
             stats: BankHashStats::default(),
         };
@@ -12901,7 +12901,7 @@ pub mod tests {
 
         let some_bank_hash = Hash::new(&[0xca; HASH_BYTES]);
         let bank_hash_info = BankHashInfo {
-            hash: some_bank_hash,
+            accounts_delta_hash: some_bank_hash,
             accounts_hash: Hash::new(&[0xca; HASH_BYTES]),
             stats: BankHashStats::default(),
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6709,7 +6709,7 @@ impl Bank {
     ///  of the delta of the ledger since the last vote and up to now
     fn hash_internal_state(&self) -> Hash {
         // If there are no accounts, return the hash of the previous state and the latest blockhash
-        let accounts_delta_hash = self
+        let bank_hash_info = self
             .rc
             .accounts
             .bank_hash_info_at(self.slot(), &self.rewrites_skipped_this_slot);
@@ -6718,7 +6718,7 @@ impl Bank {
 
         let mut hash = hashv(&[
             self.parent_hash.as_ref(),
-            accounts_delta_hash.hash.as_ref(),
+            bank_hash_info.accounts_delta_hash.as_ref(),
             &signature_count_buf,
             self.last_blockhash().as_ref(),
         ]);
@@ -6750,7 +6750,7 @@ impl Bank {
             "bank frozen: {} hash: {} accounts_delta: {} signature_count: {} last_blockhash: {} capitalization: {}{}",
             self.slot(),
             hash,
-            accounts_delta_hash.hash,
+            bank_hash_info.accounts_delta_hash,
             self.signature_count(),
             self.last_blockhash(),
             self.capitalization(),
@@ -6764,7 +6764,7 @@ impl Bank {
         info!(
             "accounts hash slot: {} stats: {:?}",
             self.slot(),
-            accounts_delta_hash.stats,
+            bank_hash_info.stats,
         );
         hash
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -680,7 +680,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "C4asU4c7Qbd31QQDScqRPnT3iLCYc4qaGqeUQEGP7cTw")]
+    #[frozen_abi(digest = "B9ui5cFeJ5NGtXAVFXRCSX4GJ77yLc3izv1E8QE34TdQ")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem

The `hash` field in BankHashInfo could be more clear.


#### Summary of Changes

Rename it to `accounts_delta_hash`, since that's what it is.