### PR TITLE
Feature - Program redeployment cooldown

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -163,6 +163,10 @@ fn load_upgradeable_sbf_program(
         authority_keypair,
         elf,
     );
+    bank_client.set_sysvar_for_tests(&clock::Clock {
+        slot: 1,
+        ..clock::Clock::default()
+    });
 }
 
 #[cfg(feature = "sbf_rust")]
@@ -2002,6 +2006,10 @@ fn test_program_sbf_upgrade() {
         &authority_keypair,
         "solana_sbf_rust_upgraded",
     );
+    bank_client.set_sysvar_for_tests(&clock::Clock {
+        slot: 2,
+        ..clock::Clock::default()
+    });
 
     // Call upgraded program
     instruction.data[0] += 1;
@@ -2179,6 +2187,10 @@ fn test_program_sbf_invoke_upgradeable_via_cpi() {
         &authority_keypair,
         "solana_sbf_rust_upgraded",
     );
+    bank_client.set_sysvar_for_tests(&clock::Clock {
+        slot: 2,
+        ..clock::Clock::default()
+    });
 
     // Call the upgraded program
     instruction.data[0] += 1;

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -14,6 +14,7 @@ use {
         signature::{Keypair, Signature, Signer},
         signers::Signers,
         system_instruction,
+        sysvar::{Sysvar, SysvarId},
         transaction::{self, Transaction, VersionedTransaction},
         transport::{Result, TransportError},
     },
@@ -323,6 +324,10 @@ impl BankClient {
 
     pub fn new(bank: Bank) -> Self {
         Self::new_shared(&Arc::new(bank))
+    }
+
+    pub fn set_sysvar_for_tests<T: Sysvar + SysvarId>(&self, sysvar: &T) {
+        self.bank.set_sysvar_for_tests(sysvar);
     }
 }
 

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -52,6 +52,11 @@ pub enum UpgradeableLoaderState {
     },
 }
 impl UpgradeableLoaderState {
+    /// Size of a serialized program account.
+    pub const fn size_of_uninitialized() -> usize {
+        4 // see test_state_size_of_uninitialized
+    }
+
     /// Size of a buffer account's serialized metadata.
     pub const fn size_of_buffer_metadata() -> usize {
         37 // see test_state_size_of_buffer_metadata
@@ -373,6 +378,13 @@ pub fn extend_program(
 #[cfg(test)]
 mod tests {
     use {super::*, bincode::serialized_size};
+
+    #[test]
+    fn test_state_size_of_uninitialized() {
+        let buffer_state = UpgradeableLoaderState::Uninitialized;
+        let size = serialized_size(&buffer_state).unwrap();
+        assert_eq!(UpgradeableLoaderState::size_of_uninitialized() as u64, size);
+    }
 
     #[test]
     fn test_state_size_of_buffer_metadata() {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -550,6 +550,10 @@ pub mod enable_alt_bn128_syscall {
     solana_sdk::declare_id!("A16q37opZdQMCbe5qJ6xpBB9usykfv8jZaMkxvZQi4GJ");
 }
 
+pub mod enable_program_redeployment_cooldown {
+    solana_sdk::declare_id!("J4HFT8usBxpcF63y46t1upYobJgChmKyZPm5uTBRg25Z");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -682,6 +686,7 @@ lazy_static! {
         (enable_bpf_loader_set_authority_checked_ix::id(), "enable bpf upgradeable loader SetAuthorityChecked instruction #28424"),
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
         (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
+        (enable_program_redeployment_cooldown::id(), "enable program redeployment cooldown #29135"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
At the moment a program can be redeployed within the same slot. In order to switch to one validator global executor cache (instead of having one per bank) it would be useful if the program address + slot number would identify a programs version.

#### Summary of Changes
Prevent the upgradeable loader from redeploying the same program within the same slot.

Feature Gate Issue: #29135