### PR TITLE
Fixes non-binding `let` on a future (ip-echo-server)

### DIFF
--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -130,7 +130,7 @@ async fn process_connection(
             .await??;
 
             debug!("Connection established to tcp/{}", *tcp_port);
-            let _ = tcp_stream.shutdown();
+            let _ = tcp_stream.shutdown().await;
         }
     }
     let response = IpEchoServerResponse {

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -130,7 +130,7 @@ async fn process_connection(
             .await??;
 
             debug!("Connection established to tcp/{}", *tcp_port);
-            _ = tcp_stream.shutdown().await;
+            tcp_stream.shutdown().await?;
         }
     }
     let response = IpEchoServerResponse {

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -130,7 +130,7 @@ async fn process_connection(
             .await??;
 
             debug!("Connection established to tcp/{}", *tcp_port);
-            let _ = tcp_stream.shutdown().await;
+            _ = tcp_stream.shutdown().await;
         }
     }
     let response = IpEchoServerResponse {


### PR DESCRIPTION
#### Problem

Fixup clippy warnings to upgrade to Rust 1.66.0


```
warning: non-binding `let` on a future
   --> net-utils/src/ip_echo_server.rs:133:13
    |
133 |             let _ = tcp_stream.shutdown();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider awaiting the future or dropping explicitly with `std::mem::drop`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_future
    = note: `-D clippy::let-underscore-future` implied by `-D warnings`
```


#### Summary of Changes

Await the shutdown.