### PR TITLE
removes metric for process_push_success

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2266,12 +2266,7 @@ impl ClusterInfo {
             messages
                 .into_iter()
                 .flat_map(|(from, crds_values)| {
-                    let (num_success, origins) =
-                        self.gossip.process_push_message(&from, crds_values, now);
-                    self.stats
-                        .process_push_success
-                        .add_relaxed(num_success as u64);
-                    origins
+                    self.gossip.process_push_message(&from, crds_values, now)
                 })
                 .collect()
         };

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -156,7 +156,6 @@ pub struct GossipStats {
     pub(crate) process_pull_response_success: Counter,
     pub(crate) process_pull_response_timeout: Counter,
     pub(crate) process_push_message: Counter,
-    pub(crate) process_push_success: Counter,
     pub(crate) prune_message_count: Counter,
     pub(crate) prune_message_len: Counter,
     pub(crate) prune_message_timeout: Counter,
@@ -235,11 +234,6 @@ pub(crate) fn submit_gossip_stats(
         ("repair_peers", stats.repair_peers.clear(), i64),
         ("new_push_requests", stats.new_push_requests.clear(), i64),
         ("new_push_requests2", stats.new_push_requests2.clear(), i64),
-        (
-            "process_push_success",
-            stats.process_push_success.clear(),
-            i64
-        ),
         ("purge", stats.purge.clear(), i64),
         ("purge_count", stats.purge_count.clear(), i64),
         (

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -50,22 +50,12 @@ impl CrdsGossip {
         from: &Pubkey,
         values: Vec<CrdsValue>,
         now: u64,
-    ) -> (usize, HashSet<Pubkey>) {
-        let results = self
-            .push
-            .process_push_message(&self.crds, from, values, now);
-        let mut success_count = 0;
-        let successfully_inserted_origin_set: HashSet<Pubkey> = results
+    ) -> HashSet<Pubkey> {
+        self.push
+            .process_push_message(&self.crds, from, values, now)
             .into_iter()
-            .filter_map(|result| {
-                if result.is_ok() {
-                    success_count += 1;
-                }
-                Result::ok(result)
-            })
-            .collect();
-
-        (success_count, successfully_inserted_origin_set)
+            .filter_map(Result::ok)
+            .collect()
     }
 
     /// Remove redundant paths in the network.

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -365,7 +365,6 @@ fn network_run_push(
                         .unwrap()
                         .gossip
                         .process_push_message(&from, msgs.clone(), now)
-                        .1
                         .into_iter()
                         .collect();
                     let prunes_map = network


### PR DESCRIPTION

#### Problem
This is already tracked in `CrdsDataStats`:
https://github.com/solana-labs/solana/blob/5e799ad56/gossip/src/crds.rs#L96-L106 https://github.com/solana-labs/solana/blob/5e799ad56/gossip/src/cluster_info_metrics.rs#L652-L656 and is so duplicated.
Removing the metric would simplify this code path for upcoming commits.


#### Summary of Changes
removed `process_push_success`