### PR TITLE
Bump solana_rbpf to v0.2.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0669f9f5c355899600732451c65cc717d0ef0c53717749f03520337c824fd8a1"
+checksum = "a4e9e5085099858adba23d0a0b5298da8803f89999cb567ecafab9c916cdf53d"
 dependencies = [
  "byteorder",
  "combine",
@@ -7007,6 +7007,7 @@ dependencies = [
  "rustc-demangle",
  "scroll",
  "thiserror",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,7 +55,7 @@ solana-tpu-client = { path = "../tpu-client", version = "=1.15.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.15.0" }
 solana-version = { path = "../version", version = "=1.15.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
-solana_rbpf = "=0.2.37"
+solana_rbpf = "=0.2.38"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -10,7 +10,7 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
-    solana_bpf_loader_program::syscalls::register_syscalls,
+    solana_bpf_loader_program::syscalls::create_loader,
     solana_clap_utils::{self, input_parsers::*, input_validators::*, keypair::*},
     solana_cli_output::{
         CliProgram, CliProgramAccountType, CliProgramAuthority, CliProgramBuffer, CliProgramId,
@@ -21,12 +21,8 @@ use {
         connection_cache::ConnectionCache,
         tpu_client::{TpuClient, TpuClientConfig},
     },
-    solana_program_runtime::invoke_context::InvokeContext,
-    solana_rbpf::{
-        elf::Executable,
-        verifier::RequisiteVerifier,
-        vm::{Config, VerifiedExecutable},
-    },
+    solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
+    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::VerifiedExecutable},
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{
@@ -1994,15 +1990,16 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program
-    let executable = Executable::<InvokeContext>::from_elf(
-        &program_data,
-        Config {
-            reject_broken_elfs: true,
-            ..Config::default()
-        },
-        register_syscalls(&invoke_context.feature_set, true).unwrap(),
+    let (config, syscall_registry) = create_loader(
+        &invoke_context.feature_set,
+        &ComputeBudget::default(),
+        true,
+        true,
+        false,
     )
-    .map_err(|err| format!("ELF error: {err}"))?;
+    .unwrap();
+    let executable = Executable::<InvokeContext>::from_elf(&program_data, config, syscall_registry)
+        .map_err(|err| format!("ELF error: {err}"))?;
 
     let _ = VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
         .map_err(|err| format!("ELF error: {err}"))?;

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1990,7 +1990,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program
-    let (config, syscall_registry) = create_loader(
+    let loader = create_loader(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -1998,7 +1998,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         false,
     )
     .unwrap();
-    let executable = Executable::<InvokeContext>::from_elf(&program_data, config, syscall_registry)
+    let executable = Executable::<InvokeContext>::from_elf(&program_data, loader)
         .map_err(|err| format!("ELF error: {err}"))?;
 
     let _ = VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -26,7 +26,7 @@ solana-frozen-abi = { path = "../frozen-abi", version = "=1.15.0" }
 solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.15.0" }
 solana-measure = { path = "../measure", version = "=1.15.0" }
 solana-metrics = { path = "../metrics", version = "=1.15.0" }
-solana_rbpf = "=0.2.37"
+solana_rbpf = "=0.2.38"
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 thiserror = "1.0"
 

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -18,7 +18,7 @@ solana-measure = { path = "../../measure", version = "=1.15.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.15.0" }
 solana-sdk = { path = "../../sdk", version = "=1.15.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.15.0" }
-solana_rbpf = "=0.2.37"
+solana_rbpf = "=0.2.38"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -14,15 +14,13 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 libsecp256k1 = "0.6.0"
 log = "0.4.17"
+rand = "0.7.3"
 solana-measure = { path = "../../measure", version = "=1.15.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.15.0" }
 solana-sdk = { path = "../../sdk", version = "=1.15.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.15.0" }
 solana_rbpf = "=0.2.38"
 thiserror = "1.0"
-
-[dev-dependencies]
-rand = "0.7.3"
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -33,7 +33,7 @@ use {
         error::{EbpfError, UserDefinedError},
         memory_region::MemoryRegion,
         verifier::{RequisiteVerifier, VerifierError},
-        vm::{Config, ContextObject, EbpfVm, ProgramResult, VerifiedExecutable},
+        vm::{ContextObject, EbpfVm, ProgramResult, VerifiedExecutable},
     },
     solana_sdk::{
         bpf_loader, bpf_loader_deprecated,
@@ -43,9 +43,8 @@ use {
             cap_accounts_data_allocations_per_transaction, cap_bpf_program_instruction_accounts,
             check_slice_translation_size, disable_deploy_of_alloc_free_syscall,
             disable_deprecated_loader, enable_bpf_loader_extend_program_ix,
-            enable_bpf_loader_set_authority_checked_ix,
-            error_on_syscall_bpf_function_hash_collisions, limit_max_instruction_trace_length,
-            reject_callx_r10, FeatureSet,
+            enable_bpf_loader_set_authority_checked_ix, limit_max_instruction_trace_length,
+            FeatureSet,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -132,39 +131,19 @@ fn create_executor_from_bytes(
     let mut register_syscalls_time = Measure::start("register_syscalls_time");
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
-    let register_syscall_result =
-        syscalls::register_syscalls(feature_set, disable_deploy_of_alloc_free_syscall);
-    register_syscalls_time.stop();
-    create_executor_metrics.register_syscalls_us = register_syscalls_time.as_us();
-    let syscall_registry = register_syscall_result.map_err(|e| {
+    let (config, syscall_registry) = syscalls::create_loader(
+        feature_set,
+        compute_budget,
+        reject_deployment_of_broken_elfs,
+        disable_deploy_of_alloc_free_syscall,
+        false,
+    )
+    .map_err(|e| {
         ic_logger_msg!(log_collector, "Failed to register syscalls: {}", e);
         InstructionError::ProgramEnvironmentSetupFailure
     })?;
-    let config = Config {
-        max_call_depth: compute_budget.max_call_depth,
-        stack_frame_size: compute_budget.stack_frame_size,
-        enable_stack_frame_gaps: true,
-        instruction_meter_checkpoint_distance: 10000,
-        enable_instruction_meter: true,
-        enable_instruction_tracing: false,
-        enable_symbol_and_section_labels: false,
-        reject_broken_elfs: reject_deployment_of_broken_elfs,
-        noop_instruction_rate: 256,
-        sanitize_user_provided_values: true,
-        encrypt_environment_registers: true,
-        syscall_bpf_function_hash_collision: feature_set
-            .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
-        reject_callx_r10: feature_set.is_active(&reject_callx_r10::id()),
-        dynamic_stack_frames: false,
-        enable_sdiv: false,
-        optimize_rodata: false,
-        static_syscalls: false,
-        enable_elf_vaddr: false,
-        reject_rodata_stack_overlap: false,
-        new_elf_parser: false,
-        aligned_memory_mapping: true,
-        // Warning, do not use `Config::default()` so that configuration here is explicit.
-    };
+    register_syscalls_time.stop();
+    create_executor_metrics.register_syscalls_us = register_syscalls_time.as_us();
     let mut load_elf_time = Measure::start("load_elf_time");
     let executable = Executable::<InvokeContext>::from_elf(programdata, config, syscall_registry)
         .map_err(|err| {
@@ -1527,7 +1506,7 @@ mod tests {
         solana_rbpf::{
             ebpf::MM_INPUT_START,
             verifier::Verifier,
-            vm::{ContextObject, FunctionRegistry, SyscallRegistry},
+            vm::{Config, ContextObject, FunctionRegistry, SyscallRegistry},
         },
         solana_sdk::{
             account::{

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -171,7 +171,7 @@ pub fn create_loader<'a>(
             .gen::<i32>()
             .checked_shr(PROGRAM_ENVIRONMENT_KEY_SHIFT)
             .unwrap_or(0),
-        syscall_bpf_function_hash_collision: feature_set
+        external_internal_function_hash_collision: feature_set
             .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
         reject_callx_r10: feature_set.is_active(&reject_callx_r10::id()),
         dynamic_stack_frames: false,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -328,7 +328,7 @@ fn translate(
     vm_addr: u64,
     len: u64,
 ) -> Result<u64, EbpfError> {
-    memory_mapping.map(access_type, vm_addr, len).into()
+    memory_mapping.map(access_type, vm_addr, len, 0).into()
 }
 
 fn translate_type_inner<'a, T>(

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -19,7 +19,7 @@ use {
     solana_rbpf::{
         error::EbpfError,
         memory_region::{AccessType, MemoryMapping},
-        vm::{Config, ProgramResult, SyscallRegistry, PROGRAM_ENVIRONMENT_KEY_SHIFT},
+        vm::{BuiltInProgram, Config, ProgramResult, PROGRAM_ENVIRONMENT_KEY_SHIFT},
     },
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
@@ -138,10 +138,10 @@ fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<
     Ok(())
 }
 
-macro_rules! register_feature_gated_syscall {
-    ($syscall_registry:expr, $is_feature_active:expr, $name:expr, $call:expr $(,)?) => {
+macro_rules! register_feature_gated_function {
+    ($result:expr, $is_feature_active:expr, $name:expr, $call:expr $(,)?) => {
         if $is_feature_active {
-            $syscall_registry.register_syscall_by_name($name, $call)
+            $result.register_function_by_name($name, $call)
         } else {
             Ok(())
         }
@@ -154,7 +154,7 @@ pub fn create_loader<'a>(
     reject_deployment_of_broken_elfs: bool,
     disable_deploy_of_alloc_free_syscall: bool,
     debugging_features: bool,
-) -> Result<(Config, SyscallRegistry<InvokeContext<'a>>), EbpfError> {
+) -> Result<Arc<BuiltInProgram<InvokeContext<'a>>>, EbpfError> {
     use rand::Rng;
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
@@ -191,135 +191,127 @@ pub fn create_loader<'a>(
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
     let is_abi_v2 = false;
 
-    let mut syscall_registry = SyscallRegistry::default();
+    let mut result = BuiltInProgram::new_loader(config);
 
     // Abort
-    syscall_registry.register_syscall_by_name(b"abort", SyscallAbort::call)?;
+    result.register_function_by_name("abort", SyscallAbort::call)?;
 
     // Panic
-    syscall_registry.register_syscall_by_name(b"sol_panic_", SyscallPanic::call)?;
+    result.register_function_by_name("sol_panic_", SyscallPanic::call)?;
 
     // Logging
-    syscall_registry.register_syscall_by_name(b"sol_log_", SyscallLog::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_log_64_", SyscallLogU64::call)?;
-    syscall_registry
-        .register_syscall_by_name(b"sol_log_compute_units_", SyscallLogBpfComputeUnits::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_log_pubkey", SyscallLogPubkey::call)?;
+    result.register_function_by_name("sol_log_", SyscallLog::call)?;
+    result.register_function_by_name("sol_log_64_", SyscallLogU64::call)?;
+    result.register_function_by_name("sol_log_compute_units_", SyscallLogBpfComputeUnits::call)?;
+    result.register_function_by_name("sol_log_pubkey", SyscallLogPubkey::call)?;
 
     // Program defined addresses (PDA)
-    syscall_registry.register_syscall_by_name(
-        b"sol_create_program_address",
+    result.register_function_by_name(
+        "sol_create_program_address",
         SyscallCreateProgramAddress::call,
     )?;
-    syscall_registry.register_syscall_by_name(
-        b"sol_try_find_program_address",
+    result.register_function_by_name(
+        "sol_try_find_program_address",
         SyscallTryFindProgramAddress::call,
     )?;
 
     // Sha256
-    syscall_registry.register_syscall_by_name(b"sol_sha256", SyscallSha256::call)?;
+    result.register_function_by_name("sol_sha256", SyscallSha256::call)?;
 
     // Keccak256
-    syscall_registry.register_syscall_by_name(b"sol_keccak256", SyscallKeccak256::call)?;
+    result.register_function_by_name("sol_keccak256", SyscallKeccak256::call)?;
 
     // Secp256k1 Recover
-    syscall_registry
-        .register_syscall_by_name(b"sol_secp256k1_recover", SyscallSecp256k1Recover::call)?;
+    result.register_function_by_name("sol_secp256k1_recover", SyscallSecp256k1Recover::call)?;
 
     // Blake3
-    register_feature_gated_syscall!(
-        syscall_registry,
+    register_feature_gated_function!(
+        result,
         blake3_syscall_enabled,
-        b"sol_blake3",
+        "sol_blake3",
         SyscallBlake3::call,
     )?;
 
     // Elliptic Curve Operations
-    register_feature_gated_syscall!(
-        syscall_registry,
+    register_feature_gated_function!(
+        result,
         curve25519_syscall_enabled,
-        b"sol_curve_validate_point",
+        "sol_curve_validate_point",
         SyscallCurvePointValidation::call,
     )?;
-    register_feature_gated_syscall!(
-        syscall_registry,
+    register_feature_gated_function!(
+        result,
         curve25519_syscall_enabled,
-        b"sol_curve_group_op",
+        "sol_curve_group_op",
         SyscallCurveGroupOps::call,
     )?;
-    register_feature_gated_syscall!(
-        syscall_registry,
+    register_feature_gated_function!(
+        result,
         curve25519_syscall_enabled,
-        b"sol_curve_multiscalar_mul",
+        "sol_curve_multiscalar_mul",
         SyscallCurveMultiscalarMultiplication::call,
     )?;
 
     // Sysvars
-    syscall_registry
-        .register_syscall_by_name(b"sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
-    syscall_registry.register_syscall_by_name(
-        b"sol_get_epoch_schedule_sysvar",
+    result.register_function_by_name("sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
+    result.register_function_by_name(
+        "sol_get_epoch_schedule_sysvar",
         SyscallGetEpochScheduleSysvar::call,
     )?;
-    register_feature_gated_syscall!(
-        syscall_registry,
+    register_feature_gated_function!(
+        result,
         !disable_fees_sysvar,
-        b"sol_get_fees_sysvar",
+        "sol_get_fees_sysvar",
         SyscallGetFeesSysvar::call,
     )?;
-    syscall_registry
-        .register_syscall_by_name(b"sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
+    result.register_function_by_name("sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
 
     // Memory ops
-    syscall_registry.register_syscall_by_name(b"sol_memcpy_", SyscallMemcpy::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memmove_", SyscallMemmove::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memcmp_", SyscallMemcmp::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memset_", SyscallMemset::call)?;
+    result.register_function_by_name("sol_memcpy_", SyscallMemcpy::call)?;
+    result.register_function_by_name("sol_memmove_", SyscallMemmove::call)?;
+    result.register_function_by_name("sol_memcmp_", SyscallMemcmp::call)?;
+    result.register_function_by_name("sol_memset_", SyscallMemset::call)?;
 
     if !is_abi_v2 {
         // Processed sibling instructions
-        syscall_registry.register_syscall_by_name(
-            b"sol_get_processed_sibling_instruction",
+        result.register_function_by_name(
+            "sol_get_processed_sibling_instruction",
             SyscallGetProcessedSiblingInstruction::call,
         )?;
 
         // Stack height
-        syscall_registry
-            .register_syscall_by_name(b"sol_get_stack_height", SyscallGetStackHeight::call)?;
+        result.register_function_by_name("sol_get_stack_height", SyscallGetStackHeight::call)?;
 
         // Return data
-        syscall_registry
-            .register_syscall_by_name(b"sol_set_return_data", SyscallSetReturnData::call)?;
-        syscall_registry
-            .register_syscall_by_name(b"sol_get_return_data", SyscallGetReturnData::call)?;
+        result.register_function_by_name("sol_set_return_data", SyscallSetReturnData::call)?;
+        result.register_function_by_name("sol_get_return_data", SyscallGetReturnData::call)?;
 
         // Cross-program invocation
-        syscall_registry
-            .register_syscall_by_name(b"sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
-        syscall_registry
-            .register_syscall_by_name(b"sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
+        result.register_function_by_name("sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
+        result
+            .register_function_by_name("sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
 
         // Memory allocator
-        register_feature_gated_syscall!(
-            syscall_registry,
+        register_feature_gated_function!(
+            result,
             !disable_deploy_of_alloc_free_syscall,
-            b"sol_alloc_free_",
+            "sol_alloc_free_",
             SyscallAllocFree::call,
         )?;
 
         // Alt_bn128
-        register_feature_gated_syscall!(
-            syscall_registry,
+        register_feature_gated_function!(
+            result,
             enable_alt_bn128_syscall,
-            b"sol_alt_bn128_group_op",
+            "sol_alt_bn128_group_op",
             SyscallAltBn128::call,
         )?;
     }
 
     // Log data
-    syscall_registry.register_syscall_by_name(b"sol_log_data", SyscallLogData::call)?;
+    result.register_function_by_name("sol_log_data", SyscallLogData::call)?;
 
-    Ok((config, syscall_registry))
+    Ok(Arc::new(result))
 }
 
 fn translate(
@@ -1738,7 +1730,7 @@ mod tests {
             aligned_memory::AlignedMemory,
             ebpf::{self, HOST_ALIGN},
             memory_region::MemoryRegion,
-            vm::{Config, SyscallFunction},
+            vm::{BuiltInFunction, Config},
         },
         solana_sdk::{
             account::AccountSharedData,
@@ -3662,7 +3654,7 @@ mod tests {
         seeds: &[&[u8]],
         program_id: &Pubkey,
         overlap_outputs: bool,
-        syscall: SyscallFunction<InvokeContext<'b>>,
+        syscall: BuiltInFunction<InvokeContext<'b>>,
     ) -> Result<(Pubkey, u8), EbpfError> {
         const SEEDS_VA: u64 = 0x100000000;
         const PROGRAM_ID_VA: u64 = 0x200000000;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4311,6 +4311,7 @@ dependencies = [
  "byteorder 1.4.3",
  "libsecp256k1 0.6.0",
  "log",
+ "rand 0.7.3",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk 1.15.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6190,9 +6190,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0669f9f5c355899600732451c65cc717d0ef0c53717749f03520337c824fd8a1"
+checksum = "a4e9e5085099858adba23d0a0b5298da8803f89999cb567ecafab9c916cdf53d"
 dependencies = [
  "byteorder 1.4.3",
  "combine",
@@ -6204,6 +6204,7 @@ dependencies = [
  "rustc-demangle",
  "scroll",
  "thiserror",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -38,7 +38,7 @@ solana-sbf-rust-realloc = { path = "rust/realloc", version = "=1.15.0" }
 solana-sbf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.15.0" }
 solana-sdk = { path = "../../sdk", version = "=1.15.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=1.15.0" }
-solana_rbpf = "=0.2.37"
+solana_rbpf = "=0.2.38"
 
 [dev-dependencies]
 solana-ledger = { path = "../../ledger", version = "=1.15.0" }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -134,7 +134,9 @@ fn bench_program_alu(bencher: &mut Bencher) {
         .unwrap();
 
         println!("Interpreted:");
-        vm.context_object.mock_set_remaining(std::i64::MAX as u64);
+        vm.env
+            .context_object_pointer
+            .mock_set_remaining(std::i64::MAX as u64);
         let (instructions, result) = vm.execute_program(true);
         assert_eq!(SUCCESS, result.unwrap());
         assert_eq!(ARMSTRONG_LIMIT, LittleEndian::read_u64(&inner_iter));
@@ -144,7 +146,9 @@ fn bench_program_alu(bencher: &mut Bencher) {
         );
 
         bencher.iter(|| {
-            vm.context_object.mock_set_remaining(std::i64::MAX as u64);
+            vm.env
+                .context_object_pointer
+                .mock_set_remaining(std::i64::MAX as u64);
             vm.execute_program(true).1.unwrap();
         });
         let summary = bencher.bench(|_bencher| Ok(())).unwrap().unwrap();
@@ -164,7 +168,9 @@ fn bench_program_alu(bencher: &mut Bencher) {
         );
 
         bencher.iter(|| {
-            vm.context_object.mock_set_remaining(std::i64::MAX as u64);
+            vm.env
+                .context_object_pointer
+                .mock_set_remaining(std::i64::MAX as u64);
             vm.execute_program(false).1.unwrap();
         });
         let summary = bencher.bench(|_bencher| Ok(())).unwrap().unwrap();
@@ -306,12 +312,12 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 
         assert_eq!(
             0,
-            vm.context_object.get_remaining(),
+            vm.env.context_object_pointer.get_remaining(),
             "Tuner must consume the whole budget"
         );
         println!(
             "{:?} compute units took {:?} us ({:?} instructions)",
-            BUDGET - vm.context_object.get_remaining(),
+            BUDGET - vm.env.context_object_pointer.get_remaining(),
             measure.as_us(),
             instructions,
         );

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -56,14 +56,10 @@ use {
     solana_bpf_loader_program::{
         create_vm,
         serialization::{deserialize_parameters, serialize_parameters},
-        syscalls::register_syscalls,
+        syscalls::create_loader,
     },
     solana_program_runtime::invoke_context::with_mock_invoke_context,
-    solana_rbpf::{
-        elf::Executable,
-        verifier::RequisiteVerifier,
-        vm::{Config, VerifiedExecutable},
-    },
+    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::VerifiedExecutable},
     solana_runtime::{
         bank::Bank,
         bank_client::BankClient,
@@ -224,21 +220,16 @@ fn run_program(name: &str) -> u64 {
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
     with_mock_invoke_context(loader_id, 0, false, |invoke_context| {
-        let config = Config {
-            enable_instruction_tracing: true,
-            reject_broken_elfs: true,
-            ..Config::default()
-        };
-        let executable = Executable::<InvokeContext>::from_elf(
-            &data,
-            config,
-            register_syscalls(
-                &invoke_context.feature_set,
-                true, /* no sol_alloc_free */
-            )
-            .unwrap(),
+        let (config, syscall_registry) = create_loader(
+            &invoke_context.feature_set,
+            &ComputeBudget::default(),
+            true,
+            true,
+            true,
         )
         .unwrap();
+        let executable =
+            Executable::<InvokeContext>::from_elf(&data, config, syscall_registry).unwrap();
 
         #[allow(unused_mut)]
         let mut verified_executable =
@@ -293,18 +284,16 @@ fn run_program(name: &str) -> u64 {
                     assert_eq!(instruction_count, compute_units_consumed);
                 }
                 instruction_count = compute_units_consumed;
-                if config.enable_instruction_tracing {
-                    if i == 0 {
-                        trace_log = Some(vm.context_object.trace_log.clone());
-                    } else {
-                        let interpreter = trace_log.as_ref().unwrap().as_slice();
-                        let mut jit = vm.context_object.trace_log.as_slice();
-                        if jit.len() > interpreter.len() {
-                            jit = &jit[0..interpreter.len()];
-                        }
-                        assert_eq!(interpreter, jit);
-                        trace_log = None;
+                if i == 0 {
+                    trace_log = Some(vm.context_object.trace_log.clone());
+                } else {
+                    let interpreter = trace_log.as_ref().unwrap().as_slice();
+                    let mut jit = vm.context_object.trace_log.as_slice();
+                    if jit.len() > interpreter.len() {
+                        jit = &jit[0..interpreter.len()];
                     }
+                    assert_eq!(interpreter, jit);
+                    trace_log = None;
                 }
             }
             assert!(match deserialize_parameters(

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -285,10 +285,10 @@ fn run_program(name: &str) -> u64 {
                 }
                 instruction_count = compute_units_consumed;
                 if i == 0 {
-                    trace_log = Some(vm.context_object.trace_log.clone());
+                    trace_log = Some(vm.env.context_object_pointer.trace_log.clone());
                 } else {
                     let interpreter = trace_log.as_ref().unwrap().as_slice();
-                    let mut jit = vm.context_object.trace_log.as_slice();
+                    let mut jit = vm.env.context_object_pointer.trace_log.as_slice();
                     if jit.len() > interpreter.len() {
                         jit = &jit[0..interpreter.len()];
                     }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -220,7 +220,7 @@ fn run_program(name: &str) -> u64 {
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
     with_mock_invoke_context(loader_id, 0, false, |invoke_context| {
-        let (config, syscall_registry) = create_loader(
+        let loader = create_loader(
             &invoke_context.feature_set,
             &ComputeBudget::default(),
             true,
@@ -228,8 +228,7 @@ fn run_program(name: &str) -> u64 {
             true,
         )
         .unwrap();
-        let executable =
-            Executable::<InvokeContext>::from_elf(&data, config, syscall_registry).unwrap();
+        let executable = Executable::<InvokeContext>::from_elf(&data, loader).unwrap();
 
         #[allow(unused_mut)]
         let mut verified_executable =

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.15.
 solana-logger = { path = "../logger", version = "=1.15.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
-solana_rbpf = { version = "=0.2.37", features = ["debugger"] }
+solana_rbpf = { version = "=0.2.38", features = ["debugger"] }

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -345,7 +345,7 @@ impl Debug for Output {
 // Replace with std::lazy::Lazy when stabilized.
 // https://github.com/rust-lang/rust/issues/74465
 struct LazyAnalysis<'a, 'b> {
-    analysis: Option<Analysis<'a, InvokeContext<'b>>>,
+    analysis: Option<Analysis<'a>>,
     executable: &'a Executable<InvokeContext<'b>>,
 }
 
@@ -357,7 +357,7 @@ impl<'a, 'b> LazyAnalysis<'a, 'b> {
         }
     }
 
-    fn analyze(&mut self) -> &Analysis<InvokeContext<'b>> {
+    fn analyze(&mut self) -> &Analysis {
         if let Some(ref analysis) = self.analysis {
             return analysis;
         }

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -294,6 +294,9 @@ before execting it in the virtual machine.",
     )
     .unwrap();
     let start_time = Instant::now();
+    if matches.value_of("use").unwrap() == "debugger" {
+        vm.debug_port = Some(matches.value_of("port").unwrap().parse::<u16>().unwrap());
+    }
     let (instruction_count, result) = vm.execute_program(matches.value_of("use").unwrap() != "jit");
     let duration = Instant::now() - start_time;
     drop(vm);

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -10,8 +10,8 @@ use {
         invoke_context::{prepare_mock_invoke_context, InvokeContext},
     },
     solana_rbpf::{
-        assembler::assemble, debugger, elf::Executable, interpreter::Interpreter,
-        static_analysis::Analysis, verifier::RequisiteVerifier, vm::VerifiedExecutable,
+        assembler::assemble, elf::Executable, static_analysis::Analysis,
+        verifier::RequisiteVerifier, vm::VerifiedExecutable,
     },
     solana_sdk::{
         account::AccountSharedData, bpf_loader, instruction::AccountMeta, pubkey::Pubkey,
@@ -294,13 +294,7 @@ before execting it in the virtual machine.",
     )
     .unwrap();
     let start_time = Instant::now();
-    let (instruction_count, result) = if matches.value_of("use").unwrap() == "debugger" {
-        let mut interpreter = Interpreter::new(&mut vm).unwrap();
-        let port = matches.value_of("port").unwrap().parse::<u16>().unwrap();
-        debugger::execute(&mut interpreter, port)
-    } else {
-        vm.execute_program(matches.value_of("use").unwrap() == "interpreter")
-    };
+    let (instruction_count, result) = vm.execute_program(matches.value_of("use").unwrap() != "jit");
     let duration = Instant::now() - start_time;
     drop(vm);
 

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -241,7 +241,7 @@ before execting it in the virtual machine.",
     file.rewind().unwrap();
     let mut contents = Vec::new();
     file.read_to_end(&mut contents).unwrap();
-    let (config, syscall_registry) = create_loader(
+    let loader = create_loader(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -250,14 +250,10 @@ before execting it in the virtual machine.",
     )
     .unwrap();
     let executable = if magic == [0x7f, 0x45, 0x4c, 0x46] {
-        Executable::<InvokeContext>::from_elf(&contents, config, syscall_registry)
+        Executable::<InvokeContext>::from_elf(&contents, loader)
             .map_err(|err| format!("Executable constructor failed: {err:?}"))
     } else {
-        assemble::<InvokeContext>(
-            std::str::from_utf8(contents.as_slice()).unwrap(),
-            config,
-            syscall_registry,
-        )
+        assemble::<InvokeContext>(std::str::from_utf8(contents.as_slice()).unwrap(), loader)
     }
     .unwrap();
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/rbpf/releases/tag/v0.2.38 will be released.

#### Summary of Changes
Preparation for unifying the mechanics of syscalls and CPI.
Thus, `SyscallRegistry` becomes a loader `BuiltInProgram`, which is now also sharable across programs.