### PR TITLE
Fix - Turns binary `&` into logical `&&` in `translate_slice_inner()`.

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -338,7 +338,7 @@ fn translate_slice_inner<'a, T>(
     }
 
     let total_size = len.saturating_mul(size_of::<T>() as u64);
-    if check_size & isize::try_from(total_size).is_err() {
+    if check_size && isize::try_from(total_size).is_err() {
         return Err(SyscallError::InvalidLength.into());
     }
 


### PR DESCRIPTION
#### Problem
#23781 had a typo.

#### Summary of Changes
Turns binary `&` into logical `&&` in `translate_slice_inner()`.