### PR TITLE
fix: prevent the first-ever signature subscription from leaking

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3712,7 +3712,7 @@ export class Connection {
         disposeSignatureSubscriptionStateChangeObserver();
         disposeSignatureSubscriptionStateChangeObserver = undefined;
       }
-      if (signatureSubscriptionId) {
+      if (signatureSubscriptionId != null) {
         this.removeSignatureListener(signatureSubscriptionId);
         signatureSubscriptionId = undefined;
       }


### PR DESCRIPTION
Oof. Classic nullish coercion bug. This PR ensures that even subscriptions with exactly the id `0` get cleaned up when they should.