### PR TITLE
fix: make toBytes actually return the type it's typehint claims

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -112,7 +112,8 @@ export class PublicKey extends Struct {
    * Return the byte array representation of the public key in big endian
    */
   toBytes(): Uint8Array {
-    return this.toBuffer();
+    const buf = this.toBuffer();
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
 
   /**


### PR DESCRIPTION
#### Problem
toBytes claims to return a Uint8Array when in reality it returns a Buffer. This isn't a huge problem as in 99.9% of cases these two work just as well for the caller, but causes issues in some edge cases (e.g. toString() on a Uint8Array and on a Buffer over the same bytes returns different strings). It's also a code smell, due to making this method fully redundant to the toBuffer() method in addition to its typehint not returning *exactly* what it says it should.


#### Summary of Changes
Actually convert the buffer to a Uint8Array
