### PR TITLE
Feat/add non vote tps

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
         "@blockworks-foundation/mango-client": "^3.6.7",
@@ -4210,6 +4209,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-auction/-/mpl-auction-0.0.2.tgz",
       "integrity": "sha512-4UDDi8OiQr+D6KrCNTRrqf/iDD6vi5kzRtMRtuNpywTyhX9hnbr1Zkc6Ncncbh9GZhbhcn+/h5wHgzh+xA6TnQ==",
+      "peer": true,
       "dependencies": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -4220,6 +4220,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
       "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@solana/web3.js": "^1.21.0",
@@ -4250,6 +4251,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4259,6 +4261,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4267,6 +4270,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-core/-/mpl-core-0.0.2.tgz",
       "integrity": "sha512-UUJ4BlYiWdDegAWmjsNQiNehwYU3QfSFWs3sv4VX0J6/ZrQ28zqosGhQ+I2ZCTEy216finJ82sZWNjuwSWCYyQ==",
+      "peer": true,
       "dependencies": {
         "@solana/web3.js": "^1.31.0",
         "bs58": "^4.0.1"
@@ -4276,6 +4280,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-metaplex/-/mpl-metaplex-0.0.5.tgz",
       "integrity": "sha512-VRt3fiO/7/jcHwN+gWvTtpp+7wYhIcEDzMG1lOeV3yYyhz9fAT0E3LqEl2moifNTAopGCE4zYa84JA/OW+1YvA==",
+      "peer": true,
       "dependencies": {
         "@metaplex-foundation/mpl-auction": "^0.0.2",
         "@metaplex-foundation/mpl-core": "^0.0.2",
@@ -4289,6 +4294,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
       "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@solana/web3.js": "^1.21.0",
@@ -4319,6 +4325,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4328,6 +4335,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4336,6 +4344,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-0.0.2.tgz",
       "integrity": "sha512-yKJPhFlX8MkNbSCi1iwHn4xKmguLK/xFhYa+RuYdL2seuT4CKXHj2CnR2AkcdQj46Za4/nR3jZcRFKq7QlnvBw==",
+      "peer": true,
       "dependencies": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -4346,6 +4355,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
       "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@solana/web3.js": "^1.21.0",
@@ -4376,6 +4386,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4385,6 +4396,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4393,6 +4405,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-vault/-/mpl-token-vault-0.0.2.tgz",
       "integrity": "sha512-JiVcow8OzUGW0KTs/E1QrAdmYGqE9EGKE6cc2gxNNBYqDeVdjYlgEa64IiGvNF9rvbI2g2Z3jw0mYuA9LD9S/A==",
+      "peer": true,
       "dependencies": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -4403,6 +4416,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
       "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@solana/web3.js": "^1.21.0",
@@ -4433,6 +4447,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4442,6 +4457,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4481,6 +4497,7 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
       "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -4492,6 +4509,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-1.1.0.tgz",
       "integrity": "sha512-4tF+hO5H6eYJ49H72nvuID2nrD54X4yCxqKhbWLxqAI7v5vHSCH2QFVUnqbj3+P4ydxrNyof9MQm3qlzY8KU3g==",
+      "peer": true,
       "dependencies": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -4502,6 +4520,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
       "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@solana/web3.js": "^1.21.0",
@@ -4568,6 +4587,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -30636,6 +30656,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-auction/-/mpl-auction-0.0.2.tgz",
       "integrity": "sha512-4UDDi8OiQr+D6KrCNTRrqf/iDD6vi5kzRtMRtuNpywTyhX9hnbr1Zkc6Ncncbh9GZhbhcn+/h5wHgzh+xA6TnQ==",
+      "peer": true,
       "requires": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -30646,6 +30667,7 @@
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
           "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.10.5",
             "@solana/web3.js": "^1.21.0",
@@ -30659,6 +30681,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -30667,7 +30690,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "peer": true
         }
       }
     },
@@ -30675,6 +30699,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-core/-/mpl-core-0.0.2.tgz",
       "integrity": "sha512-UUJ4BlYiWdDegAWmjsNQiNehwYU3QfSFWs3sv4VX0J6/ZrQ28zqosGhQ+I2ZCTEy216finJ82sZWNjuwSWCYyQ==",
