### PR TITLE
fix: TransactionMessage.decompile() now counts the correct number of unsigned, writable accounts

### DIFF
--- a/web3.js/src/transaction/message.ts
+++ b/web3.js/src/transaction/message.ts
@@ -49,7 +49,9 @@ export class TransactionMessage {
     assert(numWritableSignedAccounts > 0, 'Message header is invalid');
 
     const numWritableUnsignedAccounts =
-      message.staticAccountKeys.length - numReadonlyUnsignedAccounts;
+      message.staticAccountKeys.length -
+      numRequiredSignatures -
+      numReadonlyUnsignedAccounts;
     assert(numWritableUnsignedAccounts >= 0, 'Message header is invalid');
 
     const accountKeys = message.getAccountKeys(args);

--- a/web3.js/test/transaction-tests/message.test.ts
+++ b/web3.js/test/transaction-tests/message.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../src/transaction';
 import {PublicKey} from '../../src/publickey';
 import {AddressLookupTableAccount} from '../../src/programs';
-import {MessageV0} from '../../src/message';
+import {Message, MessageV0} from '../../src/message';
 
 function createTestKeys(count: number): Array<PublicKey> {
   return new Array(count).fill(0).map(() => PublicKey.unique());
@@ -31,7 +31,43 @@ function createTestLookupTable(
 }
 
 describe('TransactionMessage', () => {
-  it('decompile', () => {
+  it('decompiles a legacy message', () => {
+    const keys = createTestKeys(7);
+    const recentBlockhash = bs58.encode(sha256('test'));
+    const payerKey = keys[0];
+    const instructions = [
+      new TransactionInstruction({
+        programId: keys[5],
+        keys: [
+          {pubkey: keys[0], isSigner: true, isWritable: true},
+          {pubkey: keys[6], isSigner: false, isWritable: false},
+          {pubkey: keys[1], isSigner: false, isWritable: true},
+          {pubkey: keys[3], isSigner: false, isWritable: false},
+          {pubkey: keys[4], isSigner: false, isWritable: false},
+          {pubkey: keys[2], isSigner: false, isWritable: false},
+        ],
+        data: Buffer.alloc(1),
+      }),
+    ];
+
+    const message = Message.compile({
+      instructions,
+      payerKey,
+      recentBlockhash,
+    });
+
+    expect(() => TransactionMessage.decompile(message)).not.to.throw(
+      'Failed to get account keys because address table lookups were not resolved',
+    );
+
+    const decompiledMessage = TransactionMessage.decompile(message);
+
+    expect(decompiledMessage.payerKey).to.eql(payerKey);
+    expect(decompiledMessage.recentBlockhash).to.eq(recentBlockhash);
+    expect(decompiledMessage.instructions).to.eql(instructions);
+  });
+
+  it('decompiles a V0 message', () => {
     const keys = createTestKeys(7);
     const recentBlockhash = bs58.encode(sha256('test'));
     const payerKey = keys[0];


### PR DESCRIPTION
#### Problem

Message headers give you the following:

* number of required signatures (`numRequiredSignatures`)
* number of read-only signed accounts (`numReadonlySignedAccounts`)
* number of read-only unsigned accounts (`numReadonlyUnsignedAccounts`)

If we want to know how many writable unsigned accounts there are, we have to:

* start with the total number of accounts
* subtract the number of those that are signers (`numRequiredSignatures`)
* subtract the number of read-only unsigned accounts (`numReadonlyUnsignedAccounts`)

That spells:

```ts
const numWritableUnsignedAccounts =
  message.staticAccountKeys.length -
  numRequiredSignatures -
  numReadonlyUnsignedAccounts;
```

Unfortunately, we forgot to subtract out the number of signers, making it possible to overcount `numWritableUnsignedAccounts`. This played havoc when deserializing messages like the one in #28900's repro.

All of this could result in accounts being needlessly marked as writeable, which could only serve to make the network slower (ie. causing the validator to run transactions in serial that could otherwise have been safely run in parallel).

#### Summary of Changes

* Fix the calculation of `numWritableUnsignedAccounts`
* Write a test that asserts you can decompile a legacy message with `TransactionMessage`
* Copy the repro from #28900 into a test to validate this fix and to serve as a regression going forward.

Fixes #28900.