### PR TITLE
Add slot deltas into the bank snapshot directory

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -331,7 +331,6 @@ mod tests {
                 archive_format,
             },
             block_height: slot,
-            slot_deltas: vec![],
             snapshot_links: link_snapshots_dir,
             snapshot_storages: storage_entries,
             snapshot_version: SnapshotVersion::default(),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -22,7 +22,7 @@ use {
         accounts_db::{self, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
-        bank::{Bank, BankSlotDelta},
+        bank::Bank,
         bank_forks::BankForks,
         epoch_accounts_hash::EpochAccountsHash,
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
@@ -266,13 +266,11 @@ fn run_bank_forks_snapshot_n<F>(
     let bank_snapshots_dir = &snapshot_config.bank_snapshots_dir;
     let last_bank_snapshot_info = snapshot_utils::get_highest_bank_snapshot_pre(bank_snapshots_dir)
         .expect("no bank snapshots found in path");
-    let slot_deltas = last_bank.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new_for_snapshot(
         AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
         &last_bank,
         &last_bank_snapshot_info,
         bank_snapshots_dir,
-        slot_deltas,
         &snapshot_config.full_snapshot_archives_dir,
         &snapshot_config.incremental_snapshot_archives_dir,
         last_bank.get_snapshot_storages(None),
@@ -371,8 +369,15 @@ fn test_concurrent_snapshot_packaging(
     // Take snapshot of zeroth bank
     let bank0 = bank_forks.get(0).unwrap();
     let storages = bank0.get_snapshot_storages(None);
-    snapshot_utils::add_bank_snapshot(bank_snapshots_dir, &bank0, &storages, snapshot_version)
-        .unwrap();
+    let slot_deltas = bank0.status_cache.read().unwrap().root_slot_deltas();
+    snapshot_utils::add_bank_snapshot(
+        bank_snapshots_dir,
+        &bank0,
+        &storages,
+        snapshot_version,
+        slot_deltas,
+    )
+    .unwrap();
 
     // Set up snapshotting channels
     let (real_accounts_package_sender, real_accounts_package_receiver) =
@@ -416,11 +421,13 @@ fn test_concurrent_snapshot_packaging(
         };
 
         let snapshot_storages = bank.get_snapshot_storages(None);
+        let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
         let bank_snapshot_info = snapshot_utils::add_bank_snapshot(
             bank_snapshots_dir,
             &bank,
             &snapshot_storages,
             snapshot_config.snapshot_version,
+            slot_deltas,
         )
         .unwrap();
         let accounts_package = AccountsPackage::new_for_snapshot(
@@ -428,7 +435,6 @@ fn test_concurrent_snapshot_packaging(
             &bank,
             &bank_snapshot_info,
             bank_snapshots_dir,
-            vec![],
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             snapshot_storages,
@@ -560,20 +566,6 @@ fn test_concurrent_snapshot_packaging(
         .expect("SnapshotPackagerService exited with error");
 
     // Check the archive we cached the state for earlier was generated correctly
-
-    // before we compare, stick an empty status_cache in this dir so that the package comparison works
-    // This is needed since the status_cache is added by the packager and is not collected from
-    // the source dir for snapshots
-    snapshot_utils::serialize_snapshot_data_file(
-        &saved_snapshots_dir
-            .path()
-            .join(snapshot_utils::SNAPSHOT_STATUS_CACHE_FILENAME),
-        |stream| {
-            serialize_into(stream, &[] as &[BankSlotDelta])?;
-            Ok(())
-        },
-    )
-    .unwrap();
 
     // files were saved off before we reserialized the bank in the hacked up accounts_hash_verifier stand-in.
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
-    bincode::serialize_into,
     crossbeam_channel::unbounded,
     fs_extra::dir::CopyOptions,
     itertools::Itertools,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -357,6 +357,7 @@ impl SnapshotRequestHandler {
                     &snapshot_root_bank,
                     &snapshot_storages,
                     self.snapshot_config.snapshot_version,
+                    status_cache_slot_deltas,
                 )
                 .expect("snapshot bank");
                 AccountsPackage::new_for_snapshot(
@@ -364,7 +365,6 @@ impl SnapshotRequestHandler {
                     &snapshot_root_bank,
                     &bank_snapshot_info,
                     &self.snapshot_config.bank_snapshots_dir,
-                    status_cache_slot_deltas,
                     &self.snapshot_config.full_snapshot_archives_dir,
                     &self.snapshot_config.incremental_snapshot_archives_dir,
                     snapshot_storages,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -93,12 +93,9 @@ impl AccountsPackage {
             fs::create_dir_all(&snapshot_hardlink_dir)?;
             let snapshot_path = bank_snapshot_info.snapshot_path();
             let file_name = snapshot_utils::path_to_file_name_str(&snapshot_path)?;
-            fs::hard_link(
-                bank_snapshot_info.snapshot_path(),
-                snapshot_hardlink_dir.join(file_name),
-            )?;
+            fs::hard_link(&snapshot_path, snapshot_hardlink_dir.join(file_name))?;
             let status_cache_path = bank_snapshot_info
-                .bank_snapshot_dir
+                .snapshot_dir
                 .join(SNAPSHOT_STATUS_CACHE_FILENAME);
             let status_cache_file_name = snapshot_utils::path_to_file_name_str(&status_cache_path)?;
             fs::hard_link(

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -3,7 +3,7 @@ use {
         accounts::Accounts,
         accounts_db::AccountStorageEntry,
         accounts_hash::AccountsHash,
-        bank::{Bank, BankSlotDelta},
+        bank::Bank,
         epoch_accounts_hash::EpochAccountsHash,
         rent_collector::RentCollector,
         snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
@@ -59,7 +59,6 @@ impl AccountsPackage {
         bank: &Bank,
         bank_snapshot_info: &BankSnapshotInfo,
         bank_snapshots_dir: impl AsRef<Path>,
-        slot_deltas: Vec<BankSlotDelta>,
         full_snapshot_archives_dir: impl AsRef<Path>,
         incremental_snapshot_archives_dir: impl AsRef<Path>,
         snapshot_storages: Vec<Arc<AccountStorageEntry>>,
@@ -98,10 +97,15 @@ impl AccountsPackage {
                 &bank_snapshot_info.snapshot_path,
                 snapshot_hardlink_dir.join(file_name),
             )?;
+            let status_cache_file_name =
+                snapshot_utils::path_to_file_name_str(&bank_snapshot_info.status_cache_path)?;
+            fs::hard_link(
+                &bank_snapshot_info.status_cache_path,
+                snapshot_links.path().join(status_cache_file_name),
+            )?;
         }
 
         let snapshot_info = SupplementalSnapshotInfo {
-            slot_deltas,
             snapshot_links,
             archive_format,
             snapshot_version,
@@ -174,7 +178,6 @@ impl AccountsPackage {
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),
             snapshot_info: Some(SupplementalSnapshotInfo {
-                slot_deltas: Vec::default(),
                 snapshot_links: TempDir::new().unwrap(),
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
@@ -215,7 +218,6 @@ impl std::fmt::Debug for AccountsPackage {
 
 /// Supplemental information needed for snapshots
 pub struct SupplementalSnapshotInfo {
-    pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
     pub archive_format: ArchiveFormat,
     pub snapshot_version: SnapshotVersion,
@@ -237,7 +239,6 @@ pub enum AccountsPackageType {
 pub struct SnapshotPackage {
     pub snapshot_archive_info: SnapshotArchiveInfo,
     pub block_height: Slot,
-    pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
     pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     pub snapshot_version: SnapshotVersion,
@@ -286,7 +287,6 @@ impl SnapshotPackage {
                 archive_format: snapshot_info.archive_format,
             },
             block_height: accounts_package.block_height,
-            slot_deltas: snapshot_info.slot_deltas,
             snapshot_links: snapshot_info.snapshot_links,
             snapshot_storages,
             snapshot_version: snapshot_info.snapshot_version,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -10,7 +10,7 @@ use {
         snapshot_hash::SnapshotHash,
         snapshot_utils::{
             self, ArchiveFormat, BankSnapshotInfo, Result, SnapshotVersion,
-            TMP_BANK_SNAPSHOT_PREFIX,
+            SNAPSHOT_STATUS_CACHE_FILENAME, TMP_BANK_SNAPSHOT_PREFIX,
         },
     },
     log::*,
@@ -97,10 +97,12 @@ impl AccountsPackage {
                 &bank_snapshot_info.snapshot_path,
                 snapshot_hardlink_dir.join(file_name),
             )?;
-            let status_cache_file_name =
-                snapshot_utils::path_to_file_name_str(&bank_snapshot_info.status_cache_path)?;
+            let status_cache_path = bank_snapshot_info
+                .bank_snapshot_dir
+                .join(SNAPSHOT_STATUS_CACHE_FILENAME);
+            let status_cache_file_name = snapshot_utils::path_to_file_name_str(&status_cache_path)?;
             fs::hard_link(
-                &bank_snapshot_info.status_cache_path,
+                &status_cache_path,
                 snapshot_links.path().join(status_cache_file_name),
             )?;
         }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -91,10 +91,10 @@ impl AccountsPackage {
                 .path()
                 .join(bank_snapshot_info.slot.to_string());
             fs::create_dir_all(&snapshot_hardlink_dir)?;
-            let file_name =
-                snapshot_utils::path_to_file_name_str(&bank_snapshot_info.snapshot_path)?;
+            let snapshot_path = bank_snapshot_info.snapshot_path();
+            let file_name = snapshot_utils::path_to_file_name_str(&snapshot_path)?;
             fs::hard_link(
-                &bank_snapshot_info.snapshot_path,
+                bank_snapshot_info.snapshot_path(),
                 snapshot_hardlink_dir.join(file_name),
             )?;
             let status_cache_path = bank_snapshot_info

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -592,6 +592,8 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                 let bank_snapshot_outer_dir = get_bank_snapshots_dir(&bank_snapshots_dir, slot);
                 let bank_snapshot_post_path =
                     bank_snapshot_outer_dir.join(get_snapshot_file_name(slot));
+                let status_cache_path =
+                    bank_snapshot_outer_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
                 let mut bank_snapshot_pre_path = bank_snapshot_post_path.clone();
                 bank_snapshot_pre_path.set_extension(BANK_SNAPSHOT_PRE_FILENAME_EXTENSION);
 
@@ -600,8 +602,7 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                         slot,
                         snapshot_path: bank_snapshot_pre_path,
                         snapshot_type: BankSnapshotType::Pre,
-                        status_cache_path: bank_snapshot_outer_dir
-                            .join(SNAPSHOT_STATUS_CACHE_FILENAME),
+                        status_cache_path: status_cache_path.clone(),
                     });
                 }
 
@@ -610,8 +611,7 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                         slot,
                         snapshot_path: bank_snapshot_post_path,
                         snapshot_type: BankSnapshotType::Post,
-                        status_cache_path: bank_snapshot_outer_dir
-                            .join(SNAPSHOT_STATUS_CACHE_FILENAME),
+                        status_cache_path,
                     });
                 }
             }),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -136,12 +136,12 @@ impl SnapshotVersion {
 pub struct BankSnapshotInfo {
     /// Slot of the bank
     pub slot: Slot,
-    /// Path to the snapshot
+    /// Path to the snapshot file
     pub snapshot_path: PathBuf,
     /// Type of the snapshot
     pub snapshot_type: BankSnapshotType,
-    /// Path to the status cache (transaction history)
-    pub status_cache_path: PathBuf,
+    /// Path to the bank snapshot directory
+    pub bank_snapshot_dir: PathBuf,
 }
 
 impl PartialOrd for BankSnapshotInfo {
@@ -592,8 +592,6 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                 let bank_snapshot_outer_dir = get_bank_snapshots_dir(&bank_snapshots_dir, slot);
                 let bank_snapshot_post_path =
                     bank_snapshot_outer_dir.join(get_snapshot_file_name(slot));
-                let status_cache_path =
-                    bank_snapshot_outer_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
                 let mut bank_snapshot_pre_path = bank_snapshot_post_path.clone();
                 bank_snapshot_pre_path.set_extension(BANK_SNAPSHOT_PRE_FILENAME_EXTENSION);
 
@@ -602,7 +600,7 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                         slot,
                         snapshot_path: bank_snapshot_pre_path,
                         snapshot_type: BankSnapshotType::Pre,
-                        status_cache_path: status_cache_path.clone(),
+                        bank_snapshot_dir: bank_snapshot_outer_dir.clone(),
                     });
                 }
 
@@ -611,7 +609,7 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
                         slot,
                         snapshot_path: bank_snapshot_post_path,
                         snapshot_type: BankSnapshotType::Post,
-                        status_cache_path,
+                        bank_snapshot_dir: bank_snapshot_outer_dir,
                     });
                 }
             }),
@@ -929,7 +927,7 @@ pub fn add_bank_snapshot(
         slot,
         snapshot_path: bank_snapshot_path,
         snapshot_type: BankSnapshotType::Pre,
-        status_cache_path,
+        bank_snapshot_dir,
     })
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2174,6 +2174,22 @@ pub fn verify_snapshot_archive<P, Q, R>(
         assert!(crate::serde_snapshot::compare_two_serialized_banks(&p1, &p2).unwrap());
         std::fs::remove_file(p1).unwrap();
         std::fs::remove_file(p2).unwrap();
+
+        // The new the status_cache file is inside the slot directory together with the snapshot file.
+        // When unpacking an archive, the status_cache file from the archive is one-level up outside of
+        //  the slot direcotry.
+        // The unpacked status_cache file need to be put back into the slot directory for the directory
+        // comparison to pass.
+        let existing_unpacked_status_cache_file =
+            unpacked_snapshots.join(SNAPSHOT_STATUS_CACHE_FILENAME);
+        let new_unpacked_status_cache_file = unpacked_snapshots
+            .join(&slot)
+            .join(SNAPSHOT_STATUS_CACHE_FILENAME);
+        fs::rename(
+            existing_unpacked_status_cache_file,
+            new_unpacked_status_cache_file,
+        )
+        .unwrap();
     }
 
     assert!(!dir_diff::is_different(&snapshots_to_verify, unpacked_snapshots).unwrap());

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -139,7 +139,7 @@ pub struct BankSnapshotInfo {
     /// Type of the snapshot
     pub snapshot_type: BankSnapshotType,
     /// Path to the bank snapshot directory
-    pub bank_snapshot_dir: PathBuf,
+    pub snapshot_dir: PathBuf,
 }
 
 impl PartialOrd for BankSnapshotInfo {
@@ -158,7 +158,7 @@ impl Ord for BankSnapshotInfo {
 impl BankSnapshotInfo {
     pub fn new_from_dir(
         bank_snapshots_dir: impl AsRef<Path>,
-        slot: u64,
+        slot: Slot,
     ) -> Option<BankSnapshotInfo> {
         // check this directory to see if there is a BankSnapshotPre and/or
         // BankSnapshotPost file
@@ -171,7 +171,7 @@ impl BankSnapshotInfo {
             return Some(BankSnapshotInfo {
                 slot,
                 snapshot_type: BankSnapshotType::Pre,
-                bank_snapshot_dir,
+                snapshot_dir: bank_snapshot_dir,
             });
         }
 
@@ -179,7 +179,7 @@ impl BankSnapshotInfo {
             return Some(BankSnapshotInfo {
                 slot,
                 snapshot_type: BankSnapshotType::Post,
-                bank_snapshot_dir,
+                snapshot_dir: bank_snapshot_dir,
             });
         }
 
@@ -187,9 +187,7 @@ impl BankSnapshotInfo {
     }
 
     pub fn snapshot_path(&self) -> PathBuf {
-        let mut bank_snapshot_path = self
-            .bank_snapshot_dir
-            .join(get_snapshot_file_name(self.slot));
+        let mut bank_snapshot_path = self.snapshot_dir.join(get_snapshot_file_name(self.slot));
 
         let ext = match self.snapshot_type {
             BankSnapshotType::Pre => BANK_SNAPSHOT_PRE_FILENAME_EXTENSION,
@@ -949,7 +947,7 @@ pub fn add_bank_snapshot(
     Ok(BankSnapshotInfo {
         slot,
         snapshot_type: BankSnapshotType::Pre,
-        bank_snapshot_dir,
+        snapshot_dir: bank_snapshot_dir,
     })
 }
 
@@ -2237,7 +2235,7 @@ pub fn purge_old_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) {
                 if r.is_err() {
                     warn!(
                         "Couldn't remove bank snapshot at: {}",
-                        bank_snapshot.bank_snapshot_dir.display()
+                        bank_snapshot.snapshot_dir.display()
                     );
                 }
             })


### PR DESCRIPTION
#### Problem
The slot_deltas is a necessary part of the bank state, needed for reconstructing the bank.  It should be serialized together with the bank.

#### Summary of Changes
Serialize the slot_deltas into the bank snapshot directory in add_bank_snapshot, so it is generated with the bank file.  Move it out of the AccountsPackage data structure.  When building the archive, instead of using the data structure inside the AccountsPackage, hard-link the serialized slot-delta file in the bank snapshot directory.

This is one of the split PRs from https://github.com/solana-labs/solana/pull/28745/

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
