### PR TITLE
update poh_config to have hashrate be private, with a getter and setter

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2071,10 +2071,9 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                target_tick_count: Some(bank.max_tick_height() + num_extra_ticks),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            poh_config.target_tick_count = Some(bank.max_tick_height() + num_extra_ticks);
+
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -2148,12 +2147,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -2304,12 +2301,10 @@ mod tests {
                     Blockstore::open(ledger_path.path())
                         .expect("Expected to be able to open database ledger"),
                 );
-                let poh_config = PohConfig {
-                    // limit tick count to avoid clearing working_bank at
-                    // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                    target_tick_count: Some(bank.max_tick_height() - 1),
-                    ..PohConfig::default()
-                };
+                let mut poh_config = PohConfig::default();
+                // limit tick count to avoid clearing working_bank at
+                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+                poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
                 let (exit, poh_recorder, poh_service, entry_receiver) =
                     create_test_recorder(&bank, &blockstore, Some(poh_config), None);
                 let cluster_info = new_test_cluster_info(Node::new_localhost().info);
@@ -3852,12 +3847,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at
-                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at
+            // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
 
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
@@ -3959,12 +3952,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at
-                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at
+            // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
 
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
@@ -4077,12 +4068,10 @@ mod tests {
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
             );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
+            let mut poh_config = PohConfig::default();
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
             let (exit, poh_recorder, poh_service, _entry_receiver) =
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2463,12 +2463,12 @@ mod tests {
     #[test]
     fn test_poh_speed() {
         solana_logger::setup();
-        let poh_config = PohConfig {
-            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+        let poh_config = PohConfig::new(
+            Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            None,
             // make PoH rate really fast to cause the panic condition
-            hashes_per_tick: Some(100 * solana_sdk::clock::DEFAULT_HASHES_PER_TICK),
-            ..PohConfig::default()
-        };
+            Some(100 * solana_sdk::clock::DEFAULT_HASHES_PER_TICK),
+        );
         let genesis_config = GenesisConfig {
             poh_config,
             ..GenesisConfig::default()
@@ -2478,11 +2478,11 @@ mod tests {
 
     #[test]
     fn test_poh_speed_no_hashes_per_tick() {
-        let poh_config = PohConfig {
-            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
-            hashes_per_tick: None,
-            ..PohConfig::default()
-        };
+        let poh_config = PohConfig::new(
+            Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            None,
+            None,
+        );
         let genesis_config = GenesisConfig {
             poh_config,
             ..GenesisConfig::default()

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -350,7 +350,7 @@ pub fn initialize_state(
         vec![stake; validator_keypairs.len()],
     );
 
-    genesis_config.poh_config.hashes_per_tick = Some(2);
+    genesis_config.poh_config.set_hashes_per_tick(Some(2));
     let bank0 = Bank::new_for_tests(&genesis_config);
 
     for pubkey in validator_keypairs_map.keys() {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -445,14 +445,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
     fee_rate_governor.burn_percent = value_t_or_exit!(matches, "fee_burn_percentage", u8);
 
-    let mut poh_config = PohConfig {
-        target_tick_duration: if matches.is_present("target_tick_duration") {
+    let mut poh_config = PohConfig::new(
+        if matches.is_present("target_tick_duration") {
             Duration::from_micros(value_t_or_exit!(matches, "target_tick_duration", u64))
         } else {
             Duration::from_micros(default_target_tick_duration)
         },
-        ..PohConfig::default()
-    };
+        None,
+        None,
+    );
 
     let cluster_type = cluster_type_of(&matches, "cluster_type").unwrap();
 
@@ -461,17 +462,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             ClusterType::Development => {
                 let hashes_per_tick =
                     compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
-                poh_config.hashes_per_tick = Some(hashes_per_tick / 2); // use 50% of peak ability
+                poh_config.set_hashes_per_tick(Some(hashes_per_tick / 2)); // use 50% of peak ability
             }
             ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => {
-                poh_config.hashes_per_tick = Some(clock::DEFAULT_HASHES_PER_TICK);
+                poh_config.set_hashes_per_tick(Some(clock::DEFAULT_HASHES_PER_TICK));
             }
         },
         "sleep" => {
-            poh_config.hashes_per_tick = None;
+            poh_config.set_hashes_per_tick(None);
         }
         _ => {
-            poh_config.hashes_per_tick = Some(value_t_or_exit!(matches, "hashes_per_tick", u64));
+            poh_config.set_hashes_per_tick(Some(value_t_or_exit!(matches, "hashes_per_tick", u64)));
         }
     }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2363,11 +2363,13 @@ fn main() {
                 }
 
                 if let Some(hashes_per_tick) = arg_matches.value_of("hashes_per_tick") {
-                    genesis_config.poh_config.hashes_per_tick = match hashes_per_tick {
-                        // Note: Unlike `solana-genesis`, "auto" is not supported here.
-                        "sleep" => None,
-                        _ => Some(value_t_or_exit!(arg_matches, "hashes_per_tick", u64)),
-                    }
+                    genesis_config
+                        .poh_config
+                        .set_hashes_per_tick(match hashes_per_tick {
+                            // Note: Unlike `solana-genesis`, "auto" is not supported here.
+                            "sleep" => None,
+                            _ => Some(value_t_or_exit!(arg_matches, "hashes_per_tick", u64)),
+                        })
                 }
 
                 create_new_ledger(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3861,7 +3861,7 @@ pub fn create_new_ledger(
         },
     )?;
     let ticks_per_slot = genesis_config.ticks_per_slot;
-    let hashes_per_tick = genesis_config.poh_config.hashes_per_tick.unwrap_or(0);
+    let hashes_per_tick = genesis_config.poh_config.get_hashes_per_tick().unwrap_or(0);
     let entries = create_ticks(ticks_per_slot, hashes_per_tick, genesis_config.hash());
     let last_hash = entries.last().unwrap().hash;
     let version = solana_sdk::shred_version::version_from_hash(&last_hash);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1946,7 +1946,9 @@ pub mod tests {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(hashes_per_tick);
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(hashes_per_tick));
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         let (ledger_path, blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
@@ -2638,7 +2640,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(mint, &leader_pubkey, 50);
-        genesis_config.poh_config.hashes_per_tick = Some(hashes_per_tick);
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(hashes_per_tick));
         let (ledger_path, mut last_entry_hash) =
             create_new_tmp_ledger_auto_delete!(&genesis_config);
         debug!("ledger_path: {:?}", ledger_path);
@@ -2669,7 +2673,7 @@ pub mod tests {
         // Fill up the rest of slot 1 with ticks
         entries.extend(create_ticks(
             genesis_config.ticks_per_slot - 1,
-            genesis_config.poh_config.hashes_per_tick.unwrap(),
+            genesis_config.poh_config.get_hashes_per_tick().unwrap(),
             last_entry_hash,
         ));
         let last_blockhash = entries.last().unwrap().hash;
@@ -4184,7 +4188,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(HASHES_PER_TICK);
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 
@@ -4452,7 +4458,9 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        genesis_config.poh_config.hashes_per_tick = Some(HASHES_PER_TICK);
+        genesis_config
+            .poh_config
+            .set_hashes_per_tick(Some(HASHES_PER_TICK));
         genesis_config.ticks_per_slot = TICKS_PER_SLOT;
         let genesis_hash = genesis_config.hash();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -239,7 +239,7 @@ impl LocalCluster {
             config.stakers_slot_offset,
             !config.skip_warmup_slots,
         );
-        genesis_config.poh_config = config.poh_config.clone();
+        genesis_config.poh_config = config.poh_config;
         genesis_config
             .native_instruction_processors
             .extend_from_slice(&config.native_instruction_processors);

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -466,7 +466,7 @@ impl PohRecorder {
         let blockhash = reset_bank.last_blockhash();
         let poh_hash = {
             let mut poh = self.poh.lock().unwrap();
-            poh.reset(blockhash, self.poh_config.hashes_per_tick);
+            poh.reset(blockhash, self.poh_config.get_hashes_per_tick());
             poh.hash
         };
         info!(
@@ -834,7 +834,7 @@ impl PohRecorder {
         let tick_number = 0;
         let poh = Arc::new(Mutex::new(Poh::new_with_slot_info(
             last_entry_hash,
-            poh_config.hashes_per_tick,
+            poh_config.get_hashes_per_tick(),
             ticks_per_slot,
             tick_number,
         )));

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -109,7 +109,7 @@ impl PohService {
             .name("solPohTickProd".to_string())
             .spawn(move || {
                 solana_sys_tuner::request_realtime_poh();
-                if poh_config.hashes_per_tick.is_none() {
+                if poh_config.get_hashes_per_tick().is_none() {
                     if poh_config.target_tick_count.is_none() {
                         Self::sleepy_tick_producer(
                             poh_recorder,
@@ -516,13 +516,13 @@ mod tests {
                 if entry.is_tick() {
                     num_ticks += 1;
                     assert!(
-                        entry.num_hashes <= poh_config.hashes_per_tick.unwrap(),
+                        entry.num_hashes <= poh_config.get_hashes_per_tick().unwrap(),
                         "{} <= {}",
                         entry.num_hashes,
-                        poh_config.hashes_per_tick.unwrap()
+                        poh_config.get_hashes_per_tick().unwrap()
                     );
 
-                    if entry.num_hashes == poh_config.hashes_per_tick.unwrap() {
+                    if entry.num_hashes == poh_config.get_hashes_per_tick().unwrap() {
                         need_tick = false;
                     } else {
                         need_partial = false;
@@ -530,7 +530,7 @@ mod tests {
 
                     hashes += entry.num_hashes;
 
-                    assert_eq!(hashes, poh_config.hashes_per_tick.unwrap());
+                    assert_eq!(hashes, poh_config.get_hashes_per_tick().unwrap());
 
                     hashes = 0;
                 } else {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2030,10 +2030,7 @@ impl Bank {
             "Bank snapshot genesis creation time does not match genesis.bin creation time.\
              The snapshot and genesis.bin might pertain to different clusters"
         );
-        assert_eq!(
-            bank.hashes_per_tick,
-            genesis_config.poh_config.hashes_per_tick
-        );
+        assert_eq!(bank.hashes_per_tick, genesis_config.hashes_per_tick());
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
         assert_eq!(
             bank.ns_per_slot,
@@ -10212,13 +10209,9 @@ pub(crate) mod tests {
                 })
                 .collect(),
             // set it up so the first epoch is a full year long
-            poh_config: PohConfig {
-                target_tick_duration: Duration::from_secs(
-                    SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
-                ),
-                hashes_per_tick: None,
-                target_tick_count: None,
-            },
+            poh_config: PohConfig::new_sleep(Duration::from_secs(
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
+            )),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()
@@ -10341,13 +10334,9 @@ pub(crate) mod tests {
                 })
                 .collect(),
             // set it up so the first epoch is a full year long
-            poh_config: PohConfig {
-                target_tick_duration: Duration::from_secs(
-                    SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
-                ),
-                hashes_per_tick: None,
-                target_tick_count: None,
-            },
+            poh_config: PohConfig::new_sleep(Duration::from_secs(
+                SECONDS_PER_YEAR as u64 / MINIMUM_SLOTS_PER_EPOCH / DEFAULT_TICKS_PER_SLOT,
+            )),
             cluster_type: ClusterType::MainnetBeta,
 
             ..GenesisConfig::default()

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -246,11 +246,20 @@ pub struct SnapshotPackage {
 
 impl SnapshotPackage {
     pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHash) -> Self {
-        let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type else {
-            panic!("The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!");
-        };
-        let Some(snapshot_info) = accounts_package.snapshot_info else {
-            panic!("The AccountsPackage must have snapshot info in order to make a SnapshotPackage!");
+        let snapshot_type =
+            if let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type {
+                snapshot_type
+            } else {
+                panic!(
+                "The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!"
+            );
+            };
+        let snapshot_info = if let Some(snapshot_info) = accounts_package.snapshot_info {
+            snapshot_info
+        } else {
+            panic!(
+                "The AccountsPackage must have snapshot info in order to make a SnapshotPackage!"
+            );
         };
         let snapshot_hash =
             SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref());

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -212,7 +212,11 @@ impl GenesisConfig {
     }
 
     pub fn hashes_per_tick(&self) -> Option<u64> {
-        self.poh_config.hashes_per_tick
+        self.poh_config.get_hashes_per_tick()
+    }
+
+    pub fn set_hashes_per_tick(&mut self, hashes: Option<u64>) {
+        self.poh_config.set_hashes_per_tick(hashes)
     }
 
     pub fn ticks_per_slot(&self) -> u64 {
@@ -262,7 +266,7 @@ impl fmt::Display for GenesisConfig {
             self.hash(),
             compute_shred_version(&self.hash(), None),
             self.ticks_per_slot,
-            self.poh_config.hashes_per_tick,
+            self.hashes_per_tick(),
             self.poh_config.target_tick_duration,
             self.epoch_schedule.slots_per_epoch,
             if self.epoch_schedule.warmup {

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -15,10 +15,30 @@ pub struct PohConfig {
     /// None enables "Low power mode", which implies:
     /// * sleep for `target_tick_duration` instead of hashing
     /// * the number of hashes per tick will be variable
-    pub hashes_per_tick: Option<u64>,
+    hashes_per_tick: Option<u64>,
 }
 
 impl PohConfig {
+    pub fn set_hashes_per_tick(&mut self, hashes: Option<u64>) {
+        self.hashes_per_tick = hashes;
+    }
+
+    pub fn get_hashes_per_tick(&self) -> Option<u64> {
+        self.hashes_per_tick
+    }
+
+    pub fn new(
+        target_tick_duration: Duration,
+        target_tick_count: Option<u64>,
+        hashes_per_tick: Option<u64>,
+    ) -> Self {
+        PohConfig {
+            target_tick_duration,
+            target_tick_count,
+            hashes_per_tick,
+        }
+    }
+
     pub fn new_sleep(target_tick_duration: Duration) -> Self {
         Self {
             target_tick_duration,


### PR DESCRIPTION
#### Problem
In order to increase the hashes-per-tick rate, we need to add a feature gate on it. Since it's a constant, we can't directly add a gate; instead we need to gate the getter for the struct that holds it.

Added getter and setter for hashes-per-tick in poh_config struct. Added "new" as well, to support existing usage by test functions. Updated code and tests.

There should be no functional change to any code.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
