### PR TITLE
storage rebuilder regex cleanup

### DIFF
--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -391,10 +391,10 @@ pub(crate) fn get_slot_and_append_vec_id(filename: &str) -> (Slot, usize) {
     STORAGE_FILE_REGEX
         .captures(filename)
         .map(|cap| {
-            let slot_str = cap.name("slot").map(|m| m.as_str());
-            let id_str = cap.name("id").map(|m| m.as_str());
-            let slot: Slot = slot_str.unwrap().parse::<u64>().unwrap();
-            let id = id_str.unwrap().parse::<u32>().unwrap() as usize;
+            let slot_str = cap.name("slot").map(|m| m.as_str()).unwrap();
+            let id_str = cap.name("id").map(|m| m.as_str()).unwrap();
+            let slot = slot_str.parse().unwrap();
+            let id = id_str.parse().unwrap();
             (slot, id)
         })
         .unwrap()

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -31,6 +31,14 @@ use {
         time::Instant,
     },
 };
+
+lazy_static! {
+    static ref VERSION_FILE_REGEX: Regex = Regex::new(r"^version$").unwrap();
+    static ref BANK_FIELDS_FILE_REGEX: Regex = Regex::new(r"^[0-9]+(\.pre)?$").unwrap();
+    static ref STORAGE_FILE_REGEX: Regex =
+        Regex::new(r"^(?P<slot>[0-9]+)\.(?P<id>[0-9]+)$").unwrap();
+}
+
 /// Convenient wrapper for snapshot version and rebuilt storages
 pub(crate) struct RebuiltSnapshotStorage {
     /// Snapshot version
@@ -367,12 +375,6 @@ enum SnapshotFileKind {
 
 /// Determines `SnapshotFileKind` for `filename` if any
 fn get_snapshot_file_kind(filename: &str) -> Option<SnapshotFileKind> {
-    lazy_static! {
-        static ref VERSION_FILE_REGEX: Regex = Regex::new(r"^version$").unwrap();
-        static ref BANK_FIELDS_FILE_REGEX: Regex = Regex::new(r"^[0-9]+$").unwrap();
-        static ref STORAGE_FILE_REGEX: Regex = Regex::new(r"^[0-9]+\.[0-9]+$").unwrap();
-    };
-
     if VERSION_FILE_REGEX.is_match(filename) {
         Some(SnapshotFileKind::Version)
     } else if BANK_FIELDS_FILE_REGEX.is_match(filename) {
@@ -385,13 +387,17 @@ fn get_snapshot_file_kind(filename: &str) -> Option<SnapshotFileKind> {
 }
 
 /// Get the slot and append vec id from the filename
-fn get_slot_and_append_vec_id(filename: &str) -> (Slot, usize) {
-    let mut split = filename.split('.');
-    let slot = split.next().unwrap().parse().unwrap();
-    let append_vec_id = split.next().unwrap().parse().unwrap();
-    assert!(split.next().is_none());
-
-    (slot, append_vec_id)
+pub(crate) fn get_slot_and_append_vec_id(filename: &str) -> (Slot, usize) {
+    STORAGE_FILE_REGEX
+        .captures(filename)
+        .map(|cap| {
+            let slot_str = cap.name("slot").map(|m| m.as_str());
+            let id_str = cap.name("id").map(|m| m.as_str());
+            let slot: Slot = slot_str.unwrap().parse::<u64>().unwrap();
+            let id = id_str.unwrap().parse::<u32>().unwrap() as usize;
+            (slot, id)
+        })
+        .unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Minor cleanup in regex code in snapshot_storage_rebuilder.rs
One of the split PRs from https://github.com/solana-labs/solana/pull/28745

#### Summary of Changes
Move duplicated regex from inside function to top of the file;
Change get_slot_and_append_vec_id() implementation to use regex.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
