### PR TITLE
chore: correct the name of the STALEBOT_START_DATE_RFC_2822 variable

### DIFF
--- a/.github/workflows/manage-stale-issues-and-prs.yml
+++ b/.github/workflows/manage-stale-issues-and-prs.yml
@@ -40,4 +40,4 @@ jobs:
           # Time immemorial when in debug-only mode (ie. on pull requests).
           # `STALEBOT_START_DATE` otherwise.
           # You can use this as a killswitch by setting `STALEBOT_START_DATE` in the far future.
-          start-date: ${{ github.event_name == 'pull_request' && '1970-01-01T00:00:00Z' || secrets.STALEBOT_START_DATE }} # ISO 8601 or RFC 2822
+          start-date: ${{ github.event_name == 'pull_request' && '1970-01-01T00:00:00Z' || secrets.STALEBOT_START_DATE_RFC_2822 }} # ISO 8601 or RFC 2822


### PR DESCRIPTION
Oops. Changed this in the repository, but failed to update it in code.

_Note to self: land this _after_ 8:00UTC Dec 10_
