### PR TITLE
feat: add commission fields matching RPC spec

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -767,6 +767,8 @@ export type InflationReward = {
   amount: number;
   /** post balance of the account in lamports */
   postBalance: number;
+  /** vote account commission when the reward was credited */
+  commission: number | null;
 };
 
 /**
@@ -780,6 +782,7 @@ const GetInflationRewardResult = jsonRpcResult(
         effectiveSlot: number(),
         amount: number(),
         postBalance: number(),
+        commission: optional(nullable(number())),
       }),
     ),
   ),
@@ -1232,6 +1235,8 @@ export type BlockResponse = {
     postBalance: number | null;
     /** Type of reward received */
     rewardType: string | null;
+    /** Vote account commission when the reward was credited, only present for voting and staking rewards */
+    commission: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1276,6 +1281,8 @@ export type ParsedBlockResponse = {
     postBalance: number | null;
     /** Type of reward received */
     rewardType: string | null;
+    /** Vote account commission when the reward was credited, only present for voting and staking rewards */
+    commission: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1344,6 +1351,8 @@ export type VersionedBlockResponse = {
     postBalance: number | null;
     /** Type of reward received */
     rewardType: string | null;
+    /** Vote account commission when the reward was credited, only present for voting and staking rewards */
+    commission: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1399,6 +1408,7 @@ export type ConfirmedBlock = {
     lamports: number;
     postBalance: number | null;
     rewardType: string | null;
+    commission: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -2297,6 +2307,7 @@ const RewardsResult = pick({
   lamports: number(),
   postBalance: nullable(number()),
   rewardType: nullable(string()),
+  commission: optional(nullable(number())),
 });
 
 /**

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -768,7 +768,7 @@ export type InflationReward = {
   /** post balance of the account in lamports */
   postBalance: number;
   /** vote account commission when the reward was credited */
-  commission: number | null;
+  commission?: number | null;
 };
 
 /**
@@ -1236,7 +1236,7 @@ export type BlockResponse = {
     /** Type of reward received */
     rewardType: string | null;
     /** Vote account commission when the reward was credited, only present for voting and staking rewards */
-    commission: number | null;
+    commission?: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1282,7 +1282,7 @@ export type ParsedBlockResponse = {
     /** Type of reward received */
     rewardType: string | null;
     /** Vote account commission when the reward was credited, only present for voting and staking rewards */
-    commission: number | null;
+    commission?: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1352,7 +1352,7 @@ export type VersionedBlockResponse = {
     /** Type of reward received */
     rewardType: string | null;
     /** Vote account commission when the reward was credited, only present for voting and staking rewards */
-    commission: number | null;
+    commission?: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;
@@ -1408,7 +1408,7 @@ export type ConfirmedBlock = {
     lamports: number;
     postBalance: number | null;
     rewardType: string | null;
-    commission: number | null;
+    commission?: number | null;
   }>;
   /** The unix timestamp of when the block was processed */
   blockTime: number | null;

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -808,6 +808,7 @@ describe('Connection', function () {
             effectiveSlot: 432000,
             epoch: 0,
             postBalance: 30504783,
+            commission: 0,
           },
           null,
         ],


### PR DESCRIPTION
#### Problem
The `@solana/web3.js` SDK `InflationReward` type and `rewards` in the `meta` for `transaction status metadata object` properties do not match the JSON RPC spec in that they are missing the `commission` field. This is causing an issue with the types when attempting to access field value.

See:
- https://docs.solana.com/developing/clients/jsonrpc-api#getinflationreward
- https://docs.solana.com/developing/clients/jsonrpc-api#getblock

#### Summary of Changes
Adds the commission field in the `src/connection.ts`
- `InflationReward`
- `RewardsResult`
- `GetInflationRewardResult`
- `BlockResponse`
- `ParsedBlockResponse`
- `VersionedBlockResponse`
- `ConfirmedBlock`

Adds commission field in the `mockRpcResponse` in the `tests/connection.test.ts` file.