### PR TITLE
TPU client fix for leader schedule cache lookup

### DIFF
--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -145,10 +145,10 @@ impl LeaderTpuCache {
     }
 
     // Get the TPU sockets for the current leader and upcoming leaders according to fanout size
-    pub fn get_leader_sockets(&self, current_slot: Slot, fanout_slots: u64) -> Vec<SocketAddr> {
+    fn get_leader_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
         let mut leader_set = HashSet::new();
         let mut leader_sockets = Vec::new();
-        for leader_slot in current_slot..current_slot + fanout_slots {
+        for leader_slot in self.first_slot..self.first_slot + fanout_slots {
             if let Some(leader) = self.get_slot_leader(leader_slot) {
                 if let Some(tpu_socket) = self.leader_tpu_map.get(leader) {
                     if leader_set.insert(*leader) {
@@ -628,11 +628,10 @@ impl LeaderTpuService {
     }
 
     pub fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
-        let current_slot = self.recent_slots.estimated_current_slot();
         self.leader_tpu_cache
             .read()
             .unwrap()
-            .get_leader_sockets(current_slot, fanout_slots)
+            .get_leader_sockets(fanout_slots)
     }
 
     async fn run(


### PR DESCRIPTION
#### Problem
The client is sometimes unable to send transactions using TPU client.

#### Summary of Changes
The leader schedule cache in TPU client advances in the middle of transaction dispatch. Due to this it is unable to lookup the leader address from the cache, since the target slot is out of bound.

With this PR, the value of `first_slot` is being read inside the `read()` lock of the cache. This will ensure that the first_slot and the cache will be in sync.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
