### PR TITLE
fix: support `VersionedMessage` in `getFeeForMessage`

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4154,10 +4154,10 @@ export class Connection {
    * Fetch the fee for a message from the cluster, return with context
    */
   async getFeeForMessage(
-    message: Message,
+    message: VersionedMessage,
     commitment?: Commitment,
   ): Promise<RpcResponseAndContext<number>> {
-    const wireMessage = message.serialize().toString('base64');
+    const wireMessage = toBuffer(message.serialize()).toString('base64');
     const args = this._buildArgs([wireMessage], commitment);
     const unsafeRes = await this._rpcRequest('getFeeForMessage', args);
 


### PR DESCRIPTION
#### Problem

As noticed in https://solana.stackexchange.com/questions/4597/how-getfeeformessage-for-versioned-transaction, we can't use `getFeeForMessage` with a versioned message.

#### Summary of Changes

Similar to how versioned and legacy transactions are supported in `sendTransaction`, accept `VersionedMessage` in `getFeeForMessage`, and serialize it properly.

There's some mismatch in how the types are defined between `VersionedTransaction` and `VersionedMessage`, so here's the type definition for reference:

```
export type VersionedMessage = Message | MessageV0;
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
