### PR TITLE
Prune redundant const SLOT_MS

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -19,7 +19,7 @@ use {
         sorted_storages::SortedStorages,
     },
     solana_sdk::{
-        clock::{Slot, SLOT_MS},
+        clock::{Slot, DEFAULT_MS_PER_SLOT},
         hash::Hash,
         pubkey::Pubkey,
     },
@@ -51,7 +51,7 @@ impl AccountsHashVerifier {
         snapshot_config: SnapshotConfig,
     ) -> Self {
         // If there are no accounts packages to process, limit how often we re-check
-        const LOOP_LIMITER: Duration = Duration::from_millis(SLOT_MS);
+        const LOOP_LIMITER: Duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
         let t_accounts_hash_verifier = Builder::new()

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -22,7 +22,7 @@ use {
     },
     solana_runtime::bank::Bank,
     solana_sdk::{
-        clock::{Slot, SLOT_MS},
+        clock::{Slot, DEFAULT_MS_PER_SLOT},
         pubkey::Pubkey,
         signature::Signable,
         signer::keypair::Keypair,
@@ -553,7 +553,7 @@ impl AncestorHashesService {
                     &mut request_throttle,
                 );
 
-                sleep(Duration::from_millis(SLOT_MS));
+                sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
             })
             .unwrap()
     }

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -8,7 +8,7 @@ use {
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},
     solana_measure::measure::Measure,
     solana_sdk::{
-        clock::{Slot, SLOT_MS},
+        clock::{Slot, DEFAULT_MS_PER_SLOT},
         timing::AtomicInterval,
     },
     std::{
@@ -22,7 +22,7 @@ use {
 };
 pub type Age = u8;
 
-const AGE_MS: u64 = SLOT_MS; // match one age per slot time
+const AGE_MS: u64 = DEFAULT_MS_PER_SLOT; // match one age per slot time
 
 // 10 GB limit for in-mem idx. In practice, we don't get this high. This tunes how aggressively to save items we expect to use soon.
 pub const DEFAULT_DISK_INDEX: Option<usize> = Some(10_000);

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -33,6 +33,9 @@ static_assertions::const_assert_eq!(MS_PER_TICK, 6);
 /// The number of milliseconds per tick (6).
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 
+// Slated for deprecation in the next major version (use DEFAULT_MS_PER_SLOT instead).
+pub const SLOT_MS: u64 = DEFAULT_MS_PER_SLOT;
+
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -7,7 +7,7 @@
 //! by their slot number, and some slots do not contain a block.
 //!
 //! An approximation of the passage of real-world time can be calculated by
-//! multiplying a number of slots by [`SLOT_MS`], which is a constant target
+//! multiplying a number of slots by [`DEFAULT_MS_PER_SLOT`], which is a constant target
 //! time for the network to produce slots. Note though that this method suffers
 //! a variable amount of drift, as the network does not produce slots at exactly
 //! the target rate, and the greater number of slots being calculated for, the
@@ -32,12 +32,6 @@ static_assertions::const_assert_eq!(MS_PER_TICK, 6);
 
 /// The number of milliseconds per tick (6).
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
-
-#[cfg(test)]
-static_assertions::const_assert_eq!(SLOT_MS, 400);
-
-/// The expected duration of a slot (400 milliseconds).
-pub const SLOT_MS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SECOND;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -33,7 +33,10 @@ static_assertions::const_assert_eq!(MS_PER_TICK, 6);
 /// The number of milliseconds per tick (6).
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 
-// Slated for deprecation in the next major version (use DEFAULT_MS_PER_SLOT instead).
+#[deprecated(
+    since = "1.15.0",
+    note = "Please use DEFAULT_MS_PER_SLOT instead"
+)]
 pub const SLOT_MS: u64 = DEFAULT_MS_PER_SLOT;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -33,10 +33,8 @@ static_assertions::const_assert_eq!(MS_PER_TICK, 6);
 /// The number of milliseconds per tick (6).
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 
-#[deprecated(
-    since = "1.15.0",
-    note = "Please use DEFAULT_MS_PER_SLOT instead"
-)]
+#[deprecated(since = "1.15.0", note = "Please use DEFAULT_MS_PER_SLOT instead")]
+/// The expected duration of a slot (400 milliseconds).
 pub const SLOT_MS: u64 = DEFAULT_MS_PER_SLOT;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
@@ -74,6 +72,7 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 
 #[cfg(test)]
 static_assertions::const_assert_eq!(DEFAULT_MS_PER_SLOT, 400);
+/// The expected duration of a slot (400 milliseconds).
 pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 pub const DEFAULT_S_PER_SLOT: f64 = DEFAULT_TICKS_PER_SLOT as f64 / DEFAULT_TICKS_PER_SECOND as f64;
 


### PR DESCRIPTION
#### Problem
We have redundant constants `SLOT_MS` and `DEFAULT_MS_PER_SLOT`, which can be confusing

#### Summary of Changes
eliminate `SLOT_MS` and replace all usages with `DEFAULT_MS_PER_SLOT` because it is more widely adopted
