### PR TITLE
Fix snapshot download test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -489,10 +489,6 @@ fn test_snapshot_download() {
         .validator_config
         .snapshot_config
         .full_snapshot_archives_dir;
-    let incremental_snapshot_archives_dir = &leader_snapshot_test_config
-        .validator_config
-        .snapshot_config
-        .incremental_snapshot_archives_dir;
 
     trace!("Waiting for snapshot");
     let full_snapshot_archive_info = cluster.wait_for_next_full_snapshot(
@@ -504,8 +500,14 @@ fn test_snapshot_download() {
     // Download the snapshot, then boot a validator from it.
     download_snapshot_archive(
         &cluster.entry_point_info.rpc,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .full_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .incremental_snapshot_archives_dir,
         (
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
@@ -629,8 +631,14 @@ fn test_incremental_snapshot_download() {
     // Download the snapshots, then boot a validator from them.
     download_snapshot_archive(
         &cluster.entry_point_info.rpc,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .full_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .incremental_snapshot_archives_dir,
         (
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),


### PR DESCRIPTION
#### Problem
`test_snapshot_download` and `test_incremental_snapshot_download` are not testing what they intend to. Intention is to generate snapshot(s), download the snapshot(s) to a validator, and boot from the snapshot(s). Problem is that the snapshots are downloaded to the leader's snapshot folder, so when the validator boots, it doesn't find any snapshots and instead loads from genesis.

#### Summary of Changes
Download snapshots to validator's snapshot folders (as opposed to leader's).