### PR TITLE
Add Poseidon syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926696e3091580355cadb023fffd24999ccce2ed88302d01b411bf42023b6b7b"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "thiserror",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5984,6 +5995,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libsecp256k1",
+ "light-poseidon",
  "log",
  "memoffset",
  "num-derive",

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -136,6 +136,8 @@ pub struct ComputeBudget {
     /// + alt_bn128_pairing_one_pair_cost_other * (num_elems - 1)
     pub alt_bn128_pairing_one_pair_cost_first: u64,
     pub alt_bn128_pairing_one_pair_cost_other: u64,
+    /// Number of compute units consumed to calculate a Poseidon hash
+    pub poseidon_cost: u64,
 }
 
 impl Default for ComputeBudget {
@@ -184,6 +186,7 @@ impl ComputeBudget {
             alt_bn128_multiplication_cost: 3_840,
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
+            poseidon_cost: 666,
         }
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2411,6 +2411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926696e3091580355cadb023fffd24999ccce2ed88302d01b411bf42023b6b7b"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "thiserror",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,6 +4994,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libsecp256k1 0.6.0",
+ "light-poseidon",
  "log",
  "memoffset",
  "num-derive",
@@ -5554,6 +5566,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
+version = "1.15.0"
+dependencies = [
+ "solana-program 1.15.0",
+]
+
+[[package]]
+name = "solana-sbf-rust-poseidon"
 version = "1.15.0"
 dependencies = [
  "solana-program 1.15.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "rust/panic",
     "rust/param_passing",
     "rust/param_passing_dep",
+    "rust/poseidon",
     "rust/rand",
     "rust/realloc",
     "rust/realloc_invoke",

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-sbf-rust-poseidon"
+version = "1.15.0"
+description = "Solana SBF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-sbf-rust-poseidon"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.15.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/poseidon/src/lib.rs
+++ b/programs/sbf/rust/poseidon/src/lib.rs
@@ -1,0 +1,48 @@
+//! Example SBF program using Poseidon syscall
+
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    msg,
+    poseidon::{prelude::poseidon_hash, PoseidonSyscallError},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+fn test_poseidon_hash() -> Result<(), PoseidonSyscallError> {
+    let input1 = [1u8; 32];
+    let input2 = [2u8; 32];
+
+    let hash = poseidon_hash(&[&input1, &input2])?;
+
+    assert_eq!(
+        hash.to_bytes(),
+        [
+            40, 7, 251, 60, 51, 30, 115, 141, 251, 200, 13, 46, 134, 91, 113, 170, 131, 90, 53,
+            175, 9, 61, 242, 164, 127, 33, 249, 65, 253, 131, 35, 116
+        ]
+    );
+
+    Ok(())
+}
+
+solana_program::entrypoint!(process_instruction);
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("poseidon_hash");
+
+    test_poseidon_hash().map_err(|e| ProgramError::from(u64::from(e)))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_poseidon_hash() {
+        super::test_poseidon_hash().unwrap();
+    }
+}

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -47,6 +47,7 @@ curve25519-dalek = { version = "3.2.1", features = ["serde"] }
 itertools = "0.10.1"
 libc = { version = "0.2.126", features = ["extra_traits"] }
 libsecp256k1 = "0.6.0"
+light-poseidon = "0.0.2"
 rand = "0.7"
 rand_chacha = { version = "0.2.2", default-features = true, features = ["simd", "std"] }
 tiny-bip39 = "0.8.2"

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -503,6 +503,7 @@ pub mod log;
 pub mod message;
 pub mod native_token;
 pub mod nonce;
+pub mod poseidon;
 pub mod program;
 pub mod program_error;
 pub mod program_memory;

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -1,0 +1,166 @@
+pub mod prelude {
+    pub use super::{consts::*, target_arch::*};
+}
+
+use {consts::*, thiserror::Error};
+
+mod consts {
+    pub const POSEIDON_HASH_BYTES: usize = 32;
+}
+
+#[derive(Error, Debug)]
+pub enum PoseidonSyscallError {
+    #[error("Failed to compute the Poseidon hash")]
+    Poseidon,
+    #[error("Failed to convert a vector of bytes into an array")]
+    VecToArray,
+    #[error("Unexpected error")]
+    Unexpected,
+}
+
+impl From<u64> for PoseidonSyscallError {
+    fn from(error: u64) -> Self {
+        match error {
+            1 => PoseidonSyscallError::Poseidon,
+            2 => PoseidonSyscallError::VecToArray,
+            _ => PoseidonSyscallError::Unexpected,
+        }
+    }
+}
+
+impl From<PoseidonSyscallError> for u64 {
+    fn from(error: PoseidonSyscallError) -> Self {
+        match error {
+            PoseidonSyscallError::Poseidon => 1,
+            PoseidonSyscallError::VecToArray => 2,
+            PoseidonSyscallError::Unexpected => 3,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct PoseidonHash(pub [u8; POSEIDON_HASH_BYTES]);
+
+impl PoseidonHash {
+    pub fn new(hash_array: [u8; POSEIDON_HASH_BYTES]) -> Self {
+        Self(hash_array)
+    }
+
+    pub fn to_bytes(&self) -> [u8; POSEIDON_HASH_BYTES] {
+        self.0
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+mod target_arch {
+    use super::*;
+    use ark_bn254::fq::Fq;
+    use ark_ff::{BigInteger, PrimeField};
+    use light_poseidon::{parameters::bn254_x5_3::poseidon_parameters, PoseidonHasher};
+
+    pub fn poseidon_hash(vals: &[&[u8]]) -> Result<PoseidonHash, PoseidonSyscallError> {
+        let params = poseidon_parameters();
+        let mut poseidon = PoseidonHasher::<Fq>::new(params);
+
+        let mut inputs = Vec::with_capacity(vals.len());
+        for val in vals {
+            inputs.push(Fq::from_be_bytes_mod_order(&val));
+        }
+
+        let res = poseidon
+            .hash(&inputs)
+            .map_err(|_| PoseidonSyscallError::Poseidon)?
+            .into_repr()
+            .to_bytes_be();
+
+        Ok(PoseidonHash(
+            res.try_into()
+                .map_err(|_| PoseidonSyscallError::VecToArray)?,
+        ))
+    }
+}
+
+#[cfg(target_os = "solana")]
+mod target_arch {
+    use super::*;
+
+    pub fn poseidon_hash(vals: &[&[u8]]) -> Result<PoseidonHash, PoseidonSyscallError> {
+        let mut hash_result = [0; POSEIDON_HASH_BYTES];
+        let result = unsafe {
+            crate::syscalls::sol_poseidon(
+                vals as *const _ as *const u8,
+                vals.len() as u64,
+                &mut hash_result as *mut _ as *mut u8,
+            )
+        };
+
+        match result {
+            0 => Ok(PoseidonHash::new(hash_result)),
+            e => Err(PoseidonSyscallError::from(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prelude::*;
+
+    #[test]
+    fn test_poseidon_input_ones_twos() {
+        let input1 = [1u8; 32];
+        let input2 = [2u8; 32];
+
+        let hash = poseidon_hash(&[&input1, &input2]).expect("Failed to compute the Poseidon hash");
+        assert_eq!(
+            hash.to_bytes(),
+            [
+                40, 7, 251, 60, 51, 30, 115, 141, 251, 200, 13, 46, 134, 91, 113, 170, 131, 90, 53,
+                175, 9, 61, 242, 164, 127, 33, 249, 65, 253, 131, 35, 116
+            ]
+        );
+    }
+
+    #[test]
+    fn test_poseidon_input_one_two() {
+        let input1 = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ];
+        let input2 = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 2,
+        ];
+
+        let hash = poseidon_hash(&[&input1, &input2]).expect("Failed to compute the Poseidon hash");
+        assert_eq!(
+            hash.to_bytes(),
+            [
+                25, 11, 182, 121, 54, 48, 205, 9, 39, 164, 111, 44, 108, 203, 20, 95, 112, 101, 97,
+                130, 151, 54, 169, 215, 37, 104, 12, 83, 176, 236, 253, 54
+            ]
+        );
+    }
+
+    #[test]
+    fn test_poseidon_input_random() {
+        let input1 = [
+            0x06, 0x9c, 0x63, 0x81, 0xac, 0x0b, 0x96, 0x8e, 0x88, 0x1c, 0x91, 0x3c, 0x17, 0xd8,
+            0x36, 0x06, 0x7f, 0xd1, 0x5f, 0x2c, 0xc7, 0x9f, 0x90, 0x2c, 0x80, 0x70, 0xb3, 0x6d,
+            0x28, 0x66, 0x17, 0xdd,
+        ];
+        let input2 = [
+            0xc3, 0x3b, 0x60, 0x04, 0x2f, 0x76, 0xc7, 0xfb, 0xd0, 0x5d, 0xb7, 0x76, 0x23, 0xcb,
+            0x17, 0xb8, 0x1d, 0x49, 0x41, 0x4b, 0x82, 0xe5, 0x6a, 0x2e, 0xc0, 0x18, 0xf7, 0xa5,
+            0x5c, 0x3f, 0x30, 0x0b,
+        ];
+
+        let hash = poseidon_hash(&[&input1, &input2]).expect("Failed to compute the Poseidon hash");
+        assert_eq!(
+            hash.to_bytes(),
+            [
+                43, 94, 133, 6, 86, 161, 42, 237, 224, 252, 105, 131, 134, 176, 141, 84, 159, 162,
+                172, 12, 155, 131, 123, 94, 218, 217, 178, 239, 100, 87, 4, 238
+            ]
+        )
+    }
+}

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -66,6 +66,7 @@ define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_a
 define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
 define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_poseidon(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/sbf/c/inc/sol/inc/poseidon.inc
+++ b/sdk/sbf/c/inc/sol/inc/poseidon.inc
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @brief Solana poseidon system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Poseidon hash result
+ */
+#define POSEIDON_RESULT_LENGTH 32
+
+/**
+ * Poseidon
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+@SYSCALL uint64_t sol_poseidon(const SolBytes *, int, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/sdk/sbf/c/inc/sol/poseidon.h
+++ b/sdk/sbf/c/inc/sol/poseidon.h
@@ -1,0 +1,39 @@
+#pragma once
+/**
+ * @brief Solana poseidon system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Poseidon hash result
+ */
+#define POSEIDON_RESULT_LENGTH 32
+
+/**
+ * Poseidon
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE sdk/sbf/c/inc/sol/inc/poseidon.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBFV2
+uint64_t sol_poseidon(const SolBytes *, int, uint8_t *);
+#else
+typedef uint64_t(*sol_poseidon_pointer_type)(const SolBytes *, int, uint8_t *);
+static uint64_t sol_poseidon(const SolBytes * arg1, int arg2, uint8_t * arg3) {
+  sol_poseidon_pointer_type sol_poseidon_pointer = (sol_poseidon_pointer_type) 3298065441;
+  return sol_poseidon_pointer(arg1, arg2, arg3);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -570,6 +570,10 @@ pub mod disable_turbine_fanout_experiments {
     solana_sdk::declare_id!("Gz1aLrbeQ4Q6PTSafCZcGWZXz91yVRi7ASFzFEr1U4sa");
 }
 
+pub mod enable_poseidon_syscall {
+    solana_sdk::declare_id!("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXPSDN");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -707,6 +711,7 @@ lazy_static! {
         (commission_updates_only_allowed_in_first_half_of_epoch::id(), "validator commission updates are only allowed in the first half of an epoch #29362"),
         (enable_turbine_fanout_experiments::id(), "enable turbine fanout experiments #29393"),
         (disable_turbine_fanout_experiments::id(), "disable turbine fanout experiments #29393"),
+        (enable_poseidon_syscall::id(), "add poseidon hash syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -48,10 +48,10 @@ pub use solana_program::{
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
     decode_error, ed25519_program, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator,
     instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction, message,
-    msg, native_token, nonce, program, program_error, program_memory, program_option, program_pack,
-    rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serialize_utils, short_vec,
-    slot_hashes, slot_history, stake, stake_history, syscalls, system_instruction, system_program,
-    sysvar, unchecked_div_by_const, vote, wasm_bindgen,
+    msg, native_token, nonce, poseidon, program, program_error, program_memory, program_option,
+    program_pack, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serialize_utils,
+    short_vec, slot_hashes, slot_history, stake, stake_history, syscalls, system_instruction,
+    system_program, sysvar, unchecked_div_by_const, vote, wasm_bindgen,
 };
 
 pub mod account;


### PR DESCRIPTION
#### Problem

Computing [Poseidon](https://eprint.iacr.org/2019/458) hashes is too expensive to be done in a Solana program in one transaction.

#### Summary of Changes

This change introduces the `sol_poseidon` syscall which takes two byte sequences as an input and then calculates a Poseidon hash using a BN254 curve and the following Poseidon parameters:

* x^5 S-boxes
* 3 prime fields (one zero prime field and two inputs from the caller)
* 8 full rounds and 57 partial rounds

[light-poseidon](https://crates.io/crates/light-poseidon) crate is used here. It has the following benchmark result for calculating a Poseidon hash:

```
poseidon_bn254_x5_3     time:   [21.980 µs 21.997 µs 22.017 µs]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```

Proposed pricing based on 33ns execution per CU:

21997 ns / 33 (ns per CU) = 666 CU

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
