### PR TITLE
shrink_slot_forced uses a single append vec

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4082,12 +4082,11 @@ impl AccountsDb {
     fn shrink_slot_forced(&self, slot: Slot) -> usize {
         debug!("shrink_slot_forced: slot: {}", slot);
 
-        if let Some(stores_lock) = self.storage.get_slot_stores(slot) {
-            let stores: SnapshotStorage = stores_lock.read().unwrap().values().cloned().collect();
-            if !Self::is_shrinking_productive(slot, stores.iter()) {
+        if let Some(store) = self.storage.get_slot_storage_entry(slot) {
+            if !Self::is_shrinking_productive(slot, std::iter::once(&store)) {
                 return 0;
             }
-            self.do_shrink_slot_stores(slot, stores.iter())
+            self.do_shrink_slot_stores(slot, std::iter::once(&store))
         } else {
             0
         }


### PR DESCRIPTION
#### Problem
moving to 1 append vec per slot

#### Summary of Changes
`shrink_slot_forced()` gets a single append vec

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
