### PR TITLE
Stream the executed transaction count in the block notification

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2644,7 +2644,7 @@ impl ReplayStage {
                         &bank.rewards,
                         Some(bank.clock().unix_timestamp),
                         Some(bank.block_height()),
-                        bank.transaction_entries_count(),
+                        bank.executed_transaction_count(),
                     )
                 }
                 bank_complete_time.stop();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2644,6 +2644,7 @@ impl ReplayStage {
                         &bank.rewards,
                         Some(bank.clock().unix_timestamp),
                         Some(bank.block_height()),
+                        bank.transaction_entries_count(),
                     )
                 }
                 bank_complete_time.stop();

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -141,7 +141,7 @@ pub struct ReplicaBlockInfoV2<'a> {
     pub rewards: &'a [Reward],
     pub block_time: Option<UnixTimestamp>,
     pub block_height: Option<u64>,
-    pub transaction_entries_count: u64,
+    pub executed_transaction_count: u64,
 }
 
 pub enum ReplicaBlockInfoVersions<'a> {

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -133,8 +133,20 @@ pub struct ReplicaBlockInfo<'a> {
     pub block_height: Option<u64>,
 }
 
+/// Extending ReplicaBlockInfo by sending the transaction_entries_count.
+#[derive(Clone, Debug)]
+pub struct ReplicaBlockInfoV2<'a> {
+    pub slot: u64,
+    pub blockhash: &'a str,
+    pub rewards: &'a [Reward],
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub transaction_entries_count: u64,
+}
+
 pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_1(&'a ReplicaBlockInfo<'a>),
+    V0_0_2(&'a ReplicaBlockInfoV2<'a>),
 }
 
 /// Errors returned by plugin calls

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -28,7 +28,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
-        transaction_entries_count: u64,
+        executed_transaction_count: u64,
     ) {
         let mut plugin_manager = self.plugin_manager.write().unwrap();
         if plugin_manager.plugins.is_empty() {
@@ -44,7 +44,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
                 &rewards,
                 block_time,
                 block_height,
-                transaction_entries_count,
+                executed_transaction_count,
             );
             let block_info = ReplicaBlockInfoVersions::V0_0_2(&block_info);
             match plugin.notify_block_metadata(block_info) {
@@ -96,7 +96,7 @@ impl BlockMetadataNotifierImpl {
         rewards: &'a [Reward],
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
-        transaction_entries_count: u64,
+        executed_transaction_count: u64,
     ) -> ReplicaBlockInfoV2<'a> {
         ReplicaBlockInfoV2 {
             slot,
@@ -104,7 +104,7 @@ impl BlockMetadataNotifierImpl {
             rewards,
             block_time,
             block_height,
-            transaction_entries_count,
+            executed_transaction_count,
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -5,7 +5,7 @@ use {
     },
     log::*,
     solana_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfo, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV2, ReplicaBlockInfoVersions,
     },
     solana_measure::measure::Measure,
     solana_metrics::*,
@@ -28,6 +28,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
+        transaction_entries_count: u64,
     ) {
         let mut plugin_manager = self.plugin_manager.write().unwrap();
         if plugin_manager.plugins.is_empty() {
@@ -38,8 +39,8 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         for plugin in plugin_manager.plugins.iter_mut() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             let block_info =
-                Self::build_replica_block_info(slot, blockhash, &rewards, block_time, block_height);
-            let block_info = ReplicaBlockInfoVersions::V0_0_1(&block_info);
+                Self::build_replica_block_info(slot, blockhash, &rewards, block_time, block_height, transaction_entries_count);
+            let block_info = ReplicaBlockInfoVersions::V0_0_2(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {
                     error!(
@@ -89,13 +90,15 @@ impl BlockMetadataNotifierImpl {
         rewards: &'a [Reward],
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
-    ) -> ReplicaBlockInfo<'a> {
-        ReplicaBlockInfo {
+        transaction_entries_count: u64,
+    ) -> ReplicaBlockInfoV2<'a> {
+        ReplicaBlockInfoV2 {
             slot,
             blockhash,
             rewards,
             block_time,
             block_height,
+            transaction_entries_count,
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -38,8 +38,14 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
 
         for plugin in plugin_manager.plugins.iter_mut() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
-            let block_info =
-                Self::build_replica_block_info(slot, blockhash, &rewards, block_time, block_height, transaction_entries_count);
+            let block_info = Self::build_replica_block_info(
+                slot,
+                blockhash,
+                &rewards,
+                block_time,
+                block_height,
+                transaction_entries_count,
+            );
             let block_info = ReplicaBlockInfoVersions::V0_0_2(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -14,6 +14,7 @@ pub trait BlockMetadataNotifier {
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
+        transaction_entries_count: u64,
     );
 }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -14,7 +14,7 @@ pub trait BlockMetadataNotifier {
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
-        transaction_entries_count: u64,
+        executed_transaction_count: u64,
     );
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6615,12 +6615,27 @@ impl Bank {
         )
     }
 
+    /// Return the accumulated executed transaction count
     pub fn transaction_count(&self) -> u64 {
         self.transaction_count.load(Relaxed)
     }
 
     pub fn non_vote_transaction_count_since_restart(&self) -> u64 {
         self.non_vote_transaction_count_since_restart.load(Relaxed)
+    }
+
+    /// Return the transaction count executed only in this bank
+    pub fn executed_transaction_count(&self) -> u64 {
+        let mut executed_transaction_count = self
+            .transaction_count()
+            .saturating_sub(self.parent().map_or(0, |parent| parent.transaction_count()));
+        if !self.bank_transaction_count_fix_enabled() {
+            // When the feature bank_tranaction_count_fix is enabled, transaction_count() excludes
+            // the transactions which were executed but landed in error, we add it here.
+            executed_transaction_count =
+                executed_transaction_count.saturating_add(self.transaction_error_count());
+        }
+        executed_transaction_count
     }
 
     pub fn transaction_error_count(&self) -> u64 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10655,6 +10655,8 @@ pub(crate) mod tests {
         );
         assert_eq!(bank.transaction_count(), 1);
         assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
+        assert_eq!(bank.executed_transaction_count(), 2);
+        assert_eq!(bank.transaction_error_count(), 1);
 
         let mint_pubkey = mint_keypair.pubkey();
         assert_eq!(bank.get_balance(&mint_pubkey), mint_amount - amount);


### PR DESCRIPTION
#### Problem

The plugins need to know when all transactions for a block have been all notified to serve getBlock request correctly. As block and transaction notifications are sent asynchronously to each other it will be difficult.
#### Summary of Changes

Include the executed transaction count in block notification which can be used to check if all transactions have been notified.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
