### PR TITLE
write_version -> write_version_obsolete

### DIFF
--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -134,7 +134,7 @@ impl AccountsUpdateNotifierImpl {
             executable: stored_account_meta.account_meta.executable,
             rent_epoch: stored_account_meta.account_meta.rent_epoch,
             data: stored_account_meta.data,
-            write_version: stored_account_meta.meta.write_version,
+            write_version: stored_account_meta.meta.write_version_obsolete,
             txn_signature: None,
         })
     }

--- a/runtime/benches/append_vec.rs
+++ b/runtime/benches/append_vec.rs
@@ -40,7 +40,7 @@ fn append_account(
         StorableAccountsWithHashesAndWriteVersions::new_with_hashes_and_write_versions(
             &accounts,
             vec![&hash],
-            vec![storage_meta.write_version],
+            vec![storage_meta.write_version_obsolete],
         );
     let res = vec.append_accounts(&storable_accounts, 0);
     res.and_then(|res| res.first().cloned())

--- a/runtime/src/accounts_db/geyser_plugin_utils.rs
+++ b/runtime/src/accounts_db/geyser_plugin_utils.rs
@@ -96,9 +96,9 @@ impl AccountsDb {
             accounts.for_each(|account| {
                 account_len += 1;
                 if let Some(previous_write_version) = previous_write_version {
-                    assert!(previous_write_version < account.meta.write_version);
+                    assert!(previous_write_version < account.meta.write_version_obsolete);
                 }
-                previous_write_version = Some(account.meta.write_version);
+                previous_write_version = Some(account.meta.write_version_obsolete);
                 if notified_accounts.contains(&account.meta.pubkey) {
                     notify_stats.skipped_accounts += 1;
                     return;

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -135,7 +135,7 @@ pub mod tests {
         let hash = Hash::new(&[2; 32]);
         let stored_meta = StoredMeta {
             /// global write version
-            write_version: 0,
+            write_version_obsolete: 0,
             /// key for the account
             pubkey,
             data_len: 43,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -150,7 +150,10 @@ impl<'a: 'b, 'b, T: ReadableAccount + Sync + 'b, U: StorableAccounts<'a, T>, V: 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StoredMeta {
     /// global write version
-    pub write_version: StoredMetaWriteVersion,
+    /// This will be made completely obsolete such that we stop storing it.
+    /// We will not support multiple append vecs per slot anymore, so this concept is no longer necessary.
+    /// Order of stores of an account to an append vec will determine 'latest' account data per pubkey.
+    pub write_version_obsolete: StoredMetaWriteVersion,
     /// key for the account
     pub pubkey: Pubkey,
     pub data_len: u64,
@@ -656,7 +659,7 @@ impl AppendVec {
                 data_len: account
                     .map(|account| account.data().len())
                     .unwrap_or_default() as u64,
-                write_version: accounts.write_version(i),
+                write_version_obsolete: accounts.write_version(i),
             };
             let meta_ptr = &stored_meta as *const StoredMeta;
             let account_meta_ptr = &account_meta as *const AccountMeta;
@@ -716,7 +719,7 @@ pub mod tests {
                 StorableAccountsWithHashesAndWriteVersions::new_with_hashes_and_write_versions(
                     &account_data,
                     vec![&hash],
-                    vec![data.0.write_version],
+                    vec![data.0.write_version_obsolete],
                 );
 
             self.append_accounts(&storable_accounts, 0)

--- a/runtime/src/append_vec/test_utils.rs
+++ b/runtime/src/append_vec/test_utils.rs
@@ -39,7 +39,7 @@ pub fn create_test_account(sample: usize) -> (StoredMeta, AccountSharedData) {
     let mut account = AccountSharedData::new(sample as u64, 0, &Pubkey::default());
     account.set_data((0..data_len).map(|_| data_len as u8).collect());
     let stored_meta = StoredMeta {
-        write_version: 0,
+        write_version_obsolete: 0,
         pubkey: Pubkey::default(),
         data_len: data_len as u64,
     };

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -363,7 +363,7 @@ impl<'a> SnapshotMinimizer<'a> {
             for alive_account in keep_accounts {
                 accounts.push(&alive_account.account);
                 hashes.push(alive_account.account.hash);
-                write_versions.push(alive_account.account.meta.write_version);
+                write_versions.push(alive_account.account.meta.write_version_obsolete);
             }
 
             let new_storage = self.accounts_db().get_store_for_shrink(slot, aligned_total);

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -195,7 +195,7 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
         self.1[index].hash
     }
     fn write_version(&self, index: usize) -> u64 {
-        self.1[index].meta.write_version
+        self.1[index].meta.write_version_obsolete
     }
 }
 
@@ -238,7 +238,7 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
         self.1[index].account.hash
     }
     fn write_version(&self, index: usize) -> u64 {
-        self.1[index].account.meta.write_version
+        self.1[index].account.meta.write_version_obsolete
     }
 }
 #[cfg(test)]
@@ -281,7 +281,7 @@ pub mod tests {
         let executable = false;
         let rent_epoch = 0;
         let meta = StoredMeta {
-            write_version: 5,
+            write_version_obsolete: 5,
             pubkey: pk,
             data_len: 7,
         };
@@ -338,7 +338,7 @@ pub mod tests {
                             account.clone(),
                             starting_slot % max_slots,
                             StoredMeta {
-                                write_version: 0, // just something
+                                write_version_obsolete: 0, // just something
                                 pubkey: pk,
                                 data_len: u64::MAX, // just something
                             },

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
         info!(
             "  account: {:?} version: {} lamports: {} data: {} hash: {:?}",
             account.pubkey(),
-            account.meta.write_version,
+            account.meta.write_version_obsolete,
             account.account_meta.lamports,
             account.meta.data_len,
             account.hash
@@ -59,7 +59,7 @@ fn main() {
 fn is_account_zeroed(account: &StoredAccountMeta) -> bool {
     account.hash == &Hash::default()
         && account.meta.data_len == 0
-        && account.meta.write_version == 0
+        && account.meta.write_version_obsolete == 0
         && account.pubkey() == &Pubkey::default()
         && account.clone_account() == AccountSharedData::default()
 }


### PR DESCRIPTION
#### Problem
Staging to get rid of the use of `write_version`. Now that the write cache is always enabled, we never use 2 append vecs per slot. This means we don't need `write_version` anymore.

Note that we can't stop writing `write_version` in incrementing values because there are asserts that the value increments when we find the same account in the same slot multiple times. Of course, that may only be possible with ancient append vecs now that the write cache is on all the time.

#### Summary of Changes
rename to add `_obsolete`. This will make it easier to safely remove dependency on `write_version` and remove uses from other structs and functions.
Previously added a few asserts to make sure behavior is as expected.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
