### PR TITLE
docs: Accounts must be rent exempt

### DIFF
--- a/docs/src/storage_rent_economics.md
+++ b/docs/src/storage_rent_economics.md
@@ -29,3 +29,11 @@ deducted at a rate specified in genesis, in lamports per kilobyte-year.
 
 For information on the technical implementation details of this design, see the
 [Rent](implemented-proposals/rent.md) section.
+
+**Note:** New accounts now **are required** to be initialized with enough
+lamports to be rent exempt. Additionally, transactions that leave an account's
+balance below the rent exempt minimum (and non-zero) will **fail**. This
+essentially renders all accounts rent exempt. Rent-paying accounts that were
+created before this requirement will continue paying rent until either (1)
+their balance falls to zero, or (2) a transaction increases the account's
+balance to be rent exempt.


### PR DESCRIPTION
#### Problem

The [Storage Rent Economics](https://docs.solana.com/storage_rent_economics) page does not mention that accounts must be rent exempt. The [Intro page on Rent](https://docs.solana.com/developing/intro/rent#rent-exempt) _does_ mention this requirement, so it's possible to see these pages and interpret conflicting requirements around rent.


#### Summary of Changes

Update the Storage Rent Economics page to explicitly say accounts must be rent exempt.