### PR TITLE
remove metrics from prior to rent_epoch feature activation

### DIFF
--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,15 +1,12 @@
 //! calculate and collect rent from Accounts
-use {
-    log::*,
-    solana_sdk::{
-        account::{AccountSharedData, ReadableAccount, WritableAccount},
-        clock::Epoch,
-        epoch_schedule::EpochSchedule,
-        genesis_config::GenesisConfig,
-        incinerator,
-        pubkey::Pubkey,
-        rent::{Rent, RentDue},
-    },
+use solana_sdk::{
+    account::{AccountSharedData, ReadableAccount, WritableAccount},
+    clock::Epoch,
+    epoch_schedule::EpochSchedule,
+    genesis_config::GenesisConfig,
+    incinerator,
+    pubkey::Pubkey,
+    rent::{Rent, RentDue},
 };
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, AbiExample)]
@@ -101,19 +98,6 @@ impl RentCollector {
 
             // we know this account is not exempt
             let due = self.rent.due_amount(account.data().len(), years_elapsed);
-
-            // we expect rent_epoch to always be one of: {0, self.epoch-1, self.epoch, self.epoch+1}
-            if account_rent_epoch != 0
-                && (account_rent_epoch + 1 < self.epoch || account_rent_epoch > self.epoch + 1)
-            {
-                // this should not occur in a running validator
-                if due == 0 {
-                    inc_new_counter_info!("rent-collector-rent-epoch-range-large-exempt", 1);
-                } else {
-                    inc_new_counter_info!("rent-collector-rent-epoch-range-large-paying", 1);
-                }
-            }
-
             RentDue::Paying(due)
         }
     }


### PR DESCRIPTION
#### Problem
These metrics pre-dated the feature activation that caused us to stop updating `rent_epoch` for rent exempt accounts.

#### Summary of Changes
Remove the metrics.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
