### PR TITLE
Restrict QUIC to use single self signed client cert

### DIFF
--- a/streamer/src/tls_certificates.rs
+++ b/streamer/src/tls_certificates.rs
@@ -57,7 +57,8 @@ pub fn new_self_signed_tls_certificate_chain(
 }
 
 pub fn get_pubkey_from_tls_certificate(certificates: &[rustls::Certificate]) -> Option<Pubkey> {
-    certificates.first().and_then(|der_cert| {
+    if certificates.len() == 1 {
+        let der_cert = &certificates[0];
         X509Certificate::from_der(der_cert.as_ref())
             .ok()
             .and_then(|(_, cert)| {
@@ -66,7 +67,9 @@ pub fn get_pubkey_from_tls_certificate(certificates: &[rustls::Certificate]) -> 
                     _ => None,
                 })
             })
-    })
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
QUIC allows clients to use certificate chain during connection setup. Solana's use case is restricted to using single self signed certificates. The code should be updated to this specific use of the API.

#### Summary of Changes
Updated code to restrict using single self signed certificates.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
