### PR TITLE
Add metrics for min/max priority fee per slot, and counters for fee/non-fee transactions

### DIFF
--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -50,12 +50,13 @@ impl PrioritizationFeeMetrics {
         // update prioritized transaction fee metrics.
         saturating_add_assign!(self.prioritized_transactions_count, 1);
 
-        self.max_prioritization_fee =
-            self.max_prioritization_fee.max(fee);
+        self.max_prioritization_fee = self.max_prioritization_fee.max(fee);
 
-        self.min_prioritization_fee = self
-            .min_prioritization_fee
-            .map_or(fee, |min_fee| min_fee.min(fee));
+        self.min_prioritization_fee = Some(
+            self.min_prioritization_fee
+                .map_or(fee, |min_fee| min_fee.min(fee)),
+        );
+    }
 
     fn report(&self, slot: Slot) {
         datapoint_info!(

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -53,10 +53,9 @@ impl PrioritizationFeeMetrics {
         self.max_prioritization_fee =
             self.max_prioritization_fee.max(fee);
 
-        if self.min_prioritization_fee.is_none() || fee < self.min_prioritization_fee.unwrap() {
-            self.min_prioritization_fee = Some(fee);
-        }
-    }
+        self.min_prioritization_fee = self
+            .min_prioritization_fee
+            .map_or(fee, |min_fee| min_fee.min(fee));
 
     fn report(&self, slot: Slot) {
         datapoint_info!(

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -16,16 +16,16 @@ struct PrioritizationFeeMetrics {
     // Count of transactions that have non-zero prioritization fee.
     prioritized_transactions_count: u64,
 
-    // Count of transactions that have no prioritization fee.
+    // Count of transactions that have zero prioritization fee.
     non_prioritized_transactions_count: u64,
 
     // Total prioritization fees included in this slot.
     total_prioritization_fee: u64,
 
-    // The minimum prioritization fee in this slot.
+    // The minimum prioritization fee of prioritized transactions in this slot.
     min_prioritization_fee: Option<u64>,
 
-    // The maximum prioritization fee in this slot.
+    // The maximum prioritization fee of prioritized transactions in this slot.
     max_prioritization_fee: u64,
 
     // Accumulated time spent on tracking prioritization fee for each slot.
@@ -44,9 +44,11 @@ impl PrioritizationFeeMetrics {
     fn update_prioritization_fee(&mut self, fee: u64) {
         if fee == 0 {
             saturating_add_assign!(self.non_prioritized_transactions_count, 1);
-        } else {
-            saturating_add_assign!(self.prioritized_transactions_count, 1);
+            return;
         }
+
+        // update prioritized transaction fee metrics.
+        saturating_add_assign!(self.prioritized_transactions_count, 1);
 
         if fee > self.max_prioritization_fee {
             self.max_prioritization_fee = fee;

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -13,8 +13,20 @@ struct PrioritizationFeeMetrics {
     // fee for this slot.
     relevant_writable_accounts_count: u64,
 
+    // Count of transactions that have non-zero prioritization fee.
+    prioritized_transactions_count: u64,
+
+    // Count of transactions that have no prioritization fee.
+    non_prioritized_transactions_count: u64,
+
     // Total prioritization fees included in this slot.
     total_prioritization_fee: u64,
+
+    // The minimum prioritization fee in this slot.
+    min_prioritization_fee: Option<u64>,
+
+    // The maximum prioritization fee in this slot.
+    max_prioritization_fee: u64,
 
     // Accumulated time spent on tracking prioritization fee for each slot.
     total_update_elapsed_us: u64,
@@ -27,6 +39,22 @@ impl PrioritizationFeeMetrics {
 
     fn accumulate_total_update_elapsed_us(&mut self, val: u64) {
         saturating_add_assign!(self.total_update_elapsed_us, val);
+    }
+
+    fn update_prioritization_fee(&mut self, fee: u64) {
+        if fee == 0 {
+            saturating_add_assign!(self.non_prioritized_transactions_count, 1);
+        } else {
+            saturating_add_assign!(self.prioritized_transactions_count, 1);
+        }
+
+        if fee > self.max_prioritization_fee {
+            self.max_prioritization_fee = fee;
+        }
+
+        if self.min_prioritization_fee.is_none() || fee < self.min_prioritization_fee.unwrap() {
+            self.min_prioritization_fee = Some(fee);
+        }
     }
 
     fn report(&self, slot: Slot) {
@@ -44,8 +72,28 @@ impl PrioritizationFeeMetrics {
                 i64
             ),
             (
+                "prioritized_transactions_count",
+                self.prioritized_transactions_count as i64,
+                i64
+            ),
+            (
+                "non_prioritized_transactions_count",
+                self.non_prioritized_transactions_count as i64,
+                i64
+            ),
+            (
                 "total_prioritization_fee",
                 self.total_prioritization_fee as i64,
+                i64
+            ),
+            (
+                "min_prioritization_fee",
+                self.min_prioritization_fee.unwrap_or(0) as i64,
+                i64
+            ),
+            (
+                "max_prioritization_fee",
+                self.max_prioritization_fee as i64,
                 i64
             ),
             (
@@ -125,6 +173,7 @@ impl PrioritizationFee {
 
                 self.metrics
                     .accumulate_total_prioritization_fee(transaction_fee);
+                self.metrics.update_prioritization_fee(transaction_fee);
             },
             "update_time",
         );

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -50,9 +50,8 @@ impl PrioritizationFeeMetrics {
         // update prioritized transaction fee metrics.
         saturating_add_assign!(self.prioritized_transactions_count, 1);
 
-        if fee > self.max_prioritization_fee {
-            self.max_prioritization_fee = fee;
-        }
+        self.max_prioritization_fee =
+            self.max_prioritization_fee.max(fee);
 
         if self.min_prioritization_fee.is_none() || fee < self.min_prioritization_fee.unwrap() {
             self.min_prioritization_fee = Some(fee);


### PR DESCRIPTION
#### Problem
Would like to add min/max fee to [fee_market](https://metrics.solana.com:3000/d/0n54roOVz/fee-market?orgId=1) dashboard, as well as counts of transactions with and without fee.

#### Summary of Changes
- add counters

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
