### PR TITLE
take rust version from toolchain file

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -10,7 +10,7 @@ if [[ -n $APPVEYOR ]]; then
 
   appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   export USERPROFILE="D:\\"
-  ./rustup-init -yv --default-toolchain $rust_stable --default-host x86_64-pc-windows-msvc
+  ./rustup-init -yv --default-toolchain "$rust_stable" --default-host x86_64-pc-windows-msvc
   export PATH="$PATH:/d/.cargo/bin"
   rustc -vV
   cargo -vV

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,12 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.65.0
+  # read rust version from rust-toolchain.toml file
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  # pacify shellcheck: cannot follow dynamic path
+  # shellcheck disable=SC1090,SC1091
+  source "$base/../scripts/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.65.0"


### PR DESCRIPTION
#### Problem

Spin off PR for https://github.com/solana-labs/solana/pull/27018

#### Summary of Changes

* Introduce `rust-toolchain.toml` file
* Use version specified in this file instead of specifying one in `ci/rust-version.sh`
