### PR TITLE
just use slot to determine alive while shrinking

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -144,13 +144,6 @@ impl AccountInfo {
         self.stored_size_mask & !ALL_FLAGS
     }
 
-    /// true iff store_id and offset match self AND self is not cached
-    /// If self is cached, then store_id and offset are meaningless.
-    pub fn matches_storage_location(&self, store_id: AppendVecId, offset: Offset) -> bool {
-        // order is set for best short circuit
-        self.store_id == store_id && self.offset() == offset && !self.is_cached()
-    }
-
     pub fn storage_location(&self) -> StorageLocation {
         if self.is_cached() {
             StorageLocation::Cached
@@ -181,27 +174,5 @@ mod test {
     fn test_alignment() {
         let offset = 1; // not aligned
         AccountInfo::new(StorageLocation::AppendVec(0, offset), 0, 0);
-    }
-
-    #[test]
-    fn test_matches_storage_location() {
-        let offset = 0;
-        let id = 0;
-        let info = AccountInfo::new(StorageLocation::AppendVec(id, offset), 0, 0);
-        assert!(info.matches_storage_location(id, offset));
-
-        // wrong offset
-        let offset = ALIGN_BOUNDARY_OFFSET;
-        assert!(!info.matches_storage_location(id, offset));
-
-        // wrong id
-        let offset = 0;
-        let id = 1;
-        assert!(!info.matches_storage_location(id, offset));
-
-        // is cached
-        let id = CACHE_VIRTUAL_STORAGE_ID;
-        let info = AccountInfo::new(StorageLocation::Cached, 0, 0);
-        assert!(!info.matches_storage_location(id, offset));
     }
 }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3626,12 +3626,9 @@ impl AccountsDb {
                 let mut result = AccountsIndexScanResult::None;
                 if let Some((slot_list, _ref_count)) = slots_refs {
                     let stored_account = &accounts[index];
-                    let is_alive = slot_list.iter().any(|(slot, acct_info)| {
+                    let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
+                        // if the accounts index contains an entry at this slot, then the append vec we're asking about contains this item and thus, it is alive at this slot
                         *slot == slot_to_shrink
-                            && acct_info.matches_storage_location(
-                                acct_info.store_id(),
-                                stored_account.account.offset,
-                            )
                     });
                     if !is_alive {
                         // This pubkey was found in the storage, but no longer exists in the index.


### PR DESCRIPTION
#### Problem
There could be race conditions in tests without this change. Recent changes are moving towards 1 append vec per slot.
The comparison here was asking for `.store_id()` of account info. This asserts if the account info refers to data in the write cache. It is sufficient to just test the slot since there can only be one append vec per slot.
We were hitting this specific case because a test was running shrink and flush in parallel. This meant that flush could create an append vec to flush to, then shrink could concurrently try to shrink that append vec. This is undefined behavior. A way to avoid this at a higher level is #29615. It already was my intuition that checking for any entry at the shrinking slot was sufficient to mean the account is alive. So, this change is simpler and correct as well. The original code was looking for store_ids to match, where store_id was correlated with the slot we were shrinking. Since there will be only 1 append vec/store_id per slot, then comparing with slot is equivalent since store_id will be directly correlated with slot.

#### Summary of Changes
Remove account info specific check to avoid assert.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
