### PR TITLE
update leger tool help for db verify refcounts

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1330,7 +1330,7 @@ fn main() {
     let accountsdb_verify_refcounts = Arg::with_name("accounts_db_verify_refcounts")
         .long("accounts-db-verify-refcounts")
         .help(
-            "Debug option to scan all append vecs and verify account index refcounts prior to clean",
+            "Debug option to scan all AppendVecs and verify account index refcounts prior to clean",
         )
         .hidden(true);
     let accounts_filler_count = Arg::with_name("accounts_filler_count")


### PR DESCRIPTION
#### Problem

In ledger-tool command line help, we use both "append vec" and "AppendVec". It
is better to use the same term for the help messages.


#### Summary of Changes

Change "append vec" to "AppendVec" in ledger-tool command line help message.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
