### PR TITLE
rpc: replace default encoding from Binary to Base64

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -408,7 +408,7 @@ impl JsonRpcRequestProcessor {
             commitment,
             min_context_slot,
         })?;
-        let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
+        let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
 
         let response = get_encoded_account(&bank, pubkey, encoding, data_slice)?;
         Ok(new_response(&bank, response))
@@ -464,7 +464,7 @@ impl JsonRpcRequestProcessor {
             commitment,
             min_context_slot,
         })?;
-        let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
+        let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
         optimize_filters(&mut filters);
         let keyed_accounts = {
             if let Some(owner) = get_spl_token_owner_filter(program_id, &filters) {
@@ -1880,7 +1880,7 @@ impl JsonRpcRequestProcessor {
             commitment,
             min_context_slot,
         })?;
-        let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
+        let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
         let (token_program_id, mint) = get_token_program_id_and_mint(&bank, token_account_filter)?;
 
         let mut filters = vec![];
@@ -1930,7 +1930,7 @@ impl JsonRpcRequestProcessor {
             commitment,
             min_context_slot,
         })?;
-        let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
+        let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
         let (token_program_id, mint) = get_token_program_id_and_mint(&bank, token_account_filter)?;
 
         let mut filters = vec![
@@ -5648,7 +5648,7 @@ pub mod tests {
             account: UiAccount::encode(
                 &new_program_account_key,
                 &new_program_account,
-                UiAccountEncoding::Binary,
+                UiAccountEncoding::Base64,
                 None,
                 None,
             ),


### PR DESCRIPTION
#### Problem

Right now JS library use `base64` as the default encoding and `solana-client` do not use `Binary`/`Base64` as the default encoding. But RPC still assumes `Binary` as default which has a length limitation of encoding account data (128 bytes).

#### Summary of Changes

This PR change `UiAccountEncoding::Binary` is few RPC methods to `UiAccountEncoding::Base64`.