### PR TITLE
Fix mergify for docs PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,8 +41,10 @@ pull_request_rules:
         - author≠@dont-squash-my-commits
         - or:
           # only require docs checks if docs files changed
-          - status-success=docs-build
           - -files~=^docs/
+          - and:
+            - status-success=build & deploy
+            - check-skipped=error_reporting
         - or:
           # only require explorer checks if explorer files changed
           - status-success=check-explorer
@@ -67,8 +69,10 @@ pull_request_rules:
         - author=@dont-squash-my-commits
         - or:
           # only require docs checks if docs files changed
-          - status-success=docs-build
           - -files~=^docs/
+          - and:
+            - status-success=build & deploy
+            - check-skipped=error_reporting
         - or:
           # only require explorer checks if explorer files changed
           - status-success=check-explorer

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,9 +42,7 @@ pull_request_rules:
         - or:
           # only require docs checks if docs files changed
           - -files~=^docs/
-          - and:
-            - status-success=build & deploy
-            - check-skipped=error_reporting
+          - status-success=build & deploy docs
         - or:
           # only require explorer checks if explorer files changed
           - status-success=check-explorer
@@ -70,9 +68,7 @@ pull_request_rules:
         - or:
           # only require docs checks if docs files changed
           - -files~=^docs/
-          - and:
-            - status-success=build & deploy
-            - check-skipped=error_reporting
+          - status-success=build & deploy docs
         - or:
           # only require explorer checks if explorer files changed
           - status-success=check-explorer


### PR DESCRIPTION
#### Problem
Mergify seems broken on docs PRs (eg https://github.com/solana-labs/solana/pull/29017/checks?check_run_id=9830706173), presumably since https://github.com/solana-labs/solana/pull/28852

#### Summary of Changes
Fix
It might be enough to use just the `check-skipped=error_reporting` condition. Wdyt @yihau ?
