### PR TITLE
Removes AccountsDb::hash_account_with_rent_epoch()

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6085,25 +6085,6 @@ impl AccountsDb {
         }
     }
 
-    pub fn hash_account_with_rent_epoch<T: ReadableAccount>(
-        slot: Slot,
-        account: &T,
-        pubkey: &Pubkey,
-        rent_epoch: Epoch,
-        include_slot: IncludeSlotInHash,
-    ) -> Hash {
-        Self::hash_account_data(
-            slot,
-            account.lamports(),
-            account.owner(),
-            account.executable(),
-            rent_epoch,
-            account.data(),
-            pubkey,
-            include_slot,
-        )
-    }
-
     pub fn hash_account<T: ReadableAccount>(
         slot: Slot,
         account: &T,
@@ -16646,27 +16627,6 @@ pub mod tests {
                 max_clean_root: None,
                 should_contain: false,
             });
-        }
-    }
-
-    #[test]
-    fn test_hash_account_with_rent_epoch() {
-        let owner = solana_sdk::pubkey::new_rand();
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let slot = 9;
-        let mut account = AccountSharedData::new(2, 1, &owner);
-        for rent in 0..3 {
-            account.set_rent_epoch(rent);
-            assert_eq!(
-                AccountsDb::hash_account(slot, &account, &pubkey, INCLUDE_SLOT_IN_HASH_TESTS),
-                AccountsDb::hash_account_with_rent_epoch(
-                    slot,
-                    &account,
-                    &pubkey,
-                    rent,
-                    INCLUDE_SLOT_IN_HASH_TESTS
-                )
-            );
         }
     }
 


### PR DESCRIPTION
#### Problem

For Incremental Accounts Hash, I will need the ability to hash a *zero-lamport* account. The family of `AccountsDb::hash_account()` functions return a default hash if the account is zero-lamport, which I will be modifying.

`AccountsDb::hash_account_with_rent_epoch()` is currently only used in tests. It would make my work mentioned above easier by having fewer entrypoints to the `hash_account` functions.


#### Summary of Changes

Remove `AccountsDb::hash_account_with_rent_epoch()`