### PR TITLE
use atomicu64 for bucket maxsize instead of lock

### DIFF
--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -1,9 +1,12 @@
-use std::sync::{atomic::AtomicU64, Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 #[derive(Debug, Default)]
 pub struct BucketStats {
     pub resizes: AtomicU64,
-    pub max_size: Mutex<u64>,
+    pub max_size: AtomicU64,
     pub resize_us: AtomicU64,
     pub new_file_us: AtomicU64,
     pub flush_file_us: AtomicU64,
@@ -13,8 +16,7 @@ pub struct BucketStats {
 
 impl BucketStats {
     pub fn update_max_size(&self, size: u64) {
-        let mut max = self.max_size.lock().unwrap();
-        *max = std::cmp::max(*max, size);
+        self.max_size.fetch_max(size, Ordering::Relaxed);
     }
 }
 

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -378,13 +378,8 @@ impl BucketMapHolderStats {
                 ),
                 (
                     "disk_index_max_size",
-                    disk.map(|disk| {
-                        let mut lock = disk.stats.index.max_size.lock().unwrap();
-                        let value = *lock;
-                        *lock = 0;
-                        value
-                    })
-                    .unwrap_or_default(),
+                    disk.map(|disk| { disk.stats.index.max_size.swap(0, Ordering::Relaxed) })
+                        .unwrap_or_default(),
                     i64
                 ),
                 (
@@ -429,13 +424,8 @@ impl BucketMapHolderStats {
                 ),
                 (
                     "disk_data_max_size",
-                    disk.map(|disk| {
-                        let mut lock = disk.stats.data.max_size.lock().unwrap();
-                        let value = *lock;
-                        *lock = 0;
-                        value
-                    })
-                    .unwrap_or_default(),
+                    disk.map(|disk| { disk.stats.data.max_size.swap(0, Ordering::Relaxed) })
+                        .unwrap_or_default(),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem

A lock (mutex) for max_size stat on bucketstats is unnecessary. It can be replaced with Atomic variable.


#### Summary of Changes

Use atomicu64 for max_size in bucketstats



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
