### PR TITLE
Snapshot download test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -659,8 +659,14 @@ fn test_incremental_snapshot_download() {
 
     download_snapshot_archive(
         &cluster.entry_point_info.rpc,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .full_snapshot_archives_dir,
+        &validator_snapshot_test_config
+            .validator_config
+            .snapshot_config
+            .incremental_snapshot_archives_dir,
         (
             incremental_snapshot_archive_info.slot(),
             *incremental_snapshot_archive_info.hash(),


### PR DESCRIPTION
#### Problem
See #29457 - missed one spot to point at proper snapshot directories

#### Summary of Changes
Download incremental snapshot to right directory so validator loads from it for `test_incremental_snapshot_download`
