### PR TITLE
chore: increase stable-perf timeout_in_minutes to 35

### DIFF
--- a/ci/buildkite-pipeline-in-disk.sh
+++ b/ci/buildkite-pipeline-in-disk.sh
@@ -207,7 +207,7 @@ EOF
     cat >> "$output_file" <<"EOF"
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
-    timeout_in_minutes: 20
+    timeout_in_minutes: 35
     artifact_paths: "log-*.txt"
     agents:
       queue: "cuda"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -216,7 +216,7 @@ EOF
     cat >> "$output_file" <<"EOF"
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
-    timeout_in_minutes: 20
+    timeout_in_minutes: 35
     artifact_paths: "log-*.txt"
     agents:
       queue: "cuda"


### PR DESCRIPTION
#### Problem

some context: https://discord.com/channels/428295358100013066/560503042458517505/1060679253290655785

The time which stable-perf taking is so closing to the origin timeout limit, 20 min.

![Screenshot 2023-01-06 at 5 17 06 PM](https://user-images.githubusercontent.com/8209234/210970051-82772bac-454b-4d92-a8dc-5108e94cd877.png)

I think we can either 1) increasing timeout limit or 2) upgrade our gcp agent's hardware.

I do 1) atm.
