### PR TITLE
add balance to cap overflow message

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -706,9 +706,12 @@ impl AccountsHasher {
     }
 
     pub fn checked_cast_for_capitalization(balance: u128) -> u64 {
-        balance
-            .try_into()
-            .expect("overflow is detected while summing capitalization")
+        balance.try_into().unwrap_or_else(|_| {
+            panic!(
+                "overflow is detected while summing capitalization: {}",
+                balance
+            )
+        })
     }
 
     /// return references to cache hash data, grouped by bin, sourced from 'sorted_data_by_pubkey',


### PR DESCRIPTION
#### Problem
At least 2 validators have reported this failure. A bit flip is a likely cause. Having the actual 128 bit value could be helpful.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
