### PR TITLE
CI: Add ci label to the version bump PRs generated when a release is tagged

### DIFF
--- a/.github/workflows/increment-cargo-version-on-release.yml
+++ b/.github/workflows/increment-cargo-version-on-release.yml
@@ -36,4 +36,4 @@ jobs:
           body: PR opened by Github Action
           branch: update-version-${{ env.SOLANA_NEW_VERSION }}
           base: ${{ github.event.release.target_commitish }}
-          labels: automerge
+          labels: automerge,ci


### PR DESCRIPTION
solana-grimes requires the `ci` label. Adding it here to reduce toil.

I'm not sure if this will work but it's an easy first step