### PR TITLE
test: local-cluster: Enable test_votes_land_in_fork_during_long_partition

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2747,7 +2747,6 @@ fn test_oc_bad_signatures() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_votes_land_in_fork_during_long_partition() {
     let total_stake = 3 * DEFAULT_NODE_STAKE;
     // Make `lighter_stake` insufficient for switching threshold


### PR DESCRIPTION
#### Problem

`tests/local_cluster.rs::test_votes_land_in_fork_during_long_partition` has been broken by [Enable QUIC client by default. Add arg to disable QUIC client. Take 2](https://github.com/solana-labs/solana/pull/26927).

#### Summary of changes

Re-enabled the test, it is passing now.
