### PR TITLE
Added mainnet and devnet

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -212,8 +212,10 @@ where
 pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
     match url_or_moniker.as_ref() {
         "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "m-a" | "mainnet-alchemy" =>"https://solana-mainnet.g.alchemy.com/v2/Alchemy_API_Key",
         "t" | "testnet" => "https://api.testnet.solana.com",
         "d" | "devnet" => "https://api.devnet.solana.com",
+        "d-a" | "devnet-alchemy"=>"https://solana-devnet.g.alchemy.com/v2/Alchemy_API_Key",
         "l" | "localhost" => "http://localhost:8899",
         url => url,
     }


### PR DESCRIPTION
Hey there - added in Alchemy's (free) mainnet and devnet RPC URL. Wanted to give developers a second option to how they could easily start writing and reading on the Solana chain using an RPC endpoint. I'm from Alchemy, and we're seeing our Solana RPC endpoint getting more and more traffic each week at increasing rates. Lmk of any questions, thanks!

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
