### PR TITLE
Provide a way to get the internal representation of Pubkey

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -7,6 +7,7 @@ use {
     bytemuck::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     std::{
+        borrow,
         convert::{Infallible, TryFrom},
         fmt, mem,
         str::FromStr,
@@ -634,6 +635,12 @@ impl AsRef<[u8]> for Pubkey {
 impl AsMut<[u8]> for Pubkey {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0[..]
+    }
+}
+
+impl borrow::Borrow<[u8; 32]> for Pubkey {
+    fn borrow(&self) -> &[u8; 32] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
The problem here is that `Pubkey` only provides the slice representation of the underlying bytes, which means that at compile-time the actual length of the underlying array is unknown to external actors. Just to give you an example, it is much trivial, faster and optimal to copy an array using `*` instead of having to resort to `copy_from_slice`.

Revival of https://github.com/solana-labs/solana/pull/27640. The PR was automatically closed due to the lack of additional feedback from the responsible authorities.
