### PR TITLE
Fix "tranaction" typo in code base

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4883,7 +4883,7 @@ impl Bank {
             signature_count,
         } = counts;
 
-        let tx_count = if self.bank_tranaction_count_fix_enabled() {
+        let tx_count = if self.bank_transaction_count_fix_enabled() {
             committed_transactions_count
         } else {
             committed_transactions_count.saturating_sub(committed_with_failure_result_count)
@@ -7378,9 +7378,9 @@ impl Bank {
         self.rc.accounts.accounts_db.print_accounts_stats("");
     }
 
-    pub fn bank_tranaction_count_fix_enabled(&self) -> bool {
+    pub fn bank_transaction_count_fix_enabled(&self) -> bool {
         self.feature_set
-            .is_active(&feature_set::bank_tranaction_count_fix::id())
+            .is_active(&feature_set::bank_transaction_count_fix::id())
     }
 
     pub fn shrink_candidate_slots(&self) -> usize {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -305,7 +305,7 @@ pub mod add_get_processed_sibling_instruction_syscall {
     solana_sdk::declare_id!("CFK1hRCNy8JJuAAY8Pb2GjLFNdCThS2qwZNe3izzBMgn");
 }
 
-pub mod bank_tranaction_count_fix {
+pub mod bank_transaction_count_fix {
     solana_sdk::declare_id!("Vo5siZ442SaZBKPXNocthiXysNviW4UYPwRFggmbgAp");
 }
 
@@ -624,7 +624,7 @@ lazy_static! {
         (spl_associated_token_account_v1_0_4::id(), "SPL Associated Token Account Program release version 1.0.4, tied to token 3.3.0 #22648"),
         (reject_vote_account_close_unless_zero_credit_epoch::id(), "fail vote account withdraw to 0 unless account earned 0 credits in last completed epoch"),
         (add_get_processed_sibling_instruction_syscall::id(), "add add_get_processed_sibling_instruction_syscall"),
-        (bank_tranaction_count_fix::id(), "fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
+        (bank_transaction_count_fix::id(), "fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
         (disable_bpf_deprecated_load_instructions::id(), "disable ldabs* and ldind* SBF instructions"),
         (disable_bpf_unresolved_symbols_at_runtime::id(), "disable reporting of unresolved SBF symbols at runtime"),
         (record_instruction_in_transaction_context_push::id(), "move the CPI stack overflow check to the end of push"),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -796,7 +796,7 @@ mod test {
         let (sender, receiver) = unbounded();
 
         let connection_cache = Arc::new(ConnectionCache::default());
-        let send_tranaction_service = SendTransactionService::new::<NullTpuInfo>(
+        let send_transaction_service = SendTransactionService::new::<NullTpuInfo>(
             tpu_address,
             &bank_forks,
             None,
@@ -807,7 +807,7 @@ mod test {
         );
 
         drop(sender);
-        send_tranaction_service.join().unwrap();
+        send_transaction_service.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Found a couple typos

#### Summary of Changes
Fix them.
The edit to `feature_set.rs` should not cause any issues, since it is just the module name used under the hood and doesn't touch cli output.
Just as a fun walk down memory lane: the STS typo has been there since https://github.com/solana-labs/solana/pull/10446
