### PR TITLE
remove cli arg "--no-accounts-db-caching"

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1313,10 +1313,6 @@ fn main() {
         .long("no-bpf-jit")
         .takes_value(false)
         .help("Disable the just-in-time compiler and instead use the interpreter for BP");
-    let no_accounts_db_caching_arg = Arg::with_name("no_accounts_db_caching")
-        .long("no-accounts-db-caching")
-        .takes_value(false)
-        .help("Disables accounts-db caching");
     let accounts_index_bins = Arg::with_name("accounts_index_bins")
         .long("accounts-index-bins")
         .value_name("BINS")
@@ -1791,7 +1787,6 @@ fn main() {
             .arg(&ancient_append_vecs)
             .arg(&halt_at_slot_store_hash_raw_data)
             .arg(&hard_forks_arg)
-            .arg(&no_accounts_db_caching_arg)
             .arg(&accounts_db_test_hash_calculation_arg)
             .arg(&no_os_memory_stats_reporting_arg)
             .arg(&no_bpf_jit_arg)
@@ -2777,7 +2772,7 @@ fn main() {
                     run_final_accounts_hash_calc: true,
                     halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                     debug_keys,
-                    accounts_db_caching_enabled: !arg_matches.is_present("no_accounts_db_caching"),
+                    accounts_db_caching_enabled: true,
                     limit_load_slot_count_from_snapshot: value_t!(
                         arg_matches,
                         "limit_load_slot_count_from_snapshot",

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -332,7 +332,7 @@ fn main() {
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
     genesis.max_genesis_archive_unpacked_size = Some(u64::MAX);
-    genesis.accounts_db_caching_enabled = !matches.is_present("no_accounts_db_caching");
+    genesis.accounts_db_caching_enabled = true;
     genesis.log_messages_bytes_limit = value_t!(matches, "log_messages_bytes_limit", usize).ok();
     genesis.transaction_account_lock_limit =
         value_t!(matches, "transaction_account_lock_limit", usize).ok();

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1158,11 +1158,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("When account indexes are enabled, only include specific keys in the index. This overrides --account-index-exclude-key."),
         )
         .arg(
-            Arg::with_name("no_accounts_db_caching")
-                .long("no-accounts-db-caching")
-                .help("Disables accounts caching"),
-        )
-        .arg(
             Arg::with_name("accounts_db_verify_refcounts")
                 .long("accounts-db-verify-refcounts")
                 .help("Debug option to scan all append vecs and verify account index refcounts prior to clean")
@@ -1503,7 +1498,6 @@ fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
     vec![
         Arg::with_name("accounts_db_caching_enabled")
             .long("accounts-db-caching-enabled")
-            .conflicts_with("no_accounts_db_caching")
             .hidden(true),
         Arg::with_name("accounts_db_index_hashing")
             .long("accounts-db-index-hashing")
@@ -2148,11 +2142,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .multiple(true)
                 .help("Specify the configuration file for the Geyser plugin."),
-        )
-        .arg(
-            Arg::with_name("no_accounts_db_caching")
-                .long("no-accounts-db-caching")
-                .help("Disables accounts caching"),
         )
         .arg(
             Arg::with_name("deactivate_feature")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1150,7 +1150,7 @@ pub fn main() {
             .unwrap_or(poh_service::DEFAULT_HASHES_PER_BATCH),
         process_ledger_before_services: matches.is_present("process_ledger_before_services"),
         account_indexes,
-        accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
+        accounts_db_caching_enabled: true,
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         accounts_db_config,
         accounts_db_skip_shrink: matches.is_present("accounts_db_skip_shrink"),


### PR DESCRIPTION
#### Problem
Disabled caching is already not well tested and it is about to get less tested.
We already default to caching for validators and ledger-tool.

#### Summary of Changes
Remove the ability to disable the accounts write cache.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
