### PR TITLE
Increase ws thread stack size

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -633,9 +633,11 @@ impl RpcSubscriptions {
                 Builder::new()
                     .name("solRpcNotifier".to_string())
                     .spawn(move || {
+                        const RPC_NOTIFICATION_STACK_SIZE: usize = 8 * 1024 * 1024;
                         let pool = rayon::ThreadPoolBuilder::new()
                             .num_threads(notification_threads)
                             .thread_name(|i| format!("solRpcNotify{i:02}"))
+                            .stack_size(RPC_NOTIFICATION_STACK_SIZE)
                             .build()
                             .unwrap();
                         pool.install(|| {


### PR DESCRIPTION
#### Problem
As described in #29032, the websocket notification threads have the default stack size set currently. This leads to a stack overflow if a RPC node has too many websocket connections or if a websocket connection receives a large notification. We bumped this up to 8mb and we have not seen the same stack overflow that was occurring on various clusters around every 2 hours before this patch was made.

This was not scientifically done. I'd recommend someone from the core team investigate this issue further to figure out the optimal stack size for websocket threads. Unfortunately, we were not provided with enough instructions or guidance to dig into this issue further. It's very apparent that it's either too many websocket connections OR there's some things you can subscribe to on mainnet-beta that will lead to a websocket notification larger than 2mb.

#### Summary of Changes
- Specify a `stack_size` of 8mb for `solRpcNotifier` threads

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
