### PR TITLE
Add support for fetching transaction data in program-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6045,6 +6045,8 @@ dependencies = [
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
+ "itertools",
+ "lazy_static",
  "log",
  "serde",
  "solana-banks-client",

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -27,3 +27,5 @@ solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
+lazy_static = "1.1.1"
+itertools = "0.10.5"


### PR DESCRIPTION
#### Problem
It is currently impossible to get any context about the executed transactions in the `program-test` module

#### Summary of Changes
This should be a simple change, but it was annoying to support thread safety.

The solution here was to create a unique hash that combines the `invoke_context` and client `transaction`. The problem is that these values can non-deterministically fall out of sync.

The structure roughly looks like this:

We map over blockhashes in the invoke context to generate a set of candidate keys
`candidates = [invoke_ctx_hash0, ..., invoke_ctx_hash1] -> index -> Vec<ExecutedInstructions>`

We pray that `hash(transaction)` is in candidates (it _should_ be)

Calling `ctx.get_transaction_details(tx, index)` will perform
`hash(transaction) -> index -> Vec<ExecutedInstructions>`
