### PR TITLE
quic test timeout fix

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -567,7 +567,7 @@ async fn handle_connection(
                         tokio::spawn(async move {
                             let mut maybe_batch = None;
                             let exit_check_interval =
-                                (wait_for_chunk_timeout_ms / 10).min(10).max(1000);
+                                (wait_for_chunk_timeout_ms / 10).clamp(10, 1000);
                             let mut start = Instant::now();
                             while !stream_exit.load(Ordering::Relaxed) {
                                 if let Ok(chunk) = tokio::time::timeout(

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1020,7 +1020,7 @@ pub mod test {
             MAX_STAKED_CONNECTIONS,
             MAX_UNSTAKED_CONNECTIONS,
             stats.clone(),
-            1000,
+            1000, // shortened from the default.
         )
         .unwrap();
         (t, exit, receiver, server_address, stats)

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -566,6 +566,11 @@ async fn handle_connection(
                         let last_update = last_update.clone();
                         tokio::spawn(async move {
                             let mut maybe_batch = None;
+                            // The min is to guard against a value too small which can wake up unnecessarily
+                            // frequently and wasting CPU cycles. The max guard against waiting for too long
+                            // which delay exit and cause some test failures when the timeout value is large.
+                            // Within this value, the heuristic is to wake up 10 times to check for exit
+                            // for the set timeout if there are no data.
                             let exit_check_interval =
                                 (wait_for_chunk_timeout_ms / 10).clamp(10, 1000);
                             let mut start = Instant::now();


### PR DESCRIPTION
#### Problem

Still seeing timeout https://buildkite.com/solana-labs/solana/builds/86606#01850f20-ff56-4c79-bd59-3ca8f3f8a25b in quic streamer test. Locally it is hard to reproduce, it seems to show up in recent CI builds.

#### Summary of Changes

Allow longer chunk receive timeout without impacting testing the stream exit condition for unit tests. The exit is periodically checked, we will break only when the total allowed chunk receive timed out. The start time is reset when a new chunk is received.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
