### PR TITLE
Cfg disable JIT code on systems where it is not supported

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -161,6 +161,7 @@ fn create_executor_from_bytes(
             })?;
     verify_code_time.stop();
     create_executor_metrics.verify_code_us = verify_code_time.as_us();
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     if use_jit {
         let mut jit_compile_time = Measure::start("jit_compile_time");
         let jit_compile_result = verified_executable.jit_compile();


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/pull/29137#issuecomment-1346264535
The bpf loader should not try to use the JIT compiler on windows and ARM systems.

#### Summary of Changes
Adds a `cfg` attribute to disable the code block which won't compile on these systems.