### PR TITLE
add sendandconfirm with retry to connection object. Adapted from the solana cookbook

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2574,8 +2574,7 @@ export type SignatureResult = {
 /**
  * Signature result with signature trying to confirm
  */
- export type SignatureResultWithContext = {
-  err: TransactionError | null;
+ export type SignatureResultWithContext = SignatureResult & {
   signature?: string;
 };
 


### PR DESCRIPTION
#### Problem
Transaction failures while sending or confirming can cause some business logic problems when you need to know how to handle it yourself. Adapting this method from the Solana Cookbook recommendation for retrying transactions. That way reducing a huge chunk of code to one liner that uses already existing methods on the Connection object.  

Open to suggestions if there is a better way to do this but would help to be able to use this straight from the package instead of implementing it your own way for base cases. Some more complex scenarios I can see why you would want to leave this up to the programmer to decide. 

#### Summary of Changes
Add SendAndConfirmRawTransactionWithRetry function and SendRawTransactionWithRetry to the connection object
Extend the SignatureResult type to include a signature string you can parse out from the result. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
