### PR TITLE
Add fully-reproducible online tracer for banking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4082,6 +4082,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolling-file"
+version = "0.1.0"
+source = "git+https://github.com/ryoqun/rolling-file-rs?rev=664504e77fad7292dedf5a119d950b80aef67934#664504e77fad7292dedf5a119d950b80aef67934"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,6 +5198,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "raptorq",
  "rayon",
+ "rolling-file",
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,8 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "rolling-file"
-version = "0.1.0"
-source = "git+https://github.com/ryoqun/rolling-file-rs?rev=664504e77fad7292dedf5a119d950b80aef67934#664504e77fad7292dedf5a119d950b80aef67934"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
 dependencies = [
  "chrono",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "strsim 0.10.0",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2263,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4399,6 +4440,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,6 +6524,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "sha2 0.10.5",
  "sha3 0.10.4",
  "solana-frozen-abi 1.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,9 +4441,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
  "serde",
  "serde_with_macros",
@@ -4451,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling",
  "proc-macro2 1.0.41",

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -8,7 +8,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_core::{
         banking_stage::BankingStage,
-        banking_trace::{BankingPacketBatch, BankingTracer, DEFAULT_BANKING_TRACE_SIZE},
+        banking_trace::{BankingPacketBatch, BankingTracer, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
     },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -419,7 +419,7 @@ fn main() {
         let banking_tracer = BankingTracer::new(matches.is_present("trace_banking").then_some((
             blockstore.banking_trace_path(),
             exit.clone(),
-            DEFAULT_BANKING_TRACE_SIZE,
+            BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
         )))
         .unwrap();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -6,7 +6,10 @@ use {
     rand::{thread_rng, Rng},
     rayon::prelude::*,
     solana_client::connection_cache::ConnectionCache,
-    solana_core::banking_stage::BankingStage,
+    solana_core::{
+        banking_stage::BankingStage,
+        banking_trace::{BankingPacketBatch, BankingTracer, DEFAULT_BANKING_TRACE_SIZE},
+    },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
         blockstore::Blockstore,
@@ -256,6 +259,12 @@ fn main() {
                 .help("Skip transaction sanity execution"),
         )
         .arg(
+            Arg::new("trace_banking")
+                .long("trace-banking")
+                .takes_value(false)
+                .help("Enable banking tracing"),
+        )
+        .arg(
             Arg::new("write_lock_contention")
                 .long("write-lock-contention")
                 .takes_value(true)
@@ -407,9 +416,16 @@ fn main() {
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (exit, poh_recorder, poh_service, signal_receiver) =
             create_test_recorder(&bank, &blockstore, None, Some(leader_schedule_cache));
-        let (non_vote_sender, non_vote_receiver) = unbounded();
-        let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
-        let (gossip_vote_sender, gossip_vote_receiver) = unbounded();
+        let banking_tracer = BankingTracer::new(matches.is_present("trace_banking").then_some((
+            blockstore.banking_tracer_path(),
+            exit.clone(),
+            DEFAULT_BANKING_TRACE_SIZE,
+        )))
+        .unwrap();
+        let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
+        let (tpu_vote_sender, tpu_vote_receiver) = banking_tracer.create_channel_tpu_vote();
+        let (gossip_vote_sender, gossip_vote_receiver) =
+            banking_tracer.create_channel_gossip_vote();
         let cluster_info = {
             let keypair = Arc::new(Keypair::new());
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
@@ -433,6 +449,7 @@ fn main() {
             None,
             Arc::new(connection_cache),
             bank_forks.clone(),
+            banking_tracer,
         );
         poh_recorder.write().unwrap().set_bank(&bank, false);
 
@@ -462,7 +479,7 @@ fn main() {
                     timestamp(),
                 );
                 non_vote_sender
-                    .send((vec![packet_batch.clone()], None))
+                    .send(BankingPacketBatch::new((vec![packet_batch.clone()], None)))
                     .unwrap();
             }
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -449,7 +449,6 @@ fn main() {
             None,
             Arc::new(connection_cache),
             bank_forks.clone(),
-            banking_tracer,
         );
         poh_recorder.write().unwrap().set_bank(&bank, false);
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -418,7 +418,7 @@ fn main() {
             create_test_recorder(&bank, &blockstore, None, Some(leader_schedule_cache));
         let (banking_tracer, tracer_thread) =
             BankingTracer::new(matches.is_present("trace_banking").then_some((
-                blockstore.banking_trace_path(),
+                &blockstore.banking_trace_path(),
                 exit.clone(),
                 BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
             )))

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -600,7 +600,9 @@ fn main() {
         poh_service.join().unwrap();
         sleep(Duration::from_secs(1));
         debug!("waited for poh_service");
-        tracer_thread.unwrap().join().unwrap().unwrap();
+        if let Some(tracer_thread) = tracer_thread {
+            tracer_thread.join().unwrap().unwrap();
+        }
     }
     let _unused = Blockstore::destroy(&ledger_path);
 }

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -417,7 +417,7 @@ fn main() {
         let (exit, poh_recorder, poh_service, signal_receiver) =
             create_test_recorder(&bank, &blockstore, None, Some(leader_schedule_cache));
         let banking_tracer = BankingTracer::new(matches.is_present("trace_banking").then_some((
-            blockstore.banking_tracer_path(),
+            blockstore.banking_trace_path(),
             exit.clone(),
             DEFAULT_BANKING_TRACE_SIZE,
         )))

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,6 +34,7 @@ num_enum = "0.5.7"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.3"
+rolling-file = { git = "https://github.com/ryoqun/rolling-file-rs", rev = "664504e77fad7292dedf5a119d950b80aef67934" }
 serde = "1.0.144"
 serde_derive = "1.0.103"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.15.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,7 @@ num_enum = "0.5.7"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.3"
-rolling-file = { git = "https://github.com/ryoqun/rolling-file-rs", rev = "664504e77fad7292dedf5a119d950b80aef67934" }
+rolling-file = "0.2.0"
 serde = "1.0.144"
 serde_derive = "1.0.103"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.15.0" }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -103,7 +103,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &BankingStageStats::default(),
                 &recorder,
                 &QosService::new(1),
-                &mut LeaderSlotMetricsTracker::new_for_test(),
+                &mut LeaderSlotMetricsTracker::new(0),
                 None,
             );
         });

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -11,6 +11,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_core::{
         banking_stage::{BankingStage, BankingStageStats},
+        banking_trace::{BankingPacketBatch, BankingTracer},
         leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
         qos_service::QosService,
         unprocessed_packet_batches::*,
@@ -102,7 +103,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &BankingStageStats::default(),
                 &recorder,
                 &QosService::new(1),
-                &mut LeaderSlotMetricsTracker::new(0),
+                &mut LeaderSlotMetricsTracker::new_for_test(),
                 None,
             );
         });
@@ -197,9 +198,10 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     // during the benchmark
     genesis_config.ticks_per_slot = 10_000;
 
-    let (non_vote_sender, non_vote_receiver) = unbounded();
-    let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
-    let (gossip_vote_sender, gossip_vote_receiver) = unbounded();
+    let banking_tracer = BankingTracer::new_disabled();
+    let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
+    let (tpu_vote_sender, tpu_vote_receiver) = banking_tracer.create_channel_tpu_vote();
+    let (gossip_vote_sender, gossip_vote_receiver) = banking_tracer.create_channel_gossip_vote();
 
     let mut bank = Bank::new_for_benches(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench
@@ -288,6 +290,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             None,
             Arc::new(ConnectionCache::default()),
             bank_forks,
+            banking_tracer,
         );
         poh_recorder.write().unwrap().set_bank(&bank, false);
 
@@ -304,10 +307,16 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             let mut sent = 0;
             if let Some(vote_packets) = &vote_packets {
                 tpu_vote_sender
-                    .send((vote_packets[start..start + chunk_len].to_vec(), None))
+                    .send(BankingPacketBatch::new((
+                        vote_packets[start..start + chunk_len].to_vec(),
+                        None,
+                    )))
                     .unwrap();
                 gossip_vote_sender
-                    .send((vote_packets[start..start + chunk_len].to_vec(), None))
+                    .send(BankingPacketBatch::new((
+                        vote_packets[start..start + chunk_len].to_vec(),
+                        None,
+                    )))
                     .unwrap();
             }
             for v in verified[start..start + chunk_len].chunks(chunk_len / num_threads) {
@@ -321,7 +330,9 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
                 for xv in v {
                     sent += xv.len();
                 }
-                non_vote_sender.send((v.to_vec(), None)).unwrap();
+                non_vote_sender
+                    .send(BankingPacketBatch::new((v.to_vec(), None)))
+                    .unwrap();
             }
 
             check_txs(&signal_receiver2, txes / CHUNKS);

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -290,7 +290,6 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             None,
             Arc::new(ConnectionCache::default()),
             bank_forks,
-            banking_tracer,
         );
         poh_recorder.write().unwrap().set_bank(&bank, false);
 

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -4,9 +4,11 @@ extern crate test;
 
 use {
     solana_core::banking_trace::{
-        drop_and_clean_temp_dir_unless_suppressed, sample_packet_batch,
-        sender_overhead_minimized_receiver_loop, terminate_tracer, BankingPacketBatch,
-        BankingTracer, TraceError, TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
+        for_test::{
+            drop_and_clean_temp_dir_unless_suppressed, sample_packet_batch, terminate_tracer,
+        },
+        sender_overhead_minimized_receiver_loop, BankingPacketBatch, BankingTracer, TraceError,
+        TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
     },
     std::{
         path::PathBuf,

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -1,0 +1,148 @@
+#![feature(test)]
+
+extern crate test;
+
+use {
+    solana_core::banking_trace::{
+        drop_and_clean_temp_dir_unless_suppressed, sample_packet_batch,
+        sender_overhead_minimized_receiver_loop, terminate_tracer, BankingPacketBatch,
+        BankingTracer, TraceError, TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
+    },
+    std::{
+        path::PathBuf,
+        sync::{atomic::AtomicBool, Arc},
+        thread,
+    },
+    tempfile::TempDir,
+    test::Bencher,
+};
+
+fn ensure_fresh_setup_to_benchmark(path: &PathBuf) {
+    // make sure fresh setup; otherwise banking tracer appends and rotates
+    // trace files created by prior bench iterations, slightly skewing perf
+    // result...
+    BankingTracer::ensure_cleanup_path(path).unwrap();
+}
+
+fn black_box_packet_batch(packet_batch: BankingPacketBatch) -> TracerThreadResult {
+    test::black_box(packet_batch);
+    Ok(())
+}
+
+#[bench]
+fn bench_banking_tracer_main_thread_overhead_noop_baseline(bencher: &mut Bencher) {
+    let exit = Arc::<AtomicBool>::default();
+    let tracer = BankingTracer::new_disabled();
+    let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+    let exit_for_dummy_thread = exit.clone();
+    let dummy_main_thread = thread::spawn(move || {
+        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            exit_for_dummy_thread,
+            non_vote_receiver,
+            black_box_packet_batch,
+        )
+    });
+
+    let packet_batch = sample_packet_batch();
+    bencher.iter(|| {
+        non_vote_sender.send(packet_batch.clone()).unwrap();
+    });
+    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+}
+
+#[bench]
+fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Bencher) {
+    let temp_dir = TempDir::new().unwrap();
+
+    let exit = Arc::<AtomicBool>::default();
+    let tracer = BankingTracer::new(Some((
+        temp_dir.path().join("banking-trace"),
+        exit.clone(),
+        DEFAULT_BANKING_TRACE_SIZE,
+    )))
+    .unwrap();
+    let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+    let exit_for_dummy_thread = exit.clone();
+    let dummy_main_thread = thread::spawn(move || {
+        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            exit_for_dummy_thread,
+            non_vote_receiver,
+            black_box_packet_batch,
+        )
+    });
+
+    let packet_batch = sample_packet_batch();
+    bencher.iter(|| {
+        non_vote_sender.send(packet_batch.clone()).unwrap();
+    });
+
+    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+    drop_and_clean_temp_dir_unless_suppressed(temp_dir);
+}
+
+#[bench]
+fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut Bencher) {
+    let temp_dir = TempDir::new().unwrap();
+
+    let exit = Arc::<AtomicBool>::default();
+    let tracer = BankingTracer::new(Some((
+        temp_dir.path().join("banking-trace"),
+        exit.clone(),
+        1024 * 1024, // cause more frequent trace file rotation
+    )))
+    .unwrap();
+    let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+    let exit_for_dummy_thread = exit.clone();
+    let dummy_main_thread = thread::spawn(move || {
+        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            exit_for_dummy_thread,
+            non_vote_receiver,
+            black_box_packet_batch,
+        )
+    });
+
+    let packet_batch = sample_packet_batch();
+    bencher.iter(|| {
+        non_vote_sender.send(packet_batch.clone()).unwrap();
+    });
+
+    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+    drop_and_clean_temp_dir_unless_suppressed(temp_dir);
+}
+
+#[bench]
+fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path();
+
+    let packet_batch = sample_packet_batch();
+
+    bencher.iter(move || {
+        let path = base_path.join("banking-trace");
+        ensure_fresh_setup_to_benchmark(&path);
+
+        let exit = Arc::<AtomicBool>::default();
+
+        let tracer = BankingTracer::new(Some((path, exit.clone(), 50 * 1024 * 1024))).unwrap();
+        let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+        let dummy_main_thread = thread::spawn(move || {
+            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+                exit.clone(),
+                non_vote_receiver,
+                black_box_packet_batch,
+            )
+        });
+
+        for _ in 0..1000 {
+            non_vote_sender.send(packet_batch.clone()).unwrap();
+        }
+
+        terminate_tracer(tracer, dummy_main_thread, non_vote_sender, None);
+    });
+
+    drop_and_clean_temp_dir_unless_suppressed(temp_dir);
+}

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -8,7 +8,7 @@ use {
             drop_and_clean_temp_dir_unless_suppressed, sample_packet_batch, terminate_tracer,
         },
         receiving_loop_with_minimized_sender_overhead, BankingPacketBatch, BankingTracer,
