### PR TITLE
parallel repair request decode

### DIFF
--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -1,6 +1,7 @@
 //! The `result` module exposes a Result type that propagates one of many different Error types.
 
 use {
+    crate::serve_repair::RepairVerifyError,
     solana_gossip::{cluster_info, gossip_error::GossipError},
     solana_ledger::blockstore,
     thiserror::Error,
@@ -30,6 +31,8 @@ pub enum Error {
     Serialize(#[from] std::boxed::Box<bincode::ErrorKind>),
     #[error(transparent)]
     WeightedIndex(#[from] rand::distributions::weighted::WeightedError),
+    #[error(transparent)]
+    RepairVerify(#[from] RepairVerifyError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
#### Problem
repair request decode is single threaded. parallel decode can allow for more speculative decode before load shedding.

#### Summary of Changes
parallelize decode before stake/whitelist based prioritization.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
