### PR TITLE
Cleanup - `disable_deprecated_loader`

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -42,9 +42,8 @@ use {
         feature_set::{
             cap_accounts_data_allocations_per_transaction, cap_bpf_program_instruction_accounts,
             check_slice_translation_size, disable_deploy_of_alloc_free_syscall,
-            disable_deprecated_loader, enable_bpf_loader_extend_program_ix,
-            enable_bpf_loader_set_authority_checked_ix, enable_program_redeployment_cooldown,
-            limit_max_instruction_trace_length, FeatureSet,
+            enable_bpf_loader_extend_program_ix, enable_bpf_loader_set_authority_checked_ix,
+            enable_program_redeployment_cooldown, limit_max_instruction_trace_length, FeatureSet,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -439,20 +438,15 @@ fn process_instruction_common(
     } else {
         drop(program);
         debug_assert_eq!(first_instruction_account, 1);
-        let disable_deprecated_loader = invoke_context
-            .feature_set
-            .is_active(&disable_deprecated_loader::id());
         if bpf_loader_upgradeable::check_id(program_id) {
             process_loader_upgradeable_instruction(
                 first_instruction_account,
                 invoke_context,
                 use_jit,
             )
-        } else if bpf_loader::check_id(program_id)
-            || (!disable_deprecated_loader && bpf_loader_deprecated::check_id(program_id))
-        {
+        } else if bpf_loader::check_id(program_id) {
             process_loader_instruction(first_instruction_account, invoke_context, use_jit)
-        } else if disable_deprecated_loader && bpf_loader_deprecated::check_id(program_id) {
+        } else if bpf_loader_deprecated::check_id(program_id) {
             ic_logger_msg!(log_collector, "Deprecated loader is no longer supported");
             Err(InstructionError::UnsupportedProgramId)
         } else {

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -26,7 +26,7 @@ use {
         bank::Bank,
         bank_client::BankClient,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        loader_utils::{create_deprecated_program, load_program_from_file},
+        loader_utils::{load_program, load_program_from_file},
     },
     solana_sdk::{
         bpf_loader,
@@ -159,8 +159,7 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let invoke_program_id =
-        create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
+    let invoke_program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
 
     let mint_pubkey = mint_keypair.pubkey();
     let account_metas = vec![AccountMeta::new(mint_pubkey, true)];

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -21,9 +21,9 @@ use {
             TransactionExecutionResult, TransactionResults,
         },
         loader_utils::{
-            create_deprecated_program, load_and_finalize_deprecated_program,
-            load_program_from_file, load_upgradeable_buffer, load_upgradeable_program,
-            set_upgrade_authority, upgrade_program,
+            create_program, load_and_finalize_program, load_program, load_program_from_file,
+            load_upgradeable_buffer, load_upgradeable_program, set_upgrade_authority,
+            upgrade_program,
         },
     },
     solana_sbf_rust_invoke::instructions::*,
@@ -421,8 +421,7 @@ fn test_program_sbf_sanity() {
         let bank_client = BankClient::new(bank);
 
         // Call user program
-        let program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.0);
+        let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.0);
         let account_metas = vec![
             AccountMeta::new(mint_keypair.pubkey(), true),
             AccountMeta::new(Keypair::new().pubkey(), false),
@@ -462,23 +461,14 @@ fn test_program_sbf_loader_deprecated() {
         } = create_genesis_config(50);
         genesis_config
             .accounts
-            .remove(&solana_sdk::feature_set::disable_deprecated_loader::id())
-            .unwrap();
-        genesis_config
-            .accounts
             .remove(&solana_sdk::feature_set::disable_deploy_of_alloc_free_syscall::id())
             .unwrap();
         let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_deprecated_program!();
         bank.add_builtin(&name, &id, entrypoint);
-        let bank_client = BankClient::new(bank);
+        let program_id = create_program(&bank, &bpf_loader_deprecated::id(), program);
 
-        let program_id = create_deprecated_program(
-            &bank_client,
-            &bpf_loader_deprecated::id(),
-            &mint_keypair,
-            program,
-        );
+        let bank_client = BankClient::new(bank);
         let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
@@ -600,8 +590,7 @@ fn test_program_sbf_duplicate_accounts() {
         bank.add_builtin(&name, &id, entrypoint);
         let bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&bank);
-        let program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
+        let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
         let payee_account = AccountSharedData::new(10, 1, &program_id);
         let payee_pubkey = Pubkey::new_unique();
         bank.store_account(&payee_pubkey, &payee_account);
@@ -701,8 +690,7 @@ fn test_program_sbf_error_handling() {
         let (name, id, entrypoint) = solana_bpf_loader_program!();
         bank.add_builtin(&name, &id, entrypoint);
         let bank_client = BankClient::new(bank);
-        let program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
+        let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
         let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
 
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas.clone());
@@ -806,8 +794,7 @@ fn test_return_data_and_log_data_syscall() {
         let bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&bank);
 
-        let program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
+        let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
 
         bank.freeze();
 
@@ -873,11 +860,11 @@ fn test_program_sbf_invoke_sanity() {
         let bank_client = BankClient::new_shared(&bank);
 
         let invoke_program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.1);
+            load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.1);
         let invoked_program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.2);
+            load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.2);
         let noop_program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.3);