+      "peer": true,
       "requires": {
         "@solana/web3.js": "^1.31.0",
         "bs58": "^4.0.1"
@@ -30684,6 +30709,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-metaplex/-/mpl-metaplex-0.0.5.tgz",
       "integrity": "sha512-VRt3fiO/7/jcHwN+gWvTtpp+7wYhIcEDzMG1lOeV3yYyhz9fAT0E3LqEl2moifNTAopGCE4zYa84JA/OW+1YvA==",
+      "peer": true,
       "requires": {
         "@metaplex-foundation/mpl-auction": "^0.0.2",
         "@metaplex-foundation/mpl-core": "^0.0.2",
@@ -30697,6 +30723,7 @@
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
           "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.10.5",
             "@solana/web3.js": "^1.21.0",
@@ -30710,6 +30737,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -30718,7 +30746,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "peer": true
         }
       }
     },
@@ -30726,6 +30755,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-0.0.2.tgz",
       "integrity": "sha512-yKJPhFlX8MkNbSCi1iwHn4xKmguLK/xFhYa+RuYdL2seuT4CKXHj2CnR2AkcdQj46Za4/nR3jZcRFKq7QlnvBw==",
+      "peer": true,
       "requires": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -30736,6 +30766,7 @@
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
           "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.10.5",
             "@solana/web3.js": "^1.21.0",
@@ -30749,6 +30780,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -30757,7 +30789,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "peer": true
         }
       }
     },
@@ -30765,6 +30798,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-vault/-/mpl-token-vault-0.0.2.tgz",
       "integrity": "sha512-JiVcow8OzUGW0KTs/E1QrAdmYGqE9EGKE6cc2gxNNBYqDeVdjYlgEa64IiGvNF9rvbI2g2Z3jw0mYuA9LD9S/A==",
+      "peer": true,
       "requires": {
         "@metaplex-foundation/mpl-core": "^0.0.2",
         "@solana/spl-token": "^0.1.8",
@@ -30775,6 +30809,7 @@
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
           "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.10.5",
             "@solana/web3.js": "^1.21.0",
@@ -30788,6 +30823,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -30796,7 +30832,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "peer": true
         }
       }
     },
