### PR TITLE
Add getInflationRate RPC call to web3.js

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -785,6 +785,27 @@ const GetInflationRewardResult = jsonRpcResult(
   ),
 );
 
+export type InflationRate = {
+  /** total inflation */
+  total: number;
+  /** inflation allocated to validators */
+  validator: number;
+  /** inflation allocated to the foundation */
+  foundation: number;
+  /** epoch for which these values are valid */
+  epoch: number;
+}
+
+/**
+ * Expected JSON RPC response for the "getInflationRate" message
+ */
+const GetInflationRateResult = pick({
+  total: number(),
+  validator: number(),
+  foundation: number(),
+  epoch: number(),
+})
+
 /**
  * Information about the current epoch
  */
@@ -1625,6 +1646,11 @@ function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
  * Expected JSON RPC response for the "getInflationGovernor" message
  */
 const GetInflationGovernorRpcResult = jsonRpcResult(GetInflationGovernorResult);
+
+/**
+ * Expected JSON RPC response for the "getInflationRate" message
+ */
+const GetInflationRateRpcResult = jsonRpcResult(GetInflationRateResult);
 
 /**
  * Expected JSON RPC response for the "getEpochInfo" message
@@ -4250,6 +4276,18 @@ export class Connection {
     const res = create(unsafeRes, GetInflationRewardResult);
     if ('error' in res) {
       throw new SolanaJSONRPCError(res.error, 'failed to get inflation reward');
+    }
+    return res.result;
+  }
+  
+  /**
+   * Fetch the specific inflation values for the current epoch
+   */
+ async getInflationRate(): Promise<InflationRate> {
+    const unsafeRes = await this._rpcRequest('getInflationRate', []);
+    const res = create(unsafeRes, GetInflationRateRpcResult);
+    if ('error' in res) {
+      throw new SolanaJSONRPCError(res.error, 'failed to get inflation rate');
     }
     return res.result;
   }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -794,7 +794,7 @@ export type InflationRate = {
   foundation: number;
   /** epoch for which these values are valid */
   epoch: number;
-}
+};
 
 /**
  * Expected JSON RPC response for the "getInflationRate" message
@@ -804,7 +804,7 @@ const GetInflationRateResult = pick({
   validator: number(),
   foundation: number(),
   epoch: number(),
-})
+});
 
 /**
  * Information about the current epoch
@@ -4279,11 +4279,11 @@ export class Connection {
     }
     return res.result;
   }
-  
+
   /**
    * Fetch the specific inflation values for the current epoch
    */
- async getInflationRate(): Promise<InflationRate> {
+  async getInflationRate(): Promise<InflationRate> {
     const unsafeRes = await this._rpcRequest('getInflationRate', []);
     const res = create(unsafeRes, GetInflationRateRpcResult);
     if ('error' in res) {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -826,7 +826,7 @@ describe('Connection', function () {
   });
 
   it('get inflation rate', async () => {
-     await mockRpcResponse({
+    await mockRpcResponse({
       method: 'getInflationRate',
       params: [],
       value: {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -39,6 +39,7 @@ import {
   Context,
   EpochInfo,
   InflationGovernor,
+  InflationRate,
   Logs,
   SignatureResult,
   SlotInfo,
@@ -821,6 +822,32 @@ describe('Connection', function () {
       );
 
       expect(inflationReward).to.have.lengthOf(2);
+    }
+  });
+
+  it('get inflation rate', async () => {
+     await mockRpcResponse({
+      method: 'getInflationRate',
+      params: [],
+      value: {
+        total: 0.08,
+        validator: 0.076,
+        foundation: 0.004,
+        epoch: 1,
+      },
+    });
+
+    const inflation = await connection.getInflationRate();
+    const inflationKeys: (keyof InflationRate)[] = [
+      'total',
+      'validator',
+      'foundation',
+      'epoch',
+    ];
+
+    for (const key of inflationKeys) {
+      expect(inflation).to.have.property(key);
+      expect(inflation[key]).to.be.greaterThan(0);
     }
   });
 


### PR DESCRIPTION
#### Problem
The web3.js wrapper does not currently support the JSON RPC call "getInflationRate". 

#### Summary of Changes
This change adds a function to the Connection object to expose the JSON RPC call "getinflationRate", as well as adds a test for the function call.