### PR TITLE
Bidirectional quic communication support

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -118,6 +118,7 @@ impl ConnectionCache {
         if self.use_quic() && !force_use_udp {
             Some(Arc::new(QuicLazyInitializedEndpoint::new(
                 self.client_certificate.clone(),
+                None,
             )))
         } else {
             None

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -157,7 +157,7 @@ impl Tpu {
         let (verified_sender, verified_receiver) = unbounded();
 
         let stats = Arc::new(StreamStats::default());
-        let tpu_quic_t = spawn_server(
+        let (_, tpu_quic_t) = spawn_server(
             transactions_quic_sockets,
             keypair,
             cluster_info.my_contact_info().tpu.ip(),
@@ -172,7 +172,7 @@ impl Tpu {
         )
         .unwrap();
 
-        let tpu_forwards_quic_t = spawn_server(
+        let (_, tpu_forwards_quic_t) = spawn_server(
             transactions_forwards_quic_sockets,
             keypair,
             cluster_info.my_contact_info().tpu_forwards.ip(),

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -117,6 +117,7 @@ impl QuicConfig {
     fn create_endpoint(&self) -> Arc<QuicLazyInitializedEndpoint> {
         Arc::new(QuicLazyInitializedEndpoint::new(
             self.client_certificate.clone(),
+            None,
         ))
     }
 

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -71,6 +71,7 @@ pub struct QuicClientCertificate {
 pub struct QuicLazyInitializedEndpoint {
     endpoint: RwLock<Option<Arc<Endpoint>>>,
     client_certificate: Arc<QuicClientCertificate>,
+    client_endpoint: Option<Endpoint>,
 }
 
 #[derive(Error, Debug)]
@@ -90,19 +91,31 @@ impl From<QuicError> for ClientErrorKind {
 }
 
 impl QuicLazyInitializedEndpoint {
-    pub fn new(client_certificate: Arc<QuicClientCertificate>) -> Self {
+    pub fn new(
+        client_certificate: Arc<QuicClientCertificate>,
+        client_endpoint: Option<Endpoint>,
+    ) -> Self {
         Self {
             endpoint: RwLock::new(None),
             client_certificate,
+            client_endpoint,
         }
     }
 
     fn create_endpoint(&self) -> Endpoint {
-        let (_, client_socket) = solana_net_utils::bind_in_range(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            VALIDATOR_PORT_RANGE,
-        )
-        .expect("QuicLazyInitializedEndpoint::create_endpoint bind_in_range");
+        let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
+            let endpoint = endpoint.clone();
+            endpoint
+        } else {
+            let client_socket = solana_net_utils::bind_in_range(
+                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                VALIDATOR_PORT_RANGE,
+            )
+            .expect("QuicLazyInitializedEndpoint::create_endpoint bind_in_range")
+            .1;
+
+            QuicNewConnection::create_endpoint(EndpointConfig::default(), client_socket)
+        };
 
         let mut crypto = rustls::ClientConfig::builder()
             .with_safe_defaults()
@@ -115,9 +128,6 @@ impl QuicLazyInitializedEndpoint {
         crypto.enable_early_data = true;
         crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
-        let mut endpoint =
-            QuicNewConnection::create_endpoint(EndpointConfig::default(), client_socket);
-
         let mut config = ClientConfig::new(Arc::new(crypto));
         let transport_config = Arc::get_mut(&mut config.transport)
             .expect("QuicLazyInitializedEndpoint::create_endpoint Arc::get_mut");
@@ -126,6 +136,7 @@ impl QuicLazyInitializedEndpoint {
         transport_config.keep_alive_interval(Some(Duration::from_millis(QUIC_KEEP_ALIVE_MS)));
 
         endpoint.set_default_client_config(config);
+
         endpoint
     }
 
@@ -160,10 +171,13 @@ impl Default for QuicLazyInitializedEndpoint {
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         )
         .expect("Failed to create QUIC client certificate");
-        Self::new(Arc::new(QuicClientCertificate {
-            certificates: certs,
-            key: priv_key,
-        }))
+        Self::new(
+            Arc::new(QuicClientCertificate {
+                certificates: certs,
+                key: priv_key,
+            }),
+            None,
+        )
     }
 }
 

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -103,6 +103,7 @@ pub mod temporary_pub {
         )
         .await;
         ASYNC_TASK_SEMAPHORE.release();
+        info!("Done sending txn batch");
         handle_send_result(result, connection)
     }
 


### PR DESCRIPTION
#### Problem
To support repair over quic -- we need to support sending repair request and receiving the response on the same quic endpoint so that the the request sever can simply sending back responses to the client using its from address. 

#### Summary of Changes

This is the first installment -- it allows the spawned quic streamer to return the endpoint and allow the quic client to use the optionally passed-in endpoint.

A unit test is developed to show this bi-directional communication.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
