### PR TITLE
handle unclean roots explicitly during index generation

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9207,12 +9207,10 @@ impl AccountsDb {
                 let uncleaned_roots = uncleaned_roots.into_inner().unwrap();
                 // Need to add these last, otherwise older updates will be cleaned
                 for root in &slots {
-                    // passing 'false' to 'add_root' causes 'root' to be added to 'accounts_index.roots_tracker.uncleaned_roots'
-                    // passing 'true' to 'add_root' does NOT add 'root' to 'accounts_index.roots_tracker.uncleaned_roots'
-                    // So, don't add all slots to 'uncleaned_roots' here since we know which slots contain duplicate pubkeys.
-                    let uncleaned_root = uncleaned_roots.contains(root);
-                    self.accounts_index.add_root(*root, !uncleaned_root);
+                    self.accounts_index.add_root(*root, true);
                 }
+                self.accounts_index
+                    .add_uncleaned_roots(uncleaned_roots.into_iter());
 
                 self.set_storage_count_and_alive_bytes(storage_info, &mut timings);
             }


### PR DESCRIPTION
#### Problem
getting rid of `caching_enabled` everywhere.
Right now, `add_root` takes a `caching_enabled` parameter that determines whether we add a root to `uncleaned_roots` or not. `caching_enabled` is going away, so we need to handle adding to `uncleaned_roots` during index generation separately.

#### Summary of Changes
Previously, we relied on `add_root` to add roots to `uncleaned_roots`. That functionality will soon be removed from `add_root`. Index generation is the only caller that passes `caching_enabled=false` to `add_root`. So, we get rid of the case where any caller passes `caching_enabled=false` to `add_root` so we can remove `caching_enabled` as a parameter to `add_root`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
