### PR TITLE
fix: pretty print PublicKey objects in node and in the browser

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -129,6 +129,10 @@ export class PublicKey extends Struct {
     return zeroPad;
   }
 
+  get [Symbol.toStringTag](): string {
+    return `PublicKey(${this.toString()})`;
+  }
+
   /**
    * Return the base-58 representation of the public key
    */

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -4472,7 +4472,8 @@ describe('Connection', function () {
 
         expect(largestAccounts).to.have.length(2);
         const largestAccount = largestAccounts[0];
-        expect(largestAccount.address).to.eql(testTokenAccountPubkey);
+        expect(largestAccount.address.equals(testTokenAccountPubkey)).to.be
+          .true;
         expect(largestAccount.amount).to.eq('11110');
         expect(largestAccount.decimals).to.eq(2);
         expect(largestAccount.uiAmount).to.eq(111.1);


### PR DESCRIPTION
#### Problem

`console.log(publicKey)` is unreadable in Node.

#### Summary of Changes

Add an object stringifier that includes the base58 string.

#### Test plan 

##### Node

```shell
$ node
Welcome to Node.js v16.18.1.
Type ".help" for more information.
> const {PublicKey} = require('./lib/index.cjs.js')
undefined
> console.log(PublicKey.default.toString())
11111111111111111111111111111111
undefined
> console.log(PublicKey.default)
PublicKey [PublicKey(11111111111111111111111111111111)] {
  _bn: <BN: 0>
}
undefined
```

##### Browser
<img width="350" alt="image" src="https://user-images.githubusercontent.com/13243/205415894-bfd74b00-cf09-4dd9-bbc7-e27c2d25f523.png">

Fixes #20022.