### PR TITLE
pass alive bytes to AccountsToStore::new

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4566,6 +4566,7 @@ impl AccountsDb {
         let (to_store, find_alive_elapsed) = measure!(AccountsToStore::new(
             available_bytes,
             &shrink_collect.alive_accounts,
+            shrink_collect.alive_total_bytes,
             slot
         ));
 
@@ -9995,7 +9996,8 @@ pub mod tests {
         };
         let found = FoundStoredAccount { account, store_id };
         let map = vec![&found];
-        let to_store = AccountsToStore::new(available_bytes, &map, slot0);
+        let alive_total_bytes = found.account.stored_size;
+        let to_store = AccountsToStore::new(available_bytes, &map, alive_total_bytes, slot0);
         // Done: setup 'to_store'
 
         current_ancient.create_ancient_append_vec(slot0, &db);


### PR DESCRIPTION
#### Problem
While combining into an ancient append vec, avoid iterating all accounts to check for size if we already know the total size and all accounts fit (which is the common case).

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
