### PR TITLE
Add an RPC API that can query the list of Top N secondary index keys and their sizes

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1487,6 +1487,27 @@ impl<T: IndexValue> AccountsIndex<T> {
         }
     }
 
+    pub fn get_largest_keys(
+        &self,
+        index: &AccountIndex,
+        max_entries: usize,
+    ) -> Vec<(usize, Pubkey)> {
+        match index {
+            AccountIndex::ProgramId => self
+                .program_id_index
+                .key_size_index
+                .get_largest_keys(max_entries),
+            AccountIndex::SplTokenOwner => self
+                .spl_token_owner_index
+                .key_size_index
+                .get_largest_keys(max_entries),
+            AccountIndex::SplTokenMint => self
+                .spl_token_mint_index
+                .key_size_index
+                .get_largest_keys(max_entries),
+        }
+    }
+
     /// log any secondary index counts, if non-zero
     pub(crate) fn log_secondary_indexes(&self) {
         if !self.program_id_index.index.is_empty() {


### PR DESCRIPTION
#### Problem
Secondary account indexes can become quite large for certain keys which have many associated accounts in the system and thus require many GB of ram to store and can cause the validator to OOM. When the RPC call is made to the validator it also will just spin in a core and allocate memory and the resulting request will be too large to transmit over a single RPC request requiring many seconds and hitting connection timeouts. So often even indexing these keys is not useful at least with the current apis. 

#### Summary of Changes
Add an RPC API that can query the list of secondary index keys and their sizes such that we can figure out which keys are taking a lot of ram and add them to the exclusion list.

Fixes # 
https://github.com/solana-labs/solana/issues/28666
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
