### PR TITLE
2xTx: Refactor to separate Transaction packets from MTU packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
  "solana-net-utils",
+ "solana-sdk 1.15.0",
  "solana-streamer",
  "solana-version",
 ]

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -15,13 +15,14 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_measure::measure::Measure,
-    solana_perf::packet::{to_packet_batches, PacketBatch},
+    solana_perf::packet::{to_packet_batches, Batch},
     solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
         compute_budget::ComputeBudgetInstruction,
         hash::Hash,
         message::Message,
+        packet::Packet,
         pubkey::{self, Pubkey},
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
@@ -179,7 +180,7 @@ fn make_transfer_transaction_with_compute_unit_price(
 }
 
 struct PacketsPerIteration {
-    packet_batches: Vec<PacketBatch>,
+    packet_batches: Vec<Batch<Packet>>,
     transactions: Vec<Transaction>,
     packets_per_batch: usize,
 }
@@ -203,7 +204,8 @@ impl PacketsPerIteration {
             mint_txs_percentage,
         );
 
-        let packet_batches: Vec<PacketBatch> = to_packet_batches(&transactions, packets_per_batch);
+        let packet_batches: Vec<Batch<Packet>> =
+            to_packet_batches(&transactions, packets_per_batch);
         assert_eq!(packet_batches.len(), batches_per_iteration);
         Self {
             packet_batches,
@@ -457,7 +459,7 @@ fn main() {
             {
                 sent += packet_batch.len();
                 trace!(
-                    "Sending PacketBatch index {}, {}",
+                    "Sending Packet Batch index {}, {}",
                     packet_batch_index,
                     timestamp(),
                 );

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -15,7 +15,7 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_measure::measure::Measure,
-    solana_perf::packet::{to_packet_batches, Batch},
+    solana_perf::packet::{to_packet_batches, PacketBatch},
     solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
@@ -180,7 +180,7 @@ fn make_transfer_transaction_with_compute_unit_price(
 }
 
 struct PacketsPerIteration<const N: usize> {
-    packet_batches: Vec<Batch<N>>,
+    packet_batches: Vec<PacketBatch<N>>,
     transactions: Vec<Transaction>,
     packets_per_batch: usize,
 }
@@ -204,7 +204,8 @@ impl<const N: usize> PacketsPerIteration<N> {
             mint_txs_percentage,
         );
 
-        let packet_batches: Vec<Batch<N>> = to_packet_batches(&transactions, packets_per_batch);
+        let packet_batches: Vec<PacketBatch<N>> =
+            to_packet_batches(&transactions, packets_per_batch);
         assert_eq!(packet_batches.len(), batches_per_iteration);
         Self {
             packet_batches,

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 clap = { version = "3.1.5", features = ["cargo"] }
 crossbeam-channel = "0.5"
 solana-net-utils = { path = "../net-utils", version = "=1.15.0" }
+solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-streamer = { path = "../streamer", version = "=1.15.0" }
 solana-version = { path = "../version", version = "=1.15.0" }
 

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -26,8 +26,8 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
     let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
     packet_batch.resize(batch_size, Packet::default());
     for w in packet_batch.iter_mut() {
-        w.meta_mut().size = Packet::DATA_SIZE;
-        w.meta_mut().set_socket_addr(addr);
+        w.meta.size = Packet::DATA_SIZE;
+        w.meta.set_socket_addr(addr);
     }
     let packet_batch = Arc::new(packet_batch);
     spawn(move || loop {
@@ -36,8 +36,8 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         }
         let mut num = 0;
         for p in packet_batch.iter() {
-            let a = p.meta().socket_addr();
-            assert!(p.meta().size <= Packet::DATA_SIZE);
+            let a = p.meta.socket_addr();
+            assert!(p.meta.size <= Packet::DATA_SIZE);
             let data = p.data(..).unwrap_or_default();
             send.send_to(data, a).unwrap();
             num += 1;

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -4,7 +4,7 @@ use {
     clap::{crate_description, crate_name, Arg, Command},
     crossbeam_channel::unbounded,
     solana_streamer::{
-        packet::{Packet, PacketBatch, PacketBatchRecycler, PACKET_DATA_SIZE},
+        packet::{Packet, PacketBatch, PacketBatchRecycler},
         streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
     },
     std::{
@@ -25,7 +25,7 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
     let mut packet_batch = PacketBatch::with_capacity(batch_size);
     packet_batch.resize(batch_size, Packet::default());
     for w in packet_batch.iter_mut() {
-        w.meta_mut().size = PACKET_DATA_SIZE;
+        w.meta_mut().size = Packet::DATA_SIZE;
         w.meta_mut().set_socket_addr(addr);
     }
     let packet_batch = Arc::new(packet_batch);
@@ -36,7 +36,7 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         let mut num = 0;
         for p in packet_batch.iter() {
             let a = p.meta().socket_addr();
-            assert!(p.meta().size <= PACKET_DATA_SIZE);
+            assert!(p.meta().size <= Packet::DATA_SIZE);
             let data = p.data(..).unwrap_or_default();
             send.send_to(data, a).unwrap();
             num += 1;

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -5,8 +5,8 @@ use {
     crossbeam_channel::unbounded,
     solana_sdk::packet::Packet,
     solana_streamer::{
-        packet::{Batch, BatchRecycler},
-        streamer::{receiver, BatchReceiver, StreamerReceiveStats},
+        packet::{BatchRecycler, PacketBatch},
+        streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
     },
     std::{
         cmp::max,
@@ -23,7 +23,7 @@ use {
 fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
     let send = UdpSocket::bind("0.0.0.0:0").unwrap();
     let batch_size = 10;
-    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
+    let mut packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
     packet_batch.resize(batch_size, Packet::default());
     for w in packet_batch.iter_mut() {
         w.meta.size = Packet::DATA_SIZE;
@@ -49,7 +49,7 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
 fn sink(
     exit: Arc<AtomicBool>,
     rvs: Arc<AtomicUsize>,
-    r: BatchReceiver<{ Packet::DATA_SIZE }>,
+    r: PacketBatchReceiver<{ Packet::DATA_SIZE }>,
 ) -> JoinHandle<()> {
     spawn(move || loop {
         if exit.load(Ordering::Relaxed) {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -39,7 +39,7 @@ use {
         loader_instruction,
         message::Message,
         native_token::Sol,
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         signature::{keypair_from_seed, read_keypair_file, Keypair, Signature, Signer},
         system_instruction::{self, SystemError},

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -39,7 +39,7 @@ use {
         loader_instruction,
         message::Message,
         native_token::Sol,
-        packet::PACKET_DATA_SIZE,
+        packet::Packet,
         pubkey::Pubkey,
         signature::{keypair_from_seed, read_keypair_file, Keypair, Signature, Signer},
         system_instruction::{self, SystemError},
@@ -1728,7 +1728,7 @@ where
     })
     .unwrap() as usize;
     // add 1 byte buffer to account for shortvec encoding
-    PACKET_DATA_SIZE.saturating_sub(tx_size).saturating_sub(1)
+    Packet::DATA_SIZE.saturating_sub(tx_size).saturating_sub(1)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -39,7 +39,7 @@ use {
         loader_instruction,
         message::Message,
         native_token::Sol,
-        packet::Packet,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::{keypair_from_seed, read_keypair_file, Keypair, Signature, Signer},
         system_instruction::{self, SystemError},

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -465,6 +465,7 @@ mod tests {
         rand::{Rng, SeedableRng},
         rand_chacha::ChaChaRng,
         solana_sdk::{
+            packet::TransactionPacket,
             pubkey::Pubkey,
             quic::{
                 QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
@@ -657,20 +658,21 @@ mod tests {
 
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
 
-        let (response_recv_endpoint, response_recv_thread) = solana_streamer::quic::spawn_server(
-            response_recv_socket,
-            &keypair2,
-            response_recv_ip,
-            sender2,
-            response_recv_exit.clone(),
-            1,
-            staked_nodes,
-            10,
-            10,
-            response_recv_stats,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
-        )
-        .unwrap();
+        let (response_recv_endpoint, response_recv_thread) =
+            solana_streamer::quic::spawn_server::<{ TransactionPacket::DATA_SIZE }>(
+                response_recv_socket,
+                &keypair2,
+                response_recv_ip,
+                sender2,
+                response_recv_exit.clone(),
+                1,
+                staked_nodes,
+                10,
+                10,
+                response_recv_stats,
+                DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            )
+            .unwrap();
 
         let connection_cache = ConnectionCache::new_with_endpoint(1, response_recv_endpoint);
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -31,6 +31,7 @@ use {
         genesis_config::GenesisConfig,
         hash::Hash,
         message::Message,
+        packet::{BasePacket, Packet},
         pubkey,
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
@@ -251,9 +252,9 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         assert!(r.is_ok(), "sanity parallel execution");
     }
     bank.clear_signatures();
-    let verified: Vec<_> = to_packet_batches(&transactions, PACKETS_PER_BATCH);
+    let verified: Vec<_> = to_packet_batches::<Packet, _>(&transactions, PACKETS_PER_BATCH);
     let vote_packets = vote_txs.map(|vote_txs| {
-        let mut packet_batches = to_packet_batches(&vote_txs, PACKETS_PER_BATCH);
+        let mut packet_batches = to_packet_batches::<Packet, _>(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
             for packet in batch.iter_mut() {
                 packet.meta_mut().set_simple_vote(true);

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -31,7 +31,7 @@ use {
         genesis_config::GenesisConfig,
         hash::Hash,
         message::Message,
-        packet::{BasePacket, Packet},
+        packet::{BasePacket, Packet, TransactionPacket},
         pubkey,
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
@@ -84,7 +84,8 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
 
         let tx = test_tx();
         let transactions = vec![tx; 4194304];
-        let batches = transactions_to_deserialized_packets(&transactions).unwrap();
+        let batches =
+            transactions_to_deserialized_packets::<TransactionPacket>(&transactions).unwrap();
         let batches_len = batches.len();
         let mut transaction_buffer = UnprocessedTransactionStorage::new_transaction_storage(
             UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len),
@@ -252,7 +253,8 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         assert!(r.is_ok(), "sanity parallel execution");
     }
     bank.clear_signatures();
-    let verified: Vec<_> = to_packet_batches::<Packet, _>(&transactions, PACKETS_PER_BATCH);
+    let verified: Vec<_> =
+        to_packet_batches::<TransactionPacket, _>(&transactions, PACKETS_PER_BATCH);
     let vote_packets = vote_txs.map(|vote_txs| {
         let mut packet_batches = to_packet_batches::<Packet, _>(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -31,7 +31,7 @@ use {
         genesis_config::GenesisConfig,
         hash::Hash,
         message::Message,
-        packet::{BasePacket, Packet, TransactionPacket},
+        packet::{Packet, TransactionPacket},
         pubkey,
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
@@ -85,7 +85,8 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let tx = test_tx();
         let transactions = vec![tx; 4194304];
         let batches =
-            transactions_to_deserialized_packets::<TransactionPacket>(&transactions).unwrap();
+            transactions_to_deserialized_packets::<{ TransactionPacket::DATA_SIZE }>(&transactions)
+                .unwrap();
         let batches_len = batches.len();
         let mut transaction_buffer = UnprocessedTransactionStorage::new_transaction_storage(
             UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len),
@@ -254,9 +255,10 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     }
     bank.clear_signatures();
     let verified: Vec<_> =
-        to_packet_batches::<TransactionPacket, _>(&transactions, PACKETS_PER_BATCH);
+        to_packet_batches::<{ TransactionPacket::DATA_SIZE }, _>(&transactions, PACKETS_PER_BATCH);
     let vote_packets = vote_txs.map(|vote_txs| {
-        let mut packet_batches = to_packet_batches::<Packet, _>(&vote_txs, PACKETS_PER_BATCH);
+        let mut packet_batches =
+            to_packet_batches::<{ Packet::DATA_SIZE }, _>(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
             for packet in batch.iter_mut() {
                 packet.meta_mut().set_simple_vote(true);

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -261,7 +261,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             to_packet_batches::<{ Packet::DATA_SIZE }, _>(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
             for packet in batch.iter_mut() {
-                packet.meta_mut().set_simple_vote(true);
+                packet.meta.set_simple_vote(true);
             }
         }
         packet_batches

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -12,7 +12,7 @@ use {
         Shred, ShredFlags, Shredder, DATA_SHREDS_PER_FEC_BLOCK, LEGACY_SHRED_DATA_CAPACITY,
     },
     solana_perf::test_tx,
-    solana_sdk::{hash::Hash, packet::PACKET_DATA_SIZE, signature::Keypair},
+    solana_sdk::{hash::Hash, packet::Packet, signature::Keypair},
     test::Bencher,
 };
 
@@ -22,7 +22,7 @@ use {
 // size of nonce: 4
 // size of common shred header: 83
 // size of coding shred header: 6
-const VALID_SHRED_DATA_LEN: usize = PACKET_DATA_SIZE - 4 - 83 - 6;
+const VALID_SHRED_DATA_LEN: usize = Packet::DATA_SIZE - 4 - 83 - 6;
 
 fn make_test_entry(txs_per_entry: u64) -> Entry {
     Entry {

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -12,11 +12,7 @@ use {
         Shred, ShredFlags, Shredder, DATA_SHREDS_PER_FEC_BLOCK, LEGACY_SHRED_DATA_CAPACITY,
     },
     solana_perf::test_tx,
-    solana_sdk::{
-        hash::Hash,
-        packet::{BasePacket, Packet},
-        signature::Keypair,
-    },
+    solana_sdk::{hash::Hash, packet::Packet, signature::Keypair},
     test::Bencher,
 };
 

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -12,7 +12,11 @@ use {
         Shred, ShredFlags, Shredder, DATA_SHREDS_PER_FEC_BLOCK, LEGACY_SHRED_DATA_CAPACITY,
     },
     solana_perf::test_tx,
-    solana_sdk::{hash::Hash, packet::Packet, signature::Keypair},
+    solana_sdk::{
+        hash::Hash,
+        packet::{BasePacket, Packet},
+        signature::Keypair,
+    },
     test::Bencher,
 };
 

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -49,7 +49,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
         total += batch.len();
         for p in batch.iter_mut() {
             let ip_index = thread_rng().gen_range(0, ips.len());
-            p.meta_mut().addr = ips[ip_index];
+            p.meta.addr = ips[ip_index];
         }
     }
     info!("total packets: {}", total);
@@ -59,10 +59,10 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for p in batch.iter_mut() {
-                if !p.meta().discard() {
+                if !p.meta.discard() {
                     num_packets += 1;
                 }
-                p.meta_mut().set_discard(false);
+                p.meta.set_discard(false);
             }
         }
         assert_eq!(num_packets, 10_000);
@@ -95,7 +95,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     for batch in batches.iter_mut() {
         for packet in batch.iter_mut() {
             // One spam address, ~1000 unique addresses.
-            packet.meta_mut().addr = if rng.gen_ratio(1, 30) {
+            packet.meta.addr = if rng.gen_ratio(1, 30) {
                 new_rand_addr(&mut rng)
             } else {
                 spam_addr
@@ -107,10 +107,10 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for packet in batch.iter_mut() {
-                if !packet.meta().discard() {
+                if !packet.meta.discard() {
                     num_packets += 1;
                 }
-                packet.meta_mut().set_discard(false);
+                packet.meta.set_discard(false);
             }
         }
         assert_eq!(num_packets, 10_000);
@@ -213,7 +213,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<Batch<{ Packet::DATA_SIZE }>>, u
         batch.iter_mut().for_each(|p| {
             let throw = die.sample(&mut rng);
             if throw < discard_factor {
-                p.meta_mut().set_discard(true);
+                p.meta.set_discard(true);
                 c += 1;
             }
         })

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -14,7 +14,7 @@ use {
     solana_core::{sigverify::TransactionSigVerifier, sigverify_stage::SigVerifyStage},
     solana_measure::measure::Measure,
     solana_perf::{
-        packet::{to_packet_batches, Batch},
+        packet::{to_packet_batches, PacketBatch},
         test_tx::test_tx,
     },
     solana_sdk::{
@@ -117,7 +117,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     });
 }
 
-fn gen_batches(use_same_tx: bool) -> Vec<Batch<{ Packet::DATA_SIZE }>> {
+fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch<{ Packet::DATA_SIZE }>> {
     let len = 4096;
     let chunk_size = 1024;
     if use_same_tx {
@@ -185,7 +185,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     stage.join().unwrap();
 }
 
-fn prepare_batches(discard_factor: i32) -> (Vec<Batch<{ Packet::DATA_SIZE }>>, usize) {
+fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch<{ Packet::DATA_SIZE }>>, usize) {
     let len = 10_000; // max batch size
     let chunk_size = 1024;
 

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -19,7 +19,7 @@ use {
     },
     solana_sdk::{
         hash::Hash,
-        packet::{BasePacket, Packet},
+        packet::Packet,
         signature::{Keypair, Signer},
         system_transaction,
         timing::duration_as_ms,
@@ -33,7 +33,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
     let len = 30 * 1000;
     let chunk_size = 1024;
     let tx = test_tx();
-    let mut batches = to_packet_batches::<Packet, _>(&vec![tx; len], chunk_size);
+    let mut batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(&vec![tx; len], chunk_size);
 
     let mut total = 0;
 
@@ -89,7 +89,8 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         std::net::IpAddr::from(addr)
     }
     let mut rng = thread_rng();
-    let mut batches = to_packet_batches::<Packet, _>(&vec![test_tx(); SIZE], CHUNK_SIZE);
+    let mut batches =
+        to_packet_batches::<{ Packet::DATA_SIZE }, _>(&vec![test_tx(); SIZE], CHUNK_SIZE);
     let spam_addr = new_rand_addr(&mut rng);
     for batch in batches.iter_mut() {
         for packet in batch.iter_mut() {
@@ -116,7 +117,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     });
 }
 
-fn gen_batches(use_same_tx: bool) -> Vec<Batch<Packet>> {
+fn gen_batches(use_same_tx: bool) -> Vec<Batch<{ Packet::DATA_SIZE }>> {
     let len = 4096;
     let chunk_size = 1024;
     if use_same_tx {
@@ -184,7 +185,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     stage.join().unwrap();
 }
 
-fn prepare_batches(discard_factor: i32) -> (Vec<Batch<Packet>>, usize) {
+fn prepare_batches(discard_factor: i32) -> (Vec<Batch<{ Packet::DATA_SIZE }>>, usize) {
     let len = 10_000; // max batch size
     let chunk_size = 1024;
 
@@ -202,7 +203,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<Batch<Packet>>, usize) {
             )
         })
         .collect();
-    let mut batches = to_packet_batches::<Packet, _>(&txs, chunk_size);
+    let mut batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(&txs, chunk_size);
 
     let mut rng = rand::thread_rng();
     let die = Uniform::<i32>::from(1..100);

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -17,11 +17,12 @@ use {
     },
     solana_measure::measure::Measure,
     solana_perf::{
-        packet::{to_packet_batches, PacketBatch},
+        packet::{to_packet_batches, Batch},
         test_tx::test_tx,
     },
     solana_sdk::{
         hash::Hash,
+        packet::{BasePacket, Packet},
         signature::{Keypair, Signer},
         system_transaction,
         timing::duration_as_ms,
@@ -35,7 +36,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
     let len = 30 * 1000;
     let chunk_size = 1024;
     let tx = test_tx();
-    let mut batches = to_packet_batches(&vec![tx; len], chunk_size);
+    let mut batches = to_packet_batches::<Packet, _>(&vec![tx; len], chunk_size);
 
     let mut total = 0;
 
@@ -91,7 +92,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         std::net::IpAddr::from(addr)
     }
     let mut rng = thread_rng();
-    let mut batches = to_packet_batches(&vec![test_tx(); SIZE], CHUNK_SIZE);
+    let mut batches = to_packet_batches::<Packet, _>(&vec![test_tx(); SIZE], CHUNK_SIZE);
     let spam_addr = new_rand_addr(&mut rng);
     for batch in batches.iter_mut() {
         for packet in batch.iter_mut() {
@@ -118,7 +119,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     });
 }
 
-fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch> {
+fn gen_batches(use_same_tx: bool) -> Vec<Batch<Packet>> {
     let len = 4096;
     let chunk_size = 1024;
     if use_same_tx {
@@ -186,7 +187,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     stage.join().unwrap();
 }
 
-fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
+fn prepare_batches(discard_factor: i32) -> (Vec<Batch<Packet>>, usize) {
     let len = 10_000; // max batch size
     let chunk_size = 1024;
 
@@ -204,7 +205,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
             )
         })
         .collect();
-    let mut batches = to_packet_batches(&txs, chunk_size);
+    let mut batches = to_packet_batches::<Packet, _>(&txs, chunk_size);
 
     let mut rng = rand::thread_rng();
     let die = Uniform::<i32>::from(1..100);

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -11,10 +11,7 @@ use {
         distributions::{Distribution, Uniform},
         thread_rng, Rng,
     },
-    solana_core::{
-        sigverify::TransactionSigVerifier,
-        sigverify_stage::{SigVerifier, SigVerifyStage},
-    },
+    solana_core::{sigverify::TransactionSigVerifier, sigverify_stage::SigVerifyStage},
     solana_measure::measure::Measure,
     solana_perf::{
         packet::{to_packet_batches, Batch},

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -19,12 +19,7 @@ use {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     },
-    solana_sdk::{
-        hash::Hash,
-        packet::{BasePacket, Packet},
-        signature::Keypair,
-        system_transaction,
-    },
+    solana_sdk::{hash::Hash, packet::Packet, signature::Keypair, system_transaction},
     std::sync::{Arc, RwLock},
     test::Bencher,
 };
@@ -32,8 +27,8 @@ use {
 fn build_packet_batch(
     packet_per_batch_count: usize,
     recent_blockhash: Option<Hash>,
-) -> (Batch<Packet>, Vec<usize>) {
-    let packet_batch = Batch::<Packet>::new(
+) -> (Batch<{ Packet::DATA_SIZE }>, Vec<usize>) {
+    let packet_batch = Batch::<{ Packet::DATA_SIZE }>::new(
         (0..packet_per_batch_count)
             .map(|sender_stake| {
                 let tx = system_transaction::transfer(
@@ -56,11 +51,11 @@ fn build_packet_batch(
 fn build_randomized_packet_batch(
     packet_per_batch_count: usize,
     recent_blockhash: Option<Hash>,
-) -> (Batch<Packet>, Vec<usize>) {
+) -> (Batch<{ Packet::DATA_SIZE }>, Vec<usize>) {
     let mut rng = rand::thread_rng();
     let distribution = Uniform::from(0..200_000);
 
-    let packet_batch = Batch::<Packet>::new(
+    let packet_batch = Batch::<{ Packet::DATA_SIZE }>::new(
         (0..packet_per_batch_count)
             .map(|_| {
                 let tx = system_transaction::transfer(
@@ -114,7 +109,7 @@ fn bench_packet_clone(bencher: &mut Bencher) {
     let batch_count = 1000;
     let packet_per_batch_count = UNPROCESSED_BUFFER_STEP_SIZE;
 
-    let packet_batches: Vec<Batch<Packet>> = (0..batch_count)
+    let packet_batches: Vec<Batch<{ Packet::DATA_SIZE }>> = (0..batch_count)
         .map(|_| build_packet_batch(packet_per_batch_count, None).0)
         .collect();
 

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -6,14 +6,14 @@ extern crate test;
 use {
     rand::distributions::{Distribution, Uniform},
     solana_core::{
-        forward_packet_batches_by_accounts::ForwardBatchesByAccounts,
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         unprocessed_packet_batches::*,
         unprocessed_transaction_storage::{
             ThreadType, UnprocessedTransactionStorage, UNPROCESSED_BUFFER_STEP_SIZE,
         },
     },
     solana_measure::measure::Measure,
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
@@ -27,8 +27,8 @@ use {
 fn build_packet_batch(
     packet_per_batch_count: usize,
     recent_blockhash: Option<Hash>,
-) -> (Batch<{ Packet::DATA_SIZE }>, Vec<usize>) {
-    let packet_batch = Batch::<{ Packet::DATA_SIZE }>::new(
+) -> (PacketBatch<{ Packet::DATA_SIZE }>, Vec<usize>) {
+    let packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::new(
         (0..packet_per_batch_count)
             .map(|sender_stake| {
                 let tx = system_transaction::transfer(
@@ -51,11 +51,11 @@ fn build_packet_batch(
 fn build_randomized_packet_batch(
     packet_per_batch_count: usize,
     recent_blockhash: Option<Hash>,
-) -> (Batch<{ Packet::DATA_SIZE }>, Vec<usize>) {
+) -> (PacketBatch<{ Packet::DATA_SIZE }>, Vec<usize>) {
     let mut rng = rand::thread_rng();
     let distribution = Uniform::from(0..200_000);
 
-    let packet_batch = Batch::<{ Packet::DATA_SIZE }>::new(
+    let packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::new(
         (0..packet_per_batch_count)
             .map(|_| {
                 let tx = system_transaction::transfer(
@@ -109,7 +109,7 @@ fn bench_packet_clone(bencher: &mut Bencher) {
     let batch_count = 1000;
     let packet_per_batch_count = UNPROCESSED_BUFFER_STEP_SIZE;
 
-    let packet_batches: Vec<Batch<{ Packet::DATA_SIZE }>> = (0..batch_count)
+    let packet_batches: Vec<PacketBatch<{ Packet::DATA_SIZE }>> = (0..batch_count)
         .map(|_| build_packet_batch(packet_per_batch_count, None).0)
         .collect();
 
@@ -233,7 +233,7 @@ fn buffer_iter_desc_and_forward(
             ThreadType::Transactions,
         );
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
         let _ = transaction_storage.filter_forwardable_packets_and_add_batches(
             current_bank,
             &mut forward_packet_batches_by_accounts,

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -38,7 +38,7 @@ fn build_packet_batch(
                     recent_blockhash.unwrap_or_else(Hash::new_unique),
                 );
                 let mut packet = Packet::from_data(None, tx).unwrap();
-                packet.meta_mut().sender_stake = sender_stake as u64;
+                packet.meta.sender_stake = sender_stake as u64;
                 packet
             })
             .collect(),
@@ -66,7 +66,7 @@ fn build_randomized_packet_batch(
                 );
                 let mut packet = Packet::from_data(None, tx).unwrap();
                 let sender_stake = distribution.sample(&mut rng);
-                packet.meta_mut().sender_stake = sender_stake as u64;
+                packet.meta.sender_stake = sender_stake as u64;
                 packet
             })
             .collect(),
@@ -120,8 +120,8 @@ fn bench_packet_clone(bencher: &mut Bencher) {
             let mut timer = Measure::start("insert_batch");
             packet_batch.iter().for_each(|packet| {
                 let mut packet = packet.clone();
-                packet.meta_mut().sender_stake *= 2;
-                if packet.meta().sender_stake > 2 {
+                packet.meta.sender_stake *= 2;
+                if packet.meta.sender_stake > 2 {
                     outer_packet = packet;
                 }
             });

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -1224,9 +1224,7 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet
-            .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+        packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1603,9 +1601,7 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet
-            .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+        packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -17,18 +17,19 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, ping_pong::Pong},
     solana_ledger::blockstore::Blockstore,
     solana_perf::{
-        packet::{deserialize_from_with_limit, Packet, PacketBatch},
+        packet::{deserialize_from_with_limit, Batch},
         recycler::Recycler,
     },
     solana_runtime::bank::Bank,
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT},
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::Signable,
         signer::keypair::Keypair,
         timing::timestamp,
     },
-    solana_streamer::streamer::{self, PacketBatchReceiver, StreamerReceiveStats},
+    solana_streamer::streamer::{self, BatchReceiver, StreamerReceiveStats},
     std::{
         collections::HashSet,
         io::{Cursor, Read},
@@ -205,7 +206,7 @@ impl AncestorHashesService {
     /// Listen for responses to our ancestors hashes repair requests
     fn run_responses_listener(
         ancestor_hashes_request_statuses: Arc<DashMap<Slot, DeadSlotAncestorRequestStatus>>,
-        response_receiver: PacketBatchReceiver,
+        response_receiver: BatchReceiver<Packet>,
         blockstore: Arc<Blockstore>,
         outstanding_requests: Arc<RwLock<OutstandingAncestorHashesRepairs>>,
         exit: Arc<AtomicBool>,
@@ -254,7 +255,7 @@ impl AncestorHashesService {
     #[allow(clippy::too_many_arguments)]
     fn process_new_packets_from_channel(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        response_receiver: &PacketBatchReceiver,
+        response_receiver: &BatchReceiver<Packet>,
         blockstore: &Blockstore,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         stats: &mut AncestorHashesResponsesStats,
@@ -301,7 +302,7 @@ impl AncestorHashesService {
 
     fn process_packet_batch(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        packet_batch: PacketBatch,
+        packet_batch: Batch<Packet>,
         stats: &mut AncestorHashesResponsesStats,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         blockstore: &Blockstore,
@@ -949,7 +950,7 @@ mod test {
         t_listen: JoinHandle<()>,
         exit: Arc<AtomicBool>,
         responder_info: ContactInfo,
-        response_receiver: PacketBatchReceiver,
+        response_receiver: BatchReceiver<Packet>,
         correct_bank_hashes: HashMap<Slot, Hash>,
     }
 

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -17,7 +17,7 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, ping_pong::Pong},
     solana_ledger::blockstore::Blockstore,
     solana_perf::{
-        packet::{deserialize_from_with_limit, Batch},
+        packet::{deserialize_from_with_limit, PacketBatch},
         recycler::Recycler,
     },
     solana_runtime::bank::Bank,
@@ -29,7 +29,7 @@ use {
         signer::keypair::Keypair,
         timing::timestamp,
     },
-    solana_streamer::streamer::{self, BatchReceiver, StreamerReceiveStats},
+    solana_streamer::streamer::{self, PacketBatchReceiver, StreamerReceiveStats},
     std::{
         collections::HashSet,
         io::{Cursor, Read},
@@ -206,7 +206,7 @@ impl AncestorHashesService {
     /// Listen for responses to our ancestors hashes repair requests
     fn run_responses_listener(
         ancestor_hashes_request_statuses: Arc<DashMap<Slot, DeadSlotAncestorRequestStatus>>,
-        response_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
+        response_receiver: PacketBatchReceiver<{ Packet::DATA_SIZE }>,
         blockstore: Arc<Blockstore>,
         outstanding_requests: Arc<RwLock<OutstandingAncestorHashesRepairs>>,
         exit: Arc<AtomicBool>,
@@ -255,7 +255,7 @@ impl AncestorHashesService {
     #[allow(clippy::too_many_arguments)]
     fn process_new_packets_from_channel(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        response_receiver: &BatchReceiver<{ Packet::DATA_SIZE }>,
+        response_receiver: &PacketBatchReceiver<{ Packet::DATA_SIZE }>,
         blockstore: &Blockstore,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         stats: &mut AncestorHashesResponsesStats,
@@ -302,7 +302,7 @@ impl AncestorHashesService {
 
     fn process_packet_batch(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        packet_batch: Batch<{ Packet::DATA_SIZE }>,
+        packet_batch: PacketBatch<{ Packet::DATA_SIZE }>,
         stats: &mut AncestorHashesResponsesStats,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         blockstore: &Blockstore,
@@ -950,7 +950,7 @@ mod test {
         t_listen: JoinHandle<()>,
         exit: Arc<AtomicBool>,
         responder_info: ContactInfo,
-        response_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
+        response_receiver: PacketBatchReceiver<{ Packet::DATA_SIZE }>,
         correct_bank_hashes: HashMap<Slot, Hash>,
     }
 

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -23,7 +23,7 @@ use {
     solana_runtime::bank::Bank,
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT},
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         signature::Signable,
         signer::keypair::Keypair,
@@ -206,7 +206,7 @@ impl AncestorHashesService {
     /// Listen for responses to our ancestors hashes repair requests
     fn run_responses_listener(
         ancestor_hashes_request_statuses: Arc<DashMap<Slot, DeadSlotAncestorRequestStatus>>,
-        response_receiver: BatchReceiver<Packet>,
+        response_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
         blockstore: Arc<Blockstore>,
         outstanding_requests: Arc<RwLock<OutstandingAncestorHashesRepairs>>,
         exit: Arc<AtomicBool>,
@@ -255,7 +255,7 @@ impl AncestorHashesService {
     #[allow(clippy::too_many_arguments)]
     fn process_new_packets_from_channel(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        response_receiver: &BatchReceiver<Packet>,
+        response_receiver: &BatchReceiver<{ Packet::DATA_SIZE }>,
         blockstore: &Blockstore,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         stats: &mut AncestorHashesResponsesStats,
@@ -302,7 +302,7 @@ impl AncestorHashesService {
 
     fn process_packet_batch(
         ancestor_hashes_request_statuses: &DashMap<Slot, DeadSlotAncestorRequestStatus>,
-        packet_batch: Batch<Packet>,
+        packet_batch: Batch<{ Packet::DATA_SIZE }>,
         stats: &mut AncestorHashesResponsesStats,
         outstanding_requests: &RwLock<OutstandingAncestorHashesRepairs>,
         blockstore: &Blockstore,
@@ -950,7 +950,7 @@ mod test {
         t_listen: JoinHandle<()>,
         exit: Arc<AtomicBool>,
         responder_info: ContactInfo,
-        response_receiver: BatchReceiver<Packet>,
+        response_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
         correct_bank_hashes: HashMap<Slot, Hash>,
     }
 

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -344,7 +344,7 @@ impl AncestorHashesService {
         keypair: &Keypair,
         ancestor_socket: &UdpSocket,
     ) -> Option<(Slot, DuplicateAncestorDecision)> {
-        let from_addr = packet.meta().socket_addr();
+        let from_addr = packet.meta.socket_addr();
         let packet_data = match packet.data(..) {
             Some(data) => data,
             None => {
@@ -1264,9 +1264,7 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet
-            .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+        packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1526,7 +1524,7 @@ mod test {
 
         // Create invalid packet with fewer bytes than the size of the nonce
         let mut packet = Packet::default();
-        packet.meta_mut().size = 0;
+        packet.meta.size = 0;
 
         assert!(AncestorHashesService::verify_and_process_ancestor_response(
             &packet,
@@ -1665,9 +1663,7 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet
-            .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+        packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::{
-        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
+        forward_packet_batches_by_accounts::ForwardBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{LatestUnprocessedVotes, VoteSource},
         leader_slot_banking_stage_metrics::{
@@ -40,7 +40,7 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Packet, PacketBatch, PACKETS_PER_BATCH},
+        packet::{Batch, PACKETS_PER_BATCH},
     },
     solana_poh::poh_recorder::{BankStart, PohRecorder, PohRecorderError, TransactionRecorder},
     solana_program_runtime::timings::ExecuteTimings,
@@ -63,6 +63,7 @@ use {
             HOLD_TRANSACTIONS_SLOT_OFFSET, MAX_PROCESSING_AGE,
         },
         feature_set::allow_votes_to_directly_update_vote_state,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         saturating_add_assign,
         timing::{duration_as_ms, timestamp, AtomicInterval},
@@ -99,9 +100,9 @@ const MIN_THREADS_BANKING: u32 = 1;
 const MIN_TOTAL_THREADS: u32 = NUM_VOTE_PROCESSING_THREADS + MIN_THREADS_BANKING;
 
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
-pub type BankingPacketBatch = (Vec<PacketBatch>, Option<SigverifyTracerPacketStats>);
-pub type BankingPacketSender = CrossbeamSender<BankingPacketBatch>;
-pub type BankingPacketReceiver = CrossbeamReceiver<BankingPacketBatch>;
+pub type BankingBatch<P> = (Vec<Batch<P>>, Option<SigverifyTracerPacketStats>);
+pub type BankingSender<P> = CrossbeamSender<BankingBatch<P>>;
+pub type BankingReceiver<P> = CrossbeamReceiver<BankingBatch<P>>;
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -385,9 +386,9 @@ impl BankingStage {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        verified_receiver: BankingPacketReceiver,
-        tpu_verified_vote_receiver: BankingPacketReceiver,
-        verified_vote_receiver: BankingPacketReceiver,
+        verified_receiver: BankingReceiver<Packet>,
+        tpu_verified_vote_receiver: BankingReceiver<Packet>,
+        verified_vote_receiver: BankingReceiver<Packet>,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
@@ -413,9 +414,9 @@ impl BankingStage {
     pub fn new_num_threads(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        verified_receiver: BankingPacketReceiver,
-        tpu_verified_vote_receiver: BankingPacketReceiver,
-        verified_vote_receiver: BankingPacketReceiver,
+        verified_receiver: BankingReceiver<Packet>,
+        tpu_verified_vote_receiver: BankingReceiver<Packet>,
+        verified_vote_receiver: BankingReceiver<Packet>,
         num_threads: u32,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
@@ -613,7 +614,7 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     fn do_process_packets(
         bank_start: &BankStart,
-        payload: &mut ConsumeScannerPayload,
+        payload: &mut ConsumeScannerPayload<Packet>,
         recorder: &TransactionRecorder,
         transaction_status_sender: &Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
@@ -623,7 +624,7 @@ impl BankingStage {
         consumed_buffered_packets_count: &mut usize,
         rebuffered_packet_count: &mut usize,
         test_fn: &Option<impl Fn()>,
-        packets_to_process: &Vec<Arc<ImmutableDeserializedPacket>>,
+        packets_to_process: &Vec<Arc<ImmutableDeserializedPacket<Packet>>>,
     ) -> Option<Vec<usize>> {
         if payload.reached_end_of_slot {
             return None;
@@ -690,7 +691,7 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     pub fn consume_buffered_packets(
         bank_start: &BankStart,
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
+        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage<Packet>,
         transaction_status_sender: &Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
         test_fn: Option<impl Fn()>,
@@ -825,7 +826,7 @@ impl BankingStage {
         socket: &UdpSocket,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         cluster_info: &ClusterInfo,
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
+        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage<Packet>,
         transaction_status_sender: &Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
         banking_stage_stats: &BankingStageStats,
@@ -921,7 +922,7 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     fn handle_forwarding(
         cluster_info: &ClusterInfo,
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
+        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage<Packet>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         socket: &UdpSocket,
         hold: bool,
@@ -939,7 +940,7 @@ impl BankingStage {
         let current_bank = bank_forks.read().unwrap().root_bank();
 
         let mut forward_packet_batches_by_accounts =
-            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
+            ForwardBatchesByAccounts::new_with_default_batch_limits();
 
         // sanitize and filter packets that are no longer valid (could be too old, a duplicate of something
         // already processed), then add to forwarding buffer.
@@ -1017,7 +1018,7 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     fn process_loop(
-        packet_deserializer: &mut PacketDeserializer,
+        packet_deserializer: &mut PacketDeserializer<Packet>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         cluster_info: &ClusterInfo,
         recv_start: &mut Instant,
@@ -1028,7 +1029,7 @@ impl BankingStage {
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: &Arc<RwLock<BankForks>>,
-        mut unprocessed_transaction_storage: UnprocessedTransactionStorage,
+        mut unprocessed_transaction_storage: UnprocessedTransactionStorage<Packet>,
     ) {
         let recorder = poh_recorder.read().unwrap().recorder();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
@@ -1808,11 +1809,11 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     /// Receive incoming packets, push into unprocessed buffer with packet indexes
     fn receive_and_buffer_packets(
-        packet_deserializer: &mut PacketDeserializer,
+        packet_deserializer: &mut PacketDeserializer<Packet>,
         recv_start: &mut Instant,
         recv_timeout: Duration,
         id: u32,
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
+        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage<Packet>,
         banking_stage_stats: &mut BankingStageStats,
         tracer_packet_stats: &mut TracerPacketStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
@@ -1877,8 +1878,8 @@ impl BankingStage {
     }
 
     fn push_unprocessed(
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
-        deserialized_packets: Vec<ImmutableDeserializedPacket>,
+        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage<Packet>,
+        deserialized_packets: Vec<ImmutableDeserializedPacket<Packet>>,
         dropped_packets_count: &mut usize,
         newly_buffered_packets_count: &mut usize,
         banking_stage_stats: &mut BankingStageStats,
@@ -2124,8 +2125,8 @@ mod tests {
     }
 
     pub fn convert_from_old_verified(
-        mut with_vers: Vec<(PacketBatch, Vec<u8>)>,
-    ) -> Vec<PacketBatch> {
+        mut with_vers: Vec<(Batch<Packet>, Vec<u8>)>,
+    ) -> Vec<Batch<Packet>> {
         with_vers.iter_mut().for_each(|(b, v)| {
             b.iter_mut()
                 .zip(v)
@@ -3833,7 +3834,7 @@ mod tests {
     #[ignore]
     fn test_forwarder_budget() {
         solana_logger::setup();
-        // Create `PacketBatch` with 1 unprocessed packet
+        // Create `Batch<Packet>` with 1 unprocessed packet
         let tx = system_transaction::transfer(
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),
@@ -3881,11 +3882,10 @@ mod tests {
             let connection_cache = ConnectionCache::default();
             let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
             for (name, data_budget, expected_num_forwarded) in test_cases {
-                let unprocessed_packet_batches: UnprocessedPacketBatches =
-                    UnprocessedPacketBatches::from_iter(
-                        vec![deserialized_packet.clone()].into_iter(),
-                        1,
-                    );
+                let unprocessed_packet_batches = UnprocessedPacketBatches::from_iter(
+                    vec![deserialized_packet.clone()].into_iter(),
+                    1,
+                );
                 let stats = BankingStageStats::default();
                 BankingStage::handle_forwarding(
                     &cluster_info,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::{
-        forward_packet_batches_by_accounts::ForwardBatchesByAccounts,
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{LatestUnprocessedVotes, VoteSource},
         leader_slot_banking_stage_metrics::{
@@ -40,7 +40,7 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Batch, PACKETS_PER_BATCH},
+        packet::{PacketBatch, PACKETS_PER_BATCH},
     },
     solana_poh::poh_recorder::{BankStart, PohRecorder, PohRecorderError, TransactionRecorder},
     solana_program_runtime::timings::ExecuteTimings,
@@ -100,9 +100,9 @@ const MIN_THREADS_BANKING: u32 = 1;
 const MIN_TOTAL_THREADS: u32 = NUM_VOTE_PROCESSING_THREADS + MIN_THREADS_BANKING;
 
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
-pub type BankingBatch<const N: usize> = (Vec<Batch<N>>, Option<SigverifyTracerPacketStats>);
-pub type BankingSender<const N: usize> = CrossbeamSender<BankingBatch<N>>;
-pub type BankingReceiver<const N: usize> = CrossbeamReceiver<BankingBatch<N>>;
+pub type BankingBatch<const N: usize> = (Vec<PacketBatch<N>>, Option<SigverifyTracerPacketStats>);
+pub type BankingPacketSender<const N: usize> = CrossbeamSender<BankingBatch<N>>;
+pub type BankingPacketReceiver<const N: usize> = CrossbeamReceiver<BankingBatch<N>>;
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -386,9 +386,9 @@ impl BankingStage {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        verified_receiver: BankingReceiver<{ TransactionPacket::DATA_SIZE }>,
-        tpu_verified_vote_receiver: BankingReceiver<{ Packet::DATA_SIZE }>,
-        verified_vote_receiver: BankingReceiver<{ Packet::DATA_SIZE }>,
+        verified_receiver: BankingPacketReceiver<{ TransactionPacket::DATA_SIZE }>,
+        tpu_verified_vote_receiver: BankingPacketReceiver<{ Packet::DATA_SIZE }>,
+        verified_vote_receiver: BankingPacketReceiver<{ Packet::DATA_SIZE }>,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
@@ -414,9 +414,9 @@ impl BankingStage {
     pub fn new_num_threads(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        verified_receiver: BankingReceiver<{ TransactionPacket::DATA_SIZE }>,
-        tpu_verified_vote_receiver: BankingReceiver<{ Packet::DATA_SIZE }>,
-        verified_vote_receiver: BankingReceiver<{ Packet::DATA_SIZE }>,
+        verified_receiver: BankingPacketReceiver<{ TransactionPacket::DATA_SIZE }>,
+        tpu_verified_vote_receiver: BankingPacketReceiver<{ Packet::DATA_SIZE }>,
+        verified_vote_receiver: BankingPacketReceiver<{ Packet::DATA_SIZE }>,
         num_threads: u32,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
@@ -968,7 +968,7 @@ impl BankingStage {
         let current_bank = bank_forks.read().unwrap().root_bank();
 
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
 
         // sanitize and filter packets that are no longer valid (could be too old, a duplicate of something
         // already processed), then add to forwarding buffer.
@@ -2153,8 +2153,8 @@ mod tests {
     }
 
     pub fn convert_from_old_verified<const N: usize>(
-        mut with_vers: Vec<(Batch<N>, Vec<u8>)>,
-    ) -> Vec<Batch<N>> {
+        mut with_vers: Vec<(PacketBatch<N>, Vec<u8>)>,
+    ) -> Vec<PacketBatch<N>> {
         with_vers.iter_mut().for_each(|(b, v)| {
             b.iter_mut()
                 .zip(v)
@@ -3866,7 +3866,7 @@ mod tests {
     #[ignore]
     fn test_forwarder_budget() {
         solana_logger::setup();
-        // Create `Batch<{Packet::DATA_SIZE}>` with 1 unprocessed packet
+        // Create `PacketBatch<{Packet::DATA_SIZE}>` with 1 unprocessed packet
         let tx = system_transaction::transfer(
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -452,9 +452,13 @@ impl BankingStage {
                 let data_budget = data_budget.clone();
                 let connection_cache = connection_cache.clone();
                 let bank_forks = bank_forks.clone();
+                // Otherwise said: i < NUM_VOTE_PROCESSING_THREADS, but safe in
+                // case NUM_VOTE_PROCESSING_THREADS is changed
                 if i == 0 || i == 1 {
+                    // build vote processing threads
                     let (verified_receiver, unprocessed_transaction_storage) =
                         match (i, should_split_voting_threads) {
+                            // first thread is for gossip votes
                             (0, false) => (
                                 verified_vote_receiver.clone(),
                                 UnprocessedTransactionStorage::new_transaction_storage(
@@ -469,6 +473,7 @@ impl BankingStage {
                                     VoteSource::Gossip,
                                 ),
                             ),
+                            // second thread is for tpu votes
                             (1, false) => (
                                 tpu_verified_vote_receiver.clone(),
                                 UnprocessedTransactionStorage::new_transaction_storage(
@@ -506,6 +511,7 @@ impl BankingStage {
                         })
                         .unwrap()
                 } else {
+                    // all other threads are non-vote banking threads
                     let mut packet_deserializer =
                         PacketDeserializer::new(verified_receiver.clone());
                     let unprocessed_transaction_storage =

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -587,7 +587,7 @@ impl BankingStage {
 
         let packet_vec: Vec<_> = forwardable_packets
             .filter_map(|p| {
-                if !p.meta().forwarded() && data_budget.take(p.meta().size) {
+                if !p.meta.forwarded() && data_budget.take(p.meta.size) {
                     Some(p.data(..)?.to_vec())
                 } else {
                     None
@@ -2158,7 +2158,7 @@ mod tests {
         with_vers.iter_mut().for_each(|(b, v)| {
             b.iter_mut()
                 .zip(v)
-                .for_each(|(p, f)| p.meta_mut().set_discard(*f == 0))
+                .for_each(|(p, f)| p.meta.set_discard(*f == 0))
         });
         with_vers.into_iter().map(|(b, _)| b).collect()
     }
@@ -3964,7 +3964,7 @@ mod tests {
         let forwarded_packet = {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, fwd_block_hash);
             let mut packet = Packet::from_data(None, transaction).unwrap();
-            packet.meta_mut().flags |= PacketFlags::FORWARDED;
+            packet.meta.flags |= PacketFlags::FORWARDED;
             DeserializedPacket::new(packet).unwrap()
         };
 
@@ -4044,7 +4044,7 @@ mod tests {
                 let num_received = recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
                 assert_eq!(num_received, expected_ids.len(), "{name}");
                 for (i, expected_id) in expected_ids.iter().enumerate() {
-                    assert_eq!(packets[i].meta().size, 215);
+                    assert_eq!(packets[i].meta.size, 215);
                     let recv_transaction: VersionedTransaction =
                         packets[i].deserialize_slice(..).unwrap();
                     assert_eq!(

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        banking_stage::BankingSender,
+        banking_stage::BankingPacketSender,
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
         result::{Error, Result},
@@ -234,7 +234,7 @@ impl ClusterInfoVoteListener {
     pub fn new(
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        verified_packets_sender: BankingSender<{ Packet::DATA_SIZE }>,
+        verified_packets_sender: BankingPacketSender<{ Packet::DATA_SIZE }>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -377,7 +377,7 @@ impl ClusterInfoVoteListener {
         exit: Arc<AtomicBool>,
         verified_vote_label_packets_receiver: VerifiedLabelVotePacketsReceiver,
         poh_recorder: Arc<RwLock<PohRecorder>>,
-        verified_packets_sender: &BankingSender<{ Packet::DATA_SIZE }>,
+        verified_packets_sender: &BankingPacketSender<{ Packet::DATA_SIZE }>,
     ) -> Result<()> {
         let mut verified_vote_packets = VerifiedVotePackets::default();
         let mut time_since_lock = Instant::now();
@@ -432,7 +432,7 @@ impl ClusterInfoVoteListener {
     fn check_for_leader_bank_and_send_votes(
         bank_vote_sender_state_option: &mut Option<BankVoteSenderState>,
         current_working_bank: Arc<Bank>,
-        verified_packets_sender: &BankingSender<{ Packet::DATA_SIZE }>,
+        verified_packets_sender: &BankingPacketSender<{ Packet::DATA_SIZE }>,
         verified_vote_packets: &VerifiedVotePackets,
     ) -> Result<()> {
         // We will take this lock at most once every `BANK_SEND_VOTES_LOOP_SLEEP_MS`

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        banking_stage::BankingPacketSender,
+        banking_stage::BankingSender,
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
         result::{Error, Result},
@@ -37,6 +37,7 @@ use {
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
         hash::Hash,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::Signature,
         slot_hashes,
@@ -233,7 +234,7 @@ impl ClusterInfoVoteListener {
     pub fn new(
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        verified_packets_sender: BankingPacketSender,
+        verified_packets_sender: BankingSender<Packet>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -376,7 +377,7 @@ impl ClusterInfoVoteListener {
         exit: Arc<AtomicBool>,
         verified_vote_label_packets_receiver: VerifiedLabelVotePacketsReceiver,
         poh_recorder: Arc<RwLock<PohRecorder>>,
-        verified_packets_sender: &BankingPacketSender,
+        verified_packets_sender: &BankingSender<Packet>,
     ) -> Result<()> {
         let mut verified_vote_packets = VerifiedVotePackets::default();
         let mut time_since_lock = Instant::now();
@@ -431,7 +432,7 @@ impl ClusterInfoVoteListener {
     fn check_for_leader_bank_and_send_votes(
         bank_vote_sender_state_option: &mut Option<BankVoteSenderState>,
         current_working_bank: Arc<Bank>,
-        verified_packets_sender: &BankingPacketSender,
+        verified_packets_sender: &BankingSender<Packet>,
         verified_vote_packets: &VerifiedVotePackets,
     ) -> Result<()> {
         // We will take this lock at most once every `BANK_SEND_VOTES_LOOP_SLEEP_MS`
@@ -914,7 +915,7 @@ mod tests {
         use bincode::serialized_size;
         info!("max vote size {}", serialized_size(&vote_tx).unwrap());
 
-        let packet_batches = packet::to_packet_batches(&[vote_tx], 1); // panics if won't fit
+        let packet_batches = packet::to_packet_batches::<Packet, _>(&[vote_tx], 1); // panics if won't fit
 
         assert_eq!(packet_batches.len(), 1);
     }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -348,7 +348,7 @@ impl ClusterInfoVoteListener {
             .filter(|(_, packet_batch)| {
                 // to_packet_batches() above splits into 1 packet long batches
                 assert_eq!(packet_batch.len(), 1);
-                !packet_batch[0].meta().discard()
+                !packet_batch[0].meta.discard()
             })
             .filter_map(|(tx, packet_batch)| {
                 let (vote_account_key, vote, ..) = vote_parser::parse_vote_transaction(&tx)?;

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -332,7 +332,7 @@ impl ClusterInfoVoteListener {
         votes: Vec<Transaction>,
         bank_forks: &RwLock<BankForks>,
     ) -> (Vec<Transaction>, Vec<VerifiedVoteMetadata>) {
-        let mut packet_batches = packet::to_packet_batches(&votes, 1);
+        let mut packet_batches = packet::to_packet_batches::<Packet, _>(&votes, 1);
 
         // Votes should already be filtered by this point.
         sigverify::ed25519_verify_cpu(

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -10,7 +10,9 @@ use {
         clock::{DEFAULT_TICKS_PER_SLOT, HOLD_TRANSACTIONS_SLOT_OFFSET},
         packet::{Packet, PacketFlags, TransactionPacket},
     },
-    solana_streamer::streamer::{self, BatchReceiver, BatchSender, StreamerReceiveStats},
+    solana_streamer::streamer::{
+        self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats,
+    },
     solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
     std::{
         net::UdpSocket,
@@ -38,8 +40,8 @@ impl FetchStage {
         coalesce_ms: u64,
     ) -> (
         Self,
-        BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
-        BatchReceiver<{ Packet::DATA_SIZE }>,
+        PacketBatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        PacketBatchReceiver<{ Packet::DATA_SIZE }>,
     ) {
         let (sender, receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
@@ -70,10 +72,10 @@ impl FetchStage {
         tpu_forwards_sockets: Vec<UdpSocket>,
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: &Arc<AtomicBool>,
-        sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
-        vote_sender: &BatchSender<{ Packet::DATA_SIZE }>,
-        forward_sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
-        forward_receiver: BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        sender: &PacketBatchSender<{ TransactionPacket::DATA_SIZE }>,
+        vote_sender: &PacketBatchSender<{ Packet::DATA_SIZE }>,
+        forward_sender: &PacketBatchSender<{ TransactionPacket::DATA_SIZE }>,
+        forward_receiver: PacketBatchReceiver<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
@@ -99,8 +101,8 @@ impl FetchStage {
     }
 
     fn handle_forwarded_packets(
-        recvr: &BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
-        sendr: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
+        recvr: &PacketBatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        sendr: &PacketBatchSender<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> Result<()> {
         let mark_forwarded = |packet: &mut TransactionPacket| {
@@ -146,10 +148,10 @@ impl FetchStage {
         tpu_forwards_sockets: Vec<Arc<UdpSocket>>,
         tpu_vote_sockets: Vec<Arc<UdpSocket>>,
         exit: &Arc<AtomicBool>,
-        sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
-        vote_sender: &BatchSender<{ Packet::DATA_SIZE }>,
-        forward_sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
-        forward_receiver: BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        sender: &PacketBatchSender<{ TransactionPacket::DATA_SIZE }>,
+        vote_sender: &PacketBatchSender<{ Packet::DATA_SIZE }>,
+        forward_sender: &PacketBatchSender<{ TransactionPacket::DATA_SIZE }>,
+        forward_receiver: PacketBatchReceiver<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -104,7 +104,7 @@ impl FetchStage {
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> Result<()> {
         let mark_forwarded = |packet: &mut TransactionPacket| {
-            packet.meta_mut().flags |= PacketFlags::FORWARDED;
+            packet.meta.flags |= PacketFlags::FORWARDED;
         };
 
         let mut packet_batch = recvr.recv()?;

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -8,7 +8,7 @@ use {
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{
         clock::{DEFAULT_TICKS_PER_SLOT, HOLD_TRANSACTIONS_SLOT_OFFSET},
-        packet::{BasePacket, Packet, PacketFlags, TransactionPacket},
+        packet::{Packet, PacketFlags, TransactionPacket},
     },
     solana_streamer::streamer::{self, BatchReceiver, BatchSender, StreamerReceiveStats},
     solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
@@ -38,8 +38,8 @@ impl FetchStage {
         coalesce_ms: u64,
     ) -> (
         Self,
-        BatchReceiver<TransactionPacket>,
-        BatchReceiver<Packet>,
+        BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        BatchReceiver<{ Packet::DATA_SIZE }>,
     ) {
         let (sender, receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
@@ -70,10 +70,10 @@ impl FetchStage {
         tpu_forwards_sockets: Vec<UdpSocket>,
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: &Arc<AtomicBool>,
-        sender: &BatchSender<TransactionPacket>,
-        vote_sender: &BatchSender<Packet>,
-        forward_sender: &BatchSender<TransactionPacket>,
-        forward_receiver: BatchReceiver<TransactionPacket>,
+        sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
+        vote_sender: &BatchSender<{ Packet::DATA_SIZE }>,
+        forward_sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
+        forward_receiver: BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
@@ -99,8 +99,8 @@ impl FetchStage {
     }
 
     fn handle_forwarded_packets(
-        recvr: &BatchReceiver<TransactionPacket>,
-        sendr: &BatchSender<TransactionPacket>,
+        recvr: &BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
+        sendr: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> Result<()> {
         let mark_forwarded = |packet: &mut TransactionPacket| {
@@ -146,10 +146,10 @@ impl FetchStage {
         tpu_forwards_sockets: Vec<Arc<UdpSocket>>,
         tpu_vote_sockets: Vec<Arc<UdpSocket>>,
         exit: &Arc<AtomicBool>,
-        sender: &BatchSender<TransactionPacket>,
-        vote_sender: &BatchSender<Packet>,
-        forward_sender: &BatchSender<TransactionPacket>,
-        forward_receiver: BatchReceiver<TransactionPacket>,
+        sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
+        vote_sender: &BatchSender<{ Packet::DATA_SIZE }>,
+        forward_sender: &BatchSender<{ TransactionPacket::DATA_SIZE }>,
+        forward_receiver: BatchReceiver<{ TransactionPacket::DATA_SIZE }>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -2,7 +2,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_measure::measure::Measure,
     solana_perf::packet::Batch,
-    solana_sdk::{packet::BasePacket, timing::timestamp},
+    solana_sdk::timing::timestamp,
     solana_streamer::streamer::{self, StakedNodes, StreamerError},
     std::{
         collections::HashMap,
@@ -17,8 +17,8 @@ use {
 // 50ms/(200ns/packet) = 250k packets
 const MAX_FINDPACKETSENDERSTAKE_BATCH: usize = 250_000;
 
-pub type FindPacketSenderStakeSender<P> = Sender<Vec<Batch<P>>>;
-pub type FindPacketSenderStakeReceiver<P> = Receiver<Vec<Batch<P>>>;
+pub type FindPacketSenderStakeSender<const N: usize> = Sender<Vec<Batch<N>>>;
+pub type FindPacketSenderStakeReceiver<const N: usize> = Receiver<Vec<Batch<N>>>;
 
 #[derive(Debug, Default)]
 struct FindPacketSenderStakeStats {
@@ -76,9 +76,9 @@ pub struct FindPacketSenderStakeStage {
 }
 
 impl FindPacketSenderStakeStage {
-    pub fn new<P: BasePacket + 'static>(
-        packet_receiver: streamer::BatchReceiver<P>,
-        sender: FindPacketSenderStakeSender<P>,
+    pub fn new<const N: usize>(
+        packet_receiver: streamer::BatchReceiver<N>,
+        sender: FindPacketSenderStakeSender<N>,
         staked_nodes: Arc<RwLock<StakedNodes>>,
         name: &'static str,
     ) -> Self {
@@ -145,8 +145,8 @@ impl FindPacketSenderStakeStage {
         Self { thread_hdl }
     }
 
-    fn apply_sender_stakes<P: BasePacket>(
-        batches: &mut [Batch<P>],
+    fn apply_sender_stakes<const N: usize>(
+        batches: &mut [Batch<N>],
         ip_to_stake: &HashMap<IpAddr, u64>,
     ) {
         batches

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -1,7 +1,7 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_measure::measure::Measure,
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_sdk::timing::timestamp,
     solana_streamer::streamer::{self, StakedNodes, StreamerError},
     std::{
@@ -17,8 +17,8 @@ use {
 // 50ms/(200ns/packet) = 250k packets
 const MAX_FINDPACKETSENDERSTAKE_BATCH: usize = 250_000;
 
-pub type FindPacketSenderStakeSender<const N: usize> = Sender<Vec<Batch<N>>>;
-pub type FindPacketSenderStakeReceiver<const N: usize> = Receiver<Vec<Batch<N>>>;
+pub type FindPacketSenderStakeSender<const N: usize> = Sender<Vec<PacketBatch<N>>>;
+pub type FindPacketSenderStakeReceiver<const N: usize> = Receiver<Vec<PacketBatch<N>>>;
 
 #[derive(Debug, Default)]
 struct FindPacketSenderStakeStats {
@@ -77,7 +77,7 @@ pub struct FindPacketSenderStakeStage {
 
 impl FindPacketSenderStakeStage {
     pub fn new<const N: usize>(
-        packet_receiver: streamer::BatchReceiver<N>,
+        packet_receiver: streamer::PacketBatchReceiver<N>,
         sender: FindPacketSenderStakeSender<N>,
         staked_nodes: Arc<RwLock<StakedNodes>>,
         name: &'static str,
@@ -146,7 +146,7 @@ impl FindPacketSenderStakeStage {
     }
 
     fn apply_sender_stakes<const N: usize>(
-        batches: &mut [Batch<N>],
+        batches: &mut [PacketBatch<N>],
         ip_to_stake: &HashMap<IpAddr, u64>,
     ) {
         batches

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -153,8 +153,8 @@ impl FindPacketSenderStakeStage {
             .iter_mut()
             .flat_map(|batch| batch.iter_mut())
             .for_each(|packet| {
-                packet.meta_mut().sender_stake = ip_to_stake
-                    .get(&packet.meta().addr)
+                packet.meta.sender_stake = ip_to_stake
+                    .get(&packet.meta.addr)
                     .copied()
                     .unwrap_or_default();
             });

--- a/core/src/forward_packet_batches_by_accounts.rs
+++ b/core/src/forward_packet_batches_by_accounts.rs
@@ -93,14 +93,14 @@ impl<const N: usize> ForwardBatch<N> {
 /// to allow transactions on non-congested accounts to be forwarded alongside higher fee
 /// transactions that saturate those highly demanded accounts.
 #[derive(Debug)]
-pub struct ForwardBatchesByAccounts<const N: usize> {
+pub struct ForwardPacketBatchesByAccounts<const N: usize> {
     // Forwardable packets are staged in number of batches, each batch is limited
     // by cost_tracker on both account limit and block limits. Those limits are
     // set as `limit_ratio` of regular block limits to facilitate quicker iteration.
     forward_batches: Vec<ForwardBatch<N>>,
 }
 
-impl<const N: usize> ForwardBatchesByAccounts<N> {
+impl<const N: usize> ForwardPacketBatchesByAccounts<N> {
     pub fn new_with_default_batch_limits() -> Self {
         Self::new(FORWARDED_BLOCK_COMPUTE_RATIO, DEFAULT_NUMBER_OF_BATCHES)
     }
@@ -238,7 +238,7 @@ mod tests {
         // setup forwarding with 2 buckets, each only allow one transaction
         let number_of_batches = 2;
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new(limit_ratio, number_of_batches);
+            ForwardPacketBatchesByAccounts::new(limit_ratio, number_of_batches);
 
         // Assert initially both batches are empty
         {
@@ -309,7 +309,7 @@ mod tests {
             build_test_transaction_and_packet(10, &solana_sdk::pubkey::new_rand());
         let number_of_batches = 1;
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new(limit_ratio, number_of_batches);
+            ForwardPacketBatchesByAccounts::new(limit_ratio, number_of_batches);
 
         // Assert initially batch is empty, and accepting new packets
         {

--- a/core/src/forward_packet_batches_by_accounts.rs
+++ b/core/src/forward_packet_batches_by_accounts.rs
@@ -5,7 +5,9 @@ use {
         cost_model::CostModel,
         cost_tracker::{CostTracker, CostTrackerError},
     },
-    solana_sdk::{feature_set::FeatureSet, packet::BasePacket, transaction::SanitizedTransaction},
+    solana_sdk::{
+        feature_set::FeatureSet, packet::GenericPacket, transaction::SanitizedTransaction,
+    },
     std::sync::Arc,
 };
 
@@ -23,21 +25,21 @@ const DEFAULT_NUMBER_OF_BATCHES: u32 = 100;
 /// `ForwardBatch` represents one forwardable batch of transactions with a
 /// limited number of total compute units
 #[derive(Debug)]
-pub struct ForwardBatch<P: BasePacket> {
+pub struct ForwardBatch<const N: usize> {
     cost_tracker: CostTracker,
     // `forwardable_packets` keeps forwardable packets in a vector in its
     // original fee prioritized order
-    forwardable_packets: Vec<Arc<ImmutableDeserializedPacket<P>>>,
+    forwardable_packets: Vec<Arc<ImmutableDeserializedPacket<N>>>,
 }
 
-impl<P: BasePacket> Default for ForwardBatch<P> {
+impl<const N: usize> Default for ForwardBatch<N> {
     /// default ForwardBatch has cost_tracker with default limits
     fn default() -> Self {
         Self::new(1)
     }
 }
 
-impl<P: BasePacket> ForwardBatch<P> {
+impl<const N: usize> ForwardBatch<N> {
     /// `ForwardBatch` keeps forwardable packets in a vector in its original fee prioritized order,
     /// Number of packets are limited by `cost_tracker` with customized `limit_ratio` to lower
     /// (when `limit_ratio` > 1) `cost_tracker`'s default limits.
@@ -58,7 +60,7 @@ impl<P: BasePacket> ForwardBatch<P> {
     fn try_add(
         &mut self,
         sanitized_transaction: &SanitizedTransaction,
-        immutable_packet: Arc<ImmutableDeserializedPacket<P>>,
+        immutable_packet: Arc<ImmutableDeserializedPacket<N>>,
         feature_set: &FeatureSet,
     ) -> Result<u64, CostTrackerError> {
         let tx_cost = CostModel::calculate_cost(sanitized_transaction, feature_set);
@@ -78,8 +80,8 @@ impl<P: BasePacket> ForwardBatch<P> {
     }
 }
 
-impl<P: BasePacket> ForwardBatch<P> {
-    pub fn get_forwardable_packets(&self) -> impl Iterator<Item = &P> {
+impl<const N: usize> ForwardBatch<N> {
+    pub fn get_forwardable_packets(&self) -> impl Iterator<Item = &GenericPacket<N>> {
         self.forwardable_packets
             .iter()
             .map(|immutable_packet| immutable_packet.original_packet())
@@ -91,14 +93,14 @@ impl<P: BasePacket> ForwardBatch<P> {
 /// to allow transactions on non-congested accounts to be forwarded alongside higher fee
 /// transactions that saturate those highly demanded accounts.
 #[derive(Debug)]
-pub struct ForwardBatchesByAccounts<P: BasePacket> {
+pub struct ForwardBatchesByAccounts<const N: usize> {
     // Forwardable packets are staged in number of batches, each batch is limited
     // by cost_tracker on both account limit and block limits. Those limits are
     // set as `limit_ratio` of regular block limits to facilitate quicker iteration.
-    forward_batches: Vec<ForwardBatch<P>>,
+    forward_batches: Vec<ForwardBatch<N>>,
 }
 
-impl<P: BasePacket> ForwardBatchesByAccounts<P> {
+impl<const N: usize> ForwardBatchesByAccounts<N> {
     pub fn new_with_default_batch_limits() -> Self {
         Self::new(FORWARDED_BLOCK_COMPUTE_RATIO, DEFAULT_NUMBER_OF_BATCHES)
     }
@@ -114,7 +116,7 @@ impl<P: BasePacket> ForwardBatchesByAccounts<P> {
     pub fn try_add_packet(
         &mut self,
         sanitized_transaction: &SanitizedTransaction,
-        immutable_packet: Arc<ImmutableDeserializedPacket<P>>,
+        immutable_packet: Arc<ImmutableDeserializedPacket<N>>,
         feature_set: &FeatureSet,
     ) -> bool {
         for forward_batch in self.forward_batches.iter_mut() {
@@ -128,7 +130,7 @@ impl<P: BasePacket> ForwardBatchesByAccounts<P> {
         false
     }
 
-    pub fn iter_batches(&self) -> impl Iterator<Item = &ForwardBatch<P>> {
+    pub fn iter_batches(&self) -> impl Iterator<Item = &ForwardBatch<N>> {
         self.forward_batches.iter()
     }
 }
@@ -167,7 +169,11 @@ mod tests {
     fn build_test_transaction_and_packet(
         priority: u64,
         write_to_account: &Pubkey,
-    ) -> (SanitizedTransaction, DeserializedPacket<Packet>, u32) {
+    ) -> (
+        SanitizedTransaction,
+        DeserializedPacket<{ Packet::DATA_SIZE }>,
+        u32,
+    ) {
         let (mint_keypair, start_hash) = test_setup();
         let transaction =
             system_transaction::transfer(&mint_keypair, write_to_account, 2, start_hash);

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -54,7 +54,7 @@ impl<const N: usize> ImmutableDeserializedPacket<N> {
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
         let message_hash = Message::hash_raw_message(message_bytes);
-        let is_simple_vote = packet.meta().is_simple_vote_tx();
+        let is_simple_vote = packet.meta.is_simple_vote_tx();
 
         // drop transaction if prioritization fails.
         let mut priority_details = priority_details

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        forward_packet_batches_by_accounts::ForwardBatchesByAccounts,
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::{DeserializedPacketError, ImmutableDeserializedPacket},
     },
     itertools::Itertools,
@@ -237,7 +237,7 @@ impl<const N: usize> LatestUnprocessedVotes<N> {
     pub fn get_and_insert_forwardable_packets(
         &self,
         bank: Arc<Bank>,
-        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<N>,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts<N>,
     ) -> usize {
         let mut continue_forwarding = true;
         let pubkeys_by_stake = weighted_random_order_by_stake(
@@ -325,7 +325,7 @@ mod tests {
         super::*,
         itertools::Itertools,
         rand::{thread_rng, Rng},
-        solana_perf::packet::{Batch, Packet, PacketFlags},
+        solana_perf::packet::{Packet, PacketBatch, PacketFlags},
         solana_runtime::{
             bank::Bank,
             genesis_utils::{self, ValidatorVoteKeypairs},
@@ -358,7 +358,7 @@ mod tests {
     }
 
     fn deserialize_packets<'a, const N: usize>(
-        packet_batch: &'a Batch<N>,
+        packet_batch: &'a PacketBatch<N>,
         packet_indexes: &'a [usize],
         vote_source: VoteSource,
     ) -> impl Iterator<Item = LatestValidatorVotePacket<N>> + 'a {
@@ -446,7 +446,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let packet_batch = Batch::<{ Packet::DATA_SIZE }>::new(vec![
+        let packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::new(vec![
             vote,
             vote_switch,
             vote_state_update,
@@ -592,7 +592,7 @@ mod tests {
         let latest_unprocessed_votes = LatestUnprocessedVotes::new();
         let bank = Arc::new(Bank::default_for_tests());
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
 
         let keypair_a = ValidatorVoteKeypairs::new_rand();
         let keypair_b = ValidatorVoteKeypairs::new_rand();
@@ -622,7 +622,7 @@ mod tests {
         .genesis_config;
         let bank = Bank::new_for_tests(&config);
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
 
         // Don't forward votes from gossip
         let forwarded = latest_unprocessed_votes.get_and_insert_forwardable_packets(
@@ -647,7 +647,7 @@ mod tests {
         .genesis_config;
         let bank = Arc::new(Bank::new_for_tests(&config));
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
 
         // Forward from TPU
         let forwarded = latest_unprocessed_votes.get_and_insert_forwardable_packets(
@@ -666,7 +666,7 @@ mod tests {
 
         // Don't forward again
         let mut forward_packet_batches_by_accounts =
-            ForwardBatchesByAccounts::new_with_default_batch_limits();
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
         let forwarded = latest_unprocessed_votes
             .get_and_insert_forwardable_packets(bank, &mut forward_packet_batches_by_accounts);
 

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -38,7 +38,7 @@ impl<const N: usize> LatestValidatorVotePacket<N> {
         packet: GenericPacket<N>,
         vote_source: VoteSource,
     ) -> Result<Self, DeserializedPacketError> {
-        if !packet.meta().is_simple_vote_tx() {
+        if !packet.meta.is_simple_vote_tx() {
             return Err(DeserializedPacketError::VoteTransactionError);
         }
 
@@ -353,10 +353,7 @@ mod tests {
             None,
         );
         let mut packet = Packet::from_data(None, vote_tx).unwrap();
-        packet
-            .meta_mut()
-            .flags
-            .set(PacketFlags::SIMPLE_VOTE_TX, true);
+        packet.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
         LatestValidatorVotePacket::new(packet, vote_source).unwrap()
     }
 
@@ -389,7 +386,7 @@ mod tests {
             ),
         )
         .unwrap();
-        vote.meta_mut().flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
+        vote.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_switch = Packet::from_data(
             None,
             new_vote_transaction(
@@ -404,7 +401,7 @@ mod tests {
         )
         .unwrap();
         vote_switch
-            .meta_mut()
+            .meta
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_state_update = Packet::from_data(
@@ -420,7 +417,7 @@ mod tests {
         )
         .unwrap();
         vote_state_update
-            .meta_mut()
+            .meta
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_state_update_switch = Packet::from_data(
@@ -436,7 +433,7 @@ mod tests {
         )
         .unwrap();
         vote_state_update_switch
-            .meta_mut()
+            .meta
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let random_transaction = Packet::from_data(

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -122,7 +122,7 @@ impl<const N: usize> PacketDeserializer<N> {
         packet_batch
             .iter()
             .enumerate()
-            .filter(|(_, pkt)| !pkt.meta().discard())
+            .filter(|(_, pkt)| !pkt.meta.discard())
             .map(|(index, _)| index)
             .collect()
     }
@@ -180,7 +180,7 @@ mod tests {
         let transactions = vec![random_transfer(), random_transfer()];
         let mut packet_batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
-        packet_batches[0][0].meta_mut().set_discard(true);
+        packet_batches[0][0].meta.set_discard(true);
 
         let results = PacketDeserializer::deserialize_and_collect_packets(&packet_batches, None);
         assert_eq!(results.deserialized_packets.len(), 1);

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -6,17 +6,18 @@ use {
         sigverify::SigverifyTracerPacketStats,
     },
     crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError},
-    solana_perf::packet::PacketBatch,
+    solana_perf::packet::Batch,
+    solana_sdk::packet::BasePacket,
     std::time::{Duration, Instant},
 };
 
-pub type BankingPacketBatch = (Vec<PacketBatch>, Option<SigverifyTracerPacketStats>);
-pub type BankingPacketReceiver = CrossbeamReceiver<BankingPacketBatch>;
+pub type BankingBatch<P> = (Vec<Batch<P>>, Option<SigverifyTracerPacketStats>);
+pub type BankingReceiver<P> = CrossbeamReceiver<BankingBatch<P>>;
 
 /// Results from deserializing packet batches.
-pub struct ReceivePacketResults {
+pub struct ReceivePacketResults<P: BasePacket> {
     /// Deserialized packets from all received packet batches
-    pub deserialized_packets: Vec<ImmutableDeserializedPacket>,
+    pub deserialized_packets: Vec<ImmutableDeserializedPacket<P>>,
     /// Aggregate tracer stats for all received packet batches
     pub new_tracer_stats_option: Option<SigverifyTracerPacketStats>,
     /// Number of packets passing sigverify
@@ -25,13 +26,13 @@ pub struct ReceivePacketResults {
     pub failed_sigverify_count: u64,
 }
 
-pub struct PacketDeserializer {
+pub struct PacketDeserializer<P: BasePacket> {
     /// Receiver for packet batches from sigverify stage
-    packet_batch_receiver: BankingPacketReceiver,
+    packet_batch_receiver: BankingReceiver<P>,
 }
 
-impl PacketDeserializer {
-    pub fn new(packet_batch_receiver: BankingPacketReceiver) -> Self {
+impl<P: BasePacket> PacketDeserializer<P> {
+    pub fn new(packet_batch_receiver: BankingReceiver<P>) -> Self {
         Self {
             packet_batch_receiver,
         }
@@ -42,7 +43,7 @@ impl PacketDeserializer {
         &self,
         recv_timeout: Duration,
         capacity: usize,
-    ) -> Result<ReceivePacketResults, RecvTimeoutError> {
+    ) -> Result<ReceivePacketResults<P>, RecvTimeoutError> {
         let (packet_batches, sigverify_tracer_stats_option) =
             self.receive_until(recv_timeout, capacity)?;
         Ok(Self::deserialize_and_collect_packets(
@@ -53,9 +54,9 @@ impl PacketDeserializer {
 
     /// Deserialize packet batches and collect them into ReceivePacketResults
     fn deserialize_and_collect_packets(
-        packet_batches: &[PacketBatch],
+        packet_batches: &[Batch<P>],
         sigverify_tracer_stats_option: Option<SigverifyTracerPacketStats>,
-    ) -> ReceivePacketResults {
+    ) -> ReceivePacketResults<P> {
         let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
         let mut passed_sigverify_count: usize = 0;
         let mut failed_sigverify_count: usize = 0;
@@ -82,7 +83,7 @@ impl PacketDeserializer {
         &self,
         recv_timeout: Duration,
         packet_count_upperbound: usize,
-    ) -> Result<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>), RecvTimeoutError> {
+    ) -> Result<(Vec<Batch<P>>, Option<SigverifyTracerPacketStats>), RecvTimeoutError> {
         let start = Instant::now();
         let (mut packet_batches, mut aggregated_tracer_packet_stats_option) =
             self.packet_batch_receiver.recv_timeout(recv_timeout)?;
@@ -118,7 +119,7 @@ impl PacketDeserializer {
         Ok((packet_batches, aggregated_tracer_packet_stats_option))
     }
 
-    fn generate_packet_indexes(packet_batch: &PacketBatch) -> Vec<usize> {
+    fn generate_packet_indexes(packet_batch: &Batch<P>) -> Vec<usize> {
         packet_batch
             .iter()
             .enumerate()
@@ -128,9 +129,9 @@ impl PacketDeserializer {
     }
 
     fn deserialize_packets<'a>(
-        packet_batch: &'a PacketBatch,
+        packet_batch: &'a Batch<P>,
         packet_indexes: &'a [usize],
-    ) -> impl Iterator<Item = ImmutableDeserializedPacket> + 'a {
+    ) -> impl Iterator<Item = ImmutableDeserializedPacket<P>> + 'a {
         packet_indexes.iter().filter_map(move |packet_index| {
             ImmutableDeserializedPacket::new(packet_batch[*packet_index].clone(), None).ok()
         })
@@ -143,7 +144,7 @@ mod tests {
         super::*,
         solana_perf::packet::to_packet_batches,
         solana_sdk::{
-            hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction,
+            hash::Hash, packet::Packet, pubkey::Pubkey, signature::Keypair, system_transaction,
             transaction::Transaction,
         },
     };
@@ -154,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_and_collect_packets_empty() {
-        let results = PacketDeserializer::deserialize_and_collect_packets(&[], None);
+        let results = PacketDeserializer::<Packet>::deserialize_and_collect_packets(&[], None);
         assert_eq!(results.deserialized_packets.len(), 0);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 0);
@@ -164,7 +165,7 @@ mod tests {
     #[test]
     fn test_deserialize_and_collect_packets_simple_batches() {
         let transactions = vec![random_transfer(), random_transfer()];
-        let packet_batches = to_packet_batches(&transactions, 1);
+        let packet_batches = to_packet_batches::<Packet, _>(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
 
         let results = PacketDeserializer::deserialize_and_collect_packets(&packet_batches, None);
@@ -177,7 +178,7 @@ mod tests {
     #[test]
     fn test_deserialize_and_collect_packets_simple_batches_with_failure() {
         let transactions = vec![random_transfer(), random_transfer()];
-        let mut packet_batches = to_packet_batches(&transactions, 1);
+        let mut packet_batches = to_packet_batches::<Packet, _>(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
         packet_batches[0][0].meta_mut().set_discard(true);
 

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -4,7 +4,7 @@
 use {
     ahash::AHasher,
     rand::{thread_rng, Rng},
-    solana_sdk::packet::BasePacket,
+    solana_sdk::packet::GenericPacket,
     std::hash::Hasher,
 };
 
@@ -24,7 +24,7 @@ impl Default for PacketHasher {
 }
 
 impl PacketHasher {
-    pub(crate) fn hash_packet<P: BasePacket>(&self, packet: &P) -> u64 {
+    pub(crate) fn hash_packet<const N: usize>(&self, packet: &GenericPacket<N>) -> u64 {
         self.hash_data(packet.data(..).unwrap_or_default())
     }
 

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -4,7 +4,7 @@
 use {
     ahash::AHasher,
     rand::{thread_rng, Rng},
-    solana_perf::packet::Packet,
+    solana_sdk::packet::BasePacket,
     std::hash::Hasher,
 };
 
@@ -24,7 +24,7 @@ impl Default for PacketHasher {
 }
 
 impl PacketHasher {
-    pub(crate) fn hash_packet(&self, packet: &Packet) -> u64 {
+    pub(crate) fn hash_packet<P: BasePacket>(&self, packet: &P) -> u64 {
         self.hash_data(packet.data(..).unwrap_or_default())
     }
 

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -3,7 +3,10 @@ use {
         blockstore::Blockstore,
         shred::{Nonce, SIZE_OF_NONCE},
     },
-    solana_sdk::{clock::Slot, packet::Packet},
+    solana_sdk::{
+        clock::Slot,
+        packet::{BasePacket, Packet},
+    },
     std::{io, net::SocketAddr},
 };
 

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -3,10 +3,7 @@ use {
         blockstore::Blockstore,
         shred::{Nonce, SIZE_OF_NONCE},
     },
-    solana_sdk::{
-        clock::Slot,
-        packet::{BasePacket, Packet},
-    },
+    solana_sdk::{clock::Slot, packet::Packet},
     std::{io, net::SocketAddr},
 };
 

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -32,8 +32,8 @@ pub fn repair_response_packet_from_bytes(
     if size > packet.buffer_mut().len() {
         return None;
     }
-    packet.meta_mut().size = size;
-    packet.meta_mut().set_socket_addr(dest);
+    packet.meta.size = size;
+    packet.meta.set_socket_addr(dest);
     packet.buffer_mut()[..bytes.len()].copy_from_slice(&bytes);
     let mut wr = io::Cursor::new(&mut packet.buffer_mut()[bytes.len()..]);
     bincode::serialize_into(&mut wr, &nonce).expect("Buffer not large enough to fit nonce");
@@ -90,7 +90,7 @@ mod test {
             nonce,
         )
         .unwrap();
-        packet.meta_mut().flags |= PacketFlags::REPAIR;
+        packet.meta.flags |= PacketFlags::REPAIR;
 
         let leader_slots = [(slot, keypair.pubkey().to_bytes())]
             .iter()

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -34,7 +34,7 @@ use {
         clock::Slot,
         genesis_config::ClusterType,
         hash::{Hash, HASH_BYTES},
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Signable, Signature, Signer, SIGNATURE_BYTES},
         signer::keypair::Keypair,
@@ -348,7 +348,7 @@ impl ServeRepair {
         request: RepairProtocol,
         stats: &mut ServeRepairStats,
         ping_cache: &mut PingCache,
-    ) -> Option<Batch<Packet>> {
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
         let now = Instant::now();
         let (res, label) = {
             match &request {
@@ -451,8 +451,8 @@ impl ServeRepair {
         ping_cache: &mut PingCache,
         recycler: &BatchRecycler<Packet>,
         blockstore: &Blockstore,
-        requests_receiver: &BatchReceiver<Packet>,
-        response_sender: &BatchSender<Packet>,
+        requests_receiver: &BatchReceiver<{ Packet::DATA_SIZE }>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
     ) -> Result<()> {
@@ -661,8 +661,8 @@ impl ServeRepair {
     pub fn listen(
         self,
         blockstore: Arc<Blockstore>,
-        requests_receiver: BatchReceiver<Packet>,
-        response_sender: BatchSender<Packet>,
+        requests_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
+        response_sender: BatchSender<{ Packet::DATA_SIZE }>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         const INTERVAL_MS: u64 = 1000;
@@ -819,7 +819,7 @@ impl ServeRepair {
         recycler: &BatchRecycler<Packet>,
         blockstore: &Blockstore,
         requests: Vec<RepairRequestWithMeta>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
         cluster_type: ClusterType,
@@ -876,7 +876,7 @@ impl ServeRepair {
 
         if !pending_pings.is_empty() {
             stats.pings_sent += pending_pings.len();
-            let batch = Batch::<Packet>::new(pending_pings);
+            let batch = Batch::<{ Packet::DATA_SIZE }>::new(pending_pings);
             let _ignore = response_sender.send(batch);
         }
     }
@@ -1037,7 +1037,7 @@ impl ServeRepair {
     pub(crate) fn handle_repair_response_pings(
         repair_socket: &UdpSocket,
         keypair: &Keypair,
-        packet_batch: &mut Batch<Packet>,
+        packet_batch: &mut Batch<{ Packet::DATA_SIZE }>,
         stats: &mut ShredFetchStats,
     ) {
         let mut pending_pongs = Vec::default();
@@ -1118,7 +1118,7 @@ impl ServeRepair {
         slot: Slot,
         shred_index: u64,
         nonce: Nonce,
-    ) -> Option<Batch<Packet>> {
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
         // Try to find the requested index in one of the slots
         let packet = repair_response::repair_response_packet(
             blockstore,
@@ -1129,11 +1129,13 @@ impl ServeRepair {
         )?;
 
         inc_new_counter_debug!("serve_repair-window-request-ledger", 1);
-        Some(Batch::<Packet>::new_unpinned_with_recycler_data(
-            recycler,
-            "run_window_request",
-            vec![packet],
-        ))
+        Some(
+            Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+                recycler,
+                "run_window_request",
+                vec![packet],
+            ),
+        )
     }
 
     fn run_highest_window_request(
@@ -1143,7 +1145,7 @@ impl ServeRepair {
         slot: Slot,
         highest_index: u64,
         nonce: Nonce,
-    ) -> Option<Batch<Packet>> {
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
         // Try to find the requested index in one of the slots
         let meta = blockstore.meta(slot).ok()??;
         if meta.received > highest_index {
@@ -1155,11 +1157,13 @@ impl ServeRepair {
                 from_addr,
                 nonce,
             )?;
-            return Some(Batch::<Packet>::new_unpinned_with_recycler_data(
-                recycler,
-                "run_highest_window_request",
-                vec![packet],
-            ));
+            return Some(
+                Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+                    recycler,
+                    "run_highest_window_request",
+                    vec![packet],
+                ),
+            );
         }
         None
     }
@@ -1171,8 +1175,8 @@ impl ServeRepair {
         mut slot: Slot,
         max_responses: usize,
         nonce: Nonce,
-    ) -> Option<Batch<Packet>> {
-        let mut res = Batch::<Packet>::new_unpinned_with_recycler(
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+        let mut res = Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler(
             recycler.clone(),
             max_responses,
             "run_orphan",
@@ -1213,7 +1217,7 @@ impl ServeRepair {
         blockstore: &Blockstore,
         slot: Slot,
         nonce: Nonce,
-    ) -> Option<Batch<Packet>> {
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
         let ancestor_slot_hashes = if blockstore.is_duplicate_confirmed(slot) {
             let ancestor_iterator =
                 AncestorIteratorWithHash::from(AncestorIterator::new_inclusive(slot, blockstore));
@@ -1233,11 +1237,13 @@ impl ServeRepair {
             from_addr,
             nonce,
         )?;
-        Some(Batch::<Packet>::new_unpinned_with_recycler_data(
-            recycler,
-            "run_ancestor_hashes",
-            vec![packet],
-        ))
+        Some(
+            Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+                recycler,
+                "run_ancestor_hashes",
+                vec![packet],
+            ),
+        )
     }
 }
 

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -27,14 +27,14 @@ use {
     solana_metrics::inc_new_counter_debug,
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Packet, PacketBatch, PacketBatchRecycler},
+        packet::{PacketBatch, PacketBatchRecycler},
     },
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
         clock::Slot,
         genesis_config::ClusterType,
         hash::{Hash, HASH_BYTES},
-        packet::PACKET_DATA_SIZE,
+        packet::Packet,
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Signable, Signature, Signer, SIGNATURE_BYTES},
         signer::keypair::Keypair,
@@ -66,7 +66,7 @@ pub(crate) const REPAIR_PEERS_CACHE_CAPACITY: usize = 128;
 // Limit cache entries ttl in order to avoid re-using outdated data.
 const REPAIR_PEERS_CACHE_TTL: Duration = Duration::from_secs(10);
 pub const MAX_ANCESTOR_BYTES_IN_PACKET: usize =
-    PACKET_DATA_SIZE -
+    Packet::DATA_SIZE -
     SIZE_OF_NONCE -
     4 /*(response version enum discriminator)*/ -
     4 /*slot_hash length*/;

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -27,7 +27,7 @@ use {
     solana_metrics::inc_new_counter_debug,
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Batch, BatchRecycler},
+        packet::{BatchRecycler, PacketBatch},
     },
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
@@ -42,7 +42,7 @@ use {
     },
     solana_streamer::{
         sendmmsg::{batch_send, SendPktsError},
-        streamer::{BatchReceiver, BatchSender},
+        streamer::{PacketBatchReceiver, PacketBatchSender},
     },
     std::{
         cmp::Reverse,
@@ -348,7 +348,7 @@ impl ServeRepair {
         request: RepairProtocol,
         stats: &mut ServeRepairStats,
         ping_cache: &mut PingCache,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
         let now = Instant::now();
         let (res, label) = {
             match &request {
@@ -451,8 +451,8 @@ impl ServeRepair {
         ping_cache: &mut PingCache,
         recycler: &BatchRecycler<Packet>,
         blockstore: &Blockstore,
-        requests_receiver: &BatchReceiver<{ Packet::DATA_SIZE }>,
-        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
+        requests_receiver: &PacketBatchReceiver<{ Packet::DATA_SIZE }>,
+        response_sender: &PacketBatchSender<{ Packet::DATA_SIZE }>,
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
     ) -> Result<()> {
@@ -661,8 +661,8 @@ impl ServeRepair {
     pub fn listen(
         self,
         blockstore: Arc<Blockstore>,
-        requests_receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
-        response_sender: BatchSender<{ Packet::DATA_SIZE }>,
+        requests_receiver: PacketBatchReceiver<{ Packet::DATA_SIZE }>,
+        response_sender: PacketBatchSender<{ Packet::DATA_SIZE }>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         const INTERVAL_MS: u64 = 1000;
@@ -819,7 +819,7 @@ impl ServeRepair {
         recycler: &BatchRecycler<Packet>,
         blockstore: &Blockstore,
         requests: Vec<RepairRequestWithMeta>,
-        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
+        response_sender: &PacketBatchSender<{ Packet::DATA_SIZE }>,
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
         cluster_type: ClusterType,
@@ -876,7 +876,7 @@ impl ServeRepair {
 
         if !pending_pings.is_empty() {
             stats.pings_sent += pending_pings.len();
-            let batch = Batch::<{ Packet::DATA_SIZE }>::new(pending_pings);
+            let batch = PacketBatch::<{ Packet::DATA_SIZE }>::new(pending_pings);
             let _ignore = response_sender.send(batch);
         }
     }
@@ -1037,7 +1037,7 @@ impl ServeRepair {
     pub(crate) fn handle_repair_response_pings(
         repair_socket: &UdpSocket,
         keypair: &Keypair,
-        packet_batch: &mut Batch<{ Packet::DATA_SIZE }>,
+        packet_batch: &mut PacketBatch<{ Packet::DATA_SIZE }>,
         stats: &mut ShredFetchStats,
     ) {
         let mut pending_pongs = Vec::default();
@@ -1118,7 +1118,7 @@ impl ServeRepair {
         slot: Slot,
         shred_index: u64,
         nonce: Nonce,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
         // Try to find the requested index in one of the slots
         let packet = repair_response::repair_response_packet(
             blockstore,
@@ -1130,7 +1130,7 @@ impl ServeRepair {
 
         inc_new_counter_debug!("serve_repair-window-request-ledger", 1);
         Some(
-            Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+            PacketBatch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
                 recycler,
                 "run_window_request",
                 vec![packet],
@@ -1145,7 +1145,7 @@ impl ServeRepair {
         slot: Slot,
         highest_index: u64,
         nonce: Nonce,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
         // Try to find the requested index in one of the slots
         let meta = blockstore.meta(slot).ok()??;
         if meta.received > highest_index {
@@ -1158,7 +1158,7 @@ impl ServeRepair {
                 nonce,
             )?;
             return Some(
-                Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+                PacketBatch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
                     recycler,
                     "run_highest_window_request",
                     vec![packet],
@@ -1175,8 +1175,8 @@ impl ServeRepair {
         mut slot: Slot,
         max_responses: usize,
         nonce: Nonce,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
-        let mut res = Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler(
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
+        let mut res = PacketBatch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler(
             recycler.clone(),
             max_responses,
             "run_orphan",
@@ -1217,7 +1217,7 @@ impl ServeRepair {
         blockstore: &Blockstore,
         slot: Slot,
         nonce: Nonce,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
         let ancestor_slot_hashes = if blockstore.is_duplicate_confirmed(slot) {
             let ancestor_iterator =
                 AncestorIteratorWithHash::from(AncestorIterator::new_inclusive(slot, blockstore));
@@ -1238,7 +1238,7 @@ impl ServeRepair {
             nonce,
         )?;
         Some(
-            Batch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
+            PacketBatch::<{ Packet::DATA_SIZE }>::new_unpinned_with_recycler_data(
                 recycler,
                 "run_ancestor_hashes",
                 vec![packet],

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -506,7 +506,7 @@ impl ServeRepair {
                     }
                 };
 
-                let from_addr = packet.meta().socket_addr();
+                let from_addr = packet.meta.socket_addr();
                 if !ContactInfo::is_valid_address(&from_addr, &socket_addr_space) {
                     stats.err_malformed += 1;
                     continue;
@@ -860,7 +860,7 @@ impl ServeRepair {
                 Some(rsp) => rsp,
             };
             let num_response_packets = rsp.len();
-            let num_response_bytes = rsp.iter().map(|p| p.meta().size).sum();
+            let num_response_bytes = rsp.iter().map(|p| p.meta.size).sum();
             if data_budget.take(num_response_bytes) && response_sender.send(rsp).is_ok() {
                 stats.total_response_packets += num_response_packets;
                 match stake > 0 {
@@ -1042,7 +1042,7 @@ impl ServeRepair {
     ) {
         let mut pending_pongs = Vec::default();
         for packet in packet_batch.iter_mut() {
-            if packet.meta().size != REPAIR_RESPONSE_SERIALIZED_PING_BYTES {
+            if packet.meta.size != REPAIR_RESPONSE_SERIALIZED_PING_BYTES {
                 continue;
             }
             if let Ok(RepairResponse::Ping(ping)) = packet.deserialize_slice(..) {
@@ -1056,12 +1056,12 @@ impl ServeRepair {
                     stats.ping_err_verify_count += 1;
                     continue;
                 }
-                packet.meta_mut().set_discard(true);
+                packet.meta.set_discard(true);
                 stats.ping_count += 1;
                 if let Ok(pong) = Pong::new(&ping, keypair) {
                     let pong = RepairProtocol::Pong(pong);
                     if let Ok(pong_bytes) = serialize(&pong) {
-                        let from_addr = packet.meta().socket_addr();
+                        let from_addr = packet.meta.socket_addr();
                         pending_pongs.push((pong_bytes, from_addr));
                     }
                 }
@@ -1277,7 +1277,7 @@ mod tests {
         let ping = Ping::new_rand(&mut rng, &keypair).unwrap();
         let ping = RepairResponse::Ping(ping);
         let pkt = Packet::from_data(None, ping).unwrap();
-        assert_eq!(pkt.meta().size, REPAIR_RESPONSE_SERIALIZED_PING_BYTES);
+        assert_eq!(pkt.meta.size, REPAIR_RESPONSE_SERIALIZED_PING_BYTES);
     }
 
     #[test]
@@ -1297,7 +1297,7 @@ mod tests {
         shred.sign(&keypair);
         let mut pkt = Packet::default();
         shred.copy_to_packet(&mut pkt);
-        pkt.meta_mut().size = REPAIR_RESPONSE_SERIALIZED_PING_BYTES;
+        pkt.meta.size = REPAIR_RESPONSE_SERIALIZED_PING_BYTES;
         let res = pkt.deserialize_slice::<RepairResponse, _>(..);
         if let Ok(RepairResponse::Ping(ping)) = res {
             assert!(!ping.verify());
@@ -1953,7 +1953,7 @@ mod tests {
     fn test_run_ancestor_hashes() {
         fn deserialize_ancestor_hashes_response(packet: &Packet) -> AncestorHashesResponse {
             packet
-                .deserialize_slice(..packet.meta().size - SIZE_OF_NONCE)
+                .deserialize_slice(..packet.meta.size - SIZE_OF_NONCE)
                 .unwrap()
         }
 

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -98,9 +98,9 @@ impl ShredFetchStage {
                     &mut shreds_received,
                     &mut stats,
                 ) {
-                    packet.meta_mut().set_discard(true);
+                    packet.meta.set_discard(true);
                 } else {
-                    packet.meta_mut().flags.insert(flags);
+                    packet.meta.flags.insert(flags);
                 }
             }
             stats.maybe_submit(name, STATS_SUBMIT_CADENCE);

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -10,7 +10,7 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT},
-        packet::{BasePacket, Packet},
+        packet::Packet,
     },
     solana_streamer::streamer::{self, BatchReceiver, StreamerReceiveStats},
     std::{
@@ -31,8 +31,8 @@ pub(crate) struct ShredFetchStage {
 impl ShredFetchStage {
     // updates packets received on a channel and sends them on another channel
     fn modify_packets(
-        recvr: BatchReceiver<Packet>,
-        sendr: Sender<Batch<Packet>>,
+        recvr: BatchReceiver<{ Packet::DATA_SIZE }>,
+        sendr: Sender<Batch<{ Packet::DATA_SIZE }>>,
         bank_forks: &RwLock<BankForks>,
         shred_version: u16,
         name: &'static str,
@@ -113,7 +113,7 @@ impl ShredFetchStage {
     fn packet_modifier(
         sockets: Vec<Arc<UdpSocket>>,
         exit: &Arc<AtomicBool>,
-        sender: Sender<Batch<Packet>>,
+        sender: Sender<Batch<{ Packet::DATA_SIZE }>>,
         recycler: BatchRecycler<Packet>,
         bank_forks: Arc<RwLock<BankForks>>,
         shred_version: u16,
@@ -161,7 +161,7 @@ impl ShredFetchStage {
         sockets: Vec<Arc<UdpSocket>>,
         forward_sockets: Vec<Arc<UdpSocket>>,
         repair_socket: Arc<UdpSocket>,
-        sender: Sender<Batch<Packet>>,
+        sender: Sender<Batch<{ Packet::DATA_SIZE }>>,
         shred_version: u16,
         bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: Arc<ClusterInfo>,

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -6,13 +6,13 @@ use {
     lru::LruCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::shred::{should_discard_shred, ShredFetchStats},
-    solana_perf::packet::{Batch, BatchRecycler, PacketFlags},
+    solana_perf::packet::{BatchRecycler, PacketBatch, PacketFlags},
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT},
         packet::Packet,
     },
-    solana_streamer::streamer::{self, BatchReceiver, StreamerReceiveStats},
+    solana_streamer::streamer::{self, PacketBatchReceiver, StreamerReceiveStats},
     std::{
         net::UdpSocket,
         sync::{atomic::AtomicBool, Arc, RwLock},
@@ -31,8 +31,8 @@ pub(crate) struct ShredFetchStage {
 impl ShredFetchStage {
     // updates packets received on a channel and sends them on another channel
     fn modify_packets(
-        recvr: BatchReceiver<{ Packet::DATA_SIZE }>,
-        sendr: Sender<Batch<{ Packet::DATA_SIZE }>>,
+        recvr: PacketBatchReceiver<{ Packet::DATA_SIZE }>,
+        sendr: Sender<PacketBatch<{ Packet::DATA_SIZE }>>,
         bank_forks: &RwLock<BankForks>,
         shred_version: u16,
         name: &'static str,
@@ -113,7 +113,7 @@ impl ShredFetchStage {
     fn packet_modifier(
         sockets: Vec<Arc<UdpSocket>>,
         exit: &Arc<AtomicBool>,
-        sender: Sender<Batch<{ Packet::DATA_SIZE }>>,
+        sender: Sender<PacketBatch<{ Packet::DATA_SIZE }>>,
         recycler: BatchRecycler<Packet>,
         bank_forks: Arc<RwLock<BankForks>>,
         shred_version: u16,
@@ -161,7 +161,7 @@ impl ShredFetchStage {
         sockets: Vec<Arc<UdpSocket>>,
         forward_sockets: Vec<Arc<UdpSocket>>,
         repair_socket: Arc<UdpSocket>,
-        sender: Sender<Batch<{ Packet::DATA_SIZE }>>,
+        sender: Sender<PacketBatch<{ Packet::DATA_SIZE }>>,
         shred_version: u16,
         bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: Arc<ClusterInfo>,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -87,7 +87,7 @@ impl<const N: usize> TransactionSigVerifier<N> {
         is_dup: bool,
     ) {
         sigverify::check_for_tracer_packet(packet);
-        if packet.meta().is_tracer_packet() {
+        if packet.meta.is_tracer_packet() {
             if removed_before_sigverify_stage {
                 self.tracer_packet_stats
                     .total_removed_before_sigverify_stage += 1;
@@ -103,14 +103,14 @@ impl<const N: usize> TransactionSigVerifier<N> {
 
     #[inline(always)]
     pub fn process_excess_packet(&mut self, packet: &GenericPacket<N>) {
-        if packet.meta().is_tracer_packet() {
+        if packet.meta.is_tracer_packet() {
             self.tracer_packet_stats.total_excess_tracer_packets += 1;
         }
     }
 
     #[inline(always)]
     pub fn process_passed_sigverify_packet(&mut self, packet: &GenericPacket<N>) {
-        if packet.meta().is_tracer_packet() {
+        if packet.meta.is_tracer_packet() {
             self.tracer_packet_stats
                 .total_tracker_packets_passed_sigverify += 1;
         }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -10,7 +10,7 @@ pub use solana_perf::sigverify::{
 use {
     crate::{banking_stage::BankingBatch, sigverify_stage::SigVerifyServiceError},
     crossbeam_channel::Sender,
-    solana_perf::{cuda_runtime::PinnedVec, packet::Batch, recycler::Recycler, sigverify},
+    solana_perf::{cuda_runtime::PinnedVec, packet::PacketBatch, recycler::Recycler, sigverify},
     solana_sdk::{packet::GenericPacket, saturating_add_assign},
 };
 
@@ -118,7 +118,7 @@ impl<const N: usize> TransactionSigVerifier<N> {
 
     pub fn send_packets(
         &mut self,
-        packet_batches: Vec<Batch<N>>,
+        packet_batches: Vec<PacketBatch<N>>,
     ) -> Result<(), SigVerifyServiceError<BankingBatch<N>, N>> {
         let tracer_packet_stats_to_send = std::mem::take(&mut self.tracer_packet_stats);
         self.packet_sender
@@ -128,9 +128,9 @@ impl<const N: usize> TransactionSigVerifier<N> {
 
     pub fn verify_batches(
         &self,
-        mut batches: Vec<Batch<N>>,
+        mut batches: Vec<PacketBatch<N>>,
         valid_packets: usize,
-    ) -> Vec<Batch<N>> {
+    ) -> Vec<PacketBatch<N>> {
         sigverify::ed25519_verify(
             &mut batches,
             &self.recycler,

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -3,7 +3,7 @@ use {
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache, shred, sigverify_shreds::verify_shreds_gpu,
     },
-    solana_perf::{self, packet::Batch, recycler_cache::RecyclerCache},
+    solana_perf::{self, packet::PacketBatch, recycler_cache::RecyclerCache},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{clock::Slot, packet::Packet, pubkey::Pubkey},
     std::{
@@ -29,9 +29,9 @@ pub(crate) fn spawn_shred_sigverify(
     self_pubkey: Pubkey,
     bank_forks: Arc<RwLock<BankForks>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
-    shred_fetch_receiver: Receiver<Batch<{ Packet::DATA_SIZE }>>,
+    shred_fetch_receiver: Receiver<PacketBatch<{ Packet::DATA_SIZE }>>,
     retransmit_sender: Sender<Vec</*shred:*/ Vec<u8>>>,
-    verified_sender: Sender<Vec<Batch<{ Packet::DATA_SIZE }>>>,
+    verified_sender: Sender<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>,
     turbine_disabled: Arc<AtomicBool>,
 ) -> JoinHandle<()> {
     let recycler_cache = RecyclerCache::warmed();
@@ -65,9 +65,9 @@ fn run_shred_sigverify(
     bank_forks: &RwLock<BankForks>,
     leader_schedule_cache: &LeaderScheduleCache,
     recycler_cache: &RecyclerCache,
-    shred_fetch_receiver: &Receiver<Batch<{ Packet::DATA_SIZE }>>,
+    shred_fetch_receiver: &Receiver<PacketBatch<{ Packet::DATA_SIZE }>>,
     retransmit_sender: &Sender<Vec</*shred:*/ Vec<u8>>>,
-    verified_sender: &Sender<Vec<Batch<{ Packet::DATA_SIZE }>>>,
+    verified_sender: &Sender<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>,
     turbine_disabled: &AtomicBool,
     stats: &mut ShredSigVerifyStats,
 ) -> Result<(), Error> {
@@ -80,7 +80,7 @@ fn run_shred_sigverify(
     stats.num_iters += 1;
     stats.num_packets += packets
         .iter()
-        .map(Batch::<{ Packet::DATA_SIZE }>::len)
+        .map(PacketBatch::<{ Packet::DATA_SIZE }>::len)
         .sum::<usize>();
     stats.num_discards_pre += count_discards(&packets);
     verify_packets(
@@ -94,7 +94,7 @@ fn run_shred_sigverify(
     // Exclude repair packets from retransmit.
     let shreds: Vec<_> = packets
         .iter()
-        .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
+        .flat_map(PacketBatch::<{ Packet::DATA_SIZE }>::iter)
         .filter(|packet| !packet.meta.discard() && !packet.meta.repair())
         .filter_map(shred::layout::get_shred)
         .map(<[u8]>::to_vec)
@@ -113,7 +113,7 @@ fn verify_packets(
     bank_forks: &RwLock<BankForks>,
     leader_schedule_cache: &LeaderScheduleCache,
     recycler_cache: &RecyclerCache,
-    packets: &mut [Batch<{ Packet::DATA_SIZE }>],
+    packets: &mut [PacketBatch<{ Packet::DATA_SIZE }>],
 ) {
     let working_bank = bank_forks.read().unwrap().working_bank();
     let leader_slots: HashMap<Slot, [u8; 32]> =
@@ -133,7 +133,7 @@ fn verify_packets(
 //   - slot leader is the node itself (circular transmission).
 fn get_slot_leaders(
     self_pubkey: &Pubkey,
-    batches: &mut [Batch<{ Packet::DATA_SIZE }>],
+    batches: &mut [PacketBatch<{ Packet::DATA_SIZE }>],
     leader_schedule_cache: &LeaderScheduleCache,
     bank: &Bank,
 ) -> HashMap<Slot, Option<Pubkey>> {
@@ -164,10 +164,10 @@ fn get_slot_leaders(
     leaders
 }
 
-fn count_discards(packets: &[Batch<{ Packet::DATA_SIZE }>]) -> usize {
+fn count_discards(packets: &[PacketBatch<{ Packet::DATA_SIZE }>]) -> usize {
     packets
         .iter()
-        .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
+        .flat_map(PacketBatch::<{ Packet::DATA_SIZE }>::iter)
         .filter(|packet| packet.meta.discard())
         .count()
 }
@@ -254,7 +254,7 @@ mod tests {
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
         let bank_forks = RwLock::new(BankForks::new(bank));
         let batch_size = 2;
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
         batch.resize(batch_size, Packet::default());
         let mut batches = vec![batch];
 

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -95,7 +95,7 @@ fn run_shred_sigverify(
     let shreds: Vec<_> = packets
         .iter()
         .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
-        .filter(|packet| !packet.meta().discard() && !packet.meta().repair())
+        .filter(|packet| !packet.meta.discard() && !packet.meta.repair())
         .filter_map(shred::layout::get_shred)
         .map(<[u8]>::to_vec)
         .collect();
@@ -140,13 +140,13 @@ fn get_slot_leaders(
     let mut leaders = HashMap::<Slot, Option<Pubkey>>::new();
     for batch in batches {
         for packet in batch.iter_mut() {
-            if packet.meta().discard() {
+            if packet.meta.discard() {
                 continue;
             }
             let shred = shred::layout::get_shred(packet);
             let slot = match shred.and_then(shred::layout::get_slot) {
                 None => {
-                    packet.meta_mut().set_discard(true);
+                    packet.meta.set_discard(true);
                     continue;
                 }
                 Some(slot) => slot,
@@ -157,7 +157,7 @@ fn get_slot_leaders(
                 (&leader != self_pubkey).then_some(leader)
             });
             if leader.is_none() {
-                packet.meta_mut().set_discard(true);
+                packet.meta.set_discard(true);
             }
         }
     }
@@ -168,7 +168,7 @@ fn count_discards(packets: &[Batch<{ Packet::DATA_SIZE }>]) -> usize {
     packets
         .iter()
         .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
-        .filter(|packet| packet.meta().discard())
+        .filter(|packet| packet.meta.discard())
         .count()
 }
 
@@ -270,7 +270,7 @@ mod tests {
         );
         shred.sign(&leader_keypair);
         batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batches[0][0].meta.size = shred.payload().len();
 
         let mut shred = Shred::new_from_data(
             0,
@@ -285,7 +285,7 @@ mod tests {
         let wrong_keypair = Keypair::new();
         shred.sign(&wrong_keypair);
         batches[0][1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][1].meta_mut().size = shred.payload().len();
+        batches[0][1].meta.size = shred.payload().len();
 
         verify_packets(
             &Pubkey::new_unique(), // self_pubkey
@@ -294,7 +294,7 @@ mod tests {
             &RecyclerCache::warmed(),
             &mut batches,
         );
-        assert!(!batches[0][0].meta().discard());
-        assert!(batches[0][1].meta().discard());
+        assert!(!batches[0][0].meta.discard());
+        assert!(batches[0][1].meta.discard());
     }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -223,8 +223,8 @@ impl SigVerifyStage {
             .iter_mut()
             .rev()
             .flat_map(|batch| batch.iter_mut().rev())
-            .filter(|packet| !packet.meta().discard())
-            .map(|packet| (packet.meta().addr, packet))
+            .filter(|packet| !packet.meta.discard())
+            .map(|packet| (packet.meta.addr, packet))
             .into_group_map();
         // Allocate max_packets evenly across addresses.
         while max_packets > 0 && !addrs.is_empty() {
@@ -239,7 +239,7 @@ impl SigVerifyStage {
         // Discard excess packets from each address.
         for packet in addrs.into_values().flatten() {
             process_excess_packet(packet);
-            packet.meta_mut().set_discard(true);
+            packet.meta.set_discard(true);
         }
     }
 
@@ -445,7 +445,7 @@ mod tests {
         packet_batches
             .iter()
             .flatten()
-            .filter(|p| !p.meta().discard())
+            .filter(|p| !p.meta.discard())
             .count()
     }
 
@@ -455,18 +455,18 @@ mod tests {
         let batch_size = 10;
         let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
         let mut tracer_packet = Packet::default();
-        tracer_packet.meta_mut().flags |= PacketFlags::TRACER_PACKET;
+        tracer_packet.meta.flags |= PacketFlags::TRACER_PACKET;
         batch.resize(batch_size, tracer_packet);
-        batch[3].meta_mut().addr = std::net::IpAddr::from([1u16; 8]);
-        batch[3].meta_mut().set_discard(true);
+        batch[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
+        batch[3].meta.set_discard(true);
         let num_discarded_before_filter = 1;
-        batch[4].meta_mut().addr = std::net::IpAddr::from([2u16; 8]);
+        batch[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
         let total_num_packets = batch.len();
         let mut batches = vec![batch];
         let max = 3;
         let mut total_tracer_packets_discarded = 0;
         SigVerifyStage::discard_excess_packets(&mut batches, max, |packet| {
-            if packet.meta().is_tracer_packet() {
+            if packet.meta.is_tracer_packet() {
                 total_tracer_packets_discarded += 1;
             }
         });
@@ -480,9 +480,9 @@ mod tests {
             total_discarded - num_discarded_before_filter
         );
         assert_eq!(total_non_discard, max);
-        assert!(!batches[0][0].meta().discard());
-        assert!(batches[0][3].meta().discard());
-        assert!(!batches[0][4].meta().discard());
+        assert!(!batches[0][0].meta.discard());
+        assert!(batches[0][3].meta.discard());
+        assert!(!batches[0][4].meta.discard());
     }
 
     fn gen_batches(
@@ -528,7 +528,7 @@ mod tests {
                 sent_len += batch.len();
                 batch
                     .iter_mut()
-                    .for_each(|packet| packet.meta_mut().flags |= PacketFlags::TRACER_PACKET);
+                    .for_each(|packet| packet.meta.flags |= PacketFlags::TRACER_PACKET);
                 assert_eq!(batch.len(), packets_per_batch);
                 packet_s.send(vec![batch]).unwrap();
             }
@@ -609,7 +609,7 @@ mod tests {
             batches.iter_mut().for_each(|batch| {
                 batch.iter_mut().for_each(|p| {
                     if ((index + 1) as f64 / num_packets as f64) < MAX_DISCARDED_PACKET_RATE {
-                        p.meta_mut().set_discard(true);
+                        p.meta.set_discard(true);
                     }
                     index += 1;
                 })
@@ -619,7 +619,7 @@ mod tests {
         assert_eq!(SigVerifyStage::maybe_shrink_batches(&mut batches).1, 0);
 
         // discard one more to exceed shrink threshold
-        batches.last_mut().unwrap()[0].meta_mut().set_discard(true);
+        batches.last_mut().unwrap()[0].meta.set_discard(true);
 
         let expected_num_shrunk_batches =
             1.max((num_generated_batches as f64 * MAX_DISCARDED_PACKET_RATE) as usize);

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -15,7 +15,7 @@ use {
     itertools::Itertools,
     solana_measure::measure::Measure,
     solana_perf::{
-        packet::Batch,
+        packet::PacketBatch,
         sigverify::{
             count_discarded_packets, count_packets_in_batches, count_valid_packets, shrink_batches,
             Deduper,
@@ -214,7 +214,7 @@ impl SigVerifyStage {
     }
 
     pub fn discard_excess_packets<const N: usize>(
-        batches: &mut [Batch<N>],
+        batches: &mut [PacketBatch<N>],
         mut max_packets: usize,
         mut process_excess_packet: impl FnMut(&GenericPacket<N>),
     ) {
@@ -245,7 +245,7 @@ impl SigVerifyStage {
 
     /// make this function public so that it is available for benchmarking
     pub fn maybe_shrink_batches<const N: usize>(
-        packet_batches: &mut Vec<Batch<N>>,
+        packet_batches: &mut Vec<PacketBatch<N>>,
     ) -> (u64, usize) {
         let mut shrink_time = Measure::start("sigverify_shrink_time");
         let num_packets = count_packets_in_batches(packet_batches);
@@ -441,7 +441,7 @@ mod tests {
         solana_sdk::packet::PacketFlags,
     };
 
-    fn count_non_discard(packet_batches: &[Batch<{ Packet::DATA_SIZE }>]) -> usize {
+    fn count_non_discard(packet_batches: &[PacketBatch<{ Packet::DATA_SIZE }>]) -> usize {
         packet_batches
             .iter()
             .flatten()
@@ -453,7 +453,7 @@ mod tests {
     fn test_packet_discard() {
         solana_logger::setup();
         let batch_size = 10;
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
         let mut tracer_packet = Packet::default();
         tracer_packet.meta.flags |= PacketFlags::TRACER_PACKET;
         batch.resize(batch_size, tracer_packet);
@@ -489,7 +489,7 @@ mod tests {
         use_same_tx: bool,
         packets_per_batch: usize,
         total_packets: usize,
-    ) -> Vec<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Vec<PacketBatch<{ Packet::DATA_SIZE }>> {
         if use_same_tx {
             let tx = test_tx();
             to_packet_batches(&vec![tx; total_packets], packets_per_batch)

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -6,7 +6,10 @@
 //! if perf-libs are available
 
 use {
-    crate::{find_packet_sender_stake_stage, sigverify},
+    crate::{
+        banking_stage::BankingBatch, find_packet_sender_stake_stage,
+        sigverify::TransactionSigVerifier,
+    },
     core::time::Duration,
     crossbeam_channel::{RecvTimeoutError, SendError},
     itertools::Itertools,
@@ -18,10 +21,7 @@ use {
             Deduper,
         },
     },
-    solana_sdk::{
-        packet::{BasePacket, Packet},
-        timing,
-    },
+    solana_sdk::{packet::BasePacket, timing},
     solana_streamer::streamer::{self, StreamerError},
     std::{
         thread::{self, Builder, JoinHandle},
@@ -43,41 +43,20 @@ const MAX_SIGVERIFY_BATCH: usize = 2_000;
 const MAX_DISCARDED_PACKET_RATE: f64 = 0.10;
 
 #[derive(Error, Debug)]
-pub enum SigVerifyServiceError<SendType> {
+pub enum SigVerifyServiceError<SendType, PacketType: BasePacket> {
     #[error("send packets batch error")]
     Send(#[from] SendError<SendType>),
 
     #[error("streamer error")]
-    Streamer(#[from] StreamerError),
+    Streamer(#[from] StreamerError<PacketType>),
 }
 
-type Result<T, SendType> = std::result::Result<T, SigVerifyServiceError<SendType>>;
+type Result<T, SendType, PacketType> =
+    std::result::Result<T, SigVerifyServiceError<SendType, PacketType>>;
 
 pub struct SigVerifyStage {
     thread_hdl: JoinHandle<()>,
 }
-
-pub trait SigVerifier {
-    type SendType: std::fmt::Debug;
-    fn verify_batches(
-        &self,
-        batches: Vec<Batch<Packet>>,
-        valid_packets: usize,
-    ) -> Vec<Batch<Packet>>;
-    fn process_received_packet(
-        &mut self,
-        _packet: &mut Packet,
-        _removed_before_sigverify_stage: bool,
-        _is_dup: bool,
-    ) {
-    }
-    fn process_excess_packet(&mut self, _packet: &Packet) {}
-    fn process_passed_sigverify_packet(&mut self, _packet: &Packet) {}
-    fn send_packets(&mut self, packet_batches: Vec<Batch<Packet>>) -> Result<(), Self::SendType>;
-}
-
-#[derive(Default, Clone)]
-pub struct DisabledSigVerifier {}
 
 #[derive(Default)]
 struct SigVerifierStats {
@@ -223,37 +202,21 @@ impl SigVerifierStats {
     }
 }
 
-impl SigVerifier for DisabledSigVerifier {
-    type SendType = ();
-    fn verify_batches(
-        &self,
-        mut batches: Vec<Batch<Packet>>,
-        _valid_packets: usize,
-    ) -> Vec<Batch<Packet>> {
-        sigverify::ed25519_verify_disabled(&mut batches);
-        batches
-    }
-
-    fn send_packets(&mut self, _packet_batches: Vec<Batch<Packet>>) -> Result<(), Self::SendType> {
-        Ok(())
-    }
-}
-
 impl SigVerifyStage {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<T: SigVerifier + 'static + Send + Clone>(
-        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
-        verifier: T,
+    pub fn new<P: BasePacket + 'static>(
+        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver<P>,
+        verifier: TransactionSigVerifier<P>,
         name: &'static str,
     ) -> Self {
         let thread_hdl = Self::verifier_services(packet_receiver, verifier, name);
         Self { thread_hdl }
     }
 
-    pub fn discard_excess_packets(
-        batches: &mut [Batch<Packet>],
+    pub fn discard_excess_packets<P: BasePacket>(
+        batches: &mut [Batch<P>],
         mut max_packets: usize,
-        mut process_excess_packet: impl FnMut(&Packet),
+        mut process_excess_packet: impl FnMut(&P),
     ) {
         // Group packets by their incoming IP address.
         let mut addrs = batches
@@ -281,7 +244,7 @@ impl SigVerifyStage {
     }
 
     /// make this function public so that it is available for benchmarking
-    pub fn maybe_shrink_batches(packet_batches: &mut Vec<Batch<Packet>>) -> (u64, usize) {
+    pub fn maybe_shrink_batches<P: BasePacket>(packet_batches: &mut Vec<Batch<P>>) -> (u64, usize) {
         let mut shrink_time = Measure::start("sigverify_shrink_time");
         let num_packets = count_packets_in_batches(packet_batches);
         let num_discarded_packets = count_discarded_packets(packet_batches);
@@ -296,12 +259,12 @@ impl SigVerifyStage {
         (shrink_time.as_us(), shrink_total)
     }
 
-    fn verifier<T: SigVerifier>(
+    fn verifier<P: BasePacket>(
         deduper: &Deduper,
-        recvr: &find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
-        verifier: &mut T,
+        recvr: &find_packet_sender_stake_stage::FindPacketSenderStakeReceiver<P>,
+        verifier: &mut TransactionSigVerifier<P>,
         stats: &mut SigVerifierStats,
-    ) -> Result<(), T::SendType> {
+    ) -> Result<(), BankingBatch<P>, P> {
         let (mut batches, num_packets, recv_duration) = streamer::recv_vec_packet_batches(recvr)?;
 
         let batches_len = batches.len();
@@ -409,9 +372,9 @@ impl SigVerifyStage {
         Ok(())
     }
 
-    fn verifier_service<T: SigVerifier + 'static + Send + Clone>(
-        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
-        mut verifier: T,
+    fn verifier_service<P: BasePacket + 'static>(
+        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver<P>,
+        mut verifier: TransactionSigVerifier<P>,
         name: &'static str,
     ) -> JoinHandle<()> {
         let mut stats = SigVerifierStats::default();
@@ -450,9 +413,9 @@ impl SigVerifyStage {
             .unwrap()
     }
 
-    fn verifier_services<T: SigVerifier + 'static + Send + Clone>(
-        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
-        verifier: T,
+    fn verifier_services<P: BasePacket + 'static>(
+        packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver<P>,
+        verifier: TransactionSigVerifier<P>,
         name: &'static str,
     ) -> JoinHandle<()> {
         Self::verifier_service(packet_receiver, verifier, name)

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -141,22 +141,24 @@ impl Tpu {
 
         let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) = unbounded();
 
-        let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new::<TransactionPacket>(
-            packet_receiver,
-            find_packet_sender_stake_sender,
-            staked_nodes.clone(),
-            "Tpu",
-        );
+        let find_packet_sender_stake_stage =
+            FindPacketSenderStakeStage::new::<{ TransactionPacket::DATA_SIZE }>(
+                packet_receiver,
+                find_packet_sender_stake_sender,
+                staked_nodes.clone(),
+                "Tpu",
+            );
 
         let (vote_find_packet_sender_stake_sender, vote_find_packet_sender_stake_receiver) =
             unbounded();
 
-        let vote_find_packet_sender_stake_stage = FindPacketSenderStakeStage::new::<Packet>(
-            vote_packet_receiver,
-            vote_find_packet_sender_stake_sender,
-            staked_nodes.clone(),
-            "Vote",
-        );
+        let vote_find_packet_sender_stake_stage =
+            FindPacketSenderStakeStage::new::<{ Packet::DATA_SIZE }>(
+                vote_packet_receiver,
+                vote_find_packet_sender_stake_sender,
+                staked_nodes.clone(),
+                "Vote",
+            );
 
         let (verified_sender, verified_receiver) = unbounded();
 
@@ -192,14 +194,15 @@ impl Tpu {
         .unwrap();
 
         let sigverify_stage = {
-            let verifier = TransactionSigVerifier::<TransactionPacket>::new(verified_sender);
+            let verifier =
+                TransactionSigVerifier::<{ TransactionPacket::DATA_SIZE }>::new(verified_sender);
             SigVerifyStage::new(find_packet_sender_stake_receiver, verifier, "tpu-verifier")
         };
 
         let (verified_tpu_vote_packets_sender, verified_tpu_vote_packets_receiver) = unbounded();
 
         let vote_sigverify_stage = {
-            let verifier = TransactionSigVerifier::<Packet>::new_reject_non_vote(
+            let verifier = TransactionSigVerifier::<{ Packet::DATA_SIZE }>::new_reject_non_vote(
                 verified_tpu_vote_packets_sender,
             );
             SigVerifyStage::new(

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,7 +1,7 @@
 use {
     crate::immutable_deserialized_packet::{DeserializedPacketError, ImmutableDeserializedPacket},
     min_max_heap::MinMaxHeap,
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_runtime::transaction_priority_details::TransactionPriorityDetails,
     solana_sdk::{hash::Hash, packet::GenericPacket, transaction::Transaction},
     std::{
@@ -76,7 +76,7 @@ pub struct PacketBatchInsertionMetrics {
 }
 
 /// Currently each banking_stage thread has a `UnprocessedPacketBatches` buffer to store
-/// Batch<{Packet::DATA_SIZE}>s received from sigverify. Banking thread continuously scans the buffer
+/// PacketBatch<{Packet::DATA_SIZE}>s received from sigverify. Banking thread continuously scans the buffer
 /// to pick proper packets to add to the block.
 #[derive(Debug, Default)]
 pub struct UnprocessedPacketBatches<const N: usize> {
@@ -315,7 +315,7 @@ impl<const N: usize> UnprocessedPacketBatches<N> {
 }
 
 pub fn deserialize_packets<'a, const N: usize>(
-    packet_batch: &'a Batch<N>,
+    packet_batch: &'a PacketBatch<N>,
     packet_indexes: &'a [usize],
 ) -> impl Iterator<Item = DeserializedPacket<N>> + 'a {
     packet_indexes.iter().filter_map(move |packet_index| {

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -128,7 +128,7 @@ impl<const N: usize> UnprocessedPacketBatches<N> {
                 if dropped_packet
                     .immutable_section()
                     .original_packet()
-                    .meta()
+                    .meta
                     .is_tracer_packet()
                 {
                     num_dropped_tracer_packets += 1;
@@ -491,7 +491,7 @@ mod tests {
             packet_vector.push(Packet::from_data(None, tx).unwrap());
         }
         for index in vote_indexes.iter() {
-            packet_vector[*index].meta_mut().flags |= PacketFlags::SIMPLE_VOTE_TX;
+            packet_vector[*index].meta.flags |= PacketFlags::SIMPLE_VOTE_TX;
         }
 
         packet_vector

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -931,7 +931,7 @@ impl<const N: usize> ThreadLocalUnprocessedPackets<N> {
             .filter_map(|immutable_deserialized_packet| {
                 let is_tracer_packet = immutable_deserialized_packet
                     .original_packet()
-                    .meta()
+                    .meta
                     .is_tracer_packet();
                 if is_tracer_packet {
                     saturating_add_assign!(*total_tracer_packets_in_buffer, 1);
@@ -1050,8 +1050,8 @@ mod tests {
             .enumerate()
             .map(|(packets_id, transaction)| {
                 let mut p = Packet::from_data(None, transaction).unwrap();
-                p.meta_mut().port = packets_id as u16;
-                p.meta_mut().set_tracer(true);
+                p.meta.port = packets_id as u16;
+                p.meta.set_tracer(true);
                 DeserializedPacket::new(p).unwrap()
             })
             .collect_vec();
@@ -1085,7 +1085,7 @@ mod tests {
             let expected_ports: Vec<_> = (0..256).collect();
             let mut forwarded_ports: Vec<_> = forward_packet_batches_by_accounts
                 .iter_batches()
-                .flat_map(|batch| batch.get_forwardable_packets().map(|p| p.meta().port))
+                .flat_map(|batch| batch.get_forwardable_packets().map(|p| p.meta.port))
                 .collect();
             forwarded_ports.sort_unstable();
             assert_eq!(expected_ports, forwarded_ports);
@@ -1181,7 +1181,7 @@ mod tests {
                 None,
             ),
         )?;
-        vote.meta_mut().flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
+        vote.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
         let big_transfer = Packet::from_data(
             None,
             system_transaction::transfer(&keypair, &pubkey, 1000000, Hash::new_unique()),
@@ -1254,8 +1254,8 @@ mod tests {
             .enumerate()
             .map(|(packets_id, transaction)| {
                 let mut p = Packet::from_data(None, transaction).unwrap();
-                p.meta_mut().port = packets_id as u16;
-                p.meta_mut().set_tracer(true);
+                p.meta.port = packets_id as u16;
+                p.meta.set_tracer(true);
                 DeserializedPacket::new(p).unwrap()
             })
             .collect_vec();

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         banking_stage::{BankingStageStats, FilterForwardingResults, ForwardOption},
-        forward_packet_batches_by_accounts::ForwardBatchesByAccounts,
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{
             LatestUnprocessedVotes, LatestValidatorVotePacket, VoteBatchInsertionMetrics,
@@ -319,7 +319,7 @@ impl<const N: usize> UnprocessedTransactionStorage<N> {
     pub fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<N>,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         match self {
             Self::LocalTransactionStorage(transaction_storage) => transaction_storage
@@ -415,7 +415,7 @@ impl<const N: usize> VoteStorage<N> {
     fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<N>,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         if matches!(self.vote_source, VoteSource::Tpu) {
             let total_forwardable_packets = self
@@ -555,7 +555,7 @@ impl<const N: usize> ThreadLocalUnprocessedPackets<N> {
     fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_buffer: &mut ForwardBatchesByAccounts<N>,
+        forward_buffer: &mut ForwardPacketBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         let mut total_forwardable_tracer_packets: usize = 0;
         let mut total_tracer_packets_in_buffer: usize = 0;
@@ -569,7 +569,7 @@ impl<const N: usize> ThreadLocalUnprocessedPackets<N> {
         let mut new_priority_queue = MinMaxHeap::with_capacity(original_capacity);
 
         // indicates if `forward_buffer` still accept more packets, see details at
-        // `ForwardBatchesByAccounts.rs`.
+        // `ForwardPacketBatchesByAccounts.rs`.
         let mut accepting_packets = true;
         // batch iterate through self.unprocessed_packet_batches in desc priority order
         new_priority_queue.extend(
@@ -786,7 +786,7 @@ impl<const N: usize> ThreadLocalUnprocessedPackets<N> {
     /// try to add filtered forwardable and valid packets to forward buffer;
     /// returns vector of packet indexes that were accepted for forwarding.
     fn add_filtered_packets_to_forward_buffer(
-        forward_buffer: &mut ForwardBatchesByAccounts<N>,
+        forward_buffer: &mut ForwardPacketBatchesByAccounts<N>,
         packets_to_process: &[Arc<ImmutableDeserializedPacket<N>>],
         transactions: &[SanitizedTransaction],
         transaction_to_packet_indexes: &[usize],
@@ -1064,8 +1064,10 @@ mod tests {
                 buffered_packet_batches,
                 ThreadType::Transactions,
             );
-            let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
+            let mut forward_packet_batches_by_accounts = ForwardPacketBatchesByAccounts::<
+                { Packet::DATA_SIZE },
+            >::new_with_default_batch_limits(
+            );
 
             let FilterForwardingResults {
                 total_forwardable_packets,
@@ -1103,8 +1105,10 @@ mod tests {
                 buffered_packet_batches,
                 ThreadType::Transactions,
             );
-            let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
+            let mut forward_packet_batches_by_accounts = ForwardPacketBatchesByAccounts::<
+                { Packet::DATA_SIZE },
+            >::new_with_default_batch_limits(
+            );
             let FilterForwardingResults {
                 total_forwardable_packets,
                 total_tracer_packets_in_buffer,
@@ -1137,8 +1141,10 @@ mod tests {
                 buffered_packet_batches,
                 ThreadType::Transactions,
             );
-            let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
+            let mut forward_packet_batches_by_accounts = ForwardPacketBatchesByAccounts::<
+                { Packet::DATA_SIZE },
+            >::new_with_default_batch_limits(
+            );
             let FilterForwardingResults {
                 total_forwardable_packets,
                 total_tracer_packets_in_buffer,

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -20,7 +20,7 @@ use {
     solana_runtime::bank::Bank,
     solana_sdk::{
         clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, feature_set::FeatureSet, hash::Hash,
-        packet::BasePacket, saturating_add_assign, transaction::SanitizedTransaction,
+        saturating_add_assign, transaction::SanitizedTransaction,
     },
     std::{
         collections::HashMap,
@@ -36,20 +36,20 @@ pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 64;
 const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 
 #[derive(Debug)]
-pub enum UnprocessedTransactionStorage<P: BasePacket> {
-    VoteStorage(VoteStorage<P>),
-    LocalTransactionStorage(ThreadLocalUnprocessedPackets<P>),
+pub enum UnprocessedTransactionStorage<const N: usize> {
+    VoteStorage(VoteStorage<N>),
+    LocalTransactionStorage(ThreadLocalUnprocessedPackets<N>),
 }
 
 #[derive(Debug)]
-pub struct ThreadLocalUnprocessedPackets<P: BasePacket> {
-    unprocessed_packet_batches: UnprocessedPacketBatches<P>,
+pub struct ThreadLocalUnprocessedPackets<const N: usize> {
+    unprocessed_packet_batches: UnprocessedPacketBatches<N>,
     thread_type: ThreadType,
 }
 
 #[derive(Debug)]
-pub struct VoteStorage<P: BasePacket> {
-    latest_unprocessed_votes: Arc<LatestUnprocessedVotes<P>>,
+pub struct VoteStorage<const N: usize> {
+    latest_unprocessed_votes: Arc<LatestUnprocessedVotes<N>>,
     vote_source: VoteSource,
 }
 
@@ -130,19 +130,19 @@ fn filter_processed_packets<'a, F>(
 
 /// Convenient wrapper for shared-state between banking stage processing and the
 /// multi-iterator checking function.
-pub struct ConsumeScannerPayload<'a, P: BasePacket> {
+pub struct ConsumeScannerPayload<'a, const N: usize> {
     pub reached_end_of_slot: bool,
     pub account_locks: ReadWriteAccountSet,
     pub sanitized_transactions: Vec<SanitizedTransaction>,
     pub slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
-    pub message_hash_to_transaction: &'a mut HashMap<Hash, DeserializedPacket<P>>,
+    pub message_hash_to_transaction: &'a mut HashMap<Hash, DeserializedPacket<N>>,
 }
 
-fn consume_scan_should_process_packet<P: BasePacket>(
+fn consume_scan_should_process_packet<const N: usize>(
     bank: &Bank,
     banking_stage_stats: &BankingStageStats,
-    packet: &ImmutableDeserializedPacket<P>,
-    payload: &mut ConsumeScannerPayload<P>,
+    packet: &ImmutableDeserializedPacket<N>,
+    payload: &mut ConsumeScannerPayload<N>,
 ) -> ProcessingDecision {
     // If end of the slot, return should process (quick loop after reached end of slot)
     if payload.reached_end_of_slot {
@@ -196,16 +196,16 @@ fn consume_scan_should_process_packet<P: BasePacket>(
     }
 }
 
-fn create_consume_multi_iterator<'a, 'b, F, P: BasePacket>(
-    packets: &'a [Arc<ImmutableDeserializedPacket<P>>],
+fn create_consume_multi_iterator<'a, 'b, F, const N: usize>(
+    packets: &'a [Arc<ImmutableDeserializedPacket<N>>],
     slot_metrics_tracker: &'b mut LeaderSlotMetricsTracker,
-    message_hash_to_transaction: &'b mut HashMap<Hash, DeserializedPacket<P>>,
+    message_hash_to_transaction: &'b mut HashMap<Hash, DeserializedPacket<N>>,
     should_process_packet: F,
-) -> MultiIteratorScanner<'a, Arc<ImmutableDeserializedPacket<P>>, ConsumeScannerPayload<'b, P>, F>
+) -> MultiIteratorScanner<'a, Arc<ImmutableDeserializedPacket<N>>, ConsumeScannerPayload<'b, N>, F>
 where
     F: FnMut(
-        &Arc<ImmutableDeserializedPacket<P>>,
-        &mut ConsumeScannerPayload<'b, P>,
+        &Arc<ImmutableDeserializedPacket<N>>,
+        &mut ConsumeScannerPayload<'b, N>,
     ) -> ProcessingDecision,
     'b: 'a,
 {
@@ -224,9 +224,9 @@ where
     )
 }
 
-impl<P: BasePacket> UnprocessedTransactionStorage<P> {
+impl<const N: usize> UnprocessedTransactionStorage<N> {
     pub fn new_transaction_storage(
-        unprocessed_packet_batches: UnprocessedPacketBatches<P>,
+        unprocessed_packet_batches: UnprocessedPacketBatches<N>,
         thread_type: ThreadType,
     ) -> Self {
         Self::LocalTransactionStorage(ThreadLocalUnprocessedPackets {
@@ -236,7 +236,7 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
     }
 
     pub fn new_vote_storage(
-        latest_unprocessed_votes: Arc<LatestUnprocessedVotes<P>>,
+        latest_unprocessed_votes: Arc<LatestUnprocessedVotes<N>>,
         vote_source: VoteSource,
     ) -> Self {
         Self::VoteStorage(VoteStorage {
@@ -279,7 +279,7 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
     }
 
     #[cfg(test)]
-    pub fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket<P>> {
+    pub fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket<N>> {
         match self {
             Self::LocalTransactionStorage(transaction_storage) => transaction_storage.iter(),
             _ => panic!(),
@@ -304,7 +304,7 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
 
     pub(crate) fn insert_batch(
         &mut self,
-        deserialized_packets: Vec<ImmutableDeserializedPacket<P>>,
+        deserialized_packets: Vec<ImmutableDeserializedPacket<N>>,
     ) -> InsertPacketBatchSummary {
         match self {
             Self::VoteStorage(vote_storage) => {
@@ -319,7 +319,7 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
     pub fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<P>,
+        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         match self {
             Self::LocalTransactionStorage(transaction_storage) => transaction_storage
@@ -348,8 +348,8 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
     ) -> bool
     where
         F: FnMut(
-            &Vec<Arc<ImmutableDeserializedPacket<P>>>,
-            &mut ConsumeScannerPayload<P>,
+            &Vec<Arc<ImmutableDeserializedPacket<N>>>,
+            &mut ConsumeScannerPayload<N>,
         ) -> Option<Vec<usize>>,
     {
         match self {
@@ -370,7 +370,7 @@ impl<P: BasePacket> UnprocessedTransactionStorage<P> {
     }
 }
 
-impl<P: BasePacket> VoteStorage<P> {
+impl<const N: usize> VoteStorage<N> {
     fn is_empty(&self) -> bool {
         self.latest_unprocessed_votes.is_empty()
     }
@@ -396,7 +396,7 @@ impl<P: BasePacket> VoteStorage<P> {
 
     fn insert_batch(
         &mut self,
-        deserialized_packets: Vec<ImmutableDeserializedPacket<P>>,
+        deserialized_packets: Vec<ImmutableDeserializedPacket<N>>,
     ) -> VoteBatchInsertionMetrics {
         self.latest_unprocessed_votes
             .insert_batch(
@@ -415,7 +415,7 @@ impl<P: BasePacket> VoteStorage<P> {
     fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<P>,
+        forward_packet_batches_by_accounts: &mut ForwardBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         if matches!(self.vote_source, VoteSource::Tpu) {
             let total_forwardable_packets = self
@@ -439,8 +439,8 @@ impl<P: BasePacket> VoteStorage<P> {
     ) -> bool
     where
         F: FnMut(
-            &Vec<Arc<ImmutableDeserializedPacket<P>>>,
-            &mut ConsumeScannerPayload<P>,
+            &Vec<Arc<ImmutableDeserializedPacket<N>>>,
+            &mut ConsumeScannerPayload<N>,
         ) -> Option<Vec<usize>>,
     {
         if matches!(self.vote_source, VoteSource::Gossip) {
@@ -448,8 +448,8 @@ impl<P: BasePacket> VoteStorage<P> {
         }
 
         let should_process_packet =
-            |packet: &Arc<ImmutableDeserializedPacket<P>>,
-             payload: &mut ConsumeScannerPayload<P>| {
+            |packet: &Arc<ImmutableDeserializedPacket<N>>,
+             payload: &mut ConsumeScannerPayload<N>| {
                 consume_scan_should_process_packet(&bank, banking_stage_stats, packet, payload)
             };
 
@@ -494,12 +494,12 @@ impl<P: BasePacket> VoteStorage<P> {
     }
 }
 
-type PacketsToForward<P> = (
-    Vec<Arc<ImmutableDeserializedPacket<P>>>,
-    Vec<Arc<ImmutableDeserializedPacket<P>>>,
+type PacketsToForward<const N: usize> = (
+    Vec<Arc<ImmutableDeserializedPacket<N>>>,
+    Vec<Arc<ImmutableDeserializedPacket<N>>>,
     Vec<bool>,
 );
-impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
+impl<const N: usize> ThreadLocalUnprocessedPackets<N> {
     fn is_empty(&self) -> bool {
         self.unprocessed_packet_batches.is_empty()
     }
@@ -517,11 +517,11 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     }
 
     #[cfg(test)]
-    fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket<P>> {
+    fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket<N>> {
         self.unprocessed_packet_batches.iter()
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DeserializedPacket<P>> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DeserializedPacket<N>> {
         self.unprocessed_packet_batches.iter_mut()
     }
 
@@ -539,7 +539,7 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
 
     fn insert_batch(
         &mut self,
-        deserialized_packets: Vec<ImmutableDeserializedPacket<P>>,
+        deserialized_packets: Vec<ImmutableDeserializedPacket<N>>,
     ) -> PacketBatchInsertionMetrics {
         self.unprocessed_packet_batches.insert_batch(
             deserialized_packets
@@ -555,7 +555,7 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     fn filter_forwardable_packets_and_add_batches(
         &mut self,
         bank: Arc<Bank>,
-        forward_buffer: &mut ForwardBatchesByAccounts<P>,
+        forward_buffer: &mut ForwardBatchesByAccounts<N>,
     ) -> FilterForwardingResults {
         let mut total_forwardable_tracer_packets: usize = 0;
         let mut total_tracer_packets_in_buffer: usize = 0;
@@ -688,7 +688,7 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     }
 
     /// Take self.unprocessed_packet_batches's priority_queue out, leave empty MinMaxHeap in its place.
-    fn take_priority_queue(&mut self) -> MinMaxHeap<Arc<ImmutableDeserializedPacket<P>>> {
+    fn take_priority_queue(&mut self) -> MinMaxHeap<Arc<ImmutableDeserializedPacket<N>>> {
         std::mem::replace(
             &mut self.unprocessed_packet_batches.packet_priority_queue,
             MinMaxHeap::new(), // <-- no need to reserve capacity as we will replace this
@@ -715,7 +715,7 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     /// sanitize un-forwarded packet into SanitizedTransaction for validation and forwarding.
     fn sanitize_unforwarded_packets(
         &mut self,
-        packets_to_process: &[Arc<ImmutableDeserializedPacket<P>>],
+        packets_to_process: &[Arc<ImmutableDeserializedPacket<N>>],
         bank: &Arc<Bank>,
     ) -> (Vec<SanitizedTransaction>, Vec<usize>) {
         // Get ref of ImmutableDeserializedPacket
@@ -786,8 +786,8 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     /// try to add filtered forwardable and valid packets to forward buffer;
     /// returns vector of packet indexes that were accepted for forwarding.
     fn add_filtered_packets_to_forward_buffer(
-        forward_buffer: &mut ForwardBatchesByAccounts<P>,
-        packets_to_process: &[Arc<ImmutableDeserializedPacket<P>>],
+        forward_buffer: &mut ForwardBatchesByAccounts<N>,
+        packets_to_process: &[Arc<ImmutableDeserializedPacket<N>>],
         transactions: &[SanitizedTransaction],
         transaction_to_packet_indexes: &[usize],
         forwardable_transaction_indexes: &[usize],
@@ -823,10 +823,10 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     }
 
     fn collect_retained_packets(
-        message_hash_to_transaction: &mut HashMap<Hash, DeserializedPacket<P>>,
-        packets_to_process: &[Arc<ImmutableDeserializedPacket<P>>],
+        message_hash_to_transaction: &mut HashMap<Hash, DeserializedPacket<N>>,
+        packets_to_process: &[Arc<ImmutableDeserializedPacket<N>>],
         retained_packet_indexes: &[usize],
-    ) -> Vec<Arc<ImmutableDeserializedPacket<P>>> {
+    ) -> Vec<Arc<ImmutableDeserializedPacket<N>>> {
         Self::remove_non_retained_packets(
             message_hash_to_transaction,
             packets_to_process,
@@ -841,8 +841,8 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     /// remove packets from UnprocessedPacketBatches.message_hash_to_transaction after they have
     /// been removed from UnprocessedPacketBatches.packet_priority_queue
     fn remove_non_retained_packets(
-        message_hash_to_transaction: &mut HashMap<Hash, DeserializedPacket<P>>,
-        packets_to_process: &[Arc<ImmutableDeserializedPacket<P>>],
+        message_hash_to_transaction: &mut HashMap<Hash, DeserializedPacket<N>>,
+        packets_to_process: &[Arc<ImmutableDeserializedPacket<N>>],
         retained_packet_indexes: &[usize],
     ) {
         filter_processed_packets(
@@ -867,8 +867,8 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     ) -> bool
     where
         F: FnMut(
-            &Vec<Arc<ImmutableDeserializedPacket<P>>>,
-            &mut ConsumeScannerPayload<P>,
+            &Vec<Arc<ImmutableDeserializedPacket<N>>>,
+            &mut ConsumeScannerPayload<N>,
         ) -> Option<Vec<usize>>,
     {
         let mut retryable_packets = self.take_priority_queue();
@@ -877,8 +877,8 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
         let all_packets_to_process = retryable_packets.drain_desc().collect_vec();
 
         let should_process_packet =
-            |packet: &Arc<ImmutableDeserializedPacket<P>>,
-             payload: &mut ConsumeScannerPayload<P>| {
+            |packet: &Arc<ImmutableDeserializedPacket<N>>,
+             payload: &mut ConsumeScannerPayload<N>| {
                 consume_scan_should_process_packet(bank, banking_stage_stats, packet, payload)
             };
         let mut scanner = create_consume_multi_iterator(
@@ -922,10 +922,10 @@ impl<P: BasePacket> ThreadLocalUnprocessedPackets<P> {
     /// packet is tracer packet.
     fn prepare_packets_to_forward(
         &self,
-        packets_to_forward: impl Iterator<Item = Arc<ImmutableDeserializedPacket<P>>>,
+        packets_to_forward: impl Iterator<Item = Arc<ImmutableDeserializedPacket<N>>>,
         total_tracer_packets_in_buffer: &mut usize,
-    ) -> PacketsToForward<P> {
-        let mut forwarded_packets: Vec<Arc<ImmutableDeserializedPacket<P>>> = vec![];
+    ) -> PacketsToForward<N> {
+        let mut forwarded_packets: Vec<Arc<ImmutableDeserializedPacket<N>>> = vec![];
         let (forwardable_packets, is_tracer_packet) = packets_to_forward
             .into_iter()
             .filter_map(|immutable_deserialized_packet| {
@@ -1065,7 +1065,7 @@ mod tests {
                 ThreadType::Transactions,
             );
             let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<Packet>::new_with_default_batch_limits();
+                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
 
             let FilterForwardingResults {
                 total_forwardable_packets,
@@ -1104,7 +1104,7 @@ mod tests {
                 ThreadType::Transactions,
             );
             let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<Packet>::new_with_default_batch_limits();
+                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
             let FilterForwardingResults {
                 total_forwardable_packets,
                 total_tracer_packets_in_buffer,
@@ -1138,7 +1138,7 @@ mod tests {
                 ThreadType::Transactions,
             );
             let mut forward_packet_batches_by_accounts =
-                ForwardBatchesByAccounts::<Packet>::new_with_default_batch_limits();
+                ForwardBatchesByAccounts::<{ Packet::DATA_SIZE }>::new_with_default_batch_limits();
             let FilterForwardingResults {
                 total_forwardable_packets,
                 total_tracer_packets_in_buffer,
@@ -1262,7 +1262,7 @@ mod tests {
 
         // test preparing buffered packets for forwarding
         let test_prepareing_buffered_packets_for_forwarding =
-            |buffered_packet_batches: UnprocessedPacketBatches<_>| -> (usize, usize, usize) {
+            |buffered_packet_batches: UnprocessedPacketBatches<{Packet::DATA_SIZE}>| -> (usize, usize, usize) {
                 let mut total_tracer_packets_in_buffer: usize = 0;
                 let mut total_packets_to_forward: usize = 0;
                 let mut total_tracer_packets_to_forward: usize = 0;
@@ -1287,7 +1287,7 @@ mod tests {
                         total_tracer_packets_to_forward += is_tracer_packet.len();
                         packets_to_forward
                     })
-                    .collect::<MinMaxHeap<Arc<ImmutableDeserializedPacket<_>>>>();
+                    .collect::<MinMaxHeap<Arc<ImmutableDeserializedPacket<{Packet::DATA_SIZE}>>>>();
                 (
                     total_tracer_packets_in_buffer,
                     total_packets_to_forward,

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -1,6 +1,6 @@
 use {
     crate::{cluster_info_vote_listener::VerifiedLabelVotePacketsReceiver, result::Result},
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_runtime::{
         bank::Bank,
         vote_transaction::{VoteTransaction, VoteTransaction::VoteStateUpdate},
@@ -28,7 +28,7 @@ const MAX_VOTES_PER_VALIDATOR: usize = 1000;
 pub struct VerifiedVoteMetadata {
     pub vote_account_key: Pubkey,
     pub vote: VoteTransaction,
-    pub packet_batch: Batch<{ Packet::DATA_SIZE }>,
+    pub packet_batch: PacketBatch<{ Packet::DATA_SIZE }>,
     pub signature: Signature,
 }
 
@@ -76,9 +76,9 @@ impl<'a> ValidatorGossipVotesIterator<'a> {
         &mut self,
         slot: &Slot,
         hash: &Hash,
-        packet: &Batch<{ Packet::DATA_SIZE }>,
+        packet: &PacketBatch<{ Packet::DATA_SIZE }>,
         tx_signature: &Signature,
-    ) -> Option<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Option<PacketBatch<{ Packet::DATA_SIZE }>> {
         // Don't send the same vote to the same bank multiple times
         if self.previously_sent_to_bank_votes.contains(tx_signature) {
             return None;
@@ -104,7 +104,7 @@ impl<'a> ValidatorGossipVotesIterator<'a> {
 ///
 /// Iterator is done after iterating through all vote accounts
 impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
-    type Item = Vec<Batch<{ Packet::DATA_SIZE }>>;
+    type Item = Vec<PacketBatch<{ Packet::DATA_SIZE }>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         use SingleValidatorVotes::*;
@@ -144,7 +144,7 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
                                             .filter_map(|((slot, hash), (packet, tx_signature))| {
                                                 self.filter_vote(slot, hash, packet, tx_signature)
                                             })
-                                            .collect::<Vec<Batch<{ Packet::DATA_SIZE }>>>()
+                                            .collect::<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>()
                                     }
                                 }
                             })
@@ -164,13 +164,13 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
 pub struct GossipVote {
     slot: Slot,
     hash: Hash,
-    packet_batch: Batch<{ Packet::DATA_SIZE }>,
+    packet_batch: PacketBatch<{ Packet::DATA_SIZE }>,
     signature: Signature,
 }
 
 pub enum SingleValidatorVotes {
     FullTowerVote(GossipVote),
-    IncrementalVotes(BTreeMap<(Slot, Hash), (Batch<{ Packet::DATA_SIZE }>, Signature)>),
+    IncrementalVotes(BTreeMap<(Slot, Hash), (PacketBatch<{ Packet::DATA_SIZE }>, Signature)>),
 }
 
 impl SingleValidatorVotes {
@@ -269,7 +269,7 @@ impl VerifiedVotePackets {
                             };
                             let validator_votes: &mut BTreeMap<
                                 (Slot, Hash),
-                                (Batch<{ Packet::DATA_SIZE }>, Signature),
+                                (PacketBatch<{ Packet::DATA_SIZE }>, Signature),
                             > = match self
                                 .0
                                 .entry(vote_account_key)
@@ -319,7 +319,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote: VoteTransaction::from(vote.clone()),
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -339,7 +339,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote: VoteTransaction::from(vote),
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -361,7 +361,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote: VoteTransaction::from(vote),
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -384,7 +384,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote: VoteTransaction::from(vote),
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[2u8; 64]),
         }])
         .unwrap();
@@ -423,7 +423,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
             .unwrap();
@@ -460,7 +460,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new_unique(),
             }])
             .unwrap();
@@ -514,7 +514,7 @@ mod tests {
                 s.send(vec![VerifiedVoteMetadata {
                     vote_account_key,
                     vote: VoteTransaction::from(vote),
-                    packet_batch: Batch::<{ Packet::DATA_SIZE }>::new(vec![
+                    packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::new(vec![
                         Packet::default();
                         num_packets
                     ]),
@@ -550,7 +550,7 @@ mod tests {
         // Get and verify batches
         let num_expected_batches = 2;
         for _ in 0..num_expected_batches {
-            let validator_batch: Vec<Batch<{ Packet::DATA_SIZE }>> =
+            let validator_batch: Vec<PacketBatch<{ Packet::DATA_SIZE }>> =
                 gossip_votes_iterator.next().unwrap();
             assert_eq!(validator_batch.len(), slot_hashes.slot_hashes().len());
             let expected_len = validator_batch[0].len();
@@ -585,7 +585,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new_unique(),
         }])
         .unwrap();
@@ -616,7 +616,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
             .unwrap();
@@ -642,7 +642,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote: VoteTransaction::from(third_vote.clone()),
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -662,7 +662,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
             .unwrap();
@@ -694,7 +694,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote,
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
             .unwrap();
@@ -731,7 +731,7 @@ mod tests {
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
                 vote,
-                packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+                packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
             .unwrap();
@@ -761,7 +761,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -792,7 +792,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -817,7 +817,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();
@@ -840,7 +840,7 @@ mod tests {
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,
-            packet_batch: Batch::<{ Packet::DATA_SIZE }>::default(),
+            packet_batch: PacketBatch::<{ Packet::DATA_SIZE }>::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
         .unwrap();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -233,14 +233,14 @@ where
     ws_metrics.shred_receiver_elapsed_us += shred_receiver_elapsed.as_us();
     ws_metrics.run_insert_count += 1;
     let handle_packet = |packet: &Packet| {
-        if packet.meta().discard() {
+        if packet.meta.discard() {
             return None;
         }
         let shred = shred::layout::get_shred(packet)?;
         let shred = Shred::new_from_serialized_shred(shred.to_vec()).ok()?;
-        if packet.meta().repair() {
+        if packet.meta.repair() {
             let repair_info = RepairMeta {
-                _from_addr: packet.meta().socket_addr(),
+                _from_addr: packet.meta.socket_addr(),
                 // If can't parse the nonce, dump the packet.
                 nonce: repair_response::nonce(packet)?,
             };
@@ -267,7 +267,7 @@ where
         .iter()
         .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
     {
-        let addr = packet.meta().socket_addr();
+        let addr = packet.meta.socket_addr();
         *ws_metrics.addrs.entry(addr).or_default() += 1;
     }
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -20,9 +20,12 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
-    solana_perf::packet::{Packet, PacketBatch},
+    solana_perf::packet::Batch,
     solana_rayon_threadlimit::get_thread_count,
-    solana_sdk::clock::Slot,
+    solana_sdk::{
+        clock::Slot,
+        packet::{BasePacket, Packet},
+    },
     std::{
         cmp::Reverse,
         collections::{HashMap, HashSet},
@@ -211,7 +214,7 @@ fn prune_shreds_invalid_repair(
 #[allow(clippy::too_many_arguments)]
 fn run_insert<F>(
     thread_pool: &ThreadPool,
-    verified_receiver: &Receiver<Vec<PacketBatch>>,
+    verified_receiver: &Receiver<Vec<Batch<Packet>>>,
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
@@ -257,10 +260,10 @@ where
             .unzip()
     });
     ws_metrics.handle_packets_elapsed_us += now.elapsed().as_micros() as u64;
-    ws_metrics.num_packets += packets.iter().map(PacketBatch::len).sum::<usize>();
+    ws_metrics.num_packets += packets.iter().map(Batch::<Packet>::len).sum::<usize>();
     ws_metrics.num_repairs += repair_infos.iter().filter(|r| r.is_some()).count();
     ws_metrics.num_shreds_received += shreds.len();
-    for packet in packets.iter().flat_map(PacketBatch::iter) {
+    for packet in packets.iter().flat_map(Batch::<Packet>::iter) {
         let addr = packet.meta().socket_addr();
         *ws_metrics.addrs.entry(addr).or_default() += 1;
     }
@@ -306,7 +309,7 @@ impl WindowService {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         blockstore: Arc<Blockstore>,
-        verified_receiver: Receiver<Vec<PacketBatch>>,
+        verified_receiver: Receiver<Vec<Batch<Packet>>>,
         retransmit_sender: Sender<Vec<ShredPayload>>,
         repair_socket: Arc<UdpSocket>,
         ancestor_hashes_socket: Arc<UdpSocket>,
@@ -396,7 +399,7 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        verified_receiver: Receiver<Vec<PacketBatch>>,
+        verified_receiver: Receiver<Vec<Batch<Packet>>>,
         check_duplicate_sender: Sender<Shred>,
         completed_data_sets_sender: CompletedDataSetsSender,
         retransmit_sender: Sender<Vec<ShredPayload>>,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -22,10 +22,7 @@ use {
     solana_metrics::inc_new_counter_error,
     solana_perf::packet::Batch,
     solana_rayon_threadlimit::get_thread_count,
-    solana_sdk::{
-        clock::Slot,
-        packet::{BasePacket, Packet},
-    },
+    solana_sdk::{clock::Slot, packet::Packet},
     std::{
         cmp::Reverse,
         collections::{HashMap, HashSet},
@@ -214,7 +211,7 @@ fn prune_shreds_invalid_repair(
 #[allow(clippy::too_many_arguments)]
 fn run_insert<F>(
     thread_pool: &ThreadPool,
-    verified_receiver: &Receiver<Vec<Batch<Packet>>>,
+    verified_receiver: &Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
@@ -260,10 +257,16 @@ where
             .unzip()
     });
     ws_metrics.handle_packets_elapsed_us += now.elapsed().as_micros() as u64;
-    ws_metrics.num_packets += packets.iter().map(Batch::<Packet>::len).sum::<usize>();
+    ws_metrics.num_packets += packets
+        .iter()
+        .map(Batch::<{ Packet::DATA_SIZE }>::len)
+        .sum::<usize>();
     ws_metrics.num_repairs += repair_infos.iter().filter(|r| r.is_some()).count();
     ws_metrics.num_shreds_received += shreds.len();
-    for packet in packets.iter().flat_map(Batch::<Packet>::iter) {
+    for packet in packets
+        .iter()
+        .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
+    {
         let addr = packet.meta().socket_addr();
         *ws_metrics.addrs.entry(addr).or_default() += 1;
     }
@@ -309,7 +312,7 @@ impl WindowService {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         blockstore: Arc<Blockstore>,
-        verified_receiver: Receiver<Vec<Batch<Packet>>>,
+        verified_receiver: Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
         retransmit_sender: Sender<Vec<ShredPayload>>,
         repair_socket: Arc<UdpSocket>,
         ancestor_hashes_socket: Arc<UdpSocket>,
@@ -399,7 +402,7 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        verified_receiver: Receiver<Vec<Batch<Packet>>>,
+        verified_receiver: Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
         check_duplicate_sender: Sender<Shred>,
         completed_data_sets_sender: CompletedDataSetsSender,
         retransmit_sender: Sender<Vec<ShredPayload>>,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{clock::Slot, packet::Packet},
     std::{
@@ -211,7 +211,7 @@ fn prune_shreds_invalid_repair(
 #[allow(clippy::too_many_arguments)]
 fn run_insert<F>(
     thread_pool: &ThreadPool,
-    verified_receiver: &Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
+    verified_receiver: &Receiver<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>,
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
@@ -259,13 +259,13 @@ where
     ws_metrics.handle_packets_elapsed_us += now.elapsed().as_micros() as u64;
     ws_metrics.num_packets += packets
         .iter()
-        .map(Batch::<{ Packet::DATA_SIZE }>::len)
+        .map(PacketBatch::<{ Packet::DATA_SIZE }>::len)
         .sum::<usize>();
     ws_metrics.num_repairs += repair_infos.iter().filter(|r| r.is_some()).count();
     ws_metrics.num_shreds_received += shreds.len();
     for packet in packets
         .iter()
-        .flat_map(Batch::<{ Packet::DATA_SIZE }>::iter)
+        .flat_map(PacketBatch::<{ Packet::DATA_SIZE }>::iter)
     {
         let addr = packet.meta.socket_addr();
         *ws_metrics.addrs.entry(addr).or_default() += 1;
@@ -312,7 +312,7 @@ impl WindowService {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         blockstore: Arc<Blockstore>,
-        verified_receiver: Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
+        verified_receiver: Receiver<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>,
         retransmit_sender: Sender<Vec<ShredPayload>>,
         repair_socket: Arc<UdpSocket>,
         ancestor_hashes_socket: Arc<UdpSocket>,
@@ -402,7 +402,7 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        verified_receiver: Receiver<Vec<Batch<{ Packet::DATA_SIZE }>>>,
+        verified_receiver: Receiver<Vec<PacketBatch<{ Packet::DATA_SIZE }>>>,
         check_duplicate_sender: Sender<Shred>,
         completed_data_sets_sender: CompletedDataSetsSender,
         retransmit_sender: Sender<Vec<ShredPayload>>,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -17,7 +17,7 @@ use {
     solana_metrics::*,
     solana_perf::{
         cuda_runtime::PinnedVec,
-        packet::{Batch, BatchRecycler, PACKETS_PER_BATCH},
+        packet::{BatchRecycler, PacketBatch, PACKETS_PER_BATCH},
         perf_libs,
         recycler::Recycler,
         sigverify,
@@ -494,7 +494,7 @@ pub fn start_verify_transactions(
                 .chunks(PACKETS_PER_BATCH)
                 .map(|slice| {
                     let vec_size = slice.len();
-                    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::new_with_recycler(
+                    let mut packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::new_with_recycler(
                         verify_recyclers.packet_recycler.clone(),
                         vec_size,
                         "entry-sig-verify",

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -25,7 +25,7 @@ use {
     solana_rayon_threadlimit::get_max_thread_count,
     solana_sdk::{
         hash::Hash,
-        packet::{BasePacket, Meta, Packet},
+        packet::{Meta, Packet},
         timing,
         transaction::{
             Result, SanitizedTransaction, Transaction, TransactionError,
@@ -494,7 +494,7 @@ pub fn start_verify_transactions(
                 .chunks(PACKETS_PER_BATCH)
                 .map(|slice| {
                     let vec_size = slice.len();
-                    let mut packet_batch = Batch::<Packet>::new_with_recycler(
+                    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::new_with_recycler(
                         verify_recyclers.packet_recycler.clone(),
                         vec_size,
                         "entry-sig-verify",

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -512,7 +512,7 @@ pub fn start_verify_transactions(
                         .map(|tx| tx.to_versioned_transaction());
 
                     let res = packet_batch.par_iter_mut().zip(entry_tx_iter).all(|pair| {
-                        *pair.0.meta_mut() = Meta::default();
+                        pair.0.meta = Meta::default();
                         Packet::populate_packet(pair.0, None, &pair.1).is_ok()
                     });
                     if res {
@@ -539,7 +539,7 @@ pub fn start_verify_transactions(
                     );
                     let verified = packet_batches
                         .iter()
-                        .all(|batch| batch.iter().all(|p| !p.meta().discard()));
+                        .all(|batch| batch.iter().all(|p| !p.meta.discard()));
                     verify_time.stop();
                     (verified, verify_time.as_us())
                 })

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -16,7 +16,7 @@ use {
         instruction::Instruction,
         message::Message,
         native_token::lamports_to_sol,
-        packet::PACKET_DATA_SIZE,
+        packet::TransactionPacket,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction,
@@ -306,7 +306,7 @@ pub fn request_airdrop_transaction(
         err
     })?;
     let transaction_length = LittleEndian::read_u16(&buffer) as usize;
-    if transaction_length > PACKET_DATA_SIZE {
+    if transaction_length > TransactionPacket::DATA_SIZE {
         return Err(FaucetError::TransactionDataTooLarge(transaction_length));
     } else if transaction_length == 0 {
         return Err(FaucetError::NoDataReceived);

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -16,7 +16,7 @@ use {
         instruction::Instruction,
         message::Message,
         native_token::lamports_to_sol,
-        packet::{BasePacket, TransactionPacket},
+        packet::TransactionPacket,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction,

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -16,7 +16,7 @@ use {
         instruction::Instruction,
         message::Message,
         native_token::lamports_to_sol,
-        packet::TransactionPacket,
+        packet::{BasePacket, TransactionPacket},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1958,7 +1958,7 @@ impl ClusterInfo {
             }
             check
         };
-        // Because pull-responses are sent back to packet.meta().socket_addr() of
+        // Because pull-responses are sent back to packet.meta.socket_addr() of
         // incoming pull-requests, pings are also sent to request.from_addr (as
         // opposed to caller.gossip address).
         move |request| {
@@ -2052,8 +2052,8 @@ impl ClusterInfo {
             match Packet::from_data(Some(addr), response) {
                 Err(err) => error!("failed to write pull-response packet: {:?}", err),
                 Ok(packet) => {
-                    if self.outbound_budget.take(packet.meta().size) {
-                        total_bytes += packet.meta().size;
+                    if self.outbound_budget.take(packet.meta.size) {
+                        total_bytes += packet.meta.size;
                         packet_batch.push(packet);
                         sent += 1;
                     } else {
@@ -2520,7 +2520,7 @@ impl ClusterInfo {
             let protocol: Protocol = packet.deserialize_slice(..).ok()?;
             protocol.sanitize().ok()?;
             let protocol = protocol.par_verify(&self.stats)?;
-            Some((packet.meta().socket_addr(), protocol))
+            Some((packet.meta.socket_addr(), protocol))
         };
         let packets: Vec<_> = {
             let _st = ScopedTimer::from(&self.stats.verify_gossip_packets_time);
@@ -3412,7 +3412,7 @@ RPC Enabled Nodes: 1"#;
             remote_nodes.into_iter(),
             pongs.into_iter()
         ) {
-            assert_eq!(packet.meta().socket_addr(), socket);
+            assert_eq!(packet.meta.socket_addr(), socket);
             let bytes = serialize(&pong).unwrap();
             match packet.deserialize_slice(..).unwrap() {
                 Protocol::PongMessage(pong) => assert_eq!(serialize(&pong).unwrap(), bytes),

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -62,7 +62,7 @@ use {
         clock::{Slot, DEFAULT_MS_PER_SLOT, DEFAULT_SLOTS_PER_EPOCH},
         feature_set::FeatureSet,
         hash::Hash,
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         quic::QUIC_PORT_OFFSET,
         sanitize::{Sanitize, SanitizeError},
@@ -489,7 +489,7 @@ impl ClusterInfo {
         recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        sender: &BatchSender<Packet>,
+        sender: &BatchSender<{ Packet::DATA_SIZE }>,
     ) {
         let ContactInfo { shred_version, .. } = *self.my_contact_info.read().unwrap();
         let self_keypair: Arc<Keypair> = self.keypair().clone();
@@ -514,7 +514,7 @@ impl ClusterInfo {
             self.stats
                 .packets_sent_gossip_requests_count
                 .add_relaxed(pings.len() as u64);
-            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "refresh_push_active_set",
                 &pings,
@@ -1604,7 +1604,7 @@ impl ClusterInfo {
         gossip_validators: Option<&HashSet<Pubkey>>,
         recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        sender: &BatchSender<Packet>,
+        sender: &BatchSender<{ Packet::DATA_SIZE }>,
         generate_pull_requests: bool,
     ) -> Result<(), GossipError> {
         let _st = ScopedTimer::from(&self.stats.gossip_transmit_loop_time);
@@ -1615,7 +1615,7 @@ impl ClusterInfo {
             generate_pull_requests,
         );
         if !reqs.is_empty() {
-            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "run_gossip",
                 &reqs,
@@ -1721,7 +1721,7 @@ impl ClusterInfo {
     pub fn gossip(
         self: Arc<Self>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
-        sender: BatchSender<Packet>,
+        sender: BatchSender<{ Packet::DATA_SIZE }>,
         gossip_validators: Option<HashSet<Pubkey>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -1872,7 +1872,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_requests_time);
         if requests.is_empty() {
@@ -1934,7 +1934,7 @@ impl ClusterInfo {
         &'a self,
         now: Instant,
         mut rng: &'a mut R,
-        packet_batch: &'a mut Batch<Packet>,
+        packet_batch: &'a mut Batch<{ Packet::DATA_SIZE }>,
     ) -> impl FnMut(&PullData) -> bool + 'a
     where
         R: Rng + CryptoRng,
@@ -1977,7 +1977,7 @@ impl ClusterInfo {
         recycler: &BatchRecycler<Packet>,
         requests: Vec<PullData>,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> Batch<Packet> {
+    ) -> Batch<{ Packet::DATA_SIZE }> {
         const DEFAULT_EPOCH_DURATION_MS: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT;
         let mut time = Measure::start("handle_pull_requests");
         let callers = crds_value::filter_current(requests.iter().map(|r| &r.caller));
@@ -1988,11 +1988,8 @@ impl ClusterInfo {
         }
         let output_size_limit =
             self.update_data_budget(stakes.len()) / PULL_RESPONSE_MIN_SERIALIZED_SIZE;
-        let mut packet_batch = Batch::<Packet>::new_unpinned_with_recycler(
-            recycler.clone(),
-            64,
-            "handle_pull_requests",
-        );
+        let mut packet_batch =
+            Batch::new_unpinned_with_recycler(recycler.clone(), 64, "handle_pull_requests");
         let (caller_and_filters, addrs): (Vec<_>, Vec<_>) = {
             let mut rng = rand::thread_rng();
             let check_pull_request =
@@ -2203,7 +2200,7 @@ impl ClusterInfo {
         &self,
         pings: I,
         recycler: &BatchRecycler<Packet>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
     ) where
         I: IntoIterator<Item = (SocketAddr, Ping)>,
     {
@@ -2217,7 +2214,7 @@ impl ClusterInfo {
         &self,
         pings: I,
         recycler: &BatchRecycler<Packet>,
-    ) -> Option<Batch<Packet>>
+    ) -> Option<Batch<{ Packet::DATA_SIZE }>>
     where
         I: IntoIterator<Item = (SocketAddr, Ping)>,
     {
@@ -2233,7 +2230,7 @@ impl ClusterInfo {
         if pongs_and_dests.is_empty() {
             None
         } else {
-            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "handle_ping_messages",
                 &pongs_and_dests,
@@ -2263,7 +2260,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_push_messages_time);
         if messages.is_empty() {
@@ -2329,7 +2326,7 @@ impl ClusterInfo {
         if prune_messages.is_empty() {
             return;
         }
-        let mut packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+        let mut packet_batch = Batch::new_unpinned_with_recycler_data_and_dests(
             recycler.clone(),
             "handle_batch_push_messages",
             &prune_messages,
@@ -2377,7 +2374,7 @@ impl ClusterInfo {
         packets: VecDeque<(/*from:*/ SocketAddr, Protocol)>,
         thread_pool: &ThreadPool,
         recycler: &BatchRecycler<Packet>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
         stakes: &HashMap<Pubkey, u64>,
         _feature_set: Option<&FeatureSet>,
         epoch_duration: Duration,
@@ -2485,12 +2482,12 @@ impl ClusterInfo {
     // handling of requests/messages.
     fn run_socket_consume(
         &self,
-        receiver: &BatchReceiver<Packet>,
+        receiver: &BatchReceiver<{ Packet::DATA_SIZE }>,
         sender: &Sender<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         thread_pool: &ThreadPool,
     ) -> Result<(), GossipError> {
         const RECV_TIMEOUT: Duration = Duration::from_secs(1);
-        fn count_packets_received(packets: &Batch<Packet>, counts: &mut [u64; 7]) {
+        fn count_packets_received<const N: usize>(packets: &Batch<N>, counts: &mut [u64; 7]) {
             for packet in packets {
                 let k = match packet
                     .data(..4)
@@ -2565,7 +2562,7 @@ impl ClusterInfo {
         recycler: &BatchRecycler<Packet>,
         bank_forks: Option<&RwLock<BankForks>>,
         receiver: &Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
-        response_sender: &BatchSender<Packet>,
+        response_sender: &BatchSender<{ Packet::DATA_SIZE }>,
         thread_pool: &ThreadPool,
         last_print: &mut Instant,
         should_check_duplicate_instance: bool,
@@ -2617,7 +2614,7 @@ impl ClusterInfo {
 
     pub(crate) fn start_socket_consume_thread(
         self: Arc<Self>,
-        receiver: BatchReceiver<Packet>,
+        receiver: BatchReceiver<{ Packet::DATA_SIZE }>,
         sender: Sender<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -2647,7 +2644,7 @@ impl ClusterInfo {
         self: Arc<Self>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
         requests_receiver: Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
-        response_sender: BatchSender<Packet>,
+        response_sender: BatchSender<{ Packet::DATA_SIZE }>,
         should_check_duplicate_instance: bool,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -3057,7 +3054,7 @@ pub fn push_messages_to_peer(
     let reqs: Vec<_> = ClusterInfo::split_gossip_messages(PUSH_MESSAGE_MAX_PAYLOAD_SIZE, messages)
         .map(move |payload| (peer_gossip, Protocol::PushMessage(self_id, payload)))
         .collect();
-    let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+    let packet_batch = Batch::new_unpinned_with_recycler_data_and_dests(
         BatchRecycler::<Packet>::default(),
         "push_messages_to_peer",
         &reqs,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -54,7 +54,7 @@ use {
     },
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Packet, PacketBatch, PacketBatchRecycler},
+        packet::{Batch, BatchRecycler},
     },
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::{bank_forks::BankForks, vote_parser},
@@ -62,6 +62,7 @@ use {
         clock::{Slot, DEFAULT_MS_PER_SLOT, DEFAULT_SLOTS_PER_EPOCH},
         feature_set::FeatureSet,
         hash::Hash,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         quic::QUIC_PORT_OFFSET,
         sanitize::{Sanitize, SanitizeError},
@@ -72,7 +73,7 @@ use {
     solana_streamer::{
         packet,
         socket::SocketAddrSpace,
-        streamer::{PacketBatchReceiver, PacketBatchSender},
+        streamer::{BatchReceiver, BatchSender},
     },
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
     std::{
@@ -485,10 +486,10 @@ impl ClusterInfo {
 
     fn refresh_push_active_set(
         &self,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        sender: &PacketBatchSender,
+        sender: &BatchSender<Packet>,
     ) {
         let ContactInfo { shred_version, .. } = *self.my_contact_info.read().unwrap();
         let self_keypair: Arc<Keypair> = self.keypair().clone();
@@ -513,7 +514,7 @@ impl ClusterInfo {
             self.stats
                 .packets_sent_gossip_requests_count
                 .add_relaxed(pings.len() as u64);
-            let packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "refresh_push_active_set",
                 &pings,
@@ -1601,9 +1602,9 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        sender: &PacketBatchSender,
+        sender: &BatchSender<Packet>,
         generate_pull_requests: bool,
     ) -> Result<(), GossipError> {
         let _st = ScopedTimer::from(&self.stats.gossip_transmit_loop_time);
@@ -1614,7 +1615,7 @@ impl ClusterInfo {
             generate_pull_requests,
         );
         if !reqs.is_empty() {
-            let packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "run_gossip",
                 &reqs,
@@ -1720,7 +1721,7 @@ impl ClusterInfo {
     pub fn gossip(
         self: Arc<Self>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
-        sender: PacketBatchSender,
+        sender: BatchSender<Packet>,
         gossip_validators: Option<HashSet<Pubkey>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -1736,7 +1737,7 @@ impl ClusterInfo {
                 let mut last_contact_info_trace = timestamp();
                 let mut last_contact_info_save = timestamp();
                 let mut entrypoints_processed = false;
-                let recycler = PacketBatchRecycler::default();
+                let recycler = BatchRecycler::<Packet>::default();
                 let crds_data = vec![
                     CrdsData::Version(Version::new(self.id())),
                     CrdsData::NodeInstance(
@@ -1869,9 +1870,9 @@ impl ClusterInfo {
         // from address, crds filter, caller contact info
         requests: Vec<(SocketAddr, CrdsFilter, CrdsValue)>,
         thread_pool: &ThreadPool,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        response_sender: &PacketBatchSender,
+        response_sender: &BatchSender<Packet>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_requests_time);
         if requests.is_empty() {
@@ -1933,7 +1934,7 @@ impl ClusterInfo {
         &'a self,
         now: Instant,
         mut rng: &'a mut R,
-        packet_batch: &'a mut PacketBatch,
+        packet_batch: &'a mut Batch<Packet>,
     ) -> impl FnMut(&PullData) -> bool + 'a
     where
         R: Rng + CryptoRng,
@@ -1973,10 +1974,10 @@ impl ClusterInfo {
     fn handle_pull_requests(
         &self,
         thread_pool: &ThreadPool,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         requests: Vec<PullData>,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> PacketBatch {
+    ) -> Batch<Packet> {
         const DEFAULT_EPOCH_DURATION_MS: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT;
         let mut time = Measure::start("handle_pull_requests");
         let callers = crds_value::filter_current(requests.iter().map(|r| &r.caller));
@@ -1987,8 +1988,11 @@ impl ClusterInfo {
         }
         let output_size_limit =
             self.update_data_budget(stakes.len()) / PULL_RESPONSE_MIN_SERIALIZED_SIZE;
-        let mut packet_batch =
-            PacketBatch::new_unpinned_with_recycler(recycler.clone(), 64, "handle_pull_requests");
+        let mut packet_batch = Batch::<Packet>::new_unpinned_with_recycler(
+            recycler.clone(),
+            64,
+            "handle_pull_requests",
+        );
         let (caller_and_filters, addrs): (Vec<_>, Vec<_>) = {
             let mut rng = rand::thread_rng();
             let check_pull_request =
@@ -2198,8 +2202,8 @@ impl ClusterInfo {
     fn handle_batch_ping_messages<I>(
         &self,
         pings: I,
-        recycler: &PacketBatchRecycler,
-        response_sender: &PacketBatchSender,
+        recycler: &BatchRecycler<Packet>,
+        response_sender: &BatchSender<Packet>,
     ) where
         I: IntoIterator<Item = (SocketAddr, Ping)>,
     {
@@ -2212,8 +2216,8 @@ impl ClusterInfo {
     fn handle_ping_messages<I>(
         &self,
         pings: I,
-        recycler: &PacketBatchRecycler,
-    ) -> Option<PacketBatch>
+        recycler: &BatchRecycler<Packet>,
+    ) -> Option<Batch<Packet>>
     where
         I: IntoIterator<Item = (SocketAddr, Ping)>,
     {
@@ -2229,7 +2233,7 @@ impl ClusterInfo {
         if pongs_and_dests.is_empty() {
             None
         } else {
-            let packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
+            let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
                 recycler.clone(),
                 "handle_ping_messages",
                 &pongs_and_dests,
@@ -2257,9 +2261,9 @@ impl ClusterInfo {
         &self,
         messages: Vec<(Pubkey, Vec<CrdsValue>)>,
         thread_pool: &ThreadPool,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         stakes: &HashMap<Pubkey, u64>,
-        response_sender: &PacketBatchSender,
+        response_sender: &BatchSender<Packet>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_push_messages_time);
         if messages.is_empty() {
@@ -2325,7 +2329,7 @@ impl ClusterInfo {
         if prune_messages.is_empty() {
             return;
         }
-        let mut packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
+        let mut packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
             recycler.clone(),
             "handle_batch_push_messages",
             &prune_messages,
@@ -2372,8 +2376,8 @@ impl ClusterInfo {
         &self,
         packets: VecDeque<(/*from:*/ SocketAddr, Protocol)>,
         thread_pool: &ThreadPool,
-        recycler: &PacketBatchRecycler,
-        response_sender: &PacketBatchSender,
+        recycler: &BatchRecycler<Packet>,
+        response_sender: &BatchSender<Packet>,
         stakes: &HashMap<Pubkey, u64>,
         _feature_set: Option<&FeatureSet>,
         epoch_duration: Duration,
@@ -2481,12 +2485,12 @@ impl ClusterInfo {
     // handling of requests/messages.
     fn run_socket_consume(
         &self,
-        receiver: &PacketBatchReceiver,
+        receiver: &BatchReceiver<Packet>,
         sender: &Sender<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         thread_pool: &ThreadPool,
     ) -> Result<(), GossipError> {
         const RECV_TIMEOUT: Duration = Duration::from_secs(1);
-        fn count_packets_received(packets: &PacketBatch, counts: &mut [u64; 7]) {
+        fn count_packets_received(packets: &Batch<Packet>, counts: &mut [u64; 7]) {
             for packet in packets {
                 let k = match packet
                     .data(..4)
@@ -2558,10 +2562,10 @@ impl ClusterInfo {
     /// Process messages from the network
     fn run_listen(
         &self,
-        recycler: &PacketBatchRecycler,
+        recycler: &BatchRecycler<Packet>,
         bank_forks: Option<&RwLock<BankForks>>,
         receiver: &Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
-        response_sender: &PacketBatchSender,
+        response_sender: &BatchSender<Packet>,
         thread_pool: &ThreadPool,
         last_print: &mut Instant,
         should_check_duplicate_instance: bool,
@@ -2613,7 +2617,7 @@ impl ClusterInfo {
 
     pub(crate) fn start_socket_consume_thread(
         self: Arc<Self>,
-        receiver: PacketBatchReceiver,
+        receiver: BatchReceiver<Packet>,
         sender: Sender<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -2643,12 +2647,12 @@ impl ClusterInfo {
         self: Arc<Self>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
         requests_receiver: Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
-        response_sender: PacketBatchSender,
+        response_sender: BatchSender<Packet>,
         should_check_duplicate_instance: bool,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         let mut last_print = Instant::now();
-        let recycler = PacketBatchRecycler::default();
+        let recycler = BatchRecycler::<Packet>::default();
         let thread_pool = ThreadPoolBuilder::new()
             .num_threads(get_thread_count().min(8))
             .thread_name(|i| format!("solGossipWork{i:02}"))
@@ -3053,8 +3057,8 @@ pub fn push_messages_to_peer(
     let reqs: Vec<_> = ClusterInfo::split_gossip_messages(PUSH_MESSAGE_MAX_PAYLOAD_SIZE, messages)
         .map(move |payload| (peer_gossip, Protocol::PushMessage(self_id, payload)))
         .collect();
-    let packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
-        PacketBatchRecycler::default(),
+    let packet_batch = Batch::<Packet>::new_unpinned_with_recycler_data_and_dests(
+        BatchRecycler::<Packet>::default(),
         "push_messages_to_peer",
         &reqs,
     );
@@ -3395,7 +3399,7 @@ RPC Enabled Nodes: 1"#;
             .iter()
             .map(|ping| Pong::new(ping, &this_node).unwrap())
             .collect();
-        let recycler = PacketBatchRecycler::default();
+        let recycler = BatchRecycler::<Packet>::default();
         let packets = cluster_info
             .handle_ping_messages(
                 remote_nodes

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -2,7 +2,7 @@
 //!
 //! This module ties together Crds and the push and pull gossip overlays.  The interface is
 //! designed to run with a simulator or over a UDP network connection with messages up to a
-//! packet::PACKET_DATA_SIZE size.
+//! packet::Packet::DATA_SIZE size.
 
 use {
     crate::{

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -672,7 +672,7 @@ pub(crate) mod tests {
         solana_perf::test_tx::new_test_vote_tx,
         solana_sdk::{
             hash::{hash, HASH_BYTES},
-            packet::{BasePacket, Packet},
+            packet::Packet,
             timing::timestamp,
         },
     };

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -672,7 +672,7 @@ pub(crate) mod tests {
         solana_perf::test_tx::new_test_vote_tx,
         solana_sdk::{
             hash::{hash, HASH_BYTES},
-            packet::Packet,
+            packet::{BasePacket, Packet},
             timing::timestamp,
         },
     };

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -672,7 +672,7 @@ pub(crate) mod tests {
         solana_perf::test_tx::new_test_vote_tx,
         solana_sdk::{
             hash::{hash, HASH_BYTES},
-            packet::PACKET_DATA_SIZE,
+            packet::Packet,
             timing::timestamp,
         },
     };
@@ -1024,7 +1024,7 @@ pub(crate) mod tests {
                 0,
                 None,
                 &HashMap::new(),
-                PACKET_DATA_SIZE,
+                Packet::DATA_SIZE,
                 &ping_cache,
                 &mut pings,
                 &SocketAddrSpace::Unspecified,
@@ -1045,7 +1045,7 @@ pub(crate) mod tests {
                 0,
                 None,
                 &HashMap::new(),
-                PACKET_DATA_SIZE,
+                Packet::DATA_SIZE,
                 &ping_cache,
                 &mut pings,
                 &SocketAddrSpace::Unspecified,
@@ -1071,7 +1071,7 @@ pub(crate) mod tests {
             now,
             None,
             &HashMap::new(),
-            PACKET_DATA_SIZE,
+            Packet::DATA_SIZE,
             &ping_cache,
             &mut pings,
             &SocketAddrSpace::Unspecified,
@@ -1094,7 +1094,7 @@ pub(crate) mod tests {
             now,
             None,
             &HashMap::new(),
-            PACKET_DATA_SIZE,
+            Packet::DATA_SIZE,
             &ping_cache,
             &mut pings,
             &SocketAddrSpace::Unspecified,
@@ -1150,9 +1150,9 @@ pub(crate) mod tests {
                     &node_keypair,
                     0, // self_shred_version
                     now,
-                    None,             // gossip_validators
-                    &HashMap::new(),  // stakes
-                    PACKET_DATA_SIZE, // bloom_size
+                    None,              // gossip_validators
+                    &HashMap::new(),   // stakes
+                    Packet::DATA_SIZE, // bloom_size
                     &ping_cache,
                     &mut pings,
                     &SocketAddrSpace::Unspecified,
@@ -1235,7 +1235,7 @@ pub(crate) mod tests {
             0,
             None,
             &HashMap::new(),
-            PACKET_DATA_SIZE,
+            Packet::DATA_SIZE,
             &Mutex::new(ping_cache),
             &mut pings,
             &SocketAddrSpace::Unspecified,
@@ -1338,7 +1338,7 @@ pub(crate) mod tests {
             0,
             None,
             &HashMap::new(),
-            PACKET_DATA_SIZE,
+            Packet::DATA_SIZE,
             &Mutex::new(ping_cache),
             &mut pings,
             &SocketAddrSpace::Unspecified,
@@ -1426,7 +1426,7 @@ pub(crate) mod tests {
                 0,
                 None,
                 &HashMap::new(),
-                PACKET_DATA_SIZE,
+                Packet::DATA_SIZE,
                 &ping_cache,
                 &mut pings,
                 &SocketAddrSpace::Unspecified,
@@ -1530,7 +1530,7 @@ pub(crate) mod tests {
             // there is a chance of a false positive with bloom filters
             // assert that purged value is still in the set
             // chance of 30 consecutive false positives is 0.1^30
-            let filters = node.build_crds_filters(&thread_pool, &node_crds, PACKET_DATA_SIZE);
+            let filters = node.build_crds_filters(&thread_pool, &node_crds, Packet::DATA_SIZE);
             assert!(filters.iter().any(|filter| filter.contains(&value_hash)));
         }
 

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -26,7 +26,7 @@ use {
     itertools::Itertools,
     rand::Rng,
     solana_sdk::{
-        packet::Packet,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         timing::timestamp,

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -26,7 +26,7 @@ use {
     itertools::Itertools,
     rand::Rng,
     solana_sdk::{
-        packet::PACKET_DATA_SIZE,
+        packet::Packet,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         timing::timestamp,
@@ -79,7 +79,7 @@ impl Default for CrdsGossipPush {
     fn default() -> Self {
         Self {
             // Allow upto 64 Crds Values per PUSH
-            max_bytes: PACKET_DATA_SIZE * 64,
+            max_bytes: Packet::DATA_SIZE * 64,
             active_set: RwLock::default(),
             crds_cursor: Mutex::default(),
             received_cache: Mutex::new(ReceivedCache::new(2 * CRDS_UNIQUE_PUBKEY_CAPACITY)),

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -26,7 +26,7 @@ use {
     itertools::Itertools,
     rand::Rng,
     solana_sdk::{
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         timing::timestamp,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -10,10 +10,10 @@ use {
         gossip_service::GossipService,
         legacy_contact_info::LegacyContactInfo as ContactInfo,
     },
-    solana_perf::packet::Packet,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
         hash::Hash,
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         timing::timestamp,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -13,7 +13,7 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
         hash::Hash,
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         timing::timestamp,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -255,7 +255,7 @@ pub fn cluster_info_retransmit() {
     }
     assert!(done);
     let mut p = Packet::default();
-    p.meta_mut().size = 10;
+    p.meta.size = 10;
     let peers = c1.tvu_peers();
     let retransmit_peers: Vec<_> = peers.iter().collect();
     retransmit_to(

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -6,11 +6,8 @@ use {
         shred::{Shred, ShredFlags, LEGACY_SHRED_DATA_CAPACITY},
         sigverify_shreds::{sign_shreds_cpu, sign_shreds_gpu, sign_shreds_gpu_pinned_keypair},
     },
-    solana_perf::{
-        packet::{Packet, PacketBatch},
-        recycler_cache::RecyclerCache,
-    },
-    solana_sdk::signature::Keypair,
+    solana_perf::{packet::Batch, recycler_cache::RecyclerCache},
+    solana_sdk::{packet::Packet, signature::Keypair},
     std::sync::Arc,
     test::Bencher,
 };
@@ -21,7 +18,7 @@ const NUM_BATCHES: usize = 1;
 fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let recycler_cache = RecyclerCache::default();
 
-    let mut packet_batch = PacketBatch::new_pinned_with_capacity(NUM_PACKETS);
+    let mut packet_batch = Batch::<Packet>::new_pinned_with_capacity(NUM_PACKETS);
     packet_batch.resize(NUM_PACKETS, Packet::default());
     let slot = 0xdead_c0de;
     for p in packet_batch.iter_mut() {
@@ -52,7 +49,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
-    let mut packet_batch = PacketBatch::default();
+    let mut packet_batch = Batch::<Packet>::default();
     let slot = 0xdead_c0de;
     packet_batch.resize(NUM_PACKETS, Packet::default());
     for p in packet_batch.iter_mut() {

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -6,7 +6,7 @@ use {
         shred::{Shred, ShredFlags, LEGACY_SHRED_DATA_CAPACITY},
         sigverify_shreds::{sign_shreds_cpu, sign_shreds_gpu, sign_shreds_gpu_pinned_keypair},
     },
-    solana_perf::{packet::Batch, recycler_cache::RecyclerCache},
+    solana_perf::{packet::PacketBatch, recycler_cache::RecyclerCache},
     solana_sdk::{packet::Packet, signature::Keypair},
     std::sync::Arc,
     test::Bencher,
@@ -18,7 +18,8 @@ const NUM_BATCHES: usize = 1;
 fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let recycler_cache = RecyclerCache::default();
 
-    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::new_pinned_with_capacity(NUM_PACKETS);
+    let mut packet_batch =
+        PacketBatch::<{ Packet::DATA_SIZE }>::new_pinned_with_capacity(NUM_PACKETS);
     packet_batch.resize(NUM_PACKETS, Packet::default());
     let slot = 0xdead_c0de;
     for p in packet_batch.iter_mut() {
@@ -49,7 +50,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
-    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::default();
+    let mut packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::default();
     let slot = 0xdead_c0de;
     packet_batch.resize(NUM_PACKETS, Packet::default());
     for p in packet_batch.iter_mut() {

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -18,7 +18,7 @@ const NUM_BATCHES: usize = 1;
 fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let recycler_cache = RecyclerCache::default();
 
-    let mut packet_batch = Batch::<Packet>::new_pinned_with_capacity(NUM_PACKETS);
+    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::new_pinned_with_capacity(NUM_PACKETS);
     packet_batch.resize(NUM_PACKETS, Packet::default());
     let slot = 0xdead_c0de;
     for p in packet_batch.iter_mut() {
@@ -49,7 +49,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
-    let mut packet_batch = Batch::<Packet>::default();
+    let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::default();
     let slot = 0xdead_c0de;
     packet_batch.resize(NUM_PACKETS, Packet::default());
     for p in packet_batch.iter_mut() {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4384,7 +4384,7 @@ pub mod tests {
             hash::{self, hash, Hash},
             instruction::CompiledInstruction,
             message::v0::LoadedAddresses,
-            packet::{BasePacket, Packet},
+            packet::Packet,
             pubkey::Pubkey,
             signature::Signature,
             transaction::{Transaction, TransactionError},

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4384,7 +4384,7 @@ pub mod tests {
             hash::{self, hash, Hash},
             instruction::CompiledInstruction,
             message::v0::LoadedAddresses,
-            packet::PACKET_DATA_SIZE,
+            packet::Packet,
             pubkey::Pubkey,
             signature::Signature,
             transaction::{Transaction, TransactionError},
@@ -4981,7 +4981,7 @@ pub mod tests {
         let shreds_per_slot = 5_u64;
         let entry_serialized_size =
             bincode::serialized_size(&create_ticks(1, 0, Hash::default())).unwrap();
-        let entries_per_slot = (shreds_per_slot * PACKET_DATA_SIZE as u64) / entry_serialized_size;
+        let entries_per_slot = (shreds_per_slot * Packet::DATA_SIZE as u64) / entry_serialized_size;
 
         // Write entries
         for slot in 0..num_slots {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4384,7 +4384,7 @@ pub mod tests {
             hash::{self, hash, Hash},
             instruction::CompiledInstruction,
             message::v0::LoadedAddresses,
-            packet::Packet,
+            packet::{BasePacket, Packet},
             pubkey::Pubkey,
             signature::Signature,
             transaction::{Transaction, TransactionError},

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -345,7 +345,7 @@ impl Shred {
         let payload = self.payload();
         let size = payload.len();
         packet.buffer_mut()[..size].copy_from_slice(&payload[..]);
-        packet.meta_mut().size = size;
+        packet.meta.size = size;
     }
 
     // TODO: Should this sanitize output?
@@ -565,7 +565,7 @@ pub mod layout {
 
     fn get_shred_size(packet: &Packet) -> Option<usize> {
         let size = packet.data(..)?.len();
-        if packet.meta().repair() {
+        if packet.meta.repair() {
             size.checked_sub(SIZE_OF_NONCE)
         } else {
             Some(size)
@@ -1173,7 +1173,7 @@ mod tests {
         ));
         assert_eq!(stats, ShredFetchStats::default());
 
-        packet.meta_mut().size = OFFSET_OF_SHRED_VARIANT;
+        packet.meta.size = OFFSET_OF_SHRED_VARIANT;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1183,7 +1183,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 1);
 
-        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX;
+        packet.meta.size = OFFSET_OF_SHRED_INDEX;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1193,7 +1193,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 2);
 
-        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + 1;
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + 1;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1203,7 +1203,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 3);
 
-        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1213,7 +1213,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 4);
 
-        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1526,7 +1526,7 @@ mod tests {
         });
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta_mut().size = payload.len();
+        packet.meta.size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);
@@ -1559,7 +1559,7 @@ mod tests {
         let payload = bs58_decode(PAYLOAD);
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta_mut().size = payload.len();
+        packet.meta.size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);
@@ -1599,7 +1599,7 @@ mod tests {
         });
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta_mut().size = payload.len();
+        packet.meta.size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -61,10 +61,10 @@ use {
     reed_solomon_erasure::Error::TooFewShardsPresent,
     serde::{Deserialize, Serialize},
     solana_entry::entry::{create_ticks, Entry},
-    solana_perf::packet::Packet,
     solana_sdk::{
         clock::Slot,
         hash::{hashv, Hash},
+        packet::{BasePacket, Packet},
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer, SIGNATURE_BYTES},
     },

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -64,7 +64,7 @@ use {
     solana_sdk::{
         clock::Slot,
         hash::{hashv, Hash},
-        packet::{BasePacket, Packet},
+        packet::Packet,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer, SIGNATURE_BYTES},
     },

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -9,11 +9,7 @@ use {
         },
         shredder::ERASURE_BATCH_SIZE,
     },
-    solana_sdk::{
-        clock::Slot,
-        packet::{BasePacket, Packet},
-        signature::Signature,
-    },
+    solana_sdk::{clock::Slot, packet::Packet, signature::Signature},
     static_assertions::const_assert_eq,
 };
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -9,7 +9,11 @@ use {
         },
         shredder::ERASURE_BATCH_SIZE,
     },
-    solana_sdk::{clock::Slot, packet::Packet, signature::Signature},
+    solana_sdk::{
+        clock::Slot,
+        packet::{BasePacket, Packet},
+        signature::Signature,
+    },
     static_assertions::const_assert_eq,
 };
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -9,7 +9,7 @@ use {
         },
         shredder::ERASURE_BATCH_SIZE,
     },
-    solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
+    solana_sdk::{clock::Slot, packet::Packet, signature::Signature},
     static_assertions::const_assert_eq,
 };
 
@@ -26,7 +26,7 @@ pub enum ShredCode {
 }
 
 impl ShredCode {
-    pub(super) const SIZE_OF_PAYLOAD: usize = PACKET_DATA_SIZE - SIZE_OF_NONCE;
+    pub(super) const SIZE_OF_PAYLOAD: usize = Packet::DATA_SIZE - SIZE_OF_NONCE;
 
     dispatch!(fn coding_header(&self) -> &CodingShredHeader);
 

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -7,7 +7,7 @@ use {
     solana_metrics::inc_new_counter_debug,
     solana_perf::{
         cuda_runtime::PinnedVec,
-        packet::Batch,
+        packet::PacketBatch,
         perf_libs,
         recycler_cache::RecyclerCache,
         sigverify::{self, count_packets_in_batches, TxOffset},
@@ -66,7 +66,7 @@ pub fn verify_shred_cpu(
 }
 
 fn verify_shreds_cpu(
-    batches: &[Batch<{ Packet::DATA_SIZE }>],
+    batches: &[PacketBatch<{ Packet::DATA_SIZE }>],
     slot_leaders: &HashMap<Slot, /*pubkey:*/ [u8; 32]>,
 ) -> Vec<Vec<u8>> {
     let packet_count = count_packets_in_batches(batches);
@@ -87,7 +87,7 @@ fn verify_shreds_cpu(
 }
 
 fn slot_key_data_for_gpu<T>(
-    batches: &[Batch<{ Packet::DATA_SIZE }>],
+    batches: &[PacketBatch<{ Packet::DATA_SIZE }>],
     slot_keys: &HashMap<Slot, /*pubkey:*/ T>,
     recycler_cache: &RecyclerCache,
 ) -> (/*pubkeys:*/ PinnedVec<u8>, TxOffset)
@@ -191,7 +191,7 @@ fn get_merkle_roots(
 // Resizes the buffer to >= size and a multiple of
 // std::mem::size_of::<Packet>().
 fn resize_buffer(buffer: &mut PinnedVec<u8>, size: usize) {
-    //HACK: Pubkeys vector is passed along as a `Batch<Packet>` buffer to the GPU
+    //HACK: Pubkeys vector is passed along as a `PacketBatch` buffer to the GPU
     //TODO: GPU needs a more opaque interface, which can handle variable sized structures for data
     //Pad the Pubkeys buffer such that it is bigger than a buffer of Packet sized elems
     let num_packets = (size + std::mem::size_of::<Packet>() - 1) / std::mem::size_of::<Packet>();
@@ -211,7 +211,7 @@ fn elems_from_buffer(buffer: &PinnedVec<u8>) -> perf_libs::Elems {
 
 fn shred_gpu_offsets(
     offset: usize,
-    batches: &[Batch<{ Packet::DATA_SIZE }>],
+    batches: &[PacketBatch<{ Packet::DATA_SIZE }>],
     merkle_roots_offsets: impl IntoIterator<Item = Option<usize>>,
     recycler_cache: &RecyclerCache,
 ) -> (TxOffset, TxOffset, TxOffset) {
@@ -253,7 +253,7 @@ fn shred_gpu_offsets(
 }
 
 pub fn verify_shreds_gpu(
-    batches: &[Batch<{ Packet::DATA_SIZE }>],
+    batches: &[PacketBatch<{ Packet::DATA_SIZE }>],
     slot_leaders: &HashMap<Slot, /*pubkey:*/ [u8; 32]>,
     recycler_cache: &RecyclerCache,
 ) -> Vec<Vec<u8>> {
@@ -262,7 +262,7 @@ pub fn verify_shreds_gpu(
         Some(api) => api,
     };
     let (pubkeys, pubkey_offsets) = slot_key_data_for_gpu(batches, slot_leaders, recycler_cache);
-    //HACK: Pubkeys vector is passed along as a `Batch<Packet>` buffer to the GPU
+    //HACK: Pubkeys vector is passed along as a `PacketBatch` buffer to the GPU
     //TODO: GPU needs a more opaque interface, which can handle variable sized structures for data
     let (merkle_roots, merkle_roots_offsets) = get_merkle_roots(batches, recycler_cache);
     // Merkle roots are placed after pubkeys; adjust offsets accordingly.
@@ -335,7 +335,7 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
     packet.buffer_mut()[sig].copy_from_slice(signature.as_ref());
 }
 
-pub fn sign_shreds_cpu(keypair: &Keypair, batches: &mut [Batch<{ Packet::DATA_SIZE }>]) {
+pub fn sign_shreds_cpu(keypair: &Keypair, batches: &mut [PacketBatch<{ Packet::DATA_SIZE }>]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("CPU SHRED ECDSA for {}", packet_count);
     SIGVERIFY_THREAD_POOL.install(|| {
@@ -368,7 +368,7 @@ pub fn sign_shreds_gpu_pinned_keypair(keypair: &Keypair, cache: &RecyclerCache) 
 pub fn sign_shreds_gpu(
     keypair: &Keypair,
     pinned_keypair: &Option<Arc<PinnedVec<u8>>>,
-    batches: &mut [Batch<{ Packet::DATA_SIZE }>],
+    batches: &mut [PacketBatch<{ Packet::DATA_SIZE }>],
     recycler_cache: &RecyclerCache,
 ) {
     let sig_size = size_of::<Signature>();
@@ -533,7 +533,7 @@ mod tests {
 
     fn run_test_sigverify_shreds_cpu(slot: Slot) {
         solana_logger::setup();
-        let mut batches = [Batch::<{ Packet::DATA_SIZE }>::default()];
+        let mut batches = [PacketBatch::<{ Packet::DATA_SIZE }>::default()];
         let mut shred = Shred::new_from_data(
             slot,
             0xc0de,
@@ -587,7 +587,7 @@ mod tests {
         solana_logger::setup();
         let recycler_cache = RecyclerCache::default();
 
-        let mut batches = [Batch::<{ Packet::DATA_SIZE }>::default()];
+        let mut batches = [PacketBatch::<{ Packet::DATA_SIZE }>::default()];
         let mut shred = Shred::new_from_data(
             slot,
             0xc0de,
@@ -652,7 +652,7 @@ mod tests {
 
         let num_packets = 32;
         let num_batches = 100;
-        let mut packet_batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets);
+        let mut packet_batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets);
         packet_batch.resize(num_packets, Packet::default());
 
         for (i, p) in packet_batch.iter_mut().enumerate() {
@@ -699,7 +699,7 @@ mod tests {
     fn run_test_sigverify_shreds_sign_cpu(slot: Slot) {
         solana_logger::setup();
 
-        let mut batches = [Batch::<{ Packet::DATA_SIZE }>::default()];
+        let mut batches = [PacketBatch::<{ Packet::DATA_SIZE }>::default()];
         let keypair = Keypair::new();
         let shred = Shred::new_from_data(
             slot,

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -37,7 +37,7 @@ pub fn verify_shred_cpu(
     packet: &Packet,
     slot_leaders: &HashMap<Slot, /*pubkey:*/ [u8; 32]>,
 ) -> bool {
-    if packet.meta().discard() {
+    if packet.meta.discard() {
         return false;
     }
     let shred = match shred::layout::get_shred(packet) {
@@ -101,7 +101,7 @@ where
             .into_par_iter()
             .flat_map_iter(|batch| {
                 batch.iter().map(|packet| {
-                    if packet.meta().discard() {
+                    if packet.meta.discard() {
                         return Slot::MAX;
                     }
                     let shred = shred::layout::get_shred(packet);
@@ -327,7 +327,7 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
         .and_then(shred::layout::get_signed_data)
         .unwrap();
     assert!(
-        packet.meta().size >= sig.end,
+        packet.meta.size >= sig.end,
         "packet is not large enough for a signature"
     );
     let signature = keypair.sign_message(msg.as_ref());
@@ -507,7 +507,7 @@ mod tests {
         shred.sign(&keypair);
         trace!("signature {}", shred.signature());
         packet.buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        packet.meta_mut().size = shred.payload().len();
+        packet.meta.size = shred.payload().len();
 
         let leader_slots = [(slot, keypair.pubkey().to_bytes())]
             .iter()
@@ -548,7 +548,7 @@ mod tests {
         shred.sign(&keypair);
         batches[0].resize(1, Packet::default());
         batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batches[0][0].meta.size = shred.payload().len();
 
         let leader_slots = [(slot, keypair.pubkey().to_bytes())]
             .iter()
@@ -573,7 +573,7 @@ mod tests {
             .iter()
             .cloned()
             .collect();
-        batches[0][0].meta_mut().size = 0;
+        batches[0][0].meta.size = 0;
         let rv = verify_shreds_cpu(&batches, &leader_slots);
         assert_eq!(rv, vec![vec![0]]);
     }
@@ -602,7 +602,7 @@ mod tests {
         shred.sign(&keypair);
         batches[0].resize(1, Packet::default());
         batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batches[0][0].meta.size = shred.payload().len();
 
         let leader_slots = [
             (std::u64::MAX, Pubkey::default().to_bytes()),
@@ -629,7 +629,7 @@ mod tests {
         let rv = verify_shreds_gpu(&batches, &leader_slots, &recycler_cache);
         assert_eq!(rv, vec![vec![0]]);
 
-        batches[0][0].meta_mut().size = 0;
+        batches[0][0].meta.size = 0;
         let leader_slots = [
             (std::u64::MAX, Pubkey::default().to_bytes()),
             (slot, keypair.pubkey().to_bytes()),
@@ -713,7 +713,7 @@ mod tests {
         );
         batches[0].resize(1, Packet::default());
         batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batches[0][0].meta.size = shred.payload().len();
 
         let pubkeys = [
             (slot, keypair.pubkey().to_bytes()),

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -148,7 +148,7 @@ where
 
 // Recovers merkle roots from shreds binary.
 fn get_merkle_roots(
-    packets: &[PacketBatch],
+    packets: &[PacketBatch<{ Packet::DATA_SIZE }>],
     recycler_cache: &RecyclerCache,
 ) -> (
     PinnedVec<u8>,      // Merkle roots
@@ -159,7 +159,7 @@ fn get_merkle_roots(
             .par_iter()
             .flat_map(|packets| {
                 packets.par_iter().map(|packet| {
-                    if packet.meta().discard() {
+                    if packet.meta.discard() {
                         return None;
                     }
                     let shred = shred::layout::get_shred(packet)?;
@@ -814,7 +814,10 @@ mod tests {
         shreds
     }
 
-    fn make_packets<R: Rng>(rng: &mut R, shreds: &[Shred]) -> Vec<PacketBatch> {
+    fn make_packets<R: Rng>(
+        rng: &mut R,
+        shreds: &[Shred],
+    ) -> Vec<PacketBatch<{ Packet::DATA_SIZE }>> {
         let mut packets = shreds.iter().map(|shred| {
             let mut packet = Packet::default();
             shred.copy_to_packet(&mut packet);

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -6,9 +6,10 @@ extern crate test;
 use {
     rand::prelude::*,
     solana_perf::{
-        packet::{to_packet_batches, PacketBatch},
+        packet::{to_packet_batches, Batch},
         sigverify,
     },
+    solana_sdk::packet::{BasePacket, Packet},
     std::time::Duration,
     test::Bencher,
 };
@@ -22,7 +23,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) {
+fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<Batch<Packet>>) {
     // verify packets
     let mut deduper = sigverify::Deduper::new(1_000_000, Duration::from_millis(2_000));
     bencher.iter(|| {

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -6,7 +6,7 @@ extern crate test;
 use {
     rand::prelude::*,
     solana_perf::{
-        packet::{to_packet_batches, Batch},
+        packet::{to_packet_batches, PacketBatch},
         sigverify,
     },
     solana_sdk::packet::Packet,
@@ -23,7 +23,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_dedup_packets<const N: usize>(bencher: &mut Bencher, mut batches: Vec<Batch<N>>) {
+fn do_bench_dedup_packets<const N: usize>(bencher: &mut Bencher, mut batches: Vec<PacketBatch<N>>) {
     // verify packets
     let mut deduper = sigverify::Deduper::new(1_000_000, Duration::from_millis(2_000));
     bencher.iter(|| {

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -31,7 +31,7 @@ fn do_bench_dedup_packets<const N: usize>(bencher: &mut Bencher, mut batches: Ve
         deduper.reset();
         batches
             .iter_mut()
-            .for_each(|b| b.iter_mut().for_each(|p| p.meta_mut().set_discard(false)));
+            .for_each(|b| b.iter_mut().for_each(|p| p.meta.set_discard(false)));
     });
 }
 

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -9,7 +9,7 @@ use {
         packet::{to_packet_batches, Batch},
         sigverify,
     },
-    solana_sdk::packet::{BasePacket, Packet},
+    solana_sdk::packet::Packet,
     std::time::Duration,
     test::Bencher,
 };
@@ -23,7 +23,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<Batch<Packet>>) {
+fn do_bench_dedup_packets<const N: usize>(bencher: &mut Bencher, mut batches: Vec<Batch<N>>) {
     // verify packets
     let mut deduper = sigverify::Deduper::new(1_000_000, Duration::from_millis(2_000));
     bencher.iter(|| {
@@ -41,7 +41,7 @@ fn bench_dedup_same_small_packets(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
     let small_packet = test_packet_with_size(128, &mut rng);
 
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(
         &std::iter::repeat(small_packet)
             .take(NUM)
             .collect::<Vec<_>>(),
@@ -57,7 +57,7 @@ fn bench_dedup_same_big_packets(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
     let big_packet = test_packet_with_size(1024, &mut rng);
 
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(
         &std::iter::repeat(big_packet).take(NUM).collect::<Vec<_>>(),
         128,
     );
@@ -70,7 +70,7 @@ fn bench_dedup_same_big_packets(bencher: &mut Bencher) {
 fn bench_dedup_diff_small_packets(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
 
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(
         &(0..NUM)
             .map(|_| test_packet_with_size(128, &mut rng))
             .collect::<Vec<_>>(),
@@ -85,7 +85,7 @@ fn bench_dedup_diff_small_packets(bencher: &mut Bencher) {
 fn bench_dedup_diff_big_packets(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
 
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(
         &(0..NUM)
             .map(|_| test_packet_with_size(1024, &mut rng))
             .collect::<Vec<_>>(),
@@ -100,7 +100,7 @@ fn bench_dedup_diff_big_packets(bencher: &mut Bencher) {
 fn bench_dedup_baseline(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
 
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<{ Packet::DATA_SIZE }, _>(
         &(0..0)
             .map(|_| test_packet_with_size(128, &mut rng))
             .collect::<Vec<_>>(),

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -4,6 +4,7 @@ extern crate test;
 
 use {
     solana_perf::{discard::discard_batches_randomly, packet::to_packet_batches, test_tx::test_tx},
+    solana_sdk::packet::TransactionPacket,
     test::Bencher,
 };
 
@@ -16,7 +17,7 @@ fn bench_discard(bencher: &mut Bencher) {
     let num_packets = NUM;
 
     // generate packet vector
-    let batches = to_packet_batches(
+    let batches = to_packet_batches::<TransactionPacket, _>(
         &std::iter::repeat(tx).take(num_packets).collect::<Vec<_>>(),
         10,
     );

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -17,7 +17,7 @@ fn bench_discard(bencher: &mut Bencher) {
     let num_packets = NUM;
 
     // generate packet vector
-    let batches = to_packet_batches::<TransactionPacket, _>(
+    let batches = to_packet_batches::<{ TransactionPacket::DATA_SIZE }, _>(
         &std::iter::repeat(tx).take(num_packets).collect::<Vec<_>>(),
         10,
     );

--- a/perf/benches/recycler.rs
+++ b/perf/benches/recycler.rs
@@ -3,7 +3,8 @@
 extern crate test;
 
 use {
-    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
+    solana_perf::{packet::BatchRecycler, recycler::Recycler},
+    solana_sdk::packet::Packet,
     test::Bencher,
 };
 
@@ -11,7 +12,7 @@ use {
 fn bench_recycler(bencher: &mut Bencher) {
     solana_logger::setup();
 
-    let recycler: PacketBatchRecycler = Recycler::default();
+    let recycler: BatchRecycler<Packet> = Recycler::default();
 
     for _ in 0..1000 {
         let _packet = recycler.allocate("");

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -6,7 +6,7 @@ extern crate test;
 use {
     rand::prelude::*,
     solana_perf::{
-        packet::{to_packet_batches, Batch, PACKETS_PER_BATCH},
+        packet::{to_packet_batches, PacketBatch, PACKETS_PER_BATCH},
         sigverify,
     },
     solana_sdk::packet::Packet,
@@ -22,7 +22,10 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<Batch<{ Packet::DATA_SIZE }>>) {
+fn do_bench_shrink_packets(
+    bencher: &mut Bencher,
+    mut batches: Vec<PacketBatch<{ Packet::DATA_SIZE }>>,
+) {
     // verify packets
     bencher.iter(|| {
         sigverify::shrink_batches(&mut batches);

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -9,7 +9,7 @@ use {
         packet::{to_packet_batches, Batch, PACKETS_PER_BATCH},
         sigverify,
     },
-    solana_sdk::packet::{BasePacket, Packet},
+    solana_sdk::packet::Packet,
     test::Bencher,
 };
 
@@ -22,7 +22,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<Batch<Packet>>) {
+fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<Batch<{ Packet::DATA_SIZE }>>) {
     // verify packets
     bencher.iter(|| {
         sigverify::shrink_batches(&mut batches);

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -6,9 +6,10 @@ extern crate test;
 use {
     rand::prelude::*,
     solana_perf::{
-        packet::{to_packet_batches, PacketBatch, PACKETS_PER_BATCH},
+        packet::{to_packet_batches, Batch, PACKETS_PER_BATCH},
         sigverify,
     },
+    solana_sdk::packet::{BasePacket, Packet},
     test::Bencher,
 };
 
@@ -21,7 +22,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
         .collect()
 }
 
-fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) {
+fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<Batch<Packet>>) {
     // verify packets
     bencher.iter(|| {
         sigverify::shrink_batches(&mut batches);
@@ -75,7 +76,7 @@ fn bench_shrink_count_packets(bencher: &mut Bencher) {
     );
     batches.iter_mut().for_each(|b| {
         b.iter_mut()
-            .for_each(|p| p.meta_mut().set_discard(thread_rng().gen()))
+            .for_each(|p: &mut Packet| p.meta_mut().set_discard(thread_rng().gen()))
     });
 
     bencher.iter(|| {

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -28,7 +28,7 @@ fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<Batch<{ Packe
         sigverify::shrink_batches(&mut batches);
         batches.iter_mut().for_each(|b| {
             b.iter_mut()
-                .for_each(|p| p.meta_mut().set_discard(thread_rng().gen()))
+                .for_each(|p| p.meta.set_discard(thread_rng().gen()))
         });
     });
 }
@@ -76,7 +76,7 @@ fn bench_shrink_count_packets(bencher: &mut Bencher) {
     );
     batches.iter_mut().for_each(|b| {
         b.iter_mut()
-            .for_each(|p: &mut Packet| p.meta_mut().set_discard(thread_rng().gen()))
+            .for_each(|p: &mut Packet| p.meta.set_discard(thread_rng().gen()))
     });
 
     bencher.iter(|| {

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -6,11 +6,12 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     solana_perf::{
-        packet::{to_packet_batches, Packet, PacketBatch},
+        packet::{to_packet_batches, Batch},
         recycler::Recycler,
         sigverify,
         test_tx::{test_multisig_tx, test_tx},
     },
+    solana_sdk::packet::{BasePacket, Packet},
     test::Bencher,
 };
 
@@ -40,7 +41,7 @@ fn gen_batches(
     use_same_tx: bool,
     packets_per_batch: usize,
     total_packets: usize,
-) -> Vec<PacketBatch> {
+) -> Vec<Batch<Packet>> {
     if use_same_tx {
         let tx = test_tx();
         to_packet_batches(&vec![tx; total_packets], packets_per_batch)
@@ -145,7 +146,7 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
             len -= current_packets - num_packets;
             current_packets = num_packets;
         }
-        let mut batch = PacketBatch::with_capacity(len);
+        let mut batch = Batch::<Packet>::with_capacity(len);
         batch.resize(len, Packet::default());
         for packet in batch.iter_mut() {
             if thread_rng().gen_ratio(1, 2) {

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -24,7 +24,7 @@ fn bench_sigverify_simple(bencher: &mut Bencher) {
     let num_packets = NUM;
 
     // generate packet vector
-    let mut batches = to_packet_batches(
+    let mut batches = to_packet_batches::<Packet, _>(
         &std::iter::repeat(tx).take(num_packets).collect::<Vec<_>>(),
         128,
     );
@@ -37,19 +37,19 @@ fn bench_sigverify_simple(bencher: &mut Bencher) {
     })
 }
 
-fn gen_batches(
+fn gen_batches<P: BasePacket>(
     use_same_tx: bool,
     packets_per_batch: usize,
     total_packets: usize,
-) -> Vec<Batch<Packet>> {
+) -> Vec<Batch<P>> {
     if use_same_tx {
         let tx = test_tx();
-        to_packet_batches(&vec![tx; total_packets], packets_per_batch)
+        to_packet_batches::<P, _>(&vec![tx; total_packets], packets_per_batch)
     } else {
         let txs: Vec<_> = std::iter::repeat_with(test_tx)
             .take(total_packets)
             .collect();
-        to_packet_batches(&txs, packets_per_batch)
+        to_packet_batches::<P, _>(&txs, packets_per_batch)
     }
 }
 
@@ -57,7 +57,7 @@ fn gen_batches(
 #[ignore]
 fn bench_sigverify_low_packets_small_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD - 1;
-    let mut batches = gen_batches(false, 1, num_packets);
+    let mut batches = gen_batches::<Packet>(false, 1, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     bencher.iter(|| {
@@ -69,7 +69,7 @@ fn bench_sigverify_low_packets_small_batch(bencher: &mut Bencher) {
 #[ignore]
 fn bench_sigverify_low_packets_large_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD - 1;
-    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
+    let mut batches = gen_batches::<Packet>(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     bencher.iter(|| {
@@ -81,7 +81,7 @@ fn bench_sigverify_low_packets_large_batch(bencher: &mut Bencher) {
 #[ignore]
 fn bench_sigverify_medium_packets_small_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 8;
-    let mut batches = gen_batches(false, 1, num_packets);
+    let mut batches = gen_batches::<Packet>(false, 1, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     bencher.iter(|| {
@@ -93,7 +93,7 @@ fn bench_sigverify_medium_packets_small_batch(bencher: &mut Bencher) {
 #[ignore]
 fn bench_sigverify_medium_packets_large_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 8;
-    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
+    let mut batches = gen_batches::<Packet>(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     bencher.iter(|| {
@@ -105,7 +105,7 @@ fn bench_sigverify_medium_packets_large_batch(bencher: &mut Bencher) {
 #[ignore]
 fn bench_sigverify_high_packets_small_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 32;
-    let mut batches = gen_batches(false, 1, num_packets);
+    let mut batches = gen_batches::<Packet>(false, 1, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     bencher.iter(|| {
@@ -117,7 +117,7 @@ fn bench_sigverify_high_packets_small_batch(bencher: &mut Bencher) {
 #[ignore]
 fn bench_sigverify_high_packets_large_batch(bencher: &mut Bencher) {
     let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 32;
-    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
+    let mut batches = gen_batches::<Packet>(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     // verify packets
@@ -179,7 +179,7 @@ fn bench_get_offsets(bencher: &mut Bencher) {
 
     // generate packet vector
     let mut batches =
-        to_packet_batches(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 1024);
+        to_packet_batches::<Packet, _>(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 1024);
 
     let recycler = Recycler::default();
     // verify packets

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -159,7 +159,7 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
             };
             Packet::populate_packet(packet, None, &tx).expect("serialize request");
             if thread_rng().gen_ratio((num_packets - NUM) as u32, num_packets as u32) {
-                packet.meta_mut().set_discard(true);
+                packet.meta.set_discard(true);
             } else {
                 num_valid += 1;
             }

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     solana_perf::{
-        packet::{to_packet_batches, Batch},
+        packet::{to_packet_batches, PacketBatch},
         recycler::Recycler,
         sigverify,
         test_tx::{test_multisig_tx, test_tx},
@@ -41,7 +41,7 @@ fn gen_batches<const N: usize>(
     use_same_tx: bool,
     packets_per_batch: usize,
     total_packets: usize,
-) -> Vec<Batch<N>> {
+) -> Vec<PacketBatch<N>> {
     if use_same_tx {
         let tx = test_tx();
         to_packet_batches::<N, _>(&vec![tx; total_packets], packets_per_batch)
@@ -149,7 +149,7 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
             len -= current_packets - num_packets;
             current_packets = num_packets;
         }
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(len);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(len);
         batch.resize(len, Packet::default());
         for packet in batch.iter_mut() {
             if thread_rng().gen_ratio(1, 2) {

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -1,11 +1,11 @@
 use {
     crate::packet::Batch,
     rand::{thread_rng, Rng},
-    solana_sdk::packet::Packet,
+    solana_sdk::packet::BasePacket,
 };
 
-pub fn discard_batches_randomly(
-    batches: &mut Vec<Batch<Packet>>,
+pub fn discard_batches_randomly<P: BasePacket>(
+    batches: &mut Vec<Batch<P>>,
     max_packets: usize,
     mut total_packets: usize,
 ) -> usize {

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -1,11 +1,10 @@
 use {
     crate::packet::Batch,
     rand::{thread_rng, Rng},
-    solana_sdk::packet::BasePacket,
 };
 
-pub fn discard_batches_randomly<P: BasePacket>(
-    batches: &mut Vec<Batch<P>>,
+pub fn discard_batches_randomly<const N: usize>(
+    batches: &mut Vec<Batch<N>>,
     max_packets: usize,
     mut total_packets: usize,
 ) -> usize {
@@ -24,7 +23,7 @@ mod tests {
     #[test]
     fn test_batch_discard_random() {
         solana_logger::setup();
-        let mut batch = Batch::<Packet>::default();
+        let mut batch = Batch::<{ Packet::DATA_SIZE }>::default();
         batch.resize(1, Packet::default());
         let num_batches = 100;
         let mut batches = vec![batch; num_batches];

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -1,10 +1,11 @@
 use {
-    crate::packet::PacketBatch,
+    crate::packet::Batch,
     rand::{thread_rng, Rng},
+    solana_sdk::packet::Packet,
 };
 
 pub fn discard_batches_randomly(
-    batches: &mut Vec<PacketBatch>,
+    batches: &mut Vec<Batch<Packet>>,
     max_packets: usize,
     mut total_packets: usize,
 ) -> usize {
@@ -23,7 +24,7 @@ mod tests {
     #[test]
     fn test_batch_discard_random() {
         solana_logger::setup();
-        let mut batch = PacketBatch::default();
+        let mut batch = Batch::<Packet>::default();
         batch.resize(1, Packet::default());
         let num_batches = 100;
         let mut batches = vec![batch; num_batches];

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -1,10 +1,10 @@
 use {
-    crate::packet::Batch,
+    crate::packet::PacketBatch,
     rand::{thread_rng, Rng},
 };
 
 pub fn discard_batches_randomly<const N: usize>(
-    batches: &mut Vec<Batch<N>>,
+    batches: &mut Vec<PacketBatch<N>>,
     max_packets: usize,
     mut total_packets: usize,
 ) -> usize {
@@ -23,7 +23,7 @@ mod tests {
     #[test]
     fn test_batch_discard_random() {
         solana_logger::setup();
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::default();
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::default();
         batch.resize(1, Packet::default());
         let num_batches = 100;
         let mut batches = vec![batch; num_batches];

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -122,7 +122,7 @@ impl<const N: usize> Batch<N> {
 
     pub fn set_addr(&mut self, addr: &SocketAddr) {
         for p in self.iter_mut() {
-            p.meta_mut().set_socket_addr(addr);
+            p.meta.set_socket_addr(addr);
         }
     }
 

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -191,7 +191,9 @@ impl<T: Default + Reset> RecyclerX<T> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::packet::PacketBatchRecycler, std::iter::repeat_with};
+    use {
+        super::*, crate::packet::BatchRecycler, solana_sdk::packet::Packet, std::iter::repeat_with,
+    };
 
     impl Reset for u64 {
         fn reset(&mut self) {
@@ -218,7 +220,7 @@ mod tests {
     #[test]
     fn test_recycler_shrink() {
         let mut rng = rand::thread_rng();
-        let recycler = PacketBatchRecycler::default();
+        let recycler = BatchRecycler::<Packet>::default();
         // Allocate a burst of packets.
         const NUM_PACKETS: usize = RECYCLER_SHRINK_SIZE * 2;
         {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -122,7 +122,7 @@ pub fn init() {
 #[must_use]
 fn verify_packet<const N: usize>(packet: &mut GenericPacket<N>, reject_non_vote: bool) -> bool {
     // If this packet was already marked as discard, drop it
-    if packet.meta().discard() {
+    if packet.meta.discard() {
         return false;
     }
 
@@ -135,7 +135,7 @@ fn verify_packet<const N: usize>(packet: &mut GenericPacket<N>, reject_non_vote:
         return false;
     }
 
-    if packet.meta().size <= msg_start {
+    if packet.meta.size <= msg_start {
         return false;
     }
 
@@ -180,7 +180,7 @@ pub fn count_valid_packets<const N: usize>(
             batch
                 .iter()
                 .filter(|p| {
-                    let should_keep = !p.meta().discard();
+                    let should_keep = !p.meta.discard();
                     if should_keep {
                         process_valid_packet(p);
                     }
@@ -194,7 +194,7 @@ pub fn count_valid_packets<const N: usize>(
 pub fn count_discarded_packets<const N: usize>(batches: &[Batch<N>]) -> usize {
     batches
         .iter()
-        .map(|batch| batch.iter().filter(|p| p.meta().discard()).count())
+        .map(|batch| batch.iter().filter(|p| p.meta.discard()).count())
         .sum()
 }
 
@@ -206,7 +206,7 @@ fn do_get_packet_offsets<const N: usize>(
     // should have at least 1 signature and sig lengths
     let _ = 1usize
         .checked_add(size_of::<Signature>())
-        .filter(|v| *v <= packet.meta().size)
+        .filter(|v| *v <= packet.meta.size)
         .ok_or(PacketError::InvalidLen)?;
 
     // read the length of Transaction.signatures (serialized with short_vec)
@@ -224,7 +224,7 @@ fn do_get_packet_offsets<const N: usize>(
     // Determine the start of the message header by checking the message prefix bit.
     let msg_header_offset = {
         // Packet should have data for prefix bit
-        if msg_start_offset >= packet.meta().size {
+        if msg_start_offset >= packet.meta.size {
             return Err(PacketError::InvalidSignatureLen);
         }
 
@@ -259,7 +259,7 @@ fn do_get_packet_offsets<const N: usize>(
     // Packet should have data at least for MessageHeader and 1 byte for Message.account_keys.len
     let _ = msg_header_offset_plus_one
         .checked_add(MESSAGE_HEADER_LENGTH)
-        .filter(|v| *v <= packet.meta().size)
+        .filter(|v| *v <= packet.meta.size)
         .ok_or(PacketError::InvalidSignatureLen)?;
 
     // read MessageHeader.num_required_signatures (serialized with u8)
@@ -299,7 +299,7 @@ fn do_get_packet_offsets<const N: usize>(
     let _ = pubkey_len
         .checked_mul(size_of::<Pubkey>())
         .and_then(|v| v.checked_add(pubkey_start))
-        .filter(|v| *v <= packet.meta().size)
+        .filter(|v| *v <= packet.meta.size)
         .ok_or(PacketError::InvalidPubkeyLen)?;
 
     if pubkey_len < sig_len_untrusted {
@@ -334,7 +334,7 @@ pub fn check_for_tracer_packet<const N: usize>(packet: &mut GenericPacket<N>) ->
     // Check for tracer pubkey
     match packet.data(first_pubkey_start..first_pubkey_end) {
         Some(pubkey) if pubkey == TRACER_KEY.as_ref() => {
-            packet.meta_mut().set_tracer(true);
+            packet.meta.set_tracer(true);
             true
         }
         _ => false,
@@ -349,7 +349,7 @@ fn get_packet_offsets<const N: usize>(
     let unsanitized_packet_offsets = do_get_packet_offsets(packet, current_offset);
     if let Ok(offsets) = unsanitized_packet_offsets {
         check_for_simple_vote_transaction(packet, &offsets, current_offset).ok();
-        if !reject_non_vote || packet.meta().is_simple_vote_tx() {
+        if !reject_non_vote || packet.meta.is_simple_vote_tx() {
             return offsets;
         }
     }
@@ -381,7 +381,7 @@ fn check_for_simple_vote_transaction<const N: usize>(
     // Packet should have at least 1 more byte for instructions.len
     let _ = instructions_len_offset
         .checked_add(1usize)
-        .filter(|v| *v <= packet.meta().size)
+        .filter(|v| *v <= packet.meta.size)
         .ok_or(PacketError::InvalidLen)?;
 
     let (instruction_len, instruction_len_size) = packet
@@ -400,7 +400,7 @@ fn check_for_simple_vote_transaction<const N: usize>(
     // Packet should have at least 1 more byte for one instructions_program_id
     let _ = instruction_start
         .checked_add(1usize)
-        .filter(|v| *v <= packet.meta().size)
+        .filter(|v| *v <= packet.meta.size)
         .ok_or(PacketError::InvalidLen)?;
 
     let instruction_program_id_index: usize = usize::from(
@@ -426,7 +426,7 @@ fn check_for_simple_vote_transaction<const N: usize>(
         .ok_or(PacketError::InvalidLen)?
         == solana_sdk::vote::program::id().as_ref()
     {
-        packet.meta_mut().flags |= PacketFlags::SIMPLE_VOTE_TX;
+        packet.meta.flags |= PacketFlags::SIMPLE_VOTE_TX;
     }
     Ok(())
 }
@@ -459,7 +459,7 @@ pub fn generate_offsets<const N: usize>(
 
                     let mut pubkey_offset = packet_offsets.pubkey_start;
                     let mut sig_offset = packet_offsets.sig_start;
-                    let msg_size = current_offset.saturating_add(packet.meta().size) as u32;
+                    let msg_size = current_offset.saturating_add(packet.meta.size) as u32;
                     for _ in 0..packet_offsets.sig_len {
                         signature_offsets.push(sig_offset);
                         sig_offset = sig_offset.saturating_add(size_of::<Signature>() as u32);
@@ -537,7 +537,7 @@ impl Deduper {
     // Deduplicates packets and returns 1 if packet is to be discarded. Else, 0.
     fn dedup_packet<const N: usize>(&self, packet: &mut GenericPacket<N>) -> u64 {
         // If this packet was already marked as discard, drop it
-        if packet.meta().discard() {
+        if packet.meta.discard() {
             return 1;
         }
         let (hash, pos) = self.compute_hash(packet);
@@ -549,7 +549,7 @@ impl Deduper {
             self.filter[pos].store(hash, Ordering::Relaxed);
         }
         if hash == prev & hash {
-            packet.meta_mut().set_discard(true);
+            packet.meta.set_discard(true);
             return 1;
         }
         0
@@ -563,7 +563,7 @@ impl Deduper {
         let mut num_removed: u64 = 0;
         batches.iter_mut().for_each(|batch| {
             batch.iter_mut().for_each(|p| {
-                let removed_before_sigverify = p.meta().discard();
+                let removed_before_sigverify = p.meta.discard();
                 let is_duplicate = self.dedup_packet(p);
                 if is_duplicate == 1 {
                     saturating_add_assign!(num_removed, 1);
@@ -582,17 +582,17 @@ pub fn shrink_batches<const N: usize>(batches: &mut Vec<Batch<N>>) {
     let mut last_valid_batch = 0;
     for batch_ix in 0..batches.len() {
         for packet_ix in 0..batches[batch_ix].len() {
-            if batches[batch_ix][packet_ix].meta().discard() {
+            if batches[batch_ix][packet_ix].meta.discard() {
                 continue;
             }
             last_valid_batch = batch_ix.saturating_add(1);
             let mut found_spot = false;
             while valid_batch_ix < batch_ix && !found_spot {
                 while valid_packet_ix < batches[valid_batch_ix].len() {
-                    if batches[valid_batch_ix][valid_packet_ix].meta().discard() {
+                    if batches[valid_batch_ix][valid_packet_ix].meta.discard() {
                         batches[valid_batch_ix][valid_packet_ix] =
                             batches[batch_ix][packet_ix].clone();
-                        batches[batch_ix][packet_ix].meta_mut().set_discard(true);
+                        batches[batch_ix][packet_ix].meta.set_discard(true);
                         last_valid_batch = valid_batch_ix.saturating_add(1);
                         found_spot = true;
                         break;
@@ -622,8 +622,8 @@ pub fn ed25519_verify_cpu<const N: usize>(
         // When using single thread, skip rayon overhead.
         batches.iter_mut().for_each(|batch| {
             batch.iter_mut().for_each(|packet| {
-                if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
-                    packet.meta_mut().set_discard(true);
+                if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
+                    packet.meta.set_discard(true);
                 }
             })
         });
@@ -638,8 +638,8 @@ pub fn ed25519_verify_cpu<const N: usize>(
                 .into_par_iter()
                 .with_min_len(packets_per_thread)
                 .for_each(|packet: &mut GenericPacket<N>| {
-                    if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
-                        packet.meta_mut().set_discard(true);
+                    if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
+                        packet.meta.set_discard(true);
                     }
                 })
         });
@@ -650,8 +650,8 @@ pub fn ed25519_verify_cpu<const N: usize>(
                 batch
                     .par_iter_mut()
                     .for_each(|packet: &mut GenericPacket<N>| {
-                        if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
-                            packet.meta_mut().set_discard(true);
+                        if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
+                            packet.meta.set_discard(true);
                         }
                     })
             });
@@ -663,11 +663,9 @@ pub fn ed25519_verify_cpu<const N: usize>(
 pub fn ed25519_verify_disabled<const N: usize>(batches: &mut [Batch<N>]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("disabled ECDSA for {}", packet_count);
-    batches.into_par_iter().for_each(|batch| {
-        batch
-            .par_iter_mut()
-            .for_each(|p| p.meta_mut().set_discard(false))
-    });
+    batches
+        .into_par_iter()
+        .for_each(|batch| batch.par_iter_mut().for_each(|p| p.meta.set_discard(false)));
     inc_new_counter_debug!("ed25519_verify_disabled", packet_count);
 }
 
@@ -717,8 +715,8 @@ pub fn get_checked_scalar(scalar: &[u8; 32]) -> Result<[u8; 32], PacketError> {
 pub fn mark_disabled<const N: usize>(batches: &mut [Batch<N>], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (pkt, f) in batch.iter_mut().zip(v) {
-            if !pkt.meta().discard() {
-                pkt.meta_mut().set_discard(*f == 0);
+            if !pkt.meta.discard() {
+                pkt.meta.set_discard(*f == 0);
             }
         }
     }
@@ -880,10 +878,10 @@ mod tests {
         batch.resize(batch_size, Packet::default());
         let mut batches: Vec<Batch<{ Packet::DATA_SIZE }>> = vec![batch];
         mark_disabled(&mut batches, &[vec![0]]);
-        assert!(batches[0][0].meta().discard());
-        batches[0][0].meta_mut().set_discard(false);
+        assert!(batches[0][0].meta.discard());
+        batches[0][0].meta.set_discard(false);
         mark_disabled(&mut batches, &[vec![1]]);
-        assert!(!batches[0][0].meta().discard());
+        assert!(!batches[0][0].meta.discard());
     }
 
     #[test]
@@ -961,7 +959,7 @@ mod tests {
 
         packet.buffer_mut()[0] = 0xff;
         packet.buffer_mut()[1] = 0xff;
-        packet.meta_mut().size = 2;
+        packet.meta.size = 2;
 
         let res = sigverify::do_get_packet_offsets(&packet, 0);
         assert_eq!(res, Err(PacketError::InvalidLen));
@@ -983,10 +981,10 @@ mod tests {
 
         assert!(!verify_packet(&mut packet, false));
 
-        packet.meta_mut().set_discard(false);
+        packet.meta.set_discard(false);
         let mut batches = generate_packet_batches(&packet, 1, 1);
         ed25519_verify(&mut batches);
-        assert!(batches[0][0].meta().discard());
+        assert!(batches[0][0].meta.discard());
     }
 
     #[test]
@@ -1017,10 +1015,10 @@ mod tests {
 
         assert!(!verify_packet(&mut packet, false));
 
-        packet.meta_mut().set_discard(false);
+        packet.meta.set_discard(false);
         let mut batches = generate_packet_batches(&packet, 1, 1);
         ed25519_verify(&mut batches);
-        assert!(batches[0][0].meta().discard());
+        assert!(batches[0][0].meta.discard());
     }
 
     #[test]
@@ -1109,8 +1107,8 @@ mod tests {
         let msg_start = legacy_offsets.msg_start as usize;
         let msg_bytes = packet.data(msg_start..).unwrap().to_vec();
         packet.buffer_mut()[msg_start] = MESSAGE_VERSION_PREFIX;
-        packet.meta_mut().size += 1;
-        let msg_end = packet.meta().size;
+        packet.meta.size += 1;
+        let msg_end = packet.meta.size;
         packet.buffer_mut()[msg_start + 1..msg_end].copy_from_slice(&msg_bytes);
 
         let offsets = sigverify::do_get_packet_offsets(&packet, 0).unwrap();
@@ -1244,7 +1242,7 @@ mod tests {
         assert!(batches
             .iter()
             .flat_map(|batch| batch.iter())
-            .all(|p| p.meta().discard() == should_discard));
+            .all(|p| p.meta.discard() == should_discard));
     }
 
     fn ed25519_verify(batches: &mut [Batch<{ Packet::DATA_SIZE }>]) {
@@ -1268,7 +1266,7 @@ mod tests {
         assert!(batches
             .iter()
             .flat_map(|batch| batch.iter())
-            .all(|p| p.meta().discard()));
+            .all(|p| p.meta.discard()));
     }
 
     #[test]
@@ -1334,9 +1332,9 @@ mod tests {
             .zip(ref_vec.into_iter().flatten())
             .all(|(p, discard)| {
                 if discard == 0 {
-                    p.meta().discard()
+                    p.meta.discard()
                 } else {
-                    !p.meta().discard()
+                    !p.meta.discard()
                 }
             }));
     }
@@ -1358,7 +1356,7 @@ mod tests {
             for _ in 0..num_modifications {
                 let batch = thread_rng().gen_range(0, batches.len());
                 let packet = thread_rng().gen_range(0, batches[batch].len());
-                let offset = thread_rng().gen_range(0, batches[batch][packet].meta().size);
+                let offset = thread_rng().gen_range(0, batches[batch][packet].meta.size);
                 let add = thread_rng().gen_range(0, 255);
                 batches[batch][packet].buffer_mut()[offset] = batches[batch][packet]
                     .data(offset)
@@ -1368,7 +1366,7 @@ mod tests {
 
             let batch_to_disable = thread_rng().gen_range(0, batches.len());
             for p in batches[batch_to_disable].iter_mut() {
-                p.meta_mut().set_discard(true);
+                p.meta.set_discard(true);
             }
 
             // verify from GPU verification pipeline (when GPU verification is enabled) are
@@ -1481,7 +1479,7 @@ mod tests {
             let mut packet = Packet::from_data(None, tx).unwrap();
             let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
             check_for_simple_vote_transaction(&mut packet, &packet_offsets, 0).ok();
-            assert!(!packet.meta().is_simple_vote_tx());
+            assert!(!packet.meta.is_simple_vote_tx());
         }
 
         // single vote tx is
@@ -1491,7 +1489,7 @@ mod tests {
             let mut packet = Packet::from_data(None, tx).unwrap();
             let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
             check_for_simple_vote_transaction(&mut packet, &packet_offsets, 0).ok();
-            assert!(packet.meta().is_simple_vote_tx());
+            assert!(packet.meta.is_simple_vote_tx());
         }
 
         // multiple mixed tx is not
@@ -1512,7 +1510,7 @@ mod tests {
             let mut packet = Packet::from_data(None, tx).unwrap();
             let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
             check_for_simple_vote_transaction(&mut packet, &packet_offsets, 0).ok();
-            assert!(!packet.meta().is_simple_vote_tx());
+            assert!(!packet.meta.is_simple_vote_tx());
         }
     }
 
@@ -1530,9 +1528,9 @@ mod tests {
             let packet_offsets = do_get_packet_offsets(packet, current_offset).unwrap();
             check_for_simple_vote_transaction(packet, &packet_offsets, current_offset).ok();
             if index == 1 {
-                assert!(packet.meta().is_simple_vote_tx());
+                assert!(packet.meta.is_simple_vote_tx());
             } else {
-                assert!(!packet.meta().is_simple_vote_tx());
+                assert!(!packet.meta.is_simple_vote_tx());
             }
 
             current_offset = current_offset.saturating_add(size_of::<Packet>());
@@ -1623,13 +1621,13 @@ mod tests {
             );
             batches.iter_mut().for_each(|b| {
                 b.iter_mut()
-                    .for_each(|p| p.meta_mut().set_discard(thread_rng().gen()))
+                    .for_each(|p| p.meta.set_discard(thread_rng().gen()))
             });
             //find all the non discarded packets
             let mut start = vec![];
             batches.iter_mut().for_each(|b| {
                 b.iter_mut()
-                    .filter(|p| !p.meta().discard())
+                    .filter(|p| !p.meta.discard())
                     .for_each(|p| start.push(p.clone()))
             });
             start.sort_by(|a, b| a.data(..).cmp(&b.data(..)));
@@ -1641,7 +1639,7 @@ mod tests {
             let mut end = vec![];
             batches.iter_mut().for_each(|b| {
                 b.iter_mut()
-                    .filter(|p| !p.meta().discard())
+                    .filter(|p| !p.meta.discard())
                     .for_each(|p| end.push(p.clone()))
             });
             end.sort_by(|a, b| a.data(..).cmp(&b.data(..)));
@@ -1813,13 +1811,13 @@ mod tests {
             batches.iter_mut().enumerate().for_each(|(i, b)| {
                 b.iter_mut()
                     .enumerate()
-                    .for_each(|(j, p)| p.meta_mut().set_discard(set_discard(i, j)))
+                    .for_each(|(j, p)| p.meta.set_discard(set_discard(i, j)))
             });
             assert_eq!(count_valid_packets(&batches, |_| ()), *expect_valid_packets);
             debug!("show valid packets for case {}", i);
             batches.iter_mut().enumerate().for_each(|(i, b)| {
                 b.iter_mut().enumerate().for_each(|(j, p)| {
-                    if !p.meta().discard() {
+                    if !p.meta.discard() {
                         trace!("{} {}", i, j)
                     }
                 })

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -18,7 +18,7 @@ use {
     solana_sdk::{
         hash::Hash,
         message::{MESSAGE_HEADER_LENGTH, MESSAGE_VERSION_PREFIX},
-        packet::{BasePacket, Packet, PacketFlags},
+        packet::{BasePacket, PacketFlags},
         pubkey::Pubkey,
         saturating_add_assign,
         short_vec::decode_shortu16_len,

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -120,7 +120,7 @@ pub fn init() {
 /// Returns true if the signatrue on the packet verifies.
 /// Caller must do packet.set_discard(true) if this returns false.
 #[must_use]
-fn verify_packet(packet: &mut Packet, reject_non_vote: bool) -> bool {
+fn verify_packet<P: BasePacket>(packet: &mut P, reject_non_vote: bool) -> bool {
     // If this packet was already marked as discard, drop it
     if packet.meta().discard() {
         return false;
@@ -166,13 +166,13 @@ fn verify_packet(packet: &mut Packet, reject_non_vote: bool) -> bool {
     true
 }
 
-pub fn count_packets_in_batches(batches: &[Batch<Packet>]) -> usize {
+pub fn count_packets_in_batches<P: BasePacket>(batches: &[Batch<P>]) -> usize {
     batches.iter().map(|batch| batch.len()).sum()
 }
 
-pub fn count_valid_packets(
-    batches: &[Batch<Packet>],
-    mut process_valid_packet: impl FnMut(&Packet),
+pub fn count_valid_packets<P: BasePacket>(
+    batches: &[Batch<P>],
+    mut process_valid_packet: impl FnMut(&P),
 ) -> usize {
     batches
         .iter()
@@ -191,7 +191,7 @@ pub fn count_valid_packets(
         .sum()
 }
 
-pub fn count_discarded_packets(batches: &[Batch<Packet>]) -> usize {
+pub fn count_discarded_packets<P: BasePacket>(batches: &[Batch<P>]) -> usize {
     batches
         .iter()
         .map(|batch| batch.iter().filter(|p| p.meta().discard()).count())
@@ -199,8 +199,8 @@ pub fn count_discarded_packets(batches: &[Batch<Packet>]) -> usize {
 }
 
 // internal function to be unit-tested; should be used only by get_packet_offsets
-fn do_get_packet_offsets(
-    packet: &Packet,
+fn do_get_packet_offsets<P: BasePacket>(
+    packet: &P,
     current_offset: usize,
 ) -> Result<PacketOffsets, PacketError> {
     // should have at least 1 signature and sig lengths
@@ -325,7 +325,7 @@ fn do_get_packet_offsets(
     ))
 }
 
-pub fn check_for_tracer_packet(packet: &mut Packet) -> bool {
+pub fn check_for_tracer_packet<P: BasePacket>(packet: &mut P) -> bool {
     let first_pubkey_start: usize = TRACER_KEY_OFFSET_IN_TRANSACTION;
     let first_pubkey_end = match first_pubkey_start.checked_add(size_of::<Pubkey>()) {
         Some(offset) => offset,
@@ -341,8 +341,8 @@ pub fn check_for_tracer_packet(packet: &mut Packet) -> bool {
     }
 }
 
-fn get_packet_offsets(
-    packet: &mut Packet,
+fn get_packet_offsets<P: BasePacket>(
+    packet: &mut P,
     current_offset: usize,
     reject_non_vote: bool,
 ) -> PacketOffsets {
@@ -357,8 +357,8 @@ fn get_packet_offsets(
     PacketOffsets::new(0, 0, 0, 0, 0)
 }
 
-fn check_for_simple_vote_transaction(
-    packet: &mut Packet,
+fn check_for_simple_vote_transaction<P: BasePacket>(
+    packet: &mut P,
     packet_offsets: &PacketOffsets,
     current_offset: usize,
 ) -> Result<(), PacketError> {
@@ -431,8 +431,8 @@ fn check_for_simple_vote_transaction(
     Ok(())
 }
 
-pub fn generate_offsets(
-    batches: &mut [Batch<Packet>],
+pub fn generate_offsets<P: BasePacket>(
+    batches: &mut [Batch<P>],
     recycler: &Recycler<TxOffset>,
     reject_non_vote: bool,
 ) -> TxOffsets {
@@ -472,7 +472,7 @@ pub fn generate_offsets(
                         let msg_size = msg_size.saturating_sub(packet_offsets.msg_start);
                         msg_sizes.push(msg_size);
                     }
-                    current_offset = current_offset.saturating_add(size_of::<Packet>());
+                    current_offset = current_offset.saturating_add(size_of::<P>());
                     packet_offsets.sig_len
                 })
                 .collect()
@@ -525,7 +525,7 @@ impl Deduper {
     }
 
     /// Compute hash from packet data, returns (hash, bin_pos).
-    fn compute_hash(&self, packet: &Packet) -> (u64, usize) {
+    fn compute_hash<P: BasePacket>(&self, packet: &P) -> (u64, usize) {
         let mut hasher = AHasher::new_with_keys(self.seed.0, self.seed.1);
         hasher.write(packet.data(..).unwrap_or_default());
         let h = hasher.finish();
@@ -535,7 +535,7 @@ impl Deduper {
     }
 
     // Deduplicates packets and returns 1 if packet is to be discarded. Else, 0.
-    fn dedup_packet(&self, packet: &mut Packet) -> u64 {
+    fn dedup_packet<P: BasePacket>(&self, packet: &mut P) -> u64 {
         // If this packet was already marked as discard, drop it
         if packet.meta().discard() {
             return 1;
@@ -555,10 +555,10 @@ impl Deduper {
         0
     }
 
-    pub fn dedup_packets_and_count_discards(
+    pub fn dedup_packets_and_count_discards<P: BasePacket>(
         &self,
-        batches: &mut [Batch<Packet>],
-        mut process_received_packet: impl FnMut(&mut Packet, bool, bool),
+        batches: &mut [Batch<P>],
+        mut process_received_packet: impl FnMut(&mut P, bool, bool),
     ) -> u64 {
         let mut num_removed: u64 = 0;
         batches.iter_mut().for_each(|batch| {
@@ -576,7 +576,7 @@ impl Deduper {
 }
 
 //inplace shrink a batch of packets
-pub fn shrink_batches(batches: &mut Vec<Batch<Packet>>) {
+pub fn shrink_batches<P: BasePacket>(batches: &mut Vec<Batch<P>>) {
     let mut valid_batch_ix = 0;
     let mut valid_packet_ix = 0;
     let mut last_valid_batch = 0;
@@ -609,8 +609,8 @@ pub fn shrink_batches(batches: &mut Vec<Batch<Packet>>) {
     batches.truncate(last_valid_batch);
 }
 
-pub fn ed25519_verify_cpu(
-    batches: &mut [Batch<Packet>],
+pub fn ed25519_verify_cpu<P: BasePacket>(
+    batches: &mut [Batch<P>],
     reject_non_vote: bool,
     packet_count: usize,
 ) {
@@ -634,10 +634,10 @@ pub fn ed25519_verify_cpu(
             batches
                 .into_par_iter()
                 .flatten()
-                .collect::<Vec<&mut Packet>>()
+                .collect::<Vec<&mut P>>()
                 .into_par_iter()
                 .with_min_len(packets_per_thread)
-                .for_each(|packet: &mut Packet| {
+                .for_each(|packet: &mut P| {
                     if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
                         packet.meta_mut().set_discard(true);
                     }
@@ -646,21 +646,19 @@ pub fn ed25519_verify_cpu(
     } else {
         // When using all available threads, skip the overhead of flattening, collecting, etc.
         PAR_THREAD_POOL.install(|| {
-            batches
-                .into_par_iter()
-                .for_each(|batch: &mut Batch<Packet>| {
-                    batch.par_iter_mut().for_each(|packet: &mut Packet| {
-                        if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
-                            packet.meta_mut().set_discard(true);
-                        }
-                    })
-                });
+            batches.into_par_iter().for_each(|batch: &mut Batch<P>| {
+                batch.par_iter_mut().for_each(|packet: &mut P| {
+                    if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
+                        packet.meta_mut().set_discard(true);
+                    }
+                })
+            });
         });
     }
     inc_new_counter_debug!("ed25519_verify_cpu", packet_count);
 }
 
-pub fn ed25519_verify_disabled(batches: &mut [Batch<Packet>]) {
+pub fn ed25519_verify_disabled<P: BasePacket>(batches: &mut [Batch<P>]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("disabled ECDSA for {}", packet_count);
     batches.into_par_iter().for_each(|batch| {
@@ -714,7 +712,7 @@ pub fn get_checked_scalar(scalar: &[u8; 32]) -> Result<[u8; 32], PacketError> {
     Ok(out)
 }
 
-pub fn mark_disabled(batches: &mut [Batch<Packet>], r: &[Vec<u8>]) {
+pub fn mark_disabled<P: BasePacket>(batches: &mut [Batch<P>], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (pkt, f) in batch.iter_mut().zip(v) {
             if !pkt.meta().discard() {
@@ -724,8 +722,8 @@ pub fn mark_disabled(batches: &mut [Batch<Packet>], r: &[Vec<u8>]) {
     }
 }
 
-pub fn ed25519_verify(
-    batches: &mut [Batch<Packet>],
+pub fn ed25519_verify<P: BasePacket>(
+    batches: &mut [Batch<P>],
     recycler: &Recycler<TxOffset>,
     recycler_out: &Recycler<PinnedVec<u8>>,
     reject_non_vote: bool,
@@ -773,14 +771,14 @@ pub fn ed25519_verify(
     out.resize(signature_offsets.len(), 0);
     trace!("Starting verify num packets: {}", num_packets);
     trace!("elem len: {}", elems.len() as u32);
-    trace!("packet sizeof: {}", size_of::<Packet>() as u32);
+    trace!("packet sizeof: {}", size_of::<P>() as u32);
     trace!("len offset: {}", PACKET_DATA_SIZE as u32);
     const USE_NON_DEFAULT_STREAM: u8 = 1;
     unsafe {
         let res = (api.ed25519_verify_many)(
             elems.as_ptr(),
             elems.len() as u32,
-            size_of::<Packet>() as u32,
+            size_of::<P>() as u32,
             num_packets as u32,
             signature_offsets.len() as u32,
             msg_sizes.as_ptr(),
@@ -816,6 +814,7 @@ mod tests {
         solana_sdk::{
             instruction::CompiledInstruction,
             message::{Message, MessageHeader},
+            packet::TransactionPacket,
             signature::{Keypair, Signature, Signer},
             transaction::Transaction,
         },
@@ -1540,8 +1539,10 @@ mod tests {
     fn test_dedup_same() {
         let tx = test_tx();
 
-        let mut batches =
-            to_packet_batches(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 128);
+        let mut batches = to_packet_batches::<TransactionPacket, _>(
+            &std::iter::repeat(tx).take(1024).collect::<Vec<_>>(),
+            128,
+        );
         let packet_count = sigverify::count_packets_in_batches(&batches);
         let filter = Deduper::new(1_000_000, Duration::from_millis(0));
         let mut num_deduped = 0;
@@ -1558,7 +1559,10 @@ mod tests {
     #[test]
     fn test_dedup_diff() {
         let mut filter = Deduper::new(1_000_000, Duration::from_millis(0));
-        let mut batches = to_packet_batches(&(0..1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
+        let mut batches = to_packet_batches::<TransactionPacket, _>(
+            &(0..1024).map(|_| test_tx()).collect::<Vec<_>>(),
+            128,
+        );
         let discard = filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
         // because dedup uses a threadpool, there maybe up to N threads of txs that go through
         assert_eq!(discard, 0);
@@ -1575,8 +1579,10 @@ mod tests {
         let mut discard = 0;
         assert!(!filter.saturated.load(Ordering::Relaxed));
         for i in 0..1000 {
-            let mut batches =
-                to_packet_batches(&(0..1000).map(|_| test_tx()).collect::<Vec<_>>(), 128);
+            let mut batches = to_packet_batches::<TransactionPacket, _>(
+                &(0..1000).map(|_| test_tx()).collect::<Vec<_>>(),
+                128,
+            );
             discard += filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
             trace!("{} {}", i, discard);
             if filter.saturated.load(Ordering::Relaxed) {
@@ -1591,8 +1597,10 @@ mod tests {
         let filter = Deduper::new(1_000_000, Duration::from_millis(0));
         let mut discard = 0;
         for i in 0..10 {
-            let mut batches =
-                to_packet_batches(&(0..1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
+            let mut batches = to_packet_batches::<TransactionPacket, _>(
+                &(0..1024).map(|_| test_tx()).collect::<Vec<_>>(),
+                128,
+            );
             discard += filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
             debug!("false positive rate: {}/{}", discard, i * 1024);
         }
@@ -1646,7 +1654,7 @@ mod tests {
 
         // No batches
         // truncate of 1 on len 0 is a noop
-        shrink_batches(&mut Vec::new());
+        shrink_batches::<Packet>(&mut Vec::new());
         // One empty batch
         {
             let mut batches = vec![Batch::<Packet>::with_capacity(0)];
@@ -1792,7 +1800,7 @@ mod tests {
         let test_cases = set_discards.iter().zip(&expect_valids).enumerate();
         for (i, (set_discard, (expect_batch_count, expect_valid_packets))) in test_cases {
             debug!("test_shrink case: {}", i);
-            let mut batches = to_packet_batches(
+            let mut batches = to_packet_batches::<TransactionPacket, _>(
                 &(0..PACKET_COUNT).map(|_| test_tx()).collect::<Vec<_>>(),
                 PACKETS_PER_BATCH,
             );

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -6,7 +6,7 @@
 use {
     crate::{
         cuda_runtime::PinnedVec,
-        packet::{Batch, PACKET_DATA_SIZE},
+        packet::{PacketBatch, PACKET_DATA_SIZE},
         perf_libs,
         recycler::Recycler,
     },
@@ -166,12 +166,12 @@ fn verify_packet<const N: usize>(packet: &mut GenericPacket<N>, reject_non_vote:
     true
 }
 
-pub fn count_packets_in_batches<const N: usize>(batches: &[Batch<N>]) -> usize {
+pub fn count_packets_in_batches<const N: usize>(batches: &[PacketBatch<N>]) -> usize {
     batches.iter().map(|batch| batch.len()).sum()
 }
 
 pub fn count_valid_packets<const N: usize>(
-    batches: &[Batch<N>],
+    batches: &[PacketBatch<N>],
     mut process_valid_packet: impl FnMut(&GenericPacket<N>),
 ) -> usize {
     batches
@@ -191,7 +191,7 @@ pub fn count_valid_packets<const N: usize>(
         .sum()
 }
 
-pub fn count_discarded_packets<const N: usize>(batches: &[Batch<N>]) -> usize {
+pub fn count_discarded_packets<const N: usize>(batches: &[PacketBatch<N>]) -> usize {
     batches
         .iter()
         .map(|batch| batch.iter().filter(|p| p.meta.discard()).count())
@@ -432,7 +432,7 @@ fn check_for_simple_vote_transaction<const N: usize>(
 }
 
 pub fn generate_offsets<const N: usize>(
-    batches: &mut [Batch<N>],
+    batches: &mut [PacketBatch<N>],
     recycler: &Recycler<TxOffset>,
     reject_non_vote: bool,
 ) -> TxOffsets {
@@ -557,7 +557,7 @@ impl Deduper {
 
     pub fn dedup_packets_and_count_discards<const N: usize>(
         &self,
-        batches: &mut [Batch<N>],
+        batches: &mut [PacketBatch<N>],
         mut process_received_packet: impl FnMut(&mut GenericPacket<N>, bool, bool),
     ) -> u64 {
         let mut num_removed: u64 = 0;
@@ -576,7 +576,7 @@ impl Deduper {
 }
 
 //inplace shrink a batch of packets
-pub fn shrink_batches<const N: usize>(batches: &mut Vec<Batch<N>>) {
+pub fn shrink_batches<const N: usize>(batches: &mut Vec<PacketBatch<N>>) {
     let mut valid_batch_ix = 0;
     let mut valid_packet_ix = 0;
     let mut last_valid_batch = 0;
@@ -610,7 +610,7 @@ pub fn shrink_batches<const N: usize>(batches: &mut Vec<Batch<N>>) {
 }
 
 pub fn ed25519_verify_cpu<const N: usize>(
-    batches: &mut [Batch<N>],
+    batches: &mut [PacketBatch<N>],
     reject_non_vote: bool,
     packet_count: usize,
 ) {
@@ -646,21 +646,23 @@ pub fn ed25519_verify_cpu<const N: usize>(
     } else {
         // When using all available threads, skip the overhead of flattening, collecting, etc.
         PAR_THREAD_POOL.install(|| {
-            batches.into_par_iter().for_each(|batch: &mut Batch<N>| {
-                batch
-                    .par_iter_mut()
-                    .for_each(|packet: &mut GenericPacket<N>| {
-                        if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
-                            packet.meta.set_discard(true);
-                        }
-                    })
-            });
+            batches
+                .into_par_iter()
+                .for_each(|batch: &mut PacketBatch<N>| {
+                    batch
+                        .par_iter_mut()
+                        .for_each(|packet: &mut GenericPacket<N>| {
+                            if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
+                                packet.meta.set_discard(true);
+                            }
+                        })
+                });
         });
     }
     inc_new_counter_debug!("ed25519_verify_cpu", packet_count);
 }
 
-pub fn ed25519_verify_disabled<const N: usize>(batches: &mut [Batch<N>]) {
+pub fn ed25519_verify_disabled<const N: usize>(batches: &mut [PacketBatch<N>]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("disabled ECDSA for {}", packet_count);
     batches
@@ -712,7 +714,7 @@ pub fn get_checked_scalar(scalar: &[u8; 32]) -> Result<[u8; 32], PacketError> {
     Ok(out)
 }
 
-pub fn mark_disabled<const N: usize>(batches: &mut [Batch<N>], r: &[Vec<u8>]) {
+pub fn mark_disabled<const N: usize>(batches: &mut [PacketBatch<N>], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (pkt, f) in batch.iter_mut().zip(v) {
             if !pkt.meta.discard() {
@@ -723,7 +725,7 @@ pub fn mark_disabled<const N: usize>(batches: &mut [Batch<N>], r: &[Vec<u8>]) {
 }
 
 pub fn ed25519_verify<const N: usize>(
-    batches: &mut [Batch<N>],
+    batches: &mut [PacketBatch<N>],
     recycler: &Recycler<TxOffset>,
     recycler_out: &Recycler<PinnedVec<u8>>,
     reject_non_vote: bool,
@@ -804,7 +806,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            packet::{to_packet_batches, Batch, Packet, PACKETS_PER_BATCH},
+            packet::{to_packet_batches, Packet, PacketBatch, PACKETS_PER_BATCH},
             sigverify::{self, PacketOffsets},
             test_tx::{new_test_vote_tx, test_multisig_tx, test_tx},
         },
@@ -874,9 +876,9 @@ mod tests {
     #[test]
     fn test_mark_disabled() {
         let batch_size = 1;
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
         batch.resize(batch_size, Packet::default());
-        let mut batches: Vec<Batch<{ Packet::DATA_SIZE }>> = vec![batch];
+        let mut batches: Vec<PacketBatch<{ Packet::DATA_SIZE }>> = vec![batch];
         mark_disabled(&mut batches, &[vec![0]]);
         assert!(batches[0][0].meta.discard());
         batches[0][0].meta.set_discard(false);
@@ -1182,13 +1184,13 @@ mod tests {
         packet: &Packet,
         max_packets_per_batch: usize,
         num_batches: usize,
-    ) -> Vec<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Vec<PacketBatch<{ Packet::DATA_SIZE }>> {
         // generate packet vector
         let batches: Vec<_> = (0..num_batches)
             .map(|_| {
                 let num_packets_per_batch = thread_rng().gen_range(1, max_packets_per_batch);
                 let mut packet_batch =
-                    Batch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets_per_batch);
+                    PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets_per_batch);
                 for _ in 0..num_packets_per_batch {
                     packet_batch.push(packet.clone());
                 }
@@ -1205,12 +1207,12 @@ mod tests {
         packet: &Packet,
         num_packets_per_batch: usize,
         num_batches: usize,
-    ) -> Vec<Batch<{ Packet::DATA_SIZE }>> {
+    ) -> Vec<PacketBatch<{ Packet::DATA_SIZE }>> {
         // generate packet vector
         let batches: Vec<_> = (0..num_batches)
             .map(|_| {
                 let mut packet_batch =
-                    Batch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets_per_batch);
+                    PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(num_packets_per_batch);
                 for _ in 0..num_packets_per_batch {
                     packet_batch.push(packet.clone());
                 }
@@ -1245,7 +1247,7 @@ mod tests {
             .all(|p| p.meta.discard() == should_discard));
     }
 
-    fn ed25519_verify(batches: &mut [Batch<{ Packet::DATA_SIZE }>]) {
+    fn ed25519_verify(batches: &mut [PacketBatch<{ Packet::DATA_SIZE }>]) {
         let recycler = Recycler::default();
         let recycler_out = Recycler::default();
         let packet_count = sigverify::count_packets_in_batches(batches);
@@ -1520,7 +1522,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let mut current_offset = 0usize;
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::default();
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::default();
         batch.push(Packet::from_data(None, test_tx()).unwrap());
         let tx = new_test_vote_tx(&mut rng);
         batch.push(Packet::from_data(None, tx).unwrap());
@@ -1659,14 +1661,14 @@ mod tests {
         shrink_batches::<{ Packet::DATA_SIZE }>(&mut Vec::new());
         // One empty batch
         {
-            let mut batches = vec![Batch::<{ Packet::DATA_SIZE }>::with_capacity(0)];
+            let mut batches = vec![PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(0)];
             shrink_batches(&mut batches);
             assert_eq!(batches.len(), 0);
         }
         // Many empty batches
         {
             let mut batches = (0..BATCH_COUNT)
-                .map(|_| Batch::<{ Packet::DATA_SIZE }>::with_capacity(0))
+                .map(|_| PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(0))
                 .collect::<Vec<_>>();
             shrink_batches(&mut batches);
             assert_eq!(batches.len(), 0);

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -42,7 +42,7 @@ mod tests {
         }
         for batch in all_packets {
             for p in &batch {
-                assert_eq!(p.meta().size, num_bytes);
+                assert_eq!(p.meta.size, num_bytes);
             }
         }
         assert_eq!(total_packets, num_expected_packets);

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -3,11 +3,14 @@ mod tests {
     use {
         crossbeam_channel::{unbounded, Receiver},
         log::*,
-        solana_perf::packet::PacketBatch,
+        solana_perf::packet::Batch,
         solana_quic_client::nonblocking::quic_client::{
             QuicClientCertificate, QuicLazyInitializedEndpoint,
         },
-        solana_sdk::{packet::PACKET_DATA_SIZE, signature::Keypair},
+        solana_sdk::{
+            packet::{BasePacket, Packet, PACKET_DATA_SIZE},
+            signature::Keypair,
+        },
         solana_streamer::{
             nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS, quic::StreamStats,
             streamer::StakedNodes, tls_certificates::new_self_signed_tls_certificate_chain,
@@ -24,7 +27,7 @@ mod tests {
     };
 
     fn check_packets(
-        receiver: Receiver<PacketBatch>,
+        receiver: Receiver<Batch<Packet>>,
         num_bytes: usize,
         num_expected_packets: usize,
     ) {

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -8,7 +8,7 @@ mod tests {
             QuicClientCertificate, QuicLazyInitializedEndpoint,
         },
         solana_sdk::{
-            packet::{BasePacket, Packet, PACKET_DATA_SIZE},
+            packet::{BasePacket, TransactionPacket},
             signature::Keypair,
         },
         solana_streamer::{
@@ -26,8 +26,8 @@ mod tests {
         },
     };
 
-    fn check_packets(
-        receiver: Receiver<Batch<Packet>>,
+    fn check_packets<P: BasePacket>(
+        receiver: Receiver<Batch<P>>,
         num_bytes: usize,
         num_expected_packets: usize,
     ) {
@@ -103,9 +103,9 @@ mod tests {
         );
 
         // Send a full size packet with single byte writes.
-        let num_bytes = PACKET_DATA_SIZE;
+        let num_bytes = TransactionPacket::DATA_SIZE;
         let num_expected_packets: usize = 3000;
-        let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
+        let packets = vec![vec![0u8; TransactionPacket::DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch_async(packets).is_ok());
 
@@ -150,9 +150,9 @@ mod tests {
         );
 
         // Send a full size packet with single byte writes.
-        let num_bytes = PACKET_DATA_SIZE;
+        let num_bytes = TransactionPacket::DATA_SIZE;
         let num_expected_packets: usize = 3000;
-        let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
+        let packets = vec![vec![0u8; TransactionPacket::DATA_SIZE]; num_expected_packets];
 
         assert!(client.send_wire_transaction_batch(&packets).await.is_ok());
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -3,7 +3,7 @@ mod tests {
     use {
         crossbeam_channel::{unbounded, Receiver},
         log::*,
-        solana_perf::packet::Batch,
+        solana_perf::packet::PacketBatch,
         solana_quic_client::nonblocking::quic_client::{
             QuicClientCertificate, QuicLazyInitializedEndpoint,
         },
@@ -24,7 +24,7 @@ mod tests {
     };
 
     fn check_packets<const N: usize>(
-        receiver: Receiver<Batch<N>>,
+        receiver: Receiver<PacketBatch<N>>,
         num_bytes: usize,
         num_expected_packets: usize,
     ) {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -65,7 +65,7 @@ use {
         fee_calculator::FeeCalculator,
         hash::Hash,
         message::SanitizedMessage,
-        packet::{BasePacket, TransactionPacket},
+        packet::TransactionPacket,
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Keypair, Signature, Signer},
         stake::state::{StakeActivationStatus, StakeState},
@@ -4634,6 +4634,7 @@ pub mod tests {
                 Message, MessageHeader, VersionedMessage,
             },
             nonce::{self, state::DurableNonce},
+            packet::TRANSACTION_DATA_SIZE,
             rpc_port,
             signature::{Keypair, Signer},
             slot_hashes::SlotHashes,
@@ -8396,7 +8397,7 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base58 encoded solana_sdk::transaction::Transaction too large: {tx58_len} bytes (max: encoded/raw {MAX_BASE58_SIZE}/{TransactionPacket::DATA_SIZE})",
+                "base58 encoded solana_sdk::transaction::Transaction too large: {tx58_len} bytes (max: encoded/raw {MAX_BASE58_SIZE}/{TRANSACTION_DATA_SIZE})",
             )
         ));
 
@@ -8406,7 +8407,7 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base64 encoded solana_sdk::transaction::Transaction too large: {tx64_len} bytes (max: encoded/raw {MAX_BASE64_SIZE}/{TransactionPacket::DATA_SIZE})",
+                "base64 encoded solana_sdk::transaction::Transaction too large: {tx64_len} bytes (max: encoded/raw {MAX_BASE64_SIZE}/{TRANSACTION_DATA_SIZE})",
             )
         ));
 
@@ -8417,7 +8418,7 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {TransactionPacket::DATA_SIZE} bytes)"
+                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {TRANSACTION_DATA_SIZE} bytes)"
             ))
         );
 
@@ -8426,7 +8427,7 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {TransactionPacket::DATA_SIZE} bytes)"
+                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {TRANSACTION_DATA_SIZE} bytes)"
             ))
         );
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -65,7 +65,7 @@ use {
         fee_calculator::FeeCalculator,
         hash::Hash,
         message::SanitizedMessage,
-        packet::TransactionPacket,
+        packet::{BasePacket, TransactionPacket},
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Keypair, Signature, Signer},
         stake::state::{StakeActivationStatus, StakeState},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -137,7 +137,7 @@ use {
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce, NONCED_TX_MARKER_IX_INDEX},
         nonce_account,
-        packet::PACKET_DATA_SIZE,
+        packet::TransactionPacket,
         precompiles::get_precompiles,
         pubkey::Pubkey,
         saturating_add_assign, secp256k1_program,
@@ -6885,7 +6885,7 @@ impl Bank {
         let sanitized_tx = {
             let size =
                 bincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
-            if size > PACKET_DATA_SIZE as u64 {
+            if size > TransactionPacket::DATA_SIZE as u64 {
                 return Err(TransactionError::SanitizeFailure);
             }
             let message_hash = if verification_mode == TransactionVerificationMode::FullVerification
@@ -18379,7 +18379,7 @@ pub(crate) mod tests {
         // Small transaction.
         {
             let tx = make_transaction(5);
-            assert!(bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64);
+            assert!(bincode::serialized_size(&tx).unwrap() <= TransactionPacket::DATA_SIZE as u64);
             assert!(bank
                 .verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
                 .is_ok(),);
@@ -18387,7 +18387,7 @@ pub(crate) mod tests {
         // Big transaction.
         {
             let tx = make_transaction(25);
-            assert!(bincode::serialized_size(&tx).unwrap() > PACKET_DATA_SIZE as u64);
+            assert!(bincode::serialized_size(&tx).unwrap() > TransactionPacket::DATA_SIZE as u64);
             assert_eq!(
                 bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
                     .err(),
@@ -18399,7 +18399,7 @@ pub(crate) mod tests {
         for size in 1..30 {
             let tx = make_transaction(size);
             assert_eq!(
-                bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64,
+                bincode::serialized_size(&tx).unwrap() <= TransactionPacket::DATA_SIZE as u64,
                 bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
                     .is_ok(),
             );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -137,7 +137,7 @@ use {
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce, NONCED_TX_MARKER_IX_INDEX},
         nonce_account,
-        packet::{BasePacket, TransactionPacket},
+        packet::TransactionPacket,
         precompiles::get_precompiles,
         pubkey::Pubkey,
         saturating_add_assign, secp256k1_program,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -137,7 +137,7 @@ use {
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce, NONCED_TX_MARKER_IX_INDEX},
         nonce_account,
-        packet::TransactionPacket,
+        packet::{BasePacket, TransactionPacket},
         precompiles::get_precompiles,
         pubkey::Pubkey,
         saturating_add_assign, secp256k1_program,

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -48,7 +48,7 @@ pub mod v0 {
         super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},
         crate::{
             hash::{Hash, Hasher},
-            packet::{BasePacket, Packet},
+            packet::Packet,
             sanitize::SanitizeError,
         },
     };

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -48,7 +48,7 @@ pub mod v0 {
         super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},
         crate::{
             hash::{Hash, Hasher},
-            packet::Packet,
+            packet::{BasePacket, Packet},
             sanitize::SanitizeError,
         },
     };

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -48,7 +48,7 @@ pub mod v0 {
         super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},
         crate::{
             hash::{Hash, Hasher},
-            packet::PACKET_DATA_SIZE,
+            packet::Packet,
             sanitize::SanitizeError,
         },
     };
@@ -67,7 +67,7 @@ pub mod v0 {
         // Max length of the OffchainMessage
         pub const MAX_LEN: usize = u16::MAX as usize - Base::HEADER_LEN - Self::HEADER_LEN;
         // Max Length of the OffchainMessage supported by the Ledger
-        pub const MAX_LEN_LEDGER: usize = PACKET_DATA_SIZE - Base::HEADER_LEN - Self::HEADER_LEN;
+        pub const MAX_LEN_LEDGER: usize = Packet::DATA_SIZE - Base::HEADER_LEN - Self::HEADER_LEN;
 
         /// Construct a new OffchainMessage object from the given message
         pub fn new(message: &[u8]) -> Result<Self, SanitizeError> {

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -44,18 +44,60 @@ pub struct Meta {
     pub sender_stake: u64,
 }
 
-pub trait BasePacket: Default + Clone + Sync + Send + Eq + fmt::Debug {
-    const DATA_SIZE: usize;
-    fn populate_packet<T: Serialize>(&mut self, dest: Option<&SocketAddr>, data: &T) -> Result<()>;
+#[derive(Clone, Eq)]
+#[repr(C)]
+pub struct GenericPacket<const N: usize> {
+    // Bytes past Packet.meta.size are not valid to read from.
+    // Use Packet.data(index) to read from the buffer.
+    buffer: [u8; N],
+    meta: Meta,
+}
 
-    fn meta(&self) -> &Meta;
-    fn meta_mut(&mut self) -> &mut Meta;
-    fn buffer(&self) -> &[u8];
+impl<const N: usize> GenericPacket<N> {
+    pub const DATA_SIZE: usize = N;
+
+    pub fn new(buffer: [u8; N], meta: Meta) -> Self {
+        Self { buffer, meta }
+    }
+
+    pub fn populate_packet<T: Serialize>(
+        &mut self,
+        dest: Option<&SocketAddr>,
+        data: &T,
+    ) -> Result<()> {
+        debug_assert!(!self.meta.discard());
+        let mut wr = io::Cursor::new(self.buffer_mut());
+        bincode::serialize_into(&mut wr, data)?;
+        self.meta.size = wr.position() as usize;
+        if let Some(dest) = dest {
+            self.meta.set_socket_addr(dest);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
+
+    #[inline]
+    pub fn meta_mut(&mut self) -> &mut Meta {
+        &mut self.meta
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
 
     /// Returns a mutable reference to the entirety of the underlying buffer to
     /// write into. The caller is responsible for updating Packet.meta.size
     /// after writing to the buffer.
-    fn buffer_mut(&mut self) -> &mut [u8];
+    #[inline]
+    pub fn buffer_mut(&mut self) -> &mut [u8] {
+        debug_assert!(!self.meta.discard());
+        &mut self.buffer[..]
+    }
 
     /// Returns an immutable reference to the underlying buffer up to
     /// packet.meta.size. The rest of the buffer is not valid to read from.
@@ -63,7 +105,7 @@ pub trait BasePacket: Default + Clone + Sync + Send + Eq + fmt::Debug {
     /// Returns None if the index is invalid or if the packet is already marked
     /// as discard.
     #[inline]
-    fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    pub fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
     where
         I: SliceIndex<[u8]>,
     {
@@ -77,13 +119,13 @@ pub trait BasePacket: Default + Clone + Sync + Send + Eq + fmt::Debug {
         }
     }
 
-    fn from_data<T: Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
+    pub fn from_data<T: Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
         let mut packet = Self::default();
         Self::populate_packet(&mut packet, dest, &data)?;
         Ok(packet)
     }
 
-    fn deserialize_slice<T, I>(&self, index: I) -> Result<T>
+    pub fn deserialize_slice<T, I>(&self, index: I) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
         I: SliceIndex<[u8], Output = [u8]>,
@@ -94,53 +136,6 @@ pub trait BasePacket: Default + Clone + Sync + Send + Eq + fmt::Debug {
             .with_fixint_encoding()
             .reject_trailing_bytes()
             .deserialize(bytes)
-    }
-}
-
-#[derive(Clone, Eq)]
-#[repr(C)]
-pub struct GenericPacket<const N: usize> {
-    // Bytes past Packet.meta.size are not valid to read from.
-    // Use Packet.data(index) to read from the buffer.
-    buffer: [u8; N],
-    meta: Meta,
-}
-
-impl<const N: usize> GenericPacket<N> {
-    pub fn new(buffer: [u8; N], meta: Meta) -> Self {
-        Self { buffer, meta }
-    }
-}
-
-impl<const N: usize> BasePacket for GenericPacket<N> {
-    const DATA_SIZE: usize = N;
-
-    fn populate_packet<T: Serialize>(&mut self, dest: Option<&SocketAddr>, data: &T) -> Result<()> {
-        debug_assert!(!self.meta.discard());
-        let mut wr = io::Cursor::new(self.buffer_mut());
-        bincode::serialize_into(&mut wr, data)?;
-        self.meta.size = wr.position() as usize;
-        if let Some(dest) = dest {
-            self.meta.set_socket_addr(dest);
-        }
-        Ok(())
-    }
-
-    fn meta(&self) -> &Meta {
-        &self.meta
-    }
-
-    fn meta_mut(&mut self) -> &mut Meta {
-        &mut self.meta
-    }
-
-    fn buffer(&self) -> &[u8] {
-        &self.buffer
-    }
-
-    fn buffer_mut(&mut self) -> &mut [u8] {
-        debug_assert!(!self.meta.discard());
-        &mut self.buffer[..]
     }
 }
 

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -44,7 +44,7 @@ pub struct Meta {
     pub sender_stake: u64,
 }
 
-pub trait BasePacket: Default + Clone + Sync + Send + Eq {
+pub trait BasePacket: Default + Clone + Sync + Send + Eq + fmt::Debug {
     const DATA_SIZE: usize;
     fn populate_packet<T: Serialize>(&mut self, dest: Option<&SocketAddr>, data: &T) -> Result<()>;
 

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -50,7 +50,7 @@ pub struct GenericPacket<const N: usize> {
     // Bytes past Packet.meta.size are not valid to read from.
     // Use Packet.data(index) to read from the buffer.
     buffer: [u8; N],
-    meta: Meta,
+    pub meta: Meta,
 }
 
 impl<const N: usize> GenericPacket<N> {
@@ -73,16 +73,6 @@ impl<const N: usize> GenericPacket<N> {
             self.meta.set_socket_addr(dest);
         }
         Ok(())
-    }
-
-    #[inline]
-    pub fn meta(&self) -> &Meta {
-        &self.meta
-    }
-
-    #[inline]
-    pub fn meta_mut(&mut self) -> &mut Meta {
-        &mut self.meta
     }
 
     #[inline]
@@ -112,10 +102,10 @@ impl<const N: usize> GenericPacket<N> {
         // If the packet is marked as discard, it is either invalid or
         // otherwise should be ignored, and so the payload should not be read
         // from.
-        if self.meta().discard() {
+        if self.meta.discard() {
             None
         } else {
-            self.buffer().get(..self.meta().size)?.get(index)
+            self.buffer().get(..self.meta.size)?.get(index)
         }
     }
 

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -12,7 +12,7 @@ where
 {
     solana_program::program_utils::limited_deserialize(
         instruction_data,
-        crate::packet::PACKET_DATA_SIZE as u64,
+        crate::packet::TransactionPacket::DATA_SIZE as u64,
     )
 }
 
@@ -27,11 +27,11 @@ pub mod tests {
             Bar(Vec<u8>),
         }
 
-        let item = Foo::Bar([1; crate::packet::PACKET_DATA_SIZE - 12].to_vec()); // crate::packet::PACKET_DATA_SIZE - 12: size limit, minus enum variant and vec len() serialized sizes
+        let item = Foo::Bar([1; crate::packet::TransactionPacket::DATA_SIZE - 12].to_vec()); // crate::packet::TransactionPacket::DATA_SIZE - 12: size limit, minus enum variant and vec len() serialized sizes
         let serialized = bincode::serialize(&item).unwrap();
         assert!(limited_deserialize::<Foo>(&serialized).is_ok());
 
-        let item = Foo::Bar([1; crate::packet::PACKET_DATA_SIZE - 11].to_vec()); // Extra byte should bump serialized size over the size limit
+        let item = Foo::Bar([1; crate::packet::TransactionPacket::DATA_SIZE - 11].to_vec()); // Extra byte should bump serialized size over the size limit
         let serialized = bincode::serialize(&item).unwrap();
         assert!(limited_deserialize::<Foo>(&serialized).is_err());
     }

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -2,7 +2,7 @@
 //!
 //! [bincode]: https://docs.rs/bincode
 
-use crate::{instruction::InstructionError, packet::BasePacket};
+use crate::instruction::InstructionError;
 
 /// Deserialize with a limit based the maximum amount of data a program can expect to get.
 /// This function should be used in place of direct deserialization to help prevent OOM errors

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -2,7 +2,7 @@
 //!
 //! [bincode]: https://docs.rs/bincode
 
-use crate::instruction::InstructionError;
+use crate::{instruction::InstructionError, packet::BasePacket};
 
 /// Deserialize with a limit based the maximum amount of data a program can expect to get.
 /// This function should be used in place of direct deserialization to help prevent OOM errors

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -21,13 +21,13 @@ pub const QUIC_KEEP_ALIVE_MS: u64 = 1_000;
 pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS: u64 = 60_000;
 
 /// The receive window for QUIC connection from unstaked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_sdk::packet::TransactionPacket::DATA_SIZE`]
 pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 1;
 
 /// The receive window for QUIC connection from minimum staked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_sdk::packet::TransactionPacket::DATA_SIZE`]
 pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 2;
 
 /// The receive window for QUIC connection from maximum staked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_sdk::packet::TransactionPacket::DATA_SIZE`]
 pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 10;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -650,8 +650,8 @@ fn handle_chunk<const N: usize>(
                 if maybe_batch.is_none() {
                     let mut batch = Batch::<N>::with_capacity(1);
                     let mut packet = GenericPacket::default();
-                    packet.meta_mut().set_socket_addr(remote_addr);
-                    packet.meta_mut().sender_stake = stake;
+                    packet.meta.set_socket_addr(remote_addr);
+                    packet.meta.sender_stake = stake;
                     batch.push(packet);
                     *maybe_batch = Some(batch);
                     stats
@@ -667,7 +667,7 @@ fn handle_chunk<const N: usize>(
                     };
                     batch[0].buffer_mut()[chunk.offset as usize..end_of_chunk]
                         .copy_from_slice(&chunk.bytes);
-                    batch[0].meta_mut().size = std::cmp::max(batch[0].meta().size, end_of_chunk);
+                    batch[0].meta.size = std::cmp::max(batch[0].meta.size, end_of_chunk);
                     stats.total_chunks_received.fetch_add(1, Ordering::Relaxed);
                     match peer_type {
                         ConnectionPeerType::Staked => {
@@ -686,7 +686,7 @@ fn handle_chunk<const N: usize>(
                 trace!("chunk is none");
                 // done receiving chunks
                 if let Some(batch) = maybe_batch.take() {
-                    let len = batch[0].meta().size;
+                    let len = batch[0].meta.size;
                     if let Err(e) = packet_sender.send(batch) {
                         stats
                             .total_packet_batch_send_err
@@ -1118,7 +1118,7 @@ pub mod test {
         }
         for batch in all_packets {
             for p in batch.iter() {
-                assert_eq!(p.meta().size, 1);
+                assert_eq!(p.meta.size, 1);
             }
         }
         assert_eq!(total_packets, num_expected_packets);
@@ -1154,7 +1154,7 @@ pub mod test {
         }
         for batch in all_packets {
             for p in batch.iter() {
-                assert_eq!(p.meta().size, num_bytes);
+                assert_eq!(p.meta.size, num_bytes);
             }
         }
         assert_eq!(total_packets, num_expected_packets);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -10,9 +10,9 @@ use {
     quinn::{Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime, VarInt},
     quinn_proto::VarIntBoundsExceeded,
     rand::{thread_rng, Rng},
-    solana_perf::packet::PacketBatch,
+    solana_perf::packet::Batch,
     solana_sdk::{
-        packet::{Packet, PACKET_DATA_SIZE},
+        packet::{BasePacket, Packet, PACKET_DATA_SIZE},
         pubkey::Pubkey,
         quic::{
             QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS, QUIC_MAX_STAKED_CONCURRENT_STREAMS,
@@ -59,7 +59,7 @@ pub fn spawn_server(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -92,7 +92,7 @@ pub fn spawn_server(
 
 pub async fn run_server(
     incoming: Endpoint,
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -224,7 +224,7 @@ enum ConnectionHandlerError {
 }
 
 struct NewConnectionHandlerParams {
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     remote_pubkey: Option<Pubkey>,
     stake: u64,
     total_stake: u64,
@@ -236,7 +236,7 @@ struct NewConnectionHandlerParams {
 
 impl NewConnectionHandlerParams {
     fn new_unstaked(
-        packet_sender: Sender<PacketBatch>,
+        packet_sender: Sender<Batch<Packet>>,
         max_connections_per_peer: usize,
         stats: Arc<StreamStats>,
     ) -> NewConnectionHandlerParams {
@@ -410,7 +410,7 @@ async fn setup_connection(
     connecting: Connecting,
     unstaked_connection_table: Arc<Mutex<ConnectionTable>>,
     staked_connection_table: Arc<Mutex<ConnectionTable>>,
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
     max_staked_connections: usize,
@@ -517,7 +517,7 @@ async fn setup_connection(
 #[allow(clippy::too_many_arguments)]
 async fn handle_connection(
     connection: Connection,
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     remote_addr: SocketAddr,
     remote_pubkey: Option<Pubkey>,
     last_update: Arc<AtomicU64>,
@@ -617,9 +617,9 @@ async fn handle_connection(
 // Return true if the server should drop the stream
 fn handle_chunk(
     chunk: &Result<Option<quinn::Chunk>, quinn::ReadError>,
-    maybe_batch: &mut Option<PacketBatch>,
+    maybe_batch: &mut Option<Batch<Packet>>,
     remote_addr: &SocketAddr,
-    packet_sender: &Sender<PacketBatch>,
+    packet_sender: &Sender<Batch<Packet>>,
     stats: Arc<StreamStats>,
     stake: u64,
     peer_type: ConnectionPeerType,
@@ -648,7 +648,7 @@ fn handle_chunk(
 
                 // chunk looks valid
                 if maybe_batch.is_none() {
-                    let mut batch = PacketBatch::with_capacity(1);
+                    let mut batch = Batch::<Packet>::with_capacity(1);
                     let mut packet = Packet::default();
                     packet.meta_mut().set_socket_addr(remote_addr);
                     packet.meta_mut().sender_stake = stake;
@@ -986,15 +986,15 @@ pub mod test {
         config
     }
 
-    fn setup_quic_server(
-        option_staked_nodes: Option<StakedNodes>,
-    ) -> (
+    type QuicServer = (
         JoinHandle<()>,
         Arc<AtomicBool>,
-        crossbeam_channel::Receiver<PacketBatch>,
+        crossbeam_channel::Receiver<Batch<Packet>>,
         SocketAddr,
         Arc<StreamStats>,
-    ) {
+    );
+
+    fn setup_quic_server(option_staked_nodes: Option<StakedNodes>) -> QuicServer {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();
         let exit = Arc::new(AtomicBool::new(false));
         let (sender, receiver) = unbounded();
@@ -1039,7 +1039,7 @@ pub mod test {
             .expect("Failed in waiting")
     }
 
-    pub async fn check_timeout(receiver: Receiver<PacketBatch>, server_address: SocketAddr) {
+    pub async fn check_timeout(receiver: Receiver<Batch<Packet>>, server_address: SocketAddr) {
         let conn1 = make_client_endpoint(&server_address, None).await;
         let total = 30;
         for i in 0..total {
@@ -1081,7 +1081,7 @@ pub mod test {
     }
 
     pub async fn check_multiple_streams(
-        receiver: Receiver<PacketBatch>,
+        receiver: Receiver<Batch<Packet>>,
         server_address: SocketAddr,
     ) {
         let conn1 = Arc::new(make_client_endpoint(&server_address, None).await);
@@ -1121,7 +1121,7 @@ pub mod test {
     }
 
     pub async fn check_multiple_writes(
-        receiver: Receiver<PacketBatch>,
+        receiver: Receiver<Batch<Packet>>,
         server_address: SocketAddr,
         client_keypair: Option<&Keypair>,
     ) {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -91,7 +91,7 @@ pub fn spawn_server<const N: usize>(
 }
 
 pub async fn run_server<const N: usize>(
-    incoming: Incoming,
+    incoming: Endpoint,
     packet_sender: Sender<PacketBatch<N>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -13,12 +13,12 @@ pub async fn recv_mmsg(
     socket: &UdpSocket,
     packets: &mut [Packet],
 ) -> io::Result</*num packets:*/ usize> {
-    debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
+    debug_assert!(packets.iter().all(|pkt| pkt.meta == Meta::default()));
     let count = cmp::min(NUM_RCVMMSGS, packets.len());
     socket.readable().await?;
     let mut i = 0;
     for p in packets.iter_mut().take(count) {
-        p.meta_mut().size = 0;
+        p.meta.size = 0;
         match socket.try_recv_from(p.buffer_mut()) {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
@@ -27,8 +27,8 @@ pub async fn recv_mmsg(
                 return Err(e);
             }
             Ok((nrecv, from)) => {
-                p.meta_mut().size = nrecv;
-                p.meta_mut().set_socket_addr(&from);
+                p.meta.size = nrecv;
+                p.meta.set_socket_addr(&from);
             }
         }
         i += 1;
@@ -82,8 +82,8 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr);
         }
     }
 
@@ -108,19 +108,19 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr);
         }
 
         let mut packets = vec![Packet::default(); sent - TEST_NUM_MSGS];
         packets
             .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            .for_each(|pkt| pkt.meta = Meta::default());
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr);
         }
     }
 
@@ -151,13 +151,13 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr);
         }
 
         packets
             .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            .for_each(|pkt| pkt.meta = Meta::default());
         let _recv = recv_mmsg(&reader, &mut packets[..]).await;
         assert!(start.elapsed().as_secs() < 5);
     }
@@ -190,22 +190,22 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(sent1) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr1);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr1);
         }
         for packet in packets.iter().skip(sent1).take(recv - sent1) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr2);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr2);
         }
 
         packets
             .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            .for_each(|pkt| pkt.meta = Meta::default());
         let recv = recv_mmsg(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent1 + sent2 - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr2);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr2);
         }
     }
 }

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -56,7 +56,7 @@ pub async fn recv_mmsg_exact(
 #[cfg(test)]
 mod tests {
     use {
-        crate::{nonblocking::recvmmsg::*, packet::PACKET_DATA_SIZE},
+        crate::nonblocking::recvmmsg::*,
         std::{net::SocketAddr, time::Instant},
         tokio::net::UdpSocket,
     };
@@ -76,7 +76,7 @@ mod tests {
     async fn test_one_iter((reader, addr, sender, saddr): TestConfig) {
         let sent = TEST_NUM_MSGS - 1;
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], &addr).await.unwrap();
         }
 
@@ -84,7 +84,7 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr);
         }
     }
@@ -102,7 +102,7 @@ mod tests {
     async fn test_multi_iter((reader, addr, sender, saddr): TestConfig) {
         let sent = TEST_NUM_MSGS + 10;
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], &addr).await.unwrap();
         }
 
@@ -110,7 +110,7 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr);
         }
 
@@ -121,7 +121,7 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr);
         }
     }
@@ -144,7 +144,7 @@ mod tests {
         let saddr = sender.local_addr().unwrap();
         let sent = TEST_NUM_MSGS;
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], &addr).await.unwrap();
         }
 
@@ -153,7 +153,7 @@ mod tests {
         let recv = recv_mmsg_exact(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr);
         }
 
@@ -178,12 +178,12 @@ mod tests {
         let sent2 = TEST_NUM_MSGS + 1;
 
         for _ in 0..sent1 {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender1.send_to(&data[..], &addr).await.unwrap();
         }
 
         for _ in 0..sent2 {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender2.send_to(&data[..], &addr).await.unwrap();
         }
 
@@ -192,11 +192,11 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(sent1) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr1);
         }
         for packet in packets.iter().skip(sent1).take(recv - sent1) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr2);
         }
 
@@ -206,7 +206,7 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).await.unwrap();
         assert_eq!(sent1 + sent2 - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr2);
         }
     }

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::recvmmsg::NUM_RCVMMSGS,
-    solana_sdk::packet::{BasePacket, Meta, Packet},
+    solana_sdk::packet::{Meta, Packet},
     std::{cmp, io},
     tokio::net::UdpSocket,
 };

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -1,10 +1,8 @@
 //! The `recvmmsg` module provides a nonblocking recvmmsg() API implementation
 
 use {
-    crate::{
-        packet::{Meta, Packet},
-        recvmmsg::NUM_RCVMMSGS,
-    },
+    crate::recvmmsg::NUM_RCVMMSGS,
+    solana_sdk::packet::{BasePacket, Meta, Packet},
     std::{cmp, io},
     tokio::net::UdpSocket,
 };

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -59,7 +59,7 @@ mod tests {
             },
             sendmmsg::SendPktsError,
         },
-        solana_sdk::packet::{BasePacket, Packet},
+        solana_sdk::packet::Packet,
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -60,7 +60,6 @@ mod tests {
             packet::Packet,
             sendmmsg::SendPktsError,
         },
-        solana_sdk::packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -74,7 +73,7 @@ mod tests {
         let addr = reader.local_addr().unwrap();
         let sender = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
 
-        let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..32).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &addr)).collect();
 
         let sent = batch_send(&sender, &packet_refs[..]).await.ok();
@@ -95,7 +94,7 @@ mod tests {
 
         let sender = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
 
-        let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..32).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets
             .iter()
             .enumerate()
@@ -166,7 +165,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_intermediate_failures_mismatched_bind() {
-        let packets: Vec<_> = (0..3).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..3).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let ip4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ip6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
         let packet_refs: Vec<_> = vec![
@@ -191,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_intermediate_failures_unreachable_address() {
-        let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..5).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
         let sender = UdpSocket::bind("0.0.0.0:0").await.expect("bind");

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -57,9 +57,9 @@ mod tests {
                 recvmmsg::{recv_mmsg, recv_mmsg_exact},
                 sendmmsg::{batch_send, multi_target_send},
             },
-            packet::Packet,
             sendmmsg::SendPktsError,
         },
+        solana_sdk::packet::{BasePacket, Packet},
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -9,13 +9,13 @@ use {
 };
 pub use {
     solana_perf::packet::{
-        to_packet_batches, Batch, BatchRecycler, NUM_PACKETS, PACKETS_PER_BATCH,
+        to_packet_batches, BatchRecycler, PacketBatch, NUM_PACKETS, PACKETS_PER_BATCH,
     },
     solana_sdk::packet::{GenericPacket, Meta},
 };
 
 pub fn recv_from<const N: usize>(
-    batch: &mut Batch<N>,
+    batch: &mut PacketBatch<N>,
     socket: &UdpSocket,
     max_wait_ms: u64,
 ) -> Result<usize> {
@@ -64,7 +64,7 @@ pub fn recv_from<const N: usize>(
 }
 
 pub fn send_to<const N: usize>(
-    batch: &Batch<N>,
+    batch: &PacketBatch<N>,
     socket: &UdpSocket,
     socket_addr_space: &SocketAddrSpace,
 ) -> Result<()> {
@@ -96,7 +96,7 @@ mod tests {
         // test that the address is actually being updated
         let send_addr: SocketAddr = "127.0.0.1:123".parse().unwrap();
         let packets = vec![Packet::default()];
-        let mut packet_batch = Batch::new(packets);
+        let mut packet_batch = PacketBatch::new(packets);
         packet_batch.set_addr(&send_addr);
         assert_eq!(packet_batch[0].meta.socket_addr(), send_addr);
     }
@@ -110,7 +110,7 @@ mod tests {
         let saddr = send_socket.local_addr().unwrap();
 
         let packet_batch_size = 10;
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(packet_batch_size);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(packet_batch_size);
         batch.resize(packet_batch_size, Packet::default());
 
         for m in batch.iter_mut() {
@@ -136,7 +136,7 @@ mod tests {
         write!(
             io::sink(),
             "{:?}",
-            Batch::<{ Packet::DATA_SIZE }>::default()
+            PacketBatch::<{ Packet::DATA_SIZE }>::default()
         )
         .unwrap();
     }
@@ -164,14 +164,14 @@ mod tests {
         let recv_socket = UdpSocket::bind("127.0.0.1:0").expect("bind");
         let addr = recv_socket.local_addr().unwrap();
         let send_socket = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(PACKETS_PER_BATCH);
+        let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(PACKETS_PER_BATCH);
         batch.resize(PACKETS_PER_BATCH, Packet::default());
 
         // Should only get PACKETS_PER_BATCH packets per iteration even
         // if a lot more were sent, and regardless of packet size
         for _ in 0..2 * PACKETS_PER_BATCH {
             let batch_size = 1;
-            let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
+            let mut batch = PacketBatch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
             batch.resize(batch_size, Packet::default());
             for p in batch.iter_mut() {
                 p.meta.set_socket_addr(&addr);

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -69,7 +69,7 @@ pub fn send_to<const N: usize>(
     socket_addr_space: &SocketAddrSpace,
 ) -> Result<()> {
     for p in batch.iter() {
-        let addr = p.meta().socket_addr();
+        let addr = p.meta.socket_addr();
         if socket_addr_space.check(&addr) {
             if let Some(data) = p.data(..) {
                 socket.send_to(data, addr)?;
@@ -98,7 +98,7 @@ mod tests {
         let packets = vec![Packet::default()];
         let mut packet_batch = Batch::new(packets);
         packet_batch.set_addr(&send_addr);
-        assert_eq!(packet_batch[0].meta().socket_addr(), send_addr);
+        assert_eq!(packet_batch[0].meta.socket_addr(), send_addr);
     }
 
     #[test]
@@ -114,21 +114,19 @@ mod tests {
         batch.resize(packet_batch_size, Packet::default());
 
         for m in batch.iter_mut() {
-            m.meta_mut().set_socket_addr(&addr);
-            m.meta_mut().size = Packet::DATA_SIZE;
+            m.meta.set_socket_addr(&addr);
+            m.meta.size = Packet::DATA_SIZE;
         }
         send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
 
-        batch
-            .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+        batch.iter_mut().for_each(|pkt| pkt.meta = Meta::default());
         let recvd = recv_from(&mut batch, &recv_socket, 1).unwrap();
 
         assert_eq!(recvd, batch.len());
 
         for m in batch.iter() {
-            assert_eq!(m.meta().size, Packet::DATA_SIZE);
-            assert_eq!(m.meta().socket_addr(), saddr);
+            assert_eq!(m.meta.size, Packet::DATA_SIZE);
+            assert_eq!(m.meta.socket_addr(), saddr);
         }
     }
 
@@ -148,10 +146,10 @@ mod tests {
         let mut p1 = Packet::default();
         let mut p2 = Packet::default();
 
-        p1.meta_mut().size = 1;
+        p1.meta.size = 1;
         p1.buffer_mut()[0] = 0;
 
-        p2.meta_mut().size = 1;
+        p2.meta.size = 1;
         p2.buffer_mut()[0] = 0;
 
         assert!(p1 == p2);
@@ -176,8 +174,8 @@ mod tests {
             let mut batch = Batch::<{ Packet::DATA_SIZE }>::with_capacity(batch_size);
             batch.resize(batch_size, Packet::default());
             for p in batch.iter_mut() {
-                p.meta_mut().set_socket_addr(&addr);
-                p.meta_mut().size = 1;
+                p.meta.set_socket_addr(&addr);
+                p.meta.size = 1;
             }
             send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
         }

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -11,7 +11,7 @@ pub use {
     solana_perf::packet::{
         to_packet_batches, PacketBatch, PacketBatchRecycler, NUM_PACKETS, PACKETS_PER_BATCH,
     },
-    solana_sdk::packet::{Meta, Packet, PACKET_DATA_SIZE},
+    solana_sdk::packet::{Meta, Packet},
 };
 
 pub fn recv_from(batch: &mut PacketBatch, socket: &UdpSocket, max_wait_ms: u64) -> Result<usize> {
@@ -110,7 +110,7 @@ mod tests {
 
         for m in batch.iter_mut() {
             m.meta_mut().set_socket_addr(&addr);
-            m.meta_mut().size = PACKET_DATA_SIZE;
+            m.meta_mut().size = Packet::DATA_SIZE;
         }
         send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
 
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(recvd, batch.len());
 
         for m in batch.iter() {
-            assert_eq!(m.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(m.meta().size, Packet::DATA_SIZE);
             assert_eq!(m.meta().socket_addr(), saddr);
         }
     }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -9,7 +9,7 @@ use {
     rustls::{server::ClientCertVerified, Certificate, DistinguishedNames},
     solana_perf::packet::Batch,
     solana_sdk::{
-        packet::{Packet, PACKET_DATA_SIZE},
+        packet::{BasePacket, TransactionPacket},
         quic::{QUIC_MAX_TIMEOUT_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS},
         signature::Keypair,
     },
@@ -84,9 +84,9 @@ pub(crate) fn configure_server(
     const MAX_CONCURRENT_UNI_STREAMS: u32 =
         (QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS.saturating_mul(2)) as u32;
     config.max_concurrent_uni_streams(MAX_CONCURRENT_UNI_STREAMS.into());
-    config.stream_receive_window((PACKET_DATA_SIZE as u32).into());
+    config.stream_receive_window((TransactionPacket::DATA_SIZE as u32).into());
     config.receive_window(
-        (PACKET_DATA_SIZE as u32)
+        (TransactionPacket::DATA_SIZE as u32)
             .saturating_mul(MAX_CONCURRENT_UNI_STREAMS)
             .into(),
     );
@@ -305,7 +305,7 @@ pub fn spawn_server(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
-    packet_sender: Sender<Batch<Packet>>,
+    packet_sender: Sender<Batch<TransactionPacket>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -354,7 +354,7 @@ mod test {
     fn setup_quic_server() -> (
         std::thread::JoinHandle<()>,
         Arc<AtomicBool>,
-        crossbeam_channel::Receiver<Batch<Packet>>,
+        crossbeam_channel::Receiver<Batch<TransactionPacket>>,
         SocketAddr,
     ) {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -7,7 +7,7 @@ use {
     pem::Pem,
     quinn::{Endpoint, IdleTimeout, ServerConfig, VarInt},
     rustls::{server::ClientCertVerified, Certificate, DistinguishedNames},
-    solana_perf::packet::Batch,
+    solana_perf::packet::PacketBatch,
     solana_sdk::{
         quic::{QUIC_MAX_TIMEOUT_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS},
         signature::Keypair,
@@ -300,7 +300,7 @@ pub fn spawn_server<const N: usize>(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
-    packet_sender: Sender<Batch<N>>,
+    packet_sender: Sender<PacketBatch<N>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -350,7 +350,7 @@ mod test {
     fn setup_quic_server() -> (
         std::thread::JoinHandle<()>,
         Arc<AtomicBool>,
-        crossbeam_channel::Receiver<Batch<{ TransactionPacket::DATA_SIZE }>>,
+        crossbeam_channel::Receiver<PacketBatch<{ TransactionPacket::DATA_SIZE }>>,
         SocketAddr,
     ) {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -7,9 +7,9 @@ use {
     pem::Pem,
     quinn::{Endpoint, IdleTimeout, ServerConfig, VarInt},
     rustls::{server::ClientCertVerified, Certificate, DistinguishedNames},
-    solana_perf::packet::PacketBatch,
+    solana_perf::packet::Batch,
     solana_sdk::{
-        packet::PACKET_DATA_SIZE,
+        packet::{Packet, PACKET_DATA_SIZE},
         quic::{QUIC_MAX_TIMEOUT_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS},
         signature::Keypair,
     },
@@ -305,7 +305,7 @@ pub fn spawn_server(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
-    packet_sender: Sender<PacketBatch>,
+    packet_sender: Sender<Batch<Packet>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -354,7 +354,7 @@ mod test {
     fn setup_quic_server() -> (
         std::thread::JoinHandle<()>,
         Arc<AtomicBool>,
-        crossbeam_channel::Receiver<PacketBatch>,
+        crossbeam_channel::Receiver<Batch<Packet>>,
         SocketAddr,
     ) {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -9,7 +9,6 @@ use {
     rustls::{server::ClientCertVerified, Certificate, DistinguishedNames},
     solana_perf::packet::Batch,
     solana_sdk::{
-        packet::{BasePacket, TransactionPacket},
         quic::{QUIC_MAX_TIMEOUT_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS},
         signature::Keypair,
     },
@@ -54,7 +53,7 @@ impl rustls::server::ClientCertVerifier for SkipClientVerification {
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
-pub(crate) fn configure_server(
+pub(crate) fn configure_server<const N: usize>(
     identity_keypair: &Keypair,
     gossip_host: IpAddr,
 ) -> Result<(ServerConfig, String), QuicServerError> {
@@ -84,12 +83,8 @@ pub(crate) fn configure_server(
     const MAX_CONCURRENT_UNI_STREAMS: u32 =
         (QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS.saturating_mul(2)) as u32;
     config.max_concurrent_uni_streams(MAX_CONCURRENT_UNI_STREAMS.into());
-    config.stream_receive_window((TransactionPacket::DATA_SIZE as u32).into());
-    config.receive_window(
-        (TransactionPacket::DATA_SIZE as u32)
-            .saturating_mul(MAX_CONCURRENT_UNI_STREAMS)
-            .into(),
-    );
+    config.stream_receive_window((N as u32).into());
+    config.receive_window((N as u32).saturating_mul(MAX_CONCURRENT_UNI_STREAMS).into());
     let timeout = IdleTimeout::from(VarInt::from_u32(QUIC_MAX_TIMEOUT_MS));
     config.max_idle_timeout(Some(timeout));
 
@@ -301,11 +296,11 @@ impl StreamStats {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn spawn_server(
+pub fn spawn_server<const N: usize>(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
-    packet_sender: Sender<Batch<TransactionPacket>>,
+    packet_sender: Sender<Batch<N>>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -348,13 +343,14 @@ mod test {
         super::*,
         crate::nonblocking::quic::{test::*, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS},
         crossbeam_channel::unbounded,
+        solana_sdk::packet::TransactionPacket,
         std::net::SocketAddr,
     };
 
     fn setup_quic_server() -> (
         std::thread::JoinHandle<()>,
         Arc<AtomicBool>,
-        crossbeam_channel::Receiver<Batch<TransactionPacket>>,
+        crossbeam_channel::Receiver<Batch<{ TransactionPacket::DATA_SIZE }>>,
         SocketAddr,
     ) {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -421,7 +417,7 @@ mod test {
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let stats = Arc::new(StreamStats::default());
-        let (_, t) = spawn_server(
+        let (_, t) = spawn_server::<{ TransactionPacket::DATA_SIZE }>(
             s,
             &keypair,
             ip,
@@ -464,7 +460,7 @@ mod test {
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let stats = Arc::new(StreamStats::default());
-        let (_, t) = spawn_server(
+        let (_, t) = spawn_server::<{ TransactionPacket::DATA_SIZE }>(
             s,
             &keypair,
             ip,

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -11,12 +11,12 @@ use {
     std::{mem, os::unix::io::AsRawFd},
 };
 use {
-    solana_sdk::packet::{BasePacket, Meta},
+    solana_sdk::packet::{GenericPacket, Meta},
     std::{cmp, io, net::UdpSocket},
 };
 
 #[cfg(not(target_os = "linux"))]
-pub fn recv_mmsg<P: BasePacket>(
+pub fn recv_mmsg<const N: usize>(
     socket: &UdpSocket,
     packets: &mut [P],
 ) -> io::Result</*num packets:*/ usize> {
@@ -72,9 +72,9 @@ fn cast_socket_addr(addr: &sockaddr_storage, hdr: &mmsghdr) -> Option<InetAddr> 
 
 #[cfg(target_os = "linux")]
 #[allow(clippy::uninit_assumed_init)]
-pub fn recv_mmsg<P: BasePacket>(
+pub fn recv_mmsg<const N: usize>(
     sock: &UdpSocket,
-    packets: &mut [P],
+    packets: &mut [GenericPacket<N>],
 ) -> io::Result</*num packets:*/ usize> {
     // Assert that there are no leftovers in packets.
     debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -118,7 +118,7 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
 #[cfg(test)]
 mod tests {
     use {
-        crate::{packet::PACKET_DATA_SIZE, recvmmsg::*},
+        crate::recvmmsg::*,
         std::{
             net::{SocketAddr, UdpSocket},
             time::{Duration, Instant},
@@ -141,7 +141,7 @@ mod tests {
         let test_one_iter = |(reader, addr, sender, saddr): TestConfig| {
             let sent = TEST_NUM_MSGS - 1;
             for _ in 0..sent {
-                let data = [0; PACKET_DATA_SIZE];
+                let data = [0; Packet::DATA_SIZE];
                 sender.send_to(&data[..], addr).unwrap();
             }
 
@@ -149,7 +149,7 @@ mod tests {
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(sent, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
                 assert_eq!(packet.meta().socket_addr(), saddr);
             }
         };
@@ -167,7 +167,7 @@ mod tests {
         let test_multi_iter = |(reader, addr, sender, saddr): TestConfig| {
             let sent = TEST_NUM_MSGS + 10;
             for _ in 0..sent {
-                let data = [0; PACKET_DATA_SIZE];
+                let data = [0; Packet::DATA_SIZE];
                 sender.send_to(&data[..], addr).unwrap();
             }
 
@@ -175,7 +175,7 @@ mod tests {
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
                 assert_eq!(packet.meta().socket_addr(), saddr);
             }
 
@@ -185,7 +185,7 @@ mod tests {
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(sent - TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
                 assert_eq!(packet.meta().socket_addr(), saddr);
             }
         };
@@ -208,7 +208,7 @@ mod tests {
         let saddr = sender.local_addr().unwrap();
         let sent = TEST_NUM_MSGS;
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], addr).unwrap();
         }
 
@@ -217,7 +217,7 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr);
         }
         reader.set_nonblocking(true).unwrap();
@@ -243,12 +243,12 @@ mod tests {
         let sent2 = TEST_NUM_MSGS + 1;
 
         for _ in 0..sent1 {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender1.send_to(&data[..], addr).unwrap();
         }
 
         for _ in 0..sent2 {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender2.send_to(&data[..], addr).unwrap();
         }
 
@@ -257,11 +257,11 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(sent1) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr1);
         }
         for packet in packets.iter().skip(sent1).take(recv - sent1) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr2);
         }
 
@@ -271,7 +271,7 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(sent1 + sent2 - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), saddr2);
         }
     }

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -4,15 +4,15 @@
 #[allow(deprecated)]
 use nix::sys::socket::InetAddr;
 pub use solana_perf::packet::NUM_RCVMMSGS;
-use {
-    crate::packet::{Meta, Packet},
-    std::{cmp, io, net::UdpSocket},
-};
 #[cfg(target_os = "linux")]
 use {
     itertools::izip,
     libc::{iovec, mmsghdr, sockaddr_storage, socklen_t, AF_INET, AF_INET6, MSG_WAITFORONE},
     std::{mem, os::unix::io::AsRawFd},
+};
+use {
+    solana_sdk::packet::{BasePacket, Meta, Packet},
+    std::{cmp, io, net::UdpSocket},
 };
 
 #[cfg(not(target_os = "linux"))]

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -18,7 +18,7 @@ use {
 #[cfg(not(target_os = "linux"))]
 pub fn recv_mmsg<const N: usize>(
     socket: &UdpSocket,
-    packets: &mut [P],
+    packets: &mut [GenericPacket<N>],
 ) -> io::Result</*num packets:*/ usize> {
     debug_assert!(packets.iter().all(|pkt| pkt.meta == Meta::default()));
     let mut i = 0;

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -20,11 +20,11 @@ pub fn recv_mmsg<const N: usize>(
     socket: &UdpSocket,
     packets: &mut [P],
 ) -> io::Result</*num packets:*/ usize> {
-    debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
+    debug_assert!(packets.iter().all(|pkt| pkt.meta == Meta::default()));
     let mut i = 0;
     let count = cmp::min(NUM_RCVMMSGS, packets.len());
     for p in packets.iter_mut().take(count) {
-        p.meta_mut().size = 0;
+        p.meta.size = 0;
         match socket.recv_from(p.buffer_mut()) {
             Err(_) if i > 0 => {
                 break;
@@ -33,8 +33,8 @@ pub fn recv_mmsg<const N: usize>(
                 return Err(e);
             }
             Ok((nrecv, from)) => {
-                p.meta_mut().size = nrecv;
-                p.meta_mut().set_socket_addr(&from);
+                p.meta.size = nrecv;
+                p.meta.set_socket_addr(&from);
                 if i == 0 {
                     socket.set_nonblocking(true)?;
                 }
@@ -77,7 +77,7 @@ pub fn recv_mmsg<const N: usize>(
     packets: &mut [GenericPacket<N>],
 ) -> io::Result</*num packets:*/ usize> {
     // Assert that there are no leftovers in packets.
-    debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
+    debug_assert!(packets.iter().all(|pkt| pkt.meta == Meta::default()));
     const SOCKADDR_STORAGE_SIZE: usize = mem::size_of::<sockaddr_storage>();
 
     let mut hdrs: [mmsghdr; NUM_RCVMMSGS] = unsafe { mem::zeroed() };
@@ -113,9 +113,9 @@ pub fn recv_mmsg<const N: usize>(
         usize::try_from(nrecv).unwrap()
     };
     for (addr, hdr, pkt) in izip!(addrs, hdrs, packets.iter_mut()).take(nrecv) {
-        pkt.meta_mut().size = hdr.msg_len as usize;
+        pkt.meta.size = hdr.msg_len as usize;
         if let Some(addr) = cast_socket_addr(&addr, &hdr) {
-            pkt.meta_mut().set_socket_addr(&addr.to_std());
+            pkt.meta.set_socket_addr(&addr.to_std());
         }
     }
     Ok(nrecv)
@@ -156,8 +156,8 @@ mod tests {
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(sent, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-                assert_eq!(packet.meta().socket_addr(), saddr);
+                assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+                assert_eq!(packet.meta.socket_addr(), saddr);
             }
         };
 
@@ -182,18 +182,18 @@ mod tests {
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-                assert_eq!(packet.meta().socket_addr(), saddr);
+                assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+                assert_eq!(packet.meta.socket_addr(), saddr);
             }
 
             packets
                 .iter_mut()
-                .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+                .for_each(|pkt| pkt.meta = Meta::default());
             let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
             assert_eq!(sent - TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
-                assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-                assert_eq!(packet.meta().socket_addr(), saddr);
+                assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+                assert_eq!(packet.meta.socket_addr(), saddr);
             }
         };
 
@@ -224,14 +224,14 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr);
         }
         reader.set_nonblocking(true).unwrap();
 
         packets
             .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            .for_each(|pkt| pkt.meta = Meta::default());
         let _recv = recv_mmsg(&reader, &mut packets[..]);
         assert!(start.elapsed().as_secs() < 5);
     }
@@ -264,22 +264,22 @@ mod tests {
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(sent1) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr1);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr1);
         }
         for packet in packets.iter().skip(sent1).take(recv - sent1) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr2);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr2);
         }
 
         packets
             .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            .for_each(|pkt| pkt.meta = Meta::default());
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(sent1 + sent2 - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
-            assert_eq!(packet.meta().size, Packet::DATA_SIZE);
-            assert_eq!(packet.meta().socket_addr(), saddr2);
+            assert_eq!(packet.meta.size, Packet::DATA_SIZE);
+            assert_eq!(packet.meta.socket_addr(), saddr2);
         }
     }
 }

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -165,7 +165,7 @@ mod tests {
             recvmmsg::recv_mmsg,
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
-        solana_sdk::packet::{BasePacket, Packet},
+        solana_sdk::packet::Packet,
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -166,7 +166,6 @@ mod tests {
             recvmmsg::recv_mmsg,
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
-        solana_sdk::packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
@@ -179,7 +178,7 @@ mod tests {
         let addr = reader.local_addr().unwrap();
         let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
 
-        let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..32).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &addr)).collect();
 
         let sent = batch_send(&sender, &packet_refs[..]).ok();
@@ -200,7 +199,7 @@ mod tests {
 
         let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
 
-        let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..32).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets
             .iter()
             .enumerate()
@@ -270,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_intermediate_failures_mismatched_bind() {
-        let packets: Vec<_> = (0..3).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..3).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let ip4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ip6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
         let packet_refs: Vec<_> = vec![
@@ -293,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_intermediate_failures_unreachable_address() {
-        let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..5).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
         let sender = UdpSocket::bind("0.0.0.0:0").expect("bind");

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -162,10 +162,10 @@ where
 mod tests {
     use {
         crate::{
-            packet::Packet,
             recvmmsg::recv_mmsg,
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
+        solana_sdk::packet::{BasePacket, Packet},
         std::{
             io::ErrorKind,
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -416,7 +416,7 @@ mod test {
     use {
         super::*,
         crate::{
-            packet::{Packet, PacketBatch, PACKET_DATA_SIZE},
+            packet::{Packet, PacketBatch},
             streamer::{receiver, responder},
         },
         crossbeam_channel::unbounded,
@@ -488,7 +488,7 @@ mod test {
                 let mut p = Packet::default();
                 {
                     p.buffer_mut()[0] = i as u8;
-                    p.meta_mut().size = PACKET_DATA_SIZE;
+                    p.meta_mut().size = Packet::DATA_SIZE;
                     p.meta_mut().set_socket_addr(&addr);
                 }
                 packet_batch.push(p);

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -287,7 +287,7 @@ impl StreamerSendStats {
     }
 
     fn record<const N: usize>(&mut self, pkt: &GenericPacket<N>) {
-        let ent = self.host_map.entry(pkt.meta().addr).or_default();
+        let ent = self.host_map.entry(pkt.meta.addr).or_default();
         ent.count += 1;
         ent.bytes += pkt.data(..).map(<[u8]>::len).unwrap_or_default() as u64;
     }
@@ -305,7 +305,7 @@ fn recv_send<const N: usize>(
         packet_batch.iter().for_each(|p| stats.record(p));
     }
     let packets = packet_batch.iter().filter_map(|pkt| {
-        let addr = pkt.meta().socket_addr();
+        let addr = pkt.meta.socket_addr();
         let data = pkt.data(..)?;
         socket_addr_space.check(&addr).then_some((data, addr))
     });
@@ -492,8 +492,8 @@ mod test {
                 let mut p = Packet::default();
                 {
                     p.buffer_mut()[0] = i as u8;
-                    p.meta_mut().size = Packet::DATA_SIZE;
-                    p.meta_mut().set_socket_addr(&addr);
+                    p.meta.size = Packet::DATA_SIZE;
+                    p.meta.set_socket_addr(&addr);
                 }
                 packet_batch.push(p);
             }

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "linux")]
 
 use {
-    solana_sdk::packet::{BasePacket, Meta, Packet},
+    solana_sdk::packet::{Meta, Packet},
     solana_streamer::recvmmsg::*,
     std::{net::UdpSocket, time::Instant},
 };

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -1,10 +1,8 @@
 #![cfg(target_os = "linux")]
 
 use {
-    solana_streamer::{
-        packet::{Meta, Packet},
-        recvmmsg::*,
-    },
+    solana_sdk::packet::{BasePacket, Meta, Packet},
+    solana_streamer::recvmmsg::*,
     std::{net::UdpSocket, time::Instant},
 };
 

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -2,7 +2,7 @@
 
 use {
     solana_streamer::{
-        packet::{Meta, Packet, PACKET_DATA_SIZE},
+        packet::{Meta, Packet},
         recvmmsg::*,
     },
     std::{net::UdpSocket, time::Instant},
@@ -21,7 +21,7 @@ pub fn test_recv_mmsg_batch_size() {
     let mut num_max_batches = 0;
     (0..1000).for_each(|_| {
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], addr).unwrap();
         }
         let mut packets = vec![Packet::default(); TEST_BATCH_SIZE];
@@ -37,7 +37,7 @@ pub fn test_recv_mmsg_batch_size() {
     let mut elapsed_in_small_batch = 0;
     (0..1000).for_each(|_| {
         for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
+            let data = [0; Packet::DATA_SIZE];
             sender.send_to(&data[..], addr).unwrap();
         }
         let mut packets = vec![Packet::default(); 4];

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -48,7 +48,7 @@ pub fn test_recv_mmsg_batch_size() {
             }
             packets
                 .iter_mut()
-                .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+                .for_each(|pkt| pkt.meta = Meta::default());
         }
         elapsed_in_small_batch += now.elapsed().as_nanos();
         assert_eq!(TEST_BATCH_SIZE, recv);

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -18,7 +18,7 @@ use {
         commitment_config::CommitmentConfig,
         instruction::{AccountMeta, Instruction},
         message::Message,
-        packet::{BasePacket, TransactionPacket},
+        packet::TransactionPacket,
         pubkey::Pubkey,
         rpc_port::DEFAULT_RPC_PORT,
         signature::{read_keypair_file, Keypair, Signer},

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -18,7 +18,7 @@ use {
         commitment_config::CommitmentConfig,
         instruction::{AccountMeta, Instruction},
         message::Message,
-        packet::TransactionPacket,
+        packet::{BasePacket, TransactionPacket},
         pubkey::Pubkey,
         rpc_port::DEFAULT_RPC_PORT,
         signature::{read_keypair_file, Keypair, Signer},

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -18,7 +18,7 @@ use {
         commitment_config::CommitmentConfig,
         instruction::{AccountMeta, Instruction},
         message::Message,
-        packet::PACKET_DATA_SIZE,
+        packet::TransactionPacket,
         pubkey::Pubkey,
         rpc_port::DEFAULT_RPC_PORT,
         signature::{read_keypair_file, Keypair, Signer},
@@ -390,7 +390,11 @@ fn run_transactions_dos(
                         let tx = Transaction::new(&signers, message, blockhash);
                         if !tested_size.load(Ordering::Relaxed) {
                             let ser_size = bincode::serialized_size(&tx).unwrap();
-                            assert!(ser_size < PACKET_DATA_SIZE as u64, "{}", ser_size);
+                            assert!(
+                                ser_size < TransactionPacket::DATA_SIZE as u64,
+                                "{}",
+                                ser_size
+                            );
                             tested_size.store(true, Ordering::Relaxed);
                         }
                         tx
@@ -668,7 +672,7 @@ pub mod test {
         let tx = Transaction::new(&signers, message, blockhash);
         let size = bincode::serialized_size(&tx).unwrap();
         info!("size:{}", size);
-        assert!(size < PACKET_DATA_SIZE as u64);
+        assert!(size < TransactionPacket::DATA_SIZE as u64);
     }
 
     #[test]

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -54,14 +54,14 @@ impl TpuConnection for UdpTpuConnection {
 mod tests {
     use {
         super::*,
-        solana_sdk::packet::{Packet, PACKET_DATA_SIZE},
+        solana_sdk::packet::Packet,
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
         tokio::net::UdpSocket,
     };
 
     async fn check_send_one(connection: &UdpTpuConnection, reader: &UdpSocket) {
-        let packet = vec![111u8; PACKET_DATA_SIZE];
+        let packet = vec![111u8; Packet::DATA_SIZE];
         connection.send_wire_transaction(&packet).await.unwrap();
         let mut packets = vec![Packet::default(); 32];
         let recv = recv_mmsg(reader, &mut packets[..]).await.unwrap();
@@ -69,7 +69,7 @@ mod tests {
     }
 
     async fn check_send_batch(connection: &UdpTpuConnection, reader: &UdpSocket) {
-        let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let packets: Vec<_> = (0..32).map(|_| vec![0u8; Packet::DATA_SIZE]).collect();
         connection
             .send_wire_transaction_batch(&packets)
             .await

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -54,7 +54,7 @@ impl TpuConnection for UdpTpuConnection {
 mod tests {
     use {
         super::*,
-        solana_sdk::packet::Packet,
+        solana_sdk::packet::{BasePacket, Packet},
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
         tokio::net::UdpSocket,

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -54,7 +54,7 @@ impl TpuConnection for UdpTpuConnection {
 mod tests {
     use {
         super::*,
-        solana_sdk::packet::{BasePacket, Packet},
+        solana_sdk::packet::Packet,
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
         tokio::net::UdpSocket,


### PR DESCRIPTION
#### Problem

As we march towards larger transaction sizes, we want to avoid having a negative impact on the rest of the networking layer.  Currently, everything is treated as a general `PacketBatch`, which is always assumed to have the same size.

For transactions, packets may be larger than 1 MTU, so we need a way to separate transaction packets from all other packets.

#### Summary of Changes

This is entirely a (pretty big) refactor to make `PacketBatch` into a generic struct that can accept either a `Packet` or a `TransactionPacket`, through a `BasePacket` trait.

In this PR, both packet types have the same size, so this PR can be merged. Here's what it does in total

* create `BasePacket` trait, implemented by `Packet` and `TransactionPacket`
* change `PacketBatch` to `Batch<P: BasePacket>`, use everywhere
* use `TransactionPacket` for transactions in RPC, banking stage, fetch stage, sigverify, and QUIC

Additional changes required to the refactor:

* removed the `SigVerifier` trait, which only had one other totally unused implementation. This made the templating much less messy
* the CUDA sig verifier used to take in `*const Packet`, while the underlying libs take `uint8_t*`, so updated that to `*const u8`. This worked fine in testing.
* fetch stage now has *two* recyclers, one for `Packet`s and one for `TransactionPacket`s. I used the same values to create both of them, but that can be tweaked if needed
* in banking stage, separated the creation of banking threads to accommodate the different types. No change to functionality 
* create two different `TransactionSigVerifier`s, one for `TransactionPacket` (normal tx processing) and one for `Packet` (vote processing). No change to functionality, just might be confusing

The only potential impact to performance would be going through the trait to get the `meta()` and `meta_mut()`, but those should get inlined by the compiler since there's no dynamic dispatch, only templating.

For testing, we can add a simple patch to this that doubles `TransactionPacket`'s size.

For future work, the idea is to update `TransactionPacket` to have variable size.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
