### PR TITLE
rolls back merkle shreds on testnet

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -473,8 +473,8 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_use_merkle_variant(slot: Slot, cluster_type: ClusterType, shred_version: u16) -> bool {
-    cluster_type == ClusterType::Testnet && shred_version == 6995 && (slot % 19 < 4)
+fn should_use_merkle_variant(_slot: Slot, _cluster_type: ClusterType, _shred_version: u16) -> bool {
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION

#### Problem
https://github.com/solana-labs/solana/pull/29339 adds hash domain to merkle shreds. In order to merge that change, need to temporarily disable merkle shreds on testnet.


#### Summary of Changes
Temporarily disable merkle shreds on testnet.
