### PR TITLE
explorer: fix blockhash into hash for Slot Hashes

### DIFF
--- a/explorer/src/components/account/SlotHashesCard.tsx
+++ b/explorer/src/components/account/SlotHashesCard.tsx
@@ -27,7 +27,7 @@ export function SlotHashesCard({
           <thead>
             <tr>
               <th className="w-1 text-muted">Slot</th>
-              <th className="text-muted">Blockhash</th>
+              <th className="text-muted">Hash</th>
             </tr>
           </thead>
           <tbody className="list">


### PR DESCRIPTION
#### Problem
Incorrect labelling, the slot hash is the hash of the parent bank. Easy to verify in the explorer that they aren't the same thing:
click on a slot, read blockhash, blockhash != slot hash
https://explorer.solana.com/address/SysvarS1otHashes111111111111111111111111111/slot-hashes

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
