### PR TITLE
repair peer selection by stake similarity experiment

### DIFF
--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -215,6 +215,54 @@ impl ClusterSlots {
             })
             .collect()
     }
+
+    fn normalize_stake_ln(stake: u64) -> u64 {
+        // cap the max balance to u32 max (it should be plenty)
+        let bal = f64::from(u32::max_value()).min(stake as f64);
+        let x = 1_f32.max((bal as f32).ln());
+        x as u64
+    }
+
+    // Create weighting of peers based on peers' similarity in stake to the node specifiied
+    // by `target_id`.
+    pub(crate) fn compute_weights_target_distance(
+        &self,
+        repair_peers: &[ContactInfo],
+        target_id: &Pubkey,
+    ) -> Vec<u64> {
+        if repair_peers.is_empty() {
+            return Vec::default();
+        }
+        let (weights, max_diff) = {
+            let validator_stakes = self.validator_stakes.read().unwrap();
+            let target_stake = validator_stakes
+                .get(target_id)
+                .map(|node| node.total_stake)
+                .unwrap_or(0);
+            let mut max_diff = 0;
+            let weights: Vec<_> = repair_peers
+                .iter()
+                .map(|peer| {
+                    let stake = validator_stakes
+                        .get(&peer.id)
+                        .map(|node| node.total_stake)
+                        .unwrap_or(0);
+                    let diff = if target_stake > stake {
+                        target_stake - stake
+                    } else {
+                        stake - target_stake
+                    };
+                    max_diff = max_diff.max(diff);
+                    diff
+                })
+                .collect();
+            (weights, max_diff)
+        };
+        weights
+            .into_iter()
+            .map(|w| Self::normalize_stake_ln(max_diff - w + 1))
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -570,6 +570,14 @@ pub mod disable_turbine_fanout_experiments {
     solana_sdk::declare_id!("Gz1aLrbeQ4Q6PTSafCZcGWZXz91yVRi7ASFzFEr1U4sa");
 }
 
+pub mod enable_repair_peer_selection_experiments {
+    solana_sdk::declare_id!("24MCz1eioJq1cDRTNtrEDnVtA9ZJkYX3BG1Apc3fkzze");
+}
+
+pub mod disable_repair_peer_selection_experiments {
+    solana_sdk::declare_id!("FiawZN6swobGq9EMozks57FhwBN8s24pQQQv9rdC3FyX");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -707,6 +715,8 @@ lazy_static! {
         (commission_updates_only_allowed_in_first_half_of_epoch::id(), "validator commission updates are only allowed in the first half of an epoch #29362"),
         (enable_turbine_fanout_experiments::id(), "enable turbine fanout experiments #29393"),
         (disable_turbine_fanout_experiments::id(), "disable turbine fanout experiments #29393"),
+        (enable_repair_peer_selection_experiments::id(), "enable repair peer selection experiments #TODO"),
+        (disable_repair_peer_selection_experiments::id(), "disable repair peer selection experiments #TODO"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Repair peers are selected based on stake weight. unstaked nodes will rarely be selected for repair requests.

#### Summary of Changes
Experiment with different peer selection strategies to more broadly distribute repair requests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
