### PR TITLE
generalizes the return type of Shred::get_signed_data

### DIFF
--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -312,7 +312,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     .original_last_data_shreds
                     .lock()
                     .unwrap()
-                    .remove(&shred.signature())
+                    .remove(shred.signature())
                 {
                     if cluster_partition.contains(&node.id) {
                         info!(
@@ -327,7 +327,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     .partition_last_data_shreds
                     .lock()
                     .unwrap()
-                    .remove(&shred.signature())
+                    .remove(shred.signature())
                 {
                     // If the shred is part of the partition, broadcast it directly to the
                     // partition node. This is to account for cases when the partition stake

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -48,7 +48,9 @@ pub struct ShredCode {
     payload: Vec<u8>,
 }
 
-impl Shred for ShredData {
+impl<'a> Shred<'a> for ShredData {
+    type SignedData = &'a [u8];
+
     impl_shred_common!();
     // Legacy data shreds are always zero padded and
     // the same size as coding shreds.
@@ -109,13 +111,15 @@ impl Shred for ShredData {
         shred_data::sanitize(self)
     }
 
-    fn signed_data(&self) -> &[u8] {
+    fn signed_data(&'a self) -> Result<Self::SignedData, Error> {
         debug_assert_eq!(self.payload.len(), Self::SIZE_OF_PAYLOAD);
-        &self.payload[SIZE_OF_SIGNATURE..]
+        Ok(&self.payload[SIZE_OF_SIGNATURE..])
     }
 }
 
-impl Shred for ShredCode {
+impl<'a> Shred<'a> for ShredCode {
+    type SignedData = &'a [u8];
+
     impl_shred_common!();
     const SIZE_OF_PAYLOAD: usize = shred_code::ShredCode::SIZE_OF_PAYLOAD;
     const SIZE_OF_HEADERS: usize = SIZE_OF_CODING_SHRED_HEADERS;
@@ -171,9 +175,9 @@ impl Shred for ShredCode {
         shred_code::sanitize(self)
     }
 
-    fn signed_data(&self) -> &[u8] {
+    fn signed_data(&'a self) -> Result<Self::SignedData, Error> {
         debug_assert_eq!(self.payload.len(), Self::SIZE_OF_PAYLOAD);
-        &self.payload[SIZE_OF_SIGNATURE..]
+        Ok(&self.payload[SIZE_OF_SIGNATURE..])
     }
 }
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -4,8 +4,8 @@ use {
             common::dispatch,
             legacy, merkle,
             traits::{Shred, ShredCode as ShredCodeTrait},
-            CodingShredHeader, Error, ShredCommonHeader, ShredType, DATA_SHREDS_PER_FEC_BLOCK,
-            MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+            CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
+            DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
         },
         shredder::ERASURE_BATCH_SIZE,
     },
@@ -39,11 +39,17 @@ impl ShredCode {
     dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
-    dispatch!(pub(super) fn signed_data(&self) -> &[u8]);
 
     // Only for tests.
     dispatch!(pub(super) fn set_index(&mut self, index: u32));
     dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
+
+    pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
+        match self {
+            Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
+            Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
 
     pub(super) fn new_from_parity_shard(
         slot: Slot,

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -4,7 +4,7 @@ use {
         common::dispatch,
         legacy, merkle,
         traits::{Shred as _, ShredData as ShredDataTrait},
-        DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant,
+        DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant, SignedData,
         MAX_DATA_SHREDS_PER_SLOT,
     },
     solana_sdk::{clock::Slot, signature::Signature},
@@ -29,11 +29,17 @@ impl ShredData {
     dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
-    dispatch!(pub(super) fn signed_data(&self) -> &[u8]);
 
     // Only for tests.
     dispatch!(pub(super) fn set_index(&mut self, index: u32));
     dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
+
+    pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
+        match self {
+            Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
+            Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
 
     pub(super) fn new_from_data(
         slot: Slot,

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -3,12 +3,14 @@ use {
     solana_sdk::{clock::Slot, signature::Signature},
 };
 
-pub(super) trait Shred: Sized {
+pub(super) trait Shred<'a>: Sized {
     // Total size of payload including headers, merkle
     // branches (if any), zero paddings, etc.
     const SIZE_OF_PAYLOAD: usize;
     // Size of common and code/data headers.
     const SIZE_OF_HEADERS: usize;
+
+    type SignedData: AsRef<[u8]>;
 
     fn from_payload(shred: Vec<u8>) -> Result<Self, Error>;
     fn common_header(&self) -> &ShredCommonHeader;
@@ -27,14 +29,14 @@ pub(super) trait Shred: Sized {
     fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>;
 
     // Portion of the payload which is signed.
-    fn signed_data(&self) -> &[u8];
+    fn signed_data(&'a self) -> Result<Self::SignedData, Error>;
 
     // Only for tests.
     fn set_index(&mut self, index: u32);
     fn set_slot(&mut self, slot: Slot);
 }
 
-pub(super) trait ShredData: Shred {
+pub(super) trait ShredData: for<'a> Shred<'a> {
     fn data_header(&self) -> &DataShredHeader;
 
     fn parent(&self) -> Result<Slot, Error> {
@@ -56,7 +58,7 @@ pub(super) trait ShredData: Shred {
     fn data(&self) -> Result<&[u8], Error>;
 }
 
-pub(super) trait ShredCode: Shred {
+pub(super) trait ShredCode: for<'a> Shred<'a> {
     fn coding_header(&self) -> &CodingShredHeader;
 
     fn first_coding_index(&self) -> Option<u32> {


### PR DESCRIPTION

#### Problem
* Working towards removing merkle root from shreds binary.
* This would require legacy and merkle shreds returning different types for `signed_data` method.

#### Summary of Changes
The commit adds an associated `SignedData` type to Shred trait so that merkle and legacy shreds can return different types for `signed_data` method.
This would allow legacy shreds to point to a section of the shred payload, whereas merkle shreds would compute and return the merkle root. Ultimately this would allow to remove the merkle root from the shreds binary.
