### PR TITLE
update to spl-token-2022 0.5.0 (backport to 1.14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,15 +3084,6 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest 0.10.3",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -4492,7 +4483,7 @@ dependencies = [
  "solana-sdk 1.14.9",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -4951,7 +4942,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5173,23 +5164,35 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5d3280421bb53fc12bdba1eaa505153fb4f99a06b5609dae22192652ead3b"
+checksum = "341bba362c91aedad2ad9fc0c28c2e39aaa606e6b9c049e8fbcc9f60675163ff"
 dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
  "bs58",
  "bv",
+ "byteorder",
+ "cc",
+ "either",
  "generic-array 0.14.5",
+ "getrandom 0.1.16",
+ "hashbrown 0.12.3",
  "im",
  "lazy_static",
  "log",
  "memmap2",
+ "once_cell",
+ "rand_core 0.6.3",
  "rustc_version 0.4.0",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.10.33",
+ "solana-frozen-abi-macro 1.14.8",
+ "subtle",
  "thiserror",
 ]
 
@@ -5228,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635c60ac96b1347af272c625465068b908aff919d19f29b5795a44310310494d"
+checksum = "b6fae474ab37e2ccc4dfd33edd36a05d7df02b8531fa9870cb244f9491b64fe3"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5456,7 +5459,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "static_assertions",
  "tempfile",
  "test-case",
@@ -5546,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12cb6e6f1f9c9876d356c928b8c2ac532f6715e7cd2a1b4343d747bee3eca73"
+checksum = "1ec82f7dedfee58ff2ac102b20a033a195950e7355fb29f1713f46cee629ffda"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5717,9 +5720,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeecf504cee2821b006871f70e7a1f54db15f914cedf259eaf5976fe606470f0"
+checksum = "f480a0a440ea15d8436de1c9ac01501cb15979dae4a0a5fc8e33198949b38681"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5730,31 +5733,38 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.1.16",
+ "getrandom 0.2.3",
  "itertools",
  "js-sys",
  "lazy_static",
+ "libc",
  "libsecp256k1",
  "log",
+ "memoffset",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rustc_version 0.4.0",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.33",
- "solana-frozen-abi-macro 1.10.33",
- "solana-sdk-macro 1.10.33",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -5930,7 +5940,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "stream-cancel",
  "symlink",
  "thiserror",
@@ -6026,9 +6036,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636f6c615aca6f75e22b6baceaf0ffed9d74367f9320b07ed57cd9b5ce2e4ff9"
+checksum = "65641c3c87a81fbbf7663360a2d8d5e145280021c444220257f9975ff6cddc80"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -6053,7 +6063,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.10.1",
+ "pbkdf2 0.11.0",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -6065,11 +6075,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.33",
- "solana-frozen-abi-macro 1.10.33",
- "solana-logger 1.10.33",
- "solana-program 1.10.33",
- "solana-sdk-macro 1.10.33",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-logger 1.14.8",
+ "solana-program 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -6131,9 +6141,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8bcac4394644f21dc013e932a7df9f536fcecef3e5df43fe362b4ec532ce30"
+checksum = "768f16d1a7315fc66ba835eebf9e95a83365ac94222551bc5cdcc6a74cb4a137"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6412,7 +6422,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -6544,9 +6554,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410ee53a26ac91098c289c983863535d4fbb6604b229ae1159503f48fa4fc90f"
+checksum = "ac5982ab9d8771b3d9bbef11ece78348c496a9f70a90a96225aee0a70bd13b9d"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6557,6 +6567,7 @@ dependencies = [
  "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.16",
+ "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
@@ -6565,8 +6576,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.10.33",
- "solana-sdk 1.10.33",
+ "solana-program 1.14.8",
+ "solana-sdk 1.14.8",
  "subtle",
  "thiserror",
  "zeroize",
@@ -6651,9 +6662,9 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.4.2",
  "thiserror",
 ]
 
@@ -6663,7 +6674,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
 ]
 
 [[package]]
@@ -6677,7 +6688,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
  "thiserror",
 ]
 
