### PR TITLE
Renames to AccountsHasher

### DIFF
--- a/merkle-root-bench/src/main.rs
+++ b/merkle-root-bench/src/main.rs
@@ -2,7 +2,7 @@ extern crate log;
 use {
     clap::{crate_description, crate_name, value_t, App, Arg},
     solana_measure::measure::Measure,
-    solana_runtime::accounts_hash::AccountsHash,
+    solana_runtime::accounts_hash::AccountsHasher,
     solana_sdk::{hash::Hash, pubkey::Pubkey},
 };
 
@@ -38,7 +38,7 @@ fn main() {
             let hashes = hashes.clone(); // done outside timing
             let mut time = Measure::start("compute_merkle_root");
             let fanout = 16;
-            AccountsHash::compute_merkle_root(hashes, fanout);
+            AccountsHasher::compute_merkle_root(hashes, fanout);
             time.stop();
             time.as_us()
         })


### PR DESCRIPTION
#### Problem

To distinguish between full and incremental accounts hashes for https://github.com/orgs/solana-labs/projects/13/, I intend to add an enum. Ideally the name would be `AccountsHash`, but that name is already taken.

The current `AccountsHash` does not _contain_ an accounts hash though, it _performs_ the calculation of the accounts hash merkle tree. So it can be renamed to make its intent clearer.


#### Summary of Changes

Rename `AccountsHash` to `AccountsHasher`.