### PR TITLE
Remove repetitive logic in SlotMeta first insert detection logic

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3353,11 +3353,11 @@ fn update_slot_meta(
     reference_tick: u8,
     received_data_shreds: &ShredIndex,
 ) -> Vec<(u32, u32)> {
-    let maybe_first_insert = slot_meta.received == 0;
+    let first_insert = slot_meta.received == 0;
     // Index is zero-indexed, while the "received" height starts from 1,
     // so received = index + 1 for the same shred.
     slot_meta.received = cmp::max(u64::from(index) + 1, slot_meta.received);
-    if maybe_first_insert && slot_meta.received > 0 {
+    if first_insert {
         // predict the timestamp of what would have been the first shred in this slot
         let slot_time_elapsed = u64::from(reference_tick) * 1000 / DEFAULT_TICKS_PER_SECOND;
         slot_meta.first_shred_timestamp = timestamp() - slot_time_elapsed;


### PR DESCRIPTION
#### Problem
The logic for detecting first insert is repetitive.
- `maybe_first_insert = slot_meta.received == 0` is calculated
- We then update `slot_meta.received` to be `max(index + 1, slot_meta_received)`
    - `index` is an unsigned int, so `index + 1` is strictly `>= 1`; thus updated `slot_meta.received` is also strictly `>= 1`
- Given the above, the `&& slot_meta.received > 0` is redundant and will always be true when this function is called

#### Summary of Changes
Remove the redundant half of `if` statement