### PR TITLE
refactor unwrap_or_default for type that will soon not have a default

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9030,11 +9030,12 @@ impl AccountsDb {
                     for (index, slot) in slots.iter().enumerate() {
                         let mut scan_time = Measure::start("scan");
                         log_status.report(index as u64);
-                        let storage_maps: SnapshotStorage = self
-                            .storage
-                            .get_slot_storage_entries(*slot)
+                        let storage_maps = self.storage.get_slot_storage_entries(*slot);
+                        let accounts_map = storage_maps
+                            .as_ref()
+                            .map(|storage_maps| self.process_storage_slot(storage_maps))
                             .unwrap_or_default();
-                        let accounts_map = self.process_storage_slot(&storage_maps);
+
                         scan_time.stop();
                         scan_time_sum += scan_time.as_us();
                         Self::update_storage_info(


### PR DESCRIPTION
#### Problem
refactor `unwrap_or_default` to get default of processed type instead. This gives us the flexibility to change the return value of `get_slot_storage_entries` to not have a default later. The plan is to remove the `Vec` that is currently returned and instead return a single entry.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
