### PR TITLE
test_process_stale_slot_with_budget never uses write cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -14973,7 +14973,17 @@ pub(crate) mod tests {
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
 
-        let mut bank = create_simple_test_arc_bank(1_000_000_000);
+        // this test only tests non-write cache code
+        // Tests need to default to use write cache by default for all tests.
+        // Once that happens, the code this test tests can be deleted, along with this test.
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
+        let mut bank = Arc::new(Bank::new_with_config_for_tests(
+            &genesis_config,
+            AccountSecondaryIndexes::default(),
+            false,
+            AccountShrinkThreshold::default(),
+        ));
+
         bank.restore_old_behavior_for_fragile_tests();
         assert_eq!(bank.process_stale_slot_with_budget(0, 0), 0);
         assert_eq!(bank.process_stale_slot_with_budget(133, 0), 133);


### PR DESCRIPTION
#### Problem
See comments in the test. This pr allows the default to be set to write cache only for all tests without affecting this test.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