-        TraceError, TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
+        TraceError, TracerThreadResult, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
     },
     std::{
         path::PathBuf,
@@ -61,7 +61,7 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
     let tracer = BankingTracer::new(Some((
         temp_dir.path().join("banking-trace"),
         exit.clone(),
-        DEFAULT_BANKING_TRACE_SIZE,
+        BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
     )))
     .unwrap();
     let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -59,7 +59,7 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
 
     let exit = Arc::<AtomicBool>::default();
     let (tracer, tracer_thread) = BankingTracer::new(Some((
-        temp_dir.path().join("banking-trace"),
+        &temp_dir.path().join("banking-trace"),
         exit.clone(),
         BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
     )))
@@ -96,7 +96,7 @@ fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut
 
     let exit = Arc::<AtomicBool>::default();
     let (tracer, tracer_thread) = BankingTracer::new(Some((
-        temp_dir.path().join("banking-trace"),
+        &temp_dir.path().join("banking-trace"),
         exit.clone(),
         1024 * 1024, // cause more frequent trace file rotation
     )))
@@ -141,7 +141,7 @@ fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
         let exit = Arc::<AtomicBool>::default();
 
         let (tracer, tracer_thread) =
-            BankingTracer::new(Some((path, exit.clone(), 50 * 1024 * 1024))).unwrap();
+            BankingTracer::new(Some((&path, exit.clone(), 50 * 1024 * 1024))).unwrap();
         let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
 
         let dummy_main_thread = thread::spawn(move || {

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -7,8 +7,8 @@ use {
         for_test::{
             drop_and_clean_temp_dir_unless_suppressed, sample_packet_batch, terminate_tracer,
         },
-        sender_overhead_minimized_receiver_loop, BankingPacketBatch, BankingTracer, TraceError,
-        TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
+        receiving_loop_with_minimized_sender_overhead, BankingPacketBatch, BankingTracer,
+        TraceError, TracerThreadResult, DEFAULT_BANKING_TRACE_SIZE,
     },
     std::{
         path::PathBuf,
@@ -39,7 +39,7 @@ fn bench_banking_tracer_main_thread_overhead_noop_baseline(bencher: &mut Bencher
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
-        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+        receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
             exit_for_dummy_thread,
             non_vote_receiver,
             black_box_packet_batch,
@@ -68,7 +68,7 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
-        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+        receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
             exit_for_dummy_thread,
             non_vote_receiver,
             black_box_packet_batch,
@@ -99,7 +99,7 @@ fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
-        sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+        receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
             exit_for_dummy_thread,
             non_vote_receiver,
             black_box_packet_batch,
@@ -132,7 +132,7 @@ fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
         let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
 
         let dummy_main_thread = thread::spawn(move || {
-            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
                 exit.clone(),
                 non_vote_receiver,
                 black_box_packet_batch,

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -50,7 +50,7 @@ fn bench_banking_tracer_main_thread_overhead_noop_baseline(bencher: &mut Bencher
     bencher.iter(|| {
         non_vote_sender.send(packet_batch.clone()).unwrap();
     });
-    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+    terminate_tracer(tracer, None, dummy_main_thread, non_vote_sender, Some(exit));
 }
 
 #[bench]
@@ -58,7 +58,7 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
     let temp_dir = TempDir::new().unwrap();
 
     let exit = Arc::<AtomicBool>::default();
-    let tracer = BankingTracer::new(Some((
+    let (tracer, tracer_thread) = BankingTracer::new(Some((
         temp_dir.path().join("banking-trace"),
         exit.clone(),
         BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
@@ -80,7 +80,13 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
         non_vote_sender.send(packet_batch.clone()).unwrap();
     });
 
-    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+    terminate_tracer(
+        tracer,
+        tracer_thread,
+        dummy_main_thread,
+        non_vote_sender,
+        Some(exit),
+    );
     drop_and_clean_temp_dir_unless_suppressed(temp_dir);
 }
 
@@ -89,7 +95,7 @@ fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut
     let temp_dir = TempDir::new().unwrap();
 
     let exit = Arc::<AtomicBool>::default();
-    let tracer = BankingTracer::new(Some((
+    let (tracer, tracer_thread) = BankingTracer::new(Some((
         temp_dir.path().join("banking-trace"),
         exit.clone(),
         1024 * 1024, // cause more frequent trace file rotation
@@ -111,7 +117,13 @@ fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut
         non_vote_sender.send(packet_batch.clone()).unwrap();
     });
 
-    terminate_tracer(tracer, dummy_main_thread, non_vote_sender, Some(exit));
+    terminate_tracer(
+        tracer,
+        tracer_thread,
+        dummy_main_thread,
+        non_vote_sender,
+        Some(exit),
+    );
     drop_and_clean_temp_dir_unless_suppressed(temp_dir);
 }
 
@@ -128,7 +140,8 @@ fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
 
         let exit = Arc::<AtomicBool>::default();
 
-        let tracer = BankingTracer::new(Some((path, exit.clone(), 50 * 1024 * 1024))).unwrap();
+        let (tracer, tracer_thread) =
+            BankingTracer::new(Some((path, exit.clone(), 50 * 1024 * 1024))).unwrap();
         let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
 
         let dummy_main_thread = thread::spawn(move || {
@@ -143,7 +156,13 @@ fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
             non_vote_sender.send(packet_batch.clone()).unwrap();
         }
 
-        terminate_tracer(tracer, dummy_main_thread, non_vote_sender, None);
+        terminate_tracer(
+            tracer,
+            tracer_thread,
+            dummy_main_thread,
+            non_vote_sender,
+            None,
+        );
     });
 
     drop_and_clean_temp_dir_unless_suppressed(temp_dir);

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -164,7 +164,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
 
     bencher.iter(move || {
         let now = Instant::now();
-        let mut batches = gen_batches(use_same_tx);
+        let batches = gen_batches(use_same_tx);
         trace!(
             "starting... generation took: {} ms batches: {}",
             duration_as_ms(&now.elapsed()),
@@ -172,14 +172,12 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
         );
 
         let mut sent_len = 0;
-        for _ in 0..batches.len() {
-            if let Some(mut batch) = batches.pop() {
-                sent_len += batch.len();
-                batch
-                    .iter_mut()
-                    .for_each(|packet| packet.meta_mut().flags |= PacketFlags::TRACER_PACKET);
-                packet_s.send(vec![batch]).unwrap();
-            }
+        for mut batch in batches.into_iter() {
+            sent_len += batch.len();
+            batch
+                .iter_mut()
+                .for_each(|packet| packet.meta_mut().flags |= PacketFlags::TRACER_PACKET);
+            packet_s.send(vec![batch]).unwrap();
         }
         let mut received = 0;
         let mut total_tracer_packets_received_in_sigverify_stage = 0;

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -12,6 +12,7 @@ use {
         thread_rng, Rng,
     },
     solana_core::{
+        banking_trace::BankingTracer,
         sigverify::TransactionSigVerifier,
         sigverify_stage::{SigVerifier, SigVerifyStage},
     },
@@ -147,7 +148,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     solana_logger::setup();
     trace!("start");
     let (packet_s, packet_r) = unbounded();
-    let (verified_s, verified_r) = unbounded();
+    let (verified_s, verified_r) = BankingTracer::channel_for_test();
     let verifier = TransactionSigVerifier::new(verified_s);
     let stage = SigVerifyStage::new(packet_r, verifier, "bench");
 
@@ -170,18 +171,21 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
         }
         let mut received = 0;
         trace!("sent: {}", sent_len);
+        let mut messages = vec![];
         loop {
-            if let Ok((mut verifieds, _)) = verified_r.recv_timeout(Duration::from_millis(10)) {
-                while let Some(v) = verifieds.pop() {
+            if let Ok(message) = verified_r.recv_timeout(Duration::from_millis(10)) {
+                let (verifieds, _) = &*message;
+                for v in verifieds.iter().rev() {
                     received += v.len();
-                    batches.push(v);
                 }
+                messages.push(message);
                 if use_same_tx || received >= sent_len {
                     break;
                 }
             }
         }
         trace!("received: {}", received);
+        test::black_box(messages);
     });
     stage.join().unwrap();
 }
@@ -224,8 +228,8 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 
 fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32) {
     let (batches0, num_valid_packets) = prepare_batches(discard_factor);
-    let (_verified_s, _verified_r) = unbounded();
-    let verifier = TransactionSigVerifier::new(_verified_s);
+    let (verified_s, _verified_r) = BankingTracer::channel_for_test();
+    let verifier = TransactionSigVerifier::new(verified_s);
 
     let mut c = 0;
     let mut total_shrink_time = 0;

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -23,6 +23,7 @@ use {
     },
     solana_sdk::{
         hash::Hash,
+        packet::PacketFlags,
         signature::{Keypair, Signer},
         system_transaction,
         timing::duration_as_ms,
@@ -172,19 +173,25 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
 
         let mut sent_len = 0;
         for _ in 0..batches.len() {
-            if let Some(batch) = batches.pop() {
+            if let Some(mut batch) = batches.pop() {
                 sent_len += batch.len();
+                batch
+                    .iter_mut()
+                    .for_each(|packet| packet.meta_mut().flags |= PacketFlags::TRACER_PACKET);
                 packet_s.send(vec![batch]).unwrap();
             }
         }
         let mut received = 0;
+        let mut total_tracer_packets_received_in_sigverify_stage = 0;
         trace!("sent: {}", sent_len);
         loop {
             if let Ok(message) = verified_r.recv_timeout(Duration::from_millis(10)) {
-                let (verifieds, _) = &*message;
+                let (verifieds, tracer_packet_stats) = (&message.0, message.1.as_ref().unwrap());
                 received += verifieds.iter().map(|batch| batch.len()).sum::<usize>();
+                total_tracer_packets_received_in_sigverify_stage +=
+                    tracer_packet_stats.total_tracer_packets_received_in_sigverify_stage;
                 test::black_box(message);
-                if use_same_tx || received >= sent_len {
+                if total_tracer_packets_received_in_sigverify_stage >= sent_len {
                     break;
                 }
             }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -500,7 +500,6 @@ impl BankingStage {
                     .unwrap()
             })
             .collect();
-
         Self { bank_thread_hdls }
     }
 
@@ -841,7 +840,7 @@ impl BankingStage {
                 // Take metrics action after forwarding packets
                 slot_metrics_tracker.apply_action(metrics_action);
             }
-            _ => {}
+            _ => (),
         }
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -851,7 +851,9 @@ impl BankingStage {
                 // Take metrics action after forwarding packets
                 slot_metrics_tracker.apply_action(metrics_action);
             }
-            _ => (),
+            BufferedPacketsDecision::Hold => {
+                slot_metrics_tracker.apply_action(metrics_action);
+            }
         }
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -8,7 +8,7 @@ use {
         packet_receiver::PacketReceiver,
     },
     crate::{
-        banking_trace::{BankingPacketReceiver, BankingTracer, TracerThreadResult},
+        banking_trace::{BankingPacketReceiver, BankingTracer, TracerThread},
         forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{LatestUnprocessedVotes, VoteSource},
@@ -349,7 +349,7 @@ pub struct BatchedTransactionErrorDetails {
 /// Stores the stage's thread handle and output receiver.
 pub struct BankingStage {
     bank_thread_hdls: Vec<JoinHandle<()>>,
-    tracer_thread_hdl: Option<JoinHandle<TracerThreadResult>>,
+    tracer_thread_hdl: TracerThread,
 }
 
 #[derive(Debug, Clone)]
@@ -382,7 +382,7 @@ impl BankingStage {
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
-        banking_tracer: BankingTracer,
+        banking_tracer: Arc<BankingTracer>,
     ) -> Self {
         Self::new_num_threads(
             cluster_info,
@@ -413,7 +413,7 @@ impl BankingStage {
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
-        banking_tracer: BankingTracer,
+        banking_tracer: Arc<BankingTracer>,
     ) -> Self {
         assert!(num_threads >= MIN_TOTAL_THREADS);
         // Single thread to generate entries from many banks.
@@ -432,7 +432,6 @@ impl BankingStage {
                     .is_active(&allow_votes_to_directly_update_vote_state::id())
             })
             .unwrap_or(false);
-        let (tracer_thread_hdl, banking_tracer) = banking_tracer.finalize_under_arc();
         // Many banks that process transactions in parallel.
         let bank_thread_hdls: Vec<JoinHandle<()>> = (0..num_threads)
             .map(|i| {
@@ -507,9 +506,10 @@ impl BankingStage {
                     .unwrap()
             })
             .collect();
+
         Self {
             bank_thread_hdls,
-            tracer_thread_hdl,
+            tracer_thread_hdl: banking_tracer.take_tracer_thread_join_handle(),
         }
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -770,7 +770,6 @@ impl BankingStage {
         connection_cache: &ConnectionCache,
         tracer_packet_stats: &mut TracerPacketStats,
         bank_forks: &Arc<RwLock<BankForks>>,
-        unreceived_batch_count: usize,
     ) {
         if unprocessed_transaction_storage.should_not_process() {
             return;
@@ -1002,7 +1001,6 @@ impl BankingStage {
                         &connection_cache,
                         &mut tracer_packet_stats,
                         bank_forks,
-                        packet_deserializer.unreceived_batch_count(),
                     ),
                     "process_buffered_packets",
                 );

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -227,25 +227,31 @@ impl BankingTracer {
         )
     }
 
-    fn bank_event(&self, slot: Slot, id: u32, status: BankStatus, unreceived_batch_count: usize) {
+    fn bank_event(
+        &self,
+        slot: Slot,
+        id: u32,
+        status: BankStatus,
+        unprocessed_transaction_count: usize,
+    ) {
         if let Some((sender, _, exit)) = &self.enabled_tracer {
             if !exit.load(Ordering::Relaxed) {
                 sender
                     .send(TimedTracedEvent(
                         SystemTime::now(),
-                        TracedEvent::Bank(slot, id, status, unreceived_batch_count),
+                        TracedEvent::Bank(slot, id, status, unprocessed_transaction_count),
                     ))
                     .expect("active tracer thread unless exited");
             }
         }
     }
 
-    pub fn bank_start(&self, slot: Slot, id: u32, unreceived_batch_count: usize) {
-        self.bank_event(slot, id, BankStatus::Started, unreceived_batch_count);
+    pub fn bank_start(&self, slot: Slot, id: u32, unprocessed_transaction_count: usize) {
+        self.bank_event(slot, id, BankStatus::Started, unprocessed_transaction_count);
     }
 
-    pub fn bank_end(&self, slot: Slot, id: u32, unreceived_batch_count: usize) {
-        self.bank_event(slot, id, BankStatus::Ended, unreceived_batch_count);
+    pub fn bank_end(&self, slot: Slot, id: u32, unprocessed_transaction_count: usize) {
+        self.bank_event(slot, id, BankStatus::Ended, unprocessed_transaction_count);
     }
 
     pub fn channel_for_test() -> (TracedSender, Receiver<BankingPacketBatch>) {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -1,0 +1,497 @@
+use {
+    crate::sigverify::SigverifyTracerPacketStats,
+    bincode::serialize_into,
+    chrono::{DateTime, Local},
+    crossbeam_channel::{unbounded, Receiver, SendError, Sender, TryRecvError},
+    rolling_file::{RollingCondition, RollingConditionBasic, RollingFileAppender},
+    solana_perf::{
+        packet::{to_packet_batches, PacketBatch},
+        test_tx::test_tx,
+    },
+    solana_sdk::slot_history::Slot,
+    std::{
+        fs::{create_dir_all, remove_dir_all},
+        io::{self, Write},
+        path::PathBuf,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::{self, sleep, JoinHandle},
+        time::{Duration, SystemTime},
+    },
+    tempfile::TempDir,
+    thiserror::Error,
+};
+
+pub type BankingPacketBatch = Arc<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>)>;
+pub type BankingPacketSender = TracedSender;
+pub type BankingPacketReceiver = Receiver<BankingPacketBatch>;
+pub type TracerThreadResult = Result<(), TraceError>;
+
+#[derive(Error, Debug)]
+pub enum TraceError {
+    #[error("IO Error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Serialization Error: {0}")]
+    SerializeError(#[from] bincode::Error),
+
+    #[error("Integer Cast Error: {0}")]
+    IntegerCastError(#[from] std::num::TryFromIntError),
+
+    #[error("Trace size is too small (must be larger than {1}): {0}")]
+    TooSmallTraceSize(u64, u64),
+}
+
+const BASENAME: &str = "events";
+const TRACE_FILE_ROTATE_COUNT: u64 = 14; // target 2 weeks retention under normal load
+const TRACE_FILE_WRITE_INTERVAL_MS: u64 = 100;
+const BUF_WRITER_CAPACITY: usize = 10 * 1024 * 1024;
+pub const TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD: u64 = 1024 * 1024 * 1024;
+pub const EMPTY_BANKING_TRACE_SIZE: u64 = 0;
+pub const DEFAULT_BANKING_TRACE_SIZE: u64 =
+    TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD * TRACE_FILE_ROTATE_COUNT;
+
+#[allow(clippy::type_complexity)]
+#[derive(Debug)]
+pub struct BankingTracer {
+    enabled_tracer: Option<(
+        Sender<TimedTracedEvent>,
+        Option<JoinHandle<TracerThreadResult>>,
+        Arc<AtomicBool>,
+    )>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TimedTracedEvent(std::time::SystemTime, TracedEvent);
+
+#[derive(Serialize, Deserialize, Debug)]
+enum TracedEvent {
+    Bank(Slot, u32, BankStatus, usize),
+    PacketBatch(ChannelLabel, BankingPacketBatch),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum BankStatus {
+    Started,
+    Ended,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum ChannelLabel {
+    NonVote,
+    TpuVote,
+    GossipVote,
+    Dummy,
+}
+
+struct RollingConditionGrouped {
+    basic: RollingConditionBasic,
+    is_checked: bool,
+}
+
+impl RollingConditionGrouped {
+    fn new(basic: RollingConditionBasic) -> Self {
+        Self {
+            basic,
+            is_checked: bool::default(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.is_checked = false;
+    }
+}
+
+struct GroupedWriter<'a> {
+    now: DateTime<Local>,
+    underlying: &'a mut RollingFileAppender<RollingConditionGrouped>,
+}
+
+impl<'a> GroupedWriter<'a> {
+    fn new(underlying: &'a mut RollingFileAppender<RollingConditionGrouped>) -> Self {
+        Self {
+            now: Local::now(),
+            underlying,
+        }
+    }
+}
+
+impl RollingCondition for RollingConditionGrouped {
+    fn should_rollover(&mut self, now: &DateTime<Local>, current_filesize: u64) -> bool {
+        if !self.is_checked {
+            self.is_checked = true;
+            self.basic.should_rollover(now, current_filesize)
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a> Write for GroupedWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, io::Error> {
+        self.underlying.write_with_datetime(buf, &self.now)
+    }
+    fn flush(&mut self) -> std::result::Result<(), io::Error> {
+        self.underlying.flush()
+    }
+}
+
+pub fn sender_overhead_minimized_receiver_loop<T, E, const SLEEP_MS: u64>(
+    exit: Arc<AtomicBool>,
+    receiver: Receiver<T>,
+    mut on_recv: impl FnMut(T) -> Result<(), E>,
+) -> Result<(), E> {
+    'outer: while !exit.load(Ordering::Relaxed) {
+        'inner: loop {
+            // avoid futex-based blocking here, otherwise a sender would have to
+            // wake me up at a syscall cost...
+            match receiver.try_recv() {
+                Ok(message) => on_recv(message)?,
+                Err(TryRecvError::Empty) => break 'inner,
+                Err(TryRecvError::Disconnected) => {
+                    assert_eq!(receiver.len(), 0);
+                    break 'outer;
+                }
+            };
+            if exit.load(Ordering::Relaxed) {
+                break 'outer;
+            }
+        }
+        sleep(Duration::from_millis(SLEEP_MS));
+    }
+
+    Ok(())
+}
+
+impl BankingTracer {
+    pub fn new(maybe_config: Option<(PathBuf, Arc<AtomicBool>, u64)>) -> Result<Self, TraceError> {
+        let enabled_tracer = maybe_config
+            .map(|(path, exit, total_size)| -> Result<_, TraceError> {
+                let rotate_threshold_size = total_size / TRACE_FILE_ROTATE_COUNT;
+                if rotate_threshold_size == 0 {
+                    return Err(TraceError::TooSmallTraceSize(
+                        total_size,
+                        TRACE_FILE_ROTATE_COUNT,
+                    ));
+                }
+
+                let (trace_sender, trace_receiver) = unbounded();
+
+                Self::ensure_prepare_path(&path)?;
+                let file_appender = Self::create_file_appender(path, rotate_threshold_size)?;
+
+                let tracing_thread =
+                    Self::spawn_background_thread(trace_receiver, file_appender, exit.clone())?;
+
+                Ok((trace_sender, Some(tracing_thread), exit))
+            })
+            .transpose()?;
+
+        Ok(Self { enabled_tracer })
+    }
+
+    pub fn new_disabled() -> Self {
+        Self {
+            enabled_tracer: None,
+        }
+    }
+
+    fn create_channel(&self, label: ChannelLabel) -> (BankingPacketSender, BankingPacketReceiver) {
+        Self::channel(
+            label,
+            self.enabled_tracer
+                .as_ref()
+                .map(|(sender, _, exit)| (sender.clone(), exit.clone())),
+        )
+    }
+
+    pub fn create_channel_non_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
+        self.create_channel(ChannelLabel::NonVote)
+    }
+
+    pub fn create_channel_tpu_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
+        self.create_channel(ChannelLabel::TpuVote)
+    }
+
+    pub fn create_channel_gossip_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
+        self.create_channel(ChannelLabel::GossipVote)
+    }
+
+    pub fn finalize_under_arc(mut self) -> (Option<JoinHandle<TracerThreadResult>>, Arc<Self>) {
+        (
+            self.enabled_tracer
+                .as_mut()
+                .and_then(|(_, tracer_thread, _)| tracer_thread.take()),
+            Arc::new(self),
+        )
+    }
+
+    fn bank_event(&self, slot: Slot, id: u32, status: BankStatus, unreceived_batch_count: usize) {
+        if let Some((sender, _, exit)) = &self.enabled_tracer {
+            if !exit.load(Ordering::Relaxed) {
+                sender
+                    .send(TimedTracedEvent(
+                        SystemTime::now(),
+                        TracedEvent::Bank(slot, id, status, unreceived_batch_count),
+                    ))
+                    .expect("active tracer thread unless exited");
+            }
+        }
+    }
+
+    pub fn bank_start(&self, slot: Slot, id: u32, unreceived_batch_count: usize) {
+        self.bank_event(slot, id, BankStatus::Started, unreceived_batch_count);
+    }
+
+    pub fn bank_end(&self, slot: Slot, id: u32, unreceived_batch_count: usize) {
+        self.bank_event(slot, id, BankStatus::Ended, unreceived_batch_count);
+    }
+
+    pub fn channel_for_test() -> (TracedSender, Receiver<BankingPacketBatch>) {
+        Self::channel(ChannelLabel::Dummy, None)
+    }
+
+    pub fn channel(
+        label: ChannelLabel,
+        trace_sender: Option<(Sender<TimedTracedEvent>, Arc<AtomicBool>)>,
+    ) -> (TracedSender, Receiver<BankingPacketBatch>) {
+        let (sender, receiver) = unbounded();
+        (TracedSender::new(label, sender, trace_sender), receiver)
+    }
+
+    fn ensure_prepare_path(path: &PathBuf) -> Result<(), io::Error> {
+        create_dir_all(path)
+    }
+
+    pub fn ensure_cleanup_path(path: &PathBuf) -> Result<(), io::Error> {
+        remove_dir_all(path).or_else(|err| {
+            if err.kind() == io::ErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })
+    }
+
+    fn create_file_appender(
+        path: PathBuf,
+        rotate_threshold_size: u64,
+    ) -> Result<RollingFileAppender<RollingConditionGrouped>, TraceError> {
+        let grouped = RollingConditionGrouped::new(
+            RollingConditionBasic::new()
+                .daily()
+                .max_size(rotate_threshold_size),
+        );
+        let appender = RollingFileAppender::new_with_buffer_capacity(
+            path.join(BASENAME),
+            grouped,
+            (TRACE_FILE_ROTATE_COUNT - 1).try_into()?,
+            BUF_WRITER_CAPACITY,
+        )?;
+        Ok(appender)
+    }
+
+    fn spawn_background_thread(
+        trace_receiver: Receiver<TimedTracedEvent>,
+        mut file_appender: RollingFileAppender<RollingConditionGrouped>,
+        exit: Arc<AtomicBool>,
+    ) -> Result<JoinHandle<TracerThreadResult>, TraceError> {
+        let thread = thread::Builder::new().name("solBanknTracer".into()).spawn(
+            move || -> TracerThreadResult {
+                sender_overhead_minimized_receiver_loop::<
+                    _,
+                    TraceError,
+                    TRACE_FILE_WRITE_INTERVAL_MS,
+                >(exit, trace_receiver, |event| -> Result<(), TraceError> {
+                    file_appender.condition_mut().reset();
+                    serialize_into(&mut GroupedWriter::new(&mut file_appender), &event)?;
+                    Ok(())
+                })?;
+                file_appender.flush()?;
+                Ok(())
+            },
+        )?;
+
+        Ok(thread)
+    }
+}
+
+pub struct TracedSender {
+    label: ChannelLabel,
+    sender: Sender<BankingPacketBatch>,
+    trace_sender: Option<(Sender<TimedTracedEvent>, Arc<AtomicBool>)>,
+}
+
+impl TracedSender {
+    fn new(
+        label: ChannelLabel,
+        sender: Sender<BankingPacketBatch>,
+        trace_sender: Option<(Sender<TimedTracedEvent>, Arc<AtomicBool>)>,
+    ) -> Self {
+        Self {
+            label,
+            sender,
+            trace_sender,
+        }
+    }
+
+    pub fn send(&self, batch: BankingPacketBatch) -> Result<(), SendError<BankingPacketBatch>> {
+        if let Some((trace_sender, exit)) = &self.trace_sender {
+            if !exit.load(Ordering::Relaxed) {
+                trace_sender
+                    .send(TimedTracedEvent(
+                        SystemTime::now(),
+                        TracedEvent::PacketBatch(self.label, Arc::clone(&batch)),
+                    ))
+                    .expect("active tracer thread unless exited");
+            }
+        }
+        self.sender.send(batch)
+    }
+}
+
+pub fn sample_packet_batch() -> BankingPacketBatch {
+    BankingPacketBatch::new((to_packet_batches(&vec![test_tx(); 4], 10), None))
+}
+
+pub fn drop_and_clean_temp_dir_unless_suppressed(temp_dir: TempDir) {
+    std::env::var("BANKING_TRACE_LEAVE_FILES_FROM_LAST_ITERATION")
+        .is_ok()
+        .then(|| {
+            eprintln!("prevented to remove {:?}", temp_dir.path());
+            drop(temp_dir.into_path());
+        });
+}
+
+pub fn terminate_tracer(
+    tracer: BankingTracer,
+    main_thread: JoinHandle<TracerThreadResult>,
+    sender: TracedSender,
+    exit: Option<Arc<AtomicBool>>,
+) {
+    if let Some(exit) = exit {
+        exit.store(true, Ordering::Relaxed);
+    }
+    let (tracer_thread, tracer) = tracer.finalize_under_arc();
+    drop((sender, tracer));
+    main_thread.join().unwrap().unwrap();
+    if let Some(tracer_thread) = tracer_thread {
+        tracer_thread.join().unwrap().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{fs::File, io::BufReader},
+    };
+
+    #[test]
+    fn test_new_disabled() {
+        let exit = Arc::<AtomicBool>::default();
+
+        let tracer = BankingTracer::new_disabled();
+        let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+        let dummy_main_thread = thread::spawn(move || {
+            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+                exit,
+                non_vote_receiver,
+                |_packet_batch| Ok(()),
+            )
+        });
+
+        non_vote_sender
+            .send(BankingPacketBatch::new((vec![], None)))
+            .unwrap();
+        terminate_tracer(tracer, dummy_main_thread, non_vote_sender, None);
+    }
+
+    #[test]
+    fn test_send_after_exited() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("banking-trace");
+        let exit = Arc::<AtomicBool>::default();
+        let tracer = BankingTracer::new(Some((path, exit.clone(), u64::max_value()))).unwrap();
+        let (tracer_thread, tracer) = tracer.finalize_under_arc();
+        let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+        let exit_for_dummy_thread = Arc::<AtomicBool>::default();
+        let exit_for_dummy_thread2 = exit_for_dummy_thread.clone();
+        let dummy_main_thread = thread::spawn(move || {
+            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+                exit_for_dummy_thread,
+                non_vote_receiver,
+                |_packet_batch| Ok(()),
+            )
+        });
+
+        // kill and join the tracer thread
+        exit.store(true, Ordering::Relaxed);
+        tracer_thread.unwrap().join().unwrap().unwrap();
+
+        // shouldn't panic
+        tracer.bank_end(1, 2, 3);
+
+        drop(tracer);
+
+        // shouldn't panic
+        non_vote_sender.send(sample_packet_batch()).unwrap();
+
+        // finally terminate and join the main thread
+        exit_for_dummy_thread2.store(true, Ordering::Relaxed);
+        dummy_main_thread.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn test_record_and_restore() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("banking-trace");
+        let exit = Arc::<AtomicBool>::default();
+        let tracer =
+            BankingTracer::new(Some((path.clone(), exit.clone(), u64::max_value()))).unwrap();
+        let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
+
+        let dummy_main_thread = thread::spawn(move || {
+            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+                exit,
+                non_vote_receiver,
+                |_packet_batch| Ok(()),
+            )
+        });
+
+        non_vote_sender.send(sample_packet_batch()).unwrap();
+        tracer.bank_start(1, 2, 3);
+
+        terminate_tracer(tracer, dummy_main_thread, non_vote_sender, None);
+
+        let mut stream = BufReader::new(File::open(path.join(BASENAME)).unwrap());
+        let results = (0..3)
+            .map(|_| bincode::deserialize_from::<_, TimedTracedEvent>(&mut stream))
+            .collect::<Vec<_>>();
+
+        assert_matches!(
+            results[0],
+            Ok(TimedTracedEvent(
+                _,
+                TracedEvent::PacketBatch(ChannelLabel::NonVote, _)
+            ))
+        );
+        assert_matches!(
+            results[1],
+            Ok(TimedTracedEvent(
+                _,
+                TracedEvent::Bank(1, 2, BankStatus::Started, 3)
+            ))
+        );
+        assert_matches!(
+            results[2],
+            Err(_) // in this way, rustfmt formats this line like the above
+        );
+
+        drop_and_clean_temp_dir_unless_suppressed(temp_dir);
+    }
+}

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -151,7 +151,6 @@ pub fn sender_overhead_minimized_receiver_loop<T, E, const SLEEP_MS: u64>(
                 Ok(message) => on_recv(message)?,
                 Err(TryRecvError::Empty) => break 'inner,
                 Err(TryRecvError::Disconnected) => {
-                    assert_eq!(receiver.len(), 0);
                     break 'outer;
                 }
             };

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -360,7 +360,7 @@ pub fn drop_and_clean_temp_dir_unless_suppressed(temp_dir: TempDir) {
     std::env::var("BANKING_TRACE_LEAVE_FILES_FROM_LAST_ITERATION")
         .is_ok()
         .then(|| {
-            eprintln!("prevented to remove {:?}", temp_dir.path());
+            warn!("prevented to remove {:?}", temp_dir.path());
             drop(temp_dir.into_path());
         });
 }

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -364,7 +364,7 @@ impl TracedSender {
                 trace_sender
                     .send(TimedTracedEvent(
                         SystemTime::now(),
-                        TracedEvent::PacketBatch(self.label, Arc::clone(&batch)),
+                        TracedEvent::PacketBatch(self.label, BankingPacketBatch::clone(&batch)),
                     ))
                     .expect("active tracer thread unless exited");
             }

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -216,6 +216,10 @@ impl BankingTracer {
         })
     }
 
+    pub fn is_enabled(&self) -> bool {
+        self.enabled_tracer.is_some()
+    }
+
     fn create_channel(&self, label: ChannelLabel) -> (BankingPacketSender, BankingPacketReceiver) {
         Self::channel(
             label,

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -366,7 +366,13 @@ impl TracedSender {
                         SystemTime::now(),
                         TracedEvent::PacketBatch(self.label, BankingPacketBatch::clone(&batch)),
                     ))
-                    .expect("active tracer thread unless exited");
+                    .map_err(|err| {
+                        error!(
+                            "unexpected error when tracing a banking event...: {:?}",
+                            err
+                        );
+                        SendError(BankingPacketBatch::clone(&batch))
+                    })?;
             }
         }
         self.sender.send(batch)

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -261,7 +261,7 @@ impl BankingTracer {
         Self::channel(ChannelLabel::Dummy, None)
     }
 
-    pub fn channel(
+    fn channel(
         label: ChannelLabel,
         trace_sender: Option<(Sender<TimedTracedEvent>, Arc<AtomicBool>)>,
     ) -> (TracedSender, Receiver<BankingPacketBatch>) {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -193,7 +193,7 @@ impl BankingTracer {
 
                 let (trace_sender, trace_receiver) = unbounded();
 
-                Self::ensure_prepare_path(&path)?;
+                create_dir_all(&path)?;
                 let file_appender = Self::create_file_appender(path, rotate_threshold_size)?;
 
                 let tracer_thread =
@@ -267,10 +267,6 @@ impl BankingTracer {
     ) -> (TracedSender, Receiver<BankingPacketBatch>) {
         let (sender, receiver) = unbounded();
         (TracedSender::new(label, sender, trace_sender), receiver)
-    }
-
-    fn ensure_prepare_path(path: &PathBuf) -> Result<(), io::Error> {
-        create_dir_all(path)
     }
 
     pub fn ensure_cleanup_path(path: &PathBuf) -> Result<(), io::Error> {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -140,7 +140,7 @@ impl<'a> Write for GroupedWriter<'a> {
     }
 }
 
-pub fn sender_overhead_minimized_receiver_loop<T, E, const SLEEP_MS: u64>(
+pub fn receiving_loop_with_minimized_sender_overhead<T, E, const SLEEP_MS: u64>(
     exit: Arc<AtomicBool>,
     receiver: Receiver<T>,
     mut on_recv: impl FnMut(T) -> Result<(), E>,
@@ -321,7 +321,7 @@ impl BankingTracer {
     ) -> Result<JoinHandle<TracerThreadResult>, TraceError> {
         let thread = thread::Builder::new().name("solBanknTracer".into()).spawn(
             move || -> TracerThreadResult {
-                sender_overhead_minimized_receiver_loop::<
+                receiving_loop_with_minimized_sender_overhead::<
                     _,
                     TraceError,
                     TRACE_FILE_WRITE_INTERVAL_MS,
@@ -427,7 +427,7 @@ mod tests {
         let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
 
         let dummy_main_thread = thread::spawn(move || {
-            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
                 exit,
                 non_vote_receiver,
                 |_packet_batch| Ok(()),
@@ -452,7 +452,7 @@ mod tests {
         let exit_for_dummy_thread = Arc::<AtomicBool>::default();
         let exit_for_dummy_thread2 = exit_for_dummy_thread.clone();
         let dummy_main_thread = thread::spawn(move || {
-            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
                 exit_for_dummy_thread,
                 non_vote_receiver,
                 |_packet_batch| Ok(()),
@@ -488,7 +488,7 @@ mod tests {
         let (non_vote_sender, non_vote_receiver) = tracer.create_channel_non_vote();
 
         let dummy_main_thread = thread::spawn(move || {
-            sender_overhead_minimized_receiver_loop::<_, TraceError, 0>(
+            receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(
                 exit,
                 non_vote_receiver,
                 |_packet_batch| Ok(()),

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -75,12 +75,6 @@ enum TracedEvent {
     BlockAndBankHash(Slot, Hash, Hash),
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-enum BankStatus {
-    Started,
-    Ended,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum ChannelLabel {
     NonVote,

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -42,7 +42,7 @@ pub enum TraceError {
     #[error("Integer Cast Error: {0}")]
     IntegerCastError(#[from] std::num::TryFromIntError),
 
-    #[error("dir byte limit is too small (must be larger than {1}): {0}")]
+    #[error("Trace directory's byte limit is too small (must be larger than {1}): {0}")]
     TooSmallDirByteLimit(DirByteLimit, DirByteLimit),
 }
 

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -452,14 +452,15 @@ mod tests {
         exit.store(true, Ordering::Relaxed);
         tracer_thread.unwrap().join().unwrap().unwrap();
 
-        // shouldn't panic
+        // .hash_event() must succeed even after exit is already set to true
         let blockhash = Hash::from_str("B1ockhash1111111111111111111111111111111111").unwrap();
         let bank_hash = Hash::from_str("BankHash11111111111111111111111111111111111").unwrap();
         tracer.hash_event(4, blockhash, bank_hash);
 
         drop(tracer);
 
-        // shouldn't panic
+        // .send() must succeed even after exit is already set to true and further tracer is
+        // already dropped
         non_vote_sender
             .send(for_test::sample_packet_batch())
             .unwrap();

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -377,7 +377,7 @@ impl LeaderSlotMetricsTracker {
     }
 
     pub fn new_for_test() -> Self {
-        Self::new(0, Arc::new(BankingTracer::new_disabled()))
+        Self::new(0, BankingTracer::new_disabled())
     }
 
     fn create_new_slot_metrics(&self, bank_start: &BankStart) -> Option<LeaderSlotMetrics> {

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -359,7 +359,7 @@ pub struct LeaderSlotMetricsTracker {
     leader_slot_metrics: Option<LeaderSlotMetrics>,
     id: u32,
     banking_tracer: Arc<BankingTracer>,
-    unreceived_batch_count: usize,
+    unprocessed_transaction_count: usize,
 }
 
 impl LeaderSlotMetricsTracker {
@@ -368,12 +368,12 @@ impl LeaderSlotMetricsTracker {
             leader_slot_metrics: None,
             id,
             banking_tracer,
-            unreceived_batch_count: 0,
+            unprocessed_transaction_count: 0,
         }
     }
 
-    pub fn refresh_unreceived_batch_count(&mut self, batch_count: usize) {
-        self.unreceived_batch_count = batch_count;
+    pub fn refresh_unprocessed_transaction_count(&mut self, batch_count: usize) {
+        self.unprocessed_transaction_count = batch_count;
     }
 
     pub fn new_for_test() -> Self {
@@ -387,14 +387,14 @@ impl LeaderSlotMetricsTracker {
             &bank_start.bank_creation_time,
         );
         self.banking_tracer
-            .bank_start(metrics.slot, self.id, self.unreceived_batch_count);
+            .bank_start(metrics.slot, self.id, self.unprocessed_transaction_count);
 
         Some(metrics)
     }
 
     pub fn trace_bank_end(&self, metrics_slot: Slot) {
         self.banking_tracer
-            .bank_end(metrics_slot, self.id, self.unreceived_batch_count);
+            .bank_end(metrics_slot, self.id, self.unprocessed_transaction_count);
     }
 
     // Check leader slot, return MetricsTrackerAction to be applied by apply_action()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod accounts_hash_verifier;
 pub mod ancestor_hashes_service;
 pub mod banking_stage;
+pub mod banking_trace;
 pub mod broadcast_stage;
 pub mod cache_block_meta_service;
 pub mod cluster_info_vote_listener;

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -40,10 +40,6 @@ impl PacketDeserializer {
         }
     }
 
-    pub fn unreceived_batch_count(&self) -> usize {
-        self.packet_batch_receiver.len()
-    }
-
     /// Handles receiving packet batches from sigverify and returns a vector of deserialized packets
     pub fn handle_received_packets(
         &self,

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -122,6 +122,7 @@ impl PacketDeserializer {
                 .iter()
                 .map(|batch| batch.len())
                 .sum::<usize>();
+            messages.push(message);
 
             if let Some(tracer_packet_stats) = &tracer_packet_stats_option {
                 if let Some(aggregated_tracer_packet_stats) =
@@ -132,7 +133,6 @@ impl PacketDeserializer {
                     aggregated_tracer_packet_stats_option = tracer_packet_stats_option;
                 }
             }
-            messages.push(message);
 
             if start.elapsed() >= recv_timeout || num_packets_received >= packet_count_upperbound {
                 break;

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -2,16 +2,14 @@
 
 use {
     crate::{
+        banking_trace::{BankingPacketBatch, BankingPacketReceiver},
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         sigverify::SigverifyTracerPacketStats,
     },
-    crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError},
+    crossbeam_channel::RecvTimeoutError,
     solana_perf::packet::PacketBatch,
     std::time::{Duration, Instant},
 };
-
-pub type BankingPacketBatch = (Vec<PacketBatch>, Option<SigverifyTracerPacketStats>);
-pub type BankingPacketReceiver = CrossbeamReceiver<BankingPacketBatch>;
 
 /// Results from deserializing packet batches.
 pub struct ReceivePacketResults {
@@ -37,37 +35,53 @@ impl PacketDeserializer {
         }
     }
 
+    pub fn unreceived_batch_count(&self) -> usize {
+        self.packet_batch_receiver.len()
+    }
+
     /// Handles receiving packet batches from sigverify and returns a vector of deserialized packets
     pub fn handle_received_packets(
         &self,
         recv_timeout: Duration,
         capacity: usize,
     ) -> Result<ReceivePacketResults, RecvTimeoutError> {
-        let (packet_batches, sigverify_tracer_stats_option) =
+        let (packet_count, packet_batches, sigverify_tracer_stats_option) =
             self.receive_until(recv_timeout, capacity)?;
         Ok(Self::deserialize_and_collect_packets(
+            packet_count,
             &packet_batches,
             sigverify_tracer_stats_option,
         ))
     }
 
+    fn for_each_packet_batch(
+        banking_batches: &[BankingPacketBatch],
+        mut for_each: impl FnMut(&PacketBatch),
+    ) {
+        for banking_batch in banking_batches {
+            for batch in &banking_batch.0 {
+                for_each(batch)
+            }
+        }
+    }
+
     /// Deserialize packet batches and collect them into ReceivePacketResults
     fn deserialize_and_collect_packets(
-        packet_batches: &[PacketBatch],
+        packet_count: usize,
+        packet_batches: &[BankingPacketBatch],
         sigverify_tracer_stats_option: Option<SigverifyTracerPacketStats>,
     ) -> ReceivePacketResults {
-        let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
         let mut passed_sigverify_count: usize = 0;
         let mut failed_sigverify_count: usize = 0;
         let mut deserialized_packets = Vec::with_capacity(packet_count);
-        for packet_batch in packet_batches {
+        Self::for_each_packet_batch(packet_batches, |packet_batch| {
             let packet_indexes = Self::generate_packet_indexes(packet_batch);
 
             passed_sigverify_count += packet_indexes.len();
             failed_sigverify_count += packet_batch.len().saturating_sub(packet_indexes.len());
 
             deserialized_packets.extend(Self::deserialize_packets(packet_batch, &packet_indexes));
-        }
+        });
 
         ReceivePacketResults {
             deserialized_packets,
@@ -82,25 +96,32 @@ impl PacketDeserializer {
         &self,
         recv_timeout: Duration,
         packet_count_upperbound: usize,
-    ) -> Result<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>), RecvTimeoutError> {
+    ) -> Result<
+        (
+            usize,
+            Vec<BankingPacketBatch>,
+            Option<SigverifyTracerPacketStats>,
+        ),
+        RecvTimeoutError,
+    > {
         let start = Instant::now();
 
-        let (mut packet_batches_received_so_far, mut aggregated_tracer_packet_stats_option) =
-            self.packet_batch_receiver.recv_timeout(recv_timeout)?;
-        let mut num_packets_received = packet_batches_received_so_far
+        let message = self.packet_batch_receiver.recv_timeout(recv_timeout)?;
+        let (packet_batches, mut aggregated_tracer_packet_stats_option) =
+            (&message.0, message.1.clone());
+        let mut num_packets_received = packet_batches
             .iter()
             .map(|batch| batch.len())
             .sum::<usize>();
+        let mut messages = vec![message];
 
-        while let Ok((packet_batches, tracer_packet_stats_option)) =
-            self.packet_batch_receiver.try_recv()
-        {
+        while let Ok(message) = self.packet_batch_receiver.try_recv() {
+            let (packet_batches, tracer_packet_stats_option) = (&message.0, message.1.clone());
             trace!("got more packet batches in packet deserializer");
             num_packets_received += packet_batches
                 .iter()
                 .map(|batch| batch.len())
                 .sum::<usize>();
-            packet_batches_received_so_far.extend(packet_batches);
 
             if let Some(tracer_packet_stats) = &tracer_packet_stats_option {
                 if let Some(aggregated_tracer_packet_stats) =
@@ -111,6 +132,7 @@ impl PacketDeserializer {
                     aggregated_tracer_packet_stats_option = tracer_packet_stats_option;
                 }
             }
+            messages.push(message);
 
             if start.elapsed() >= recv_timeout || num_packets_received >= packet_count_upperbound {
                 break;
@@ -118,7 +140,8 @@ impl PacketDeserializer {
         }
 
         Ok((
-            packet_batches_received_so_far,
+            num_packets_received,
+            messages,
             aggregated_tracer_packet_stats_option,
         ))
     }
@@ -159,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_and_collect_packets_empty() {
-        let results = PacketDeserializer::deserialize_and_collect_packets(&[], None);
+        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[], None);
         assert_eq!(results.deserialized_packets.len(), 0);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 0);
@@ -172,7 +195,12 @@ mod tests {
         let packet_batches = to_packet_batches(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
 
-        let results = PacketDeserializer::deserialize_and_collect_packets(&packet_batches, None);
+        let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
+        let results = PacketDeserializer::deserialize_and_collect_packets(
+            packet_count,
+            &[BankingPacketBatch::new((packet_batches, None))],
+            None,
+        );
         assert_eq!(results.deserialized_packets.len(), 2);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 2);
@@ -186,7 +214,12 @@ mod tests {
         assert_eq!(packet_batches.len(), 2);
         packet_batches[0][0].meta_mut().set_discard(true);
 
-        let results = PacketDeserializer::deserialize_and_collect_packets(&packet_batches, None);
+        let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
+        let results = PacketDeserializer::deserialize_and_collect_packets(
+            packet_count,
+            &[BankingPacketBatch::new((packet_batches, None))],
+            None,
+        );
         assert_eq!(results.deserialized_packets.len(), 1);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 1);

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -28,6 +28,11 @@ pub struct PacketDeserializer {
     packet_batch_receiver: BankingPacketReceiver,
 }
 
+enum ForEach<'a> {
+    Batch(&'a PacketBatch),
+    Stats(&'a SigverifyTracerPacketStats),
+}
+
 impl PacketDeserializer {
     pub fn new(packet_batch_receiver: BankingPacketReceiver) -> Self {
         Self {
@@ -45,22 +50,24 @@ impl PacketDeserializer {
         recv_timeout: Duration,
         capacity: usize,
     ) -> Result<ReceivePacketResults, RecvTimeoutError> {
-        let (packet_count, packet_batches, sigverify_tracer_stats_option) =
-            self.receive_until(recv_timeout, capacity)?;
+        let (packet_count, packet_batches) = self.receive_until(recv_timeout, capacity)?;
         Ok(Self::deserialize_and_collect_packets(
             packet_count,
             &packet_batches,
-            sigverify_tracer_stats_option,
         ))
     }
 
     fn for_each_packet_batch(
         banking_batches: &[BankingPacketBatch],
-        mut for_each: impl FnMut(&PacketBatch),
+        mut for_each: impl FnMut(ForEach),
     ) {
         for banking_batch in banking_batches {
             for batch in &banking_batch.0 {
-                for_each(batch)
+                for_each(ForEach::Batch(batch))
+            }
+
+            if let Some(stats) = &banking_batch.1 {
+                for_each(ForEach::Stats(stats))
             }
         }
     }
@@ -69,23 +76,39 @@ impl PacketDeserializer {
     fn deserialize_and_collect_packets(
         packet_count: usize,
         packet_batches: &[BankingPacketBatch],
-        sigverify_tracer_stats_option: Option<SigverifyTracerPacketStats>,
     ) -> ReceivePacketResults {
         let mut passed_sigverify_count: usize = 0;
         let mut failed_sigverify_count: usize = 0;
         let mut deserialized_packets = Vec::with_capacity(packet_count);
-        Self::for_each_packet_batch(packet_batches, |packet_batch| {
-            let packet_indexes = Self::generate_packet_indexes(packet_batch);
+        let mut aggregated_tracer_packet_stats_option = None::<SigverifyTracerPacketStats>;
 
-            passed_sigverify_count += packet_indexes.len();
-            failed_sigverify_count += packet_batch.len().saturating_sub(packet_indexes.len());
+        Self::for_each_packet_batch(packet_batches, |packet_batch_or_stat| {
+            match packet_batch_or_stat {
+                ForEach::Batch(packet_batch) => {
+                    let packet_indexes = Self::generate_packet_indexes(packet_batch);
 
-            deserialized_packets.extend(Self::deserialize_packets(packet_batch, &packet_indexes));
+                    passed_sigverify_count += packet_indexes.len();
+                    failed_sigverify_count +=
+                        packet_batch.len().saturating_sub(packet_indexes.len());
+
+                    deserialized_packets
+                        .extend(Self::deserialize_packets(packet_batch, &packet_indexes));
+                }
+                ForEach::Stats(tracer_packet_stats) => {
+                    if let Some(aggregated_tracer_packet_stats) =
+                        &mut aggregated_tracer_packet_stats_option
+                    {
+                        aggregated_tracer_packet_stats.aggregate(tracer_packet_stats);
+                    } else {
+                        aggregated_tracer_packet_stats_option = Some(tracer_packet_stats.clone());
+                    }
+                }
+            }
         });
 
         ReceivePacketResults {
             deserialized_packets,
-            new_tracer_stats_option: sigverify_tracer_stats_option,
+            new_tracer_stats_option: aggregated_tracer_packet_stats_option,
             passed_sigverify_count: passed_sigverify_count as u64,
             failed_sigverify_count: failed_sigverify_count as u64,
         }
@@ -96,19 +119,11 @@ impl PacketDeserializer {
         &self,
         recv_timeout: Duration,
         packet_count_upperbound: usize,
-    ) -> Result<
-        (
-            usize,
-            Vec<BankingPacketBatch>,
-            Option<SigverifyTracerPacketStats>,
-        ),
-        RecvTimeoutError,
-    > {
+    ) -> Result<(usize, Vec<BankingPacketBatch>), RecvTimeoutError> {
         let start = Instant::now();
 
         let message = self.packet_batch_receiver.recv_timeout(recv_timeout)?;
-        let (packet_batches, mut aggregated_tracer_packet_stats_option) =
-            (&message.0, message.1.clone());
+        let packet_batches = &message.0;
         let mut num_packets_received = packet_batches
             .iter()
             .map(|batch| batch.len())
@@ -116,7 +131,7 @@ impl PacketDeserializer {
         let mut messages = vec![message];
 
         while let Ok(message) = self.packet_batch_receiver.try_recv() {
-            let (packet_batches, tracer_packet_stats_option) = (&message.0, message.1.clone());
+            let packet_batches = &message.0;
             trace!("got more packet batches in packet deserializer");
             num_packets_received += packet_batches
                 .iter()
@@ -124,26 +139,12 @@ impl PacketDeserializer {
                 .sum::<usize>();
             messages.push(message);
 
-            if let Some(tracer_packet_stats) = &tracer_packet_stats_option {
-                if let Some(aggregated_tracer_packet_stats) =
-                    &mut aggregated_tracer_packet_stats_option
-                {
-                    aggregated_tracer_packet_stats.aggregate(tracer_packet_stats);
-                } else {
-                    aggregated_tracer_packet_stats_option = tracer_packet_stats_option;
-                }
-            }
-
             if start.elapsed() >= recv_timeout || num_packets_received >= packet_count_upperbound {
                 break;
             }
         }
 
-        Ok((
-            num_packets_received,
-            messages,
-            aggregated_tracer_packet_stats_option,
-        ))
+        Ok((num_packets_received, messages))
     }
 
     fn generate_packet_indexes(packet_batch: &PacketBatch) -> Vec<usize> {
@@ -182,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_and_collect_packets_empty() {
-        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[], None);
+        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[]);
         assert_eq!(results.deserialized_packets.len(), 0);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 0);
@@ -199,7 +200,6 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
-            None,
         );
         assert_eq!(results.deserialized_packets.len(), 2);
         assert!(results.new_tracer_stats_option.is_none());
@@ -218,7 +218,6 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
-            None,
         );
         assert_eq!(results.deserialized_packets.len(), 1);
         assert!(results.new_tracer_stats_option.is_none());

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3,6 +3,7 @@
 use {
     crate::{
         ancestor_hashes_service::AncestorHashesReplayUpdateSender,
+        banking_trace::BankingTracer,
         broadcast_stage::RetransmitSlotsSender,
         cache_block_meta_service::CacheBlockMetaSender,
         cluster_info_vote_listener::{
@@ -402,6 +403,7 @@ impl ReplayStage {
         log_messages_bytes_limit: Option<usize>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         dumped_slots_sender: DumpedSlotsSender,
+        banking_tracer: Arc<BankingTracer>,
     ) -> Result<Self, String> {
         let mut tower = if let Some(process_blockstore) = maybe_process_blockstore {
             let tower = process_blockstore.process_to_create_tower()?;
@@ -943,6 +945,7 @@ impl ReplayStage {
                         &mut progress,
                         &retransmit_slots_sender,
                         &mut skipped_slots_info,
+                        &banking_tracer,
                         has_new_vote_been_rooted,
                         transaction_status_sender.is_some(),
                     );
@@ -1654,6 +1657,7 @@ impl ReplayStage {
         progress_map: &mut ProgressMap,
         retransmit_slots_sender: &RetransmitSlotsSender,
         skipped_slots_info: &mut SkippedSlotsInfo,
+        banking_tracer: &Arc<BankingTracer>,
         has_new_vote_been_rooted: bool,
         track_transaction_indexes: bool,
     ) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1778,6 +1778,9 @@ impl ReplayStage {
                 rpc_subscriptions,
                 NewBankOptions { vote_only_bank },
             );
+            // make sure parent is frozen for finalized hashes via the above
+            // new()-ing of its child bank
+            banking_tracer.hash_event(parent.slot(), parent.last_blockhash(), parent.hash());
 
             let tpu_bank = bank_forks.write().unwrap().insert(tpu_bank);
             poh_recorder

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1780,7 +1780,7 @@ impl ReplayStage {
             );
             // make sure parent is frozen for finalized hashes via the above
             // new()-ing of its child bank
-            banking_tracer.hash_event(parent.slot(), parent.last_blockhash(), parent.hash());
+            banking_tracer.hash_event(parent.slot(), &parent.last_blockhash(), &parent.hash());
 
             let tpu_bank = bank_forks.write().unwrap().insert(tpu_bank);
             poh_recorder

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -9,15 +9,14 @@ pub use solana_perf::sigverify::{
 };
 use {
     crate::{
-        banking_stage::BankingPacketBatch,
+        banking_trace::{BankingPacketBatch, BankingPacketSender},
         sigverify_stage::{SigVerifier, SigVerifyServiceError},
     },
-    crossbeam_channel::Sender,
     solana_perf::{cuda_runtime::PinnedVec, packet::PacketBatch, recycler::Recycler, sigverify},
     solana_sdk::{packet::Packet, saturating_add_assign},
 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SigverifyTracerPacketStats {
     pub total_removed_before_sigverify_stage: usize,
     pub total_tracer_packets_received_in_sigverify_stage: usize,
@@ -55,9 +54,8 @@ impl SigverifyTracerPacketStats {
     }
 }
 
-#[derive(Clone)]
 pub struct TransactionSigVerifier {
-    packet_sender: Sender<<Self as SigVerifier>::SendType>,
+    packet_sender: BankingPacketSender,
     tracer_packet_stats: SigverifyTracerPacketStats,
     recycler: Recycler<TxOffset>,
     recycler_out: Recycler<PinnedVec<u8>>,
@@ -65,13 +63,13 @@ pub struct TransactionSigVerifier {
 }
 
 impl TransactionSigVerifier {
-    pub fn new_reject_non_vote(packet_sender: Sender<<Self as SigVerifier>::SendType>) -> Self {
+    pub fn new_reject_non_vote(packet_sender: BankingPacketSender) -> Self {
         let mut new_self = Self::new(packet_sender);
         new_self.reject_non_vote = true;
         new_self
     }
 
-    pub fn new(packet_sender: Sender<<Self as SigVerifier>::SendType>) -> Self {
+    pub fn new(packet_sender: BankingPacketSender) -> Self {
         init();
         Self {
             packet_sender,
@@ -128,8 +126,10 @@ impl SigVerifier for TransactionSigVerifier {
         packet_batches: Vec<PacketBatch>,
     ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
         let tracer_packet_stats_to_send = std::mem::take(&mut self.tracer_packet_stats);
-        self.packet_sender
-            .send((packet_batches, Some(tracer_packet_stats_to_send)))?;
+        self.packet_sender.send(BankingPacketBatch::new((
+            packet_batches,
+            Some(tracer_packet_stats_to_send),
+        )))?;
         Ok(())
     }
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -531,7 +531,16 @@ mod tests {
     }
 
     #[test]
-    fn test_sigverify_stage() {
+    fn test_sigverify_stage_with_same_tx() {
+        test_sigverify_stage(true)
+    }
+
+    #[test]
+    fn test_sigverify_stage_without_same_tx() {
+        test_sigverify_stage(false)
+    }
+
+    fn test_sigverify_stage(use_same_tx: bool) {
         solana_logger::setup();
         trace!("start");
         let (packet_s, packet_r) = unbounded();
@@ -539,7 +548,6 @@ mod tests {
         let verifier = TransactionSigVerifier::new(verified_s);
         let stage = SigVerifyStage::new(packet_r, verifier, "test");
 
-        let use_same_tx = true;
         let now = Instant::now();
         let packets_per_batch = 128;
         let total_packets = 1920;
@@ -607,10 +615,7 @@ mod tests {
                     );
                 }
                 assert_eq!(tracer_packet_stats.total_excess_tracer_packets, 0);
-                for v in verifieds.iter().rev() {
-                    received += v.len();
-                    batches.push(v.clone());
-                }
+                received += verifieds.iter().map(|batch| batch.len()).sum::<usize>();
             }
 
             if total_tracer_packets_received_in_sigverify_stage >= sent_len {

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -577,8 +577,7 @@ mod tests {
         trace!("sent: {}", sent_len);
         loop {
             if let Ok(message) = verified_r.recv() {
-                let (verifieds, tracer_packet_stats_option) = (&message.0, message.1.clone());
-                let tracer_packet_stats = tracer_packet_stats_option.unwrap();
+                let (verifieds, tracer_packet_stats) = (&message.0, message.1.as_ref().unwrap());
                 total_tracer_packets_received_in_sigverify_stage +=
                     tracer_packet_stats.total_tracer_packets_received_in_sigverify_stage;
                 assert_eq!(

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -234,7 +234,7 @@ impl SigVerifier for DisabledSigVerifier {
 
 impl SigVerifyStage {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<T: SigVerifier + 'static + Send + Clone>(
+    pub fn new<T: SigVerifier + 'static + Send>(
         packet_receiver: FindPacketSenderStakeReceiver,
         verifier: T,
         name: &'static str,
@@ -402,7 +402,7 @@ impl SigVerifyStage {
         Ok(())
     }
 
-    fn verifier_service<T: SigVerifier + 'static + Send + Clone>(
+    fn verifier_service<T: SigVerifier + 'static + Send>(
         packet_receiver: FindPacketSenderStakeReceiver,
         mut verifier: T,
         name: &'static str,
@@ -443,7 +443,7 @@ impl SigVerifyStage {
             .unwrap()
     }
 
-    fn verifier_services<T: SigVerifier + 'static + Send + Clone>(
+    fn verifier_services<T: SigVerifier + 'static + Send>(
         packet_receiver: FindPacketSenderStakeReceiver,
         verifier: T,
         name: &'static str,
@@ -460,7 +460,10 @@ impl SigVerifyStage {
 mod tests {
     use {
         super::*,
-        crate::{sigverify::TransactionSigVerifier, sigverify_stage::timing::duration_as_ms},
+        crate::{
+            banking_trace::BankingTracer, sigverify::TransactionSigVerifier,
+            sigverify_stage::timing::duration_as_ms,
+        },
         crossbeam_channel::unbounded,
         solana_perf::{
             packet::{to_packet_batches, Packet},
@@ -532,7 +535,7 @@ mod tests {
         solana_logger::setup();
         trace!("start");
         let (packet_s, packet_r) = unbounded();
-        let (verified_s, verified_r) = unbounded();
+        let (verified_s, verified_r) = BankingTracer::channel_for_test();
         let verifier = TransactionSigVerifier::new(verified_s);
         let stage = SigVerifyStage::new(packet_r, verifier, "test");
 
@@ -565,7 +568,8 @@ mod tests {
         let mut total_tracer_packets_received_in_sigverify_stage = 0;
         trace!("sent: {}", sent_len);
         loop {
-            if let Ok((mut verifieds, tracer_packet_stats_option)) = verified_r.recv() {
+            if let Ok(message) = verified_r.recv() {
+                let (verifieds, tracer_packet_stats_option) = (&message.0, message.1.clone());
                 let tracer_packet_stats = tracer_packet_stats_option.unwrap();
                 total_tracer_packets_received_in_sigverify_stage +=
                     tracer_packet_stats.total_tracer_packets_received_in_sigverify_stage;
@@ -603,9 +607,9 @@ mod tests {
                     );
                 }
                 assert_eq!(tracer_packet_stats.total_excess_tracer_packets, 0);
-                while let Some(v) = verifieds.pop() {
+                for v in verifieds.iter().rev() {
                     received += v.len();
-                    batches.push(v);
+                    batches.push(v.clone());
                 }
             }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -99,8 +99,8 @@ impl Tpu {
         log_messages_bytes_limit: Option<usize>,
         staked_nodes: &Arc<RwLock<StakedNodes>>,
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
+        banking_tracer: Arc<BankingTracer>,
         tpu_enable_udp: bool,
-        banking_tracer: BankingTracer,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -101,6 +101,7 @@ impl Tpu {
         staked_nodes: &Arc<RwLock<StakedNodes>>,
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
         banking_tracer: Arc<BankingTracer>,
+        tracer_thread_hdl: TracerThread,
         tpu_enable_udp: bool,
     ) -> Self {
         let TpuSockets {
@@ -260,7 +261,7 @@ impl Tpu {
             find_packet_sender_stake_stage,
             vote_find_packet_sender_stake_stage,
             staked_nodes_updater_service,
-            tracer_thread_hdl: banking_tracer.take_tracer_thread_join_handle(),
+            tracer_thread_hdl,
         }
     }
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -3,6 +3,7 @@
 
 use {
     crate::{
+        banking_trace::BankingTracer,
         broadcast_stage::RetransmitSlotsSender,
         cache_block_meta_service::CacheBlockMetaSender,
         cluster_info_vote_listener::{
@@ -135,6 +136,7 @@ impl Tvu {
         log_messages_bytes_limit: Option<usize>,
         connection_cache: &Arc<ConnectionCache>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        banking_tracer: Arc<BankingTracer>,
     ) -> Result<Self, String> {
         let TvuSockets {
             repair: repair_socket,
@@ -299,6 +301,7 @@ impl Tvu {
             log_messages_bytes_limit,
             prioritization_fee_cache.clone(),
             dumped_slots_sender,
+            banking_tracer,
         )?;
 
         let ledger_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {
@@ -468,6 +471,7 @@ pub mod tests {
             None,
             &Arc::new(ConnectionCache::default()),
             &_ignored_prioritization_fee_cache,
+            BankingTracer::new_disabled(),
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -942,6 +942,14 @@ impl Validator {
                 config.banking_trace_dir_byte_limit,
             )))
             .map_err(|err| format!("{} [{:?}]", &err, &err))?;
+        if banking_tracer.is_enabled() {
+            info!(
+                "Enabled banking tracer (dir_byte_limit: {})",
+                config.banking_trace_dir_byte_limit
+            );
+        } else {
+            info!("Disabled banking tracer");
+        }
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let tvu = Tvu::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -935,6 +935,13 @@ impl Validator {
             exit.clone(),
         );
 
+        let banking_tracer = BankingTracer::new((config.banking_trace_size > 0).then_some((
+            blockstore.banking_tracer_path(),
+            exit.clone(),
+            config.banking_trace_size,
+        )))
+        .map_err(|err| format!("{} [{:?}]", &err, &err))?;
+
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let tvu = Tvu::new(
             vote_account,
@@ -984,14 +991,8 @@ impl Validator {
             config.runtime_config.log_messages_bytes_limit,
             &connection_cache,
             &prioritization_fee_cache,
+            banking_tracer.clone(),
         )?;
-
-        let banking_tracer = BankingTracer::new((config.banking_trace_size > 0).then_some((
-            blockstore.banking_tracer_path(),
-            exit.clone(),
-            config.banking_trace_size,
-        )))
-        .map_err(|err| format!("{} [{:?}]", &err, &err))?;
 
         let tpu = Tpu::new(
             &cluster_info,
@@ -1026,8 +1027,8 @@ impl Validator {
             config.runtime_config.log_messages_bytes_limit,
             &staked_nodes,
             config.staked_nodes_overrides.clone(),
-            tpu_enable_udp,
             banking_tracer,
+            tpu_enable_udp,
         );
 
         datapoint_info!(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -937,7 +937,7 @@ impl Validator {
 
         let (banking_tracer, tracer_thread) =
             BankingTracer::new((config.banking_trace_dir_byte_limit > 0).then_some((
-                blockstore.banking_trace_path(),
+                &blockstore.banking_trace_path(),
                 exit.clone(),
                 config.banking_trace_dir_byte_limit,
             )))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,7 +4,7 @@ pub use solana_perf::report_target_features;
 use {
     crate::{
         accounts_hash_verifier::AccountsHashVerifier,
-        banking_trace::BankingTracer,
+        banking_trace::{self, BankingTracer},
         broadcast_stage::BroadcastStageType,
         cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
         cluster_info_vote_listener::VoteTracker,
@@ -177,7 +177,7 @@ pub struct ValidatorConfig {
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
     pub replay_slots_concurrently: bool,
-    pub banking_trace_size: u64,
+    pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
 }
 
 impl Default for ValidatorConfig {
@@ -240,7 +240,7 @@ impl Default for ValidatorConfig {
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
             replay_slots_concurrently: false,
-            banking_trace_size: 0,
+            banking_trace_dir_byte_limit: 0,
         }
     }
 }
@@ -935,12 +935,13 @@ impl Validator {
             exit.clone(),
         );
 
-        let banking_tracer = BankingTracer::new((config.banking_trace_size > 0).then_some((
-            blockstore.banking_trace_path(),
-            exit.clone(),
-            config.banking_trace_size,
-        )))
-        .map_err(|err| format!("{} [{:?}]", &err, &err))?;
+        let banking_tracer =
+            BankingTracer::new((config.banking_trace_dir_byte_limit > 0).then_some((
+                blockstore.banking_trace_path(),
+                exit.clone(),
+                config.banking_trace_dir_byte_limit,
+            )))
+            .map_err(|err| format!("{} [{:?}]", &err, &err))?;
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let tvu = Tvu::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -936,7 +936,7 @@ impl Validator {
         );
 
         let banking_tracer = BankingTracer::new((config.banking_trace_size > 0).then_some((
-            blockstore.banking_tracer_path(),
+            blockstore.banking_trace_path(),
             exit.clone(),
             config.banking_trace_size,
         )))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -935,7 +935,7 @@ impl Validator {
             exit.clone(),
         );
 
-        let banking_tracer =
+        let (banking_tracer, tracer_thread) =
             BankingTracer::new((config.banking_trace_dir_byte_limit > 0).then_some((
                 blockstore.banking_trace_path(),
                 exit.clone(),
@@ -1037,6 +1037,7 @@ impl Validator {
             &staked_nodes,
             config.staked_nodes_overrides.clone(),
             banking_tracer,
+            tracer_thread,
             tpu_enable_udp,
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,6 +4,7 @@ pub use solana_perf::report_target_features;
 use {
     crate::{
         accounts_hash_verifier::AccountsHashVerifier,
+        banking_trace::BankingTracer,
         broadcast_stage::BroadcastStageType,
         cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
         cluster_info_vote_listener::VoteTracker,
@@ -176,6 +177,7 @@ pub struct ValidatorConfig {
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
     pub replay_slots_concurrently: bool,
+    pub banking_trace_size: u64,
 }
 
 impl Default for ValidatorConfig {
@@ -238,6 +240,7 @@ impl Default for ValidatorConfig {
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
             replay_slots_concurrently: false,
+            banking_trace_size: 0,
         }
     }
 }
@@ -983,6 +986,13 @@ impl Validator {
             &prioritization_fee_cache,
         )?;
 
+        let banking_tracer = BankingTracer::new((config.banking_trace_size > 0).then_some((
+            blockstore.banking_tracer_path(),
+            exit.clone(),
+            config.banking_trace_size,
+        )))
+        .map_err(|err| format!("{} [{:?}]", &err, &err))?;
+
         let tpu = Tpu::new(
             &cluster_info,
             &poh_recorder,
@@ -1017,6 +1027,7 @@ impl Validator {
             &staked_nodes,
             config.staked_nodes_overrides.clone(),
             tpu_enable_udp,
+            banking_tracer,
         );
 
         datapoint_info!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -225,7 +225,7 @@ impl Blockstore {
         &self.ledger_path
     }
 
-    pub fn banking_tracer_path(&self) -> PathBuf {
+    pub fn banking_trace_path(&self) -> PathBuf {
         self.ledger_path.join("banking_trace")
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -221,9 +221,12 @@ impl Blockstore {
         self.db
     }
 
-    /// The path to the ledger store
     pub fn ledger_path(&self) -> &PathBuf {
         &self.ledger_path
+    }
+
+    pub fn banking_tracer_path(&self) -> PathBuf {
+        self.ledger_path.join("banking_trace")
     }
 
     /// Opens a Ledger in directory, provides "infinite" window of shreds

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -64,6 +64,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
+        banking_trace_size: config.banking_trace_size,
     }
 }
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -64,7 +64,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
-        banking_trace_size: config.banking_trace_size,
+        banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
     }
 }
 

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -12,6 +12,7 @@ use {
     },
     rand::{seq::SliceRandom, Rng},
     rayon::prelude::*,
+    serde::{Deserialize, Serialize},
     std::{
         ops::{Index, IndexMut},
         os::raw::c_int,
@@ -53,11 +54,12 @@ fn unpin<T>(_mem: *mut T) {
 // A vector wrapper where the underlying memory can be
 // page-pinned. Controlled by flags in case user only wants
 // to pin in certain circumstances.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct PinnedVec<T: Default + Clone + Sized> {
     x: Vec<T>,
     pinned: bool,
     pinnable: bool,
+    #[serde(skip)]
     recycler: Weak<RecyclerX<PinnedVec<T>>>,
 }
 

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -4,7 +4,7 @@ use {
     crate::{cuda_runtime::PinnedVec, recycler::Recycler},
     bincode::config::Options,
     rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator},
-    serde::{de::DeserializeOwned, Serialize},
+    serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         io::Read,
         net::SocketAddr,
@@ -18,7 +18,7 @@ pub const NUM_PACKETS: usize = 1024 * 8;
 pub const PACKETS_PER_BATCH: usize = 64;
 pub const NUM_RCVMMSGS: usize = 64;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PacketBatch {
     packets: PinnedVec<Packet>,
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3695,6 +3695,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolling-file"
+version = "0.1.0"
+source = "git+https://github.com/ryoqun/rolling-file-rs?rev=664504e77fad7292dedf5a119d950b80aef67934#664504e77fad7292dedf5a119d950b80aef67934"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,6 +4481,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
+ "rolling-file",
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -745,9 +745,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -3737,8 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "rolling-file"
-version = "0.1.0"
-source = "git+https://github.com/ryoqun/rolling-file-rs?rev=664504e77fad7292dedf5a119d950b80aef67934#664504e77fad7292dedf5a119d950b80aef67934"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
 dependencies = [
  "chrono",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4039,9 +4039,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
  "serde",
  "serde_with_macros",
@@ -4049,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling",
  "proc-macro2 1.0.41",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1035,6 +1035,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "strsim 0.10.0",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2002,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3997,6 +4038,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5784,6 +5847,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "sha2 0.10.5",
  "sha3 0.10.4",
  "solana-frozen-abi 1.15.0",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,7 +70,7 @@ serde = "1.0.144"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
 serde_json = { version = "1.0.83", optional = true }
-serde_with = { version = "2.1.0", default-features = false, features = ["macros"] }
+serde_with = { version = "2.2.0", default-features = false, features = ["macros"] }
 sha2 = "0.10.5"
 sha3 = { version = "0.10.4", optional = true }
 solana-frozen-abi = { path = "../frozen-abi", version = "=1.15.0" }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,6 +70,7 @@ serde = "1.0.144"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
 serde_json = { version = "1.0.83", optional = true }
+serde_with = { version = "2.1.0", default-features = false, features = ["macros"] }
 sha2 = "0.10.5"
 sha3 = { version = "0.10.4", optional = true }
 solana-frozen-abi = { path = "../frozen-abi", version = "=1.15.0" }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -3,7 +3,7 @@
 use {
     bincode::{Options, Result},
     bitflags::bitflags,
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     std::{
         fmt, io,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -21,6 +21,7 @@ pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
 
 bitflags! {
     #[repr(C)]
+    #[derive(Serialize, Deserialize)]
     pub struct PacketFlags: u8 {
         const DISCARD        = 0b0000_0001;
         const FORWARDED      = 0b0000_0010;
@@ -30,7 +31,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Meta {
     pub size: usize,
@@ -40,11 +41,39 @@ pub struct Meta {
     pub sender_stake: u64,
 }
 
-#[derive(Clone, Eq)]
+mod serde_bytes_array {
+    use {
+        core::convert::TryInto,
+        serde::{de::Error, Deserializer, Serializer},
+    };
+
+    pub(crate) fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serde_bytes::serialize(bytes, serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec: Vec<u8> = serde_bytes::deserialize(deserializer)?;
+        let vec_len = vec.len();
+        let array: [u8; N] = vec.try_into().map_err(|_| {
+            let expected = format!("[u8; {}]", N);
+            D::Error::invalid_length(vec_len, &expected.as_str())
+        })?;
+        Ok(array)
+    }
+}
+
+#[derive(Clone, Eq, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Packet {
     // Bytes past Packet.meta.size are not valid to read from.
     // Use Packet.data(index) to read from the buffer.
+    #[serde(with = "serde_bytes_array")]
     buffer: [u8; PACKET_DATA_SIZE],
     meta: Meta,
 }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -45,6 +45,7 @@ mod serde_bytes_array {
     use {
         core::convert::TryInto,
         serde::{de::Error, Deserializer, Serializer},
+        std::borrow::Cow,
     };
 
     pub(crate) fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
@@ -58,11 +59,11 @@ mod serde_bytes_array {
     where
         D: Deserializer<'de>,
     {
-        let vec: Vec<u8> = serde_bytes::deserialize(deserializer)?;
-        let vec_len = vec.len();
-        let array: [u8; N] = vec.try_into().map_err(|_| {
+        let slice: Cow<'de, [u8]> = serde_bytes::deserialize(deserializer)?;
+
+        let array: [u8; N] = (&*slice).try_into().map_err(|_| {
             let expected = format!("[u8; {}]", N);
-            D::Error::invalid_length(vec_len, &expected.as_str())
+            D::Error::invalid_length(slice.len(), &expected.as_str())
         })?;
         Ok(array)
     }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -42,6 +42,31 @@ pub struct Meta {
     pub sender_stake: u64,
 }
 
+// serde_as is used as a work around because array isn't supported by serde
+// (and serde_bytes).
+//
+// the root cause is of a historical special handling for [T; 0] in rust's
+// `Default` and supposedly mirrored serde's `Serialize` (macro) impls,
+// pre-dating stabilized const generics, meaning it'll take long time...:
+//   https://github.com/rust-lang/rust/issues/61415
+//   https://github.com/rust-lang/rust/issues/88744#issuecomment-1138678928
+//
+// Due to the nature of the root cause, the current situation is complicated.
+// All in all, the serde_as solution is chosen for good perf and low maintenance
+// need at the cost of another crate dependency..
+//
+// For details, please refer to the below various links...
+//
+// relevant merged/published pr for this serde_as functionality used here:
+//   https://github.com/jonasbb/serde_with/pull/277
+// open pr at serde_bytes:
+//   https://github.com/serde-rs/bytes/pull/28
+// open issue at serde:
+//   https://github.com/serde-rs/serde/issues/1937
+// closed pr at serde (due to the above mentioned [N; 0] issue):
+//   https://github.com/serde-rs/serde/pull/1860
+// ryoqun's dirty experiments:
+//   https://github.com/ryoqun/serde-array-comparisons
 #[serde_as]
 #[derive(Clone, Eq, Serialize, Deserialize)]
 #[repr(C)]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -4,6 +4,7 @@ use {
     bincode::{Options, Result},
     bitflags::bitflags,
     serde::{Deserialize, Serialize},
+    serde_with::{serde_as, Bytes},
     std::{
         fmt, io,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -41,40 +42,13 @@ pub struct Meta {
     pub sender_stake: u64,
 }
 
-mod serde_bytes_array {
-    use {
-        core::convert::TryInto,
-        serde::{de::Error, Deserializer, Serializer},
-        std::borrow::Cow,
-    };
-
-    pub(crate) fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serde_bytes::serialize(bytes, serializer)
-    }
-
-    pub(crate) fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let slice: Cow<'de, [u8]> = serde_bytes::deserialize(deserializer)?;
-
-        let array: [u8; N] = (&*slice).try_into().map_err(|_| {
-            let expected = format!("[u8; {}]", N);
-            D::Error::invalid_length(slice.len(), &expected.as_str())
-        })?;
-        Ok(array)
-    }
-}
-
+#[serde_as]
 #[derive(Clone, Eq, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Packet {
     // Bytes past Packet.meta.size are not valid to read from.
     // Use Packet.data(index) to read from the buffer.
-    #[serde(with = "serde_bytes_array")]
+    #[serde_as(as = "Bytes")]
     buffer: [u8; PACKET_DATA_SIZE],
     meta: Meta,
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1308,7 +1308,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 // expose friendly alternative name to cli than internal
                 // implementation-oriented one
                 .long("enable-banking-trace")
-                .value_name("MAX_BYTES")
+                .value_name("BYTES")
                 .validator(is_parsable::<DirByteLimit>)
                 .takes_value(true)
                 // Firstly, zero limit value causes tracer to be disabled

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -10,7 +10,7 @@ use {
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
-    solana_core::banking_trace::DEFAULT_BANKING_TRACE_SIZE,
+    solana_core::banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
@@ -1304,13 +1304,22 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Allow concurrent replay of slots on different forks")
         )
         .arg(
-            Arg::with_name("banking_trace_size")
+            Arg::with_name("banking_trace_dir_byte_limit")
+                // expose friendly alternative name to cli than internal
+                // implementation-oriented one
                 .long("enable-banking-trace")
                 .value_name("MAX_BYTES")
-                .validator(is_parsable::<u64>)
+                .validator(is_parsable::<DirByteLimit>)
                 .takes_value(true)
-                .default_value(&default_args.banking_trace_size)
-                .help("Write trace files for simulate-leader-blocks, retaining up to the maximum total bytes")
+                // Firstly, zero limit value causes tracer to be disabled
+                // altogether, intuitively. On the other hand, this non-zero
+                // default doesn't enable banking tracer unless this flag is
+                // explicitly given, similar to --limit-ledger-size.
+                // see configure_banking_trace_dir_byte_limit() for this.
+                .default_value(&default_args.banking_trace_dir_byte_limit)
+                .help("Write trace files for simulate-leader-blocks, retaining \
+                       up to the default or specified total bytes in the \
+                       ledger")
         )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
@@ -1694,7 +1703,7 @@ pub struct DefaultArgs {
     pub wait_for_restart_window_min_idle_time: String,
     pub wait_for_restart_window_max_delinquent_stake: String,
 
-    pub banking_trace_size: String,
+    pub banking_trace_dir_byte_limit: String,
 }
 
 impl DefaultArgs {
@@ -1773,7 +1782,7 @@ impl DefaultArgs {
             exit_max_delinquent_stake: "5".to_string(),
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
-            banking_trace_size: DEFAULT_BANKING_TRACE_SIZE.to_string(),
+            banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -10,6 +10,7 @@ use {
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
+    solana_core::banking_trace::DEFAULT_BANKING_TRACE_SIZE,
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
@@ -1302,6 +1303,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("replay-slots-concurrently")
                 .help("Allow concurrent replay of slots on different forks")
         )
+        .arg(
+            Arg::with_name("banking_trace_size")
+                .long("enable-banking-trace")
+                .value_name("MAX_BYTES")
+                .validator(is_parsable::<u64>)
+                .takes_value(true)
+                .default_value(&default_args.banking_trace_size)
+                .help("Write trace files for simulate-leader-blocks, retaining up to the maximum total bytes")
+        )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
         .subcommand(
@@ -1683,6 +1693,8 @@ pub struct DefaultArgs {
     // Wait subcommand
     pub wait_for_restart_window_min_idle_time: String,
     pub wait_for_restart_window_max_delinquent_stake: String,
+
+    pub banking_trace_size: String,
 }
 
 impl DefaultArgs {
@@ -1761,6 +1773,7 @@ impl DefaultArgs {
             exit_max_delinquent_stake: "5".to_string(),
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
+            banking_trace_size: DEFAULT_BANKING_TRACE_SIZE.to_string(),
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -8,6 +8,7 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
     solana_core::{
+        banking_trace::EMPTY_BANKING_TRACE_SIZE,
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         system_monitor_service::SystemMonitorService,
         tower_storage,
@@ -1426,6 +1427,15 @@ pub fn main() {
         }
         validator_config.max_ledger_shreds = Some(limit_ledger_size);
     }
+
+    validator_config.banking_trace_size = if matches.occurrences_of("banking_trace_size") == 0 {
+        // disable with no explicit flag; then, this effectively becomes `opt-in` even if we're
+        // specifying a default value in clap configuration.
+        EMPTY_BANKING_TRACE_SIZE
+    } else {
+        // DEFAULT_BANKING_TRACE_SIZE or user-supplied override value
+        value_t_or_exit!(matches, "banking_trace_size", u64)
+    };
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -8,7 +8,7 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
     solana_core::{
-        banking_trace::EMPTY_BANKING_TRACE_SIZE,
+        banking_trace::DISABLED_BAKING_TRACE_DIR,
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         system_monitor_service::SystemMonitorService,
         tower_storage,
@@ -426,6 +426,21 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr]) -> Option<u16> {
         }
     }
     None
+}
+
+fn configure_banking_trace_dir_byte_limit(
+    validator_config: &mut ValidatorConfig,
+    matches: &ArgMatches,
+) {
+    validator_config.banking_trace_dir_byte_limit =
+        if matches.occurrences_of("banking_trace_dir_byte_limit") == 0 {
+            // disable with no explicit flag; then, this effectively becomes `opt-in` even if we're
+            // specifying a default value in clap configuration.
+            DISABLED_BAKING_TRACE_DIR
+        } else {
+            // BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT or user-supplied override value
+            value_t_or_exit!(matches, "banking_trace_dir_byte_limit", u64)
+        };
 }
 
 pub fn main() {
@@ -1428,14 +1443,7 @@ pub fn main() {
         validator_config.max_ledger_shreds = Some(limit_ledger_size);
     }
 
-    validator_config.banking_trace_size = if matches.occurrences_of("banking_trace_size") == 0 {
-        // disable with no explicit flag; then, this effectively becomes `opt-in` even if we're
-        // specifying a default value in clap configuration.
-        EMPTY_BANKING_TRACE_SIZE
-    } else {
-        // DEFAULT_BANKING_TRACE_SIZE or user-supplied override value
-        value_t_or_exit!(matches, "banking_trace_size", u64)
-    };
+    configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {


### PR DESCRIPTION
#### Problem


It's hard to reproduce/examine past banking-related performance problems which are observed only at mainnet-beta.

The underlying problem is that it's not easy to create a similar load on test/dev environments. Worse, we also don't have good visibility of actual load due to limited set of metrics, which are indirect by nature and aggregated in ad-hoc definitions.
This is especially so for banking, say unlike replay performance. That's because any discarded packets are unavailable afterwards like later investigating/benchmarking.

Lastly, the performance profile of banking isn't linear by any means as well. There's various factors affecting its throughput (account access pattern, qos, resource contentions across banking threads...)



#### Summary of Changes

So, let's get to bottom of this.

Namely, start to collect all of REAL trace data fed into BankingStage on production environment.
Once provided from validator-node operators, we will be able to consume these trace data later with `solana-ledger-tool simulate-leader-blocks` (not included in this pr)

The obvious concerns is of any overhead. So, background trace writer thread is introduced and its work is rather simple: just writing packet blobs. Casual testing shows 1GB/s write throughput is possible.

On the other hand, any critical-code path's overhead will be creating/cloning Arcs and sending `PacketBatch`es off over crossbeam_channel. Specifically, this results in additional 100ns per `Vec<PacketBatch>`, which should be negligible.

Also, the trace file will be discarded 14days old or more than 14G is written. So, ram/disk usage is capped.
Hard to imagine 10G link (if employed) is fully saturated under quic, even if all of three banking channels (non-vote, tpu-vote, gossip-vote) are combined.

So, i think attack are correctly mitigated as well.

Currently, banking tracing is opt-in. but planned to be promoted to opt-out.

along side the obvious packets tracing, banking start and end events are recorded as well.

Also, backport to mb is desired. the pr is prepared in that mind (I'll spin off a preparatory cleanup pr...).
Unlike all of this other draft my prs, this pr is ready for review (except the diff size, warranting the cleanup pr....) and I've polished it up to the extreme.

#### spin-off pr statuses/tasks <span id=spin-off-pr-statuses>

- [ ] this pr
   - [x] (not strictly blocked; I submitted a doc pr to `serde_with` as a gratitude: https://github.com/jonasbb/serde_with/pull/536) => released https://crates.io/crates/serde_with/2.2.0
   - [x] ...is blocked on https://github.com/Axcient/rolling-file-rs/pull/3 and https://github.com/Axcient/rolling-file-rs/pull/4 => released https://crates.io/crates/rolling-file/0.2.0
     - [x] ... using the published version is further blocked on our update of `chrono`: #29709 
   - [x] ... is blocked on overflow removal pr: https://github.com/solana-labs/solana/pull/29715
   - [x] ... rename stale vars `ReplayVoteSender`: https://github.com/solana-labs/solana/pull/29716
     - [x]  ... is further block on grand rename of the packetbatch receiver trio: https://github.com/solana-labs/solana/pull/29752
   - [ ] ... the simulation code would be merged later: https://github.com/ryoqun/solana/pull/2
