### PR TITLE
Cleans up CacheHashData

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7234,7 +7234,7 @@ impl AccountsDb {
                         hash
                     );
                     if load_from_cache {
-                        if let Ok(mapped_file) = cache_hash_data.load_map(&Path::new(&file_name)) {
+                        if let Ok(mapped_file) = cache_hash_data.load_map(&file_name) {
                             return Some(mapped_file);
                         }
                     }
@@ -7276,8 +7276,7 @@ impl AccountsDb {
                         assert!(!file_name.is_empty());
                         (!r.is_empty() && r.iter().any(|b| !b.is_empty())).then(|| {
                             // error if we can't write this
-                            let file_name = Path::new(&file_name);
-                            cache_hash_data.save(Path::new(&file_name), &r).unwrap();
+                            cache_hash_data.save(&file_name, &r).unwrap();
                             cache_hash_data.load_map(&file_name).unwrap()
                         })
                     })
@@ -9566,7 +9565,7 @@ pub mod tests {
             let temp_dir = TempDir::new().unwrap();
             let accounts_hash_cache_path = temp_dir.path();
             self.scan_snapshot_stores_with_cache(
-                &CacheHashData::new(&accounts_hash_cache_path),
+                &CacheHashData::new(accounts_hash_cache_path),
                 storage,
                 stats,
                 bins,
@@ -10455,7 +10454,7 @@ pub mod tests {
         };
 
         let result = accounts_db.scan_account_storage_no_bank(
-            &CacheHashData::new(&accounts_hash_cache_path),
+            &CacheHashData::new(accounts_hash_cache_path),
             &CalcAccountsHashConfig::default(),
             &get_storage_refs(&storages),
             test_scan,


### PR DESCRIPTION
#### Problem

To add support for Incremental Accounts Hash, I'll need to add support for another accounts hash cache directory, for caching incremental accounts hashes. While I was working on the plumbing, there were a number of small fixups on `CacheHashData` itself to remove unnecessary clones and/or type conversions.


#### Summary of Changes

Cleanup CacheHashData and its callers