### PR TITLE
Cfg disable JIT code on systems where it is not supported (2)

### DIFF
--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -262,6 +262,7 @@ before execting it in the virtual machine.",
             .map_err(|err| format!("Executable verifier failed: {err:?}"))
             .unwrap();
 
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     verified_executable.jit_compile().unwrap();
     let mut analysis = LazyAnalysis::new(verified_executable.get_executable());
 


### PR DESCRIPTION
Same as in #29208 just in the rbpf CLI tool.