### PR TITLE
fix intermittent ci faiure test_quic_server_multiple_writes

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1159,7 +1159,7 @@ pub mod test {
         // So when the test call finishes after sending multiple writes on quic,
         // a Stopped from peer should be fine. We expect a result of Ok or
         // Stopped from peer.
-        if !result.is_ok() && !matches!(result, quinn::WriteError::Stopped(_)) {
+        if result.is_err() && !matches!(result, Err(quinn::WriteError::Stopped(_))) {
             panic!("Failed to finish writes on quic connection");
         }
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1152,7 +1152,13 @@ pub mod test {
         for _ in 0..num_bytes {
             s1.write_all(&[0u8]).await.unwrap();
         }
-        s1.finish().await.unwrap();
+        let result = s1.finish().await;
+        match result {
+            Err(quinn::WriteError::UnknownStream) => {
+                assert!(false, "expect a valid stream");
+            }
+            _ => {}
+        };
 
         let mut all_packets = vec![];
         let now = Instant::now();


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/29096

The call to `finish`, after sending multiple writes on quic in the test, is to make sure that we `Stop` writing any bytes on the connect. Then, we can check on the receiver to verify the bytes are indeed received. Therefore, when the test call finishes after sending multiple writes on quic, a `Stopped` from peer should be fine. We expect a result of `Ok` or `Stopped` from peer. 

#### Summary of Changes

Change unwarp(), which fails on all Error to only fails on non `Stopped` errors.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
