### PR TITLE
Removed lamports balance and added message for reaped accounts 

### DIFF
--- a/explorer/src/components/account/UnknownAccountCard.tsx
+++ b/explorer/src/components/account/UnknownAccountCard.tsx
@@ -34,7 +34,11 @@ export function UnknownAccountCard({ account }: { account: Account }) {
         <tr>
           <td>Balance (SOL)</td>
           <td className="text-lg-end">
-            <SolBalance lamports={account.lamports} />
+            {account.lamports === 0 ? (
+              "No longer exists on chain"
+            ) : (
+              <SolBalance lamports={account.lamports} />
+            )}
           </td>
         </tr>
 


### PR DESCRIPTION
#### Problem
When an account have 0 lamports and is purged, user wants to remove amount
balance and add message along the line that it doesn't exists [#28273](https://github.com/solana-labs/solana/issues/28273#issue-1400105550)

#### Summary of Changes

If account have 0 balance, showed message instead of lamports

#### Output

![Screenshot 2022-10-21 at 01-06-09 Explorer Solana](https://user-images.githubusercontent.com/59670962/197041586-6854c52a-e37b-4ef8-b77a-b2dc6d64277d.png)


