### PR TITLE
fix: verify commitment level when confirming transactions with one-shot fetch

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3386,7 +3386,7 @@ export class Connection {
 
     assert(decodedSignature.length === 64, 'signature has invalid length');
 
-    const subscriptionCommitment = commitment || this.commitment;
+    const confirmationCommitment = commitment || this.commitment;
     let timeoutId;
     let signatureSubscriptionId: number | undefined;
     let disposeSignatureSubscriptionStateChangeObserver:
@@ -3410,7 +3410,7 @@ export class Connection {
             done = true;
             resolve({__type: TransactionStatus.PROCESSED, response});
           },
-          subscriptionCommitment,
+          confirmationCommitment,
         );
         const subscriptionSetupPromise = new Promise<void>(
           resolveSubscriptionSetup => {
@@ -3463,7 +3463,7 @@ export class Connection {
     >(resolve => {
       if (typeof strategy === 'string') {
         let timeoutMs = this._confirmTransactionInitialTimeout || 60 * 1000;
-        switch (subscriptionCommitment) {
+        switch (confirmationCommitment) {
           case 'processed':
           case 'recent':
           case 'single':

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3444,6 +3444,30 @@ export class Connection {
           if (value?.err) {
             reject(value.err);
           } else {
+            switch (confirmationCommitment) {
+              case 'confirmed':
+              case 'single':
+              case 'singleGossip': {
+                if (value.confirmationStatus === 'processed') {
+                  return;
+                }
+                break;
+              }
+              case 'finalized':
+              case 'max':
+              case 'root': {
+                if (
+                  value.confirmationStatus === 'processed' ||
+                  value.confirmationStatus === 'confirmed'
+                ) {
+                  return;
+                }
+                break;
+              }
+              // exhaust enums to ensure full coverage
+              case 'processed':
+              case 'recent':
+            }
             done = true;
             resolve({
               __type: TransactionStatus.PROCESSED,

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3438,10 +3438,12 @@ export class Connection {
             return;
           }
           const {context, value} = response;
+          if (value == null) {
+            return;
+          }
           if (value?.err) {
             reject(value.err);
-          }
-          if (value) {
+          } else {
             done = true;
             resolve({
               __type: TransactionStatus.PROCESSED,


### PR DESCRIPTION
#### Problem

A small bug snuck in at #28290 where the one-shot fetch for the current commitment status could result in a transaction being confirmed when it shouldn't be. The reason was because we did not check that the result _met_ the target commitment.

#### Summary of Changes

When fetching the one-shot `getSignatureStatus` for a given transaction, make sure that the instantaneous signature status at least meets the target commitment.