### PR TITLE
recovers merkle roots from shreds binary in {verify,sign}_shreds_gpu

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -49,10 +49,11 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
+pub(crate) use self::merkle::{MerkleRoot, SIZE_OF_MERKLE_ROOT};
 #[cfg(test)]
-pub(crate) use shred_code::MAX_CODE_SHREDS_PER_SLOT;
+pub(crate) use self::shred_code::MAX_CODE_SHREDS_PER_SLOT;
 use {
-    self::{merkle::MerkleRoot, shred_code::ShredCode, traits::Shred as _},
+    self::{shred_code::ShredCode, traits::Shred as _},
     crate::blockstore::{self, MAX_DATA_SHREDS_PER_SLOT},
     bitflags::bitflags,
     num_enum::{IntoPrimitive, TryFromPrimitive},
@@ -678,7 +679,6 @@ pub mod layout {
         Ok(flags & ShredFlags::SHRED_TICK_REFERENCE_MASK.bits())
     }
 
-    #[cfg(test)]
     pub(crate) fn get_merkle_root(shred: &[u8]) -> Option<MerkleRoot> {
         match get_shred_variant(shred).ok()? {
             ShredVariant::LegacyCode | ShredVariant::LegacyData => None,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -36,7 +36,7 @@ use {
 };
 
 const_assert_eq!(SIZE_OF_MERKLE_ROOT, 20);
-const SIZE_OF_MERKLE_ROOT: usize = std::mem::size_of::<MerkleRoot>();
+pub(crate) const SIZE_OF_MERKLE_ROOT: usize = std::mem::size_of::<MerkleRoot>();
 const_assert_eq!(SIZE_OF_MERKLE_PROOF_ENTRY, 20);
 const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
 const_assert_eq!(ShredData::SIZE_OF_PAYLOAD, 1203);


### PR DESCRIPTION
```diff
- This is a prerequisite of
- https://github.com/solana-labs/solana/pull/29427
```

#### Problem
`{verify,sign}_shreds_gpu` need to point to offsets within the packets for the signed data. For merkle shreds this signed data is the merkle root of the erasure batch and this would necessitate embedding merkle roots in the shreds payload.
However this is wasteful and reduces shreds capacity to store data because the merkle root can already be recovered from the embedded merkle proof.



#### Summary of Changes
Instead of pointing to offsets within shreds payload, this commit recovers merkle roots from the merkle proofs and stores them in an allocated buffer. `{verify,sign}_shreds_gpu` would then point to offsets within this new buffer for the respective signed data.

This would unblock us from removing merkle roots from shreds payload which would save capacity to send more data with each shred.

Test coverage was added in: https://github.com/solana-labs/solana/pull/29429, https://github.com/solana-labs/solana/pull/29424
