### PR TITLE
ledger-tool create-snapshot uses write cache

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3219,8 +3219,6 @@ fn main() {
                             }
                         }
 
-                        bank.accounts().accounts_db.add_root(bank.slot());
-                        bank.force_flush_accounts_cache();
                         bank.set_capitalization();
 
                         let bank = if let Some(warp_slot) = warp_slot {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3018,6 +3018,7 @@ fn main() {
                     &genesis_config,
                     &blockstore,
                     ProcessOptions {
+                        accounts_db_caching_enabled: true,
                         new_hard_forks,
                         halt_at_slot: Some(snapshot_slot),
                         poh_verify: false,
@@ -3218,6 +3219,8 @@ fn main() {
                             }
                         }
 
+                        bank.accounts().accounts_db.add_root(bank.slot());
+                        bank.force_flush_accounts_cache();
                         bank.set_capitalization();
 
                         let bank = if let Some(warp_slot) = warp_slot {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -884,6 +884,7 @@ impl Accounts {
         debug_verify: bool,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        data_source: CalcAccountsHashDataSource,
     ) -> u64 {
         let is_startup = true;
         self.accounts_db
@@ -891,7 +892,7 @@ impl Accounts {
             .wait_for_complete();
         self.accounts_db
             .update_accounts_hash(
-                CalcAccountsHashDataSource::Storages,
+                data_source,
                 debug_verify,
                 slot,
                 ancestors,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7009,6 +7009,8 @@ impl Bank {
             debug_verify,
             self.epoch_schedule(),
             &self.rent_collector,
+            // we have to use the index since the slot could be in the write cache still
+            CalcAccountsHashDataSource::IndexForTests,
         )
     }
 
@@ -7031,7 +7033,10 @@ impl Bank {
     /// This should only be used for developing purposes.
     pub fn set_capitalization(&self) -> u64 {
         let old = self.capitalization();
-        let debug_verify = true;
+        // We cannot debug verify the hash calculation here becuase calculate_capitalization will use the index calculation due to callers using the write cache.
+        // debug_verify only exists as an extra debugging step under the assumption that this code path is only used for tests. But, this is used by ledger-tool create-snapshot
+        // for example.
+        let debug_verify = false;
         self.capitalization
             .store(self.calculate_capitalization(debug_verify), Relaxed);
         old


### PR DESCRIPTION
#### Problem
Migrating everything to use write cache so we can eliminate the old code path.
ledger-tool create-snapshot does not use the write cache.
The biggest hang up with using the write cache is a call to `calculate_capitalization`. That tries to scan storages. But, if we have not written to storages yet because we're using the write cache, then we can't calculate cap correctly. But, if we flush to the write cache, then we later update sys vars in the same slot. As a result, we violate some design constraints by writing to a slot that has already been flushed from the write cache.
A solution to this is to have `calculate_capitalization` use the index to calculate that capitalization. This could be revisited later but is sufficient for now since it does not affect any real validators.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
