### PR TITLE
docs: add endianess for pubkey byte/buffer functions

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -109,14 +109,14 @@ export class PublicKey extends Struct {
   }
 
   /**
-   * Return the byte array representation of the public key
+   * Return the byte array representation of the public key in big endian
    */
   toBytes(): Uint8Array {
     return this.toBuffer();
   }
 
   /**
-   * Return the Buffer representation of the public key
+   * Return the Buffer representation of the public key in big endian
    */
   toBuffer(): Buffer {
     const b = this._bn.toArrayLike(Buffer);


### PR DESCRIPTION
#### Problem
Need to try it out/check code to find out in what endianess the bytes/buffer of the PublicKey are returned

#### Summary of Changes
Specify it's in big endian in the comment/docs
