### PR TITLE
add AccountStorage.is_empty_entry for tests

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -48,6 +48,14 @@ impl AccountStorage {
             .unwrap_or(true)
     }
 
+    /// returns true if there is an entry in the map for 'slot', but it contains no append vec
+    #[cfg(test)]
+    pub(crate) fn is_empty_entry(&self, slot: Slot) -> bool {
+        self.get_slot_stores(slot)
+            .map(|storages| storages.read().unwrap().is_empty())
+            .unwrap_or(false)
+    }
+
     /// initialize the storage map to 'all_storages'
     pub(crate) fn initialize(&mut self, all_storages: AccountStorageMap) {
         assert!(self.map.is_empty());

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -16529,7 +16529,7 @@ pub mod tests {
             } else {
                 assert!(db.dirty_stores.is_empty());
             }
-            assert!(db.get_storages_for_slot(slot).unwrap().is_empty());
+            assert!(db.storage.is_empty_entry(slot));
         }
     }
 
@@ -17579,7 +17579,7 @@ pub mod tests {
             &mut AncientSlotPubkeys::default(),
             &mut dropped_roots,
         );
-        assert!(db.get_storages_for_slot(next_slot).unwrap().is_empty());
+        assert!(db.storage.is_empty_entry(next_slot));
         // this removes the storages entry completely from the hashmap for 'next_slot'.
         // Otherwise, we have a zero length vec in that hashmap
         db.handle_dropped_roots_for_ancient(dropped_roots);


### PR DESCRIPTION
#### Problem
moving to 1 append vec per slot
A few tests want to verify that there is an entry for a slot, but that it is empty.

#### Summary of Changes
Introduce `AccountStorage`::`is_empty_entry()` to answer the question correctly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
