### PR TITLE
simplifies sigverify copy_return_values

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -312,12 +312,9 @@ pub fn verify_shreds_gpu(
     trace!("out buf {:?}", out);
 
     // Each shred has exactly one signature.
-    let v_sig_lens: Vec<_> = batches
-        .iter()
-        .map(|batch| vec![1u32; batch.len()])
-        .collect();
+    let v_sig_lens = batches.iter().map(|batch| repeat(1u32).take(batch.len()));
     let mut rvs: Vec<_> = batches.iter().map(|batch| vec![0u8; batch.len()]).collect();
-    sigverify::copy_return_values(&v_sig_lens, &out, &mut rvs);
+    sigverify::copy_return_values(v_sig_lens, &out, &mut rvs);
 
     inc_new_counter_debug!("ed25519_shred_verify_gpu", out.len());
     rvs


### PR DESCRIPTION
#### Problem
* don't need to allocate a vector for signature lengths in sigverify shreds.
* verbose  code.


#### Summary of Changes
* changed arg type to iterator.
* simplified the code.
