### PR TITLE
Fix ledger-tool bigtable upload default starting-slot behavior

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -38,7 +38,7 @@ use {
 
 async fn upload(
     blockstore: Blockstore,
-    mut starting_slot: Slot,
+    starting_slot: Option<Slot>,
     ending_slot: Option<Slot>,
     force_reupload: bool,
     config: solana_storage_bigtable::LedgerStorageConfig,
@@ -53,6 +53,13 @@ async fn upload(
     };
     let blockstore = Arc::new(blockstore);
 
+    let mut starting_slot = starting_slot.unwrap_or_else(|| {
+        if let Ok(Some(first_root)) = blockstore.first_root() {
+            first_root
+        } else {
+            0
+        }
+    });
     let ending_slot = ending_slot.unwrap_or_else(|| blockstore.last_root());
 
     while starting_slot <= ending_slot {
@@ -640,7 +647,7 @@ pub fn bigtable_process_command(
 
     let future = match (subcommand, sub_matches) {
         ("upload", Some(arg_matches)) => {
-            let starting_slot = value_t!(arg_matches, "starting_slot", Slot).unwrap_or(0);
+            let starting_slot = value_t!(arg_matches, "starting_slot", Slot).ok();
             let ending_slot = value_t!(arg_matches, "ending_slot", Slot).ok();
             let force_reupload = arg_matches.is_present("force_reupload");
             let blockstore = crate::open_blockstore(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3189,6 +3189,10 @@ impl Blockstore {
         Ok(duplicate_slots_iterator.map(|(slot, _)| slot))
     }
 
+    pub fn first_root(&self) -> Result<Option<Slot>> {
+        Ok(self.rooted_slot_iterator(0)?.next())
+    }
+
     pub fn last_root(&self) -> Slot {
         *self.last_root.read().unwrap()
     }


### PR DESCRIPTION
#### Problem
The help for starting-slot claims that the first available slot will be picked for upload if the arg is unspecified. However, the starting slot is currently set to 0 when the arg is unspecified.

#### Summary of Changes
So, this change actually queries lowest root when starting slot is unspecified.