### PR TITLE
vote: Prevent commission update in the second half of epochs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6897,6 +6897,7 @@ dependencies = [
  "solana-program 1.15.0",
  "solana-program-runtime",
  "solana-sdk 1.15.0",
+ "test-case",
  "thiserror",
 ]
 

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 solana-logger = { path = "../../logger", version = "=1.15.0" }
+test-case = "2.2.2"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -135,10 +135,9 @@ pub fn process_instruction(
             vote_state::update_validator_identity(&mut me, node_pubkey, &signers)
         }
         VoteInstruction::UpdateCommission(commission) => {
-            if invoke_context
-                .feature_set
-                .is_active(&feature_set::prevent_commission_update_in_second_half_of_epoch::id())
-            {
+            if invoke_context.feature_set.is_active(
+                &feature_set::commission_updates_only_allowed_in_first_half_of_epoch::id(),
+            ) {
                 let sysvar_cache = invoke_context.get_sysvar_cache();
                 let epoch_schedule = sysvar_cache.get_epoch_schedule()?;
                 let clock = sysvar_cache.get_clock()?;

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -9,6 +9,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::{Epoch, Slot, UnixTimestamp},
+        epoch_schedule::EpochSchedule,
         feature_set::{self, filter_votes_outside_slot_hashes, FeatureSet},
         hash::Hash,
         instruction::InstructionError,
@@ -797,6 +798,22 @@ pub fn update_commission<S: std::hash::BuildHasher>(
     vote_account.set_state(&VoteStateVersions::new_current(vote_state))
 }
 
+/// Given the current slot and epoch schedule, determine if a commission change
+/// is allowed
+pub fn is_commission_update_allowed(slot: Slot, epoch_schedule: &EpochSchedule) -> bool {
+    // always allowed during warmup epochs
+    if let Some(relative_slot) = slot
+        .saturating_sub(epoch_schedule.first_normal_slot)
+        .checked_rem(epoch_schedule.slots_per_epoch)
+    {
+        // allowed up to the midpoint of the epoch
+        relative_slot.saturating_mul(2) <= epoch_schedule.slots_per_epoch
+    } else {
+        // no slots per epoch, just allow it, even though this should never happen
+        true
+    }
+}
+
 fn verify_authorized_signer<S: std::hash::BuildHasher>(
     authorized: &Pubkey,
     signers: &HashSet<Pubkey, S>,
@@ -1020,8 +1037,12 @@ mod tests {
     use {
         super::*,
         crate::vote_state,
-        solana_sdk::{account::AccountSharedData, account_utils::StateMut, hash::hash},
+        solana_sdk::{
+            account::AccountSharedData, account_utils::StateMut, clock::DEFAULT_SLOTS_PER_EPOCH,
+            epoch_schedule::DEFAULT_FIRST_NORMAL_SLOT, hash::hash,
+        },
         std::cell::RefCell,
+        test_case::test_case,
     };
 
     const MAX_RECENT_VOTES: usize = 16;
@@ -2953,6 +2974,21 @@ mod tests {
                 Some(&FeatureSet::all_enabled())
             ),
             Err(VoteError::SlotHashMismatch),
+        );
+    }
+
+    #[test_case(0, true; "first slot")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT - 1, true; "right before first normal slot")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT, true; "first normal slot")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT + DEFAULT_SLOTS_PER_EPOCH / 2, true; "halfway first normal epoch")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT + DEFAULT_SLOTS_PER_EPOCH / 2 + 1, false; "halfway first normal epoch plus one")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT + DEFAULT_SLOTS_PER_EPOCH - 1, false; "last slot in first normal epoch")]
+    #[test_case(DEFAULT_FIRST_NORMAL_SLOT + DEFAULT_SLOTS_PER_EPOCH, true; "first slot in second normal epoch")]
+    fn test_epoch_half_check(slot: Slot, expected_allowed: bool) {
+        let epoch_schedule = EpochSchedule::default();
+        assert_eq!(
+            is_commission_update_allowed(slot, &epoch_schedule),
+            expected_allowed
         );
     }
 }

--- a/sdk/program/src/epoch_schedule.rs
+++ b/sdk/program/src/epoch_schedule.rs
@@ -28,6 +28,12 @@ pub const MAX_LEADER_SCHEDULE_EPOCH_OFFSET: u64 = 3;
 /// Based on `MAX_LOCKOUT_HISTORY` from `vote_program`.
 pub const MINIMUM_SLOTS_PER_EPOCH: u64 = 32;
 
+/// The default first normal slot on the epoch schedule, given warmup
+pub const DEFAULT_FIRST_NORMAL_SLOT: u64 = first_normal_epoch_and_slot(DEFAULT_SLOTS_PER_EPOCH).1;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(DEFAULT_FIRST_NORMAL_SLOT, 524_256);
+
 #[repr(C)]
 #[derive(Debug, CloneZeroed, Copy, PartialEq, Eq, Deserialize, Serialize, AbiExample)]
 #[serde(rename_all = "camelCase")]
@@ -63,6 +69,18 @@ impl Default for EpochSchedule {
     }
 }
 
+const fn first_normal_epoch_and_slot(slots_per_epoch: u64) -> (u64, u64) {
+    let next_power_of_two = slots_per_epoch.next_power_of_two();
+    let log2_slots_per_epoch = next_power_of_two
+        .trailing_zeros()
+        .saturating_sub(MINIMUM_SLOTS_PER_EPOCH.trailing_zeros());
+
+    (
+        log2_slots_per_epoch as u64, // safe cast from u32
+        next_power_of_two.saturating_sub(MINIMUM_SLOTS_PER_EPOCH),
+    )
+}
+
 impl EpochSchedule {
     pub fn new(slots_per_epoch: u64) -> Self {
         Self::custom(slots_per_epoch, slots_per_epoch, true)
@@ -77,15 +95,7 @@ impl EpochSchedule {
     pub fn custom(slots_per_epoch: u64, leader_schedule_slot_offset: u64, warmup: bool) -> Self {
         assert!(slots_per_epoch >= MINIMUM_SLOTS_PER_EPOCH);
         let (first_normal_epoch, first_normal_slot) = if warmup {
-            let next_power_of_two = slots_per_epoch.next_power_of_two();
-            let log2_slots_per_epoch = next_power_of_two
-                .trailing_zeros()
-                .saturating_sub(MINIMUM_SLOTS_PER_EPOCH.trailing_zeros());
-
-            (
-                u64::from(log2_slots_per_epoch),
-                next_power_of_two.saturating_sub(MINIMUM_SLOTS_PER_EPOCH),
-            )
+            first_normal_epoch_and_slot(slots_per_epoch)
         } else {
             (0, 0)
         };

--- a/sdk/program/src/vote/error.rs
+++ b/sdk/program/src/vote/error.rs
@@ -66,6 +66,9 @@ pub enum VoteError {
 
     #[error("Cannot close vote account unless it stopped voting at least one full epoch ago")]
     ActiveVoteAccountClose,
+
+    #[error("Cannot update commission at this point in the epoch")]
+    CommissionUpdateTooLate,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -554,7 +554,7 @@ pub mod enable_program_redeployment_cooldown {
     solana_sdk::declare_id!("J4HFT8usBxpcF63y46t1upYobJgChmKyZPm5uTBRg25Z");
 }
 
-pub mod prevent_commission_update_in_second_half_of_epoch {
+pub mod commission_updates_only_allowed_in_first_half_of_epoch {
     // This is a feature-proposal *feature id*.  The feature keypair address is `ComffCcTMthDAx5AbFA4LeRzGRUB4Z1wNhXz354zvAmT`.
     solana_sdk::declare_id!("8K7PhS5tViXeTXn3ycyWakme98UwfFJYPPcijtSHWsyi");
 }
@@ -692,7 +692,7 @@ lazy_static! {
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
         (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
         (enable_program_redeployment_cooldown::id(), "enable program redeployment cooldown #29135"),
-        (prevent_commission_update_in_second_half_of_epoch::id(), "prevent updating validator commission in the second half of an epoch"),
+        (commission_updates_only_allowed_in_first_half_of_epoch::id(), "validator commission updates are only allowed in the first half of an epoch #29362"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -555,7 +555,7 @@ pub mod enable_program_redeployment_cooldown {
 }
 
 pub mod commission_updates_only_allowed_in_first_half_of_epoch {
-    solana_sdk::declare_id!("ComffCcTMthDAx5AbFA4LeRzGRUB4Z1wNhXz354zvAmT");
+    solana_sdk::declare_id!("noRuG2kzACwgaY7TVmLRnUNPLKNVQE1fb7X55YWBehp");
 }
 
 lazy_static! {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -555,8 +555,7 @@ pub mod enable_program_redeployment_cooldown {
 }
 
 pub mod commission_updates_only_allowed_in_first_half_of_epoch {
-    // This is a feature-proposal *feature id*.  The feature keypair address is `ComffCcTMthDAx5AbFA4LeRzGRUB4Z1wNhXz354zvAmT`.
-    solana_sdk::declare_id!("8K7PhS5tViXeTXn3ycyWakme98UwfFJYPPcijtSHWsyi");
+    solana_sdk::declare_id!("ComffCcTMthDAx5AbFA4LeRzGRUB4Z1wNhXz354zvAmT");
 }
 
 lazy_static! {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -554,6 +554,11 @@ pub mod enable_program_redeployment_cooldown {
     solana_sdk::declare_id!("J4HFT8usBxpcF63y46t1upYobJgChmKyZPm5uTBRg25Z");
 }
 
+pub mod prevent_commission_update_in_second_half_of_epoch {
+    // This is a feature-proposal *feature id*.  The feature keypair address is `ComffCcTMthDAx5AbFA4LeRzGRUB4Z1wNhXz354zvAmT`.
+    solana_sdk::declare_id!("8K7PhS5tViXeTXn3ycyWakme98UwfFJYPPcijtSHWsyi");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -687,6 +692,7 @@ lazy_static! {
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to its compute unit limits #27839"),
         (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
         (enable_program_redeployment_cooldown::id(), "enable program redeployment cooldown #29135"),
+        (prevent_commission_update_in_second_half_of_epoch::id(), "prevent updating validator commission in the second half of an epoch"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Commission ruggers are a big annoyance.

#### Summary of Changes

Following the proposal in #29346, simply prohibit updating commissions in the second half of epochs.

Fixes #29346
Feature Gate Issue: #29361