### PR TITLE
Fix solana-stake-accounts version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,6 +6524,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk 1.15.0",
  "solana-stake-program",
+ "solana-version",
 ]
 
 [[package]]

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -18,6 +18,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=1.15.0" }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.15.0" }
+solana-version = { path = "../version", version = "=1.15.0" }
 
 [dev-dependencies]
 solana-runtime = { path = "../runtime", version = "=1.15.0" }

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -3,7 +3,9 @@ use {
         Args, AuthorizeArgs, Command, CountArgs, MoveArgs, NewArgs, QueryArgs, RebaseArgs,
         SetLockupArgs,
     },
-    clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand},
+    clap::{
+        crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
+    },
     solana_clap_utils::{
         input_parsers::unix_timestamp_from_rfc3339_datetime,
         input_validators::{is_amount, is_rfc3339_datetime, is_valid_pubkey, is_valid_signer},
@@ -133,9 +135,9 @@ where
     T: Into<OsString> + Clone,
 {
     let default_config_file = CONFIG_FILE.as_ref().unwrap();
-    App::new("solana-stake-accounts")
-        .about("about")
-        .version("version")
+    App::new(crate_name!())
+        .about(crate_description!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("config_file")
                 .long("config")


### PR DESCRIPTION
#### Problem
```
$ solana-stake-accounts -V
solana-stake-accounts version
```

#### Summary of Changes
Fix clap inputs, including version (minor cleanup on a largely unsupported bin, but doing it since it's still in the monorepo)

```
$ cd stake-accounts && cargo run -- -V
solana-stake-accounts 1.15.0 (src:devbuild; feat:629316760)
```


Fixes #20413
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
