### PR TITLE
sdk: Make Packet::meta private, use accessor functions

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -25,8 +25,8 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
     let mut packet_batch = PacketBatch::with_capacity(batch_size);
     packet_batch.resize(batch_size, Packet::default());
     for w in packet_batch.iter_mut() {
-        w.meta.size = PACKET_DATA_SIZE;
-        w.meta.set_socket_addr(addr);
+        w.meta_mut().size = PACKET_DATA_SIZE;
+        w.meta_mut().set_socket_addr(addr);
     }
     let packet_batch = Arc::new(packet_batch);
     spawn(move || loop {
@@ -35,8 +35,8 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         }
         let mut num = 0;
         for p in packet_batch.iter() {
-            let a = p.meta.socket_addr();
-            assert!(p.meta.size <= PACKET_DATA_SIZE);
+            let a = p.meta().socket_addr();
+            assert!(p.meta().size <= PACKET_DATA_SIZE);
             let data = p.data(..).unwrap_or_default();
             send.send_to(data, a).unwrap();
             num += 1;

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -255,7 +255,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         let mut packet_batches = to_packet_batches(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
             for packet in batch.iter_mut() {
-                packet.meta.set_simple_vote(true);
+                packet.meta_mut().set_simple_vote(true);
             }
         }
         packet_batches

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -52,7 +52,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
         total += batch.len();
         for p in batch.iter_mut() {
             let ip_index = thread_rng().gen_range(0, ips.len());
-            p.meta.addr = ips[ip_index];
+            p.meta_mut().addr = ips[ip_index];
         }
     }
     info!("total packets: {}", total);
@@ -62,10 +62,10 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for p in batch.iter_mut() {
-                if !p.meta.discard() {
+                if !p.meta().discard() {
                     num_packets += 1;
                 }
-                p.meta.set_discard(false);
+                p.meta_mut().set_discard(false);
             }
         }
         assert_eq!(num_packets, 10_000);
@@ -97,7 +97,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     for batch in batches.iter_mut() {
         for packet in batch.iter_mut() {
             // One spam address, ~1000 unique addresses.
-            packet.meta.addr = if rng.gen_ratio(1, 30) {
+            packet.meta_mut().addr = if rng.gen_ratio(1, 30) {
                 new_rand_addr(&mut rng)
             } else {
                 spam_addr
@@ -109,10 +109,10 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for packet in batch.iter_mut() {
-                if !packet.meta.discard() {
+                if !packet.meta().discard() {
                     num_packets += 1;
                 }
-                packet.meta.set_discard(false);
+                packet.meta_mut().set_discard(false);
             }
         }
         assert_eq!(num_packets, 10_000);
@@ -215,7 +215,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
         batch.iter_mut().for_each(|p| {
             let throw = die.sample(&mut rng);
             if throw < discard_factor {
-                p.meta.set_discard(true);
+                p.meta_mut().set_discard(true);
                 c += 1;
             }
         })

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -38,7 +38,7 @@ fn build_packet_batch(
                     recent_blockhash.unwrap_or_else(Hash::new_unique),
                 );
                 let mut packet = Packet::from_data(None, tx).unwrap();
-                packet.meta.sender_stake = sender_stake as u64;
+                packet.meta_mut().sender_stake = sender_stake as u64;
                 packet
             })
             .collect(),
@@ -66,7 +66,7 @@ fn build_randomized_packet_batch(
                 );
                 let mut packet = Packet::from_data(None, tx).unwrap();
                 let sender_stake = distribution.sample(&mut rng);
-                packet.meta.sender_stake = sender_stake as u64;
+                packet.meta_mut().sender_stake = sender_stake as u64;
                 packet
             })
             .collect(),
@@ -120,8 +120,8 @@ fn bench_packet_clone(bencher: &mut Bencher) {
             let mut timer = Measure::start("insert_batch");
             packet_batch.iter().for_each(|packet| {
                 let mut packet = packet.clone();
-                packet.meta.sender_stake *= 2;
-                if packet.meta.sender_stake > 2 {
+                packet.meta_mut().sender_stake *= 2;
+                if packet.meta().sender_stake > 2 {
                     outer_packet = packet;
                 }
             });

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -343,7 +343,7 @@ impl AncestorHashesService {
         keypair: &Keypair,
         ancestor_socket: &UdpSocket,
     ) -> Option<(Slot, DuplicateAncestorDecision)> {
-        let from_addr = packet.meta.socket_addr();
+        let from_addr = packet.meta().socket_addr();
         let packet_data = match packet.data(..) {
             Some(data) => data,
             None => {
@@ -1205,7 +1205,9 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet.meta.set_socket_addr(&responder_info.serve_repair);
+        packet
+            .meta_mut()
+            .set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1465,7 +1467,7 @@ mod test {
 
         // Create invalid packet with fewer bytes than the size of the nonce
         let mut packet = Packet::default();
-        packet.meta.size = 0;
+        packet.meta_mut().size = 0;
 
         assert!(AncestorHashesService::verify_and_process_ancestor_response(
             &packet,
@@ -1573,7 +1575,9 @@ mod test {
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
         let packet = &mut response_packet[0];
-        packet.meta.set_socket_addr(&responder_info.serve_repair);
+        packet
+            .meta_mut()
+            .set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -556,7 +556,7 @@ impl BankingStage {
 
         let packet_vec: Vec<_> = forwardable_packets
             .filter_map(|p| {
-                if !p.meta.forwarded() && data_budget.take(p.meta.size) {
+                if !p.meta().forwarded() && data_budget.take(p.meta().size) {
                     Some(p.data(..)?.to_vec())
                 } else {
                     None
@@ -2122,7 +2122,7 @@ mod tests {
         with_vers.iter_mut().for_each(|(b, v)| {
             b.iter_mut()
                 .zip(v)
-                .for_each(|(p, f)| p.meta.set_discard(*f == 0))
+                .for_each(|(p, f)| p.meta_mut().set_discard(*f == 0))
         });
         with_vers.into_iter().map(|(b, _)| b).collect()
     }
@@ -3925,7 +3925,7 @@ mod tests {
         let forwarded_packet = {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, fwd_block_hash);
             let mut packet = Packet::from_data(None, transaction).unwrap();
-            packet.meta.flags |= PacketFlags::FORWARDED;
+            packet.meta_mut().flags |= PacketFlags::FORWARDED;
             DeserializedPacket::new(packet).unwrap()
         };
 
@@ -4005,7 +4005,7 @@ mod tests {
                 let num_received = recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
                 assert_eq!(num_received, expected_ids.len(), "{}", name);
                 for (i, expected_id) in expected_ids.iter().enumerate() {
-                    assert_eq!(packets[i].meta.size, 215);
+                    assert_eq!(packets[i].meta().size, 215);
                     let recv_transaction: VersionedTransaction =
                         packets[i].deserialize_slice(..).unwrap();
                     assert_eq!(

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -347,7 +347,7 @@ impl ClusterInfoVoteListener {
             .filter(|(_, packet_batch)| {
                 // to_packet_batches() above splits into 1 packet long batches
                 assert_eq!(packet_batch.len(), 1);
-                !packet_batch[0].meta.discard()
+                !packet_batch[0].meta().discard()
             })
             .filter_map(|(tx, packet_batch)| {
                 let (vote_account_key, vote, ..) = vote_parser::parse_vote_transaction(&tx)?;

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -102,7 +102,7 @@ impl FetchStage {
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> Result<()> {
         let mark_forwarded = |packet: &mut Packet| {
-            packet.meta.flags |= PacketFlags::FORWARDED;
+            packet.meta_mut().flags |= PacketFlags::FORWARDED;
         };
 
         let mut packet_batch = recvr.recv()?;

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -150,8 +150,8 @@ impl FindPacketSenderStakeStage {
             .iter_mut()
             .flat_map(|batch| batch.iter_mut())
             .for_each(|packet| {
-                packet.meta.sender_stake = ip_to_stake
-                    .get(&packet.meta.addr)
+                packet.meta_mut().sender_stake = ip_to_stake
+                    .get(&packet.meta().addr)
                     .copied()
                     .unwrap_or_default();
             });

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -54,7 +54,7 @@ impl ImmutableDeserializedPacket {
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
         let message_hash = Message::hash_raw_message(message_bytes);
-        let is_simple_vote = packet.meta.is_simple_vote_tx();
+        let is_simple_vote = packet.meta().is_simple_vote_tx();
 
         // drop transaction if prioritization fails.
         let mut priority_details = priority_details

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -34,7 +34,7 @@ pub struct LatestValidatorVotePacket {
 
 impl LatestValidatorVotePacket {
     pub fn new(packet: Packet, vote_source: VoteSource) -> Result<Self, DeserializedPacketError> {
-        if !packet.meta.is_simple_vote_tx() {
+        if !packet.meta().is_simple_vote_tx() {
             return Err(DeserializedPacketError::VoteTransactionError);
         }
 
@@ -347,7 +347,10 @@ mod tests {
             None,
         );
         let mut packet = Packet::from_data(None, vote_tx).unwrap();
-        packet.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
+        packet
+            .meta_mut()
+            .flags
+            .set(PacketFlags::SIMPLE_VOTE_TX, true);
         LatestValidatorVotePacket::new(packet, vote_source).unwrap()
     }
 
@@ -380,7 +383,7 @@ mod tests {
             ),
         )
         .unwrap();
-        vote.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
+        vote.meta_mut().flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_switch = Packet::from_data(
             None,
             new_vote_transaction(
@@ -395,7 +398,7 @@ mod tests {
         )
         .unwrap();
         vote_switch
-            .meta
+            .meta_mut()
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_state_update = Packet::from_data(
@@ -411,7 +414,7 @@ mod tests {
         )
         .unwrap();
         vote_state_update
-            .meta
+            .meta_mut()
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let mut vote_state_update_switch = Packet::from_data(
@@ -427,7 +430,7 @@ mod tests {
         )
         .unwrap();
         vote_state_update_switch
-            .meta
+            .meta_mut()
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
         let random_transaction = Packet::from_data(

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -122,7 +122,7 @@ impl PacketDeserializer {
         packet_batch
             .iter()
             .enumerate()
-            .filter(|(_, pkt)| !pkt.meta.discard())
+            .filter(|(_, pkt)| !pkt.meta().discard())
             .map(|(index, _)| index)
             .collect()
     }
@@ -179,7 +179,7 @@ mod tests {
         let transactions = vec![random_transfer(), random_transfer()];
         let mut packet_batches = to_packet_batches(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
-        packet_batches[0][0].meta.set_discard(true);
+        packet_batches[0][0].meta_mut().set_discard(true);
 
         let results = PacketDeserializer::deserialize_and_collect_packets(&packet_batches, None);
         assert_eq!(results.deserialized_packets.len(), 1);

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -32,8 +32,8 @@ pub fn repair_response_packet_from_bytes(
     if size > packet.buffer_mut().len() {
         return None;
     }
-    packet.meta.size = size;
-    packet.meta.set_socket_addr(dest);
+    packet.meta_mut().size = size;
+    packet.meta_mut().set_socket_addr(dest);
     packet.buffer_mut()[..bytes.len()].copy_from_slice(&bytes);
     let mut wr = io::Cursor::new(&mut packet.buffer_mut()[bytes.len()..]);
     bincode::serialize_into(&mut wr, &nonce).expect("Buffer not large enough to fit nonce");
@@ -90,7 +90,7 @@ mod test {
             nonce,
         )
         .unwrap();
-        packet.meta.flags |= PacketFlags::REPAIR;
+        packet.meta_mut().flags |= PacketFlags::REPAIR;
 
         let leader_slots = [(slot, keypair.pubkey().to_bytes())]
             .iter()

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -95,9 +95,9 @@ impl ShredFetchStage {
                     &mut shreds_received,
                     &mut stats,
                 ) {
-                    packet.meta.set_discard(true);
+                    packet.meta_mut().set_discard(true);
                 } else {
-                    packet.meta.flags.insert(flags);
+                    packet.meta_mut().flags.insert(flags);
                 }
             }
             stats.maybe_submit(name, STATS_SUBMIT_CADENCE);

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -94,7 +94,7 @@ impl SigVerifier for TransactionSigVerifier {
         is_dup: bool,
     ) {
         sigverify::check_for_tracer_packet(packet);
-        if packet.meta.is_tracer_packet() {
+        if packet.meta().is_tracer_packet() {
             if removed_before_sigverify_stage {
                 self.tracer_packet_stats
                     .total_removed_before_sigverify_stage += 1;
@@ -110,14 +110,14 @@ impl SigVerifier for TransactionSigVerifier {
 
     #[inline(always)]
     fn process_excess_packet(&mut self, packet: &Packet) {
-        if packet.meta.is_tracer_packet() {
+        if packet.meta().is_tracer_packet() {
             self.tracer_packet_stats.total_excess_tracer_packets += 1;
         }
     }
 
     #[inline(always)]
     fn process_passed_sigverify_packet(&mut self, packet: &Packet) {
-        if packet.meta.is_tracer_packet() {
+        if packet.meta().is_tracer_packet() {
             self.tracer_packet_stats
                 .total_tracker_packets_passed_sigverify += 1;
         }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -253,8 +253,8 @@ impl SigVerifyStage {
             .iter_mut()
             .rev()
             .flat_map(|batch| batch.iter_mut().rev())
-            .filter(|packet| !packet.meta.discard())
-            .map(|packet| (packet.meta.addr, packet))
+            .filter(|packet| !packet.meta().discard())
+            .map(|packet| (packet.meta().addr, packet))
             .into_group_map();
         // Allocate max_packets evenly across addresses.
         while max_packets > 0 && !addrs.is_empty() {
@@ -269,7 +269,7 @@ impl SigVerifyStage {
         // Discard excess packets from each address.
         for packet in addrs.into_values().flatten() {
             process_excess_packet(packet);
-            packet.meta.set_discard(true);
+            packet.meta_mut().set_discard(true);
         }
     }
 
@@ -473,7 +473,7 @@ mod tests {
         packet_batches
             .iter()
             .flatten()
-            .filter(|p| !p.meta.discard())
+            .filter(|p| !p.meta().discard())
             .count()
     }
 
@@ -483,18 +483,18 @@ mod tests {
         let batch_size = 10;
         let mut batch = PacketBatch::with_capacity(batch_size);
         let mut tracer_packet = Packet::default();
-        tracer_packet.meta.flags |= PacketFlags::TRACER_PACKET;
+        tracer_packet.meta_mut().flags |= PacketFlags::TRACER_PACKET;
         batch.resize(batch_size, tracer_packet);
-        batch[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
-        batch[3].meta.set_discard(true);
+        batch[3].meta_mut().addr = std::net::IpAddr::from([1u16; 8]);
+        batch[3].meta_mut().set_discard(true);
         let num_discarded_before_filter = 1;
-        batch[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
+        batch[4].meta_mut().addr = std::net::IpAddr::from([2u16; 8]);
         let total_num_packets = batch.len();
         let mut batches = vec![batch];
         let max = 3;
         let mut total_tracer_packets_discarded = 0;
         SigVerifyStage::discard_excess_packets(&mut batches, max, |packet| {
-            if packet.meta.is_tracer_packet() {
+            if packet.meta().is_tracer_packet() {
                 total_tracer_packets_discarded += 1;
             }
         });
@@ -508,9 +508,9 @@ mod tests {
             total_discarded - num_discarded_before_filter
         );
         assert_eq!(total_non_discard, max);
-        assert!(!batches[0][0].meta.discard());
-        assert!(batches[0][3].meta.discard());
-        assert!(!batches[0][4].meta.discard());
+        assert!(!batches[0][0].meta().discard());
+        assert!(batches[0][3].meta().discard());
+        assert!(!batches[0][4].meta().discard());
     }
 
     fn gen_batches(
@@ -556,7 +556,7 @@ mod tests {
                 sent_len += batch.len();
                 batch
                     .iter_mut()
-                    .for_each(|packet| packet.meta.flags |= PacketFlags::TRACER_PACKET);
+                    .for_each(|packet| packet.meta_mut().flags |= PacketFlags::TRACER_PACKET);
                 assert_eq!(batch.len(), packets_per_batch);
                 packet_s.send(vec![batch]).unwrap();
             }
@@ -637,7 +637,7 @@ mod tests {
             batches.iter_mut().for_each(|batch| {
                 batch.iter_mut().for_each(|p| {
                     if ((index + 1) as f64 / num_packets as f64) < MAX_DISCARDED_PACKET_RATE {
-                        p.meta.set_discard(true);
+                        p.meta_mut().set_discard(true);
                     }
                     index += 1;
                 })
@@ -647,7 +647,7 @@ mod tests {
         assert_eq!(SigVerifyStage::maybe_shrink_batches(&mut batches).1, 0);
 
         // discard one more to exceed shrink threshold
-        batches.last_mut().unwrap()[0].meta.set_discard(true);
+        batches.last_mut().unwrap()[0].meta_mut().set_discard(true);
 
         let expected_num_shrunk_batches =
             1.max((num_generated_batches as f64 * MAX_DISCARDED_PACKET_RATE) as usize);

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -126,7 +126,7 @@ impl UnprocessedPacketBatches {
                 if dropped_packet
                     .immutable_section()
                     .original_packet()
-                    .meta
+                    .meta()
                     .is_tracer_packet()
                 {
                     num_dropped_tracer_packets += 1;
@@ -478,7 +478,7 @@ mod tests {
             packet_vector.push(Packet::from_data(None, tx).unwrap());
         }
         for index in vote_indexes.iter() {
-            packet_vector[*index].meta.flags |= PacketFlags::SIMPLE_VOTE_TX;
+            packet_vector[*index].meta_mut().flags |= PacketFlags::SIMPLE_VOTE_TX;
         }
 
         packet_vector

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -941,7 +941,7 @@ impl ThreadLocalUnprocessedPackets {
             .filter_map(|immutable_deserialized_packet| {
                 let is_tracer_packet = immutable_deserialized_packet
                     .original_packet()
-                    .meta
+                    .meta()
                     .is_tracer_packet();
                 if is_tracer_packet {
                     saturating_add_assign!(*total_tracer_packets_in_buffer, 1);
@@ -1060,8 +1060,8 @@ mod tests {
             .enumerate()
             .map(|(packets_id, transaction)| {
                 let mut p = Packet::from_data(None, transaction).unwrap();
-                p.meta.port = packets_id as u16;
-                p.meta.set_tracer(true);
+                p.meta_mut().port = packets_id as u16;
+                p.meta_mut().set_tracer(true);
                 DeserializedPacket::new(p).unwrap()
             })
             .collect_vec();
@@ -1099,7 +1099,7 @@ mod tests {
                     batch
                         .get_forwardable_packets()
                         .into_iter()
-                        .map(|p| p.meta.port)
+                        .map(|p| p.meta().port)
                 })
                 .collect();
             forwarded_ports.sort_unstable();
@@ -1196,7 +1196,7 @@ mod tests {
                 None,
             ),
         )?;
-        vote.meta.flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
+        vote.meta_mut().flags.set(PacketFlags::SIMPLE_VOTE_TX, true);
         let big_transfer = Packet::from_data(
             None,
             system_transaction::transfer(&keypair, &pubkey, 1000000, Hash::new_unique()),
@@ -1269,8 +1269,8 @@ mod tests {
             .enumerate()
             .map(|(packets_id, transaction)| {
                 let mut p = Packet::from_data(None, transaction).unwrap();
-                p.meta.port = packets_id as u16;
-                p.meta.set_tracer(true);
+                p.meta_mut().port = packets_id as u16;
+                p.meta_mut().set_tracer(true);
                 DeserializedPacket::new(p).unwrap()
             })
             .collect_vec();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -233,14 +233,14 @@ where
     ws_metrics.shred_receiver_elapsed_us += shred_receiver_elapsed.as_us();
     ws_metrics.run_insert_count += 1;
     let handle_packet = |packet: &Packet| {
-        if packet.meta.discard() {
+        if packet.meta().discard() {
             return None;
         }
         let shred = shred::layout::get_shred(packet)?;
         let shred = Shred::new_from_serialized_shred(shred.to_vec()).ok()?;
-        if packet.meta.repair() {
+        if packet.meta().repair() {
             let repair_info = RepairMeta {
-                _from_addr: packet.meta.socket_addr(),
+                _from_addr: packet.meta().socket_addr(),
                 // If can't parse the nonce, dump the packet.
                 nonce: repair_response::nonce(packet)?,
             };
@@ -261,7 +261,7 @@ where
     ws_metrics.num_repairs += repair_infos.iter().filter(|r| r.is_some()).count();
     ws_metrics.num_shreds_received += shreds.len();
     for packet in packets.iter().flat_map(PacketBatch::iter) {
-        let addr = packet.meta.socket_addr();
+        let addr = packet.meta().socket_addr();
         *ws_metrics.addrs.entry(addr).or_default() += 1;
     }
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -511,7 +511,7 @@ pub fn start_verify_transactions(
                         .map(|tx| tx.to_versioned_transaction());
 
                     let res = packet_batch.par_iter_mut().zip(entry_tx_iter).all(|pair| {
-                        pair.0.meta = Meta::default();
+                        *pair.0.meta_mut() = Meta::default();
                         Packet::populate_packet(pair.0, None, &pair.1).is_ok()
                     });
                     if res {
@@ -538,7 +538,7 @@ pub fn start_verify_transactions(
                     );
                     let verified = packet_batches
                         .iter()
-                        .all(|batch| batch.iter().all(|p| !p.meta.discard()));
+                        .all(|batch| batch.iter().all(|p| !p.meta().discard()));
                     verify_time.stop();
                     (verified, verify_time.as_us())
                 })

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1947,7 +1947,7 @@ impl ClusterInfo {
             }
             check
         };
-        // Because pull-responses are sent back to packet.meta.socket_addr() of
+        // Because pull-responses are sent back to packet.meta().socket_addr() of
         // incoming pull-requests, pings are also sent to request.from_addr (as
         // opposed to caller.gossip address).
         move |request| {
@@ -2041,8 +2041,8 @@ impl ClusterInfo {
             match Packet::from_data(Some(addr), response) {
                 Err(err) => error!("failed to write pull-response packet: {:?}", err),
                 Ok(packet) => {
-                    if self.outbound_budget.take(packet.meta.size) {
-                        total_bytes += packet.meta.size;
+                    if self.outbound_budget.take(packet.meta().size) {
+                        total_bytes += packet.meta().size;
                         packet_batch.push(packet);
                         sent += 1;
                     } else {
@@ -2520,7 +2520,7 @@ impl ClusterInfo {
             let protocol: Protocol = packet.deserialize_slice(..).ok()?;
             protocol.sanitize().ok()?;
             let protocol = protocol.par_verify(&self.stats)?;
-            Some((packet.meta.socket_addr(), protocol))
+            Some((packet.meta().socket_addr(), protocol))
         };
         let packets: Vec<_> = {
             let _st = ScopedTimer::from(&self.stats.verify_gossip_packets_time);
@@ -3412,7 +3412,7 @@ RPC Enabled Nodes: 1"#;
             remote_nodes.into_iter(),
             pongs.into_iter()
         ) {
-            assert_eq!(packet.meta.socket_addr(), socket);
+            assert_eq!(packet.meta().socket_addr(), socket);
             let bytes = serialize(&pong).unwrap();
             match packet.deserialize_slice(..).unwrap() {
                 Protocol::PongMessage(pong) => assert_eq!(serialize(&pong).unwrap(), bytes),

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -255,7 +255,7 @@ pub fn cluster_info_retransmit() {
     }
     assert!(done);
     let mut p = Packet::default();
-    p.meta.size = 10;
+    p.meta_mut().size = 10;
     let peers = c1.tvu_peers();
     let retransmit_peers: Vec<_> = peers.iter().collect();
     retransmit_to(

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -330,7 +330,7 @@ impl Shred {
         let payload = self.payload();
         let size = payload.len();
         packet.buffer_mut()[..size].copy_from_slice(&payload[..]);
-        packet.meta.size = size;
+        packet.meta_mut().size = size;
     }
 
     // TODO: Should this sanitize output?
@@ -542,7 +542,7 @@ pub mod layout {
 
     fn get_shred_size(packet: &Packet) -> Option<usize> {
         let size = packet.data(..)?.len();
-        if packet.meta.repair() {
+        if packet.meta().repair() {
             size.checked_sub(SIZE_OF_NONCE)
         } else {
             Some(size)
@@ -1066,7 +1066,7 @@ mod tests {
         ));
         assert_eq!(stats, ShredFetchStats::default());
 
-        packet.meta.size = OFFSET_OF_SHRED_VARIANT;
+        packet.meta_mut().size = OFFSET_OF_SHRED_VARIANT;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1076,7 +1076,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 1);
 
-        packet.meta.size = OFFSET_OF_SHRED_INDEX;
+        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1086,7 +1086,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 2);
 
-        packet.meta.size = OFFSET_OF_SHRED_INDEX + 1;
+        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + 1;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1096,7 +1096,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 3);
 
-        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
+        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1106,7 +1106,7 @@ mod tests {
         ));
         assert_eq!(stats.index_overrun, 4);
 
-        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
+        packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
         assert!(should_discard_shred(
             &packet,
             root,
@@ -1419,7 +1419,7 @@ mod tests {
         });
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta.size = payload.len();
+        packet.meta_mut().size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);
@@ -1452,7 +1452,7 @@ mod tests {
         let payload = bs58_decode(PAYLOAD);
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta.size = payload.len();
+        packet.meta_mut().size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);
@@ -1492,7 +1492,7 @@ mod tests {
         });
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
-        packet.meta.size = payload.len();
+        packet.meta_mut().size = payload.len();
         assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(shred, Shred::new_from_serialized_shred(payload).unwrap());
         verify_shred_layout(&shred, &packet);

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -30,7 +30,7 @@ fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) 
         deduper.reset();
         batches
             .iter_mut()
-            .for_each(|b| b.iter_mut().for_each(|p| p.meta.set_discard(false)));
+            .for_each(|b| b.iter_mut().for_each(|p| p.meta_mut().set_discard(false)));
     });
 }
 

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -27,7 +27,7 @@ fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>)
         sigverify::shrink_batches(&mut batches);
         batches.iter_mut().for_each(|b| {
             b.iter_mut()
-                .for_each(|p| p.meta.set_discard(thread_rng().gen()))
+                .for_each(|p| p.meta_mut().set_discard(thread_rng().gen()))
         });
     });
 }
@@ -75,7 +75,7 @@ fn bench_shrink_count_packets(bencher: &mut Bencher) {
     );
     batches.iter_mut().for_each(|b| {
         b.iter_mut()
-            .for_each(|p| p.meta.set_discard(thread_rng().gen()))
+            .for_each(|p| p.meta_mut().set_discard(thread_rng().gen()))
     });
 
     bencher.iter(|| {

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -155,7 +155,7 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
             };
             Packet::populate_packet(packet, None, &tx).expect("serialize request");
             if thread_rng().gen_ratio((num_packets - NUM) as u32, num_packets as u32) {
-                packet.meta.set_discard(true);
+                packet.meta_mut().set_discard(true);
             } else {
                 num_valid += 1;
             }

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -122,7 +122,7 @@ impl PacketBatch {
 
     pub fn set_addr(&mut self, addr: &SocketAddr) {
         for p in self.iter_mut() {
-            p.meta.set_socket_addr(addr);
+            p.meta_mut().set_socket_addr(addr);
         }
     }
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -36,7 +36,7 @@ mod tests {
         }
         for batch in all_packets {
             for p in &batch {
-                assert_eq!(p.meta.size, num_bytes);
+                assert_eq!(p.meta().size, num_bytes);
             }
         }
         assert_eq!(total_packets, num_expected_packets);

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -44,7 +44,7 @@ pub struct Packet {
     // Bytes past Packet.meta.size are not valid to read from.
     // Use Packet.data(index) to read from the buffer.
     buffer: [u8; PACKET_DATA_SIZE],
-    pub meta: Meta,
+    meta: Meta,
 }
 
 impl Packet {
@@ -79,6 +79,16 @@ impl Packet {
     pub fn buffer_mut(&mut self) -> &mut [u8] {
         debug_assert!(!self.meta.discard());
         &mut self.buffer[..]
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
+
+    #[inline]
+    pub fn meta_mut(&mut self) -> &mut Meta {
+        &mut self.meta
     }
 
     pub fn from_data<T: Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
@@ -140,7 +150,7 @@ impl Default for Packet {
 
 impl PartialEq for Packet {
     fn eq(&self, other: &Packet) -> bool {
-        self.meta == other.meta && self.data(..) == other.data(..)
+        self.meta() == other.meta() && self.data(..) == other.data(..)
     }
 }
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -653,8 +653,8 @@ fn handle_chunk(
                 if maybe_batch.is_none() {
                     let mut batch = PacketBatch::with_capacity(1);
                     let mut packet = Packet::default();
-                    packet.meta.set_socket_addr(remote_addr);
-                    packet.meta.sender_stake = stake;
+                    packet.meta_mut().set_socket_addr(remote_addr);
+                    packet.meta_mut().sender_stake = stake;
                     batch.push(packet);
                     *maybe_batch = Some(batch);
                     stats
@@ -670,7 +670,7 @@ fn handle_chunk(
                     };
                     batch[0].buffer_mut()[chunk.offset as usize..end_of_chunk]
                         .copy_from_slice(&chunk.bytes);
-                    batch[0].meta.size = std::cmp::max(batch[0].meta.size, end_of_chunk);
+                    batch[0].meta_mut().size = std::cmp::max(batch[0].meta().size, end_of_chunk);
                     stats.total_chunks_received.fetch_add(1, Ordering::Relaxed);
                     match peer_type {
                         ConnectionPeerType::Staked => {
@@ -689,7 +689,7 @@ fn handle_chunk(
                 trace!("chunk is none");
                 // done receiving chunks
                 if let Some(batch) = maybe_batch.take() {
-                    let len = batch[0].meta.size;
+                    let len = batch[0].meta().size;
                     if let Err(e) = packet_sender.send(batch) {
                         stats
                             .total_packet_batch_send_err
@@ -1116,7 +1116,7 @@ pub mod test {
         }
         for batch in all_packets {
             for p in batch.iter() {
-                assert_eq!(p.meta.size, 1);
+                assert_eq!(p.meta().size, 1);
             }
         }
         assert_eq!(total_packets, num_expected_packets);
@@ -1152,7 +1152,7 @@ pub mod test {
         }
         for batch in all_packets {
             for p in batch.iter() {
-                assert_eq!(p.meta.size, num_bytes);
+                assert_eq!(p.meta().size, num_bytes);
             }
         }
         assert_eq!(total_packets, num_expected_packets);

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -65,7 +65,7 @@ pub fn send_to(
     socket_addr_space: &SocketAddrSpace,
 ) -> Result<()> {
     for p in batch.iter() {
-        let addr = p.meta.socket_addr();
+        let addr = p.meta().socket_addr();
         if socket_addr_space.check(&addr) {
             if let Some(data) = p.data(..) {
                 socket.send_to(data, addr)?;
@@ -93,7 +93,7 @@ mod tests {
         let packets = vec![Packet::default()];
         let mut packet_batch = PacketBatch::new(packets);
         packet_batch.set_addr(&send_addr);
-        assert_eq!(packet_batch[0].meta.socket_addr(), send_addr);
+        assert_eq!(packet_batch[0].meta().socket_addr(), send_addr);
     }
 
     #[test]
@@ -109,19 +109,21 @@ mod tests {
         batch.resize(packet_batch_size, Packet::default());
 
         for m in batch.iter_mut() {
-            m.meta.set_socket_addr(&addr);
-            m.meta.size = PACKET_DATA_SIZE;
+            m.meta_mut().set_socket_addr(&addr);
+            m.meta_mut().size = PACKET_DATA_SIZE;
         }
         send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
 
-        batch.iter_mut().for_each(|pkt| pkt.meta = Meta::default());
+        batch
+            .iter_mut()
+            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
         let recvd = recv_from(&mut batch, &recv_socket, 1).unwrap();
 
         assert_eq!(recvd, batch.len());
 
         for m in batch.iter() {
-            assert_eq!(m.meta.size, PACKET_DATA_SIZE);
-            assert_eq!(m.meta.socket_addr(), saddr);
+            assert_eq!(m.meta().size, PACKET_DATA_SIZE);
+            assert_eq!(m.meta().socket_addr(), saddr);
         }
     }
 
@@ -136,10 +138,10 @@ mod tests {
         let mut p1 = Packet::default();
         let mut p2 = Packet::default();
 
-        p1.meta.size = 1;
+        p1.meta_mut().size = 1;
         p1.buffer_mut()[0] = 0;
 
-        p2.meta.size = 1;
+        p2.meta_mut().size = 1;
         p2.buffer_mut()[0] = 0;
 
         assert!(p1 == p2);
@@ -164,8 +166,8 @@ mod tests {
             let mut batch = PacketBatch::with_capacity(batch_size);
             batch.resize(batch_size, Packet::default());
             for p in batch.iter_mut() {
-                p.meta.set_socket_addr(&addr);
-                p.meta.size = 1;
+                p.meta_mut().set_socket_addr(&addr);
+                p.meta_mut().size = 1;
             }
             send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
         }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -287,7 +287,7 @@ impl StreamerSendStats {
     }
 
     fn record(&mut self, pkt: &Packet) {
-        let ent = self.host_map.entry(pkt.meta.addr).or_default();
+        let ent = self.host_map.entry(pkt.meta().addr).or_default();
         ent.count += 1;
         ent.bytes += pkt.data(..).map(<[u8]>::len).unwrap_or_default() as u64;
     }
@@ -305,7 +305,7 @@ fn recv_send(
         packet_batch.iter().for_each(|p| stats.record(p));
     }
     let packets = packet_batch.iter().filter_map(|pkt| {
-        let addr = pkt.meta.socket_addr();
+        let addr = pkt.meta().socket_addr();
         let data = pkt.data(..)?;
         socket_addr_space.check(&addr).then_some((data, addr))
     });
@@ -488,8 +488,8 @@ mod test {
                 let mut p = Packet::default();
                 {
                     p.buffer_mut()[0] = i as u8;
-                    p.meta.size = PACKET_DATA_SIZE;
-                    p.meta.set_socket_addr(&addr);
+                    p.meta_mut().size = PACKET_DATA_SIZE;
+                    p.meta_mut().set_socket_addr(&addr);
                 }
                 packet_batch.push(p);
             }

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -50,7 +50,7 @@ pub fn test_recv_mmsg_batch_size() {
             }
             packets
                 .iter_mut()
-                .for_each(|pkt| pkt.meta = Meta::default());
+                .for_each(|pkt| *pkt.meta_mut() = Meta::default());
         }
         elapsed_in_small_batch += now.elapsed().as_nanos();
         assert_eq!(TEST_BATCH_SIZE, recv);


### PR DESCRIPTION
#### Problem

As part of the Packet refactoring in #29055, there's a new `BasePacket` trait introduced for both normal and larger packets, and all users of packets will go through the `BasePacket` interface to access all parts of the packet, which is typically the `Meta`.

#### Summary of Changes

To make the changes easier to process in the refactor, start here by making the `meta` field private, and use the `meta()` and `meta_mut()` accessors instead.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
