### PR TITLE
fix solRptLdgrStat thread hang

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1590,6 +1590,7 @@ impl<'a> ProcessBlockStore<'a> {
                 self.cache_block_meta_sender.as_ref(),
                 &self.accounts_background_request_sender,
             ) {
+                exit.store(true, Ordering::Relaxed);
                 return Err(format!("Failed to load ledger: {e:?}"));
             }
 


### PR DESCRIPTION
#### Problem

When failed to process_blockstore_from_root, solRptLdgrStat thread will hang.


#### Summary of Changes
exit solRptLdgrStat thread when process_blockstore_from_root failed.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
