### PR TITLE
should_move_to_ancient_append_vec works with a single storage

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -1,7 +1,9 @@
 //! Manage the map of slot -> append vecs
 
+#[cfg(test)]
+use crate::accounts_db::SnapshotStorage;
 use {
-    crate::accounts_db::{AccountStorageEntry, AppendVecId, SlotStores, SnapshotStorage},
+    crate::accounts_db::{AccountStorageEntry, AppendVecId, SlotStores},
     dashmap::DashMap,
     solana_sdk::clock::Slot,
     std::{
@@ -43,6 +45,7 @@ impl AccountStorage {
     }
 
     /// return all append vecs for 'slot' if any exist
+    #[cfg(test)]
     pub(crate) fn get_slot_storage_entries(&self, slot: Slot) -> Option<SnapshotStorage> {
         self.get_slot_stores(slot)
             .map(|res| res.read().unwrap().values().cloned().collect())


### PR DESCRIPTION
#### Problem
moving to a single append vec per slot.
Ancient append vec code was written to handle Vec

#### Summary of Changes
`should_move_to_ancient_append_vec()` now requires a single append vec per slot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
