### PR TITLE
Update filter docs, v1.11 -> v1.14

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1956,7 +1956,7 @@ Returns all accounts owned by the provided program Pubkey
   - `offset: <usize>` - offset into program account data to start comparison
   - `bytes: <string>` - data to match, as encoded string
   - `encoding: <string>` - encoding for filter `bytes` data, either "base58" or "base64". Data is limited in size to 128 or fewer decoded bytes.
-    **NEW: This field, and base64 support generally, is only available in solana-core v1.11.2 or newer. Please omit when querying nodes on earlier versions**
+    **NEW: This field, and base64 support generally, is only available in solana-core v1.14.0 or newer. Please omit when querying nodes on earlier versions**
 
 - `dataSize: <u64>` - compares the program account data length with the provided data size
 


### PR DESCRIPTION
#### Problem
Docs say base64 encoding in filters is supported in v1.11.2+. This is confusing, since it isn't supported in v1.13, which was built on v1.10.

#### Summary of Changes
Update docs to reference v1.14. Technically, the parameter is supported in v1.11.2-v1.11.10, but since no public clusters are running the v1.11 line, doesn't seem worth the potential confusion of including those details.
