### PR TITLE
ci: don't run openbook_dex downstream-project test temporarily

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -113,4 +113,4 @@ EOF
 
 _ example_helloworld
 _ spl
-_ openbook_dex
+# _ openbook_dex


### PR DESCRIPTION
#### Problem

seems their latest commit will broke their tests. I've made a PR there (https://www.github.com/openbook-dex/program/pull/22). will revert this PR when their test is fine.

