### PR TITLE
get_slot_stores -> get_slot_storage_entry

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -14894,7 +14894,7 @@ pub(crate) mod tests {
             .accounts
             .accounts_db
             .storage
-            .get_slot_stores(1)
+            .get_slot_storage_entry(1)
             .is_none());
 
         bank3.print_accounts_stats();


### PR DESCRIPTION
#### Problem
Moving to 1 append vec per slot.
`get_slot_stores(slot)` returns internals of the map and callers expect `Vec<...>` return value.
`get_slot_storage_entry(slot)` addresses both problems.

#### Summary of Changes
`get_slot_stores` -> `get_slot_storage_entry`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
