### PR TITLE
Remove tpu udp

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -416,11 +416,7 @@ fn main() {
             SocketAddrSpace::Unspecified,
         );
         let cluster_info = Arc::new(cluster_info);
-        let tpu_use_quic = matches.is_present("tpu_use_quic");
-        let connection_cache = match tpu_use_quic {
-            true => ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-            false => ConnectionCache::with_udp(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-        };
+        let connection_cache = ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE);
         let banking_stage = BankingStage::new_num_threads(
             &cluster_info,
             &poh_recorder,

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -8,9 +8,7 @@ use {
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair},
     },
-    solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
-    },
+    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_CONNECTION_POOL_SIZE,
     std::{net::SocketAddr, process::exit, time::Duration},
 };
 
@@ -60,7 +58,6 @@ pub struct Config {
     pub target_slots_per_epoch: u64,
     pub target_node: Option<Pubkey>,
     pub external_client_type: ExternalClientType,
-    pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
     pub use_randomized_compute_unit_price: bool,
     pub use_durable_nonce: bool,
@@ -90,7 +87,6 @@ impl Default for Config {
             target_slots_per_epoch: 0,
             target_node: None,
             external_client_type: ExternalClientType::default(),
-            use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             use_randomized_compute_unit_price: false,
             use_durable_nonce: false,
@@ -385,10 +381,6 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         args.external_client_type = ExternalClientType::TpuClient;
     } else if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
-    }
-
-    if matches.is_present("tpu_disable_quic") {
-        args.use_quic = false;
     }
 
     if let Some(v) = matches.value_of("tpu_connection_pool_size") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -39,7 +39,6 @@ fn create_client(
     json_rpc_url: &str,
     websocket_url: &str,
     multi_client: bool,
-    use_quic: bool,
     tpu_connection_pool_size: usize,
     rpc_tpu_sockets: Option<(SocketAddr, SocketAddr)>,
     num_nodes: usize,
@@ -51,10 +50,7 @@ fn create_client(
             CommitmentConfig::confirmed(),
         )),
         ExternalClientType::ThinClient => {
-            let connection_cache = match use_quic {
-                true => Arc::new(ConnectionCache::new(tpu_connection_pool_size)),
-                false => Arc::new(ConnectionCache::with_udp(tpu_connection_pool_size)),
-            };
+            let connection_cache = Arc::new(ConnectionCache::new(tpu_connection_pool_size));
 
             if let Some((rpc, tpu)) = rpc_tpu_sockets {
                 Arc::new(ThinClient::new(rpc, tpu, connection_cache))
@@ -106,10 +102,7 @@ fn create_client(
                 json_rpc_url.to_string(),
                 CommitmentConfig::confirmed(),
             ));
-            let connection_cache = match use_quic {
-                true => ConnectionCache::new(tpu_connection_pool_size),
-                false => ConnectionCache::with_udp(tpu_connection_pool_size),
-            };
+            let connection_cache = ConnectionCache::new(tpu_connection_pool_size);
 
             Arc::new(
                 TpuClient::new_with_connection_cache(
@@ -150,7 +143,6 @@ fn main() {
         num_lamports_per_account,
         target_node,
         external_client_type,
-        use_quic,
         tpu_connection_pool_size,
         use_randomized_compute_unit_price,
         use_durable_nonce,
@@ -218,7 +210,6 @@ fn main() {
         json_rpc_url,
         websocket_url,
         *multi_client,
-        *use_quic,
         *tpu_connection_pool_size,
         rpc_tpu_sockets,
         *num_nodes,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -31,7 +31,6 @@ use {
         stake::{instruction::LockupArgs, state::Lockup},
         transaction::{TransactionError, VersionedTransaction},
     },
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
     solana_vote_program::vote_state::VoteAuthorize,
     std::{collections::HashMap, error, io::stdout, str::FromStr, sync::Arc, time::Duration},
     thiserror::Error,
@@ -508,7 +507,6 @@ pub struct CliConfig<'a> {
     pub send_transaction_config: RpcSendTransactionConfig,
     pub confirm_transaction_initial_timeout: Duration,
     pub address_labels: HashMap<String, String>,
-    pub use_quic: bool,
 }
 
 impl CliConfig<'_> {
@@ -556,7 +554,6 @@ impl Default for CliConfig<'_> {
                 u64::from_str(DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS).unwrap(),
             ),
             address_labels: HashMap::new(),
-            use_quic: !DEFAULT_TPU_ENABLE_UDP,
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,6 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
     std::{collections::HashMap, error, path::PathBuf, sync::Arc, time::Duration},
 };
 
@@ -203,14 +202,6 @@ pub fn parse_args<'a>(
         config.address_labels
     };
 
-    let use_quic = if matches.is_present("use_quic") {
-        true
-    } else if matches.is_present("use_udp") {
-        false
-    } else {
-        !DEFAULT_TPU_ENABLE_UDP
-    };
-
     Ok((
         CliConfig {
             command,
@@ -229,7 +220,6 @@ pub fn parse_args<'a>(
             },
             confirm_transaction_initial_timeout,
             address_labels,
-            use_quic,
         },
         signers,
     ))

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2158,11 +2158,7 @@ fn send_deploy_messages(
     if !write_messages.is_empty() {
         if let Some(write_signer) = write_signer {
             trace!("Writing program data");
-            let connection_cache = if config.use_quic {
-                Arc::new(ConnectionCache::new(1))
-            } else {
-                Arc::new(ConnectionCache::with_udp(1))
-            };
+            let connection_cache = Arc::new(ConnectionCache::new(1));
             let tpu_client = TpuClient::new_with_connection_cache(
                 rpc_client.clone(),
                 &config.websocket_url,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -56,7 +56,6 @@ impl FetchStage {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_sender(
-
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: &Arc<AtomicBool>,
         sender: &PacketBatchSender,
@@ -183,13 +182,10 @@ impl FetchStage {
             .unwrap();
 
         Self {
-            thread_hdls: [
-                tpu_vote_threads,
-                vec![fwd_thread_hdl, metrics_thread_hdl],
-            ]
-            .into_iter()
-            .flatten()
-            .collect(),
+            thread_hdls: [tpu_vote_threads, vec![fwd_thread_hdl, metrics_thread_hdl]]
+                .into_iter()
+                .flatten()
+                .collect(),
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -98,7 +98,6 @@ impl Tpu {
         log_messages_bytes_limit: Option<usize>,
         staked_nodes: &Arc<RwLock<StakedNodes>>,
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
-        tpu_enable_udp: bool,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -124,7 +123,6 @@ impl Tpu {
             poh_recorder,
             tpu_coalesce_ms,
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
-            tpu_enable_udp,
         );
 
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -48,8 +48,6 @@ pub const DEFAULT_TPU_COALESCE_MS: u64 = 5;
 pub const MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 
 pub struct TpuSockets {
-    pub transactions: Vec<UdpSocket>,
-    pub transaction_forwards: Vec<UdpSocket>,
     pub vote: Vec<UdpSocket>,
     pub broadcast: Vec<UdpSocket>,
     pub transactions_quic: UdpSocket,
@@ -100,8 +98,6 @@ impl Tpu {
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     ) -> Self {
         let TpuSockets {
-            transactions: transactions_sockets,
-            transaction_forwards: tpu_forwards_sockets,
             vote: tpu_vote_sockets,
             broadcast: broadcast_sockets,
             transactions_quic: transactions_quic_sockets,
@@ -112,17 +108,13 @@ impl Tpu {
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
         let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
-            transactions_sockets,
-            tpu_forwards_sockets,
             tpu_vote_sockets,
             exit,
             &packet_sender,
             &vote_packet_sender,
-            &forwarded_packet_sender,
             forwarded_packet_receiver,
             poh_recorder,
             tpu_coalesce_ms,
-            Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
         );
 
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -984,8 +984,6 @@ impl Validator {
             entry_receiver,
             retransmit_slots_receiver,
             TpuSockets {
-                transactions: node.sockets.tpu,
-                transaction_forwards: node.sockets.tpu_forwards,
                 vote: node.sockets.tpu_vote,
                 broadcast: node.sockets.broadcast,
                 transactions_quic: node.sockets.tpu_quic,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2046,7 +2046,7 @@ mod tests {
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
         solana_tpu_client::tpu_connection_cache::{
-            DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         },
         std::{fs::remove_dir_all, thread, time::Duration},
     };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2045,9 +2045,7 @@ mod tests {
         crossbeam_channel::{bounded, RecvTimeoutError},
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
-        solana_tpu_client::tpu_connection_cache::{
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-        },
+        solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_CONNECTION_POOL_SIZE,
         std::{fs::remove_dir_all, thread, time::Duration},
     };
 

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -240,7 +240,6 @@ mod tests {
             "--valid-signatures",
             "--num-signatures",
             "8",
-            "--tpu-use-quic",
             "--send-batch-size",
             "1",
         ])

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -58,13 +58,6 @@ pub struct DosClientParameters {
     #[clap(flatten)]
     pub transaction_params: TransactionParams,
 
-    #[clap(
-        long,
-        conflicts_with("skip-gossip"),
-        help = "Submit transactions via QUIC"
-    )]
-    pub tpu_use_quic: bool,
-
     #[clap(long, default_value = "16384", help = "Size of the transactions batch")]
     pub send_batch_size: usize,
 }
@@ -228,7 +221,6 @@ mod tests {
                 skip_gossip: false,
                 allow_private_addr: false,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 num_gen_threads: 1,
                 send_batch_size: 16384,
             },
@@ -272,7 +264,6 @@ mod tests {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: true,
                 send_batch_size: 1,
             },
         );
@@ -316,7 +307,6 @@ mod tests {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
-                tpu_use_quic: false,
                 send_batch_size: 1,
             },
         );
@@ -375,7 +365,6 @@ mod tests {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(8),
                 },
-                tpu_use_quic: false,
                 send_batch_size: 1,
             },
         );
@@ -417,7 +406,6 @@ mod tests {
                     transaction_type: Some(TransactionType::AccountCreation),
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
                 send_batch_size: 1,
             },
         );

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -251,13 +251,9 @@ fn create_sender_thread(
     tx_receiver: Receiver<TransactionBatchMsg>,
     iterations: usize,
     target: &SocketAddr,
-    tpu_use_quic: bool,
 ) -> thread::JoinHandle<()> {
     // ConnectionCache is used instead of client because it gives ~6% higher pps
-    let connection_cache = match tpu_use_quic {
-        true => ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-        false => ConnectionCache::with_udp(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-    };
+    let connection_cache = ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE);
     let connection = connection_cache.get_connection(target);
 
     let stats_timer_receiver = tick(Duration::from_millis(SAMPLE_PERIOD_MS));
@@ -562,7 +558,6 @@ fn run_dos_transactions<T: 'static + BenchTpsClient + Send + Sync>(
     iterations: usize,
     client: Option<Arc<T>>,
     transaction_params: TransactionParams,
-    tpu_use_quic: bool,
     num_gen_threads: usize,
     send_batch_size: usize,
 ) {
@@ -577,7 +572,7 @@ fn run_dos_transactions<T: 'static + BenchTpsClient + Send + Sync>(
     let mut transaction_generator = TransactionGenerator::new(transaction_params);
     let (tx_sender, tx_receiver) = unbounded();
 
-    let sender_thread = create_sender_thread(tx_receiver, iterations, &target, tpu_use_quic);
+    let sender_thread = create_sender_thread(tx_receiver, iterations, &target);
     let tx_generator_threads: Vec<_> = payers
         .into_iter()
         .map(|payer| {
@@ -629,7 +624,6 @@ fn run_dos<T: 'static + BenchTpsClient + Send + Sync>(
             iterations,
             client,
             params.transaction_params,
-            params.tpu_use_quic,
             params.num_gen_threads,
             params.send_batch_size,
         );
@@ -756,10 +750,7 @@ fn main() {
             exit(1);
         });
 
-        let connection_cache = match cmd_params.tpu_use_quic {
-            true => ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-            false => ConnectionCache::with_udp(DEFAULT_TPU_CONNECTION_POOL_SIZE),
-        };
+        let connection_cache = ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE);
         let (client, num_clients) = get_multi_client(
             &validators,
             &SocketAddrSpace::Unspecified,
@@ -827,7 +818,6 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -845,7 +835,6 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -863,7 +852,6 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -881,7 +869,6 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -914,7 +901,6 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -960,7 +946,6 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -987,7 +972,6 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1014,13 +998,12 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
     }
 
-    fn run_dos_with_blockhash_and_payer(tpu_use_quic: bool) {
+    fn run_dos_with_blockhash_and_payer() {
         solana_logger::setup();
 
         // 1. Create faucet thread
@@ -1093,7 +1076,6 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
-                tpu_use_quic,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1122,7 +1104,6 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
-                tpu_use_quic,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1150,7 +1131,6 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(8),
                 },
-                tpu_use_quic,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1178,7 +1158,6 @@ pub mod test {
                     transaction_type: Some(TransactionType::AccountCreation),
                     num_instructions: None,
                 },
-                tpu_use_quic,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1186,11 +1165,6 @@ pub mod test {
 
     #[test]
     fn test_dos_with_blockhash_and_payer() {
-        run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ false)
-    }
-
-    #[test]
-    fn test_dos_with_blockhash_and_payer_and_quic() {
-        run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ true)
+        run_dos_with_blockhash_and_payer()
     }
 }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -276,9 +276,7 @@ impl LocalCluster {
             true, // should_check_duplicate_instance
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
         )
         .expect("assume successful validator start");
 
@@ -476,9 +474,7 @@ impl LocalCluster {
             true, // should_check_duplicate_instance
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
         )
         .expect("assume successful validator start");
 
@@ -837,9 +833,7 @@ impl Cluster for LocalCluster {
             true, // should_check_duplicate_instance
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -44,7 +44,7 @@ use {
     solana_stake_program::{config::create_account as create_stake_config_account, stake_state},
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
     },
     solana_vote_program::{
         vote_instruction,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -43,9 +43,7 @@ use {
     },
     solana_stake_program::{config::create_account as create_stake_config_account, stake_state},
     solana_streamer::socket::SocketAddrSpace,
-    solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
-    },
+    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_CONNECTION_POOL_SIZE,
     solana_vote_program::{
         vote_instruction,
         vote_state::{self, VoteInit},
@@ -86,7 +84,6 @@ pub struct ClusterConfig {
     pub cluster_type: ClusterType,
     pub poh_config: PohConfig,
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
-    pub tpu_use_quic: bool,
     pub tpu_connection_pool_size: usize,
 }
 
@@ -107,7 +104,6 @@ impl Default for ClusterConfig {
             poh_config: PohConfig::default(),
             skip_warmup_slots: false,
             additional_accounts: vec![],
-            tpu_use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
         }
     }
@@ -300,10 +296,7 @@ impl LocalCluster {
             entry_point_info: leader_contact_info,
             validators,
             genesis_config,
-            connection_cache: match config.tpu_use_quic {
-                true => Arc::new(ConnectionCache::new(config.tpu_connection_pool_size)),
-                false => Arc::new(ConnectionCache::with_udp(config.tpu_connection_pool_size)),
-            },
+            connection_cache: Arc::new(ConnectionCache::new(config.tpu_connection_pool_size)),
         };
 
         let node_pubkey_to_vote_key: HashMap<Pubkey, Arc<Keypair>> = keys_in_genesis

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -450,7 +450,7 @@ fn test_rpc_subscriptions() {
     }
 }
 
-fn run_tpu_send_transaction(tpu_use_quic: bool) {
+fn run_tpu_send_transaction() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let test_validator =
@@ -459,10 +459,7 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
         test_validator.rpc_url(),
         CommitmentConfig::processed(),
     ));
-    let connection_cache = match tpu_use_quic {
-        true => Arc::new(ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE)),
-        false => Arc::new(ConnectionCache::with_udp(DEFAULT_TPU_CONNECTION_POOL_SIZE)),
-    };
+    let connection_cache = Arc::new(ConnectionCache::new(DEFAULT_TPU_CONNECTION_POOL_SIZE));
     let tpu_client = TpuClient::new_with_connection_cache(
         rpc_client.clone(),
         &test_validator.rpc_pubsub_url(),
@@ -490,12 +487,7 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
 
 #[test]
 fn test_tpu_send_transaction() {
-    run_tpu_send_transaction(/*tpu_use_quic*/ false)
-}
-
-#[test]
-fn test_tpu_send_transaction_with_quic() {
-    run_tpu_send_transaction(/*tpu_use_quic*/ true)
+    run_tpu_send_transaction()
 }
 
 #[test]

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -45,7 +45,7 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP,
     },
     std::{
         collections::{HashMap, HashSet},

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -838,9 +838,7 @@ impl TestValidator {
             true, // should_check_duplicate_instance
             config.start_progress.clone(),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            config.tpu_enable_udp,
         )?);
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -746,26 +746,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
         )
         .arg(
-            Arg::with_name("tpu_use_quic")
-                .long("tpu-use-quic")
-                .takes_value(false)
-                .hidden(true)
-                .conflicts_with("tpu_disable_quic")
-                .help("Use QUIC to send transactions."),
-        )
-        .arg(
-            Arg::with_name("tpu_disable_quic")
-                .long("tpu-disable-quic")
-                .takes_value(false)
-                .help("Do not use QUIC to send transactions."),
-        )
-        .arg(
-            Arg::with_name("tpu_enable_udp")
-                .long("tpu-enable-udp")
-                .takes_value(false)
-                .help("Enable UDP for receiving/sending transactions."),
-        )
-        .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1635,9 +1635,7 @@ pub fn main() {
         should_check_duplicate_instance,
         start_progress,
         socket_addr_space,
-        tpu_use_quic,
         tpu_connection_pool_size,
-        tpu_enable_udp,
     )
     .unwrap_or_else(|e| {
         error!("Failed to start validator: {:?}", e);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -45,7 +45,6 @@ use {
     },
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::socket::SocketAddrSpace,
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
     solana_validator::{
         admin_rpc_service,
         admin_rpc_service::{load_staked_nodes_overrides, StakedNodesOverrides},
@@ -887,13 +886,6 @@ pub fn main() {
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
-    let tpu_use_quic = !matches.is_present("tpu_disable_quic");
-    let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
-        true
-    } else {
-        DEFAULT_TPU_ENABLE_UDP
-    };
-
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);


### PR DESCRIPTION
#### Problem
We'e now running smoothly with Quic on by default in MNB. UDP TPU support is extra unneeded code and that also takes up an extra UDP port that could be used for other things.

#### Summary of Changes
Remove TPU UDP support
- Remove the "tpu_use_quic", "tpu_disable_quic", and "tpu_enable_udp" CLI options from the validator and test utilities
- Make all tests use Quic
- Does not remove the UDP TpuClient to keep the PR reasonably small - will be in a followup PR

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
