### PR TITLE
remove unnecessary to_vec()

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -17198,7 +17198,7 @@ pub mod tests {
                                     );
                                 });
 
-                                let storages = db.get_storages_for_slot(slot5).unwrap().to_vec();
+                                let storages = db.get_storages_for_slot(slot5).unwrap();
                                 let mut stored_accounts = Vec::default();
                                 assert_eq!(storages.len(), 1);
                                 let shrink_collect = db.shrink_collect(


### PR DESCRIPTION
#### Problem
unnecessary call to `to_vec()`, adds uncertainty to refactoring

#### Summary of Changes
remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
