### PR TITLE
Promotes accounts hash to a strong type

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
             }
             println!(
                 "hash,{},{},{},{}%",
-                results.0,
+                results.0 .0,
                 time,
                 time_store,
                 (time_store.as_us() as f64 / time.as_us() as f64 * 100.0f64) as u32

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -326,7 +326,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                     },
                 )
                 .unwrap();
-            expected_epoch_accounts_hash = Some(EpochAccountsHash::new(accounts_hash));
+            expected_epoch_accounts_hash = Some(EpochAccountsHash::from(accounts_hash));
             debug!(
                 "slot {}, expected epoch accounts hash: {:?}",
                 bank.slot(),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -17,6 +17,7 @@ use {
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         accounts_db::{self, ACCOUNTS_DB_CONFIG_FOR_TESTING},
+        accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta},
         bank_forks::BankForks,
@@ -277,13 +278,14 @@ fn run_bank_forks_snapshot_n<F>(
         None,
     )
     .unwrap();
+    let accounts_hash = last_bank.get_accounts_hash();
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         accounts_package.snapshot_links_dir(),
         accounts_package.slot,
-        &last_bank.get_accounts_hash(),
+        &accounts_hash,
         None,
     );
-    let snapshot_package = SnapshotPackage::new(accounts_package, last_bank.get_accounts_hash());
+    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash);
     snapshot_utils::archive_snapshot_package(
         &snapshot_package,
         &snapshot_config.full_snapshot_archives_dir,
@@ -527,10 +529,10 @@ fn test_concurrent_snapshot_packaging(
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
                 accounts_package.snapshot_links_dir(),
                 accounts_package.slot,
-                &Hash::default(),
+                &AccountsHash::default(),
                 None,
             );
-            let snapshot_package = SnapshotPackage::new(accounts_package, Hash::default());
+            let snapshot_package = SnapshotPackage::new(accounts_package, AccountsHash::default());
             pending_snapshot_package
                 .lock()
                 .unwrap()
@@ -571,7 +573,7 @@ fn test_concurrent_snapshot_packaging(
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         saved_snapshots_dir.path(),
         saved_slot,
-        &Hash::default(),
+        &AccountsHash::default(),
         None,
     );
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1079,6 +1079,10 @@ impl AccountsHasher {
     }
 }
 
