### PR TITLE
logger: Update to env_logger 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-logger"
 edition = "2021"
 
 [dependencies]
-env_logger = "0.9.0"
+env_logger = "0.9.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -55,8 +55,6 @@ pub fn setup() {
 }
 
 // Configures file logging with a default filter if RUST_LOG is not set
-//
-// NOTE: This does not work at the moment, pending the resolution of https://github.com/env-logger-rs/env_logger/issues/208
 pub fn setup_file_with_default(logfile: &str, filter: &str) {
     use std::fs::OpenOptions;
     let file = OpenOptions::new()

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { version = "0.11.12", default-features = false, features = ["blocking
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.9.3"
 rand = "0.7.0"
 serial_test = "0.9.0"
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",


### PR DESCRIPTION
#### Problem

With https://github.com/env-logger-rs/env_logger/issues/208 resolved, `env_logger::Target::Pipe` works properly, but the validator still outputs to console on Windows since it's on an older version.

#### Summary of Changes

Update to version 0.9.3 to pick up the fix, and have file logging work properly on Windows.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
