### PR TITLE
snapshot storage path uses 1 append vec per slot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -328,7 +328,7 @@ mod tests {
             block_height: slot,
             slot_deltas: vec![],
             snapshot_links: link_snapshots_dir,
-            snapshot_storages: vec![storage_entries],
+            snapshot_storages: storage_entries,
             snapshot_version: SnapshotVersion::default(),
             snapshot_type: SnapshotType::FullSnapshot,
         };

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -442,7 +442,6 @@ fn test_concurrent_snapshot_packaging(
             let snapshot_storage_files: HashSet<_> = bank_forks[slot]
                 .get_snapshot_storages(None)
                 .into_iter()
-                .flatten()
                 .map(|s| s.get_path())
                 .collect();
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_db::{SnapshotStorages, PUBKEY_BINS_FOR_CALCULATING_HASHES},
+        accounts_db::{SnapshotStoragesOne, PUBKEY_BINS_FOR_CALCULATING_HASHES},
         ancestors::Ancestors,
         rent_collector::RentCollector,
     },
@@ -173,20 +173,14 @@ pub struct HashStats {
     pub count_ancient_scans: AtomicU64,
 }
 impl HashStats {
-    pub fn calc_storage_size_quartiles(&mut self, storages: &SnapshotStorages) {
+    pub fn calc_storage_size_quartiles(&mut self, storages: &SnapshotStoragesOne) {
         let mut sum = 0;
         let mut sizes = storages
             .iter()
-            .flat_map(|storages| {
-                let result = storages
-                    .iter()
-                    .map(|storage| {
-                        let cap = storage.accounts.capacity() as usize;
-                        sum += cap;
-                        cap
-                    })
-                    .collect::<Vec<_>>();
-                result
+            .map(|storage| {
+                let cap = storage.accounts.capacity() as usize;
+                sum += cap;
+                cap
             })
             .collect::<Vec<_>>();
         sizes.sort_unstable();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -45,7 +45,7 @@ use {
         },
         accounts_db::{
             AccountShrinkThreshold, AccountsDbConfig, CalcAccountsHashDataSource,
-            IncludeSlotInHash, SnapshotStorages, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
+            IncludeSlotInHash, SnapshotStoragesOne, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_hash::AccountsHash,
@@ -6848,7 +6848,7 @@ impl Bank {
     /// Get this bank's storages to use for snapshots.
     ///
     /// If a base slot is provided, return only the storages that are *higher* than this slot.
-    pub fn get_snapshot_storages(&self, base_slot: Option<Slot>) -> SnapshotStorages {
+    pub fn get_snapshot_storages(&self, base_slot: Option<Slot>) -> SnapshotStoragesOne {
         // if a base slot is provided, request storages starting at the slot *after*
         let start_slot = base_slot.map_or(0, |slot| slot.saturating_add(1));
         // we want to *include* the storage at our slot

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -13,7 +13,7 @@ use {
         bank::{Bank, BankTestConfig},
         epoch_accounts_hash,
         genesis_utils::{self, activate_all_features, activate_feature},
-        snapshot_utils::ArchiveFormat,
+        snapshot_utils::{get_storages_to_serialize, ArchiveFormat},
         status_cache::StatusCache,
     },
     bincode::serialize_into,
@@ -43,7 +43,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
     let storage_entries = accounts_db.get_snapshot_storages(RangeFull, None).0;
     let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
     let mut next_append_vec_id = 0;
-    for storage_entry in storage_entries.into_iter().flatten() {
+    for storage_entry in storage_entries.into_iter() {
         // Copy file to new directory
         let storage_path = storage_entry.get_path();
         let file_name = AppendVec::file_name(storage_entry.slot(), storage_entry.append_vec_id());
@@ -187,7 +187,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &mut writer,
         &accounts.accounts_db,
         0,
-        &accounts.accounts_db.get_snapshot_storages(..=0, None).0,
+        &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=0, None).0),
     )
     .unwrap();
 
@@ -281,7 +281,7 @@ fn test_bank_serialize_style(
         serde_style,
         &mut std::io::BufWriter::new(&mut writer),
         &bank2,
-        &snapshot_storages,
+        &get_storages_to_serialize(&snapshot_storages),
     )
     .unwrap();
 
@@ -431,7 +431,7 @@ pub(crate) fn reconstruct_accounts_db_via_serialization(
         &mut writer,
         accounts,
         slot,
-        &snapshot_storages,
+        &get_storages_to_serialize(&snapshot_storages),
     )
     .unwrap();
 
@@ -516,11 +516,12 @@ fn test_extra_fields_eof() {
     let snapshot_storages = bank.get_snapshot_storages(None);
     let mut buf = vec![];
     let mut writer = Cursor::new(&mut buf);
+
     crate::serde_snapshot::bank_to_stream(
         SerdeStyle::Newer,
         &mut std::io::BufWriter::new(&mut writer),
         &bank,
-        &snapshot_storages,
+        &get_storages_to_serialize(&snapshot_storages),
     )
     .unwrap();
 
@@ -643,11 +644,12 @@ fn test_blank_extra_fields() {
     let snapshot_storages = bank.get_snapshot_storages(None);
     let mut buf = vec![];
     let mut writer = Cursor::new(&mut buf);
+
     crate::serde_snapshot::bank_to_stream_no_extra_fields(
         SerdeStyle::Newer,
         &mut std::io::BufWriter::new(&mut writer),
         &bank,
-        &snapshot_storages,
+        &get_storages_to_serialize(&snapshot_storages),
     )
     .unwrap();
 
@@ -713,7 +715,7 @@ mod test_bank_serialize {
 
         (SerializableBankAndStorage::<newer::Context> {
             bank,
-            snapshot_storages: &snapshot_storages,
+            snapshot_storages: &get_storages_to_serialize(&snapshot_storages),
             phantom: std::marker::PhantomData::default(),
         })
         .serialize(s)


### PR DESCRIPTION
#### Problem
Moving to 1 append vec per slot. The entire snapshot storage path used a Vec<> per slot.

#### Summary of Changes
Convert this code path to use `Vec<AccountStorageEntry>` per slot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
