### PR TITLE
stop returning remaining # stores from mark_dirty_dead_stores

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -380,7 +380,7 @@ impl<'a> SnapshotMinimizer<'a> {
             new_storage.flush().unwrap();
         }
 
-        let (_, mut dead_storages_this_time) = self.accounts_db().mark_dirty_dead_stores(
+        let mut dead_storages_this_time = self.accounts_db().mark_dirty_dead_stores(
             slot,
             true, // add_dirty_stores
             shrink_in_progress,


### PR DESCRIPTION
#### Problem
Moving towards 1 append vec per slot.
It is inconvenient and now unnecessary to return # remaining append vecs after `mark_dirty_dead_stores()`. The answer will always be 1 or 0 now. We were previously using this to assert it was never > 1. That will always be true now.

#### Summary of Changes
Remove return value, simplify calling code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
