### PR TITLE
update to spl-token-2022 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk 1.15.0",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -5335,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f07a997db3dac7b9da06b007d4a8df6dbd8281182e6ebbbd8a56f935f540b0a"
+checksum = "341bba362c91aedad2ad9fc0c28c2e39aaa606e6b9c049e8fbcc9f60675163ff"
 dependencies = [
  "ahash",
  "blake3",
@@ -5362,7 +5362,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.5",
- "solana-frozen-abi-macro 1.14.5",
+ "solana-frozen-abi-macro 1.14.8",
  "subtle",
  "thiserror",
 ]
@@ -5402,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd7d529da0fa5b3b5ca71645122fc94c2aaf867744497969c109e1d4b8ad02d"
+checksum = "b6fae474ab37e2ccc4dfd33edd36a05d7df02b8531fa9870cb244f9491b64fe3"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5633,7 +5633,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "static_assertions",
  "tempfile",
  "test-case",
@@ -5730,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c690a6ae623bdd2d71229880a9f668ff714b5c6a9bc180a1abef4887da8b6f27"
+checksum = "1ec82f7dedfee58ff2ac102b20a033a195950e7355fb29f1713f46cee629ffda"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f835be7a20e172209538241cdf46451c08b38eaaca65cf16e65658700c447b17"
+checksum = "f480a0a440ea15d8436de1c9ac01501cb15979dae4a0a5fc8e33198949b38681"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5944,9 +5944,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.5",
  "sha3 0.10.4",
- "solana-frozen-abi 1.14.5",
- "solana-frozen-abi-macro 1.14.5",
- "solana-sdk-macro 1.14.5",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -6187,7 +6187,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "stream-cancel",
  "symlink",
  "thiserror",
@@ -6240,7 +6240,7 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -6358,9 +6358,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74e8d699c3a441a5b0cd94c718e75b25c1a4295c2180a714b12fb1bcf66a51e"
+checksum = "65641c3c87a81fbbf7663360a2d8d5e145280021c444220257f9975ff6cddc80"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -6397,11 +6397,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.5",
  "sha3 0.10.4",
- "solana-frozen-abi 1.14.5",
- "solana-frozen-abi-macro 1.14.5",
- "solana-logger 1.14.5",
- "solana-program 1.14.5",
- "solana-sdk-macro 1.14.5",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-logger 1.14.8",
+ "solana-program 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -6464,9 +6464,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ffde9b5b7313629780baca10eaffec7421d53be725c76031ca409a5298705c"
+checksum = "768f16d1a7315fc66ba835eebf9e95a83365ac94222551bc5cdcc6a74cb4a137"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6782,7 +6782,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -6932,9 +6932,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.14.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a23a2c443027e8cc2981131a38928cb37e554970c497b5735e888049cc85d3f"
+checksum = "ac5982ab9d8771b3d9bbef11ece78348c496a9f70a90a96225aee0a70bd13b9d"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6954,8 +6954,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.14.5",
- "solana-sdk 1.14.5",
+ "solana-program 1.14.8",
+ "solana-sdk 1.14.8",
  "subtle",
  "thiserror",
  "zeroize",
@@ -7041,9 +7041,9 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.14.5",
+ "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.4.3",
  "thiserror",
 ]
 
@@ -7054,7 +7054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c5557ec281a34f7f9053feb6e0d795162ba0c6a52898b21c3d1e899481191d5"
 dependencies = [
  "num_enum",
- "solana-program 1.14.5",
+ "solana-program 1.14.8",
 ]
 
 [[package]]
@@ -7063,7 +7063,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.14.5",
+ "solana-program 1.14.8",
 ]
 
 [[package]]
@@ -7077,7 +7077,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.5",
+ "solana-program 1.14.8",
  "thiserror",
 ]
 
