### PR TITLE
Cli: the authority passed to `solana program write-buffer` must be a proper signer

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -461,19 +461,9 @@ pub fn parse_program_subcommand(
                 pubkey_of_signer(matches, "program_id", wallet_manager)?
             };
 
-            let upgrade_authority_pubkey =
-                if let Ok((upgrade_authority_signer, Some(upgrade_authority_pubkey))) =
-                    signer_of(matches, "upgrade_authority", wallet_manager)
-                {
-                    bulk_signers.push(upgrade_authority_signer);
-                    Some(upgrade_authority_pubkey)
-                } else {
-                    Some(
-                        default_signer
-                            .signer_from_path(matches, wallet_manager)?
-                            .pubkey(),
-                    )
-                };
+            let (upgrade_authority, upgrade_authority_pubkey) =
+                signer_of(matches, "upgrade_authority", wallet_manager)?;
+            bulk_signers.push(upgrade_authority);
 
             let max_len = value_of(matches, "max_len");
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -81,7 +81,7 @@ pub enum ProgramCliCommand {
         program_location: String,
         buffer_signer_index: Option<SignerIndex>,
         buffer_pubkey: Option<Pubkey>,
-        buffer_authority_signer_index: Option<SignerIndex>,
+        buffer_authority_signer_index: SignerIndex,
         max_len: Option<usize>,
         skip_fee_check: bool,
     },
@@ -502,19 +502,9 @@ pub fn parse_program_subcommand(
                 pubkey_of_signer(matches, "buffer", wallet_manager)?
             };
 
-            let buffer_authority_pubkey =
-                if let Ok((buffer_authority_signer, Some(buffer_authority_pubkey))) =
-                    signer_of(matches, "buffer_authority", wallet_manager)
-                {
-                    bulk_signers.push(buffer_authority_signer);
-                    Some(buffer_authority_pubkey)
-                } else {
-                    Some(
-                        default_signer
-                            .signer_from_path(matches, wallet_manager)?
-                            .pubkey(),
-                    )
-                };
+            let (buffer_authority, buffer_authority_pubkey) =
+                signer_of(matches, "buffer_authority", wallet_manager)?;
+            bulk_signers.push(buffer_authority);
 
             let max_len = value_of(matches, "max_len");
 
@@ -527,7 +517,8 @@ pub fn parse_program_subcommand(
                     buffer_signer_index: signer_info.index_of_or_none(buffer_pubkey),
                     buffer_pubkey,
                     buffer_authority_signer_index: signer_info
-                        .index_of_or_none(buffer_authority_pubkey),
+                        .index_of(buffer_authority_pubkey)
+                        .unwrap(),
                     max_len,
                     skip_fee_check,
                 }),
@@ -1057,7 +1048,7 @@ fn process_write_buffer(
     program_location: &str,
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
-    buffer_authority_signer_index: Option<SignerIndex>,
+    buffer_authority_signer_index: SignerIndex,
     max_len: Option<usize>,
     skip_fee_check: bool,
 ) -> ProcessResult {
@@ -1073,11 +1064,7 @@ fn process_write_buffer(
             buffer_keypair.pubkey(),
         )
     };
-    let buffer_authority = if let Some(i) = buffer_authority_signer_index {
-        config.signers[i]
-    } else {
-        config.signers[0]
-    };
+    let buffer_authority = config.signers[buffer_authority_signer_index];
 
     if let Some(account) = rpc_client
         .get_account_with_commitment(&buffer_pubkey, config.commitment)?
@@ -2555,7 +2542,7 @@ mod tests {
                     program_location: "/Users/test/program.so".to_string(),
                     buffer_signer_index: None,
                     buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(0),
+                    buffer_authority_signer_index: 0,
                     max_len: None,
                     skip_fee_check: false,
                 }),
@@ -2579,7 +2566,7 @@ mod tests {
                     program_location: "/Users/test/program.so".to_string(),
                     buffer_signer_index: None,
                     buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(0),
+                    buffer_authority_signer_index: 0,
                     max_len: Some(42),
                     skip_fee_check: false,
                 }),
@@ -2606,7 +2593,7 @@ mod tests {
                     program_location: "/Users/test/program.so".to_string(),
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
-                    buffer_authority_signer_index: Some(0),
+                    buffer_authority_signer_index: 0,
                     max_len: None,
                     skip_fee_check: false,
                 }),
@@ -2636,7 +2623,7 @@ mod tests {
                     program_location: "/Users/test/program.so".to_string(),
                     buffer_signer_index: None,
                     buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(1),
+                    buffer_authority_signer_index: 1,
                     max_len: None,
                     skip_fee_check: false,
                 }),
@@ -2671,7 +2658,7 @@ mod tests {
                     program_location: "/Users/test/program.so".to_string(),
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
-                    buffer_authority_signer_index: Some(2),
+                    buffer_authority_signer_index: 2,
                     max_len: None,
                     skip_fee_check: false,
                 }),

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -778,7 +778,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: None,
         buffer_pubkey: None,
-        buffer_authority_signer_index: None,
+        buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
     });
@@ -813,7 +813,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: None,
+        buffer_authority_signer_index: 0,
         max_len: Some(max_len),
         skip_fee_check: false,
     });
@@ -875,7 +875,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: Some(2),
+        buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
     });
@@ -913,7 +913,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: None,
         buffer_pubkey: None,
-        buffer_authority_signer_index: Some(2),
+        buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
     });
@@ -987,7 +987,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: None,
         buffer_pubkey: None,
-        buffer_authority_signer_index: None,
+        buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
     });
@@ -1028,7 +1028,7 @@ fn test_cli_program_write_buffer() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: None,
+        buffer_authority_signer_index: 0,
         max_len: None, //Some(max_len),
         skip_fee_check: false,
     });
@@ -1100,7 +1100,7 @@ fn test_cli_program_set_buffer_authority() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: None,
+        buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
     });
@@ -1216,7 +1216,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: Some(2),
+        buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
     });
@@ -1312,7 +1312,7 @@ fn test_cli_program_show() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: Some(2),
+        buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
     });
@@ -1499,7 +1499,7 @@ fn test_cli_program_dump() {
         program_location: noop_path.to_str().unwrap().to_string(),
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
-        buffer_authority_signer_index: Some(2),
+        buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
     });


### PR DESCRIPTION
#### Problem
`solana program` uses some bespoke signer-parsing logic in a couple places to fall back to the DefaultSigner. This allows `solana program write-buffer --buffer-authority <PUBKEY>` to succeed, even though `--buffer-authority` must be a Signer. (As described in https://github.com/solana-labs/solana/issues/17890, the result is that the authority is unexpectedly set as the DefaultSigner.)

#### Summary of Changes
Fix parsing logic. In the case of `solana program deploy`, the changes are a noop.


Fixes #29451
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
