### PR TITLE
add cli command: solana program dump-owned-accounts

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -637,7 +637,7 @@ pub fn parse_program_subcommand(
                 signers: vec![],
             }
         }
-        ("dump-executabe", Some(matches)) => CliCommandInfo {
+        ("dump-executable", Some(matches)) => CliCommandInfo {
             command: CliCommand::Program(ProgramCliCommand::DumpExecutable {
                 account_pubkey: pubkey_of(matches, "account"),
                 output_location: matches.value_of("output_location").unwrap().to_string(),

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1537,15 +1537,34 @@ fn process_dump_owned_accounts(
                             let output_path =
                                 format!("{}/{}.json", output_directory, pubkey.to_string());
 
-                            let mut file = File::create(&output_path).unwrap();
-
-                            let acc = CliAccount::new_with_config(
-                                &pubkey,
-                                &account,
-                                &CliAccountNewConfig::default(),
-                            );
-                            file.write(serde_json::to_string(&acc).unwrap().as_bytes())
-                                .unwrap();
+                            match File::create(&output_path) {
+                                Ok(mut file) => {
+                                    let acc = CliAccount::new_with_config(
+                                        &pubkey,
+                                        &account,
+                                        &CliAccountNewConfig::default(),
+                                    );
+                                    match file
+                                        .write(serde_json::to_string(&acc).unwrap().as_bytes())
+                                    {
+                                        Ok(_) => {}
+                                        Err(e) => {
+                                            return Err(format!(
+                                                "Unable to write file={} err={:?}",
+                                                output_path, e
+                                            )
+                                            .into())
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    return Err(format!(
+                                        "Unable to create file={} err={:?}",
+                                        output_path, e
+                                    )
+                                    .into())
+                                }
+                            }
                         }
                         Ok(format!("Wrote program accounts to {}", output_directory))
                     }


### PR DESCRIPTION
#### Problem

In order to run a local test validator with mainnet state to test larger program updates, it's important to be able to import thousands of accounts.

#### Summary of Changes

Added a new subcommand to the cli: program dump-owned-accounts. It creates a directory that contains all program owned accounts in a format that can be imported by solana-test-validator.

Existing subcommand program dump has been renamed to program dump-executable.