### PR TITLE
Update getRecentPrioritizationFees json-rpc docs

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2125,7 +2125,6 @@ Result:
 
 ### getRecentPrioritizationFees
 
-**UNSTABLE**
 Returns a list of minimum prioritization fees from recent blocks. Currently, a
 node's prioritization-fee cache stores data from up to 150 blocks.
 
@@ -2139,7 +2138,7 @@ An array of:
 
 - `RpcPrioritizationFee<object>`
   - `slot: <u64>` - Slot in which minimum fee was observed
-  - `prioritizationFee: <u64>` - Minimum fee paid for a successfully landed transaction, specified in increments of 0.000001 lamports
+  - `prioritizationFee: <u64>` - a fee paid by at least one successfully landed transaction, specified in increments of 0.000001 lamports
 
 #### Example:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2125,12 +2125,13 @@ Result:
 
 ### getRecentPrioritizationFees
 
+**UNSTABLE**
 Returns a list of minimum prioritization fees from recent blocks. Currently, a
 node's prioritization-fee cache stores data from up to 150 blocks.
 
 #### Parameters:
 
-- `<array>` - (optional) An array of account address strings. If this parameter is provided, the response will reflect the minimum prioritization fee to land a transaction locking all of the provided accounts as writable.
+- `<array>` - (optional) An array of account address strings (up to a maximum of 128 addresses). If this parameter is provided, the response will reflect the minimum prioritization fee to land a transaction locking all of the provided accounts as writable.
 
 #### Results:
 
@@ -2138,7 +2139,7 @@ An array of:
 
 - `RpcPrioritizationFee<object>`
   - `slot: <u64>` - Slot in which minimum fee was observed
-  - `prioritizationFee: <u64>` - Minimum fee paid for a successfully landed transaction
+  - `prioritizationFee: <u64>` - Minimum fee paid for a successfully landed transaction, specified in increments of 0.000001 lamports
 
 #### Example:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2125,19 +2125,19 @@ Result:
 
 ### getRecentPrioritizationFees
 
-Returns a list of minimum prioritization fees from recent blocks. Currently, a
+Returns a list of prioritization fees from recent blocks. Currently, a
 node's prioritization-fee cache stores data from up to 150 blocks.
 
 #### Parameters:
 
-- `<array>` - (optional) An array of account address strings (up to a maximum of 128 addresses). If this parameter is provided, the response will reflect the minimum prioritization fee to land a transaction locking all of the provided accounts as writable.
+- `<array>` - (optional) An array of account address strings (up to a maximum of 128 addresses). If this parameter is provided, the response will reflect a fee to land a transaction locking all of the provided accounts as writable.
 
 #### Results:
 
 An array of:
 
 - `RpcPrioritizationFee<object>`
-  - `slot: <u64>` - Slot in which minimum fee was observed
+  - `slot: <u64>` - Slot in which fee was observed
   - `prioritizationFee: <u64>` - a fee paid by at least one successfully landed transaction, specified in increments of 0.000001 lamports
 
 #### Example:


### PR DESCRIPTION
#### Problem
getRecentPrioritizationFees endpoint is still unstable. Docs also missing some useful details.

#### Summary of Changes
Mark as unstable and update docs