### PR TITLE
logger: Include thread ID and name in the log messages.

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,13 +1,18 @@
 //! The `logger` module configures `env_logger`
 
 use {
+    env_logger::{fmt::Formatter, Builder, Env, Logger, Target},
     lazy_static::lazy_static,
-    std::sync::{Arc, RwLock},
+    log::Record,
+    std::{
+        io::{self, Write},
+        sync::{Arc, RwLock},
+        thread,
+    },
 };
 
 lazy_static! {
-    static ref LOGGER: Arc<RwLock<env_logger::Logger>> =
-        Arc::new(RwLock::new(env_logger::Logger::from_default_env()));
+    static ref LOGGER: Arc<RwLock<Logger>> = Arc::new(RwLock::new(Logger::from_default_env()));
 }
 
 struct LoggerShim {}
@@ -24,7 +29,60 @@ impl log::Log for LoggerShim {
     fn flush(&self) {}
 }
 
-fn replace_logger(logger: env_logger::Logger) {
+fn write_thread_name_and_id(fmt: &mut impl Write) -> io::Result<()> {
+    let current = &thread::current();
+
+    // Remove `ThreadId()` wrapping, leaving just the actual ID value.  This makes our log messages
+    // a bit shorter.
+    //
+    // TODO Switch to just calling `as_u64()`, when it is stabilized:
+    //
+    //   https://github.com/rust-lang/rust/issues/67939
+
+    // Preallocate 10 characters for `ThreadId()`, and 10 more for the number itself.
+    let mut id_buf = Vec::<u8>::with_capacity(20);
+    write!(&mut id_buf, "{:?}", current.id())?;
+    let id_part = id_buf
+        .strip_prefix(b"ThreadId(")
+        .and_then(|v| v.strip_suffix(b")"))
+        .unwrap_or_else(|| &id_buf[..]);
+
+    fmt.write_all(b" ")?;
+    fmt.write_all(id_part)?;
+
+    if let Some(name) = current.name() {
+        write!(fmt, " {name}")?;
+    }
+
+    Ok(())
+}
+
+/// Formats [`log::Record`] entries.
+///
+/// Produces result similar to the one of `env_logger::Builder().format_timestamp_nanos()`, but
+/// inserts the current thread ID into the generated message.
+fn format_record(fmt: &mut Formatter, record: &Record) -> io::Result<()> {
+    write!(fmt, "[{}", fmt.timestamp_nanos())?;
+
+    write_thread_name_and_id(fmt)?;
+
+    write!(
+        fmt,
+        " {:<5}",
+        fmt.default_styled_level(record.level()),
+        // `module_path` is disabled in the default [`env_logger::Builder`] config.
+        // fmt.module_path(),
+    )?;
+
+    match record.target() {
+        "" => write!(fmt, " ]")?,
+        target => write!(fmt, " {target}]")?,
+    }
+
+    writeln!(fmt, " {}", record.args())
+}
+
+fn replace_logger(logger: Logger) {
     log::set_max_level(logger.filter());
     *LOGGER.write().unwrap() = logger;
     let _ = log::set_boxed_logger(Box::new(LoggerShim {}));
@@ -34,17 +92,16 @@ fn replace_logger(logger: env_logger::Logger) {
 // so if set it takes precedence.
 // May be called at any time to re-configure the log filter
 pub fn setup_with(filter: &str) {
-    let logger =
-        env_logger::Builder::from_env(env_logger::Env::new().filter_or("_RUST_LOG", filter))
-            .format_timestamp_nanos()
-            .build();
+    let logger = Builder::from_env(Env::new().filter_or("_RUST_LOG", filter))
+        .format(format_record)
+        .build();
     replace_logger(logger);
 }
 
 // Configures logging with a default filter if RUST_LOG is not set
 pub fn setup_with_default(filter: &str) {
-    let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
-        .format_timestamp_nanos()
+    let logger = Builder::from_env(Env::new().default_filter_or(filter))
+        .format(format_record)
         .build();
     replace_logger(logger);
 }
@@ -63,9 +120,9 @@ pub fn setup_file_with_default(logfile: &str, filter: &str) {
         .append(true)
         .open(logfile)
         .unwrap();
-    let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
-        .format_timestamp_nanos()
-        .target(env_logger::Target::Pipe(Box::new(file)))
+    let logger = Builder::from_env(Env::new().default_filter_or(filter))
+        .format(format_record)
+        .target(Target::Pipe(Box::new(file)))
         .build();
     replace_logger(logger);
 }


### PR DESCRIPTION
#### Problem

When debugging multithreaded code, it could be hard to understand which thread generated which messages.
All the threads are actually racing when they are writing into the same log.

#### Summary of Changes

Add thread IDs into all the log messages.

Before:

```
[2023-01-11T03:09:35.349167961Z TRACE solana_streamer::nonblocking::quic] got chunk: Chunk { offset: 1181, bytes: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" }
[2023-01-11T03:09:35.349306664Z TRACE solana_streamer::nonblocking::quic] got chunk: Chunk { offset: 1208, bytes: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" }
[2023-01-11T03:09:35.349336070Z TRACE solana_streamer::nonblocking::quic] chunk is none
[2023-01-11T03:09:35.349346319Z TRACE solana_streamer::nonblocking::quic] sent 1232 byte packet
[2023-01-11T03:09:35.349710900Z DEBUG solana_streamer::nonblocking::quic] stream error: ApplicationClosed(ApplicationClose { error_code: 0, reason: b"" })
[2023-01-11T03:09:35.442150973Z TRACE mio::poll] deregistering event source from poller
[2023-01-11T03:09:36.342416074Z INFO  solana_streamer::nonblocking::quic] Timed out waiting for connection
[2023-01-11T03:09:36.342529619Z TRACE mio::poll] deregistering event source from poller
```

After:

```
[2023-01-11T22:47:14.486961072Z 3 quic-server TRACE solana_streamer::nonblocking::quic] got chunk: Chunk { offset: 1210, bytes: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" }
[2023-01-11T22:47:14.487086700Z 5 quic-server DEBUG rustls::client::tls13] Ticket saved
[2023-01-11T22:47:14.487106988Z 3 quic-server TRACE solana_streamer::nonblocking::quic] chunk is none
[2023-01-11T22:47:14.487122738Z 3 quic-server TRACE solana_streamer::nonblocking::quic] sent 1232 byte packet
[2023-01-11T22:47:14.488232225Z 3 quic-server DEBUG solana_streamer::nonblocking::quic] stream error: ApplicationClosed(ApplicationClose { error_code: 0, reason: b"" })
[2023-01-11T22:47:14.593718961Z 5 quic-server TRACE mio::poll] deregistering event source from poller
[2023-01-11T22:47:15.477674044Z 3 quic-server INFO  solana_streamer::nonblocking::quic] Timed out waiting for connection
[2023-01-11T22:47:15.477785034Z 3 quic-server TRACE mio::poll] deregistering event source from poller
```