### PR TITLE
Adds a feature ID for `enable_alt_bn128_syscall`

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -32,11 +32,12 @@ use {
         entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         feature_set::FeatureSet,
         feature_set::{
-            self, alt_bn128_syscall_enabled, blake3_syscall_enabled, check_physical_overlapping,
+            self, blake3_syscall_enabled, check_physical_overlapping,
             check_syscall_outputs_do_not_overlap, curve25519_syscall_enabled,
             disable_cpi_setting_executable_and_rent_epoch, disable_fees_sysvar,
-            enable_early_verification_of_account_modifications, libsecp256k1_0_5_upgrade_enabled,
-            limit_secp256k1_recovery_id, stop_sibling_instruction_search_at_parent,
+            enable_alt_bn128_syscall, enable_early_verification_of_account_modifications,
+            libsecp256k1_0_5_upgrade_enabled, limit_secp256k1_recovery_id,
+            stop_sibling_instruction_search_at_parent,
         },
         hash::{Hasher, HASH_BYTES},
         instruction::{
@@ -149,7 +150,7 @@ pub fn register_syscalls<'a>(
     feature_set: &FeatureSet,
     disable_deploy_of_alloc_free_syscall: bool,
 ) -> Result<SyscallRegistry<InvokeContext<'a>>, EbpfError> {
-    let alt_bn128_syscall_enabled = feature_set.is_active(&alt_bn128_syscall_enabled::id());
+    let enable_alt_bn128_syscall = feature_set.is_active(&enable_alt_bn128_syscall::id());
     let blake3_syscall_enabled = feature_set.is_active(&blake3_syscall_enabled::id());
     let curve25519_syscall_enabled = feature_set.is_active(&curve25519_syscall_enabled::id());
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
@@ -274,7 +275,7 @@ pub fn register_syscalls<'a>(
         // Alt_bn128
         register_feature_gated_syscall!(
             syscall_registry,
-            alt_bn128_syscall_enabled,
+            enable_alt_bn128_syscall,
             b"sol_alt_bn128_group_op",
             SyscallAltBn128::call,
         )?;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -542,8 +542,8 @@ pub mod cap_transaction_accounts_data_size {
     solana_sdk::declare_id!("DdLwVYuvDz26JohmgSbA7mjpJFgX5zP2dkp8qsF2C33V");
 }
 
-pub mod alt_bn128_syscall_enabled {
-    solana_sdk::declare_id!("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXALTBN128");
+pub mod enable_alt_bn128_syscall {
+    solana_sdk::declare_id!("A16q37opZdQMCbe5qJ6xpBB9usykfv8jZaMkxvZQi4GJ");
 }
 
 lazy_static! {
@@ -676,7 +676,7 @@ lazy_static! {
         (check_syscall_outputs_do_not_overlap::id(), "check syscall outputs do_not overlap #28600"),
         (enable_bpf_loader_set_authority_checked_ix::id(), "enable bpf upgradeable loader SetAuthorityChecked instruction #28424"),
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
-        (alt_bn128_syscall_enabled::id(), "add alt_bn128 syscalls"),
+        (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Community contribution #27961 was missing a feature key.

#### Summary of Changes
Renames `alt_bn128_syscall_enabled` => `enable_alt_bn128_syscall` for consistency.