### PR TITLE
Fixes format string

### DIFF
--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -357,9 +357,7 @@ mod tests {
             let result = rent_collector.calculate_rent_result(&Pubkey::default(), &account, None);
             assert!(
                 matches!(result, RentResult::Exempt),
-                "{:?}, set_exempt_rent_epoch_max: {}",
-                result,
-                set_exempt_rent_epoch_max,
+                "{result:?}, set_exempt_rent_epoch_max: {set_exempt_rent_epoch_max}",
             );
             {
                 let mut account_clone = account.clone();


### PR DESCRIPTION
#### Problem

New-clippy (for #29304) warns about format strings:

```
error: variables can be used directly in the `format!` string
   --> runtime/src/rent_collector.rs:358:13
    |
358 | /             assert!(
359 | |                 matches!(result, RentResult::Exempt),
360 | |                 "{:?}, set_exempt_rent_epoch_max: {}",
361 | |                 result,
362 | |                 set_exempt_rent_epoch_max,
363 | |             );
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
```

#### Summary of Changes

Inline the variable into the format string