### PR TITLE
Refactor - Delay visibility of program un-/re-/deployment

### DIFF
--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -43,6 +43,10 @@ impl TransactionExecutorCache {
         self.visible.get(key).cloned()
     }
 
+    pub fn set_tombstone(&mut self, key: Pubkey) {
+        self.visible.insert(key, None);
+    }
+
     pub fn set(
         &mut self,
         key: Pubkey,
@@ -54,7 +58,7 @@ impl TransactionExecutorCache {
             if delay_visibility_of_program_deployment {
                 // Place a tombstone in the cache so that
                 // we don't load the new version from the database as it should remain invisible
-                self.visible.insert(key, None);
+                self.set_tombstone(key);
             } else {
                 self.visible.insert(key, Some(executor.clone()));
             }

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -9,29 +9,10 @@ use {
         ops::Div,
         sync::{
             atomic::{AtomicU64, Ordering::Relaxed},
-            Arc, RwLock,
+            Arc,
         },
     },
 };
-
-/// Relation between a TransactionExecutorCacheEntry and its matching BankExecutorCacheEntry
-#[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum TxBankExecutorCacheDiff {
-    /// The TransactionExecutorCacheEntry did not change and is the same as the BankExecutorCacheEntry.
-    None,
-    /// The TransactionExecutorCacheEntry was inserted, no matching BankExecutorCacheEntry exists, so it needs to be inserted.
-    Inserted,
-    /// The TransactionExecutorCacheEntry was replaced, the matching BankExecutorCacheEntry needs to be updated.
-    Updated,
-}
-
-/// An entry of the TransactionExecutorCache
-#[derive(Debug)]
-pub struct TransactionExecutorCacheEntry {
-    executor: Arc<dyn Executor>,
-    difference: TxBankExecutorCacheDiff,
-}
 
 /// A subset of the BankExecutorCache containing only the executors relevant to one transaction
 ///
