### PR TITLE
Fixes format string

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -761,7 +761,7 @@ mod tests {
                 let res = io.handle_request_sync(&req, meta.clone());
                 let result: Value = serde_json::from_str(&res.expect("actual response"))
                     .expect("actual response deserialization");
-                println!("{:?}", result);
+                println!("{result:?}");
                 let sizes: HashMap<RpcAccountIndex, usize> =
                     serde_json::from_value(result["result"].clone()).unwrap();
                 assert_eq!(sizes.len(), 1);


### PR DESCRIPTION
#### Problem

Fixup clippy warnings to upgrade to Rust 1.66.0

#### Summary of Changes

Fixes format string