### PR TITLE
Explorer: account does not exist

### DIFF
--- a/explorer/src/components/account/UnknownAccountCard.tsx
+++ b/explorer/src/components/account/UnknownAccountCard.tsx
@@ -35,7 +35,7 @@ export function UnknownAccountCard({ account }: { account: Account }) {
           <td>Balance (SOL)</td>
           <td className="text-lg-end">
             {account.lamports === 0 ? (
-              "No longer exists on chain"
+              "Account does not exist"
             ) : (
               <SolBalance lamports={account.lamports} />
             )}


### PR DESCRIPTION
#### Problem

Previous description for UnknownAccountCard was misleading

#### Summary of Changes

Change description to "Account does not exist" which makes it more clear that an account may never have actually "existed" on chain. Previous description implied that non-existent accounts existed previously

Fixes #28273
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
