### PR TITLE
RPC unit test timeout fix

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1411,6 +1411,12 @@ pub(crate) mod tests {
                     encoding: UiAccountEncoding::Binary,
                 }));
 
+            // Sleep here to ensure adequate time for the async thread to fully process the
+            // subscribed notification before the bank transaction is processed. Without this
+            // sleep, the bank transaction ocassionally completes first and we hang forever
+            // waiting to receive a bank notification.
+            std::thread::sleep(Duration::from_millis(100));
+
             bank_forks
                 .read()
                 .unwrap()


### PR DESCRIPTION
### Problem
`rpc_subscriptions::tests::test_check_account_subscribe` fails sporadically in CI with a receiver timeout.

This is caused by a race condition between completing processing of the subscribed notification and processing bank transaction. We need the subscription to fully process so they will be notified of the bank transaction, but occasionally (~10% of the time) the bank transaction completes first because these activities are handled in separate threads.

Note this is essentially the same thing observed in #27480 and partially mitigated by #27481 

### Proposed Solution
Add a short delay in the `test_check_account_subscribe` test to allow for the subscribed notification to be handled before proceeding with processing the bank transaction.