### PR TITLE
Fix compile warning for some targets

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -153,15 +153,8 @@ fn create_executor_from_bytes(
     create_executor_metrics.load_elf_us = load_elf_time.as_us();
     let executable = executable?;
     let mut verify_code_time = Measure::start("verify_code_time");
-    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    #[allow(unused_mut)]
     let mut verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
-            .map_err(|err| {
-                ic_logger_msg!(log_collector, "{}", err);
-                InstructionError::InvalidAccountData
-            })?;
-    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
-    let verified_executable =
         VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
             .map_err(|err| {
                 ic_logger_msg!(log_collector, "{}", err);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -153,7 +153,15 @@ fn create_executor_from_bytes(
     create_executor_metrics.load_elf_us = load_elf_time.as_us();
     let executable = executable?;
     let mut verify_code_time = Measure::start("verify_code_time");
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     let mut verified_executable =
+        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
+            .map_err(|err| {
+                ic_logger_msg!(log_collector, "{}", err);
+                InstructionError::InvalidAccountData
+            })?;
+    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
+    let verified_executable =
         VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
             .map_err(|err| {
                 ic_logger_msg!(log_collector, "{}", err);

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -257,13 +257,8 @@ before execting it in the virtual machine.",
     }
     .unwrap();
 
-    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    #[allow(unused_mut)]
     let mut verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
-            .map_err(|err| format!("Executable verifier failed: {err:?}"))
-            .unwrap();
-    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
-    let verified_executable =
         VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
             .map_err(|err| format!("Executable verifier failed: {err:?}"))
             .unwrap();

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -257,7 +257,13 @@ before execting it in the virtual machine.",
     }
     .unwrap();
 
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     let mut verified_executable =
+        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
+            .map_err(|err| format!("Executable verifier failed: {err:?}"))
+            .unwrap();
+    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
+    let verified_executable =
         VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
             .map_err(|err| format!("Executable verifier failed: {err:?}"))
             .unwrap();


### PR DESCRIPTION
#### Problem
Windows builds and non x86__64 target architectures are throwing a warning for unused mutable variable. This is because these builds do not run executable through JIT compile

#### Summary of Changes
cfg switch for these builds to use immutable variable.