### PR TITLE
Renames fn to insert_default_bank_hash()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -218,7 +218,7 @@ impl Accounts {
 
     pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot) -> Self {
         let accounts_db = parent.accounts_db.clone();
-        accounts_db.set_hash(slot, parent_slot);
+        accounts_db.insert_default_bank_hash(slot, parent_slot);
         Self {
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4968,7 +4968,11 @@ impl AccountsDb {
         }
     }
 
-    pub fn set_hash(&self, slot: Slot, parent_slot: Slot) {
+    /// Insert a new bank hash for `slot`
+    ///
+    /// The new bank hash is empty/default except for the slot.  This fn is called when creating a
+    /// new bank from parent.  The bank hash for this slot is updated with real values later.
+    pub fn insert_default_bank_hash(&self, slot: Slot, parent_slot: Slot) {
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         if bank_hashes.get(&slot).is_some() {
             error!(
@@ -12318,12 +12322,12 @@ pub mod tests {
         accounts.add_root(0);
 
         let mut current_slot = 1;
-        accounts.set_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
         accounts.store_uncached(current_slot, &[(&pubkey, &account)]);
         accounts.add_root(current_slot);
 
         current_slot += 1;
-        accounts.set_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
         accounts.store_uncached(current_slot, &[(&pubkey, &zero_lamport_account)]);
         accounts.add_root(current_slot);
 
@@ -12331,7 +12335,7 @@ pub mod tests {
 
         // Otherwise slot 2 will not be removed
         current_slot += 1;
-        accounts.set_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
         accounts.add_root(current_slot);
 
         accounts.print_accounts_stats("pre_purge");


### PR DESCRIPTION
#### Problem

The `AccountsDb::set_hash()` method is vague, since there are so many different hashes.

#### Summary of Changes

Rename `AccountsDb::set_hash()` to `insert_default_bank_hash()`. This fn is called when creating a new bank from parent, and it inserts a bank/default BankHashInfo into the `AccountsDb::bank_hashes` map.