@@ -39,56 +20,49 @@ pub struct TransactionExecutorCacheEntry {
 /// processed in parallel, which would cause a race condition.
 #[derive(Default, Debug)]
 pub struct TransactionExecutorCache {
-    pub executors: HashMap<Pubkey, TransactionExecutorCacheEntry>,
+    /// Executors or tombstones which are visible during the transaction
+    pub visible: HashMap<Pubkey, Option<Arc<dyn Executor>>>,
+    /// Executors of programs which were re-/deploymed during the transaction
+    pub deployments: HashMap<Pubkey, Arc<dyn Executor>>,
+    /// Executors which were missing in the cache and not re-/deploymed during the transaction
+    pub add_to_cache: HashMap<Pubkey, Arc<dyn Executor>>,
 }
 
 impl TransactionExecutorCache {
     pub fn new(executable_keys: impl Iterator<Item = (Pubkey, Arc<dyn Executor>)>) -> Self {
         Self {
-            executors: executable_keys
-                .map(|(key, executor)| {
-                    let entry = TransactionExecutorCacheEntry {
-                        executor,
-                        difference: TxBankExecutorCacheDiff::None,
-                    };
-                    (key, entry)
-                })
+            visible: executable_keys
+                .map(|(id, executor)| (id, Some(executor)))
                 .collect(),
+            deployments: HashMap::new(),
+            add_to_cache: HashMap::new(),
         }
     }
 
-    pub fn get(&self, key: &Pubkey) -> Option<Arc<dyn Executor>> {
-        self.executors.get(key).map(|entry| entry.executor.clone())
+    pub fn get(&self, key: &Pubkey) -> Option<Option<Arc<dyn Executor>>> {
+        self.visible.get(key).cloned()
     }
 
-    pub fn set(&mut self, key: Pubkey, executor: Arc<dyn Executor>, replacement: bool) {
-        let difference = if replacement {
-            TxBankExecutorCacheDiff::Updated
+    pub fn set(&mut self, key: Pubkey, executor: Arc<dyn Executor>, upgrade: bool) {
+        if upgrade {
+            self.visible.insert(key, Some(executor.clone()));
+            self.deployments.insert(key, executor);
         } else {
-            TxBankExecutorCacheDiff::Inserted
-        };
-        let entry = TransactionExecutorCacheEntry {
-            executor,
-            difference,
-        };
-        let _was_replaced = self.executors.insert(key, entry).is_some();
+            self.visible.insert(key, Some(executor.clone()));
+            self.add_to_cache.insert(key, executor);
+        }
     }
 
-    pub fn update_global_cache(
-        &self,
-        global_cache: &RwLock<BankExecutorCache>,
-        selector: impl Fn(TxBankExecutorCacheDiff) -> bool,
-    ) {
-        let executors_delta: Vec<_> = self
-            .executors
-            .iter()
-            .filter_map(|(key, entry)| {
-                selector(entry.difference).then(|| (key, entry.executor.clone()))
-            })
-            .collect();
-        if !executors_delta.is_empty() {
-            global_cache.write().unwrap().put(&executors_delta);
-        }
+    pub fn get_executors_added_to_the_cache(&mut self) -> HashMap<Pubkey, Arc<dyn Executor>> {
+        let mut executors = HashMap::new();
+        std::mem::swap(&mut executors, &mut self.add_to_cache);
+        executors
+    }
+
+    pub fn get_executors_which_were_deployed(&mut self) -> HashMap<Pubkey, Arc<dyn Executor>> {
+        let mut executors = HashMap::new();
+        std::mem::swap(&mut executors, &mut self.deployments);
+        executors
     }
 }
 
@@ -197,18 +171,17 @@ impl BankExecutorCache {
         }
     }
 
-    fn put(&mut self, executors: &[(&Pubkey, Arc<dyn Executor>)]) {
+    pub fn put(&mut self, executors: impl Iterator<Item = (Pubkey, Arc<dyn Executor>)>) {
         let mut new_executors: Vec<_> = executors
-            .iter()
             .filter_map(|(key, executor)| {
-                if let Some(mut entry) = self.remove(key) {
+                if let Some(mut entry) = self.remove(&key) {
                     self.stats.replacements.fetch_add(1, Relaxed);
                     entry.executor = executor.clone();
-                    let _ = self.executors.insert(**key, entry);
+                    let _ = self.executors.insert(key, entry);
                     None
                 } else {
                     self.stats.insertions.fetch_add(1, Relaxed);
-                    Some((*key, executor))
+                    Some((key, executor))
                 }
             })
             .collect();
@@ -251,7 +224,7 @@ impl BankExecutorCache {
                     executor: executor.clone(),
                     hit_count: AtomicU64::new(1),
                 };
-                let _ = self.executors.insert(*key, entry);
+                let _ = self.executors.insert(key, entry);
             }
         }
     }
@@ -388,9 +361,9 @@ mod tests {
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
         let mut cache = BankExecutorCache::new(3, 0);
 
-        cache.put(&[(&key1, executor.clone())]);
-        cache.put(&[(&key2, executor.clone())]);
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key1, executor.clone())].into_iter());
+        cache.put([(key2, executor.clone())].into_iter());
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key2).is_some());
         assert!(cache.get(&key3).is_some());
@@ -398,7 +371,7 @@ mod tests {
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key2).is_some());
-        cache.put(&[(&key4, executor.clone())]);
+        cache.put([(key4, executor.clone())].into_iter());
         assert!(cache.get(&key4).is_some());
         let num_retained = [&key1, &key2, &key3]
             .iter()
@@ -409,7 +382,7 @@ mod tests {
         assert!(cache.get(&key4).is_some());
         assert!(cache.get(&key4).is_some());
         assert!(cache.get(&key4).is_some());
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&key3).is_some());
         let num_retained = [&key1, &key2, &key4]
             .iter()
@@ -428,9 +401,9 @@ mod tests {
         let mut cache = BankExecutorCache::new(3, 0);
         assert!(cache.current_epoch == 0);
 
-        cache.put(&[(&key1, executor.clone())]);
-        cache.put(&[(&key2, executor.clone())]);
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key1, executor.clone())].into_iter());
+        cache.put([(key2, executor.clone())].into_iter());
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key1).is_some());
@@ -441,7 +414,7 @@ mod tests {
         assert!(cache.get(&key2).is_some());
         assert!(cache.get(&key2).is_some());
         assert!(cache.get(&key3).is_some());
-        cache.put(&[(&key4, executor.clone())]);
+        cache.put([(key4, executor.clone())].into_iter());
 
         assert!(cache.get(&key4).is_some());
         let num_retained = [&key1, &key2, &key3]
@@ -450,8 +423,8 @@ mod tests {
             .count();
         assert_eq!(num_retained, 2);
 
-        cache.put(&[(&key1, executor.clone())]);
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key1, executor.clone())].into_iter());
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&key1).is_some());
         assert!(cache.get(&key3).is_some());
         let num_retained = [&key2, &key4]
