### PR TITLE
warp_from_parents works with write_cache enabled

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1668,6 +1668,7 @@ fn maybe_warp_slot(
             &root_bank,
             &Pubkey::default(),
             warp_slot,
+            solana_runtime::accounts_db::CalcAccountsHashDataSource::Storages,
         ));
         bank_forks.set_root(
             warp_slot,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -594,6 +594,7 @@ fn test_epoch_accounts_hash_and_warping() {
         &bank,
         &Pubkey::default(),
         eah_stop_slot_in_next_epoch,
+        solana_runtime::accounts_db::CalcAccountsHashDataSource::IndexForTests,
     ));
     let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
         &bank,
@@ -625,6 +626,7 @@ fn test_epoch_accounts_hash_and_warping() {
         &bank,
         &Pubkey::default(),
         eah_start_slot_in_next_epoch,
+        solana_runtime::accounts_db::CalcAccountsHashDataSource::Storages,
     ));
     let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
         &bank,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3229,6 +3229,7 @@ fn main() {
                                 &bank,
                                 bank.collector_id(),
                                 warp_slot,
+                                solana_runtime::accounts_db::CalcAccountsHashDataSource::IndexForTests,
                             ))
                         } else {
                             bank

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1125,6 +1125,8 @@ impl ProgramTestContext {
                 &bank,
                 &Pubkey::default(),
                 pre_warp_slot,
+                // some warping tests cannot use the append vecs because of the sequence of adding roots and flushing
+                solana_runtime::accounts_db::CalcAccountsHashDataSource::IndexForTests,
             ))
         };
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1881,7 +1881,12 @@ impl Bank {
     /// * Adjusts the new bank's tick height to avoid having to run PoH for millions of slots
     /// * Freezes the new bank, assuming that the user will `Bank::new_from_parent` from this bank
     /// * Calculates and sets the epoch accounts hash from the parent
-    pub fn warp_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
+    pub fn warp_from_parent(
+        parent: &Arc<Bank>,
+        collector_id: &Pubkey,
+        slot: Slot,
+        data_source: CalcAccountsHashDataSource,
+    ) -> Self {
         parent.freeze();
         parent
             .rc
@@ -1889,9 +1894,7 @@ impl Bank {
             .accounts_db
             .epoch_accounts_hash_manager
             .set_in_flight(parent.slot());
-        parent.force_flush_accounts_cache();
-        let accounts_hash =
-            parent.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, true);
+        let accounts_hash = parent.update_accounts_hash(data_source, false, true);
         let epoch_accounts_hash = accounts_hash.into();
         parent
             .rc


### PR DESCRIPTION
#### Problem
Migrating everything to write cache only. Tests that warp end up causing trouble related to setting roots, flushing the write cache, and using the write cache by default. For now, all of these code paths can use the index version of the hash calculation to get past the issue with ripping out the !accounts_caching dead code.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
