### PR TITLE
Adjusts docs about changing the data, size and balance of accounts.

### DIFF
--- a/docs/src/developing/programming-model/accounts.md
+++ b/docs/src/developing/programming-model/accounts.md
@@ -58,7 +58,9 @@ possible to upload a totally new program to an existing program address.
 To create an account, a client generates a _keypair_ and registers its public key
 using the `SystemProgram::CreateAccount` instruction with a fixed
 storage size in bytes preallocated.
-The current maximum size of an account's data is 10 megabytes.
+The current maximum size of an account's data is 10 MiB, which can be changed
+(increased or decreased) at a rate over all accounts of 20 MiB per transaction,
+and the size can be increased by 10 KiB per account and per instruction.
 
 An account address can be any arbitrary 256 bit value, and there are mechanisms
 for advanced users to create derived addresses

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -35,13 +35,19 @@ The policy is as follows:
   - And only if the data is zero-initialized or empty.
 - An account not assigned to the program cannot have its balance decrease.
 - The balance of read-only and executable accounts may not change.
-- Only the system program can change the size of the data and only if the system
-  program owns the account.
-- Only the owner may change account data.
+- Only the owner may change account size and data.
   - And if the account is writable.
   - And if the account is not executable.
 - Executable is one-way (false->true) and only the account owner may set it.
 - No one can make modifications to the rent_epoch associated with this account.
+
+## Balancing the balances
+
+Before and after each instruction, the sum of all account balances must stay the same.
+E.g. if one account's balance is increased, another's must be decreased by the same ammount.
+Because the runtime can not see changes to accounts which were not passed to it,
+all accounts for which the balances were modified must be passed,
+even if they are not needed in the called instruction.
 
 ## Compute Budget
 


### PR DESCRIPTION
#### Problem
There is a bit of stale info about who can change the account data and size (also by how much).
Also, there is no mention of how to balance accounts before CPI.

#### Summary of Changes
See the diff.