### PR TITLE
test_minimize_accounts_db uses write cache correctly

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -16191,7 +16191,7 @@ pub mod tests {
     impl AccountsDb {
         /// useful to adapt tests written prior to introduction of the write cache
         /// to use the write cache
-        fn add_root_and_flush_write_cache(&self, slot: Slot) {
+        pub fn add_root_and_flush_write_cache(&self, slot: Slot) {
             self.add_root(slot);
             self.flush_root_write_cache(slot);
         }
@@ -16212,7 +16212,7 @@ pub mod tests {
         }
 
         /// callers use to call store_uncached. But, this is not allowed anymore.
-        fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
+        pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
             self.store(
                 (slot, accounts, INCLUDE_SLOT_IN_HASH_TESTS),
                 true,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -657,14 +657,14 @@ mod tests {
             current_slot += 1;
 
             for (index, pubkey) in pubkeys.iter().enumerate() {
-                accounts.store_uncached(current_slot, &[(pubkey, &account)]);
+                accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
 
                 if current_slot % 2 == 0 && index % 100 == 0 {
                     minimized_account_set.insert(*pubkey);
                 }
             }
             accounts.get_accounts_delta_hash(current_slot);
-            accounts.add_root(current_slot);
+            accounts.add_root_and_flush_write_cache(current_slot);
         }
 
         assert_eq!(minimized_account_set.len(), 6);


### PR DESCRIPTION
#### Problem
test was writing uncached and ending up with multiple append vecs in the same slot

#### Summary of Changes
write to the cache

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
