### PR TITLE
handle ancient overflow case correctly

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4506,7 +4506,8 @@ impl AccountsDb {
             return; // skipping slot with no useful accounts to write
         }
 
-        let (shrink_in_progress, time) = measure!(current_ancient.create_if_necessary(slot, self));
+        let (mut shrink_in_progress, time) =
+            measure!(current_ancient.create_if_necessary(slot, self));
         let mut create_and_insert_store_elapsed_us = time.as_us();
         let available_bytes = current_ancient.append_vec().accounts.remaining_bytes();
         // split accounts in 'slot' into:
@@ -4537,8 +4538,17 @@ impl AccountsDb {
             // Assert: it cannot be the case that we already had an ancient append vec at this slot and
             // yet that ancient append vec does not have room for the accounts stored at this slot currently
             assert_ne!(slot, current_ancient.slot());
-            let (_, time) = measure!(current_ancient.create_ancient_append_vec(slot, self));
+            let (shrink_in_progress_overflow, time) =
+                measure!(current_ancient.create_ancient_append_vec(slot, self));
             create_and_insert_store_elapsed_us += time.as_us();
+            // We cannot possibly be shrinking the original slot that created an ancient append vec
+            // AND not have enough room in the ancient append vec at that slot
+            // to hold all the contents of that slot.
+            // We need this new 'shrink_in_progress' to be used in 'remove_old_stores_shrink' below.
+            // All non-overflow accounts were put in a prior slot's ancient append vec. All overflow accounts
+            // are essentially being shrunk into a new ancient append vec in 'slot'.
+            assert!(shrink_in_progress.is_none());
+            shrink_in_progress = Some(shrink_in_progress_overflow);
 
             // write the overflow accounts to the next ancient storage
             let timing =


### PR DESCRIPTION
#### Problem
Ancient append vec overflow was not being handled correctly with `shrink_in_progress`.
When we continue refactoring shrink, `shrink_in_progress` will be relied upon solely to determine which append vecs to drop from a slot.
This is tested by `test_shrink_ancient_overflow`. The test fails once we get rid of `should_retain` parameter from `mark_dirty_dead_stores`. At the moment, we are still relying on the append vec ids and `should_retain` to correctly remove old stores after a shrink.

#### Summary of Changes
Update `shrink_in_progress` correctly for ancient append vec overflow case.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
