### PR TITLE
get_storage_to_move_to_ancient_append_vec returns a single append vec

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4318,7 +4318,7 @@ impl AccountsDb {
         slot: Slot,
         current_ancient: &mut CurrentAncientAppendVec,
         can_randomly_shrink: bool,
-    ) -> Option<SnapshotStorage> {
+    ) -> Option<Arc<AccountStorageEntry>> {
         self.storage
             .get_slot_storage_entry(slot)
             .and_then(|storage| {
@@ -4328,7 +4328,7 @@ impl AccountsDb {
                     slot,
                     can_randomly_shrink,
                 )
-                .then_some(vec![storage])
+                .then_some(storage)
             })
     }
 
@@ -4410,7 +4410,7 @@ impl AccountsDb {
 
         let len = sorted_slots.len();
         for slot in sorted_slots {
-            let old_storages = match self.get_storages_to_move_to_ancient_append_vec(
+            let old_storage = match self.get_storages_to_move_to_ancient_append_vec(
                 slot,
                 &mut current_ancient,
                 can_randomly_shrink,
@@ -4431,6 +4431,7 @@ impl AccountsDb {
                 );
             }
 
+            let old_storages = [old_storage];
             self.combine_one_store_into_ancient(
                 slot,
                 &old_storages,


### PR DESCRIPTION
#### Problem
moving towards 1 append vec per slot

#### Summary of Changes
`get_storages_to_move_to_ancient_append_vec()` returns a single append vec instead of a vector

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
