### PR TITLE
Increase stream timeout to 1 sec to fix flaky tests

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1016,7 +1016,7 @@ pub mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats.clone(),
-            100,
+            1000,
         )
         .unwrap();
         (t, exit, receiver, server_address, stats)


### PR DESCRIPTION
#### Problem
quic::test::test_quic_server_multiple_writes is failing intermittently in CI. For example,

https://buildkite.com/solana-labs/solana/builds/85659#0184c4f7-b4a2-4d62-bdd1-2181a87b8233
https://buildkite.com/solana-labs/solana/builds/85636#0184c435-32f3-4068-a016-fa7fe6192c55

#### Summary of Changes
Increased timeout from 0.1 second to 1 second

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
