### PR TITLE
BankingStage Refactor: Separate Next Leader Functions

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod leader_slot_banking_stage_timing_metrics;
 pub mod ledger_cleanup_service;
 pub mod ledger_metric_report_service;
 pub mod multi_iterator_scanner;
+pub mod next_leader;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
 pub mod packet_deserializer;

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -1,0 +1,50 @@
+use {
+    solana_gossip::{
+        cluster_info::ClusterInfo, legacy_contact_info::LegacyContactInfo as ContactInfo,
+    },
+    solana_poh::poh_recorder::PohRecorder,
+    solana_sdk::{clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, pubkey::Pubkey},
+    std::{net::SocketAddr, sync::RwLock},
+};
+
+pub(crate) fn next_leader_tpu(
+    cluster_info: &ClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+) -> Option<(Pubkey, SocketAddr)> {
+    next_leader_x(cluster_info, poh_recorder, |leader| leader.tpu)
+}
+
+pub(crate) fn next_leader_tpu_forwards(
+    cluster_info: &ClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+) -> Option<(Pubkey, SocketAddr)> {
+    next_leader_x(cluster_info, poh_recorder, |leader| leader.tpu_forwards)
+}
+
+pub(crate) fn next_leader_tpu_vote(
+    cluster_info: &ClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+) -> Option<(Pubkey, SocketAddr)> {
+    next_leader_x(cluster_info, poh_recorder, |leader| leader.tpu_vote)
+}
+
+fn next_leader_x<F>(
+    cluster_info: &ClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+    port_selector: F,
+) -> Option<(Pubkey, SocketAddr)>
+where
+    F: FnOnce(&ContactInfo) -> SocketAddr,
+{
+    let leader_pubkey = poh_recorder
+        .read()
+        .unwrap()
+        .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET);
+    if let Some(leader_pubkey) = leader_pubkey {
+        cluster_info
+            .lookup_contact_info(&leader_pubkey, port_selector)
+            .map(|addr| (leader_pubkey, addr))
+    } else {
+        None
+    }
+}

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -82,9 +82,9 @@ impl VotingService {
         }
 
         let pubkey_and_target_address = if send_to_tpu_vote_port {
-            crate::banking_stage::next_leader_tpu_vote(cluster_info, poh_recorder)
+            crate::next_leader::next_leader_tpu_vote(cluster_info, poh_recorder)
         } else {
-            crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder)
+            crate::next_leader::next_leader_tpu(cluster_info, poh_recorder)
         };
         let _ = cluster_info.send_transaction(
             vote_op.tx(),


### PR DESCRIPTION
#### Problem
BankingStage is very large. Splitting up different functionalities into modules makes scheduler work easier.

#### Summary of Changes
**Simple Move PR**

These functions are only used by the packet forwarding logic of banking stage, but are used outside of banking stage. For this reason I've split these functions out entirely separate, and they will be used by forwarding module in follow-up PR.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
