### PR TITLE
Configure hashes per tick

### DIFF
--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -8,7 +8,7 @@ use {
 pub struct Poh {
     pub hash: Hash,
     num_hashes: u64,
-    hashes_per_tick: u64,
+    pub hashes_per_tick: u64,
     remaining_hashes: u64,
     tick_number: u64,
     slot_start_time: Instant,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -225,7 +225,6 @@ pub struct PohRecorder {
     id: Pubkey,
     blockstore: Arc<Blockstore>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
-    poh_config: PohConfig,
     ticks_per_slot: u64,
     target_ns_per_tick: u64,
     record_lock_contention_us: u64,
@@ -460,13 +459,11 @@ impl PohRecorder {
             ))
     }
 
-    // synchronize PoH with a bank
-    pub fn reset(&mut self, reset_bank: Arc<Bank>, next_leader_slot: Option<(Slot, Slot)>) {
-        self.clear_bank();
+    fn reset_poh(&mut self, reset_bank: Arc<Bank>, reset_start_bank: bool) {
         let blockhash = reset_bank.last_blockhash();
         let poh_hash = {
             let mut poh = self.poh.lock().unwrap();
-            poh.reset(blockhash, self.poh_config.hashes_per_tick);
+            poh.reset(blockhash, *reset_bank.hashes_per_tick());
             poh.hash
         };
         info!(
@@ -479,9 +476,17 @@ impl PohRecorder {
         );
 
         self.tick_cache = vec![];
-        self.start_bank = reset_bank;
+        if reset_start_bank {
+            self.start_bank = reset_bank;
+        }
         self.tick_height = (self.start_slot() + 1) * self.ticks_per_slot;
         self.start_tick_height = self.tick_height + 1;
+    }
+
+    // synchronize PoH with a bank
+    pub fn reset(&mut self, reset_bank: Arc<Bank>, next_leader_slot: Option<(Slot, Slot)>) {
+        self.clear_bank();
+        self.reset_poh(reset_bank, true);
 
         if let Some(ref sender) = self.poh_timing_point_sender {
             // start_slot() is the parent slot. current slot is start_slot() + 1.
@@ -513,6 +518,17 @@ impl PohRecorder {
         };
         trace!("new working bank");
         assert_eq!(working_bank.bank.ticks_per_slot(), self.ticks_per_slot());
+        if let Some(hashes_per_tick) = *working_bank.bank.hashes_per_tick() {
+            if self.poh.lock().unwrap().hashes_per_tick != hashes_per_tick {
+                // Reset poh when changing hashes per tick so that we ensure all ticks
+                // for this slot are created with the proper hashes per tick
+                info!(
+                    "resetting poh due to hashes per tick change detected at {}",
+                    working_bank.bank.slot()
+                );
+                self.reset_poh(working_bank.clone().bank, false);
+            }
+        }
         self.working_bank = Some(working_bank);
 
         // send poh slot start timing point
@@ -865,7 +881,6 @@ impl PohRecorder {
                 leader_schedule_cache: leader_schedule_cache.clone(),
                 ticks_per_slot,
                 target_ns_per_tick,
-                poh_config: poh_config.clone(),
                 record_lock_contention_us: 0,
                 flush_cache_tick_us: 0,
                 flush_cache_no_tick_us: 0,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -554,6 +554,10 @@ pub mod enable_program_redeployment_cooldown {
     solana_sdk::declare_id!("J4HFT8usBxpcF63y46t1upYobJgChmKyZPm5uTBRg25Z");
 }
 
+pub mod configurable_hashes_per_tick {
+    solana_sdk::declare_id!("3uFHb9oKdGfgZGJK9EHaAXN4USvnQtAFC13Fh5gGFS5B");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -687,6 +691,7 @@ lazy_static! {
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
         (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
         (enable_program_redeployment_cooldown::id(), "enable program redeployment cooldown #29135"),
+        (configurable_hashes_per_tick::id(), "Configure desired hashes per tick to update on epoch boundary"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
There currently  exists no mechanism for being able to change the number of hashes per tick. This is necessary as hashing times become faster in order to maintain 400ms slot times without large sleep times.

See [Fast PoH](https://github.com/solana-labs/solana/security/advisories/GHSA-c6rv-5hg8-26v7)

#### Summary of Changes
1. Add new feature to control updating hashes per tick on epoch boundary
2. Add framework for force enabling this feature for testing
3. When synchronizing PoH with a bank, update hashes per tick from the bank value
4. Reset PoH from `set_bank` when a new `hashes_per_tick` value is detected

Note 4 above is the key change that gets things working. With naive implementation, we see PoH continue building up tick entries with old ticks_per_slot, and once the bank with updated ticks_per_slot gets assigned, it sends these old entries associated with the new bank and Blockstore barfs. We need to kill these old tick entries and restart with updated `hashes_per_tick`

Testing these changes is difficult as we need to coerce a hashes per tick change to agitate things. The following testing has been performed on top of the normal buildkite stuff:
* Set ClusterConfig's `poh_config.hashes_per_tick` to 500 (so that we will actually hash to tick), force `apply_updated_hashes_per_tick` to execute on every epoch boundary, and run local_cluster, poh, runtime, and core cargo tests. Note: through logging it was confirmed that we reset PoH from 500 to 12500 hashes per tick on epoch boundary and all entries sent to replay/other validators were aligned with `bank.hashes_per_tick`
* New unit test added, `test_feature_activation_idempotent` ensures repeated calls to `apply_feature_activations` will not cause issues
* Run validator on MNB with these changes (feature not activated, `DEFAULT_HASHES_PER_SECOND` unchanged)
* Run validator on MNB with these changes (feature not activated, `DEFAULT_HASHES_PER_SECOND` increased)