### PR TITLE
rpc: fix possible panics in optimize_filters

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2225,10 +2225,14 @@ fn optimize_filters(filters: &mut [RpcFilterType]) {
             match &compare.bytes {
                 #[allow(deprecated)]
                 Binary(bytes) | Base58(bytes) => {
-                    compare.bytes = Bytes(bs58::decode(bytes).into_vec().unwrap());
+                    if let Ok(bytes) = bs58::decode(bytes).into_vec() {
+                        compare.bytes = Bytes(bytes);
+                    }
                 }
                 Base64(bytes) => {
-                    compare.bytes = Bytes(base64::decode(bytes).unwrap());
+                    if let Ok(bytes) = base64::decode(bytes) {
+                        compare.bytes = Bytes(bytes);
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
#### Problem

Possible panic in RPC thread in `optimize_filters`.

#### Summary of Changes

`optimize_filters` was introduced in https://github.com/solana-labs/solana/pull/20185 (by me :rofl:) but uses `.unwrap()` (my bad!). instead it would be better to ignore invalid data. It's very strange that nobody reported possible panics.