### PR TITLE
Refresh blockhash for retrials of failed get_fee calls

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -42,10 +42,15 @@ pub const MAX_RPC_CALL_RETRIES: usize = 5;
 pub fn poll_get_latest_blockhash(client: &RpcClient) -> Option<Hash> {
     let mut num_retries = MAX_RPC_CALL_RETRIES;
     loop {
-        if let Ok(blockhash) = client.get_latest_blockhash() {
+        let response = client.get_latest_blockhash();
+        if let Ok(blockhash) = response {
             return Some(blockhash);
         } else {
             num_retries -= 1;
+            warn!(
+                "get_latest_blockhash failure: {:?}. remaining retries {}",
+                response, num_retries
+            );
         }
         if num_retries == 0 {
             panic!("failed to get_latest_blockhash(), rpc node down?")
@@ -60,10 +65,15 @@ pub fn poll_get_fee_for_message(
 ) -> Option<u64> {
     let mut num_retries = MAX_RPC_CALL_RETRIES;
     loop {
-        if let Ok(fee) = client.get_fee_for_message(message) {
+        let response = client.get_fee_for_message(message);
+        if let Ok(fee) = response {
             return Some(fee);
         } else {
             num_retries -= 1;
+            warn!(
+                "get_fee_for_message failure: {:?}. remaining retries {}",
+                response, num_retries
+            );
         }
         if num_retries == 0 {
             panic!("failed to get_fee_for_message(), rpc node down?")

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -73,7 +73,7 @@ pub fn poll_get_fee_for_message(client: &RpcClient, message: &mut Message) -> (O
                 response, num_retries
             );
 
-            let blockhash = poll_get_latest_blockhash(&client).expect("blockhash");
+            let blockhash = poll_get_latest_blockhash(client).expect("blockhash");
             message.recent_blockhash = blockhash;
         }
         if num_retries == 0 {


### PR DESCRIPTION
#### Problem

```
[2023-01-04T08:03:03.172226504Z INFO  solana_accounts_cluster_bench] ids: 1
[2023-01-04T08:03:03.172910773Z WARN  solana_accounts_cluster_bench] get_fee_for_message failure: Err(Error { request: None, kind: Custom("Invalid blockhash") }). remaining retries 4
[2023-01-04T08:03:03.274184232Z WARN  solana_accounts_cluster_bench] get_fee_for_message failure: Err(Error { request: None, kind: Custom("Invalid blockhash") }). remaining retries 3
[2023-01-04T08:03:03.375479668Z WARN  solana_accounts_cluster_bench] get_fee_for_message failure: Err(Error { request: None, kind: Custom("Invalid blockhash") }). remaining retries 2
[2023-01-04T08:03:03.476697420Z WARN  solana_accounts_cluster_bench] get_fee_for_message failure: Err(Error { request: None, kind: Custom("Invalid blockhash") }). remaining retries 1
[2023-01-04T08:03:03.577929590Z WARN  solana_accounts_cluster_bench] get_fee_for_message failure: Err(Error { request: None, kind: Custom("Invalid blockhash") }). remaining retries 0
thread 'main' panicked at 'failed to get_fee_for_message(), rpc node down?', accounts-cluster-bench/src/main.rs:79:13
```

After we get the latest blockhash and use it to try to get the fees for message, the `get fees` for message rpc calls failed even with retires for 5 times. It looks like that blockhash might have expired before we get fees for the message. 

#### Summary of Changes

- When retrying for get_fee_for_message, refresh block hash .
- Add log for failed rpc calls during retry
- 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
