### PR TITLE
Removes erroneous duplicate `#[ignore]`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -14953,7 +14953,6 @@ pub(crate) mod tests {
     }
 
     // process_stale_slot_with_budget is no longer called. We'll remove this test when we remove the function
-    #[ignore]
     #[test]
     #[ignore] // this test only works when not using the write cache
     fn test_process_stale_slot_with_budget() {


### PR DESCRIPTION
#### Problem

#29117 added an erroneous duplicate `#[ignore]` on a test. This causes `cargo check` to warn, which breaks CI `checks`.

#### Summary of Changes

Remove duplicate `#[ignore]`.