### PR TITLE
Makes a new PathBuf instead of moving the test's TempDir

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -444,7 +444,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
 
             let accounts_dir = TempDir::new().unwrap();
             let deserialized_bank = snapshot_utils::bank_from_snapshot_archives(
-                &[accounts_dir.into_path()],
+                &[accounts_dir.path().to_path_buf()],
                 &snapshot_config.bank_snapshots_dir,
                 &full_snapshot_archive_info,
                 None,


### PR DESCRIPTION
#### Problem

The `test_snapshots_have_expected_epoch_accounts_hash()` sometimes did not clean up some temp directories. 


#### Summary of Changes

Make a new PathBuf for the accounts directory, instead of using `TempDir::into_path()`, which explicitly says it does *not* clean up the directory on disk.