### PR TITLE
extract max_size stat update for disk buckets

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -390,11 +390,7 @@ impl<T: Clone + Copy> Bucket<T> {
                     }
                 }
                 if valid {
-                    let sz = index.capacity();
-                    {
-                        let mut max = self.stats.index.max_size.lock().unwrap();
-                        *max = std::cmp::max(*max, sz);
-                    }
+                    self.stats.index.update_max_size(index.capacity());
                     let mut items = self.reallocated.items.lock().unwrap();
                     items.index = Some((random, index));
                     self.reallocated.add_reallocation();

--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -11,6 +11,13 @@ pub struct BucketStats {
     pub find_entry_mut_us: AtomicU64,
 }
 
+impl BucketStats {
+    pub fn update_max_size(&self, size: u64) {
+        let mut max = self.max_size.lock().unwrap();
+        *max = std::cmp::max(*max, size);
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct BucketMapStats {
     pub index: Arc<BucketStats>,

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -341,6 +341,10 @@ impl BucketStorage {
         self.stats.resize_us.fetch_add(m.as_us(), Ordering::Relaxed);
     }
 
+    pub fn update_max_size(&self) {
+        self.stats.update_max_size(self.capacity());
+    }
+
     /// allocate a new bucket, copying data from 'bucket'
     pub fn new_resized(
         drives: &Arc<Vec<PathBuf>>,
@@ -365,11 +369,7 @@ impl BucketStorage {
         if let Some(bucket) = bucket {
             new_bucket.copy_contents(bucket);
         }
-        let sz = new_bucket.capacity();
-        {
-            let mut max = new_bucket.stats.max_size.lock().unwrap();
-            *max = std::cmp::max(*max, sz);
-        }
+        new_bucket.update_max_size();
         new_bucket
     }
 


### PR DESCRIPTION
#### Problem

Extract disk bucket max_size stat update into a function to avoid code
duplication.


#### Summary of Changes

refactor disk bucket max_size stat update fn


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
