### PR TITLE
ci: use our cargo setup instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -28,9 +28,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        shell: bash
+        run: |
+          source ci/rust-version.sh stable
 
       # copy the newest version env.sh before switching version.
       - name: Copy Env Script


### PR DESCRIPTION
#### Problem

actions-rs/toolchain doesn't maintain anymore. use our cargo setup script.