@@ -6692,8 +6703,26 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.33",
- "solana-zk-token-sdk 1.10.33",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -24,7 +24,7 @@ solana-config-program = { path = "../programs/config", version = "=1.14.9" }
 solana-sdk = { path = "../sdk", version = "=1.14.9" }
 solana-vote-program = { path = "../programs/vote", version = "=1.14.9" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.11.2"
 

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -6,7 +6,7 @@ use {
     },
     solana_sdk::pubkey::Pubkey,
     spl_token_2022::{
-        extension::StateWithExtensions,
+        extension::{BaseStateWithExtensions, StateWithExtensions},
         generic_token_account::GenericTokenAccount,
         solana_program::{
             program_option::COption, program_pack::Pack, pubkey::Pubkey as SplTokenPubkey,

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -49,7 +49,7 @@ solana-streamer = { path = "../streamer", version = "=1.14.9" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.14.9" }
 solana-version = { path = "../version", version = "=1.14.9" }
 solana-vote-program = { path = "../programs/vote", version = "=1.14.9" }
-spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.9"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -53,7 +53,7 @@ solana-storage-proto = { path = "../storage-proto", version = "=1.14.9" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.14.9" }
 solana-vote-program = { path = "../programs/vote", version = "=1.14.9" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 static_assertions = "1.1.0"
 tempfile = "3.3.0"
 thiserror = "1.0"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2887,15 +2887,6 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest 0.10.3",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -4079,7 +4070,7 @@ dependencies = [
  "solana-sdk 1.14.9",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -4676,7 +4667,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4821,23 +4812,35 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5d3280421bb53fc12bdba1eaa505153fb4f99a06b5609dae22192652ead3b"
+checksum = "341bba362c91aedad2ad9fc0c28c2e39aaa606e6b9c049e8fbcc9f60675163ff"
 dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
  "bs58",
  "bv",
+ "byteorder 1.4.3",
+ "cc",
+ "either",
  "generic-array 0.14.5",
+ "getrandom 0.1.14",
+ "hashbrown 0.12.3",
  "im",
  "lazy_static",
  "log",
  "memmap2",
+ "once_cell",
+ "rand_core 0.6.3",
  "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.10.33",
+ "solana-frozen-abi-macro 1.14.8",
+ "subtle",
  "thiserror",
 ]
 
@@ -4875,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635c60ac96b1347af272c625465068b908aff919d19f29b5795a44310310494d"
+checksum = "b6fae474ab37e2ccc4dfd33edd36a05d7df02b8531fa9870cb244f9491b64fe3"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5026,7 +5029,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5037,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12cb6e6f1f9c9876d356c928b8c2ac532f6715e7cd2a1b4343d747bee3eca73"
+checksum = "1ec82f7dedfee58ff2ac102b20a033a195950e7355fb29f1713f46cee629ffda"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5148,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeecf504cee2821b006871f70e7a1f54db15f914cedf259eaf5976fe606470f0"
+checksum = "f480a0a440ea15d8436de1c9ac01501cb15979dae4a0a5fc8e33198949b38681"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5161,31 +5164,38 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.1.14",
+ "getrandom 0.2.4",
  "itertools",
  "js-sys",
  "lazy_static",
+ "libc",
  "libsecp256k1 0.6.0",
  "log",
+ "memoffset",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.33",
- "solana-frozen-abi-macro 1.10.33",
- "solana-sdk-macro 1.10.33",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -5352,7 +5362,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5419,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636f6c615aca6f75e22b6baceaf0ffed9d74367f9320b07ed57cd9b5ce2e4ff9"
+checksum = "65641c3c87a81fbbf7663360a2d8d5e145280021c444220257f9975ff6cddc80"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5446,7 +5456,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.10.1",
+ "pbkdf2 0.11.0",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -5458,11 +5468,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.33",
- "solana-frozen-abi-macro 1.10.33",
- "solana-logger 1.10.33",
- "solana-program 1.10.33",
- "solana-sdk-macro 1.10.33",
+ "solana-frozen-abi 1.14.8",
+ "solana-frozen-abi-macro 1.14.8",
+ "solana-logger 1.14.8",
+ "solana-program 1.14.8",
+ "solana-sdk-macro 1.14.8",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5519,9 +5529,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8bcac4394644f21dc013e932a7df9f536fcecef3e5df43fe362b4ec532ce30"
+checksum = "768f16d1a7315fc66ba835eebf9e95a83365ac94222551bc5cdcc6a74cb4a137"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -5711,7 +5721,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -5814,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.10.33"
+version = "1.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410ee53a26ac91098c289c983863535d4fbb6604b229ae1159503f48fa4fc90f"
+checksum = "ac5982ab9d8771b3d9bbef11ece78348c496a9f70a90a96225aee0a70bd13b9d"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5827,6 +5837,7 @@ dependencies = [
  "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.14",
+ "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
@@ -5835,8 +5846,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.10.33",
- "solana-sdk 1.10.33",
+ "solana-program 1.14.8",
+ "solana-sdk 1.14.8",
  "subtle",
  "thiserror",
  "zeroize",
@@ -5921,9 +5932,9 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.4.2",
  "thiserror",
 ]
 
@@ -5933,7 +5944,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
 ]
 
 [[package]]
@@ -5947,7 +5958,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.33",
+ "solana-program 1.14.8",
  "thiserror",
 ]
 
@@ -5962,8 +5973,26 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.33",
- "solana-zk-token-sdk 1.10.33",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program 1.14.8",
+ "solana-zk-token-sdk 1.14.8",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -50,7 +50,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.14.9
 solana-version = { path = "../version", version = "=1.14.9" }
 solana-vote-program = { path = "../programs/vote", version = "=1.14.9" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,7 +29,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.14.9" }
 spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -1,0 +1,176 @@
+use {
+    super::*,
+    spl_token_2022::{
+        extension::cpi_guard::instruction::CpiGuardInstruction,
+        instruction::decode_instruction_type,
+    },
+};
+
+pub(in crate::parse_token) fn parse_cpi_guard_instruction(
+    instruction_data: &[u8],
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 2)?;
+    let instruction_type_str = match decode_instruction_type(instruction_data)
+        .map_err(|_| ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken))?
+    {
+        CpiGuardInstruction::Enable => "enable",
+        CpiGuardInstruction::Disable => "disable",
+    };
+    let mut value = json!({
+        "account": account_keys[account_indexes[0] as usize].to_string(),
+    });
+    let map = value.as_object_mut().unwrap();
+    parse_signers(
+        map,
+        1,
+        account_keys,
+        account_indexes,
+        "owner",
+        "multisigOwner",
+    );
+    Ok(ParsedInstructionEnum {
+        instruction_type: format!("{}CpiGuard", instruction_type_str),
+        info: value,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{
+            extension::cpi_guard::instruction::{disable_cpi_guard, enable_cpi_guard},
+            solana_program::message::Message,
+        },
+    };
+
+    #[test]
+    fn test_parse_cpi_guard_instruction() {
+        let account_pubkey = Pubkey::new_unique();
+
+        // Enable, single owner
+        let owner_pubkey = Pubkey::new_unique();
+        let enable_cpi_guard_ix = enable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_cpi_guard_ix = enable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Disable, single owner
+        let enable_cpi_guard_ix = disable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_cpi_guard_ix = disable_cpi_guard(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_cpi_guard_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableCpiGuard".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+pub(super) mod cpi_guard;
 pub(super) mod default_account_state;
 pub(super) mod interest_bearing_mint;
 pub(super) mod memo_transfer;
 pub(super) mod mint_close_authority;
+pub(super) mod permanent_delegate;
 pub(super) mod reallocate;
 pub(super) mod transfer_fee;

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -1,0 +1,54 @@
+use {super::*, spl_token_2022::solana_program::pubkey::Pubkey};
+
+pub(in crate::parse_token) fn parse_initialize_permanent_delegate_instruction(
+    delegate: Pubkey,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 1)?;
+    Ok(ParsedInstructionEnum {
+        instruction_type: "initializePermanentDelegate".to_string(),
+        info: json!({
+            "mint": account_keys[account_indexes[0] as usize].to_string(),
+            "delegate": delegate.to_string(),
+        }),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{instruction::*, solana_program::message::Message},
+    };
+
+    #[test]
+    fn test_parse_initialize_permanent_delegate_instruction() {
+        let mint_pubkey = Pubkey::new_unique();
+        let delegate = Pubkey::new_unique();
+        let permanent_delegate_ix = initialize_permanent_delegate(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(delegate),
+        )
+        .unwrap();
+        let message = Message::new(&[permanent_delegate_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializePermanentDelegate".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "delegate": delegate.to_string(),
+                })
+            }
+        );
+    }
+}


### PR DESCRIPTION
this is #28932 backported to 1.14. the only difference is `Cargo.lock` changes appreciably more, because `1.14` is on `0.4.2` (whereas `1.15` is on `0.4.3`) which itself depends on `1.10`

edit: note to rebase after #28926 