### PR TITLE
Handle audio NFT with cover image and player

### DIFF
--- a/explorer/src/components/common/NFTArt.tsx
+++ b/explorer/src/components/common/NFTArt.tsx
@@ -170,6 +170,52 @@ const VideoArtContent = ({
   return content;
 };
 
+const AudioArtContent = ({
+  files,
+  uri,
+  animationURL,
+}: {
+  files?: (MetadataJsonFile | string)[];
+  uri?: string;
+  animationURL?: string;
+}) => {
+  const likelyAudio = (files || []).filter((f, index, arr) => {
+    if (typeof f !== "string") {
+      return false;
+    }
+    return arr.length >= 2 ? index === 1 : index === 0;
+  })?.[0] as string;
+
+
+  const content =
+    <div className={"d-block"}>
+      {uri && (
+        <img
+          className={"rounded mx-auto d-block"}
+          src={uri}
+          alt={"nft"}
+          style={{
+            width: 150,
+            maxHeight: 200,
+          }}
+        />
+      )}
+      {animationURL && (
+        <div>
+            <audio controls id="audio">
+              <source src={animationURL} />
+              Your browser does not support the <code>audio</code> element.
+            </audio>
+        </div>
+      )}
+      {(likelyAudio || animationURL) && (
+        <ViewOriginalArtContentLink src={(likelyAudio || animationURL)!} />
+      )}
+    </div>
+
+  return content;
+};
+
 const HTMLContent = ({
   animationUrl,
   files,
@@ -255,6 +301,8 @@ export const ArtContent = ({
       <VideoArtContent files={files} uri={uri} animationURL={animationURL} />
     ) : category === "html" || animationUrlExt === "html" ? (
       <HTMLContent animationUrl={animationURL} files={files} />
+    ) : category === "audio" ? (
+      <AudioArtContent animationURL={animationURL} uri={uri} files={files} />
     ) : (
       <CachedImageContent uri={uri} />
     );


### PR DESCRIPTION
#### Problem
In the Solana Explorer, Audio NFT's currently just show the image and do not allow the user to play the audio.

#### Summary of Changes
Check if `category` is `audio`, utilize the same image as for `image` category` NFT's but add a native audio player with controls below it to handle the audio file. @roederw it appears you are the main contributor on this component so I'd love your eyes on this if possible.

> Disclaimer: Just figured I'd take a shot at this since it seems like an easy win. Feel free to edit/close 🤷‍♂️ 

#### Example
<img width="480" alt="Screenshot 2022-12-20 at 5 18 04 PM" src="https://user-images.githubusercontent.com/22161905/208791571-d53e6a99-9007-4e4c-96c5-f5e67b42e6fe.png">
