### PR TITLE
chore: improve solana-client-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5141,6 +5141,7 @@ dependencies = [
  "solana-version",
  "systemstat",
  "tokio",
+ "tungstenite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,7 +5121,6 @@ version = "1.15.0"
 dependencies = [
  "futures-util",
  "serde_json",
- "serial_test",
  "solana-ledger",
  "solana-logger 1.15.0",
  "solana-measure",

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 [dependencies]
 futures-util = "0.3.21"
 serde_json = "1.0.83"
-serial_test = "0.9.0"
 solana-ledger = { path = "../ledger", version = "=1.15.0" }
 solana-measure = { path = "../measure", version = "=1.15.0" }
 solana-merkle-tree = { path = "../merkle-tree", version = "=1.15.0" }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -32,6 +32,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.15.0
 solana-version = { path = "../version", version = "=1.15.0" }
 systemstat = "0.2.0"
 tokio = { version = "~1.14.1", features = ["full"] }
+tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.15.0" }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -1,7 +1,6 @@
 use {
     futures_util::StreamExt,
     serde_json::{json, Value},
-    serial_test::serial,
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
     solana_pubsub_client::{nonblocking, pubsub_client::PubsubClient},
     solana_rpc::{
@@ -116,7 +115,6 @@ fn test_rpc_client() {
 }
 
 #[test]
-#[serial]
 fn test_account_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -219,7 +217,6 @@ fn test_account_subscription() {
 }
 
 #[test]
-#[serial]
 fn test_block_subscription() {
     // setup BankForks
     let exit = Arc::new(AtomicBool::new(false));
@@ -330,7 +327,6 @@ fn test_block_subscription() {
 }
 
 #[test]
-#[serial]
 fn test_program_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -426,7 +422,6 @@ fn test_program_subscription() {
 }
 
 #[test]
-#[serial]
 fn test_root_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -483,7 +478,6 @@ fn test_root_subscription() {
 }
 
 #[test]
-#[serial]
 fn test_slot_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -548,7 +542,6 @@ fn test_slot_subscription() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_slot_subscription_async() {
     let sync_service = Arc::new(AtomicU64::new(0));
     let sync_client = Arc::clone(&sync_service);

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -93,7 +93,7 @@ fn test_rpc_client() {
     let now = Instant::now();
     while now.elapsed().as_secs() <= 20 {
         let response = client
-            .confirm_transaction_with_commitment(&signature, CommitmentConfig::default())
+            .confirm_transaction_with_commitment(&signature, CommitmentConfig::processed())
             .unwrap();
 
         if response.value {
@@ -107,11 +107,11 @@ fn test_rpc_client() {
     assert!(confirmed_tx);
 
     assert_eq!(
-        client.get_balance(&bob_pubkey).unwrap(),
+        client.get_balance_with_commitment(&bob_pubkey, CommitmentConfig::processed()).unwrap().value,
         sol_to_lamports(20.0)
     );
     assert_eq!(
-        client.get_balance(&alice.pubkey()).unwrap(),
+        client.get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::processed()).unwrap().value,
         original_alice_balance - sol_to_lamports(20.0)
     );
 }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -144,9 +144,7 @@ fn test_account_subscription() {
     let (trigger, pubsub_service) =
         PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
 
-    if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(300)) {
-        eprintln!("server initialized timeout");
-    }
+    check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
     let config = Some(RpcAccountInfoConfig {
         commitment: Some(CommitmentConfig::finalized()),
@@ -268,9 +266,7 @@ fn test_block_subscription() {
     };
     let (trigger, pubsub_service) = PubSubService::new(pub_cfg, &subscriptions, pubsub_addr);
 
-    if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(300)) {
-        eprintln!("server initialized timeout");
-    }
+    check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
     // setup PubsubClient
     let (mut client, receiver) = PubsubClient::block_subscribe(
@@ -350,9 +346,7 @@ fn test_program_subscription() {
     let (trigger, pubsub_service) =
         PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
 
-    if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(300)) {
-        eprintln!("server initialized timeout");
-    }
+    check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
     let config = Some(RpcProgramAccountsConfig {
         ..RpcProgramAccountsConfig::default()
@@ -436,9 +430,7 @@ fn test_root_subscription() {
     let (trigger, pubsub_service) =
         PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
 
-    if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(300)) {
-        eprintln!("server initialized timeout");
-    }
+    check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
     let (mut client, receiver) =
         PubsubClient::root_subscribe(&format!("ws://0.0.0.0:{}/", pubsub_addr.port())).unwrap();
@@ -487,9 +479,7 @@ fn test_slot_subscription() {
     let (trigger, pubsub_service) =
         PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
 
-    if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(300)) {
-        eprintln!("server initialized timeout");
-    }
+    check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
     let (mut client, receiver) =
         PubsubClient::slot_subscribe(&format!("ws://0.0.0.0:{}/", pubsub_addr.port())).unwrap();
@@ -558,9 +548,7 @@ async fn test_slot_subscription_async() {
         let (trigger, pubsub_service) =
             PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
 
-        if !check_server_is_ready(&pubsub_addr, 10, Duration::from_millis(100)) {
-            eprintln!("server initialized timeout");
-        }
+        check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(100));
 
         sync_service.store(1, Ordering::Relaxed);
 
@@ -611,7 +599,7 @@ async fn test_slot_subscription_async() {
     unsubscribe().await;
 }
 
-fn check_server_is_ready(socket_addr: &SocketAddr, retry: u8, sleep_duration: Duration) -> bool {
+fn check_server_is_ready_or_panic(socket_addr: &SocketAddr, retry: u8, sleep_duration: Duration) {
     loop {
         if retry == 0 {
             break;
@@ -620,10 +608,10 @@ fn check_server_is_ready(socket_addr: &SocketAddr, retry: u8, sleep_duration: Du
         }
 
         if connect(format!("ws://{}", socket_addr)).is_ok() {
-            return true;
+            return;
         }
         sleep(sleep_duration);
     }
 
-    false
+    panic!("server hasn't been ready");
 }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -107,11 +107,17 @@ fn test_rpc_client() {
     assert!(confirmed_tx);
 
     assert_eq!(
-        client.get_balance_with_commitment(&bob_pubkey, CommitmentConfig::processed()).unwrap().value,
+        client
+            .get_balance_with_commitment(&bob_pubkey, CommitmentConfig::processed())
+            .unwrap()
+            .value,
         sol_to_lamports(20.0)
     );
     assert_eq!(
-        client.get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::processed()).unwrap().value,
+        client
+            .get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::processed())
+            .unwrap()
+            .value,
         original_alice_balance - sol_to_lamports(20.0)
     );
 }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -51,6 +51,13 @@ use {
     systemstat::Ipv4Addr,
 };
 
+const TEST_ACCOUNT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 1;
+const TEST_BLOCK_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 2;
+const TEST_PROGRAM_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 3;
+const TEST_ROOT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 4;
+const TEST_SLOT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 5;
+const TEST_SLOT_SUBSCRIPTION_ASYNC_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 6;
+
 #[test]
 fn test_rpc_client() {
     solana_logger::setup();
@@ -112,7 +119,7 @@ fn test_rpc_client() {
 fn test_account_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_ACCOUNT_SUBSCRIPTION_PORT,
     );
     let exit = Arc::new(AtomicBool::new(false));
 
@@ -255,7 +262,7 @@ fn test_block_subscription() {
     ));
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_BLOCK_SUBSCRIPTION_PORT,
     );
     let pub_cfg = PubSubConfig {
         enable_block_subscription: true,
@@ -320,7 +327,7 @@ fn test_block_subscription() {
 fn test_program_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_PROGRAM_SUBSCRIPTION_PORT,
     );
     let exit = Arc::new(AtomicBool::new(false));
 
@@ -412,7 +419,7 @@ fn test_program_subscription() {
 fn test_root_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_ROOT_SUBSCRIPTION_PORT,
     );
     let exit = Arc::new(AtomicBool::new(false));
 
@@ -465,7 +472,7 @@ fn test_root_subscription() {
 fn test_slot_subscription() {
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_SLOT_SUBSCRIPTION_PORT,
     );
     let exit = Arc::new(AtomicBool::new(false));
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
@@ -535,7 +542,7 @@ async fn test_slot_subscription_async() {
 
     let pubsub_addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        rpc_port::DEFAULT_RPC_PUBSUB_PORT,
+        TEST_SLOT_SUBSCRIPTION_ASYNC_PORT,
     );
 
     tokio::task::spawn_blocking(move || {

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -51,10 +51,9 @@ use {
     tungstenite::connect,
 };
 
-fn pubsub_addr() -> SocketAddr {
-    static NEXT_RPC_PUBSUB_PORT: AtomicU16 =
-        std::sync::atomic::AtomicU16::new(rpc_port::DEFAULT_RPC_PUBSUB_PORT);
+static NEXT_RPC_PUBSUB_PORT: AtomicU16 = AtomicU16::new(rpc_port::DEFAULT_RPC_PUBSUB_PORT);
 
+fn pubsub_addr() -> SocketAddr {
     SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         NEXT_RPC_PUBSUB_PORT.fetch_add(1, Ordering::Relaxed),

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -41,7 +41,7 @@ use {
         collections::HashSet,
         net::{IpAddr, SocketAddr},
         sync::{
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
             Arc, RwLock,
         },
         thread::sleep,
@@ -51,12 +51,15 @@ use {
     tungstenite::connect,
 };
 
-const TEST_ACCOUNT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 1;
-const TEST_BLOCK_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 2;
-const TEST_PROGRAM_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 3;
-const TEST_ROOT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 4;
-const TEST_SLOT_SUBSCRIPTION_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 5;
-const TEST_SLOT_SUBSCRIPTION_ASYNC_PORT: u16 = rpc_port::DEFAULT_RPC_PUBSUB_PORT + 6;
+fn pubsub_addr() -> SocketAddr {
+    static NEXT_RPC_PUBSUB_PORT: AtomicU16 =
+        std::sync::atomic::AtomicU16::new(rpc_port::DEFAULT_RPC_PUBSUB_PORT);
+
+    SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        NEXT_RPC_PUBSUB_PORT.fetch_add(1, Ordering::Relaxed),
+    )
+}
 
 #[test]
 fn test_rpc_client() {
@@ -116,10 +119,7 @@ fn test_rpc_client() {
 
 #[test]
 fn test_account_subscription() {
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_ACCOUNT_SUBSCRIPTION_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
     let exit = Arc::new(AtomicBool::new(false));
 
     let GenesisConfigInfo {
@@ -262,10 +262,7 @@ fn test_block_subscription() {
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
     ));
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_BLOCK_SUBSCRIPTION_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
     let pub_cfg = PubSubConfig {
         enable_block_subscription: true,
         ..PubSubConfig::default()
@@ -328,10 +325,7 @@ fn test_block_subscription() {
 
 #[test]
 fn test_program_subscription() {
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_PROGRAM_SUBSCRIPTION_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
     let exit = Arc::new(AtomicBool::new(false));
 
     let GenesisConfigInfo {
@@ -423,10 +417,7 @@ fn test_program_subscription() {
 
 #[test]
 fn test_root_subscription() {
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_ROOT_SUBSCRIPTION_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
     let exit = Arc::new(AtomicBool::new(false));
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
@@ -479,10 +470,7 @@ fn test_root_subscription() {
 
 #[test]
 fn test_slot_subscription() {
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_SLOT_SUBSCRIPTION_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
     let exit = Arc::new(AtomicBool::new(false));
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
@@ -551,10 +539,7 @@ async fn test_slot_subscription_async() {
         }
     }
 
-    let pubsub_addr = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        TEST_SLOT_SUBSCRIPTION_ASYNC_PORT,
-    );
+    let pubsub_addr = pubsub_addr();
 
     tokio::task::spawn_blocking(move || {
         let exit = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
#### Summary of Changes

for running them simultaneously correctly

- used `check_server_is_ready` instead of waiting a magic number time period
- separated all test ports
- removed serial_test 