### PR TITLE
bank tests use write cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1233,7 +1233,7 @@ impl Bank {
         Self::new_with_config_for_tests(
             genesis_config,
             test_config.secondary_indexes,
-            test_config.accounts_db_caching_enabled,
+            true,
             AccountShrinkThreshold::default(),
         )
     }


### PR DESCRIPTION
#### Problem
migrating all tests to use write cache.
All bank tests now support this.

#### Summary of Changes
make `new_for_tests_with_config` always enable the write cache. Other plumbing will be removed later once all tests everywhere use the write cache.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
