### PR TITLE
[keygen] grind attempt counter with mnemonics

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -469,7 +469,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .multiple_occurrences(true)
                         .multiple_values(true)
                         .validator(grind_validator_starts_and_ends_with)
-                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
+                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated prefix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
                 )
                 .arg(
                     Arg::new("num_threads")
@@ -750,7 +750,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                             break;
                         }
                         let attempts = attempts.fetch_add(1, Ordering::Relaxed);
-                        if attempts % 1_000_000 == 0 {
+                        if (!use_mnemonic && attempts % 1_000_000 == 0) || (use_mnemonic && attempts % 100_000 == 0) {
                             println!(
                                 "Searched {} keypairs in {}s. {} matches found.",
                                 attempts,


### PR DESCRIPTION
#### Problem

Since grinding for public keys using mnemonics is much slower than without, the attempt counter displaying every 1,000,000 attempts seems very high. Having a lower progress indications for grinding with mnemonics would be useful.

#### Summary of Changes

- added check for when using mnemonics on grind to display the attempt progress every `100_000`
- fixed typo in a word

