### PR TITLE
ledger/blockstore: PerfSampleV2: num_non_vote_transactions

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -832,9 +832,6 @@ impl SlotColumn for columns::PerfSamples {}
 impl ColumnName for columns::PerfSamples {
     const NAME: &'static str = PERF_SAMPLES_CF;
 }
-impl TypedColumn for columns::PerfSamples {
-    type Type = blockstore_meta::PerfSample;
-}
 
 impl SlotColumn for columns::BlockHeight {}
 impl ColumnName for columns::BlockHeight {


### PR DESCRIPTION
#### Problem

As part of work on https://github.com/solana-labs/solana/issues/29159 we need to store "non-vote transaction counts" in the blockstore.

#### Summary of Changes

Store non-vote transaction counts that will be recorded by the banks into the `blockstore`.

Part of work on #29159