### PR TITLE
Update CI pipeline to only run `checks` step on version bump PRs

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -303,6 +303,31 @@ pull_or_push_steps() {
     wait_step
   fi
 
+  # Version bump PRs are an edge case that can skip most of the CI steps
+  if affects .toml$ && affects .lock$ && ! affects_other_than .toml$ .lock$; then
+    optional_old_version_number=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD validator/Cargo.toml | \
+      grep -e "^-version" | sed  's/-version = "\(.*\)"/\1/')
+    echo "optional_old_version_number: ->$optional_old_version_number<-"
+    new_version_number=$(grep -e  "^version = " validator/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+    echo "new_version_number: ->$new_version_number<-"
+
+    # Every line in a version bump diff will match one of these patterns. Since we're using grep -v the output is the
+    # lines that don't match. Any diff that produces output here is not a version bump.
+    # | cat is a no-op. If this pull request is a version bump then grep will output no lines and have an exit code of 1.
+    # Piping the output to cat prevents that non-zero exit code from exiting this script
+    diff_other_than_version_bump=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD | \
+      grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?solana.*$optional_old_version_number|^\+( \")?solana.*$new_version_number|^-version|^\+version"|cat)
+    echo "diff_other_than_version_bump: ->$diff_other_than_version_bump<-"
+
+    if [ -z "$diff_other_than_version_bump" ]; then
+      echo "Diff only contains version bump."
+      command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+      wait_step
+      command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 80
+      exit 0
+    fi
+  fi
+
   # Run the full test suite by default, skipping only if modifications are local
   # to some particular areas of the tree
   if affects_other_than ^.buildkite ^.mergify .md$ ^docs/ ^web3.js/ ^explorer/ ^.gitbook; then

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -322,8 +322,6 @@ pull_or_push_steps() {
     if [ -z "$diff_other_than_version_bump" ]; then
       echo "Diff only contains version bump."
       command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-      wait_step
-      command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 80
       exit 0
     fi
   fi


### PR DESCRIPTION
#### Problem
Version bump PRs currently run the entire CI suite which is unnecessary and takes a few hours.

#### Summary of Changes
Add a check to the pipeline builder that detects version bump PRs and only runs the `checks` step

#### Test Plan
I don't know a way to test this in Buildkite without merging it but I stubbed out the buildkite agent and ran tests locally for:
* master minor version bump
* master and v1.14 patch version bumps
* master and v1.14 changes unrelated to version bumps
* master and v1.14 dependency version bumps (this still runs the full CI pipeline as intended)

Since it hasn't been tested in Buildkite yet I've left in some echo statements for debugging in case there are problems.