### PR TITLE
Adds SnapshotError::IoWithSourceAndFile

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -229,6 +229,9 @@ pub enum SnapshotError {
     #[error("source({1}) - I/O error: {0}")]
     IoWithSource(std::io::Error, &'static str),
 
+    #[error("source({1}) - I/O error: {0}, file: {2}")]
+    IoWithSourceAndFile(#[source] std::io::Error, &'static str, PathBuf),
+
     #[error("could not get file name from path: {}", .0.display())]
     PathToFileNameError(PathBuf),
 
@@ -328,8 +331,9 @@ pub fn archive_snapshot_package(
         .parent()
         .expect("Tar output path is invalid");
 
-    fs::create_dir_all(tar_dir)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create archive path"))?;
+    fs::create_dir_all(tar_dir).map_err(|e| {
+        SnapshotError::IoWithSourceAndFile(e, "create archive path", tar_dir.into())
+    })?;
 
     // Create the staging directories
     let staging_dir_prefix = TMP_SNAPSHOT_ARCHIVE_PREFIX;
@@ -345,8 +349,9 @@ pub fn archive_snapshot_package(
     let staging_accounts_dir = staging_dir.path().join("accounts");
     let staging_snapshots_dir = staging_dir.path().join("snapshots");
     let staging_version_file = staging_dir.path().join("version");
-    fs::create_dir_all(&staging_accounts_dir)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create staging path"))?;
+    fs::create_dir_all(&staging_accounts_dir).map_err(|e| {
+        SnapshotError::IoWithSourceAndFile(e, "create staging path", staging_accounts_dir.clone())
+    })?;
 
     // Add the snapshots to the staging directory
     symlink::symlink_dir(
@@ -377,8 +382,9 @@ pub fn archive_snapshot_package(
 
     // Write version file
     {
-        let mut f = fs::File::create(staging_version_file)
-            .map_err(|e| SnapshotError::IoWithSource(e, "create version file"))?;
+        let mut f = fs::File::create(&staging_version_file).map_err(|e| {
+            SnapshotError::IoWithSourceAndFile(e, "create version file", staging_version_file)
+        })?;
         f.write_all(snapshot_package.snapshot_version.as_str().as_bytes())
             .map_err(|e| SnapshotError::IoWithSource(e, "write version file"))?;
     }
@@ -437,8 +443,9 @@ pub fn archive_snapshot_package(
     }
 
     // Atomically move the archive into position for other validators to find
-    let metadata = fs::metadata(&archive_path)
-        .map_err(|e| SnapshotError::IoWithSource(e, "archive path stat"))?;
+    let metadata = fs::metadata(&archive_path).map_err(|e| {
+        SnapshotError::IoWithSourceAndFile(e, "archive path stat", archive_path.clone())
+    })?;
     fs::rename(&archive_path, snapshot_package.path())
         .map_err(|e| SnapshotError::IoWithSource(e, "archive path rename"))?;
 


### PR DESCRIPTION
#### Problem

We often have errors in the snapshot code that are from IO std functions. It is useful to know the path of the file that caused the error, but that's not available without creating custom errors. Since that happens in a number of places, it'd be convenient to have a SnapshotError that takes a path to automatically create the error string.




#### Summary of Changes

Add `SnapshotError::IoWithSourceAndFile`, and use it in a few places.

Here's what the various errors look like. The lines are:
1. ErrorKind
2. SnapshotError::Io
3. SnapshotError::IoWithSource
4. SnapshotError::IoWithSourceAndFile

Output for `Display`
```
                              err: io error test string
                      err from io: I/O error: io error test string
          err from io with source: source(source string) - I/O error: io error test string
 err from io with source and file: source(source string) - I/O error: io error test string, file: file path
```

Output for `Debug`
```
                              err: Custom { kind: Other, error: "io error test string" }
                      err from io: Io(Custom { kind: Other, error: "io error test string" })
          err from io with source: IoWithSource(Custom { kind: Other, error: "io error test string" }, "source string")
 err from io with source and file: IoWithSourceAndFile(Custom { kind: Other, error: "io error test string" }, "source string", "file path")
```