### PR TITLE
Add LedgerTool command to show top N accounts ranked by the specified field

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -52,6 +52,7 @@ use {
         accounts_db::{AccountsDbConfig, CalcAccountsHashDataSource, FillerAccountsConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanConfig},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
+        append_vec::AppendVec,
         bank::{Bank, RewardCalculationEvent, TotalAccountsStats},
         bank_forks::BankForks,
         cost_model::CostModel,
@@ -90,7 +91,8 @@ use {
         vote_state::{self, VoteState},
     },
     std::{
-        collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+        cmp::Reverse,
+        collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
         ffi::OsStr,
         fs::File,
         io::{self, stdout, BufRead, BufReader, Write},
@@ -112,6 +114,44 @@ mod ledger_path;
 enum LedgerOutputMethod {
     Print,
     Json,
+}
+
+#[derive(Debug, Eq)]
+struct TopAccountsStatsEntry<V: std::cmp::Ord> {
+    key: Pubkey,
+    value: V,
+}
+
+impl<V: std::cmp::Ord> Ord for TopAccountsStatsEntry<V> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<V: std::cmp::Ord> PartialOrd for TopAccountsStatsEntry<V> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<V: std::cmp::Ord> PartialEq for TopAccountsStatsEntry<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+#[derive(PartialEq)]
+enum TopAccountsRankingField {
+    AccountDataSize,
+}
+
+impl TopAccountsRankingField {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "data_size" => Some(Self::AccountDataSize),
+            _ => None,
+        }
+    }
 }
 
 fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncoding {
@@ -1504,6 +1544,7 @@ fn main() {
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
     let mut measure_total_execution_time = Measure::start("ledger tool");
+    let default_top_accounts_file_count_limit = &std::usize::MAX.to_string();
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -2233,6 +2274,44 @@ fn main() {
                     .value_name("SST_FILE_NAME")
                     .help("The ledger file name (e.g. 011080.sst.) \
                            If no file name is specified, it will print the metadata of all ledger files.")
+            )
+        )
+        .subcommand(
+            SubCommand::with_name("top-accounts")
+            .about("Print the top N accounts of the specified field.")
+            .arg(
+                Arg::with_name("accounts_db_path")
+                    .long("accounts-db-path")
+                    .takes_value(true)
+                    .value_name("ACCOUNTS_DB_PATH")
+                    .help("Path to the accounts_db.")
+            )
+            .arg(
+                Arg::with_name("field")
+                    .long("field")
+                    .takes_value(true)
+                    .value_name("FIELD")
+                    .possible_values(&["data_size"])
+                    .default_value("data_size")
+                    .help("Determine which stats to print. \
+                           Possible values are: \
+                           'data_size': print the top N accounts with the largest account data size.")
+            )
+            .arg(
+                Arg::with_name("top")
+                    .long("top")
+                    .takes_value(true)
+                    .value_name("N")
+                    .default_value("30")
+                    .help("Collect the top N entries of the specified --stats")
+            )
+            .arg(
+                Arg::with_name("limit")
+                    .long("limit")
+                    .takes_value(true)
+                    .value_name("LIMIT")
+                    .default_value(default_top_accounts_file_count_limit)
+                    .help("Collect stats from up to LIMIT accounts db files.")
             )
         )
         .get_matches();
@@ -4290,6 +4369,52 @@ fn main() {
                 let sst_file_name = arg_matches.value_of("file_name");
                 if let Err(err) = print_blockstore_file_metadata(&blockstore, &sst_file_name) {
                     eprintln!("{err}");
+                }
+            }
+            ("top-accounts", Some(arg_matches)) => {
+                let accounts_db_path = value_t_or_exit!(arg_matches, "accounts_db_path", String);
+                let append_vec_paths = std::fs::read_dir(accounts_db_path).unwrap();
+                let heap_size = value_t_or_exit!(arg_matches, "top", usize);
+                let limit = value_t_or_exit!(arg_matches, "limit", usize);
+                let field_str = value_t_or_exit!(arg_matches, "field", String);
+                let field = TopAccountsRankingField::from_str(&field_str).unwrap();
+
+                let mut min_heap = BinaryHeap::new();
+                let mut file_count = 0;
+                debug!("paths = {:?}", append_vec_paths);
+                for path in append_vec_paths {
+                    debug!("Collecting stats from {:?}", path);
+                    let av_path = path.expect("success").path();
+                    let av_len = std::fs::metadata(&av_path).unwrap().len() as usize;
+                    let mut append_vec = AppendVec::new_from_file_unchecked(av_path, av_len)
+                        .expect("should succeed");
+                    append_vec.set_no_remove_on_drop();
+
+                    // read append-vec
+                    let mut offset = 0;
+                    while let Some((account, next_offset)) = append_vec.get_account(offset) {
+                        offset = next_offset;
+                        // data_size
+                        min_heap.push(Reverse(TopAccountsStatsEntry {
+                            key: *account.pubkey(),
+                            value: match field {
+                                TopAccountsRankingField::AccountDataSize => account.data.len(),
+                            },
+                        }));
+                        if min_heap.len() > heap_size {
+                            min_heap.pop();
+                        }
+                    }
+                    file_count += 1;
+                    if file_count >= limit {
+                        break;
+                    }
+                }
+                println!("Collected top {:?} samples", min_heap.len());
+                while !min_heap.is_empty() {
+                    if let Some(Reverse(entry)) = min_heap.pop() {
+                        println!("account: {:?}, {}: {:?}", entry.key, field_str, entry.value);
+                    }
                 }
             }
             ("", _) => {


### PR DESCRIPTION
#### Summary of Changes
Add top-accounts ledger command that shows the top N
accounts ranked by the specified field.  This PR currently includes
data_size, and will add more in the follow-up PRs.

Example command and output:
```
USAGE:
    solana-ledger-tool top-accounts \
        --accounts-db-path <ACCOUNTS_DB_PATH> \
        --field <FIELD> --ledger <DIR> \
        --limit <LIMIT> --top <N>
```

Example output:
```
Collected top 5 samples
account: FiPNgZGZ7mFgJUANKdmJzNfF91tthbh9Sbz8eUy33HXH, data_size: 2323703
account: 2cLU46kJNKg4GNrN9Z9mcM7uFBVqXj5sCZKyPKmrybDZ, data_size: 2403227
account: qzywGkJjRfnKhyDkx9UkyD51M6S7mePNe6NFz82Wb2w, data_size: 2403227
account: 55z7NAmnRnpzTFcfe8o9aqQabZ7qy1QReL3rV5NAawJ, data_size: 2403227
account: H9C1NtExcopjnNNVbK1bZqmjwpQmp2G8kM5aULHGHSNk, data_size: 2403227
```