### PR TITLE
separate should_working_bank_still_be_processing_txs from wrapping option

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -69,14 +69,18 @@ pub struct BankStart {
 
 impl BankStart {
     fn get_working_bank_if_not_expired(&self) -> Option<&Arc<Bank>> {
-        if Bank::should_bank_still_be_processing_txs(
-            &self.bank_creation_time,
-            self.working_bank.ns_per_slot,
-        ) {
+        if self.should_working_bank_still_be_processing_txs() {
             Some(&self.working_bank)
         } else {
             None
         }
+    }
+
+    fn should_working_bank_still_be_processing_txs(&self) -> bool {
+        Bank::should_bank_still_be_processing_txs(
+            &self.bank_creation_time,
+            self.working_bank.ns_per_slot,
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem
determining if working_bank is expired can be made simpler, and without using Options.

#### Summary of Changes
Separate out the call to `Bank::should_bank_still_be_processing_txs`. Doesn't do much here, but I use it in another branch in order to avoid taking a lock in consume.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
