### PR TITLE
explorer: Only show supply page for custom urls

### DIFF
--- a/explorer/src/pages/SupplyPage.tsx
+++ b/explorer/src/pages/SupplyPage.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { TopAccountsCard } from "components/TopAccountsCard";
 import { SupplyCard } from "components/SupplyCard";
+import { Cluster, useCluster } from "providers/cluster";
 
 export function SupplyPage() {
+  const cluster = useCluster();
   return (
     <div className="container mt-4">
       <SupplyCard />
-      <TopAccountsCard />
+      {cluster.cluster === Cluster.Custom ? <TopAccountsCard /> : null}
     </div>
   );
 }


### PR DESCRIPTION
#### Problem
`getLargestAccounts` has been deprecated from the public explorer RPCs

#### Summary of Changes

Only show the `TopAccounts` card when there's a custom URL in use -- allowing it to be used for debugging, or in coordination with a separate RPC provider.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