@@ -7092,8 +7092,26 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.5",
- "solana-zk-token-sdk 1.14.5",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -23,7 +23,7 @@ solana-address-lookup-table-program = { path = "../programs/address-lookup-table
 solana-config-program = { path = "../programs/config", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.11.2"
 

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -6,7 +6,7 @@ use {
     },
     solana_sdk::pubkey::Pubkey,
     spl_token_2022::{
-        extension::StateWithExtensions,
+        extension::{BaseStateWithExtensions, StateWithExtensions},
         generic_token_account::GenericTokenAccount,
         solana_program::{
             program_option::COption, program_pack::Pack, pubkey::Pubkey as SplTokenPubkey,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -53,7 +53,7 @@ solana-storage-proto = { path = "../storage-proto", version = "=1.15.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.15.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
 tempfile = "3.3.0"
 thiserror = "1.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4220,7 +4220,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk 1.15.0",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -4566,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e4e35bc58c465f161bde764ebce41fdfcb503583cf3a77e0211274cc12b22d"
+checksum = "341bba362c91aedad2ad9fc0c28c2e39aaa606e6b9c049e8fbcc9f60675163ff"
 dependencies = [
  "ahash",
  "blake3",
@@ -4593,7 +4593,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.5",
- "solana-frozen-abi-macro 1.11.5",
+ "solana-frozen-abi-macro 1.14.8",
  "subtle",
  "thiserror",
 ]
@@ -4632,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708f837d748e574b1e53b250ab1f4a69ba330bbc10d041d02381165f0f36291a"
+checksum = "b6fae474ab37e2ccc4dfd33edd36a05d7df02b8531fa9870cb244f9491b64fe3"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -4785,7 +4785,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -4796,9 +4796,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ea6fc68d63d33d862d919d4c8ad7f613ec243ccf6762d595c660020b289b57"
+checksum = "1ec82f7dedfee58ff2ac102b20a033a195950e7355fb29f1713f46cee629ffda"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4907,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd314d85b171bb20ccdcaf07346a9d52a012b10d84f4706f0628813d002fef8"
+checksum = "f480a0a440ea15d8436de1c9ac01501cb15979dae4a0a5fc8e33198949b38681"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -4945,9 +4945,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.5",
  "sha3 0.10.4",
- "solana-frozen-abi 1.11.5",
- "solana-frozen-abi-macro 1.11.5",
- "solana-sdk-macro 1.11.5",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -5175,7 +5175,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5222,7 +5222,7 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -5686,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7d954df63b267857e26670e3aacfd8e2943ca703653b0418e5afc85046c2f3"
+checksum = "65641c3c87a81fbbf7663360a2d8d5e145280021c444220257f9975ff6cddc80"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5725,11 +5725,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.5",
  "sha3 0.10.4",
- "solana-frozen-abi 1.11.5",
- "solana-frozen-abi-macro 1.11.5",
- "solana-logger 1.11.5",
- "solana-program 1.11.5",
- "solana-sdk-macro 1.11.5",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-logger 1.14.8",
+ "solana-program 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5787,9 +5787,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d9e81bc46edcc517b2df504856d57a5101c7586ec63f3143ae11fbe2eba613"
+checksum = "768f16d1a7315fc66ba835eebf9e95a83365ac94222551bc5cdcc6a74cb4a137"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6008,7 +6008,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -6130,9 +6130,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.5"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62415c05a9ebfffaf8befaa61b24492ebf88269cf84cbeba714bac4125ec4ea3"
+checksum = "ac5982ab9d8771b3d9bbef11ece78348c496a9f70a90a96225aee0a70bd13b9d"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6143,6 +6143,7 @@ dependencies = [
  "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.14",
+ "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
@@ -6151,8 +6152,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.11.5",
- "solana-sdk 1.11.5",
+ "solana-program 1.14.8",
+ "solana-sdk 1.14.8",
  "subtle",
  "thiserror",
  "zeroize",
@@ -6237,9 +6238,9 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.11.5",
+ "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.4.3",
  "thiserror",
 ]
 
@@ -6249,7 +6250,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.11.5",
+ "solana-program 1.14.8",
 ]
 
 [[package]]
@@ -6263,7 +6264,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.5",
+ "solana-program 1.14.8",
  "thiserror",
 ]
 
@@ -6278,8 +6279,26 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.5",
- "solana-zk-token-sdk 1.11.5",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -22,7 +22,7 @@ solana-account-decoder = { path = "../account-decoder", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.15.0" }
 solana-version = { path = "../version", version = "=1.15.0" }
-spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -52,7 +52,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.15.0
 solana-version = { path = "../version", version = "=1.15.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -26,7 +26,7 @@ solana-sdk = { path = "../sdk", version = "=1.15.0" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -3,8 +3,9 @@ use {
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
     extension::{
-        confidential_transfer::*, default_account_state::*, interest_bearing_mint::*,
-        memo_transfer::*, mint_close_authority::*, reallocate::*, transfer_fee::*,
+        confidential_transfer::*, cpi_guard::*, default_account_state::*, interest_bearing_mint::*,
+        memo_transfer::*, mint_close_authority::*, permanent_delegate::*, reallocate::*,
+        transfer_fee::*,
     },
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{
@@ -228,7 +229,8 @@ pub fn parse_token(
                 | AuthorityType::TransferFeeConfig
                 | AuthorityType::WithheldWithdraw
                 | AuthorityType::CloseMint
-                | AuthorityType::InterestRate => "mint",
+                | AuthorityType::InterestRate
+                | AuthorityType::PermanentDelegate => "mint",
                 AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
             };
             let mut value = json!({
@@ -574,6 +576,21 @@ pub fn parse_token(
                 account_keys,
             )
         }
+        TokenInstruction::CpiGuardExtension => {
+            if instruction.data.len() < 2 {
+                return Err(ParseInstructionError::InstructionNotParsable(
+                    ParsableProgram::SplToken,
+                ));
+            }
+            parse_cpi_guard_instruction(&instruction.data[1..], &instruction.accounts, account_keys)
+        }
+        TokenInstruction::InitializePermanentDelegate { delegate } => {
+            parse_initialize_permanent_delegate_instruction(
+                delegate,
+                &instruction.accounts,
+                account_keys,
+            )
+        }
     }
 }
 
@@ -588,6 +605,7 @@ pub enum UiAuthorityType {
     WithheldWithdraw,
     CloseMint,
     InterestRate,
+    PermanentDelegate,
 }
 
 impl From<AuthorityType> for UiAuthorityType {
@@ -601,6 +619,7 @@ impl From<AuthorityType> for UiAuthorityType {
             AuthorityType::WithheldWithdraw => UiAuthorityType::WithheldWithdraw,
             AuthorityType::CloseMint => UiAuthorityType::CloseMint,
             AuthorityType::InterestRate => UiAuthorityType::InterestRate,
+            AuthorityType::PermanentDelegate => UiAuthorityType::PermanentDelegate,
         }
     }
 }
@@ -619,6 +638,8 @@ pub enum UiExtensionType {
     MemoTransfer,
     NonTransferable,
     InterestBearingConfig,
+    CpiGuard,
+    PermanentDelegate,
 }
 
 impl From<ExtensionType> for UiExtensionType {
@@ -637,6 +658,8 @@ impl From<ExtensionType> for UiExtensionType {
             ExtensionType::MemoTransfer => UiExtensionType::MemoTransfer,
             ExtensionType::NonTransferable => UiExtensionType::NonTransferable,
             ExtensionType::InterestBearingConfig => UiExtensionType::InterestBearingConfig,
+            ExtensionType::CpiGuard => UiExtensionType::CpiGuard,
+            ExtensionType::PermanentDelegate => UiExtensionType::PermanentDelegate,
         }
     }
 }

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -214,36 +214,6 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 info: value,
             })
         }
