### PR TITLE
while shrinking, old append vec is held outside of storage.map

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -15,26 +15,51 @@ pub type AccountStorageMap = DashMap<Slot, SlotStores>;
 #[derive(Clone, Default, Debug)]
 pub struct AccountStorage {
     map: AccountStorageMap,
+    /// while shrink is operating on a slot, there can be 2 append vecs active for that slot
+    /// Once the index has been updated to only refer to the new append vec, the single entry for the slot in 'map' can be updated.
+    /// Entries in 'shrink_in_progress_map' can be found by 'get_account_storage_entry'
+    shrink_in_progress_map: DashMap<Slot, Arc<AccountStorageEntry>>,
 }
 
 impl AccountStorage {
     /// Return the append vec in 'slot' and with id='store_id'.
+    /// can look in 'map' and 'shrink_in_progress_map' to find the specified append vec
+    /// when shrinking begins, shrinking_in_progress is called.
+    /// This fn looks in 'map' first, then in 'shrink_in_progress_map' because
+    /// 'shrink_in_progress_map' first inserts the old append vec into 'shrink_in_progress_map'
+    /// and then removes the old append vec from 'map'
+    /// Then, the index is updated for all entries to refer to the new id. Callers to this function
+    /// have to expect to be ready to start over and read the index again if this function returns None
+    /// because shrinking may have updated the index between when the caller read the index and found the append vec.
     pub(crate) fn get_account_storage_entry(
         &self,
         slot: Slot,
         store_id: AppendVecId,
     ) -> Option<Arc<AccountStorageEntry>> {
-        self.get_slot_stores(slot)
+        self.get_slot_stores_shrinking_in_progress_ok(slot)
             .and_then(|storage_map| storage_map.read().unwrap().get(&store_id).cloned())
+            .or_else(|| {
+                self.shrink_in_progress_map
+                    .get(&slot)
+                    .map(|entry| Arc::clone(entry.value()))
+            })
     }
 
+    /// public api, should only be called when shrinking is not in progress
     pub fn get_slot_stores(&self, slot: Slot) -> Option<SlotStores> {
+        assert!(self.shrink_in_progress_map.is_empty());
+        self.get_slot_stores_shrinking_in_progress_ok(slot)
+    }
+
+    /// safe to call while shrinking is in progress
+    fn get_slot_stores_shrinking_in_progress_ok(&self, slot: Slot) -> Option<SlotStores> {
         self.map.get(&slot).map(|result| result.value().clone())
     }
 
     /// return the append vec for 'slot' if it exists
     /// This is only ever called when shrink is not possibly running and there is a max of 1 append vec per slot.
     pub(crate) fn get_slot_storage_entry(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.get_slot_stores(slot).and_then(|res| {
             let read = res.read().unwrap();
             assert!(read.len() <= 1);
@@ -43,12 +68,14 @@ impl AccountStorage {
     }
 
     pub(crate) fn all_slots(&self) -> Vec<Slot> {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.map.iter().map(|iter_item| *iter_item.key()).collect()
     }
 
     /// returns true if there is an entry in the map for 'slot', but it contains no append vec
     #[cfg(test)]
     pub(crate) fn is_empty_entry(&self, slot: Slot) -> bool {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.get_slot_stores(slot)
             .map(|storages| storages.read().unwrap().is_empty())
             .unwrap_or(false)
@@ -57,21 +84,25 @@ impl AccountStorage {
     /// initialize the storage map to 'all_storages'
     pub(crate) fn initialize(&mut self, all_storages: AccountStorageMap) {
         assert!(self.map.is_empty());
+        assert!(self.shrink_in_progress_map.is_empty());
         self.map.extend(all_storages.into_iter())
     }
 
     /// remove all append vecs at 'slot'
     /// returns the current contents
     pub(crate) fn remove(&self, slot: &Slot) -> Option<(Slot, SlotStores)> {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.map.remove(slot)
     }
 
     /// iterate through all (slot, append-vecs)
     pub(crate) fn iter(&self) -> dashmap::iter::Iter<Slot, SlotStores> {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.map.iter()
     }
 
     pub(crate) fn insert(&self, slot: Slot, store: Arc<AccountStorageEntry>) {
+        assert!(self.shrink_in_progress_map.is_empty());
         let slot_storages: SlotStores = self.get_slot_stores(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,
             // which is dropped after this block ends, minimizing time held by the lock.
@@ -91,17 +122,35 @@ impl AccountStorage {
     /// When 'ShrinkInProgress' is dropped by caller, the old store will be removed from the storage map.
     /// Fails if there are no existing stores at the slot.
     /// 'new_store' will be replacing the current store at 'slot' in 'map'
+    /// 1. insert 'shrinking_store' into 'shrink_in_progress_map'
+    /// 2. remove 'shrinking_store' from 'map'
+    /// 3. insert 'new_store' into 'map' (atomic with #2)
+    /// #1 allows tx processing loads to find the item in 'shrink_in_progress_map' even when it is removed from 'map'
+    /// #3 allows tx processing loads to find the item in 'map' after the index is updated and it is now located in 'new_store'
+    /// loading for tx must check
+    /// a. 'map', because it is usually there
+    /// b. 'shrink_in_progress_map' because it may have moved there (#1) before it was removed from 'map' (#3)
+    /// Note that if it fails step a and b, then the retry code in accounts_db will look in the index again and should find the updated index entry to 'new_store'
     pub(crate) fn shrinking_in_progress(
         &self,
         slot: Slot,
         new_store: Arc<AccountStorageEntry>,
     ) -> ShrinkInProgress<'_> {
-        let slot_storages = self.get_slot_stores(slot).unwrap();
+        let slot_storages = self.get_slot_stores_shrinking_in_progress_ok(slot).unwrap();
         let shrinking_store = Arc::clone(slot_storages.read().unwrap().iter().next().unwrap().1);
 
+        let previous_id = shrinking_store.append_vec_id();
         let new_id = new_store.append_vec_id();
+        // 1. insert 'shrinking_store' into 'shrink_in_progress_map'
+        assert!(self
+            .shrink_in_progress_map
+            .insert(slot, Arc::clone(&shrinking_store))
+            .is_none());
+
         let mut storages = slot_storages.write().unwrap();
-        // insert 'new_store' into 'map'
+        // 2. remove 'shrinking_store' from 'map'
+        assert!(storages.remove(&previous_id).is_some());
+        // 3. insert 'new_store' into 'map' (atomic with #2)
         assert!(storages.insert(new_id, Arc::clone(&new_store)).is_none());
 
         ShrinkInProgress {
@@ -112,8 +161,16 @@ impl AccountStorage {
         }
     }
 
+    /// 'id' can now be forgotten from the storage map
+    /// It will have been in 'shrink_in_progress_map'.
+    /// 'id' will have been removed from 'map' in a prior call to 'shrinking_in_progress'
+    fn remove_shrunk_storage(&self, slot: Slot) {
+        assert!(self.shrink_in_progress_map.remove(&slot).is_some());
+    }
+
     #[cfg(test)]
     pub(crate) fn insert_empty_at_slot(&self, slot: Slot) {
+        assert!(self.shrink_in_progress_map.is_empty());
         self.map
             .entry(slot)
             .or_insert(Arc::new(RwLock::new(HashMap::new())));
@@ -139,17 +196,7 @@ pub(crate) struct ShrinkInProgress<'a> {
 /// called when the shrink is no longer in progress. This means we can release the old append vec and update the map of slot -> append vec
 impl<'a> Drop for ShrinkInProgress<'a> {
     fn drop(&mut self) {
-        // the slot must be in the map
-        let slot_storages: SlotStores = self.storage.get_slot_stores(self.slot).unwrap();
-
-        let mut storages = slot_storages.write().unwrap();
-        // the id must be in the hashmap
-        assert!(
-            storages.remove(&self.old_store.append_vec_id()).is_some(),
-            "slot: {}, len: {}",
-            self.slot,
-            storages.len()
-        );
+        self.storage.remove_shrunk_storage(self.slot);
     }
 }
 

--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -28,9 +28,12 @@ impl AccountStorage {
     /// This fn looks in 'map' first, then in 'shrink_in_progress_map' because
     /// 'shrink_in_progress_map' first inserts the old append vec into 'shrink_in_progress_map'
     /// and then removes the old append vec from 'map'
-    /// Then, the index is updated for all entries to refer to the new id. Callers to this function
-    /// have to expect to be ready to start over and read the index again if this function returns None
-    /// because shrinking may have updated the index between when the caller read the index and found the append vec.
+    /// Then, the index is updated for all entries to refer to the new id.
+    /// Callers to this function have 2 choices:
+    /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be changed prior to or during this call. (scans do this)
+    /// 2. expect to be ready to start over and read the index again if this function returns None
+    /// Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
+    /// load from the append vec specified in the index.
     pub(crate) fn get_account_storage_entry(
         &self,
         slot: Slot,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3967,8 +3967,7 @@ impl AccountsDb {
 
         if let Some(shrink_in_progress) = shrink_in_progress {
             // shrink is in progress, so 1 new append vec to keep, 1 old one to throw away
-            let store = shrink_in_progress.old_storage();
-            not_retaining_store(store);
+            not_retaining_store(shrink_in_progress.old_storage());
             // dropping 'shrink_in_progress' removes the old append vec that was being shrunk from db's storage
         } else if let Some(slot_stores) = self.storage.get_slot_stores(slot) {
             // no shrink in progress, so all append vecs in this slot are dead

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4033,7 +4033,10 @@ impl AccountsDb {
     fn shrink_slot_forced(&self, slot: Slot) -> usize {
         debug!("shrink_slot_forced: slot: {}", slot);
 
-        if let Some(store) = self.storage.get_slot_storage_entry(slot) {
+        if let Some(store) = self
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+        {
             if !Self::is_shrinking_productive(slot, &store) {
                 return 0;
             }
@@ -8398,7 +8401,10 @@ impl AccountsDb {
         self.accounts_cache.add_root(slot);
         cache_time.stop();
         let mut store_time = Measure::start("store_add_root");
-        if let Some(slot_stores) = self.storage.get_slot_stores(slot) {
+        // We would not expect this slot to be shrinking right now.
+        // But, even if it was, we would just mark a store id as dirty unnecessarily and that is ok.
+        // So, allow shrinking to be in progress.
+        if let Some(slot_stores) = self.storage.get_slot_stores_shrinking_in_progress_ok(slot) {
             for (store_id, store) in slot_stores.read().unwrap().iter() {
                 self.dirty_stores.insert((slot, *store_id), store.clone());
             }


### PR DESCRIPTION
#### Problem
Moving towards 1 append vec per slot. While shrinking is in progress, there need to be 2 findable append vecs. But, we want the data structures to be optimized for holding only 1 entry per slot.

#### Summary of Changes
Introduce `shrink_in_progress_map` to hold the append vec being shrunk while the index is being updated to the new, shrunk append vec. This allows the entry in the main `map` to not need to be a `Vec`, allowing us to move to a state where only a single entry per slot is possible in `map`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
