### PR TITLE
Mergify: don't add automerge label to backport PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -96,17 +96,6 @@ pull_request_rules:
     actions:
       dismiss_reviews:
         changes_requested: true
-  - name: set automerge label on mergify backport PRs
-    conditions:
-      - author=mergify[bot]
-      - head~=^mergify/bp/
-      - "#status-failure=0"
-      - "-merged"
-      - label!=no-automerge
-    actions:
-      label:
-        add:
-          - automerge
   - name: v1.13 feature-gate backport
     conditions:
       - label=v1.13


### PR DESCRIPTION
#### Summary of Changes
Don't automatically include the `automerge` label on backport PRs created by mergify. The label can still be added by a human. 

This change is part of a broader shift to backport less frequently and review backports more closely.

Context: https://discord.com/channels/428295358100013066/910937142182682656/1048642921517301810