### PR TITLE
chore: bump assert_matches to 1.5.0

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -68,7 +68,7 @@ parking_lot = "0.12"
 
 [dev-dependencies]
 anyhow = "1.0.58"
-assert_matches = "1.3.0"
+assert_matches = "1.5.0"
 bincode = "1.3.1"
 borsh = "0.9.1"
 borsh-derive = "0.9.1"


### PR DESCRIPTION
close #29670 