### PR TITLE
verify acct size in index can easily be recalculated

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7803,6 +7803,15 @@ impl AccountsDb {
                     "AccountsDB::accounts_index corrupted. Storage pointed to: {}, expected: {}, should only point to one slot",
                     store.slot(), *slot
                 );
+                let account = store.accounts.get_account(account_info.offset()).unwrap();
+                if account.1
+                    != account_info
+                        .offset()
+                        .saturating_add(account_info.stored_size() as usize)
+                {
+                    // this should never happen. This is a metrics based assert at the moment.
+                    inc_new_counter_info!("remove_dead_accounts-stored_size_mismatch", 1);
+                }
                 let count =
                     store.remove_account(account_info.stored_size() as usize, reset_accounts);
                 if count == 0 {


### PR DESCRIPTION
#### Problem
Would like to stop storing per-account size in the account index. If this can be easily recalculated, then there is no reason to store it.

#### Summary of Changes
assert that the calculated size when we need the size always matches the stored size.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
