### PR TITLE
account bench

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -294,7 +294,7 @@ fn run_accounts_bench(
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
                     info!(
-                        "Balance {} is less than needed: {}, doing aidrop...",
+                        "Balance {} is less than needed: {}, doing airdrop...",
                         balance, lamports
                     );
                     if !airdrop_lamports(

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -381,7 +381,7 @@ fn run_accounts_bench(
         }
 
         count += 1;
-        if last_log.elapsed().as_millis() > 3000 || count >= iterations {
+        if last_log.elapsed().as_millis() > 3000 || (count >= iterations && iterations != 0) {
             info!(
                 "total_accounts_created: {} total_accounts_closed: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
                 total_accounts_created, total_accounts_closed, tx_sent_count, count, balances


### PR DESCRIPTION
#### Problem

For long running cluster bench (i.e. iterations=0), the throttling of logging for every 3s is not working because 'count>=iterations' is always true.


#### Summary of Changes

Add iterations != 0 checks for log throttling.

- fix typo
- fix account-cluster-bench logging

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
