### PR TITLE
Configurable hashes per tick

### DIFF
--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -45,6 +45,10 @@ impl Poh {
         *self = Poh::new_with_slot_info(hash, hashes_per_tick, tick_number);
     }
 
+    pub fn hashes_per_tick(&self) -> u64 {
+        self.hashes_per_tick
+    }
+
     pub fn target_poh_time(&self, target_ns_per_tick: u64) -> Instant {
         assert!(self.hashes_per_tick > 0);
         let offset_tick_ns = target_ns_per_tick * self.tick_number;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -578,6 +578,10 @@ pub mod move_serialized_len_ptr_in_cpi {
     solana_sdk::declare_id!("74CoWuBmt3rUVUrCb2JiSTvh6nXyBWUsK4SaMj3CtE3T");
 }
 
+pub mod update_hashes_per_tick {
+    solana_sdk::declare_id!("3uFHb9oKdGfgZGJK9EHaAXN4USvnQtAFC13Fh5gGFS5B");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -717,6 +721,7 @@ lazy_static! {
         (enable_turbine_fanout_experiments::id(), "enable turbine fanout experiments #29393"),
         (disable_turbine_fanout_experiments::id(), "disable turbine fanout experiments #29393"),
         (move_serialized_len_ptr_in_cpi::id(), "cpi ignore serialized_len_ptr #29592"),
+        (update_hashes_per_tick::id(), "Update desired hashes per tick on epoch boundary"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
There currently exists no mechanism for being able to change the number of hashes per tick.

#### Summary of Changes
1. Add new feature to control updating hashes per tick on epoch boundary (to `DEFAULT_HASHES_PER_SECOND`)
2. When synchronizing PoH with a bank, update hashes per tick from the bank value
3. Reset PoH from `set_bank` when a new `hashes_per_tick` value is detected
4. Remove `poh_config` from `PohRecorder`

Note 4 above is the key change that gets things working. With naive implementation, we see PoH continue building up tick entries with old ticks_per_slot, and once the bank with updated ticks_per_slot gets assigned, it sends these old entries associated with the new bank and Blockstore barfs. We need to kill these old tick entries and restart with updated `hashes_per_tick`

#### Theory of Operation
PoH will derive appropriate hashes per tick from the associated bank for that slot (through the `reset` function which synchronizes bank and PoH). Banks will inherit hashes per tick from their parent (or load from snapshot) except in the special case where we activate the 'configurable hashes per tick' feature and force the child bank to `DEFAULT_HASHES_PER_SECOND` on epoch boundary. Thus, changing `DEFAULT_HASHES_PER_SECOND` should have no impact to what is actually happening on chain until the feature is activated. It will, of course, impact testing.

#### Testing
Testing these changes is difficult as we need to coerce a hashes per tick change to agitate things. The following testing has been performed on top of the normal buildkite stuff:
* Set ClusterConfig's `poh_config.hashes_per_tick` to 500 (so that we will actually hash to tick), force `apply_updated_hashes_per_tick` to execute on every epoch boundary, and run local_cluster, poh, runtime, and core cargo tests. Note: through logging it was confirmed that we reset PoH from 500 to 12500 hashes per tick on epoch boundary and all entries sent to replay/other validators were aligned with `bank.hashes_per_tick`
* New unit test added, `test_feature_activation_idempotent` ensures repeated calls to `apply_feature_activations` will not cause issues
* Run validator on MNB with these changes (feature not activated, `DEFAULT_HASHES_PER_SECOND` unchanged)
* Run validator on MNB with these changes (feature not activated, `DEFAULT_HASHES_PER_SECOND` increased)