### PR TITLE
removes LegacyContactInfo::is_valid_tvu_address

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1307,7 +1307,7 @@ impl ClusterInfo {
             .filter(|node| {
                 node.id != self_pubkey
                     && node.shred_version == self_shred_version
-                    && ContactInfo::is_valid_tvu_address(&node.tvu)
+                    && ContactInfo::is_valid_address(&node.tvu, &self.socket_addr_space)
             })
             .cloned()
             .collect()
@@ -1324,7 +1324,7 @@ impl ClusterInfo {
             .filter(|node| {
                 node.id != self_pubkey
                     && node.shred_version == self_shred_version
-                    && ContactInfo::is_valid_tvu_address(&node.tvu)
+                    && ContactInfo::is_valid_address(&node.tvu, &self.socket_addr_space)
                     && ContactInfo::is_valid_address(&node.serve_repair, &self.socket_addr_space)
                     && match gossip_crds.get::<&LowestSlot>(node.id) {
                         None => true, // fallback to legacy behavior

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -199,16 +199,9 @@ impl LegacyContactInfo {
     /// port must not be 0
     /// ip must be specified and not multicast
     /// loopback ip is only allowed in tests
-    // Keeping this for now not to break tvu-peers and turbine shuffle order of
-    // nodes when arranging nodes on retransmit tree. Private IP addresses in
-    // turbine are filtered out just before sending packets.
-    pub(crate) fn is_valid_tvu_address(addr: &SocketAddr) -> bool {
-        (addr.port() != 0) && Self::is_valid_ip(addr.ip())
-    }
-
     // TODO: Replace this entirely with streamer SocketAddrSpace.
     pub fn is_valid_address(addr: &SocketAddr, socket_addr_space: &SocketAddrSpace) -> bool {
-        Self::is_valid_tvu_address(addr) && socket_addr_space.check(addr)
+        addr.port() != 0u16 && Self::is_valid_ip(addr.ip()) && socket_addr_space.check(addr)
     }
 
     pub fn client_facing_addr(&self) -> (SocketAddr, SocketAddr) {


### PR DESCRIPTION

#### Problem
Since https://github.com/solana-labs/solana/pull/20480, turbine includes all epoch staked nodes in tree construction and no longer relies on obtaining their contact-info from gossip; and so distinguishing between `is_valid_address` and `is_valid_tvu_address` is no longer necessary and the latter can be removed.


#### Summary of Changes
removed `LegacyContactInfo::is_valid_tvu_address`.