### PR TITLE
test_get_snapshot_storages_only_non_empty uses write cache

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -13141,7 +13141,8 @@ pub mod tests {
 
     #[test]
     fn test_get_snapshot_storages_only_non_empty() {
-        let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
+        let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
+        db.caching_enabled = true;
 
         let key = Pubkey::default();
         let account = AccountSharedData::new(1, 0, &key);
@@ -13149,16 +13150,11 @@ pub mod tests {
         let after_slot = base_slot + 1;
 
         db.store_for_tests(base_slot, &[(&key, &account)]);
-        db.storage
-            .get_slot_stores(base_slot)
-            .unwrap()
-            .write()
-            .unwrap()
-            .clear();
-        db.add_root(base_slot);
+        // stored account is in write cache, so no storages yet
         assert!(db.get_snapshot_storages(..=after_slot, None).0.is_empty());
 
         db.store_for_tests(base_slot, &[(&key, &account)]);
+        db.add_root_and_flush_write_cache(base_slot);
         assert_eq!(1, db.get_snapshot_storages(..=after_slot, None).0.len());
     }
 


### PR DESCRIPTION
#### Problem
migrating tests to use write write cache

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
