### PR TITLE
migrate tests to get_slot_storage_entry

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4249,17 +4249,14 @@ impl AccountsDb {
 
     #[cfg(test)]
     pub(crate) fn sizes_of_accounts_in_storage_for_tests(&self, slot: Slot) -> Vec<usize> {
-        self.get_storages_for_slot(slot)
-            .map(|storages| {
-                storages
-                    .iter()
-                    .flat_map(|storage| {
-                        storage
-                            .accounts
-                            .account_iter()
-                            .map(|account| account.stored_size)
-                    })
-                    .collect::<Vec<_>>()
+        self.storage
+            .get_slot_storage_entry(slot)
+            .map(|storage| {
+                storage
+                    .accounts
+                    .account_iter()
+                    .map(|account| account.stored_size)
+                    .collect()
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
#### Problem
moving to 1 append vec per slot

#### Summary of Changes
Use `get_slot_storage_entry()` in tests to return a single append vec and assert there is only 1.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
