### PR TITLE
convert some get_slot_stores -> get_slot_storage_entry

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5852,7 +5852,7 @@ impl AccountsDb {
         // After handling the reclaimed entries, this slot's
         // storage entries should be purged from self.storage
         assert!(
-            self.storage.get_slot_stores(remove_slot).is_none(),
+            self.storage.get_slot_storage_entry(remove_slot).is_none(),
             "slot {remove_slot} is not none"
         );
     }


### PR DESCRIPTION
#### Problem
subset of #29549
That one has deeper issues that I have to untangle.

moving towards 1 append vec per slot
`get_slot_stores()` returns internals of the storage map.

#### Summary of Changes
Move to the more contained `get_slot_storage_entry()` api which can help us control the data types and expectations better.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
