### PR TITLE
Removes Accounts::bank_hash_at()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -41,7 +41,6 @@ use {
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
-        hash::Hash,
         message::{
             v0::{LoadedAddresses, MessageAddressTableLookup},
             SanitizedMessage,
@@ -1208,10 +1207,6 @@ impl Accounts {
         for k in readonly_keys {
             account_locks.unlock_readonly(k);
         }
-    }
-
-    pub fn bank_hash_at(&self, slot: Slot, rewrites: &Rewrites) -> Hash {
-        self.bank_hash_info_at(slot, rewrites).accounts_delta_hash
     }
 
     pub fn bank_hash_info_at(&self, slot: Slot, rewrites: &Rewrites) -> BankHashInfo {
@@ -2605,7 +2600,7 @@ mod tests {
             false,
             AccountShrinkThreshold::default(),
         );
-        accounts.bank_hash_at(1, &Rewrites::default());
+        accounts.bank_hash_info_at(1, &Rewrites::default());
     }
 
     #[test]

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -210,8 +210,12 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     );
     check_accounts(&daccounts, &pubkeys, 100);
     assert_eq!(
-        accounts.bank_hash_at(0, &Rewrites::default()),
-        daccounts.bank_hash_at(0, &Rewrites::default())
+        accounts
+            .bank_hash_info_at(0, &Rewrites::default())
+            .accounts_delta_hash,
+        daccounts
+            .bank_hash_info_at(0, &Rewrites::default())
+            .accounts_delta_hash
     );
 }
 


### PR DESCRIPTION
#### Problem

The term "bank hash" is somewhat overloaded/context dependent. `Accounts::bank_hash_at()` returns the bank's accounts delta hash, which isn't super clear, and is different from other uses of "bank hash". Turns out this function is only ever used in tests, so it can be fixed easily.


#### Summary of Changes

Remove `Accounts::bank_hash_at()` and use `Accounts::bank_hash_info_at().accounts_delta_hash` instead.