### PR TITLE
prioritize repairs for validator's own slots

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -196,6 +196,7 @@ impl Tvu {
                 repair_whitelist: tvu_config.repair_whitelist,
                 cluster_info: cluster_info.clone(),
                 cluster_slots: cluster_slots.clone(),
+                leader_schedule_cache: leader_schedule_cache.clone(),
             };
             WindowService::new(
                 blockstore.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -876,6 +876,7 @@ impl Validator {
             cluster_info.clone(),
             bank_forks.clone(),
             config.repair_whitelist.clone(),
+            leader_schedule_cache.clone(),
         );
         let serve_repair_service = ServeRepairService::new(
             serve_repair,


### PR DESCRIPTION
#### Problem
Repair request processing is rate limited by load shedding excess requests prior to processing. Repair requests for the validator's own leader slots should be prioritized.

#### Summary of Changes
For slots for which the validator was the slot leader prioritize these requests by doubling the effective stake of the requesting node. The effective stake of the requesting node is used to prioritize requests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
