### PR TITLE
dedups turbine retransmit peers by tvu socket addresses

### DIFF
--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -49,7 +49,7 @@ fn get_retransmit_peers_deterministic(
             0,
             0,
         );
-        let (_root_distance, _neighbors, _children) = cluster_nodes.get_retransmit_peers(
+        let _retransmit_peers = cluster_nodes.get_retransmit_peers(
             slot_leader,
             &shred.id(),
             root_bank,


### PR DESCRIPTION

#### Problem
No need to send duplicate shreds if several nodes have the same tvu socket address because they are behind a relayer or whatever.


#### Summary of Changes
Dedup turbine retransmit peers by tvu socket addresses.