### PR TITLE
ci: make docs job name more explicit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,8 @@ jobs:
     needs:
       - check
     if: ${{ needs.check.outputs.continue == 1 }}
-    name: build & deploy
+    # the name is used by .mergify.yml as well
+    name: build & deploy docs
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/29026
mergify only detects job names. make docs's job name more explicit.