@@ -30805,13 +30842,6 @@
       "resolved": "https://registry.npmjs.org/@metaplex/js/-/js-4.12.0.tgz",
       "integrity": "sha512-rIUTMXo5gIXFIZt08AEHyqH4oVoLL2dMYiNePQluw9pydesRym4jDayJ5POxEmKmyc6KGqVKw/YWUIivmUY5zg==",
       "requires": {
-        "@metaplex-foundation/mpl-auction": "^0.0.2",
-        "@metaplex-foundation/mpl-core": "^0.0.2",
-        "@metaplex-foundation/mpl-metaplex": "^0.0.5",
-        "@metaplex-foundation/mpl-token-metadata": "^1.1.0",
-        "@metaplex-foundation/mpl-token-vault": "^0.0.2",
-        "@solana/spl-token": "^0.1.8",
-        "@solana/web3.js": "^1.30.2",
         "@types/bs58": "^4.0.1",
         "axios": "^0.25.0",
         "bn.js": "^5.2.0",
@@ -30826,14 +30856,15 @@
           "version": "7.16.3",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
           "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "@metaplex-foundation/mpl-token-metadata": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-1.1.0.tgz",
+          "version": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-1.1.0.tgz",
           "integrity": "sha512-4tF+hO5H6eYJ49H72nvuID2nrD54X4yCxqKhbWLxqAI7v5vHSCH2QFVUnqbj3+P4ydxrNyof9MQm3qlzY8KU3g==",
+          "peer": true,
           "requires": {
             "@metaplex-foundation/mpl-core": "^0.0.2",
             "@solana/spl-token": "^0.1.8",
@@ -30844,6 +30875,7 @@
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
           "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.10.5",
             "@solana/web3.js": "^1.21.0",
@@ -30892,7 +30924,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "peer": true
         },
         "form-data": {
           "version": "4.0.0",

--- a/explorer/src/components/LiveTransactionStatsCard.tsx
+++ b/explorer/src/components/LiveTransactionStatsCard.tsx
@@ -172,7 +172,7 @@ type TpsBarChartProps = {
 function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
   const { perfHistory, avgTps, historyMaxTps, nonVoteTps } = performanceInfo;
   const averageTps = Math.round(avgTps).toLocaleString("en-US");
-  const nonVoteTpsLive = Math.round(nonVoteTps).toLocaleString("en-US");
+  const nonVoteTpsPretty = Math.round(nonVoteTps).toLocaleString("en-US");
   const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
   const seriesData = perfHistory[series];
   const chartOptions = React.useMemo(
@@ -204,13 +204,13 @@ function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
         </tr>
         <tr>
           <td className="w-100">Transactions per second (TPS)</td>
-          <td className="text-lg-end font-monospace">
-            {avgTps > 0 ? averageTps : "Loading..."}{" "}
-          </td>
+          <td className="text-lg-end font-monospace">{averageTps}</td>
         </tr>
         <tr>
           <td className="w-100">Non vote (TPS)</td>
-          <td className="text-lg-end font-monospace">{nonVoteTpsLive} </td>
+          <td className="text-lg-end font-monospace">
+            {nonVoteTps >= 0 ? nonVoteTpsPretty : "Loading..."}{" "}
+          </td>
         </tr>
       </TableCardBody>
 

--- a/explorer/src/components/LiveTransactionStatsCard.tsx
+++ b/explorer/src/components/LiveTransactionStatsCard.tsx
@@ -170,8 +170,9 @@ type TpsBarChartProps = {
   setSeries: SetSeries;
 };
 function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
-  const { perfHistory, avgTps, historyMaxTps } = performanceInfo;
+  const { perfHistory, avgTps, historyMaxTps, nonVoteTps } = performanceInfo;
   const averageTps = Math.round(avgTps).toLocaleString("en-US");
+  const nonVoteTpsLive = Math.round(nonVoteTps).toLocaleString("en-US");
   const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
   const seriesData = perfHistory[series];
   const chartOptions = React.useMemo(
@@ -203,7 +204,13 @@ function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
         </tr>
         <tr>
           <td className="w-100">Transactions per second (TPS)</td>
-          <td className="text-lg-end font-monospace">{averageTps} </td>
+          <td className="text-lg-end font-monospace">
+            {avgTps > 0 ? averageTps : "Loading..."}{" "}
+          </td>
+        </tr>
+        <tr>
+          <td className="w-100">Non vote (TPS)</td>
+          <td className="text-lg-end font-monospace">{nonVoteTpsLive} </td>
         </tr>
       </TableCardBody>
 

--- a/explorer/src/providers/stats/solanaClusterStats.tsx
+++ b/explorer/src/providers/stats/solanaClusterStats.tsx
@@ -31,7 +31,7 @@ export enum ClusterStatsStatus {
 const initialPerformanceInfo: PerformanceInfo = {
   status: ClusterStatsStatus.Loading,
   avgTps: 0,
-  nonVoteTps: 0,
+  nonVoteTps: -1,
   recordedNonVoteCount: 0,
   historyMaxTps: 0,
   perfHistory: {


### PR DESCRIPTION
#### Problem
Currently the explorer is not separating non-vote tps and vote tps. This has lead to confusion around how many non-vote tps Solana actually handles. Please see the discussion on twitter for a more detailed discussions
https://mobile.twitter.com/0xMert_/status/1600967856090337281

#### Summary of Changes
The proposed change is to add a field below the tps count which would show non-vote tps. The non-vote tps is calculated by 
1. taking the 10 last blocks
2. calculating the number of tx per block that has a compute budget different from 0
3. grouping by blocktime
4. removing the first and last blocktime
5. calculate number of txs over the remaining blocktimes
6. dividing the sum by number of blocktimes (blocktime in seconds)
7. then start calculating an running average of non-vote tps 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
