### PR TITLE
filter get_snapshot_storages for requested_slots earlier

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8544,10 +8544,8 @@ impl AccountsDb {
         let slots = self
             .storage
             .iter()
-            .filter_map(|k| {
-                let slot = *k.key() as Slot;
-                requested_slots.contains(&slot).then_some(slot)
-            })
+            .map(|k| *k.key() as Slot)
+            .filter(|slot| requested_slots.contains(slot))
             .collect::<Vec<_>>();
         m.stop();
         let mut m2 = Measure::start("filter");


### PR DESCRIPTION
#### Problem
instead of iterate and 
1. collect
2. iterate all
3. filter

This function is being refactored to remove the call to `AccountStorage::get`. As part of that, it makes sense to reorder how we do filtering.

#### Summary of Changes
iterate and
1. filter
2. collect
3. iterate already filtered

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
