### PR TITLE
Move BlockstoreInsertionMetrics field update to blockstore.rs

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -276,7 +276,7 @@ where
     prune_shreds_elapsed.stop();
     ws_metrics.prune_shreds_elapsed_us += prune_shreds_elapsed.as_us();
 
-    let (completed_data_sets, inserted_indices) = blockstore.insert_shreds_handle_duplicate(
+    let (completed_data_sets, _) = blockstore.insert_shreds_handle_duplicate(
         shreds,
         repairs,
         Some(leader_schedule_cache),
@@ -286,11 +286,6 @@ where
         reed_solomon_cache,
         metrics,
     )?;
-    for index in inserted_indices {
-        if repair_infos[index].is_some() {
-            metrics.num_repair += 1;
-        }
-    }
 
     completed_data_sets_sender.try_send(completed_data_sets)?;
     Ok(())

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -851,6 +851,9 @@ impl Blockstore {
                             error!("blockstore error: {}", err);
                         }
                         Ok(completed_data_sets) => {
+                            if is_repaired {
+                                metrics.num_repair += 1;
+                            }
                             newly_completed_data_sets.extend(completed_data_sets);
                             inserted_indices.push(i);
                             metrics.num_inserted += 1;


### PR DESCRIPTION
#### Problem
The num_repair field is only blockstore insertion metric being updated outside of Blockstore::insert() call chain

#### Summary of Changes
Move the update to insert() with the rest of the fields in BlockstoreInsertionMetrics struct.
