### PR TITLE
Add `MSG_WAITFORONE.try_into().unwrap()` to deal with different type signature on musl libc

### DIFF
--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -100,7 +100,7 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
         tv_nsec: 0,
     };
     let nrecv =
-        unsafe { libc::recvmmsg(sock_fd, &mut hdrs[0], count as u32, MSG_WAITFORONE, &mut ts) };
+        unsafe { libc::recvmmsg(sock_fd, &mut hdrs[0], count as u32, MSG_WAITFORONE.try_into().unwrap(), &mut ts) };
     let nrecv = if nrecv < 0 {
         return Err(io::Error::last_os_error());
     } else {


### PR DESCRIPTION
#### Problem

Related: #28156 , https://github.com/rust-lang/libc/issues/2945

As mentioned in the related issues, due to musl changing the type signature of `recvmmsg`, solana-streamer cannot compile for target `x86_64-unknown-linux-musl`.

#### Summary of Changes

Adding a `try_into().unwrap()` allows rustc to infer the arg type so that it works for both glibc and musl. 

Note that libc is in the process of making a breaking change for this, starting with deprecating the flags: https://github.com/rust-lang/libc/pull/2963 . This change should just serve as a temporary workaround until that change lands.

Fixes #28156
