### PR TITLE
test_utils::create_test_accounts pre-allocates an append vec first

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,11 +6,11 @@ use {
     rayon::prelude::*,
     solana_measure::measure::Measure,
     solana_runtime::{
-        accounts::{
+        accounts::Accounts,
+        accounts_db::{
             test_utils::{create_test_accounts, update_accounts_bench},
-            Accounts,
+            AccountShrinkThreshold, CalcAccountsHashDataSource,
         },
-        accounts_db::{AccountShrinkThreshold, CalcAccountsHashDataSource},
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         rent_collector::RentCollector,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -8,8 +8,8 @@ use {
     rand::Rng,
     rayon::iter::{IntoParallelRefIterator, ParallelIterator},
     solana_runtime::{
-        accounts::{test_utils::create_test_accounts, AccountAddressFilter, Accounts},
-        accounts_db::AccountShrinkThreshold,
+        accounts::{AccountAddressFilter, Accounts},
+        accounts_db::{test_utils::create_test_accounts, AccountShrinkThreshold},
         accounts_index::{AccountSecondaryIndexes, ScanConfig},
         ancestors::Ancestors,
         bank::*,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -27,7 +27,6 @@ use {
         DashMap,
     },
     log::*,
-    rand::{thread_rng, Rng},
     solana_address_lookup_table_program::{error::AddressLookupError, state::AddressLookupTable},
     solana_program_runtime::compute_budget::ComputeBudget,
     solana_sdk::{
@@ -1459,36 +1458,6 @@ fn prepare_if_nonce_account<'a>(
         }
     } else {
         false
-    }
-}
-
-/// A set of utility functions used for testing and benchmarking
-pub mod test_utils {
-    use super::*;
-
-    pub fn create_test_accounts(
-        accounts: &Accounts,
-        pubkeys: &mut Vec<Pubkey>,
-        num: usize,
-        slot: Slot,
-    ) {
-        for t in 0..num {
-            let pubkey = solana_sdk::pubkey::new_rand();
-            let account =
-                AccountSharedData::new((t + 1) as u64, 0, AccountSharedData::default().owner());
-            accounts.store_slow_uncached(slot, &pubkey, &account);
-            pubkeys.push(pubkey);
-        }
-    }
-
-    // Only used by bench, not safe to call otherwise accounts can conflict with the
-    // accounts cache!
-    pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64) {
-        for pubkey in pubkeys {
-            let amount = thread_rng().gen_range(0, 10);
-            let account = AccountSharedData::new(amount, 0, AccountSharedData::default().owner());
-            accounts.store_slow_uncached(slot, pubkey, &account);
-        }
     }
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9459,6 +9459,64 @@ impl AccountsDb {
     }
 }
 
+/// A set of utility functions used for testing and benchmarking
+pub mod test_utils {
+    use {
+        super::*,
+        crate::{accounts::Accounts, append_vec::aligned_stored_size},
+    };
+
+    pub fn create_test_accounts(
+        accounts: &Accounts,
+        pubkeys: &mut Vec<Pubkey>,
+        num: usize,
+        slot: Slot,
+    ) {
+        let data_size = 0;
+        if accounts.accounts_db.storage.get_slot_stores(slot).is_none() {
+            let bytes_required = num * aligned_stored_size(data_size);
+            // allocate an append vec for this slot that can hold all the test accounts. This prevents us from creating more than 1 append vec for this slot.
+            _ = accounts.accounts_db.create_and_insert_store(
+                slot,
+                bytes_required as u64,
+                "create_test_accounts",
+            );
+        }
+
+        for t in 0..num {
+            let pubkey = solana_sdk::pubkey::new_rand();
+            let account = AccountSharedData::new(
+                (t + 1) as u64,
+                data_size,
+                AccountSharedData::default().owner(),
+            );
+            /*
+                if we have to change to using the cache
+                accounts.accounts_db.store_cached(
+                (
+                    slot,
+                    &[(&pubkey, &account)][..],
+                    crate::accounts_db::INCLUDE_SLOT_IN_HASH_TESTS,
+                ),
+                None,
+            );
+             */
+            accounts.store_slow_uncached(slot, &pubkey, &account);
+            pubkeys.push(pubkey);
+        }
+    }
+
+    // Only used by bench, not safe to call otherwise accounts can conflict with the
+    // accounts cache!
+    pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64) {
+        for pubkey in pubkeys {
+            let amount = thread_rng().gen_range(0, 10);
+            let account = AccountSharedData::new(amount, 0, AccountSharedData::default().owner());
+            accounts.store_slow_uncached(slot, pubkey, &account);
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use {
@@ -16212,7 +16270,7 @@ pub mod tests {
         }
 
         /// callers use to call store_uncached. But, this is not allowed anymore.
-        fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
+        pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
             self.store(
                 (slot, accounts, INCLUDE_SLOT_IN_HASH_TESTS),
                 true,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9490,17 +9490,6 @@ pub mod test_utils {
                 data_size,
                 AccountSharedData::default().owner(),
             );
-            /*
-                if we have to change to using the cache
-                accounts.accounts_db.store_cached(
-                (
-                    slot,
-                    &[(&pubkey, &account)][..],
-                    crate::accounts_db::INCLUDE_SLOT_IN_HASH_TESTS,
-                ),
-                None,
-            );
-             */
             accounts.store_slow_uncached(slot, &pubkey, &account);
             pubkeys.push(pubkey);
         }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -4,8 +4,10 @@ use {
     super::*,
     crate::{
         account_storage::AccountStorageMap,
-        accounts::{test_utils::create_test_accounts, Accounts},
-        accounts_db::{get_temp_accounts_paths, AccountShrinkThreshold},
+        accounts::Accounts,
+        accounts_db::{
+            get_temp_accounts_paths, test_utils::create_test_accounts, AccountShrinkThreshold,
+        },
         accounts_hash::AccountsHash,
         append_vec::AppendVec,
         bank::{Bank, BankTestConfig},


### PR DESCRIPTION
#### Problem
Working on allowing 0 or 1 append vecs per slot, not > 1.
There is test code that allocates multiple append vecs for the same slot unnecessarily.
#### Summary of Changes
1. move test_utils into accounts_db.rs
2. pre-allocate an append vec that can store all test accounts


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
