### PR TITLE
Remove protoc from docker image

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -2,10 +2,6 @@
 # ci/rust-version.sh to pick up the new image tag
 FROM rust:1.65.0
 
-# Add Google Protocol Buffers for Libra's metrics library.
-ENV PROTOC_VERSION 3.8.0
-ENV PROTOC_ZIP protoc-$PROTOC_VERSION-linux-x86_64.zip
-
 RUN set -x \
  && apt update \
  && apt-get install apt-transport-https \
@@ -41,8 +37,4 @@ RUN set -x \
  && cargo install svgbob_cli \
  && cargo install wasm-pack \
  && rustc --version \
- && cargo --version \
- && curl -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
- && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
- && unzip -o $PROTOC_ZIP -d /usr/local include/* \
- && rm -f $PROTOC_ZIP
+ && cargo --version


### PR DESCRIPTION
#### Problem
Since #26854, protoc is built from source in the places that we need it (solana-storage-bigtable and solana-storage-proto). Nothing is using this protoc install; both the comment and the protoc version itself are out of date.

#### Summary of Changes
Remove

cc: https://github.com/solana-labs/solana/pull/26827
