### PR TITLE
Make devbuild binaries emit the git commit in version

### DIFF
--- a/frozen-abi/build.rs
+++ b/frozen-abi/build.rs
@@ -1,5 +1,8 @@
 extern crate rustc_version;
-use rustc_version::{version_meta, Channel};
+use {
+    rustc_version::{version_meta, Channel},
+    std::{process::Command},
+};
 
 fn main() {
     // Copied and adapted from
@@ -22,6 +25,19 @@ fn main() {
             // which currently needs `#![feature(proc_macro_hygiene)]` to
             // be applied.
             println!("cargo:rustc-cfg=RUSTC_NEEDS_PROC_MACRO_HYGIENE");
+        }
+    }
+
+    if let Ok(output) = Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+    {
+        let maybe_commit = output.stdout.as_slice();
+        if !output.stdout.is_empty() {
+            if let Ok(commit) = std::str::from_utf8(maybe_commit) {
+                println!("cargo:rustc-env=DEV_COMMIT={commit}");
+            }
         }
     }
 }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -47,12 +47,12 @@ impl From<LegacyVersion> for Version {
     }
 }
 
-fn compute_commit(sha1: Option<&'static str>) -> Option<u32> {
-    let sha1 = sha1?;
-    if sha1.len() < 8 {
+fn compute_commit(ci_sha: Option<&'static str>, dev_sha: Option<&'static str>) -> Option<u32> {
+    let sha = ci_sha.or(dev_sha.or(None))?;
+    if sha.len() < 8 {
         None
     } else {
-        u32::from_str_radix(&sha1[..8], 16).ok()
+        u32::from_str_radix(&sha[..8], 16).ok()
     }
 }
 
@@ -67,7 +67,7 @@ impl Default for Version {
             major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
             minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-            commit: compute_commit(option_env!("CI_COMMIT")),
+            commit: compute_commit(option_env!("CI_COMMIT"), option_env!("DEV_COMMIT")),
             feature_set,
         }
     }


### PR DESCRIPTION
#### Problem
Currently, our code resolves a commit to include in version at compile time by attempting to read CI_COMMIT from the env. Our CI scripts explicitly set this variable as the output of a git command that prints the commit.

For non-CI builds (such as a dev building a binary to test), this environment variable will not be set, and the commit string in version output will simply be devbuild. So, anyone who builds from source will not be able to see the commit hash emitted or in their logs.

#### Summary of Changes
This change executes a git command in the build script, and if the command succeeds, it passes the commit as a variable to rustc so the variable can be read by the compile-time env! macro.