### PR TITLE
cleanup in account_storage.rs

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -733,7 +733,7 @@ where
         .write()
         .unwrap()
         .insert(snapshot_slot, snapshot_bank_hash_info);
-    accounts_db.storage.extend(storage);
+    accounts_db.storage.initialize(storage);
     accounts_db
         .next_id
         .store(next_append_vec_id, Ordering::Release);


### PR DESCRIPTION
#### Problem
Refactoring is ongoing to only allow 1 append vec per slot.

#### Summary of Changes
add comments and renames to `account_storage.rs`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
