### PR TITLE
add note about discrepancy between accounts load and sanitize caps

### DIFF
--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -129,6 +129,8 @@ impl Message {
 
         // the combined number of static and dynamic account keys must be <= 256
         // since account indices are encoded as `u8`
+        // Note that this is different from the per-transaction account load cap
+        // as defined in `Bank::get_transaction_account_lock_limit`
         let total_account_keys = num_static_account_keys.saturating_add(num_dynamic_account_keys);
         if total_account_keys > 256 {
             return Err(SanitizeError::IndexOutOfBounds);


### PR DESCRIPTION
#### Problem

`message::versions::v0::Message` implementation of `Sanitize` allows for up to 256 accounts to be specified, but account loads are capped lower in `Bank::get_transaction_account_lock_limit`

#### Summary of Changes

add a comment to highlight the discrepancy