### PR TITLE
bank: Record non-vote transaction count

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1176,6 +1176,7 @@ impl BankingStage {
         gossip_vote_sender: &ReplayVoteSender,
         signature_count: u64,
         executed_transactions_count: usize,
+        executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         inc_new_counter_info!(
@@ -1195,6 +1196,8 @@ impl BankingStage {
                 lamports_per_signature,
                 CommitTransactionCounts {
                     committed_transactions_count: executed_transactions_count as u64,
+                    committed_non_vote_transactions_count: executed_non_vote_transactions_count
+                        as u64,
                     committed_with_failure_result_count: executed_transactions_count
                         .saturating_sub(executed_with_successful_result_count)
                         as u64,
@@ -1330,6 +1333,7 @@ impl BankingStage {
             execution_results,
             mut retryable_transaction_indexes,
             executed_transactions_count,
+            executed_non_vote_transactions_count,
             executed_with_successful_result_count,
             signature_count,
             error_counters,
@@ -1407,6 +1411,7 @@ impl BankingStage {
                 gossip_vote_sender,
                 signature_count,
                 executed_transactions_count,
+                executed_non_vote_transactions_count,
                 executed_with_successful_result_count,
             )
         } else {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -438,6 +438,8 @@ pub struct LoadAndExecuteTransactionsOutput {
     pub retryable_transaction_indexes: Vec<usize>,
     // Total number of transactions that were executed
     pub executed_transactions_count: usize,
+    // Number of non-vote transactions that were executed
+    pub executed_non_vote_transactions_count: usize,
     // Total number of the executed transactions that returned success/not
     // an error.
     pub executed_with_successful_result_count: usize,
@@ -816,6 +818,7 @@ impl PartialEq for Bank {
             parent_slot,
             hard_forks,
             transaction_count,
+            non_vote_transaction_count_since_restart: _,
             transaction_error_count: _,
             transaction_entries_count: _,
             transactions_per_entry_max: _,
@@ -978,6 +981,11 @@ pub struct Bank {
 
     /// The number of transactions processed without error
     transaction_count: AtomicU64,
+
+    /// The number of non-vote transactions processed without error since the most recent boot from
+    /// snapshot or genesis. This value is not shared though the network, nor retained within
+    /// snapshots, but is preserved in `Bank::new_from_parent`.
+    non_vote_transaction_count_since_restart: AtomicU64,
 
     /// The number of transaction errors in this slot
     transaction_error_count: AtomicU64,
@@ -1157,6 +1165,7 @@ struct PrevEpochInflationRewards {
 
 pub struct CommitTransactionCounts {
     pub committed_transactions_count: u64,
+    pub committed_non_vote_transactions_count: u64,
     pub committed_with_failure_result_count: u64,
     pub signature_count: u64,
 }
@@ -1269,6 +1278,7 @@ impl Bank {
             parent_slot: Slot::default(),
             hard_forks: Arc::<RwLock<HardForks>>::default(),
             transaction_count: AtomicU64::default(),
+            non_vote_transaction_count_since_restart: AtomicU64::default(),
             transaction_error_count: AtomicU64::default(),
             transaction_entries_count: AtomicU64::default(),
             transactions_per_entry_max: AtomicU64::default(),
@@ -1582,6 +1592,9 @@ impl Bank {
             vote_only_bank,
             inflation: parent.inflation.clone(),
             transaction_count: AtomicU64::new(parent.transaction_count()),
+            non_vote_transaction_count_since_restart: AtomicU64::new(
+                parent.non_vote_transaction_count_since_restart(),
+            ),
             transaction_error_count: AtomicU64::new(0),
             transaction_entries_count: AtomicU64::new(0),
             transactions_per_entry_max: AtomicU64::new(0),
@@ -1950,6 +1963,7 @@ impl Bank {
             parent_slot: fields.parent_slot,
             hard_forks: Arc::new(RwLock::new(fields.hard_forks)),
             transaction_count: AtomicU64::new(fields.transaction_count),
+            non_vote_transaction_count_since_restart: new(),
             transaction_error_count: new(),
             transaction_entries_count: new(),
             transactions_per_entry_max: new(),
@@ -4504,6 +4518,7 @@ impl Bank {
         timings.saturating_add_in_place(ExecuteTimingType::ExecuteUs, execution_time.as_us());
 
         let mut executed_transactions_count: usize = 0;
+        let mut executed_non_vote_transactions_count: usize = 0;
         let mut executed_with_successful_result_count: usize = 0;
         let err_count = &mut error_counters.total;
         let transaction_log_collector_config =
@@ -4520,6 +4535,8 @@ impl Bank {
                     }
                 }
             }
+
+            let is_vote = vote_parser::is_simple_vote_transaction(tx);
 
             if execution_result.was_executed() // Skip log collection for unprocessed transactions
                 && transaction_log_collector_config.filter != TransactionLogCollectorFilter::None
@@ -4539,7 +4556,6 @@ impl Bank {
                     }
                 }
 
-                let is_vote = vote_parser::is_simple_vote_transaction(tx);
                 let store = match transaction_log_collector_config.filter {
                     TransactionLogCollectorFilter::All => {
                         !is_vote || !filtered_mentioned_addresses.is_empty()
@@ -4589,6 +4605,9 @@ impl Bank {
 
             match execution_result.flattened_result() {
                 Ok(()) => {
+                    if !is_vote {
+                        executed_non_vote_transactions_count += 1;
+                    }
                     executed_with_successful_result_count += 1;
                 }
                 Err(err) => {
@@ -4615,6 +4634,7 @@ impl Bank {
             execution_results,
             retryable_transaction_indexes,
             executed_transactions_count,
+            executed_non_vote_transactions_count,
             executed_with_successful_result_count,
             signature_count,
             error_counters,
@@ -4879,6 +4899,7 @@ impl Bank {
 
         let CommitTransactionCounts {
             committed_transactions_count,
+            committed_non_vote_transactions_count,
             committed_with_failure_result_count,
             signature_count,
         } = counts;
@@ -4890,11 +4911,18 @@ impl Bank {
         };
 
         self.increment_transaction_count(tx_count);
+        self.increment_non_vote_transaction_count_since_restart(
+            committed_non_vote_transactions_count,
+        );
         self.increment_signature_count(signature_count);
 
         inc_new_counter_info!(
             "bank-process_transactions-txs",
             committed_transactions_count as usize
+        );
+        inc_new_counter_info!(
+            "bank-process_non_vote_transactions-txs",
+            committed_non_vote_transactions_count as usize
         );
         inc_new_counter_info!("bank-process_transactions-sigs", signature_count as usize);
 
@@ -6054,6 +6082,7 @@ impl Bank {
             mut loaded_transactions,
             execution_results,
             executed_transactions_count,
+            executed_non_vote_transactions_count,
             executed_with_successful_result_count,
             signature_count,
             ..
@@ -6078,6 +6107,7 @@ impl Bank {
             lamports_per_signature,
             CommitTransactionCounts {
                 committed_transactions_count: executed_transactions_count as u64,
+                committed_non_vote_transactions_count: executed_non_vote_transactions_count as u64,
                 committed_with_failure_result_count: executed_transactions_count
                     .saturating_sub(executed_with_successful_result_count)
                     as u64,
@@ -6602,6 +6632,10 @@ impl Bank {
         self.transaction_count.load(Relaxed)
     }
 
+    pub fn non_vote_transaction_count_since_restart(&self) -> u64 {
+        self.non_vote_transaction_count_since_restart.load(Relaxed)
+    }
+
     pub fn transaction_error_count(&self) -> u64 {
         self.transaction_error_count.load(Relaxed)
     }
@@ -6616,6 +6650,11 @@ impl Bank {
 
     fn increment_transaction_count(&self, tx_count: u64) {
         self.transaction_count.fetch_add(tx_count, Relaxed);
+    }
+
+    fn increment_non_vote_transaction_count_since_restart(&self, tx_count: u64) {
+        self.non_vote_transaction_count_since_restart
+            .fetch_add(tx_count, Relaxed);
     }
 
     pub fn signature_count(&self) -> u64 {
@@ -10466,6 +10505,7 @@ pub(crate) mod tests {
         bank.transfer(amount * 2, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.get_balance(&pubkey), amount * 3);
         assert_eq!(bank.transaction_count(), 2);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 2);
     }
 
     #[test]
@@ -10590,6 +10630,7 @@ pub(crate) mod tests {
             Err(TransactionError::AccountNotFound)
         );
         assert_eq!(bank.transaction_count(), 0);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 0);
     }
 
     #[test]
@@ -10601,6 +10642,7 @@ pub(crate) mod tests {
         let amount = genesis_config.rent.minimum_balance(0);
         bank.transfer(amount, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
         assert_eq!(bank.get_balance(&pubkey), amount);
         assert_eq!(
             bank.transfer((mint_amount - amount) + 1, &mint_keypair, &pubkey),
@@ -10610,6 +10652,7 @@ pub(crate) mod tests {
             ))
         );
         assert_eq!(bank.transaction_count(), 1);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
 
         let mint_pubkey = mint_keypair.pubkey();
         assert_eq!(bank.get_balance(&mint_pubkey), mint_amount - amount);
@@ -11210,6 +11253,7 @@ pub(crate) mod tests {
 
         // Assert bad transactions aren't counted.
         assert_eq!(bank.transaction_count(), 1);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
     }
 
     #[test]
@@ -11767,6 +11811,7 @@ pub(crate) mod tests {
         assert_eq!(parent.process_transaction(&tx_transfer_mint_to_1), Ok(()));
         trace!("done parent process tx ");
         assert_eq!(parent.transaction_count(), 1);
+        assert_eq!(parent.non_vote_transaction_count_since_restart(), 1);
         assert_eq!(
             parent.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
             Some(Ok(()))
@@ -11781,11 +11826,17 @@ pub(crate) mod tests {
         );
 
         assert_eq!(bank.transaction_count(), parent.transaction_count());
+        assert_eq!(
+            bank.non_vote_transaction_count_since_restart(),
+            parent.non_vote_transaction_count_since_restart()
+        );
         let tx_transfer_1_to_2 =
             system_transaction::transfer(&key1, &key2.pubkey(), amount, genesis_config.hash());
         assert_eq!(bank.process_transaction(&tx_transfer_1_to_2), Ok(()));
         assert_eq!(bank.transaction_count(), 2);
+        assert_eq!(bank.non_vote_transaction_count_since_restart(), 2);
         assert_eq!(parent.transaction_count(), 1);
+        assert_eq!(parent.non_vote_transaction_count_since_restart(), 1);
         assert_eq!(
             parent.get_signature_status(&tx_transfer_1_to_2.signatures[0]),
             None
@@ -11811,7 +11862,9 @@ pub(crate) mod tests {
             bank.squash();
 
             assert_eq!(parent.transaction_count(), 1);
+            assert_eq!(parent.non_vote_transaction_count_since_restart(), 1);
             assert_eq!(bank.transaction_count(), 2);
+            assert_eq!(bank.non_vote_transaction_count_since_restart(), 2);
         }
     }
 
@@ -12294,21 +12347,30 @@ pub(crate) mod tests {
         );
 
         assert_eq!(bank0.transaction_count(), 0);
+        assert_eq!(bank0.non_vote_transaction_count_since_restart(), 0);
         assert_eq!(bank2.transaction_count(), 0);
+        assert_eq!(bank2.non_vote_transaction_count_since_restart(), 0);
         assert_eq!(bank1.transaction_count(), 1);
+        assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
         bank1.squash();
 
         assert_eq!(bank0.transaction_count(), 0);
+        assert_eq!(bank0.non_vote_transaction_count_since_restart(), 0);
         assert_eq!(bank2.transaction_count(), 0);
+        assert_eq!(bank2.non_vote_transaction_count_since_restart(), 0);
         assert_eq!(bank1.transaction_count(), 1);
+        assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
         let bank6 = Bank::new_from_parent(&bank1, &solana_sdk::pubkey::new_rand(), 3);
         assert_eq!(bank1.transaction_count(), 1);
+        assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
         assert_eq!(bank6.transaction_count(), 1);
+        assert_eq!(bank6.non_vote_transaction_count_since_restart(), 1);
 
         bank6.squash();
         assert_eq!(bank6.transaction_count(), 1);
+        assert_eq!(bank6.non_vote_transaction_count_since_restart(), 1);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

A subsequent change to `SamplePerformanceService` introduces non-vote transaction counts, which `bank`s need to store.

#### Summary of Changes

Added the necessary counts.

Part of work on https://github.com/solana-labs/solana/issues/29159