### PR TITLE
cli: Use QUIC if the default TPU does *not* use UDP

### DIFF
--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -91,6 +91,13 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .help("Use QUIC when sending transactions."),
         )
         .arg(
+            Arg::with_name("use_udp")
+                .long("use-udp")
+                .global(true)
+                .conflicts_with("use_quic")
+                .help("Use UDP when sending transactions."),
+        )
+        .arg(
             Arg::with_name("no_address_labels")
                 .long("no-address-labels")
                 .global(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
+    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
     std::{collections::HashMap, error, path::PathBuf, sync::Arc, time::Duration},
 };
 
@@ -202,7 +203,13 @@ pub fn parse_args<'a>(
         config.address_labels
     };
 
-    let use_quic = matches.is_present("use_quic");
+    let use_quic = if matches.is_present("use_quic") {
+        true
+    } else if matches.is_present("use_udp") {
+        false
+    } else {
+        !DEFAULT_TPU_ENABLE_UDP
+    };
 
     Ok((
         CliConfig {


### PR DESCRIPTION
#### Problem

On v1.15 / master, UDP is disabled for transactions, so just running `solana program deploy ...` will fail, since it's expecting to use quic. 

#### Summary of Changes

Add a flag to force using UDP, but default to `!DEFAULT_TPU_ENABLE_UDP`.

Fixes #29131
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
