### PR TITLE
get_storages_for_slot uses get_slot_storage_entry

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -1,7 +1,5 @@
 //! Manage the map of slot -> append vecs
 
-#[cfg(test)]
-use crate::accounts_db::SnapshotStorage;
 use {
     crate::accounts_db::{AccountStorageEntry, AppendVecId, SlotStores},
     dashmap::DashMap,
@@ -42,13 +40,6 @@ impl AccountStorage {
             assert!(read.len() <= 1);
             read.values().next().cloned()
         })
-    }
-
-    /// return all append vecs for 'slot' if any exist
-    #[cfg(test)]
-    pub(crate) fn get_slot_storage_entries(&self, slot: Slot) -> Option<SnapshotStorage> {
-        self.get_slot_stores(slot)
-            .map(|res| res.read().unwrap().values().cloned().collect())
     }
 
     pub(crate) fn all_slots(&self) -> Vec<Slot> {


### PR DESCRIPTION
#### Problem
Moving to allowing only 1 append vec per slot.
Some code currently uses `get_slot_storage_entries()`.
We want to use the single version of `get_slot_storage_entry()`

#### Summary of Changes
Convert some code to use `get_slot_storage_entry()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
