### PR TITLE
Bump spl-ata to v1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk 1.15.0",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
  "zstd",
 ]
@@ -5633,7 +5633,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "static_assertions",
  "tempfile",
  "test-case",
@@ -6187,7 +6187,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "stream-cancel",
  "symlink",
  "thiserror",
@@ -6240,7 +6240,7 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -6782,7 +6782,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -7033,9 +7033,9 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a33ecc83137583902c3e13c02f34151c8b2f2b74120f9c2b3ff841953e083d"
+checksum = "fbc000f0fdf1f12f99d77d398137c1751345b18c88258ce0f99b7872cf6c9bd6"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -7043,7 +7043,7 @@ dependencies = [
  "num-traits",
  "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022 0.4.3",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -7078,24 +7078,6 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-program 1.14.8",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c0ebca4740cc4c892aa31e07d0b4dc1a24cac4748376d4b34f8eb0fee9ff46"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program 1.14.8",
- "solana-zk-token-sdk 1.14.8",
- "spl-memo",
- "spl-token",
  "thiserror",
 ]
 

--- a/fetch-spl.sh
+++ b/fetch-spl.sh
@@ -41,7 +41,7 @@ fetch_program() {
 fetch_program token 3.5.0 TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA BPFLoader2111111111111111111111111111111111
 fetch_program memo  1.0.0 Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo BPFLoader1111111111111111111111111111111111
 fetch_program memo  3.0.0 MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr BPFLoader2111111111111111111111111111111111
-fetch_program associated-token-account 1.1.1 ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL BPFLoader2111111111111111111111111111111111
+fetch_program associated-token-account 1.1.2 ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL BPFLoader2111111111111111111111111111111111
 fetch_program feature-proposal 1.0.0 Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse BPFLoader2111111111111111111111111111111111
 
 echo "${genesis_args[@]}" > spl-genesis-args.sh

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4220,7 +4220,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk 1.15.0",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
  "zstd",
 ]
@@ -4785,7 +4785,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5175,7 +5175,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5222,7 +5222,7 @@ dependencies = [
  "solana-sdk 1.15.0",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -6008,7 +6008,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022 0.5.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -6230,9 +6230,9 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a33ecc83137583902c3e13c02f34151c8b2f2b74120f9c2b3ff841953e083d"
+checksum = "fbc000f0fdf1f12f99d77d398137c1751345b18c88258ce0f99b7872cf6c9bd6"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -6240,7 +6240,7 @@ dependencies = [
  "num-traits",
  "solana-program 1.14.8",
  "spl-token",
- "spl-token-2022 0.4.3",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -6265,24 +6265,6 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-program 1.14.8",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c0ebca4740cc4c892aa31e07d0b4dc1a24cac4748376d4b34f8eb0fee9ff46"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program 1.14.8",
- "solana-zk-token-sdk 1.14.8",
- "spl-memo",
- "spl-token",
  "thiserror",
 ]
 

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -28,7 +28,7 @@ solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.15.0" }
 solana-version = { path = "../version", version = "=1.15.0" }
-spl-associated-token-account = { version = "=1.1.1" }
+spl-associated-token-account = { version = "=1.1.2" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 tempfile = "3.3.0"
 thiserror = "1.0"

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0.83"
 solana-account-decoder = { path = "../account-decoder", version = "=1.15.0" }
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
-spl-associated-token-account = { version = "=1.1.1", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "=1.1.2", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }


### PR DESCRIPTION
#### Problem
The monorepo retains a dependency on 2 versions of spl-token-2022 because of the old version of spl-associated-token-account.

#### Summary of Changes
Bump spl-ata to new version

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
