### PR TITLE
Security TXT: Add source_release and source_revision fields

### DIFF
--- a/explorer/src/components/account/SecurityCard.tsx
+++ b/explorer/src/components/account/SecurityCard.tsx
@@ -79,14 +79,24 @@ const ROWS: TableRow[] = [
     type: DisplayType.String,
   },
   {
+    display: "Secure Contact Encryption",
+    key: "encryption",
+    type: DisplayType.PGP,
+  },
+  {
     display: "Source Code URL",
     key: "source_code",
     type: DisplayType.URL,
   },
   {
-    display: "Secure Contact Encryption",
-    key: "encryption",
-    type: DisplayType.PGP,
+    display: "Source Code Release Version",
+    key: "source_release",
+    type: DisplayType.String,
+  },
+  {
+    display: "Source Code Revision",
+    key: "source_revision",
+    type: DisplayType.String,
   },
   {
     display: "Auditors",

--- a/explorer/src/utils/security-txt.ts
+++ b/explorer/src/utils/security-txt.ts
@@ -6,8 +6,10 @@ export type SecurityTXT = {
   contacts: string;
   policy: string;
   preferred_languages?: string;
-  source_code?: string;
   encryption?: string;
+  source_code?: string;
+  source_release?: string;
+  source_revision?: string;
   auditors?: string;
   acknowledgements?: string;
   expiry?: string;
@@ -24,8 +26,10 @@ const VALID_KEYS: (keyof SecurityTXT)[] = [
   "contacts",
   "policy",
   "preferred_languages",
-  "source_code",
   "encryption",
+  "source_code",
+  "source_release",
+  "source_revision",
   "auditors",
   "acknowledgements",
   "expiry",


### PR DESCRIPTION
#### Problem
We have added two new fields to the [Security Txt](https://github.com/neodyme-labs/solana-security-txt). 

#### Summary of Changes
Add `source_release` and `source_revision` fields to the security tab.
