### PR TITLE
assert write version is increasing per slot as we read from a slot

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -790,9 +790,9 @@ impl Accounts {
                         match accum.entry(loaded_account_pubkey) {
                             // Double check in case another thread interleaved a write between the read + write.
                             Occupied(mut occupied_entry) => {
-                                if loaded_write_version > occupied_entry.get().0 {
-                                    occupied_entry.insert((loaded_write_version, val));
-                                }
+                                assert!(loaded_write_version > occupied_entry.get().0);
+                                // overwrite
+                                occupied_entry.insert((loaded_write_version, val));
                             }
 
                             Vacant(vacant_entry) => {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7604,9 +7604,9 @@ impl AccountsDb {
                     // keep the latest write version for each pubkey
                     match accum.entry(*loaded_account.pubkey()) {
                         Occupied(mut occupied_entry) => {
-                            if loaded_write_version > occupied_entry.get().version() {
-                                occupied_entry.insert((loaded_write_version, loaded_hash));
-                            }
+                            assert!(loaded_write_version > occupied_entry.get().version());
+                            // overwrite
+                            occupied_entry.insert((loaded_write_version, loaded_hash));
                         }
 
                         Vacant(vacant_entry) => {


### PR DESCRIPTION
#### Problem
Trying to stop saving `write_version` in append vecs.
Now that we only ever have 1 append vec per slot, account data we find later is always more recent.

#### Summary of Changes
Assert that write_version is increasing per pubkey.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
