### PR TITLE
AccountsDb::get_snapshot_storages() takes a Range for slots

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6944,11 +6944,19 @@ impl Bank {
             .check_complete()
     }
 
+    /// Get this bank's storages to use for snapshots.
+    ///
+    /// If a base slot is provided, return only the storages that are *higher* than this slot.
     pub fn get_snapshot_storages(&self, base_slot: Option<Slot>) -> SnapshotStorages {
+        // if a base slot is provided, request storages starting at the slot *after*
+        let start_slot = base_slot.map_or(0, |slot| slot.saturating_add(1));
+        // we want to *include* the storage at our slot
+        let requested_slots = start_slot..=self.slot();
+
         self.rc
             .accounts
             .accounts_db
-            .get_snapshot_storages(self.slot(), base_slot, None)
+            .get_snapshot_storages(requested_slots, None)
             .0
     }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -25,6 +25,7 @@ use {
     },
     std::{
         io::{BufReader, Cursor},
+        ops::RangeFull,
         path::Path,
         sync::{Arc, RwLock},
     },
@@ -36,9 +37,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
     accounts_db: &AccountsDb,
     output_dir: P,
 ) -> std::io::Result<StorageAndNextAppendVecId> {
-    let storage_entries = accounts_db
-        .get_snapshot_storages(Slot::max_value(), None, None)
-        .0;
+    let storage_entries = accounts_db.get_snapshot_storages(RangeFull, None).0;
     let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
     let mut next_append_vec_id = 0;
     for storage_entry in storage_entries.into_iter().flatten() {
@@ -187,7 +186,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &mut writer,
         &accounts.accounts_db,
         0,
-        &accounts.accounts_db.get_snapshot_storages(0, None, None).0,
+        &accounts.accounts_db.get_snapshot_storages(..=0, None).0,
     )
     .unwrap();
 
@@ -430,7 +429,7 @@ pub(crate) fn reconstruct_accounts_db_via_serialization(
     slot: Slot,
 ) -> AccountsDb {
     let mut writer = Cursor::new(vec![]);
-    let snapshot_storages = accounts.get_snapshot_storages(slot, None, None).0;
+    let snapshot_storages = accounts.get_snapshot_storages(..=slot, None).0;
     accountsdb_to_stream(
         SerdeStyle::Newer,
         &mut writer,
@@ -701,7 +700,7 @@ mod test_bank_serialize {
             .rc
             .accounts
             .accounts_db
-            .get_snapshot_storages(0, None, None)
+            .get_snapshot_storages(..=0, None)
             .0;
         // ensure there is a single snapshot storage example for ABI digesting
         assert_eq!(snapshot_storages.len(), 1);

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -276,7 +276,7 @@ impl<'a> SnapshotMinimizer<'a> {
     ) -> (Vec<Slot>, Vec<Arc<AccountStorageEntry>>) {
         let snapshot_storages = self
             .accounts_db()
-            .get_snapshot_storages(self.starting_slot, None, None)
+            .get_snapshot_storages(..=self.starting_slot, None)
             .0;
 
         let dead_slots = Mutex::new(Vec::new());
@@ -680,7 +680,7 @@ mod tests {
         };
         minimizer.minimize_accounts_db();
 
-        let snapshot_storages = accounts.get_snapshot_storages(current_slot, None, None).0;
+        let snapshot_storages = accounts.get_snapshot_storages(..=current_slot, None).0;
         assert_eq!(snapshot_storages.len(), 3);
 
         let mut account_count = 0;


### PR DESCRIPTION
#### Problem

Getting the snapshot storages is clunky, when calling `AccountsDb::get_snapshot_storages()` and needing to include a base slot too.

Since Incremental Accounts Hash will exercise this path (and likely often in tests), I want to avoid anything error-prone if possible.


#### Summary of Changes

Since the parameters are basically an optional lower bound and a required upper bound, this is exactly what a Range encodes. By using a Range, now we get type safety, plus I find it more ergonomic.

The majority of non-tests still get the snapshot storages via `Bank::snapshot_storages()`; that function's signature is unchanged.