### PR TITLE
Fix doc warnings

### DIFF
--- a/core/src/multi_iterator_scanner.rs
+++ b/core/src/multi_iterator_scanner.rs
@@ -35,21 +35,28 @@ pub enum ProcessingDecision {
 /// Assume transactions with same letter conflict with each other. A typical priority ordered
 /// buffer might look like:
 ///
-///     // [A, A, B, A, C, D, B, C, D]
+/// ```text
+/// [A, A, B, A, C, D, B, C, D]
+/// ```
 ///
 /// If we want to have batches of size 4, the MultiIteratorScanner will proceed as follows:
 ///
-///     // [A, A, B, A, C, D, B, C, D]
-///     //  ^     ^     ^  ^
+/// ```text
+/// [A, A, B, A, C, D, B, C, D]
+///  ^     ^     ^  ^
 ///
-///     // [A, A, B, A, C, D, B, C, D]
-///     //     ^              ^  ^  ^
+/// [A, A, B, A, C, D, B, C, D]
+///     ^              ^  ^  ^
 ///
-///     // [A, A, B, A, C, D, B, C, D]
-///     //           ^
+/// [A, A, B, A, C, D, B, C, D]
+///           ^
+/// ```
+///
 /// The iterator will iterate with batches:
 ///
-///     // [[A, B, C, D], [A, B, C, D], [A]]
+/// ```text
+/// [[A, B, C, D], [A, B, C, D], [A]]
+/// ```
 ///
 pub struct MultiIteratorScanner<'a, T, U, F>
 where

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -641,7 +641,7 @@ pub trait ProtobufColumn: Column {
 /// essentially Slot (or more generally speaking, has a 1:1 mapping to Slot).
 ///
 /// The clean-up of any LedgerColumn that implements SlotColumn is managed by
-/// [`LedgerCleanupService`], which will periodically deprecate and purge
+/// `LedgerCleanupService`, which will periodically deprecate and purge
 /// oldest entries that are older than the latest root in order to maintain the
 /// configured --limit-ledger-size under the validator argument.
 pub trait SlotColumn<Index = u64> {}


### PR DESCRIPTION
#### Problem

`cargo doc` generates warnings

#### Summary of Changes

Turn a code block into a not-rust code block. Remove a link to `LedgerCleanupService`, which can't be reached from the `solana-ledger` crate because it is in `solana-core`.
