### PR TITLE
quic-client: prefer AES-128 cipher suite

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -23,7 +23,8 @@ use {
         transport::Result as TransportResult,
     },
     solana_streamer::{
-        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, tls_certificates::new_self_signed_tls_certificate,
+        nonblocking::quic::{SolanaQuicCryptoConfig, ALPN_TPU_PROTOCOL_ID},
+        tls_certificates::new_self_signed_tls_certificate,
     },
     solana_tpu_client::{
         connection_cache_stats::ConnectionCacheStats, nonblocking::tpu_connection::TpuConnection,
@@ -116,7 +117,7 @@ impl QuicLazyInitializedEndpoint {
         };
 
         let mut crypto = rustls::ClientConfig::builder()
-            .with_safe_defaults()
+            .with_solana_quic_crypto_config()
             .with_custom_certificate_verifier(SkipServerVerification::new())
             .with_single_cert(
                 vec![self.client_certificate.certificate.clone()],

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
-        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, streamer::StakedNodes,
+        nonblocking::quic::{SolanaQuicCryptoConfig, ALPN_TPU_PROTOCOL_ID},
+        streamer::StakedNodes,
         tls_certificates::new_self_signed_tls_certificate,
     },
     crossbeam_channel::Sender,
@@ -67,7 +68,7 @@ pub(crate) fn configure_server(
     let cert_chain_pem = pem::encode_many(&cert_chain_pem_parts);
 
     let mut server_tls_config = rustls::ServerConfig::builder()
-        .with_safe_defaults()
+        .with_solana_quic_crypto_config()
         .with_client_cert_verifier(SkipClientVerification::new())
         .with_single_cert(vec![cert], priv_key)
         .map_err(|_e| QuicServerError::ConfigureFailed)?;


### PR DESCRIPTION
#### Problem

Solana nodes currently negotiate the `TLS13_AES_256_GCM_SHA384` cipher suite.

#### Summary of Changes

Changes order of precedence to prefer `TLS13_AES_128_GCM_SHA256` -- AES-128 is secure enough for TPU traffic and faster, and SHA-256 is used in other places of the protocol already.

Relates to https://github.com/solana-foundation/specs/pull/21

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