@@ -463,7 +436,7 @@ mod tests {
         cache = BankExecutorCache::new_from_parent_bank_executors(&cache, 2);
         assert!(cache.current_epoch == 2);
 
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&key3).is_some());
     }
 
@@ -475,11 +448,11 @@ mod tests {
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
         let mut cache = BankExecutorCache::new(2, 0);
 
-        cache.put(&[(&key1, executor.clone())]);
+        cache.put([(key1, executor.clone())].into_iter());
         for _ in 0..5 {
             let _ = cache.get(&key1);
         }
-        cache.put(&[(&key2, executor.clone())]);
+        cache.put([(key2, executor.clone())].into_iter());
         // make key1's use-count for sure greater than key2's
         let _ = cache.get(&key1);
 
@@ -491,7 +464,7 @@ mod tests {
         entries.sort_by_key(|(_, v)| *v);
         assert!(entries[0].1 < entries[1].1);
 
-        cache.put(&[(&key3, executor.clone())]);
+        cache.put([(key3, executor.clone())].into_iter());
         assert!(cache.get(&entries[0].0).is_none());
         assert!(cache.get(&entries[1].0).is_some());
     }
@@ -508,10 +481,10 @@ mod tests {
         assert_eq!(cache.stats.one_hit_wonders.load(Relaxed), 0);
 
         // add our one-hit-wonder
-        cache.put(&[(&one_hit_wonder, executor.clone())]);
+        cache.put([(one_hit_wonder, executor.clone())].into_iter());
         assert_eq!(cache.executors[&one_hit_wonder].hit_count.load(Relaxed), 1);
         // displace the one-hit-wonder with "popular program"
-        cache.put(&[(&popular, executor.clone())]);
+        cache.put([(popular, executor.clone())].into_iter());
         assert_eq!(cache.executors[&popular].hit_count.load(Relaxed), 1);
 
         // one-hit-wonder counter incremented
@@ -522,7 +495,7 @@ mod tests {
         assert_eq!(cache.executors[&popular].hit_count.load(Relaxed), 2);
 
         // evict "popular program"
-        cache.put(&[(&one_hit_wonder, executor.clone())]);
+        cache.put([(one_hit_wonder, executor.clone())].into_iter());
         assert_eq!(cache.executors[&one_hit_wonder].hit_count.load(Relaxed), 1);
 
         // one-hit-wonder counter not incremented
@@ -593,13 +566,13 @@ mod tests {
         assert_eq!(ComparableStats::from(&cache.stats), expected_stats,);
 
         // insert some executors
-        cache.put(&[(&program_id1, executor.clone())]);
-        cache.put(&[(&program_id2, executor.clone())]);
+        cache.put([(program_id1, executor.clone())].into_iter());
+        cache.put([(program_id2, executor.clone())].into_iter());
         expected_stats.insertions += 2;
         assert_eq!(ComparableStats::from(&cache.stats), expected_stats);
 
         // replace a one-hit-wonder executor
-        cache.put(&[(&program_id1, executor.clone())]);
+        cache.put([(program_id1, executor.clone())].into_iter());
         expected_stats.replacements += 1;
         expected_stats.one_hit_wonders += 1;
         assert_eq!(ComparableStats::from(&cache.stats), expected_stats);
@@ -617,7 +590,7 @@ mod tests {
         assert_eq!(ComparableStats::from(&cache.stats), expected_stats);
 
         // evict an executor
-        cache.put(&[(&Pubkey::new_unique(), executor.clone())]);
+        cache.put([(Pubkey::new_unique(), executor.clone())].into_iter());
         expected_stats.insertions += 1;
         expected_stats.evictions.insert(program_id2, 1);
         assert_eq!(ComparableStats::from(&cache.stats), expected_stats);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -228,8 +228,13 @@ pub fn create_executor_from_account(
     };
 
     if let Some(ref tx_executor_cache) = tx_executor_cache {
-        if let Some(executor) = tx_executor_cache.get(program.get_key()) {
-            return Ok((executor, None));
+        match tx_executor_cache.get(program.get_key()) {
+            // Executor exists and is cached, use it
+            Some(Some(executor)) => return Ok((executor, None)),
+            // We cached that the Executor does not exist, abort
+            Some(None) => return Err(InstructionError::InvalidAccountData),
+            // Nothing cached, try to load from account instead
+            None => {}
         }
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1166,6 +1166,15 @@ fn process_loader_upgradeable_instruction(
                                 instruction_context,
                                 &log_collector,
                             )?;
+                            if invoke_context
+                                .feature_set
+                                .is_active(&delay_visibility_of_program_deployment::id())
+                            {
+                                invoke_context
+                                    .tx_executor_cache
+                                    .borrow_mut()
+                                    .set_tombstone(program_key);
+                            }
                         }
                         _ => {
                             ic_logger_msg!(log_collector, "Invalid Program account");

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7716,10 +7716,10 @@ fn test_bank_executor_cache() {
     // do work
     let mut executors =
         TransactionExecutorCache::new((2..3).map(|i| (accounts[i].0, executor.clone())));
-    executors.set(key1, executor.clone(), false);
-    executors.set(key2, executor.clone(), false);
-    executors.set(key3, executor.clone(), true);
-    executors.set(key4, executor.clone(), false);
+    executors.set(key1, executor.clone(), false, true);
+    executors.set(key2, executor.clone(), false, true);
+    executors.set(key3, executor.clone(), true, true);
+    executors.set(key4, executor.clone(), false, true);
     let executors = Rc::new(RefCell::new(executors));
 
     // store Missing
@@ -7810,7 +7810,7 @@ fn test_bank_executor_cow() {
 
     // add one to root bank
     let mut executors = TransactionExecutorCache::default();
-    executors.set(key1, executor.clone(), false);
+    executors.set(key1, executor.clone(), false, true);
     let executors = Rc::new(RefCell::new(executors));
     root.store_executors_which_added_to_the_cache(&executors);
     let executors = root.get_tx_executor_cache(accounts);
@@ -7825,7 +7825,7 @@ fn test_bank_executor_cow() {
     assert_eq!(executors.borrow().visible.len(), 1);
 
     let mut executors = TransactionExecutorCache::default();
-    executors.set(key2, executor.clone(), false);
+    executors.set(key2, executor.clone(), false, true);
     let executors = Rc::new(RefCell::new(executors));
     fork1.store_executors_which_added_to_the_cache(&executors);
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7708,10 +7708,10 @@ fn test_bank_executor_cache() {
     let executors =
         TransactionExecutorCache::new((0..4).map(|i| (accounts[i].0, executor.clone())));
     let executors = Rc::new(RefCell::new(executors));
-    bank.store_missing_executors(&executors);
-    bank.store_updated_executors(&executors);
+    bank.store_executors_which_added_to_the_cache(&executors);
+    bank.store_executors_which_were_deployed(&executors);
     let stored_executors = bank.get_tx_executor_cache(accounts);
-    assert_eq!(stored_executors.borrow().executors.len(), 0);
+    assert_eq!(stored_executors.borrow().visible.len(), 0);
 
     // do work
     let mut executors =
@@ -7723,27 +7723,27 @@ fn test_bank_executor_cache() {
     let executors = Rc::new(RefCell::new(executors));
 
     // store Missing
-    bank.store_missing_executors(&executors);
+    bank.store_executors_which_added_to_the_cache(&executors);
     let stored_executors = bank.get_tx_executor_cache(accounts);
-    assert_eq!(stored_executors.borrow().executors.len(), 2);
-    assert!(stored_executors.borrow().executors.contains_key(&key1));
-    assert!(stored_executors.borrow().executors.contains_key(&key2));
+    assert_eq!(stored_executors.borrow().visible.len(), 2);
+    assert!(stored_executors.borrow().visible.contains_key(&key1));
+    assert!(stored_executors.borrow().visible.contains_key(&key2));
 
     // store Updated
-    bank.store_updated_executors(&executors);
+    bank.store_executors_which_were_deployed(&executors);
     let stored_executors = bank.get_tx_executor_cache(accounts);
-    assert_eq!(stored_executors.borrow().executors.len(), 3);
-    assert!(stored_executors.borrow().executors.contains_key(&key1));
-    assert!(stored_executors.borrow().executors.contains_key(&key2));
-    assert!(stored_executors.borrow().executors.contains_key(&key3));
+    assert_eq!(stored_executors.borrow().visible.len(), 3);
+    assert!(stored_executors.borrow().visible.contains_key(&key1));
+    assert!(stored_executors.borrow().visible.contains_key(&key2));
+    assert!(stored_executors.borrow().visible.contains_key(&key3));
 
     // Check inheritance
     let bank = Bank::new_from_parent(&Arc::new(bank), &solana_sdk::pubkey::new_rand(), 1);
     let stored_executors = bank.get_tx_executor_cache(accounts);
-    assert_eq!(stored_executors.borrow().executors.len(), 3);
-    assert!(stored_executors.borrow().executors.contains_key(&key1));
-    assert!(stored_executors.borrow().executors.contains_key(&key2));
-    assert!(stored_executors.borrow().executors.contains_key(&key3));
+    assert_eq!(stored_executors.borrow().visible.len(), 3);
+    assert!(stored_executors.borrow().visible.contains_key(&key1));
+    assert!(stored_executors.borrow().visible.contains_key(&key2));
+    assert!(stored_executors.borrow().visible.contains_key(&key3));
 
     // Force compilation of an executor
     let mut file = File::open("../programs/bpf_loader/test_elfs/out/noop_aligned.so").unwrap();
@@ -7784,7 +7784,7 @@ fn test_bank_executor_cache() {
     bank.remove_executor(&key3);
     bank.remove_executor(&key4);
     let stored_executors = bank.get_tx_executor_cache(accounts);
-    assert_eq!(stored_executors.borrow().executors.len(), 0);
+    assert_eq!(stored_executors.borrow().visible.len(), 0);
 }
 
 #[test]
@@ -7812,34 +7812,34 @@ fn test_bank_executor_cow() {
     let mut executors = TransactionExecutorCache::default();
     executors.set(key1, executor.clone(), false);
     let executors = Rc::new(RefCell::new(executors));
-    root.store_missing_executors(&executors);
+    root.store_executors_which_added_to_the_cache(&executors);
     let executors = root.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
 
     let fork1 = Bank::new_from_parent(&root, &Pubkey::default(), 1);
     let fork2 = Bank::new_from_parent(&root, &Pubkey::default(), 2);
 
     let executors = fork1.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
     let executors = fork2.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
 
     let mut executors = TransactionExecutorCache::default();
     executors.set(key2, executor.clone(), false);
     let executors = Rc::new(RefCell::new(executors));
-    fork1.store_missing_executors(&executors);
+    fork1.store_executors_which_added_to_the_cache(&executors);
 
     let executors = fork1.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 2);
+    assert_eq!(executors.borrow().visible.len(), 2);
     let executors = fork2.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
 
     fork1.remove_executor(&key1);
 
     let executors = fork1.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
     let executors = fork2.get_tx_executor_cache(accounts);
-    assert_eq!(executors.borrow().executors.len(), 1);
+    assert_eq!(executors.borrow().visible.len(), 1);
 }
 
 #[test]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -610,6 +610,10 @@ pub mod prevent_rent_paying_rent_recipients {
     solana_sdk::declare_id!("Fab5oP3DmsLYCiQZXdjyqT3ukFFPrsmqhXU4WU1AWVVF");
 }
 
+pub mod delay_visibility_of_program_deployment {
+    solana_sdk::declare_id!("GmuBvtFb2aHfSfMXpuFeWZGHyDeCLPS79s48fmCWCfM5");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -757,6 +761,7 @@ lazy_static! {
         (remove_congestion_multiplier_from_fee_calculation::id(), "Remove congestion multiplier from transaction fee calculation #29881"),
         (enable_request_heap_frame_ix::id(), "Enable transaction to request heap frame using compute budget instruction #30076"),
         (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30151"),
+        (delay_visibility_of_program_deployment::id(), "delay visibility of program upgrades #30085"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
[Currently some changes to programs made by un-/re-/deployment are visible immediately, even within the same transaction](https://github.com/solana-labs/solana/pull/29725). These inconsistency between top-level instructions and CPI should be removed. This is a preparation for the replacement of the current executor cache by one that supports a [bitemporal model](https://en.wikipedia.org/wiki/Bitemporal_modeling). Once that is done, the new executor cache will further delay the visibility from the end of the transaction to a slot in the future, with a constant offset from the slot the action occurred in.

#### Summary of Changes
- Use three separate `HashMap`s instead of the `enum` `TxBankExecutorCacheDiff`
- Replaces all places which deploy programs by a macro
- Load previous version into the cache before deploying the new one
- Adjusts tests for un-/re-/deployment in same transaction
- Adds a feature gate

#### Old vs New Behavior (inside the same transaction)
- Initial Deployment: Was visible to CPI but not transaction level, will become invisible to both
- Upgrade / Redeployment: Was visible to both, will become unavailable to both
- Close / Undeployment: Was invisible to both, will become visible to both

In other words the new consistent behavior is, that whenever a program is un-/re-/deployed,
it becomes unavailable for the rest of the transaction.

Feature Gate Issue: #30085