### PR TITLE
change test validator from non upgradable bpf loader to upgradable bpf loader

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -207,7 +207,7 @@ fn main() {
 
                     programs_to_load.push(ProgramInfo {
                         program_id: address,
-                        loader: solana_sdk::bpf_loader::id(),
+                        loader: solana_sdk::bpf_loader_upgradeable::id(),
                         program_path,
                     });
                 }


### PR DESCRIPTION
#### Problem
while trying to run `anchor test` the `program_data` account of the program that is automatically deployed does not initialize, so some tests won't run.
If you just run  `anchor test` against a local network, it will start a new test validator using the --bpf-program argument with solana-test-validator, which defaults to the non-upgradeable loader

#### Summary of Changes
just change from using `bpf_loader` to `bpf_loader_upgradeable`

reference from StackOverflow question: https://solana.stackexchange.com/questions/4632/anchorerror-caused-by-account-program-data-error-code-accountnotinitialized/4691#4691


