### PR TITLE
Fix TransactionPrecompileVerification RPC error

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -134,7 +134,7 @@ impl From<RpcCustomError> for Error {
             },
             RpcCustomError::TransactionPrecompileVerificationFailure(e) => Self {
                 code: ErrorCode::ServerError(
-                    JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_VERIFICATION_FAILURE,
+                    JSON_RPC_SERVER_ERROR_TRANSACTION_PRECOMPILE_VERIFICATION_FAILURE,
                 ),
                 message: format!("Transaction precompile verification failure {e:?}"),
                 data: None,


### PR DESCRIPTION
#### Problem
rpc_custom_error module is returning the wrong error code for TransactionPrecompileVerificationFailures, because consts with similar names are hard.

#### Summary of Changes
Fix it


Fixes #19019
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
