### PR TITLE
Abstract AppendVec public functions into a trait

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -21,7 +21,9 @@
 use {
     crate::{
         account_info::{AccountInfo, Offset, StorageLocation, StoredSize},
-        account_storage::{AccountStorage, AccountStorageStatus, ShrinkInProgress},
+        account_storage::{
+            AccountStorage, AccountStorageFile, AccountStorageFileReader, AccountStorageStatus, ShrinkInProgress,
+        },
         accounts_background_service::{DroppedSlotsSender, SendDroppedBankCallback},
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_hash::{

--- a/runtime/src/accounts_db/geyser_plugin_utils.rs
+++ b/runtime/src/accounts_db/geyser_plugin_utils.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        account_storage::AccountStorageFileReader,
         accounts_db::AccountsDb,
         append_vec::{StoredAccountMeta, StoredMeta},
     },

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        account_storage::AccountStorageFileReader,
         accounts_db::{SnapshotStoragesOne, PUBKEY_BINS_FOR_CALCULATING_HASHES},
         ancestors::Ancestors,
         rent_collector::RentCollector,

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -4,7 +4,10 @@
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
 //! Otherwise, an ancient append vec is the same as any other append vec
 use {
-    crate::append_vec::{AppendVec, StoredAccountMeta},
+    crate::{
+        account_storage::AccountStorageFileReader,
+        append_vec::{AppendVec, StoredAccountMeta},
+    },
     solana_sdk::clock::Slot,
 };
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        account_storage::AccountStorageFileReader,
         accounts::Accounts,
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig, AppendVecId,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -1,5 +1,5 @@
 use {
-    crate::accounts_db::AccountStorageEntry,
+    crate::{account_storage::AccountStorageFileReader, accounts_db::AccountStorageEntry},
     serde::{Deserialize, Serialize},
 };
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -407,7 +407,8 @@ impl<'a> SnapshotMinimizer<'a> {
 mod tests {
     use {
         crate::{
-            bank::Bank, genesis_utils::create_genesis_config_with_leader,
+            account_storage::AccountStorageFileReader, bank::Bank,
+            genesis_utils::create_genesis_config_with_leader,
             snapshot_minimizer::SnapshotMinimizer,
         },
         dashmap::DashSet,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        account_storage::AccountStorageMap,
+        account_storage::{AccountStorageFileReader, AccountStorageMap},
         accounts_db::{
             AccountShrinkThreshold, AccountsDbConfig, AtomicAppendVecId,
             CalcAccountsHashDataSource, SnapshotStorageOne, SnapshotStorages, SnapshotStoragesOne,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -402,7 +402,10 @@ pub(crate) fn get_slot_and_append_vec_id(filename: &str) -> (Slot, usize) {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::append_vec::AppendVec};
+    use {
+        super::*,
+        crate::{account_storage::AccountStorageFileReader, append_vec::AppendVec},
+    };
 
     #[test]
     fn test_get_snapshot_file_kind() {

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -1,7 +1,10 @@
 use {
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},
     log::*,
-    solana_runtime::append_vec::{AppendVec, StoredAccountMeta},
+    solana_runtime::{
+        account_storage::{AccountStorageFile, AccountStorageFileReader},
+        append_vec::{AppendVec, StoredAccountMeta},
+    },
     solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey},
 };
 


### PR DESCRIPTION
#### Summary of Changes
This PR moves public functions of AppendVec into a trait
to make it extensible to allow different implementations.