### PR TITLE
Add pubsub address to RpcContactInfo

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2594,6 +2594,8 @@ pub struct CliGossipNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rpc_host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubsub_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub feature_set: Option<u32>,
@@ -2608,6 +2610,7 @@ impl CliGossipNode {
             gossip_port: info.gossip.map(|addr| addr.port()),
             tpu_port: info.tpu.map(|addr| addr.port()),
             rpc_host: info.rpc.map(|addr| addr.to_string()),
+            pubsub_host: info.pubsub.map(|addr| addr.to_string()),
             version: info.version,
             feature_set: info.feature_set,
         }

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -298,6 +298,8 @@ pub struct RpcContactInfo {
     pub tpu: Option<SocketAddr>,
     /// JSON RPC port
     pub rpc: Option<SocketAddr>,
+    /// WebSocket PubSub port
+    pub pubsub: Option<SocketAddr>,
     /// Software version
     pub version: Option<String>,
     /// First 4 bytes of the FeatureSet identifier

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -375,6 +375,7 @@ impl RpcSender for MockSender {
                 gossip: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
                 tpu: Some(SocketAddr::from(([10, 239, 6, 48], 8856))),
                 rpc: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
+                pubsub: Some(SocketAddr::from(([10, 239, 6, 48], 8900))),
                 version: Some("1.0.0 c375ce1f".to_string()),
                 feature_set: None,
                 shred_version: None,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3478,6 +3478,7 @@ pub mod rpc_full {
                             gossip: Some(contact_info.gossip),
                             tpu: valid_address_or_none(&contact_info.tpu),
                             rpc: valid_address_or_none(&contact_info.rpc),
+                            pubsub: valid_address_or_none(&contact_info.rpc_pubsub),
                             version,
                             feature_set,
                             shred_version: Some(my_shred_version),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5106,6 +5106,7 @@ pub mod tests {
             "shredVersion": 0u16,
             "tpu": "127.0.0.1:1234",
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
+            "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
             "version": null,
             "featureSet": null,
         }]);

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -112,6 +112,9 @@ impl Dashboard {
                 if let Some(rpc) = contact_info.rpc {
                     println_name_value("JSON RPC URL:", &format!("http://{rpc}"));
                 }
+                if let Some(pubsub) = contact_info.pubsub {
+                    println_name_value("WebSocket PubSub URL:", &format!("ws://{}", pubsub));
+                }
             }
 
             let progress_bar = new_spinner_progress_bar();


### PR DESCRIPTION
#### Problem

`getClusterNodes` response misses PubSub address, returns only the RPC address.

#### Summary of Changes

Added PubSub address in this response and respective mock sender. Additionally, added same data to CLI and dashboard.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
