### PR TITLE
clean up: remove my_pubkey arg from consume_buffered_packets

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -70,7 +70,6 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank = Arc::new(Bank::new_for_benches(&genesis_config));
     let ledger_path = get_tmp_ledger_path!();
-    let my_pubkey = pubkey::new_rand();
     {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
@@ -93,7 +92,6 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         // If the packet buffers are copied, performance will be poor.
         bencher.iter(move || {
             BankingStage::consume_buffered_packets(
-                &my_pubkey,
                 std::u128::MAX,
                 &poh_recorder,
                 &mut transaction_buffer,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -696,7 +696,6 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     pub fn consume_buffered_packets(
-        _my_pubkey: &Pubkey,
         max_tx_ingestion_ns: u128,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
@@ -890,7 +889,6 @@ impl BankingStage {
                 slot_metrics_tracker.apply_action(metrics_action);
                 let (_, consume_buffered_packets_time) = measure!(
                     Self::consume_buffered_packets(
-                        my_pubkey,
                         max_tx_ingestion_ns,
                         poh_recorder,
                         unprocessed_transaction_storage,
@@ -3699,7 +3697,6 @@ mod tests {
             assert!(!poh_recorder.read().unwrap().has_bank());
             let max_tx_processing_ns = std::u128::MAX;
             BankingStage::consume_buffered_packets(
-                &Pubkey::default(),
                 max_tx_processing_ns,
                 &poh_recorder,
                 &mut buffered_packet_batches,
@@ -3717,7 +3714,6 @@ mod tests {
             // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
             poh_recorder.write().unwrap().set_bank(&bank, false);
             BankingStage::consume_buffered_packets(
-                &Pubkey::default(),
                 max_tx_processing_ns,
                 &poh_recorder,
                 &mut buffered_packet_batches,
@@ -3780,7 +3776,6 @@ mod tests {
                             ThreadType::Transactions,
                         );
                     BankingStage::consume_buffered_packets(
-                        &Pubkey::default(),
                         std::u128::MAX,
                         &poh_recorder_,
                         &mut buffered_packet_batches,


### PR DESCRIPTION
#### Problem
Unused parameter, been here for a long while.

#### Summary of Changes
Remove it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
