### PR TITLE
Fix RPC tests race condition

### DIFF
--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -1,5 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
-
+#[cfg(test)]
+use crate::{rpc_pubsub_service, rpc_subscriptions::RpcSubscriptions};
 use {
     crate::{
         rpc::check_is_at_least_confirmed,
@@ -399,6 +400,14 @@ impl RpcSolPubSubImpl {
                 data: None,
             })
         }
+    }
+
+    #[cfg(test)]
+    pub fn block_until_processed(&self, rpc_subscriptions: &Arc<RpcSubscriptions>) {
+        let (rpc, mut receiver) = rpc_pubsub_service::test_connection(&rpc_subscriptions);
+        rpc.slot_subscribe().unwrap();
+        rpc_subscriptions.notify_slot(1, 0, 0);
+        receiver.recv();
     }
 }
 
@@ -886,12 +895,7 @@ mod tests {
             }),
         )
         .unwrap();
-
-        // Make sure the subscription is processed before continuing.
-        let (rpc2, mut receiver2) = rpc_pubsub_service::test_connection(&rpc_subscriptions);
-        rpc2.slot_subscribe().unwrap();
-        rpc_subscriptions.notify_slot(1, 0, 0);
-        receiver2.recv();
+        rpc.block_until_processed(&rpc_subscriptions);
 
         let balance = {
             let bank = bank_forks.read().unwrap().working_bank();
@@ -1015,12 +1019,7 @@ mod tests {
             }),
         )
         .unwrap();
-
-        // Make sure the subscription is processed before continuing.
-        let (rpc2, mut receiver2) = rpc_pubsub_service::test_connection(&rpc_subscriptions);
-        rpc2.slot_subscribe().unwrap();
-        rpc_subscriptions.notify_slot(1, 0, 0);
-        receiver2.recv();
+        rpc.block_until_processed(&rpc_subscriptions);
 
         let ixs = system_instruction::create_nonce_account(
             &alice.pubkey(),

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -404,7 +404,7 @@ impl RpcSolPubSubImpl {
 
     #[cfg(test)]
     pub fn block_until_processed(&self, rpc_subscriptions: &Arc<RpcSubscriptions>) {
-        let (rpc, mut receiver) = rpc_pubsub_service::test_connection(&rpc_subscriptions);
+        let (rpc, mut receiver) = rpc_pubsub_service::test_connection(rpc_subscriptions);
         rpc.slot_subscribe().unwrap();
         rpc_subscriptions.notify_slot(1, 0, 0);
         receiver.recv();


### PR DESCRIPTION
#### Problem
Many of our RPC test fail sporadically in CI with a receiver timeout.

This is caused by a race condition between completing processing of a subscription and processing some notification. We need the subscription to be processed first so we will receive a message when the notification is processed later, but occasionally (~10% of the time for some tests) the notification is processed first because these activities are handled async.

Note: this is a known issue observed in #27480 and partially mitigated by #27481 and #28998. The latest failing test observed failing was `test_logs_subscribe`

#### Summary of Changes
Add an API for unit tests, `block_until_processed`, that will not return until server side handling of notifications has completed. It does this by subscribing to slot notifications, queueing a slot notification, and waiting to receive message from the server. Because notifications are processed serially, this will guarantee that prior subscriptions have been fully processed.