### PR TITLE
Remove an unnecessary clone of a PohConfig inside Validator::new

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -715,7 +715,6 @@ impl Validator {
             max_slots.clone(),
         );
 
-        let poh_config = genesis_config.poh_config.clone();
         let startup_verification_complete;
         let (poh_recorder, entry_receiver, record_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
@@ -730,7 +729,7 @@ impl Validator {
                 &blockstore,
                 blockstore.get_new_shred_signal(0),
                 &leader_schedule_cache,
-                &poh_config,
+                &genesis_config.poh_config,
                 Some(poh_timing_point_sender),
                 exit.clone(),
             )
@@ -901,7 +900,7 @@ impl Validator {
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
-            &poh_config,
+            &genesis_config.poh_config,
             &exit,
             bank_forks.read().unwrap().root_bank().ticks_per_slot(),
             config.poh_pinned_cpu_core,


### PR DESCRIPTION
#### Problem
A clone of a PohConfig object is no longer needed due to a recent change to how PohConfigs are passed into functions.

#### Summary of Changes
Removed a local cloned copy of a PohConfig in Validator::new and replaced its use with a ref to the original object

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
