### PR TITLE
ci: rewrite Github Actions slack error reporting

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -41,16 +41,6 @@ jobs:
       - name: Stable build
         run: ./cargo stable ndk --target ${{ matrix.target }} build -p solana-client
 
-      - name: Send Slack notifiaction
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
-
   ios:
     strategy:
       matrix:
@@ -73,12 +63,23 @@ jobs:
       - name: Stable build
         run: ./cargo stable build --target ${{ matrix.target }} -p solana-client
 
-      - name: Send Slack notifiaction
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
+  error_reporting:
+    needs:
+      - android
+      - ios
+    if: failure() && github.event_name == 'push'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Slack
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST ${{ secrets.SLACK_ERROR_REPORTING_WEBHOOK }} \
+            -d '{
+              "attachments": [
+                {
+                  "color": "#AC514C",
+                  "text":
+                    "*${{ github.repository }} (${{ github.workflow }})*\n${{ github.event.head_commit.message }} - _${{ github.event.head_commit.author.name }}_\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Build>",
+                }
+              ]
+            }'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,18 +88,23 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
-  notification:
-    if: failure()
-    runs-on: ubuntu-20.04
+  error_reporting:
     needs:
       - check
       - build_and_deploy
+    if: failure() && github.event_name == 'push'
+    runs-on: ubuntu-20.04
     steps:
-      - name: Send Slack notifiaction
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
+      - name: Slack
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST ${{ secrets.SLACK_ERROR_REPORTING_WEBHOOK }} \
+            -d '{
+              "attachments": [
+                {
+                  "color": "#AC514C",
+                  "text":
+                    "*${{ github.repository }} (${{ github.workflow }})*\n${{ github.event.head_commit.message }} - _${{ github.event.head_commit.author.name }}_\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Build>",
+                }
+              ]
+            }'

--- a/.github/workflows/export-github-repo.yml
+++ b/.github/workflows/export-github-repo.yml
@@ -25,12 +25,23 @@ jobs:
           chmod +x ./ci/export-github-repo.sh
           ./ci/export-github-repo.sh web3.js/ solana-web3.js
         shell: bash
-      - name: Send Slack notifiaction
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
+
+  error_reporting:
+    needs:
+      - web3
+    if: failure() && github.event_name == 'push'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Slack
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST ${{ secrets.SLACK_ERROR_REPORTING_WEBHOOK }} \
+            -d '{
+              "attachments": [
+                {
+                  "color": "#AC514C",
+                  "text":
+                    "*${{ github.repository }} (${{ github.workflow }})*\n${{ github.event.head_commit.message }} - _${{ github.event.head_commit.author.name }}_\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Build>",
+                }
+              ]
+            }'

--- a/.github/workflows/release-artifacts-auto.yml
+++ b/.github/workflows/release-artifacts-auto.yml
@@ -18,16 +18,22 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
 
-  send-slack-notification:
-    runs-on: ubuntu-20.04
+  error_reporting:
     needs:
       - release-artifacts
-    if: failure()
+    if: failure() && github.event_name == 'push'
+    runs-on: ubuntu-20.04
     steps:
-      - env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
+      - name: Slack
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST ${{ secrets.SLACK_ERROR_REPORTING_WEBHOOK }} \
+            -d '{
+              "attachments": [
+                {
+                  "color": "#AC514C",
+                  "text":
+                    "*${{ github.repository }} (${{ github.workflow }})*\n${{ github.event.head_commit.message }} - _${{ github.event.head_commit.author.name }}_\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Build>",
+                }
+              ]
+            }'


### PR DESCRIPTION
#### Problem

`voxmedia/github-action-slack-notify-build@v1` doesn't maintain anymore. I use pure curl to replace it. I think it will be more easy for us to do some custom changes in the future.

#### Summary of Changes

- remove voxmedia/github-action-slack-notify-build@v1 action

