### PR TITLE
Download snapshot from multiple RPCs using ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -2120,6 +2120,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "http-range-header"
@@ -5282,6 +5288,7 @@ dependencies = [
  "console",
  "indicatif",
  "log",
+ "rayon",
  "reqwest",
  "solana-runtime",
  "solana-sdk 1.15.0",
@@ -6157,6 +6164,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap 4.0.2",
+ "http-range",
  "itertools",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6167,6 +6175,7 @@ dependencies = [
  "log",
  "rayon",
  "regex",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -312,11 +312,13 @@ mod tests {
         let slot = 42;
         let hash = SnapshotHash(Hash::default());
         let archive_format = ArchiveFormat::TarBzip2;
-        let output_tar_path = snapshot_utils::build_full_snapshot_archive_path(
+        let output_tar_path = snapshot_utils::build_snapshot_archive_path(
+            SnapshotType::FullSnapshot,
             &full_snapshot_archives_dir,
             slot,
             &hash,
             archive_format,
+            None,
         );
         let snapshot_package = SnapshotPackage {
             snapshot_archive_info: SnapshotArchiveInfo {

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -148,11 +148,13 @@ fn restore_from_snapshot(
     let old_last_bank = old_bank_forks.get(old_last_slot).unwrap();
 
     let check_hash_calculation = false;
-    let full_snapshot_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let full_snapshot_archive_path = snapshot_utils::build_snapshot_archive_path(
+        SnapshotType::FullSnapshot,
         full_snapshot_archives_dir,
         old_last_bank.slot(),
         &old_last_bank.get_snapshot_hash(),
         ArchiveFormat::TarBzip2,
+        None,
     );
     let full_snapshot_archive_info =
         FullSnapshotArchiveInfo::new_from_path(full_snapshot_archive_path).unwrap();
@@ -475,13 +477,15 @@ fn test_concurrent_snapshot_packaging(
             let options = CopyOptions::new();
             fs_extra::dir::copy(last_snapshot_path, &saved_snapshots_dir, &options).unwrap();
 
-            saved_archive_path = Some(snapshot_utils::build_full_snapshot_archive_path(
+            saved_archive_path = Some(snapshot_utils::build_snapshot_archive_path(
+                SnapshotType::FullSnapshot,
                 full_snapshot_archives_dir,
                 slot,
                 // this needs to match the hash value that we reserialize with later. It is complicated, so just use default.
                 // This hash value is just used to build the file name. Since this is mocked up test code, it is sufficient to pass default here.
                 &SnapshotHash(Hash::default()),
                 ArchiveFormat::TarBzip2,
+                None,
             ));
         }
     }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 console = "0.15.0"
 indicatif = "0.17.1"
 log = "0.4.17"
+rayon = "1.5.3"
 reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-runtime = { path = "../runtime", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -3,6 +3,8 @@ use {
     console::Emoji,
     indicatif::{ProgressBar, ProgressStyle},
     log::*,
+    rayon::prelude::*,
+    reqwest::{blocking::Response, header::RANGE},
     solana_runtime::{
         snapshot_hash::SnapshotHash,
         snapshot_package::SnapshotType,
@@ -10,16 +12,19 @@ use {
     },
     solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE},
     std::{
-        fs::{self, File},
-        io::{self, Read},
+        fs::{self, File, OpenOptions},
+        io::{self, Read, Write},
         net::SocketAddr,
+        ops::Range,
         path::{Path, PathBuf},
+        sync::RwLock,
         time::{Duration, Instant},
     },
 };
 
 static TRUCK: Emoji = Emoji("🚚 ", "");
 static SPARKLE: Emoji = Emoji("✨ ", "");
+const DOWNLOAD_CHUNK_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
 
 /// Creates a new process bar for processing that will take an unknown amount of time
 fn new_spinner_progress_bar() -> ProgressBar {
@@ -56,17 +61,90 @@ pub struct DownloadProgressRecord {
     pub notification_count: u64,
 }
 
-type DownloadProgressCallback<'a> = Box<dyn FnMut(&DownloadProgressRecord) -> bool + 'a>;
-type DownloadProgressCallbackOption<'a> = Option<DownloadProgressCallback<'a>>;
+#[derive(Clone, Default)]
+pub struct SnapshotAbortControl {
+    minimal_snapshot_download_speed: f32,
+    single_known_rpc: bool,
+    abort_allowed: bool,
+}
+
+pub struct ProgressCallback {
+    pub minimal_snapshot_download_speed: f32,
+    pub maximum_snapshot_download_abort: u64,
+    pub single_known_rpc: bool,
+}
+
+struct SnapshotResults {
+    completed_chunks: Vec<(PathBuf, u64)>,
+}
+
+fn progress_callback(
+    download_progress: &DownloadProgressRecord,
+    snapshot_abort_control: &SnapshotAbortControl,
+) -> bool {
+    debug!("Download progress: {:?}", download_progress);
+    if download_progress.last_throughput < snapshot_abort_control.minimal_snapshot_download_speed
+        && download_progress.notification_count <= 1
+        && download_progress.percentage_done <= 2_f32
+        && download_progress.estimated_remaining_time > 60_f32
+        && snapshot_abort_control.abort_allowed
+    {
+        if snapshot_abort_control.single_known_rpc {
+            println!(
+                "The snapshot download is too slow, throughput: {} < min speed {} \
+                bytes/sec, but will NOT abort and try a different node as it is the \
+                only known validator and the --only-known-rpc flag is set. \
+                Progress detail: {:?}",
+                download_progress.last_throughput,
+                snapshot_abort_control.minimal_snapshot_download_speed,
+                download_progress,
+            );
+            return true; // Do not abort download from the one-and-only known validator
+        }
+        println!(
+            "The snapshot download is too slow, throughput: {} < min speed {} \
+            bytes/sec, will abort and try a different node. \
+            Progress detail: {:?}",
+            download_progress.last_throughput,
+            snapshot_abort_control.minimal_snapshot_download_speed,
+            download_progress,
+        );
+        false
+    } else {
+        true
+    }
+}
+
+fn verify_response_range(range: Option<Range<u64>>, response: &Response) -> Result<(), String> {
+    if let Some(range) = range {
+        let request_range = format!("bytes={}-{}", range.start, range.end);
+        let response_range = response.headers().get(reqwest::header::CONTENT_RANGE);
+        if let Some(response_range) = response_range {
+            let x = response_range.to_str();
+            match x {
+                Ok(range) => {
+                    if range == request_range {
+                        return Ok(());
+                    }
+                }
+                Err(_err) => (),
+            }
+        }
+        Err("Didn't receive requested download range".to_string())
+    } else {
+        Ok(())
+    }
+}
 
 /// This callback allows the caller to get notified of the download progress modelled by DownloadProgressRecord
 /// Return "true" to continue the download
 /// Return "false" to abort the download
-pub fn download_file<'a, 'b>(
+pub fn download_file(
     url: &str,
     destination_file: &Path,
     use_progress_bar: bool,
-    progress_notify_callback: &'a mut DownloadProgressCallbackOption<'b>,
+    range: Option<Range<u64>>,
+    snapshot_abort_control: Option<SnapshotAbortControl>,
 ) -> Result<(), String> {
     if destination_file.is_file() {
         return Err(format!("{destination_file:?} already exists"));
@@ -91,14 +169,19 @@ pub fn download_file<'a, 'b>(
         progress_bar.set_message(format!("{TRUCK}Downloading {url}..."));
     }
 
-    let response = reqwest::blocking::Client::new()
-        .get(url)
+    let mut request = reqwest::blocking::Client::new().get(url);
+    if let Some(range) = range.clone() {
+        let header_value = format!("bytes={}-{}", range.start, range.end);
+        request = request.header(RANGE, header_value);
+    }
+    let response = request
         .send()
         .and_then(|response| response.error_for_status())
         .map_err(|err| {
             progress_bar.finish_and_clear();
             err.to_string()
         })?;
+    verify_response_range(range, &response)?;
 
     let download_size = {
         response
@@ -124,7 +207,7 @@ pub fn download_file<'a, 'b>(
         info!("Downloading {} bytes from {}", download_size, url);
     }
 
-    struct DownloadProgress<'e, 'f, R> {
+    struct DownloadProgress<R> {
         progress_bar: ProgressBar,
         response: R,
         last_print: Instant,
@@ -133,13 +216,14 @@ pub fn download_file<'a, 'b>(
         download_size: f32,
         use_progress_bar: bool,
         start_time: Instant,
-        callback: &'f mut DownloadProgressCallbackOption<'e>,
         notification_count: u64,
+        snapshot_abort_control: Option<SnapshotAbortControl>,
     }
 
-    impl<'e, 'f, R: Read> Read for DownloadProgress<'e, 'f, R> {
+    impl<R: Read> Read for DownloadProgress<R> {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            let n = self.response.read(buf)?;
+            let mut n = self.response.read(buf)?;
+            n = n.min(self.download_size as usize - self.current_bytes);
 
             self.current_bytes += n;
             let total_bytes_f32 = self.current_bytes as f32;
@@ -183,9 +267,11 @@ pub fn download_file<'a, 'b>(
                 );
             }
 
-            if let Some(callback) = self.callback {
-                if to_update_progress && !callback(&progress_record) {
-                    info!("Download is aborted by the caller");
+            if let Some(snapshot_abort_control) = &self.snapshot_abort_control {
+                if to_update_progress
+                    && !progress_callback(&progress_record, snapshot_abort_control)
+                {
+                    info!("Download is aborted by the caller!!");
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         "Download is aborted by the caller",
@@ -197,7 +283,7 @@ pub fn download_file<'a, 'b>(
         }
     }
 
-    let mut source = DownloadProgress::<'b, 'a> {
+    let mut source = DownloadProgress {
         progress_bar,
         response,
         last_print: Instant::now(),
@@ -206,15 +292,14 @@ pub fn download_file<'a, 'b>(
         download_size: (download_size as f32).max(1f32),
         use_progress_bar,
         start_time: Instant::now(),
-        callback: progress_notify_callback,
         notification_count: 0,
+        snapshot_abort_control,
     };
 
     File::create(&temp_destination_file)
         .and_then(|mut file| std::io::copy(&mut source, &mut file))
         .map_err(|err| format!("Unable to write {temp_destination_file:?}: {err:?}"))?;
 
-    source.progress_bar.finish_and_clear();
     info!(
         "  {}{}",
         SPARKLE,
@@ -246,7 +331,8 @@ pub fn download_genesis_if_missing(
             &format!("http://{rpc_addr}/{DEFAULT_GENESIS_ARCHIVE}"),
             &tmp_genesis_package,
             use_progress_bar,
-            &mut None,
+            None,
+            None,
         )?;
 
         Ok(tmp_genesis_package)
@@ -255,10 +341,156 @@ pub fn download_genesis_if_missing(
     }
 }
 
+fn get_snapshot_size(rpc_addrs: Vec<SocketAddr>, src_path: PathBuf) -> Option<u64> {
+    let url = &format!(
+        "http://{}/{}",
+        rpc_addrs[0],
+        src_path.file_name().unwrap().to_str().unwrap()
+    );
+    let response = reqwest::blocking::Client::new()
+        .get(url)
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| {
+            println!("ERROR response {}", err);
+            err.to_string()
+        });
+    if let Ok(response) = response {
+        let snapshot_size = {
+            response
+                .headers()
+                .get(reqwest::header::CONTENT_LENGTH)
+                .and_then(|content_length| content_length.to_str().ok())
+                .and_then(|content_length| content_length.parse().ok())
+                .unwrap_or(0)
+        };
+        Some(snapshot_size as u64)
+    } else {
+        None
+    }
+}
+
+fn coalesce_temp_files(mut temp_dest_paths: Vec<(u64, PathBuf)>, dest_path: PathBuf) {
+    let mut file_dest = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(dest_path.clone())
+        .expect("Unable to open destination file");
+
+    if temp_dest_paths.len() > 1 {
+        temp_dest_paths.sort();
+        for (_, temp_dest_path) in temp_dest_paths {
+            let mut file_dest_temp = OpenOptions::new()
+                .read(true)
+                .open(temp_dest_path.clone())
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Unable to open file {} for reading",
+                        temp_dest_path.display()
+                    )
+                });
+            let mut buf = vec![];
+            file_dest_temp.read_to_end(&mut buf).unwrap_or_else(|_| {
+                panic!(
+                    "Unable to read all contents from file {}",
+                    temp_dest_path.display()
+                )
+            });
+            file_dest.write_all(&buf).unwrap_or_else(|_| {
+                panic!(
+                    "Unable to write all buffer contents to file {}",
+                    dest_path.display()
+                )
+            });
+            fs::remove_file(temp_dest_path.clone()).unwrap_or_else(|_| {
+                panic!("failed to remove temp file {}", temp_dest_path.display())
+            });
+        }
+    } else {
+        let from = &temp_dest_paths[0].1;
+        // special case optimization when we only have 1 file
+        fs::rename(from, &dest_path).unwrap_or_else(|_| {
+            panic!(
+                "Unable to rename file {} to {}",
+                from.display(),
+                dest_path.display()
+            )
+        });
+    }
+}
+
+fn populate_snapshot_download_start_offsets(
+    download_start_offsets: &RwLock<(i32, Vec<u64>)>,
+    snapshot_size: u64,
+) {
+    let mut download_start_offsets_l = download_start_offsets.write().unwrap();
+    let mut start_offset = 0;
+    loop {
+        if start_offset >= snapshot_size {
+            break;
+        }
+        download_start_offsets_l.0 += 1;
+        download_start_offsets_l.1.push(start_offset);
+        start_offset += DOWNLOAD_CHUNK_SIZE_BYTES;
+    }
+}
+
+fn remove_temp_snapshot_files(temp_dest_paths: &Vec<(u64, PathBuf)>) {
+    for (_, temp_file) in temp_dest_paths {
+        if temp_file.is_file() {
+            fs::remove_file(temp_file).expect("Failed to remove file");
+        }
+    }
+}
+
+fn parse_snapshot_download_results(
+    results: &[Result<SnapshotResults, (SocketAddr, SnapshotResults)>],
+    remaining_good_rpc_addrs: &mut Vec<SocketAddr>,
+    download_abort_count: &mut u64,
+    temp_dest_paths: &mut Vec<(u64, PathBuf)>,
+) {
+    for result in results {
+        let snapshot_results = match result {
+            Err((rpc_addr, snapshot_results)) => {
+                let idx = remaining_good_rpc_addrs
+                    .iter()
+                    .position(|x| *x == *rpc_addr)
+                    .unwrap();
+                remaining_good_rpc_addrs.remove(idx);
+                *download_abort_count += 1;
+                snapshot_results
+            }
+            Ok(snapshot_results) => snapshot_results,
+        };
+
+        for (dest_path, start) in &snapshot_results.completed_chunks {
+            temp_dest_paths.push((*start, dest_path.to_path_buf()));
+        }
+    }
+}
+
+fn get_snapshot_download_start_offset(
+    download_start_offsets: &RwLock<(i32, Vec<u64>)>,
+) -> Result<u64, bool> {
+    if let Ok(mut download_start_offsets_l) = download_start_offsets.write() {
+        if let Some(start) = download_start_offsets_l.1.pop() {
+            Ok(start)
+        } else if download_start_offsets_l.0 > 0 {
+            Err(false)
+        } else {
+            // Nothing more to do!
+            Err(true)
+        }
+    } else {
+        panic!("Couldn't get write lock");
+    }
+}
+
 /// Download a snapshot archive from `rpc_addr`.  Use `snapshot_type` to specify downloading either
 /// a full snapshot or an incremental snapshot.
+#[allow(clippy::too_many_arguments)]
 pub fn download_snapshot_archive(
-    rpc_addr: &SocketAddr,
+    rpc_addrs: &[SocketAddr],
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, SnapshotHash),
@@ -266,7 +498,8 @@ pub fn download_snapshot_archive(
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,
     use_progress_bar: bool,
-    progress_notify_callback: &mut DownloadProgressCallbackOption<'_>,
+    progress_callback: Option<ProgressCallback>,
+    download_abort_count: &mut u64,
 ) -> Result<(), String> {
     snapshot_utils::purge_old_snapshot_archives(
         full_snapshot_archives_dir,
@@ -282,6 +515,16 @@ pub fn download_snapshot_archive(
         });
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
+    let snapshot_abort_control =
+        progress_callback
+            .as_ref()
+            .map(|progress_callback| SnapshotAbortControl {
+                minimal_snapshot_download_speed: progress_callback.minimal_snapshot_download_speed,
+                single_known_rpc: progress_callback.single_known_rpc,
+                abort_allowed: *download_abort_count
+                    < progress_callback.maximum_snapshot_download_abort,
+            });
+
     for archive_format in [
         ArchiveFormat::TarZstd,
         ArchiveFormat::TarGzip,
@@ -289,44 +532,157 @@ pub fn download_snapshot_archive(
         ArchiveFormat::TarLz4,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
-        let destination_path = match snapshot_type {
-            SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                &snapshot_archives_remote_dir,
-                desired_snapshot_hash.0,
-                &desired_snapshot_hash.1,
-                archive_format,
-            ),
-            SnapshotType::IncrementalSnapshot(base_slot) => {
-                snapshot_utils::build_incremental_snapshot_archive_path(
-                    &snapshot_archives_remote_dir,
-                    base_slot,
-                    desired_snapshot_hash.0,
-                    &desired_snapshot_hash.1,
-                    archive_format,
-                )
-            }
+        let path = snapshot_utils::build_snapshot_archive_path(
+            snapshot_type,
+            &snapshot_archives_remote_dir,
+            desired_snapshot_hash.0,
+            &desired_snapshot_hash.1,
+            archive_format,
+            None,
+        );
+
+        let snapshot_size = match get_snapshot_size(rpc_addrs.to_owned(), path.clone()) {
+            Some(snapshot_size) => snapshot_size,
+            None => continue,
         };
+        let download_start_offsets = RwLock::new((0, Vec::<u64>::new()));
+        populate_snapshot_download_start_offsets(&download_start_offsets, snapshot_size);
 
-        if destination_path.is_file() {
-            return Ok(());
+        let mut remaining_good_rpc_addrs = rpc_addrs.to_owned();
+        let results: Vec<Result<SnapshotResults, (SocketAddr, SnapshotResults)>> =
+            remaining_good_rpc_addrs
+                .clone()
+                .into_par_iter()
+                .map(|rpc_addr| {
+                    let mut completed_chunks = vec![];
+                    loop {
+                        let start =
+                            match get_snapshot_download_start_offset(&download_start_offsets) {
+                                Ok(start) => start,
+                                Err(done) => {
+                                    if done {
+                                        // Nothing more to do!
+                                        return Ok(SnapshotResults { completed_chunks });
+                                    } else {
+                                        // Wait to see if we need to pickup work from failed RPCs
+                                        std::thread::sleep(Duration::from_millis(1_000));
+                                        continue;
+                                    }
+                                }
+                            };
+
+                        let end = snapshot_size.min(start + DOWNLOAD_CHUNK_SIZE_BYTES) - 1;
+                        let destination_path = snapshot_utils::build_snapshot_archive_path(
+                            snapshot_type,
+                            snapshot_archives_remote_dir.clone(),
+                            desired_snapshot_hash.0,
+                            &desired_snapshot_hash.1,
+                            archive_format,
+                            Some(start),
+                        );
+
+                        if destination_path.is_file() {
+                            // Already exists! No need to download again
+                            download_start_offsets.write().unwrap().0 -= 1;
+                            completed_chunks.push((destination_path, start));
+                            continue;
+                        }
+
+                        match download_file(
+                            &format!(
+                                "http://{}/{}",
+                                rpc_addr,
+                                path.file_name().unwrap().to_str().unwrap()
+                            ),
+                            &destination_path,
+                            use_progress_bar,
+                            Some(Range { start, end }),
+                            snapshot_abort_control.clone(),
+                        ) {
+                            Ok(()) => {
+                                download_start_offsets.write().unwrap().0 -= 1;
+                                completed_chunks.push((destination_path, start));
+                            }
+                            Err(_err) => {
+                                if destination_path.is_file() {
+                                    fs::remove_file(destination_path)
+                                        .expect("Failed to remove file");
+                                }
+                                // Push this range back onto the queue so another validator can pick it up.
+                                download_start_offsets.write().unwrap().1.push(start);
+                                return Err((rpc_addr, SnapshotResults { completed_chunks }));
+                            }
+                        }
+                    }
+                })
+                .collect();
+
+        let mut temp_dest_paths = vec![];
+        parse_snapshot_download_results(
+            &results,
+            &mut remaining_good_rpc_addrs,
+            download_abort_count,
+            &mut temp_dest_paths,
+        );
+
+        if download_start_offsets.read().unwrap().0 > 0 {
+            // Didn't download all the chunks successfully.
+            remove_temp_snapshot_files(&temp_dest_paths);
+            continue;
         }
 
-        match download_file(
-            &format!(
-                "http://{}/{}",
-                rpc_addr,
-                destination_path.file_name().unwrap().to_str().unwrap()
-            ),
-            &destination_path,
-            use_progress_bar,
-            progress_notify_callback,
-        ) {
-            Ok(()) => return Ok(()),
-            Err(err) => info!("{}", err),
-        }
+        coalesce_temp_files(temp_dest_paths, path);
+        return Ok(());
     }
+
     Err(format!(
-        "Failed to download a snapshot archive for slot {} from {}",
-        desired_snapshot_hash.0, rpc_addr
+        "Failed to download a snapshot archive for slot {}",
+        desired_snapshot_hash.0,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snapshot_file_coalesce() {
+        // Create 1MB buffer for rapidly filling temporary files.
+        let buffer = vec![0_u8; 1024 * 1024];
+
+        // Create large number of temporary files.
+        let temp_file_paths = vec![
+            "./temp1", "./temp2", "./temp3", "./temp4", "./temp5", "./temp6", "./temp7", "./temp8",
+            "./temp9", "./temp10", "./temp11", "./temp12", "./temp13", "./temp14", "./temp15",
+            "./temp16", "./temp17", "./temp18", "./temp19", "./temp20", "./temp21", "./temp22",
+            "./temp23", "./temp24", "./temp25", "./temp26", "./temp27", "./temp28", "./temp29",
+            "./temp30", "./temp31", "./temp32",
+        ];
+        for file_path in &temp_file_paths {
+            let mut file = OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(*file_path)
+                .expect("Unable to open file for writing");
+            while file.metadata().unwrap().len() < 1024 * 1024 * 1024 {
+                file.write_all(&buffer)
+                    .expect("Failed to write buffer to file");
+            }
+        }
+
+        // Coalesce temporary files into single, large output file.
+        let mut temp_dest_paths = vec![];
+        temp_file_paths
+            .iter()
+            .enumerate()
+            .for_each(|(i, file_path)| {
+                temp_dest_paths.push((i as u64, PathBuf::from(*file_path)));
+            });
+        const OUTPUT_FILE: &str = "./output_file";
+        coalesce_temp_files(temp_dest_paths, PathBuf::from(OUTPUT_FILE));
+
+        // Cleanup output file.
+        fs::remove_file(OUTPUT_FILE)
+            .unwrap_or_else(|_| panic!("failed to remove file {}", OUTPUT_FILE));
+    }
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -499,7 +499,7 @@ fn test_snapshot_download() {
 
     // Download the snapshot, then boot a validator from it.
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &[cluster.entry_point_info.rpc],
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -522,7 +522,8 @@ fn test_snapshot_download() {
             .snapshot_config
             .maximum_incremental_snapshot_archives_to_retain,
         false,
-        &mut None,
+        None,
+        &mut 0,
     )
     .unwrap();
 
@@ -630,7 +631,7 @@ fn test_incremental_snapshot_download() {
 
     // Download the snapshots, then boot a validator from them.
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &[cluster.entry_point_info.rpc],
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -653,12 +654,13 @@ fn test_incremental_snapshot_download() {
             .snapshot_config
             .maximum_incremental_snapshot_archives_to_retain,
         false,
-        &mut None,
+        None,
+        &mut 0,
     )
     .unwrap();
 
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &[cluster.entry_point_info.rpc],
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -681,7 +683,8 @@ fn test_incremental_snapshot_download() {
             .snapshot_config
             .maximum_incremental_snapshot_archives_to_retain,
         false,
-        &mut None,
+        None,
+        &mut 0,
     )
     .unwrap();
 
@@ -806,7 +809,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     // Download the snapshots, then boot a validator from them.
     info!("Downloading full snapshot to validator...");
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &[cluster.entry_point_info.rpc],
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .path(),
@@ -824,7 +827,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .snapshot_config
             .maximum_incremental_snapshot_archives_to_retain,
         false,
-        &mut None,
+        None,
+        &mut 0,
     )
     .unwrap();
     let downloaded_full_snapshot_archive = snapshot_utils::get_highest_full_snapshot_archive_info(
@@ -840,7 +844,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     info!("Downloading incremental snapshot to validator...");
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &[cluster.entry_point_info.rpc],
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .path(),
@@ -861,7 +865,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .snapshot_config
             .maximum_incremental_snapshot_archives_to_retain,
         false,
-        &mut None,
+        None,
+        &mut 0,
     )
     .unwrap();
     let downloaded_incremental_snapshot_archive =
@@ -1253,13 +1258,15 @@ fn test_snapshot_restart_tower() {
     );
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let validator_archive_path = snapshot_utils::build_snapshot_archive_path(
+        SnapshotType::FullSnapshot,
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .into_path(),
         full_snapshot_archive_info.slot(),
         full_snapshot_archive_info.hash(),
         full_snapshot_archive_info.archive_format(),
+        None,
     );
     fs::hard_link(full_snapshot_archive_info.path(), validator_archive_path).unwrap();
 
@@ -1324,13 +1331,15 @@ fn test_snapshots_blockstore_floor() {
     };
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let validator_archive_path = snapshot_utils::build_snapshot_archive_path(
+        SnapshotType::FullSnapshot,
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .into_path(),
         archive_info.slot(),
         archive_info.hash(),
         ArchiveFormat::TarBzip2,
+        None,
     );
     fs::hard_link(archive_info.path(), validator_archive_path).unwrap();
     let slot_floor = archive_info.slot();

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1860,6 +1860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "http-range-header"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4518,6 +4524,7 @@ dependencies = [
  "console",
  "indicatif",
  "log",
+ "rayon",
  "reqwest",
  "solana-runtime",
  "solana-sdk 1.15.0",
@@ -5140,6 +5147,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
+ "http-range",
  "itertools",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5150,6 +5158,7 @@ dependencies = [
  "log",
  "rayon",
  "regex",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 crossbeam-channel = "0.5"
 dashmap = "4.0.2"
+http-range = "0.1.5"
 itertools = "0.10.5"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0" }
@@ -25,6 +26,14 @@ libc = "0.2.131"
 log = "0.4.17"
 rayon = "1.5.3"
 regex = "1.6.0"
+reqwest = { version = "0.11.12", default-features = false, features = [
+	"blocking",
+	"brotli",
+	"deflate",
+	"gzip",
+	"rustls-tls",
+	"json"
+] }
 serde = "1.0.144"
 serde_derive = "1.0.103"
 serde_json = "1.0.83"

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -256,11 +256,13 @@ impl SnapshotPackage {
             SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref());
         let mut snapshot_storages = accounts_package.snapshot_storages;
         let snapshot_archive_path = match snapshot_type {
-            SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
+            SnapshotType::FullSnapshot => snapshot_utils::build_snapshot_archive_path(
+                snapshot_type,
                 snapshot_info.full_snapshot_archives_dir,
                 accounts_package.slot,
                 &snapshot_hash,
                 snapshot_info.archive_format,
+                None,
             ),
             SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot) => {
                 snapshot_storages.retain(|storages| {
@@ -275,12 +277,13 @@ impl SnapshotPackage {
                         .all(|entry| entry.slot() > incremental_snapshot_base_slot)),
                     "Incremental snapshot package must only contain storage entries where slot > incremental snapshot base slot (i.e. full snapshot slot)!"
                 );
-                snapshot_utils::build_incremental_snapshot_archive_path(
+                snapshot_utils::build_snapshot_archive_path(
+                    snapshot_type,
                     snapshot_info.incremental_snapshot_archives_dir,
-                    incremental_snapshot_base_slot,
                     accounts_package.slot,
                     &snapshot_hash,
                     snapshot_info.archive_format,
+                    None,
                 )
             }
         };

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1444,39 +1444,39 @@ pub fn build_snapshot_archives_remote_dir(snapshot_archives_dir: impl AsRef<Path
         .join(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
 }
 
-/// Build the full snapshot archive path from its components: the snapshot archives directory, the
-/// snapshot slot, the accounts hash, and the archive format.
-pub fn build_full_snapshot_archive_path(
-    full_snapshot_archives_dir: impl AsRef<Path>,
+pub fn build_snapshot_archive_path(
+    snapshot_type: SnapshotType,
+    base_dir: impl AsRef<Path>,
     slot: Slot,
     hash: &SnapshotHash,
     archive_format: ArchiveFormat,
+    chunk_number: Option<u64>,
 ) -> PathBuf {
-    full_snapshot_archives_dir.as_ref().join(format!(
-        "snapshot-{}-{}.{}",
-        slot,
-        hash.0,
-        archive_format.extension(),
-    ))
-}
+    let prefix = match snapshot_type {
+        SnapshotType::FullSnapshot => "snapshot".to_owned(),
+        SnapshotType::IncrementalSnapshot(base_slot) => {
+            format!("incremental-snapshot-{}", base_slot)
+        }
+    };
 
-/// Build the incremental snapshot archive path from its components: the snapshot archives
-/// directory, the snapshot base slot, the snapshot slot, the accounts hash, and the archive
-/// format.
-pub fn build_incremental_snapshot_archive_path(
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-    base_slot: Slot,
-    slot: Slot,
-    hash: &SnapshotHash,
-    archive_format: ArchiveFormat,
-) -> PathBuf {
-    incremental_snapshot_archives_dir.as_ref().join(format!(
-        "incremental-snapshot-{}-{}-{}.{}",
-        base_slot,
-        slot,
-        hash.0,
-        archive_format.extension(),
-    ))
+    if let Some(chunk_number) = chunk_number {
+        base_dir.as_ref().join(format!(
+            "{}-{}-{}-{}.{}",
+            prefix,
+            slot,
+            hash.0,
+            chunk_number,
+            archive_format.extension(),
+        ))
+    } else {
+        base_dir.as_ref().join(format!(
+            "{}-{}-{}.{}",
+            prefix,
+            slot,
+            hash.0,
+            archive_format.extension(),
+        ))
+    }
 }
 
 /// Parse a full snapshot archive filename into its Slot, Hash, and Archive Format

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -181,7 +181,7 @@ fn install_if_missing(
         if download_file_path.exists() {
             fs::remove_file(&download_file_path).map_err(|err| err.to_string())?;
         }
-        download_file(url.as_str(), &download_file_path, true, &mut None)?;
+        download_file(url.as_str(), &download_file_path, true, None, None)?;
         let zip = File::open(&download_file_path).map_err(|err| err.to_string())?;
         let tar = BzDecoder::new(BufReader::new(zip));
         let mut archive = Archive::new(tar);


### PR DESCRIPTION
#### Problem
Snapshot download can be very slow (~30 minutes to download 30+GB snapshot) depending on which RPC gets selected for download and latest available snapshot, which causes overall validator startup time to be quite slow. See #26402 

#### Summary of Changes
- Allow for downloading snapshot from multiple RPCs in parallel using HTTP GET ranges.
- Rework snapshot path APIs (collapse unique full/incremental into a single API w/ additional parameters that can also be leveraged for generating temporary snapshot chunk paths)
- Add unit test for testing the file coalescing API

#### Overview
This PR is to socialize one strategy for accomplishing faster snapshot download. If we like this design and want to proceed, we would want to break this down into smaller PRs as well as feature gate things.

#### Open Questions
- How do we want to morph the snapshot abort logic? Currently, we will check if aborts are allowed (based on number of downloads aborted and maximum aborts) once per entry into `download_snapshot_archive`. We could make this finer grain or rework it altogether.
- How do we want to feature switch things? One possibility for avoiding feature switching could be to deploy server side support and wait for mass adoption before rolling out client side support. We could also maintain parallel paths for client side snapshot download that are feature switched.

#### Potential Individual PRs
- Snapshot path API change
- Server side range servicing (add this support before adding client range requests)