-        ConfidentialTransferInstruction::TransferWithFee => {
-            check_num_token_accounts(account_indexes, 5)?;
-            let transfer_data: TransferInstructionData = *decode_instruction_data(instruction_data)
-                .map_err(|_| {
-                    ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
-                })?;
-            let proof_instruction_offset: i8 = transfer_data.proof_instruction_offset;
-            let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "destination": account_keys[account_indexes[1] as usize].to_string(),
-                "mint": account_keys[account_indexes[2] as usize].to_string(),
-                "instructionsSysvar": account_keys[account_indexes[3] as usize].to_string(),
-                "newSourceDecryptableAvailableBalance": format!("{}", transfer_data.new_source_decryptable_available_balance),
-                "proofInstructionOffset": proof_instruction_offset,
-
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                4,
-                account_keys,
-                account_indexes,
-                "owner",
-                "multisigOwner",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "confidentialTransferWithFee".to_string(),
-                info: value,
-            })
-        }
         ConfidentialTransferInstruction::ApplyPendingBalance => {
             check_num_token_accounts(account_indexes, 2)?;
             let apply_pending_balance_data: ApplyPendingBalanceData =
@@ -273,7 +243,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 info: value,
             })
         }
-        ConfidentialTransferInstruction::EnableBalanceCredits => {
+        ConfidentialTransferInstruction::EnableConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
                 "account": account_keys[account_indexes[0] as usize].to_string(),
@@ -289,11 +259,11 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 "multisigOwner",
             );
             Ok(ParsedInstructionEnum {
-                instruction_type: "enableConfidentialTransferBalanceCredits".to_string(),
+                instruction_type: "enableConfidentialTransferConfidentialCredits".to_string(),
                 info: value,
             })
         }