+/// Hash of all the accounts
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, AbiExample)]
+pub struct AccountsHash(pub Hash);
+
 #[cfg(test)]
 pub mod tests {
     use {super::*, std::str::FromStr};

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -48,6 +48,7 @@ use {
             IncludeSlotInHash, SnapshotStorages, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
+        accounts_hash::AccountsHash,
         accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult, ZeroLamport},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::{Ancestors, AncestorsForSerialization},
@@ -1899,7 +1900,7 @@ impl Bank {
         parent.force_flush_accounts_cache();
         let accounts_hash =
             parent.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, true);
-        let epoch_accounts_hash = EpochAccountsHash::new(accounts_hash);
+        let epoch_accounts_hash = accounts_hash.into();
         parent
             .rc
             .accounts
@@ -7043,7 +7044,7 @@ impl Bank {
         old
     }
 
-    pub fn get_accounts_hash(&self) -> Hash {
+    pub fn get_accounts_hash(&self) -> AccountsHash {
         self.rc.accounts.accounts_db.get_accounts_hash(self.slot)
     }
 
@@ -7069,8 +7070,8 @@ impl Bank {
         data_source: CalcAccountsHashDataSource,
         mut debug_verify: bool,
         is_startup: bool,
-    ) -> Hash {
-        let (hash, total_lamports) = self.rc.accounts.accounts_db.update_accounts_hash(
+    ) -> AccountsHash {
+        let (accounts_hash, total_lamports) = self.rc.accounts.accounts_db.update_accounts_hash(
             data_source,
             debug_verify,
             self.slot(),
@@ -7111,10 +7112,10 @@ impl Bank {
                 self.capitalization()
             );
         }
-        hash
+        accounts_hash
     }
 
-    pub fn update_accounts_hash_for_tests(&self) -> Hash {
+    pub fn update_accounts_hash_for_tests(&self) -> AccountsHash {
         self.update_accounts_hash(CalcAccountsHashDataSource::IndexForTests, false, false)
     }
 

--- a/runtime/src/epoch_accounts_hash.rs
+++ b/runtime/src/epoch_accounts_hash.rs
@@ -7,7 +7,7 @@
 //!
 //! This results in all nodes effectively voting on the accounts state (at least) once per epoch.
 
-use solana_sdk::hash::Hash;
+use {crate::accounts_hash::AccountsHash, solana_sdk::hash::Hash};
 
 mod utils;
 pub use utils::*;
@@ -30,5 +30,11 @@ impl EpochAccountsHash {
     #[must_use]
     pub const fn new(accounts_hash: Hash) -> Self {
         Self(accounts_hash)
+    }
+}
+
+impl From<AccountsHash> for EpochAccountsHash {
+    fn from(accounts_hash: AccountsHash) -> EpochAccountsHash {
+        Self::new(accounts_hash.0)
     }
 }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -5,6 +5,7 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig, AppendVecId,
             AtomicAppendVecId, BankHashInfo, IndexGenerationInfo, SnapshotStorage,
         },
+        accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         append_vec::{AppendVec, StoredMetaWriteVersion},
@@ -65,7 +66,7 @@ pub(crate) enum SerdeStyle {
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, AbiExample, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, AbiExample, PartialEq, Eq)]
 pub struct AccountsDbFields<T>(
     HashMap<Slot, Vec<T>>,
     StoredMetaWriteVersion,
@@ -192,7 +193,7 @@ trait TypeContext<'a>: PartialEq {
     fn reserialize_bank_fields_with_hash<R, W>(
         stream_reader: &mut BufReader<R>,
         stream_writer: &mut BufWriter<W>,
-        accounts_hash: &Hash,
+        accounts_hash: &AccountsHash,
         incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     ) -> std::result::Result<(), Box<bincode::ErrorKind>>
     where
@@ -391,7 +392,7 @@ where
 fn reserialize_bank_fields_with_new_hash<W, R>(
     stream_reader: &mut BufReader<R>,
     stream_writer: &mut BufWriter<W>,
-    accounts_hash: &Hash,
+    accounts_hash: &AccountsHash,
     incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
 ) -> Result<(), Error>
 where
@@ -414,7 +415,7 @@ where
 pub fn reserialize_bank_with_new_accounts_hash(
     bank_snapshots_dir: impl AsRef<Path>,
     slot: Slot,
-    accounts_hash: &Hash,
+    accounts_hash: &AccountsHash,
     incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
 ) -> bool {
     let bank_post = snapshot_utils::get_bank_snapshots_dir(bank_snapshots_dir, slot);

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -5,6 +5,7 @@ use {
         *,
     },
     crate::{
+        accounts_hash::AccountsHash,
         ancestors::AncestorsForSerialization,
         stakes::{serde_stakes_enum_compat, StakesEnum},
     },
@@ -269,7 +270,7 @@ impl<'a> TypeContext<'a> for Context {
                 )
             }));
         let slot = serializable_db.slot;
-        let hash: BankHashInfo = serializable_db
+        let bank_hash_info: BankHashInfo = serializable_db
             .accounts_db
             .bank_hashes
             .read()
@@ -293,7 +294,7 @@ impl<'a> TypeContext<'a> for Context {
             entries,
             version,
             slot,
-            hash,
+            bank_hash_info,
             historical_roots,
             historical_roots_with_hash,
         )
@@ -346,7 +347,7 @@ impl<'a> TypeContext<'a> for Context {
     fn reserialize_bank_fields_with_hash<R, W>(
         stream_reader: &mut BufReader<R>,
         stream_writer: &mut BufWriter<W>,
-        accounts_hash: &Hash,
+        accounts_hash: &AccountsHash,
         incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     ) -> std::result::Result<(), Box<bincode::ErrorKind>>
     where

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -5,6 +5,7 @@ use {
     crate::{
         accounts::{test_utils::create_test_accounts, Accounts},
         accounts_db::{get_temp_accounts_paths, AccountShrinkThreshold, AccountStorageMap},
+        accounts_hash::AccountsHash,
         append_vec::AppendVec,
         bank::{Bank, Rewrites},
         epoch_accounts_hash,
@@ -289,12 +290,12 @@ fn test_bank_serialize_style(
     .unwrap();
 
     let accounts_hash = if update_accounts_hash {
-        let hash = Hash::new(&[1; 32]);
+        let accounts_hash = AccountsHash(Hash::new(&[1; 32]));
         bank2
             .accounts()
             .accounts_db
-            .set_accounts_hash(bank2.slot(), hash);
-        hash
+            .set_accounts_hash(bank2.slot(), accounts_hash);
+        accounts_hash
     } else {
         bank2.get_accounts_hash()
     };
@@ -685,7 +686,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "B9ui5cFeJ5NGtXAVFXRCSX4GJ77yLc3izv1E8QE34TdQ")]
+    #[frozen_abi(digest = "464v92sAyLDZWCXjH6cuQfgrSNuB3PY8cmoVu2dciXvV")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -1,6 +1,6 @@
 //! Helper types and functions for handling and dealing with snapshot hashes.
 use {
-    crate::epoch_accounts_hash::EpochAccountsHash,
+    crate::{accounts_hash::AccountsHash, epoch_accounts_hash::EpochAccountsHash},
     solana_sdk::{
         clock::Slot,
         hash::{Hash, Hasher},
@@ -56,12 +56,15 @@ pub struct SnapshotHash(pub Hash);
 impl SnapshotHash {
     /// Make a snapshot hash from an accounts hash and epoch accounts hash
     #[must_use]
-    pub fn new(accounts_hash: &Hash, epoch_accounts_hash: Option<&EpochAccountsHash>) -> Self {
+    pub fn new(
+        accounts_hash: &AccountsHash,
+        epoch_accounts_hash: Option<&EpochAccountsHash>,
+    ) -> Self {
         let snapshot_hash = match epoch_accounts_hash {
-            None => *accounts_hash,
+            None => accounts_hash.0,
             Some(epoch_accounts_hash) => {
                 let mut hasher = Hasher::default();
-                hasher.hash(accounts_hash.as_ref());
+                hasher.hash(accounts_hash.0.as_ref());
                 hasher.hash(epoch_accounts_hash.as_ref().as_ref());
                 hasher.result()
             }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         accounts::Accounts,
         accounts_db::SnapshotStorages,
+        accounts_hash::AccountsHash,
         bank::{Bank, BankSlotDelta},
         epoch_accounts_hash::EpochAccountsHash,
         rent_collector::RentCollector,
@@ -13,7 +14,7 @@ use {
         },
     },
     log::*,
-    solana_sdk::{clock::Slot, hash::Hash, sysvar::epoch_schedule::EpochSchedule},
+    solana_sdk::{clock::Slot, sysvar::epoch_schedule::EpochSchedule},
     std::{
         fs,
         path::{Path, PathBuf},
@@ -37,7 +38,7 @@ pub struct AccountsPackage {
     pub block_height: Slot,
     pub snapshot_storages: SnapshotStorages,
     pub expected_capitalization: u64,
-    pub accounts_hash_for_testing: Option<Hash>,
+    pub accounts_hash_for_testing: Option<AccountsHash>,
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
@@ -64,7 +65,7 @@ impl AccountsPackage {
         snapshot_storages: SnapshotStorages,
         archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
-        accounts_hash_for_testing: Option<Hash>,
+        accounts_hash_for_testing: Option<AccountsHash>,
     ) -> Result<Self> {
         if let AccountsPackageType::Snapshot(snapshot_type) = package_type {
             info!(
@@ -125,7 +126,7 @@ impl AccountsPackage {
         package_type: AccountsPackageType,
         bank: &Bank,
         snapshot_storages: SnapshotStorages,
-        accounts_hash_for_testing: Option<Hash>,
+        accounts_hash_for_testing: Option<AccountsHash>,
     ) -> Self {
         assert_eq!(package_type, AccountsPackageType::EpochAccountsHash);
         Self::_new(
@@ -141,7 +142,7 @@ impl AccountsPackage {
         package_type: AccountsPackageType,
         bank: &Bank,
         snapshot_storages: SnapshotStorages,
-        accounts_hash_for_testing: Option<Hash>,
+        accounts_hash_for_testing: Option<AccountsHash>,
         snapshot_info: Option<SupplementalSnapshotInfo>,
     ) -> Self {
         Self {
@@ -244,7 +245,7 @@ pub struct SnapshotPackage {
 }
 
 impl SnapshotPackage {
-    pub fn new(accounts_package: AccountsPackage, accounts_hash: Hash) -> Self {
+    pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHash) -> Self {
         let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type else {
             panic!("The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!");
         };

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2221,14 +2221,15 @@ pub fn package_and_archive_full_snapshot(
         None,
     )?;
 
+    let accounts_hash = bank.get_accounts_hash();
     crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         accounts_package.snapshot_links_dir(),
         accounts_package.slot,
-        &bank.get_accounts_hash(),
+        &accounts_hash,
         None,
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());
+    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash);
     archive_snapshot_package(
         &snapshot_package,
         full_snapshot_archives_dir,
@@ -2274,14 +2275,15 @@ pub fn package_and_archive_incremental_snapshot(
         None,
     )?;
 
+    let accounts_hash = bank.get_accounts_hash();
     crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         accounts_package.snapshot_links_dir(),
         accounts_package.slot,
-        &bank.get_accounts_hash(),
+        &accounts_hash,
         None,
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, bank.get_accounts_hash());
+    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash);
     archive_snapshot_package(
         &snapshot_package,
         full_snapshot_archives_dir,


### PR DESCRIPTION
#### Problem

The accounts hash is used as a plain `Hash` in the code base. To add support for Incremental Accounts Hash, we'll need to distinguish between different flavors of accounts hashes. Without any type information, this will be error-prone.


#### Summary of Changes

Promote accounts hash to a strong type: `AccountsHash`.

(Future work for Incremental Accounts Hash will expand/alter this type)