### PR TITLE
Fix options passing in sendTransaction method

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -5592,7 +5592,7 @@ export class Connection {
       }
 
       const wireTransaction = transaction.serialize();
-      return await this.sendRawTransaction(wireTransaction, options);
+      return await this.sendRawTransaction(wireTransaction, signersOrOptions);
     }
 
     if (signersOrOptions === undefined || !Array.isArray(signersOrOptions)) {


### PR DESCRIPTION
#### Problem
`sendTransaction` method accepts 2 params in VersionedTransaction case: transaction and options.
There is no ability to pass options because the third and undefined param `options` is passed to `sendRawTransaction` method instead of `signersOrOptions`.

#### Summary of Changes
Replace `options` param with `signersOrOptions` in case of transaction is versioned.