### PR TITLE
ci: Allows clippy uninlined format args

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -69,7 +69,7 @@ fi
 
  _ ci/order-crates-for-publishing.py
 
-nightly_clippy_allows=()
+nightly_clippy_allows=("--allow=clippy::uninlined-format-args")
 
 # -Z... is needed because of clippy bug: https://github.com/rust-lang/rust-clippy/issues/4612
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there


### PR DESCRIPTION
#### Problem

Rust 1.68 adds new clippy lints for uninlined format args. When a format string includes many variables, I find having some inlined and some not to be unideal.

See #29533 for more info.

#### Summary of Changes

Do not require that variables must be inlined into the format string