### PR TITLE
removes merkle root comparison in erasure_mismatch

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -336,12 +336,6 @@ impl ShredCode {
         Some(offset..offset + SIZE_OF_MERKLE_ROOT)
     }
 
-    pub(super) fn erasure_mismatch(&self, other: &ShredCode) -> bool {
-        shred_code::erasure_mismatch(self, other)
-            || self.merkle_root().ok() != other.merkle_root().ok()
-            || self.common_header.signature != other.common_header.signature
-    }
-
     fn from_recovered_shard(
         common_header: ShredCommonHeader,
         coding_header: CodingShredHeader,


### PR DESCRIPTION

#### Problem
 Merkle shreds within the same erasure batch have the same merkle root.
 The root of the merkle tree is signed. So either the signatures match
 or one is invalid, and the comparison of merkle roots is redundant.


#### Summary of Changes
removed merkle root comparison in erasure_mismatch
