### PR TITLE
remove cli arg to specify # accounts hash scan passes

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1224,14 +1224,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Number of bins to divide the accounts index into"),
         )
         .arg(
-            Arg::with_name("accounts_hash_num_passes")
-                .long("accounts-hash-num-passes")
-                .value_name("PASSES")
-                .validator(is_pow2)
-                .takes_value(true)
-                .help("Number of passes to calculate the hash of all accounts"),
-        )
-        .arg(
             Arg::with_name("accounts_index_path")
                 .long("accounts-index-path")
                 .value_name("PATH")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -958,7 +958,7 @@ pub fn main() {
         size: value_t_or_exit!(matches, "accounts_filler_size", usize),
     };
 
-    let mut accounts_db_config = AccountsDbConfig {
+    let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         accounts_hash_cache_path: Some(ledger_path.clone()),
         filler_accounts_config,
@@ -971,9 +971,6 @@ pub fn main() {
         ..AccountsDbConfig::default()
     };
 
-    if let Some(passes) = value_t!(matches, "accounts_hash_num_passes", usize).ok() {
-        accounts_db_config.hash_calc_num_passes = Some(passes);
-    }
     let accounts_db_config = Some(accounts_db_config);
 
     let geyser_plugin_config_files = if matches.is_present("geyser_plugin_config") {


### PR DESCRIPTION
#### Problem
We will be removing multi-pass accounts hash scanning. So, we don't need to be able to specify the # of scans passes.
The accounts scan will now use the file system to avoid memory spikes during accounts hash calculation.

#### Summary of Changes
Remove cli arg and all plumbing.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
