### PR TITLE
get_unique_accounts_from_storages takes 1 append vec

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -305,7 +305,7 @@ impl<'a> SnapshotMinimizer<'a> {
             stored_accounts, ..
         } = self
             .accounts_db()
-            .get_unique_accounts_from_storages(storages.iter());
+            .get_unique_accounts_from_storages(storages.first().unwrap());
 
         let keep_accounts_collect = Mutex::new(Vec::with_capacity(stored_accounts.len()));
         let purge_pubkeys_collect = Mutex::new(Vec::with_capacity(stored_accounts.len()));


### PR DESCRIPTION
#### Problem
moving to 1 append vec per slot
converting apis that take vec to take a single append vec
#### Summary of Changes
`get_unique_accounts_from_storages()` takes single storage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
