### PR TITLE
Actually fixes non-binding `let` on a future (quic-client)

### DIFF
--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -29,7 +29,7 @@ impl TpuConnection for QuicTpuConnection {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
 
-        _ = RUNTIME
+        let _handle = RUNTIME
             .spawn(async move { send_wire_transaction_async(inner, wire_transaction).await });
         Ok(())
     }
@@ -37,7 +37,8 @@ impl TpuConnection for QuicTpuConnection {
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
-        _ = RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
+        let _handle =
+            RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
         Ok(())
     }
 }

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -174,7 +174,7 @@ impl TpuConnection for QuicTpuConnection {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
 
-        _ = RUNTIME
+        let _handle = RUNTIME
             .spawn(async move { send_wire_transaction_async(inner, wire_transaction).await });
         Ok(())
     }
@@ -182,7 +182,8 @@ impl TpuConnection for QuicTpuConnection {
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
-        _ = RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
+        let _handle =
+            RUNTIME.spawn(async move { send_wire_transaction_batch_async(inner, buffers).await });
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem

Actually fix the clippy warning from https://github.com/solana-labs/solana/pull/29300

```
error: non-binding `let` on a future
   --> quic-client/src/quic_client.rs:177:9
    |
177 | /         _ = RUNTIME
178 | |             .spawn(async move { send_wire_transaction_async(inner, wire_transaction).await });
    | |_____________________________________________________________________________________________^
    |
    = help: consider awaiting the future or dropping explicitly with `std::mem::drop`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_future
    = note: `-D clippy::let-underscore-future` implied by `-D warnings`
```



#### Summary of Changes

https://github.com/solana-labs/solana/pull/29300#discussion_r1051224491