### PR TITLE
Use AccountsHash instead of bare Hash

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -99,7 +99,7 @@ impl AccountHashesFile {
 #[allow(dead_code)]
 pub struct FullSnapshotAccountsHashInfo {
     /// accounts hash over all accounts when the full snapshot was taken
-    hash: Hash,
+    hash: AccountsHash,
     /// slot where full snapshot was taken
     slot: Slot,
 }


### PR DESCRIPTION
#### Problem

The accounts hash in `FullSnapshotAccountsHashInfo` is a bare `Hash`, instead of `AccountsHash`.


#### Summary of Changes

Change type to `AccountsHash`.