### PR TITLE
Fix BigTable upload early return

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -60,7 +60,7 @@ async fn upload(
             ending_slot,
             starting_slot.saturating_add(config.max_num_slots_to_check as u64 * 2),
         );
-        let last_slot_uploaded = solana_ledger::bigtable_upload::upload_confirmed_blocks(
+        let last_slot_checked = solana_ledger::bigtable_upload::upload_confirmed_blocks(
             blockstore.clone(),
             bigtable.clone(),
             starting_slot,
@@ -69,8 +69,8 @@ async fn upload(
             Arc::new(AtomicBool::new(false)),
         )
         .await?;
-        info!("last slot uploaded: {}", last_slot_uploaded);
-        starting_slot = last_slot_uploaded.saturating_add(1);
+        info!("last slot checked: {}", last_slot_checked);
+        starting_slot = last_slot_checked.saturating_add(1);
     }
     info!("No more blocks to upload.");
     Ok(())

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -41,6 +41,9 @@ struct BlockstoreLoadStats {
     pub elapsed: Duration,
 }
 
+/// Uploads a range of blocks from a Blockstore to bigtable LedgerStorage
+/// Returns the Slot of the last block checked. If no blocks in the range `[staring_slot,
+/// ending_slot]` are found in Blockstore, this value is equal to `ending_slot`.
 pub async fn upload_confirmed_blocks(
     blockstore: Arc<Blockstore>,
     bigtable: solana_storage_bigtable::LedgerStorage,
@@ -61,7 +64,8 @@ pub async fn upload_confirmed_blocks(
         .collect();
 
     if blockstore_slots.is_empty() {
-        return Err(format!("Ledger has no slots from {starting_slot} to {ending_slot:?}").into());
+        info!("Ledger has no slots from {starting_slot} to {ending_slot:?}");
+        return Ok(ending_slot);
     }
 
     let first_blockstore_slot = blockstore_slots.first().unwrap();

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -64,7 +64,7 @@ pub async fn upload_confirmed_blocks(
         .collect();
 
     if blockstore_slots.is_empty() {
-        info!("Ledger has no slots from {starting_slot} to {ending_slot:?}");
+        warn!("Ledger has no slots from {starting_slot} to {ending_slot:?}");
         return Ok(ending_slot);
     }
 


### PR DESCRIPTION
#### Problem
`solana_ledger::bigtable_upload::upload_confirmed_blocks()` returns an Err if the targeted Blockstore has no blocks in the range requested. This is inconsistent with the other "nothing to upload" case where blocks exist in Blockstore but have already been uploaded to Bigtable, which returns Ok.

#### Summary of Changes
Change Err to Ok; make it more clear through docs and var names that the the slot returned by the method is the last block checked, and doesn't depend on anything actually being uploaded during that pass.
