### PR TITLE
Improve error message

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2980,7 +2980,12 @@ fn main() {
                     value_t_or_exit!(arg_matches, "snapshot_slot", Slot)
                 };
 
-                if blockstore.meta(snapshot_slot).unwrap().is_none() {
+                if blockstore
+                    .meta(snapshot_slot)
+                    .unwrap()
+                    .filter(|m| m.is_full())
+                    .is_none()
+                {
                     eprintln!(
                         "Error: snapshot slot {} does not exist in blockstore or is not full.",
                         snapshot_slot,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2981,22 +2981,9 @@ fn main() {
                 };
 
                 if blockstore.meta(snapshot_slot).unwrap().is_none() {
-                    // Find the highest full slot that is less than or equal to the snapshot slot, if it exists
-                    let most_recent_slot_before_snapshot_slot = blockstore
-                        .slot_meta_iterator(0)
-                        .ok()
-                        .map(|r| {
-                            r.filter_map(|meta| {
-                                (meta.0 <= snapshot_slot && meta.1.is_full()).then_some(meta.0)
-                            })
-                            .last()
-                        })
-                        .unwrap_or_default();
-
                     eprintln!(
-                        "Error: snapshot slot {} does not exist in blockstore or is not full. Nearest earlier full slot in blockstore is {:?}",
+                        "Error: snapshot slot {} does not exist in blockstore or is not full.",
                         snapshot_slot,
-                        most_recent_slot_before_snapshot_slot,
                     );
                     exit(1);
                 }


### PR DESCRIPTION
#### Problem
Error message when trying to create a snapshot for a slot that doesn't exist (or is not full) was not good, and done through panic.

#### Summary of Changes
Use eprintln + exit, improve error message.

Old:
```
thread 'main' panicked at 'snapshot slot doesn't exist', ledger-tool/src/main.rs:2983:17
```

New:
```
Error: snapshot slot 43 does not exist in blockstore.
```

Fixes #28896
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
