### PR TITLE
Renames EAH test fn

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -483,7 +483,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
 /// Given the scenario where two banks are rooted back-to-back, where the first bank sends an
 /// EAH request and the second bank sends a snapshot request, both requests should be handled.
 #[test]
-fn test_background_services_request_handling() {
+fn test_background_services_request_handling_for_epoch_accounts_hash() {
     solana_logger::setup();
 
     const NUM_EPOCHS_TO_TEST: u64 = 2;


### PR DESCRIPTION
#### Problem

When running EAH tests locally, I tend to do `cargo test epoch_accounts_hash`, which will run all the tests with "epoch_accounts_hash" in the test function's name. For unit tests, their file is included in the matchable string. For integration tests, the file name is not. This means when I run `cargo test epoch_accounts_hash`, I would not run one test that I _did_ want to run.


#### Summary of Changes

Rename the test to include the string "epoch_accounts_hash".

(Alternatively, I could've put the whole EAH integration test into its own module, but that felt like overkill.)