### PR TITLE
Revert "fix account resize test by requesting max tx data size"

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19874,7 +19874,6 @@ pub(crate) mod tests {
             &mock_program_id,
             mock_realloc_process_instruction,
         );
-
         let recent_blockhash = bank.last_blockhash();
 
         let funding_keypair = Keypair::new();
@@ -19891,7 +19890,7 @@ pub(crate) mod tests {
             let account_balance = LAMPORTS_PER_SOL;
             let account_size = rng.gen_range(
                 1,
-                MAX_PERMITTED_DATA_LENGTH as usize - MAX_PERMITTED_DATA_INCREASE,
+                (MAX_PERMITTED_DATA_LENGTH / 4) as usize - MAX_PERMITTED_DATA_INCREASE,
             );
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);
@@ -19921,8 +19920,9 @@ pub(crate) mod tests {
         {
             let account_pubkey = Pubkey::new_unique();
             let account_balance = LAMPORTS_PER_SOL;
-            let account_size =
-                rng.gen_range(MAX_PERMITTED_DATA_LENGTH / 2, MAX_PERMITTED_DATA_LENGTH) as usize;
+            let account_size = rng
+                .gen_range(MAX_PERMITTED_DATA_LENGTH / 8, MAX_PERMITTED_DATA_LENGTH / 4)
+                as usize;
             let account_data =
                 AccountSharedData::new(account_balance, account_size, &mock_program_id);
             bank.store_account(&account_pubkey, &account_data);


### PR DESCRIPTION
#### Problem

#29373 removes `ComputeBudgetInstruction::set_accounts_data_size_limit` instruction. 

#### Summary of Changes
Reverts solana-labs/solana#28826