### PR TITLE
move AccountStorage out of accounts_db.rs

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -1,0 +1,57 @@
+//! Manage the map of slot -> append vecs
+
+use {
+    crate::accounts_db::{AccountStorageEntry, AppendVecId, SlotStores, SnapshotStorage},
+    dashmap::DashMap,
+    solana_sdk::clock::Slot,
+    std::sync::Arc,
+};
+
+pub type AccountStorageMap = DashMap<Slot, SlotStores>;
+
+#[derive(Clone, Default, Debug)]
+pub struct AccountStorage {
+    pub map: AccountStorageMap,
+}
+
+impl AccountStorage {
+    pub(crate) fn get_account_storage_entry(
+        &self,
+        slot: Slot,
+        store_id: AppendVecId,
+    ) -> Option<Arc<AccountStorageEntry>> {
+        self.get_slot_stores(slot)
+            .and_then(|storage_map| storage_map.read().unwrap().get(&store_id).cloned())
+    }
+
+    pub fn get_slot_stores(&self, slot: Slot) -> Option<SlotStores> {
+        self.map.get(&slot).map(|result| result.value().clone())
+    }
+
+    pub(crate) fn get_slot_storage_entries(&self, slot: Slot) -> Option<SnapshotStorage> {
+        self.get_slot_stores(slot)
+            .map(|res| res.read().unwrap().values().cloned().collect())
+    }
+
+    pub(crate) fn slot_store_count(&self, slot: Slot, store_id: AppendVecId) -> Option<usize> {
+        self.get_account_storage_entry(slot, store_id)
+            .map(|store| store.count())
+    }
+
+    pub(crate) fn all_slots(&self) -> Vec<Slot> {
+        self.map.iter().map(|iter_item| *iter_item.key()).collect()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize, AbiExample, AbiEnumVisitor)]
+pub enum AccountStorageStatus {
+    Available = 0,
+    Full = 1,
+    Candidate = 2,
+}
+
+impl Default for AccountStorageStatus {
+    fn default() -> Self {
+        Self::Available
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,7 @@ extern crate lazy_static;
 pub mod account_info;
 pub mod account_overrides;
 pub mod account_rent_state;
+pub mod account_storage;
 pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -3,8 +3,9 @@
 use {
     super::*,
     crate::{
+        account_storage::AccountStorageMap,
         accounts::{test_utils::create_test_accounts, Accounts},
-        accounts_db::{get_temp_accounts_paths, AccountShrinkThreshold, AccountStorageMap},
+        accounts_db::{get_temp_accounts_paths, AccountShrinkThreshold},
         accounts_hash::AccountsHash,
         append_vec::AppendVec,
         bank::{Bank, BankTestConfig},

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
+        account_storage::AccountStorageMap,
         accounts_db::{
-            AccountShrinkThreshold, AccountStorageMap, AccountsDbConfig, AtomicAppendVecId,
+            AccountShrinkThreshold, AccountsDbConfig, AtomicAppendVecId,
             CalcAccountsHashDataSource, SnapshotStorage, SnapshotStorages,
         },
         accounts_index::AccountSecondaryIndexes,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -3,7 +3,8 @@
 use {
     super::{get_io_error, snapshot_version_from_file, SnapshotError, SnapshotVersion},
     crate::{
-        accounts_db::{AccountStorageEntry, AccountStorageMap, AppendVecId, AtomicAppendVecId},
+        account_storage::AccountStorageMap,
+        accounts_db::{AccountStorageEntry, AppendVecId, AtomicAppendVecId},
         serde_snapshot::{
             self, remap_and_reconstruct_single_storage, snapshot_storage_lengths_from_fields,
             SerdeStyle, SerializedAppendVecId,


### PR DESCRIPTION
#### Problem
Prepare to refactor slot -> append_vec(s) map.

#### Summary of Changes
Move AccountStorage to its own file. This lets us encapsulate the behavior without leaking the implementation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