+            load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.3);
 
         let argument_keypair = Keypair::new();
         let account = AccountSharedData::new(42, 100, &invoke_program_id);
@@ -1269,13 +1256,13 @@ fn test_program_sbf_program_id_spoofing() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let malicious_swap_pubkey = create_deprecated_program(
+    let malicious_swap_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_spoof1",
     );
-    let malicious_system_pubkey = create_deprecated_program(
+    let malicious_system_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1322,13 +1309,13 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let caller_pubkey = create_deprecated_program(
+    let caller_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_caller_access",
     );
-    let caller2_pubkey = create_deprecated_program(
+    let caller2_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1362,7 +1349,7 @@ fn test_program_sbf_ro_modify() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_pubkey = create_deprecated_program(
+    let program_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1417,7 +1404,7 @@ fn test_program_sbf_call_depth() {
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1452,7 +1439,7 @@ fn test_program_sbf_compute_budget() {
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1553,7 +1540,7 @@ fn test_program_sbf_instruction_introspection() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1611,7 +1598,7 @@ fn test_program_sbf_test_use_latest_executor() {
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
-    let panic_id = create_deprecated_program(
+    let panic_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1619,7 +1606,7 @@ fn test_program_sbf_test_use_latest_executor() {
     );
 
     // Write the panic program into the program account
-    let (program_keypair, instruction) = load_and_finalize_deprecated_program(
+    let (program_keypair, instruction) = load_and_finalize_program(
         &bank_client,
         &bpf_loader::id(),
         None,
@@ -1640,7 +1627,7 @@ fn test_program_sbf_test_use_latest_executor() {
         .is_err());
 
     // Write the noop program into the same program account
-    let (program_keypair, instruction) = load_and_finalize_deprecated_program(
+    let (program_keypair, instruction) = load_and_finalize_program(
         &bank_client,
         &bpf_loader::id(),
         Some(program_keypair),
@@ -1848,7 +1835,7 @@ fn test_program_sbf_invoke_upgradeable_via_cpi() {
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
-    let invoke_and_return = create_deprecated_program(
+    let invoke_and_return = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -1965,8 +1952,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
         bank.add_builtin(&name, &id, entrypoint);
         let bank_client = BankClient::new(bank);
 
-        let program_id =
-            create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
+        let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
         let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
         let instruction = Instruction::new_with_bytes(bpf_loader::id(), &[1], account_metas);
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
@@ -1997,8 +1983,7 @@ fn test_program_sbf_c_dup() {
 
     let bank_client = BankClient::new(bank);
 
-    let program_id =
-        create_deprecated_program(&bank_client, &bpf_loader::id(), &mint_keypair, "ser");
+    let program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, "ser");
     let account_metas = vec![
         AccountMeta::new_readonly(account_address, false),
         AccountMeta::new_readonly(account_address, false),
@@ -2025,7 +2010,7 @@ fn test_program_sbf_upgrade_via_cpi() {
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
-    let invoke_and_return = create_deprecated_program(
+    let invoke_and_return = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2133,7 +2118,7 @@ fn test_program_sbf_upgrade_self_via_cpi() {
     bank.add_builtin(&name, &id, entrypoint);
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
-    let noop_program_id = create_deprecated_program(
+    let noop_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2223,7 +2208,7 @@ fn test_program_sbf_set_upgrade_authority_via_cpi() {
     let bank_client = BankClient::new(bank);
 
     // Deploy CPI invoker program
-    let invoke_and_return = create_deprecated_program(
+    let invoke_and_return = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2435,7 +2420,7 @@ fn test_program_sbf_finalize() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_pubkey = create_deprecated_program(
+    let program_pubkey = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2443,7 +2428,7 @@ fn test_program_sbf_finalize() {
     );
 
     // Write the noop program into the same program account
-    let (program_keypair, _instruction) = load_and_finalize_deprecated_program(
+    let (program_keypair, _instruction) = load_and_finalize_program(
         &bank_client,
         &bpf_loader::id(),
         None,
@@ -2481,7 +2466,7 @@ fn test_program_sbf_ro_account_modify() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2548,7 +2533,7 @@ fn test_program_sbf_realloc() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -2856,14 +2841,14 @@ fn test_program_sbf_realloc_invoke() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let realloc_program_id = create_deprecated_program(
+    let realloc_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_realloc",
     );
 
-    let realloc_invoke_program_id = create_deprecated_program(
+    let realloc_invoke_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -3398,25 +3383,25 @@ fn test_program_sbf_processed_inner_instruction() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let sibling_program_id = create_deprecated_program(
+    let sibling_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_sibling_instructions",
     );
-    let sibling_inner_program_id = create_deprecated_program(
+    let sibling_inner_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_sibling_inner_instructions",
     );
-    let noop_program_id = create_deprecated_program(
+    let noop_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
         "solana_sbf_rust_noop",
     );
-    let invoke_and_return_program_id = create_deprecated_program(
+    let invoke_and_return_program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -3481,7 +3466,7 @@ fn test_program_fees() {
     bank.add_builtin(&name, &id, entrypoint);
     let bank_client = BankClient::new(bank);
 
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -3553,7 +3538,7 @@ fn test_get_minimum_delegation() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let program_id = create_deprecated_program(
+    let program_id = load_program(
         &bank_client,
         &bpf_loader::id(),
         &mint_keypair,
@@ -3576,35 +3561,21 @@ fn test_program_sbf_inner_instruction_alignment_checks() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    genesis_config
-        .accounts
-        .remove(&solana_sdk::feature_set::disable_deprecated_loader::id())
-        .unwrap();
     let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, &id, entrypoint);
     let (name, id, entrypoint) = solana_bpf_loader_deprecated_program!();
     bank.add_builtin(&name, &id, entrypoint);
-    let bank_client = BankClient::new(bank);
-
-    // load aligned program
-    let noop = create_deprecated_program(
-        &bank_client,
-        &bpf_loader::id(),
-        &mint_keypair,
-        "solana_sbf_rust_noop",
-    );
-
-    // Load unaligned program
-    let inner_instruction_alignment_check = create_deprecated_program(
-        &bank_client,
+    let noop = create_program(&bank, &bpf_loader_deprecated::id(), "solana_sbf_rust_noop");
+    let inner_instruction_alignment_check = create_program(
+        &bank,
         &bpf_loader_deprecated::id(),
-        &mint_keypair,
         "solana_sbf_rust_inner_instruction_alignment_check",
     );
 
     // invoke unaligned program, which will call aligned program twice,
     // unaligned should be allowed once invoke completes
+    let bank_client = BankClient::new(bank);
     let mut instruction = Instruction::new_with_bytes(
         inner_instruction_alignment_check,
         &[0],


### PR DESCRIPTION
#### Problem
[`GTUMCZ8LTNxVfxdrw7ZsDFTxXb7TutYkzJnFwinpE6dg`](https://github.com/solana-labs/solana/pull/23757) has been activated on all networks.

#### Summary of Changes
Removes the deployment functionality of the deprecated BPF loader and adjusts the tests.