### PR TITLE
filter_storages ignores reclaims

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -374,7 +374,7 @@ impl<'a> SnapshotMinimizer<'a> {
                 Some(hashes),
                 Some(new_storage),
                 Some(Box::new(write_versions.into_iter())),
-                StoreReclaims::Default,
+                StoreReclaims::Ignore,
             );
 
             new_storage.flush().unwrap();


### PR DESCRIPTION
#### Problem
Shrinking operations need to ignore reclaims. As we move towards limiting to 1 append vec per slot, this test causes asserts.

#### Summary of Changes
ignore reclaim while doing snapshot minimization, which is shrink operation and is a ledger-tool only functionality anyway.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
