### PR TITLE
get_snapshot_storages removes call to AccountStorage.get

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -5,7 +5,7 @@ use {
     dashmap::DashMap,
     solana_sdk::clock::Slot,
     std::{
-        collections::{hash_map::RandomState, HashMap},
+        collections::HashMap,
         sync::{Arc, RwLock},
     },
 };
@@ -63,14 +63,6 @@ impl AccountStorage {
         self.map.iter()
     }
 
-    pub(crate) fn get(
-        &self,
-        slot: &Slot,
-    ) -> Option<dashmap::mapref::one::Ref<'_, Slot, SlotStores, RandomState>> {
-        self.map.get(slot)
-    }
-
-    /// insert 'store' into 'map' at 'slot'
     pub(crate) fn insert(&self, slot: Slot, store: Arc<AccountStorageEntry>) {
         let slot_storages: SlotStores = self.get_slot_stores(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8532,8 +8532,12 @@ impl AccountsDb {
         let slots = self
             .storage
             .iter()
-            .map(|k| *k.key() as Slot)
-            .filter(|slot| requested_slots.contains(slot))
+            .filter_map(|entry| {
+                let slot = *entry.key() as Slot;
+                requested_slots
+                    .contains(&slot)
+                    .then_some((slot, Arc::clone(entry.value())))
+            })
             .collect::<Vec<_>>();
         m.stop();
         let mut m2 = Measure::start("filter");
@@ -8545,29 +8549,24 @@ impl AccountsDb {
                 .map(|slots| {
                     slots
                         .iter()
-                        .filter_map(|slot| {
+                        .filter_map(|(slot, storages)| {
                             if self.accounts_index.is_alive_root(*slot)
                                 || ancestors
                                     .map(|ancestors| ancestors.contains_key(slot))
                                     .unwrap_or_default()
                             {
-                                self.storage.get(slot).map_or_else(
-                                    || None,
-                                    |item| {
-                                        let storages = item
-                                            .read()
-                                            .unwrap()
-                                            .values()
-                                            .filter(|x| x.has_accounts())
-                                            .cloned()
-                                            .collect::<Vec<_>>();
-                                        if !storages.is_empty() {
-                                            Some((storages, *slot))
-                                        } else {
-                                            None
-                                        }
-                                    },
-                                )
+                                let storages = storages
+                                    .read()
+                                    .unwrap()
+                                    .values()
+                                    .filter(|x| x.has_accounts())
+                                    .cloned()
+                                    .collect::<Vec<_>>();
+                                if !storages.is_empty() {
+                                    Some((storages, *slot))
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             }


### PR DESCRIPTION
#### Problem
working on removing calls to `AccountStorage.get`

#### Summary of Changes
`get_snapshot_storages` uses iteration to get storages instead of calling `get`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
