### PR TITLE
Fixes non-binding `let` on a future (quic-client)

### DIFF
--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -29,7 +29,7 @@ impl TpuConnection for QuicTpuConnection {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
 
-        let _ignored = RUNTIME
+        _ = RUNTIME
             .spawn(async move { send_wire_transaction_async(inner, wire_transaction).await });
         Ok(())
     }
@@ -37,8 +37,7 @@ impl TpuConnection for QuicTpuConnection {
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
-        let _ignored =
-            RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
+        _ = RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
         Ok(())
     }
 }

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -174,7 +174,7 @@ impl TpuConnection for QuicTpuConnection {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
 
-        let _ignored = RUNTIME
+        _ = RUNTIME
             .spawn(async move { send_wire_transaction_async(inner, wire_transaction).await });
         Ok(())
     }
@@ -182,8 +182,7 @@ impl TpuConnection for QuicTpuConnection {
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
-        let _ignored =
-            RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
+        _ = RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem

Fixup clippy warnings to upgrade to Rust 1.66.0

```
error: non-binding `let` on a future
  --> client/src/quic_client.rs:40:9
   |
40 | /         let _ =
41 | |             RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
   | |__________________________________________________________________________________________________^
   |
   = help: consider awaiting the future or dropping explicitly with `std::mem::drop`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_future
```


#### Summary of Changes

Explicitly ignore the return value.