### PR TITLE
Add conflict groups to bench-tps

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1190,8 +1190,8 @@ mod tests {
     fn test_bench_tps_key_chunks_new() {
         let num_keypairs = 16;
         let chunk_size = 4;
-        let keypairs = (0..num_keypairs)
-            .map(|_| Keypair::new())
+        let keypairs = std::iter::repeat_with(Keypair::new)
+            .take(num_keypairs)
             .collect::<Vec<_>>();
 
         let chunks = KeypairChunks::new(&keypairs, chunk_size);
@@ -1218,8 +1218,8 @@ mod tests {
         let num_keypairs = 16;
         let chunk_size = 4;
         let num_conflict_groups = 2;
-        let keypairs = (0..num_keypairs)
-            .map(|_| Keypair::new())
+        let keypairs = std::iter::repeat_with(Keypair::new)
+            .take(num_keypairs)
             .collect::<Vec<_>>();
 
         let chunks =

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -74,13 +74,13 @@ struct KeypairChunks<'a> {
 }
 
 impl<'a> KeypairChunks<'a> {
-    /// Split input vector of keypairs into two sets of chunks of given size
+    /// Split input slice of keypairs into two sets of chunks of given size
     fn new(keypairs: &'a [Keypair], chunk_size: usize) -> Self {
         // Use `chunk_size` as the number of conflict groups per chunk so that each destination key is unique
         Self::new_with_conflict_groups(keypairs, chunk_size, chunk_size)
     }
 
-    /// Split input vector of keypairs into two sets of chunks of given size. Each chunk
+    /// Split input slice of keypairs into two sets of chunks of given size. Each chunk
     /// has a set of source keys and a set of destination keys. There will be
     /// `num_conflict_groups_per_chunk` unique destination keys per chunk, so that the
     /// destination keys may conflict with each other.

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -94,8 +94,9 @@ impl<'a> KeypairChunks<'a> {
         for chunk in keypairs.chunks_exact(2 * chunk_size) {
             source_keypair_chunks.push(chunk[..chunk_size].iter().collect());
             dest_keypair_chunks.push(
-                (0..chunk_size)
-                    .map(|idx| &chunk[chunk_size + (idx % num_conflict_groups_per_chunk)])
+                std::iter::repeat(&chunk[chunk_size..chunk_size + num_conflict_groups_per_chunk])
+                    .flatten()
+                    .take(chunk_size)
                     .collect(),
             );
         }

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1184,4 +1184,60 @@ mod tests {
         }
         withdraw_durable_nonce_accounts(client, &authority_keypairs, &nonce_keypairs)
     }
+
+    #[test]
+    fn test_bench_tps_key_chunks_new() {
+        let num_keypairs = 16;
+        let chunk_size = 4;
+        let keypairs = (0..num_keypairs)
+            .map(|_| Keypair::new())
+            .collect::<Vec<_>>();
+
+        let chunks = KeypairChunks::new(&keypairs, chunk_size);
+        assert_eq!(
+            chunks.source[0],
+            &[&keypairs[0], &keypairs[1], &keypairs[2], &keypairs[3]]
+        );
+        assert_eq!(
+            chunks.dest[0],
+            &[&keypairs[4], &keypairs[5], &keypairs[6], &keypairs[7]]
+        );
+        assert_eq!(
+            chunks.source[1],
+            &[&keypairs[8], &keypairs[9], &keypairs[10], &keypairs[11]]
+        );
+        assert_eq!(
+            chunks.dest[1],
+            &[&keypairs[12], &keypairs[13], &keypairs[14], &keypairs[15]]
+        );
+    }
+
+    #[test]
+    fn test_bench_tps_key_chunks_new_with_conflict_groups() {
+        let num_keypairs = 16;
+        let chunk_size = 4;
+        let num_conflict_groups = 2;
+        let keypairs = (0..num_keypairs)
+            .map(|_| Keypair::new())
+            .collect::<Vec<_>>();
+
+        let chunks =
+            KeypairChunks::new_with_conflict_groups(&keypairs, chunk_size, num_conflict_groups);
+        assert_eq!(
+            chunks.source[0],
+            &[&keypairs[0], &keypairs[1], &keypairs[2], &keypairs[3]]
+        );
+        assert_eq!(
+            chunks.dest[0],
+            &[&keypairs[4], &keypairs[5], &keypairs[4], &keypairs[5]]
+        );
+        assert_eq!(
+            chunks.source[1],
+            &[&keypairs[8], &keypairs[9], &keypairs[10], &keypairs[11]]
+        );
+        assert_eq!(
+            chunks.dest[1],
+            &[&keypairs[12], &keypairs[13], &keypairs[12], &keypairs[13]]
+        );
+    }
 }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,7 +1,7 @@
 use {
     crate::spl_convert::FromOtherSolana,
     clap::{crate_description, crate_name, App, Arg, ArgMatches},
-    solana_clap_utils::input_validators::{is_url, is_url_or_moniker},
+    solana_clap_utils::input_validators::{is_url, is_url_or_moniker, is_within_range},
     solana_cli_config::{ConfigInput, CONFIG_FILE},
     solana_sdk::{
         fee_calculator::FeeRateGovernor,
@@ -348,6 +348,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
             Arg::with_name("num_conflict_groups")
                 .long("num-conflict-groups")
                 .takes_value(true)
+                .validator(|arg| is_within_range(arg, 1, usize::MAX - 1))
                 .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
         )
 }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -65,6 +65,7 @@ pub struct Config {
     pub use_randomized_compute_unit_price: bool,
     pub use_durable_nonce: bool,
     pub instruction_padding_config: Option<InstructionPaddingConfig>,
+    pub num_conflict_groups: Option<usize>,
 }
 
 impl Default for Config {
@@ -95,6 +96,7 @@ impl Default for Config {
             use_randomized_compute_unit_price: false,
             use_durable_nonce: false,
             instruction_padding_config: None,
+            num_conflict_groups: None,
         }
     }
 }
@@ -342,6 +344,12 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .help("If set, wraps all instructions in the instruction padding program, with the given amount of padding bytes in instruction data."),
         )
+        .arg(
+            Arg::with_name("num_conflict_groups")
+                .long("num-conflict-groups")
+                .takes_value(true)
+                .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -492,6 +500,14 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
                 .parse()
                 .expect("Can't parse padded instruction data size"),
         });
+    }
+
+    if let Some(num_conflict_groups) = matches.value_of("num_conflict_groups") {
+        args.num_conflict_groups = Some(
+            num_conflict_groups
+                .parse()
+                .expect("Can't parse conflict groups"),
+        );
     }
 
     args


### PR DESCRIPTION
#### Problem
bench-tps currently has entirely non-conflicting transactions which is not useful if we want to measure performance under contentious load.

#### Summary of Changes
Add a new cli arg to `bench-tps`: `--num-conflict-groups <num_conflict_groups>` which gives us a lever to control how many txs conflict.
The number of "conflict groups" determines how many unique destination accounts we have per chunk. This means that the lower number of conflict groups means more contention, `num_conflict_groups = 1` is the maximum contention we can have (every transaction in a chunk conflicts).

Related #29126 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
