### PR TITLE
test: local-cluster: Fix test_local_cluster_signature_subscribe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5809,6 +5809,7 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "rayon",
+ "scopeguard",
  "serial_test",
  "solana-client",
  "solana-config-program",

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10.5"
 log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
+scopeguard = "1.1.0"
 solana-client = { path = "../client", version = "=1.16.0" }
 solana-config-program = { path = "../programs/config", version = "=1.16.0" }
 solana-core = { path = "../core", version = "=1.16.0" }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -345,9 +345,7 @@ impl LocalCluster {
         (0..config.num_listeners).for_each(|_| {
             cluster.add_validator_listener(
                 &listener_config,
-                0,
                 Arc::new(Keypair::new()),
-                None,
                 socket_addr_space,
             );
         });
@@ -390,17 +388,15 @@ impl LocalCluster {
     pub fn add_validator_listener(
         &mut self,
         validator_config: &ValidatorConfig,
-        stake: u64,
         validator_keypair: Arc<Keypair>,
-        voting_keypair: Option<Arc<Keypair>>,
         socket_addr_space: SocketAddrSpace,
     ) -> Pubkey {
         self.do_add_validator(
             validator_config,
             true,
-            stake,
+            0u64,
             validator_keypair,
-            voting_keypair,
+            None,
             socket_addr_space,
         )
     }


### PR DESCRIPTION
#### Problem

`tests/local_cluster.rs::test_local_cluster_signature_subscribe` has been broken by [Enable QUIC client by default. Add arg to disable QUIC client. Take 2](https://github.com/solana-labs/solana/pull/26927).

Seems like it contains a race condition, as it is expecting to see `RpcSignatureResult::ReceivedSignature` while connected to a voting validator.

#### Summary of Changes

Added an RPC listener into the cluster created by the test, and switched the RPC subscription to interact with the listner.
