### PR TITLE
ancient append vecs enabled at -10k by default

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1383,7 +1383,7 @@ fn main() {
     let ancient_append_vecs = Arg::with_name("accounts_db_ancient_append_vecs")
         .long("accounts-db-ancient-append-vecs")
         .value_name("SLOT-OFFSET")
-        .validator(is_parsable::<u64>)
+        .validator(is_parsable::<i64>)
         .takes_value(true)
         .help(
             "AppendVecs that are older than (slots_per_epoch - SLOT-OFFSET) are squashed together.",
@@ -2724,7 +2724,7 @@ fn main() {
                     ancient_append_vec_offset: value_t!(
                         matches,
                         "accounts_db_ancient_append_vecs",
-                        u64
+                        i64
                     )
                     .ok(),
                     exhaustively_verify_refcounts: arg_matches
@@ -2992,7 +2992,7 @@ fn main() {
                     ancient_append_vec_offset: value_t!(
                         matches,
                         "accounts_db_ancient_append_vecs",
-                        u64
+                        i64
                     )
                     .ok(),
                     skip_initial_hash_calc: arg_matches

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -404,15 +404,17 @@ impl Default for FillerAccountsConfig {
     }
 }
 
+const ANCIENT_APPEND_VEC_DEFAULT_OFFSET: Option<i64> = Some(-10_000);
+
 #[derive(Debug, Default, Clone)]
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub accounts_hash_cache_path: Option<PathBuf>,
     pub filler_accounts_config: FillerAccountsConfig,
     pub write_cache_limit_bytes: Option<u64>,
-    /// if None, ancient append vecs are disabled
+    /// if None, ancient append vecs are set to ANCIENT_APPEND_VEC_DEFAULT_OFFSET
     /// Some(offset) means include slots up to (max_slot - (slots_per_epoch - 'offset'))
-    pub ancient_append_vec_offset: Option<Slot>,
+    pub ancient_append_vec_offset: Option<i64>,
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
 }
@@ -1259,7 +1261,7 @@ pub struct AccountsDb {
 
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
     /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
-    pub ancient_append_vec_offset: Option<Slot>,
+    pub ancient_append_vec_offset: Option<i64>,
 
     /// true iff we want to skip the initial hash calculation on startup
     pub skip_initial_hash_calc: bool,
@@ -2389,7 +2391,7 @@ impl AccountsDb {
         let ancient_append_vec_offset = accounts_db_config
             .as_ref()
             .map(|config| config.ancient_append_vec_offset)
-            .unwrap_or_default();
+            .unwrap_or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET);
 
         let exhaustively_verify_refcounts = accounts_db_config
             .as_ref()
@@ -4170,7 +4172,7 @@ impl AccountsDb {
     fn get_sorted_potential_ancient_slots(&self) -> Vec<Slot> {
         let mut reference_slot = self.get_accounts_hash_complete_one_epoch_old();
         if let Some(offset) = self.ancient_append_vec_offset {
-            reference_slot = reference_slot.saturating_add(offset);
+            reference_slot = Self::apply_offset_to_slot(reference_slot, offset);
         }
         let mut old_slots = self.get_roots_less_than(reference_slot);
         old_slots.sort_unstable();
@@ -6986,6 +6988,15 @@ impl AccountsDb {
         }
     }
 
+    /// return slot + offset, where offset can be +/-
+    fn apply_offset_to_slot(slot: Slot, offset: i64) -> Slot {
+        if offset > 0 {
+            slot.saturating_add(offset as u64)
+        } else {
+            slot.saturating_sub(offset.unsigned_abs())
+        }
+    }
+
     /// if ancient append vecs are enabled, return a slot 'max_slot_inclusive' - (slots_per_epoch - `self.ancient_append_vec_offset`)
     /// otherwise, return 0
     fn get_one_epoch_old_slot_for_hash_calc_scan(
@@ -6998,9 +7009,8 @@ impl AccountsDb {
             // We are mainly interested in the network at steady state.
             let slots_in_epoch = config.epoch_schedule.slots_per_epoch;
             // For performance, this is required when ancient appendvecs are enabled
-            max_slot_inclusive
-                .saturating_sub(slots_in_epoch)
-                .saturating_add(offset)
+            let slot = max_slot_inclusive.saturating_sub(slots_in_epoch);
+            Self::apply_offset_to_slot(slot, offset)
         } else {
             // This causes the entire range to be chunked together, treating older append vecs just like new ones.
             // This performs well if there are many old append vecs that haven't been cleaned yet.

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1185,7 +1185,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("accounts_db_ancient_append_vecs")
                 .long("accounts-db-ancient-append-vecs")
                 .value_name("SLOT-OFFSET")
-                .validator(is_parsable::<u64>)
+                .validator(is_parsable::<i64>)
                 .takes_value(true)
                 .help("AppendVecs that are older than (slots_per_epoch - SLOT-OFFSET) are squashed together.")
                 .hidden(true),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1026,7 +1026,7 @@ pub fn main() {
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()
             .map(|mb| mb * MB as u64),
-        ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", u64).ok(),
+        ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         ..AccountsDbConfig::default()
     };


### PR DESCRIPTION
#### Problem
There will soon be a feature to enable skipping rewrites. When that occurs, we have to be able to combine into ancient append vecs, or we will run out of mmap file handles.
There is a cli arg `--accounts-db-ancient-append-vecs` This offset is usually positive for debugging, causing us to put accounts into ancient append vecs when they are less than 432k slots old. Making it negative pushes the inflection point older.

#### Summary of Changes
Enable ancient append vecs by default at -10k slots. This means we won't try to put anything into an ancient append vec until it is older than 432k + 10k slots from the max root. Until the feature gets activated, this means that nothing should get put into ancient append vecs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
