### PR TITLE
ledger-tool: Clean account paths in all cases

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1089,17 +1089,17 @@ fn load_bank_forks(
             "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
             non_primary_accounts_path
         );
-
-        if non_primary_accounts_path.exists() {
-            info!("Clearing {:?}", non_primary_accounts_path);
-            let mut measure_time = Measure::start("clean_non_primary_accounts_paths");
-            move_and_async_delete_path(&non_primary_accounts_path);
-            measure_time.stop();
-            info!("done. {}", measure_time);
-        }
-
         vec![non_primary_accounts_path]
     };
+    info!("Cleaning contents of account paths: {:?}", account_paths);
+    let mut measure = Measure::start("clean_accounts_paths");
+    account_paths.iter().for_each(|path| {
+        if path.exists() {
+            move_and_async_delete_path(path);
+        }
+    });
+    measure.stop();
+    info!("done. {}", measure);
 
     let mut accounts_update_notifier = Option::<AccountsUpdateNotifier>::default();
     if arg_matches.is_present("geyser_plugin_config") {


### PR DESCRIPTION
#### Problem
The existing logic will clean account paths only when we had secondary access to the blockstore. However, the access mode shouldn't dictate when we clean accounts data.

#### Summary of Changes
We can and should clean account data from previous runs in all instances given that we always start over from a snapshot. So, move the logic to clean old account data in all scenarios. We're about to start writing to that directory anyways.

This is expanding the logic added in https://github.com/solana-labs/solana/pull/27622 to all blockstore access mode scenarios.