-        ConfidentialTransferInstruction::DisableBalanceCredits => {
+        ConfidentialTransferInstruction::DisableConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
                 "account": account_keys[account_indexes[0] as usize].to_string(),
@@ -309,7 +279,47 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 "multisigOwner",
             );
             Ok(ParsedInstructionEnum {
-                instruction_type: "disableConfidentialTransferBalanceCredits".to_string(),
+                instruction_type: "disableConfidentialTransferConfidentialCredits".to_string(),
+                info: value,
+            })
+        }
+        ConfidentialTransferInstruction::EnableNonConfidentialCredits => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let mut value = json!({
+                "account": account_keys[account_indexes[0] as usize].to_string(),
+
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                1,
+                account_keys,
+                account_indexes,
+                "owner",
+                "multisigOwner",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "enableConfidentialTransferNonConfidentialCredits".to_string(),
+                info: value,
+            })
+        }
+        ConfidentialTransferInstruction::DisableNonConfidentialCredits => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let mut value = json!({
+                "account": account_keys[account_indexes[0] as usize].to_string(),
+
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                1,
+                account_keys,
+                account_indexes,
+                "owner",
+                "multisigOwner",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "disableNonConfidentialTransferConfidentialCredits".to_string(),
                 info: value,
             })
         }

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -1,0 +1,176 @@
+use {
+    super::*,
+    spl_token_2022::{
+        extension::cpi_guard::instruction::CpiGuardInstruction,
+        instruction::decode_instruction_type,
+    },
+};
+
+pub(in crate::parse_token) fn parse_cpi_guard_instruction(
+    instruction_data: &[u8],
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 2)?;
+    let instruction_type_str = match decode_instruction_type(instruction_data)
+        .map_err(|_| ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken))?
+    {
+        CpiGuardInstruction::Enable => "enable",
+        CpiGuardInstruction::Disable => "disable",
+    };
+    let mut value = json!({
+        "account": account_keys[account_indexes[0] as usize].to_string(),
+    });
+    let map = value.as_object_mut().unwrap();
+    parse_signers(
+        map,
+        1,
+        account_keys,
+        account_indexes,
+        "owner",
+        "multisigOwner",
+    );
+    Ok(ParsedInstructionEnum {
+        instruction_type: format!("{}CpiGuard", instruction_type_str),
+        info: value,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{
+            extension::cpi_guard::instruction::{disable_cpi_guard, enable_cpi_guard},
+            solana_program::message::Message,
+        },
+    };
+
+    #[test]
+    fn test_parse_cpi_guard_instruction() {
+        let account_pubkey = Pubkey::new_unique();
+
+        // Enable, single owner
+        let owner_pubkey = Pubkey::new_unique();
+        let enable_cpi_guard_ix = enable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_cpi_guard_ix = enable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Disable, single owner
+        let enable_cpi_guard_ix = disable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_cpi_guard_ix = disable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 pub(super) mod confidential_transfer;
+pub(super) mod cpi_guard;
 pub(super) mod default_account_state;
 pub(super) mod interest_bearing_mint;
 pub(super) mod memo_transfer;
 pub(super) mod mint_close_authority;
+pub(super) mod permanent_delegate;
 pub(super) mod reallocate;
 pub(super) mod transfer_fee;

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -1,0 +1,54 @@
+use {super::*, spl_token_2022::solana_program::pubkey::Pubkey};
+
+pub(in crate::parse_token) fn parse_initialize_permanent_delegate_instruction(
+    delegate: Pubkey,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 1)?;
+    Ok(ParsedInstructionEnum {
+        instruction_type: "initializePermanentDelegate".to_string(),
+        info: json!({
+            "mint": account_keys[account_indexes[0] as usize].to_string(),
+            "delegate": delegate.to_string(),
+        }),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{instruction::*, solana_program::message::Message},
+    };
+
+    #[test]
+    fn test_parse_initialize_permanent_delegate_instruction() {
+        let mint_pubkey = Pubkey::new_unique();
+        let delegate = Pubkey::new_unique();
+        let permanent_delegate_ix = initialize_permanent_delegate(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(delegate),
+        )
+        .unwrap();
+        let message = Message::new(&[permanent_delegate_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializePermanentDelegate".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "delegate": delegate.to_string(),
+                })
+            }
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
we just released a new version of token-2022 and would like to bring the monorepo up to this version so that we can use the account decoder in the token cli for the new extensions

#### Summary of Changes
i updated the token-2022 dependency to `=0.5.0` everywhere in the monorepo, and added support for our new extensions and instructions in account-decoder and transaction-status. most code for `CpiGuard` is copy-paste-adapted from `RequiredMemoTransfers`, and `PermanentDelegate` from `MintCloseAuthority`, because they share largely identical interfaces

im also going to pr a backport of this to 1.14 branch, since thats the version we are on. ill do it manually since `Cargo.lock` will likely differ