### PR TITLE
perf: Change underlying Elems to *const u8

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -224,7 +224,6 @@ pub fn verify_shreds_gpu(
     let mut out = recycler_cache.buffer().allocate("out_buffer");
     out.set_pinnable();
     elems.push(perf_libs::Elems {
-        #[allow(clippy::cast_ptr_alignment)]
         elems: pubkeys.as_ptr().cast::<u8>(),
         num: num_packets as u32,
     });
@@ -352,7 +351,6 @@ pub fn sign_shreds_gpu(
     signatures_out.set_pinnable();
     signatures_out.resize(total_sigs * sig_size, 0);
     elems.push(perf_libs::Elems {
-        #[allow(clippy::cast_ptr_alignment)]
         elems: pinned_keypair.as_ptr().cast::<u8>(),
         num: num_keypair_packets as u32,
     });

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -225,13 +225,13 @@ pub fn verify_shreds_gpu(
     out.set_pinnable();
     elems.push(perf_libs::Elems {
         #[allow(clippy::cast_ptr_alignment)]
-        elems: pubkeys.as_ptr() as *const solana_sdk::packet::Packet,
+        elems: pubkeys.as_ptr().cast::<u8>(),
         num: num_packets as u32,
     });
 
     for batch in batches {
         elems.push(perf_libs::Elems {
-            elems: batch.as_ptr(),
+            elems: batch.as_ptr().cast::<u8>(),
             num: batch.len() as u32,
         });
         let mut v = Vec::new();
@@ -353,13 +353,13 @@ pub fn sign_shreds_gpu(
     signatures_out.resize(total_sigs * sig_size, 0);
     elems.push(perf_libs::Elems {
         #[allow(clippy::cast_ptr_alignment)]
-        elems: pinned_keypair.as_ptr() as *const solana_sdk::packet::Packet,
+        elems: pinned_keypair.as_ptr().cast::<u8>(),
         num: num_keypair_packets as u32,
     });
 
     for batch in batches.iter() {
         elems.push(perf_libs::Elems {
-            elems: batch.as_ptr(),
+            elems: batch.as_ptr().cast::<u8>(),
             num: batch.len() as u32,
         });
         let mut v = Vec::new();

--- a/perf/src/perf_libs.rs
+++ b/perf/src/perf_libs.rs
@@ -3,7 +3,6 @@ use {
     dlopen::symbor::{Container, SymBorApi, Symbol},
     dlopen_derive::SymBorApi,
     log::*,
-    solana_sdk::packet::Packet,
     std::{
         env,
         ffi::OsStr,
@@ -16,7 +15,7 @@ use {
 
 #[repr(C)]
 pub struct Elems {
-    pub elems: *const Packet,
+    pub elems: *const u8,
     pub num: u32,
 }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -766,7 +766,7 @@ pub fn ed25519_verify(
     let mut num_packets: usize = 0;
     for batch in batches.iter() {
         elems.push(perf_libs::Elems {
-            elems: batch.as_ptr(),
+            elems: batch.as_ptr().cast::<u8>(),
             num: batch.len() as u32,
         });
         let v = vec![0u8; batch.len()];


### PR DESCRIPTION
#### Problem

As part of the work in #29055 to refactor the `Packet` type, the GPU sigverify path needs to work for two different types, and not just `Packet`.

#### Summary of Changes

The underlying perf libs take `uint8_t*`, so make `Elems` consistent with that, which will also make it work for another `Packet` type.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
