### PR TITLE
RPC getPerformanceSamples: Add `numNonVoteTransaction`

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1176,6 +1176,7 @@ impl BankingStage {
         gossip_vote_sender: &ReplayVoteSender,
         signature_count: u64,
         executed_transactions_count: usize,
+        executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         inc_new_counter_info!(
@@ -1195,6 +1196,8 @@ impl BankingStage {
                 lamports_per_signature,
                 CommitTransactionCounts {
                     committed_transactions_count: executed_transactions_count as u64,
+                    committed_non_vote_transactions_count: executed_non_vote_transactions_count
+                        as u64,
                     committed_with_failure_result_count: executed_transactions_count
                         .saturating_sub(executed_with_successful_result_count)
                         as u64,
@@ -1330,6 +1333,7 @@ impl BankingStage {
             execution_results,
             mut retryable_transaction_indexes,
             executed_transactions_count,
+            executed_non_vote_transactions_count,
             executed_with_successful_result_count,
             signature_count,
             error_counters,
@@ -1407,6 +1411,7 @@ impl BankingStage {
                 gossip_vote_sender,
                 signature_count,
                 executed_transactions_count,
+                executed_non_vote_transactions_count,
                 executed_with_successful_result_count,
             )
         } else {

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2060,8 +2060,13 @@ Result:
 
 ### getRecentPerformanceSamples
 
-Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and
-include the number of transactions and slots that occur in a given time window.
+Returns a list of recent performance samples, in reverse slot order. Performance
+samples are taken every 60 seconds and include the number of transactions and
+slots that occur in a given time window.
+
+`numNonVoteTransaction` is the number of non-voting transactions in the sample.
+To get the number of voting transactions, compute `numTransactions -
+numNonVoteTransaction`.
 
 #### Parameters:
 
@@ -2074,6 +2079,7 @@ An array of:
 - `RpcPerfSample<object>`
   - `slot: <u64>` - Slot in which sample was taken at
   - `numTransactions: <u64>` - Number of transactions in sample
+  - `numNonVoteTransaction: <u64>` - Number of non-vote transactions is sample
   - `numSlots: <u64>` - Number of slots in sample
   - `samplePeriodSecs: <u16>` - Number of seconds in a sample window
 
@@ -2097,24 +2103,28 @@ Result:
     {
       "numSlots": 126,
       "numTransactions": 126,
+      "numNonVoteTransaction": 1,
       "samplePeriodSecs": 60,
       "slot": 348125
     },
     {
       "numSlots": 126,
       "numTransactions": 126,
+      "numNonVoteTransaction": 1,
       "samplePeriodSecs": 60,
       "slot": 347999
     },
     {
       "numSlots": 125,
       "numTransactions": 125,
+      "numNonVoteTransaction": 0,
       "samplePeriodSecs": 60,
       "slot": 347873
     },
     {
       "numSlots": 125,
       "numTransactions": 125,
+      "numNonVoteTransaction": 0,
       "samplePeriodSecs": 60,
       "slot": 347748
     }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -830,7 +830,8 @@ fn analyze_storage(database: &Database) {
     analyze_column::<TransactionStatusIndex>(database, "TransactionStatusIndex");
     analyze_column::<Rewards>(database, "Rewards");
     analyze_column::<Blocktime>(database, "Blocktime");
-    analyze_column::<PerfSamples>(database, "PerfSamples");
+    analyze_column::<PerfSamplesV1>(database, "PerfSamplesV1");
+    analyze_column::<PerfSamplesV2>(database, "PerfSamplesV2");
     analyze_column::<BlockHeight>(database, "BlockHeight");
     analyze_column::<ProgramCosts>(database, "ProgramCosts");
     analyze_column::<OptimisticSlots>(database, "OptimisticSlots");
@@ -966,7 +967,8 @@ fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
         cf::TransactionStatusIndex::NAME => None, // does not implement slot()
         cf::Rewards::NAME => Some(cf::Rewards::slot(cf::Rewards::index(key))),
         cf::Blocktime::NAME => Some(cf::Blocktime::slot(cf::Blocktime::index(key))),
-        cf::PerfSamples::NAME => Some(cf::PerfSamples::slot(cf::PerfSamples::index(key))),
+        cf::PerfSamplesV1::NAME => Some(cf::PerfSamplesV1::slot(cf::PerfSamplesV1::index(key))),
+        cf::PerfSamplesV2::NAME => Some(cf::PerfSamplesV2::slot(cf::PerfSamplesV2::index(key))),
         cf::BlockHeight::NAME => Some(cf::BlockHeight::slot(cf::BlockHeight::index(key))),
         cf::ProgramCosts::NAME => None, // does not implement slot()
         cf::OptimisticSlots::NAME => {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -205,7 +205,11 @@ impl Blockstore {
                 .is_ok()
             & self
                 .db
-                .delete_range_cf::<cf::PerfSamples>(&mut write_batch, from_slot, to_slot)
+                .delete_range_cf::<cf::PerfSamplesV1>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::PerfSamplesV2>(&mut write_batch, from_slot, to_slot)
                 .is_ok()
             & self
                 .db
@@ -327,7 +331,11 @@ impl Blockstore {
                 .is_ok()
             & self
                 .db
-                .delete_file_in_range_cf::<cf::PerfSamples>(from_slot, to_slot)
+                .delete_file_in_range_cf::<cf::PerfSamplesV1>(from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_file_in_range_cf::<cf::PerfSamplesV2>(from_slot, to_slot)
                 .is_ok()
             & self
                 .db

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -86,8 +86,10 @@ const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 const REWARDS_CF: &str = "rewards";
 /// Column family for Blocktime
 const BLOCKTIME_CF: &str = "blocktime";
-/// Column family for Performance Samples
-const PERF_SAMPLES_CF: &str = "perf_samples";
+/// Column family for Performance Samples V1
+const PERF_SAMPLES_V1_CF: &str = "perf_samples";
+/// Column family for Performance Samples V2
+const PERF_SAMPLES_V2_CF: &str = "perf_samples_v2";
 /// Column family for BlockHeight
 const BLOCK_HEIGHT_CF: &str = "block_height";
 /// Column family for ProgramCosts
@@ -282,11 +284,18 @@ pub mod columns {
     pub struct Blocktime;
 
     #[derive(Debug)]
-    /// The performance samples column
+    /// The performance samples column, v1
     ///
     /// index type: u64 (see `SlotColumn`)
-    /// value type: `blockstore_meta::PerfSample`
-    pub struct PerfSamples;
+    /// value type: `blockstore_meta::PerfSampleV1`
+    pub struct PerfSamplesV1;
+
+    #[derive(Debug)]
+    /// The performance samples column, v2
+    ///
+    /// index type: u64 (see `SlotColumn`)
+    /// value type: `blockstore_meta::PerfSampleV2`
+    pub struct PerfSamplesV2;
 
     #[derive(Debug)]
     /// The block height column
@@ -431,7 +440,8 @@ impl Rocks {
             new_cf_descriptor::<TransactionStatusIndex>(options, oldest_slot),
             new_cf_descriptor::<Rewards>(options, oldest_slot),
             new_cf_descriptor::<Blocktime>(options, oldest_slot),
-            new_cf_descriptor::<PerfSamples>(options, oldest_slot),
+            new_cf_descriptor::<PerfSamplesV1>(options, oldest_slot),
+            new_cf_descriptor::<PerfSamplesV2>(options, oldest_slot),
             new_cf_descriptor::<BlockHeight>(options, oldest_slot),
             new_cf_descriptor::<ProgramCosts>(options, oldest_slot),
             new_cf_descriptor::<OptimisticSlots>(options, oldest_slot),
@@ -458,7 +468,8 @@ impl Rocks {
             TransactionStatusIndex::NAME,
             Rewards::NAME,
             Blocktime::NAME,
-            PerfSamples::NAME,
+            PerfSamplesV1::NAME,
+            PerfSamplesV2::NAME,
             BlockHeight::NAME,
             ProgramCosts::NAME,
             OptimisticSlots::NAME,
@@ -828,12 +839,20 @@ impl TypedColumn for columns::Blocktime {
     type Type = UnixTimestamp;
 }
 
-impl SlotColumn for columns::PerfSamples {}
-impl ColumnName for columns::PerfSamples {
-    const NAME: &'static str = PERF_SAMPLES_CF;
+impl SlotColumn for columns::PerfSamplesV1 {}
+impl ColumnName for columns::PerfSamplesV1 {
+    const NAME: &'static str = PERF_SAMPLES_V1_CF;
 }
-impl TypedColumn for columns::PerfSamples {
-    type Type = blockstore_meta::PerfSample;
+impl TypedColumn for columns::PerfSamplesV1 {
+    type Type = blockstore_meta::PerfSampleV1;
+}
+
+impl SlotColumn for columns::PerfSamplesV2 {}
+impl ColumnName for columns::PerfSamplesV2 {
+    const NAME: &'static str = PERF_SAMPLES_V2_CF;
+}
+impl TypedColumn for columns::PerfSamplesV2 {
+    type Type = blockstore_meta::PerfSampleV2;
 }
 
 impl SlotColumn for columns::BlockHeight {}

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -416,6 +416,7 @@ impl RpcSender for MockSender {
             "getRecentPerformanceSamples" => serde_json::to_value(vec![RpcPerfSample {
                 slot: 347873,
                 num_transactions: 125,
+                num_non_vote_transactions: Some(1),
                 num_slots: 123,
                 sample_period_secs: 60,
             }])?,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3439,6 +3439,7 @@ pub mod rpc_full {
                 .map(|(slot, sample)| RpcPerfSample {
                     slot: *slot,
                     num_transactions: sample.num_transactions,
+                    num_non_vote_transactions: sample.num_non_vote_transactions,
                     num_slots: sample.num_slots,
                     sample_period_secs: sample.sample_period_secs,
                 })
@@ -5116,6 +5117,7 @@ pub mod tests {
         let slot = 0;
         let num_slots = 1;
         let num_transactions = 4;
+        let num_non_vote_transactions = 1;
         let sample_period_secs = 60;
         rpc.blockstore
             .write_perf_sample(
@@ -5123,6 +5125,7 @@ pub mod tests {
                 &PerfSample {
                     num_slots,
                     num_transactions,
+                    num_non_vote_transactions: Some(num_non_vote_transactions),
                     sample_period_secs,
                 },
             )
@@ -5134,6 +5137,7 @@ pub mod tests {
             "slot": slot,
             "numSlots": num_slots,
             "numTransactions": num_transactions,
+            "numNonVoteTransactions": num_non_vote_transactions,
             "samplePeriodSecs": sample_period_secs,
         }]);
         assert_eq!(result, expected);


### PR DESCRIPTION
#### Problem

Allow interested parties to see both total and non-vote transaction counts in each performance sample.

#### Summary of Changes

As new stats need to be stored in the blockstore database, but as they have a different binary representation they are recorded into a new column: `perf_samples_v2`.

An alternative would have been to make `PerfSample` deserialization code smart enough to allow for deserialization of both old and new sample records.  But it is a non-trivial problem.  `serde` is designed to allow for deserialization of streams, and thus, it does not provide a mechanism for backtracking.  `bincode` does not encode enough information to know if the data being read is the v1 version of the `PerfSample` record or the v2 version.  And `rocksdb` access layer is written with a pretty deep assumption that types stored in the columns can be deseraialized using `serde`.

In order to support deserialization of `bincode` encoded records based on their size, one needs to either extend `bincode` itself, to allow for some kind of backtracking, or the `rocksdb` interaction layer would need to be changed to allow for additional flexibility.  Both options seems to be pretty complex, considering that they would allow an implementation that is not very extendable, and feels like a hack.

On the other hand, putting new `PerfSample` version into a separate column seems more robust, and will scale with no problem, allowing any number of future additions to `PerfSample`, should we be adding more stats.

Fixes #29159
