### PR TITLE
program-test: Add `ProgramTestContext::get_new_latest_blockhash`

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1180,4 +1180,14 @@ impl ProgramTestContext {
         self.last_blockhash = bank.last_blockhash();
         Ok(())
     }
+
+    /// Get a new latest blockhash, similar in spirit to RpcClient::get_latest_blockhash()
+    pub async fn get_new_latest_blockhash(&mut self) -> io::Result<Hash> {
+        let blockhash = self
+            .banks_client
+            .get_new_latest_blockhash(&self.last_blockhash)
+            .await?;
+        self.last_blockhash = blockhash;
+        Ok(blockhash)
+    }
 }


### PR DESCRIPTION
#### Problem

While fixing the various stake pool test failures, I noticed that the easy solution was to force refresh the blockhash (see https://github.com/solana-labs/solana-program-library/pull/3853 for example).  This is kind of annoying, since it forces you to constantly refresh from a previous blockhash and then keep it around in a separate variable.

#### Summary of Changes

The last blockhash is already stored on the ProgramTestContext, so just refresh it directly there, so that way you can do:

```
context.get_new_latest_blockhash().await?;
```

then use `context.last_blockhash` as normal. This will make it much easier to fix these issues anytime they come up.

I wanted to keep this consistent with the banks client extension, but happy to bikeshed a better name for it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
