### PR TITLE
Elides unnecessary lifetimes

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -100,7 +100,7 @@ impl Default for Config {
 }
 
 /// Defines and builds the CLI args for a run of the benchmark
-pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
+pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
     App::new(crate_name!()).about(crate_description!())
         .version(version)
         .arg({

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -339,11 +339,11 @@ impl UnprocessedTransactionStorage {
     /// of the unprocessed packets that are eligible for retry. A return value of None means that
     /// all packets are unprocessed and eligible for retry.
     #[must_use]
-    pub fn process_packets<'a, F>(
+    pub fn process_packets<F>(
         &mut self,
         bank: Arc<Bank>,
         banking_stage_stats: &BankingStageStats,
-        slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
         processing_function: F,
     ) -> bool
     where
@@ -430,11 +430,11 @@ impl VoteStorage {
     }
 
     // returns `true` if the end of slot is reached
-    fn process_packets<'a, F>(
+    fn process_packets<F>(
         &mut self,
         bank: Arc<Bank>,
         banking_stage_stats: &BankingStageStats,
-        slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
         mut processing_function: F,
     ) -> bool
     where
@@ -865,11 +865,11 @@ impl ThreadLocalUnprocessedPackets {
     }
 
     // returns `true` if reached end of slot
-    fn process_packets<'a, F>(
+    fn process_packets<F>(
         &mut self,
         bank: &Bank,
         banking_stage_stats: &BankingStageStats,
-        slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
         mut processing_function: F,
     ) -> bool
     where

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -257,7 +257,7 @@ pub fn download_genesis_if_missing(
 
 /// Download a snapshot archive from `rpc_addr`.  Use `snapshot_type` to specify downloading either
 /// a full snapshot or an incremental snapshot.
-pub fn download_snapshot_archive<'a, 'b>(
+pub fn download_snapshot_archive(
     rpc_addr: &SocketAddr,
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
@@ -266,7 +266,7 @@ pub fn download_snapshot_archive<'a, 'b>(
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,
     use_progress_bar: bool,
-    progress_notify_callback: &'a mut DownloadProgressCallbackOption<'b>,
+    progress_notify_callback: &mut DownloadProgressCallbackOption<'_>,
 ) -> Result<(), String> {
     snapshot_utils::purge_old_snapshot_archives(
         full_snapshot_archives_dir,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -928,8 +928,8 @@ impl PohRecorder {
 
     // Filters the return result of PohRecorder::bank_start(), returns the bank
     // if it's still processing transactions
-    pub fn get_working_bank_if_not_expired<'a, 'b>(
-        bank_start: &'b Option<&'a BankStart>,
+    pub fn get_working_bank_if_not_expired<'a>(
+        bank_start: &Option<&'a BankStart>,
     ) -> Option<&'a Arc<Bank>> {
         bank_start
             .as_ref()

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1409,12 +1409,12 @@ impl Accounts {
     }
 }
 
-fn prepare_if_nonce_account<'a>(
+fn prepare_if_nonce_account(
     address: &Pubkey,
     account: &mut AccountSharedData,
     execution_result: &Result<()>,
     is_fee_payer: bool,
-    maybe_nonce: Option<(&'a NonceFull, bool)>,
+    maybe_nonce: Option<(&NonceFull, bool)>,
     &durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
 ) -> bool {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8642,9 +8642,9 @@ impl AccountsDb {
         })
     }
 
-    fn generate_index_for_slot<'a>(
+    fn generate_index_for_slot(
         &self,
-        accounts_map: GenerateIndexAccountsMap<'a>,
+        accounts_map: GenerateIndexAccountsMap<'_>,
         slot: &Slot,
         rent_collector: &RentCollector,
     ) -> SlotIndexGenerationInfo {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1694,8 +1694,8 @@ impl<T: IndexValue> AccountsIndex<T> {
         })
     }
 
-    fn purge_secondary_indexes_by_inner_key<'a>(
-        &'a self,
+    fn purge_secondary_indexes_by_inner_key(
+        &self,
         inner_key: &Pubkey,
         account_indexes: &AccountSecondaryIndexes,
     ) {

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -153,8 +153,8 @@ pub fn ledger_lockfile(ledger_path: &Path) -> RwLock<File> {
     )
 }
 
-pub fn lock_ledger<'path, 'lock>(
-    ledger_path: &'path Path,
+pub fn lock_ledger<'lock>(
+    ledger_path: &Path,
     ledger_lockfile: &'lock mut RwLock<File>,
 ) -> RwLockWriteGuard<'lock, File> {
     ledger_lockfile.try_write().unwrap_or_else(|_| {


### PR DESCRIPTION
#### Problem

Fixup clippy warnings to upgrade to Rust 1.66.0


#### Summary of Changes

Elides unnecessary lifetimes, as recommended by clippy