### PR TITLE
Cleanup QUIC single signed client cert code

### DIFF
--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -10,7 +10,7 @@ mod tests {
         solana_sdk::{packet::PACKET_DATA_SIZE, signature::Keypair},
         solana_streamer::{
             nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS, quic::StreamStats,
-            streamer::StakedNodes, tls_certificates::new_self_signed_tls_certificate_chain,
+            streamer::StakedNodes, tls_certificates::new_self_signed_tls_certificate,
         },
         solana_tpu_client::connection_cache_stats::ConnectionCacheStats,
         std::{
@@ -228,13 +228,11 @@ mod tests {
         let tpu_addr = SocketAddr::new(addr, port);
         let connection_cache_stats = Arc::new(ConnectionCacheStats::default());
 
-        let (certs, priv_key) = new_self_signed_tls_certificate_chain(
-            &Keypair::new(),
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-        )
-        .expect("Failed to initialize QUIC client certificates");
+        let (cert, priv_key) =
+            new_self_signed_tls_certificate(&Keypair::new(), IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
+                .expect("Failed to initialize QUIC client certificates");
         let client_certificate = Arc::new(QuicClientCertificate {
-            certificates: certs,
+            certificate: cert,
             key: priv_key,
         });
 
@@ -254,14 +252,14 @@ mod tests {
         info!("Received requests!");
 
         // Response sender
-        let (certs, priv_key) = new_self_signed_tls_certificate_chain(
+        let (cert, priv_key) = new_self_signed_tls_certificate(
             &Keypair::new(),
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         )
         .expect("Failed to initialize QUIC client certificates");
 
         let client_certificate2 = Arc::new(QuicClientCertificate {
-            certificates: certs,
+            certificate: cert,
             key: priv_key,
         });
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         nonblocking::quic::ALPN_TPU_PROTOCOL_ID, streamer::StakedNodes,
-        tls_certificates::new_self_signed_tls_certificate_chain,
+        tls_certificates::new_self_signed_tls_certificate,
     },
     crossbeam_channel::Sender,
     pem::Pem,
@@ -58,22 +58,18 @@ pub(crate) fn configure_server(
     identity_keypair: &Keypair,
     gossip_host: IpAddr,
 ) -> Result<(ServerConfig, String), QuicServerError> {
-    let (cert_chain, priv_key) =
-        new_self_signed_tls_certificate_chain(identity_keypair, gossip_host)
-            .map_err(|_e| QuicServerError::ConfigureFailed)?;
-    let cert_chain_pem_parts: Vec<Pem> = cert_chain
-        .iter()
-        .map(|cert| Pem {
-            tag: "CERTIFICATE".to_string(),
-            contents: cert.0.clone(),
-        })
-        .collect();
+    let (cert, priv_key) = new_self_signed_tls_certificate(identity_keypair, gossip_host)
+        .map_err(|_e| QuicServerError::ConfigureFailed)?;
+    let cert_chain_pem_parts = vec![Pem {
+        tag: "CERTIFICATE".to_string(),
+        contents: cert.0.clone(),
+    }];
     let cert_chain_pem = pem::encode_many(&cert_chain_pem_parts);
 
     let mut server_tls_config = rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_client_cert_verifier(SkipClientVerification::new())
-        .with_single_cert(cert_chain, priv_key)
+        .with_single_cert(vec![cert], priv_key)
         .map_err(|_e| QuicServerError::ConfigureFailed)?;
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 

--- a/streamer/src/tls_certificates.rs
+++ b/streamer/src/tls_certificates.rs
@@ -6,10 +6,10 @@ use {
     x509_parser::{prelude::*, public_key::PublicKey},
 };
 
-pub fn new_self_signed_tls_certificate_chain(
+pub fn new_self_signed_tls_certificate(
     keypair: &Keypair,
     san: IpAddr,
-) -> Result<(Vec<rustls::Certificate>, rustls::PrivateKey), Box<dyn Error>> {
+) -> Result<(rustls::Certificate, rustls::PrivateKey), Box<dyn Error>> {
     // TODO(terorie): Is it safe to sign the TLS cert with the identity private key?
 
     // Unfortunately, rcgen does not accept a "raw" Ed25519 key.
@@ -52,24 +52,18 @@ pub fn new_self_signed_tls_certificate_chain(
     let cert_der = cert.serialize_der().unwrap();
     let priv_key = cert.serialize_private_key_der();
     let priv_key = rustls::PrivateKey(priv_key);
-    let cert_chain = vec![rustls::Certificate(cert_der)];
-    Ok((cert_chain, priv_key))
+    Ok((rustls::Certificate(cert_der), priv_key))
 }
 
-pub fn get_pubkey_from_tls_certificate(certificates: &[rustls::Certificate]) -> Option<Pubkey> {
-    if certificates.len() == 1 {
-        let der_cert = &certificates[0];
-        X509Certificate::from_der(der_cert.as_ref())
-            .ok()
-            .and_then(|(_, cert)| {
-                cert.public_key().parsed().ok().and_then(|key| match key {
-                    PublicKey::Unknown(inner_key) => Some(Pubkey::new(inner_key)),
-                    _ => None,
-                })
+pub fn get_pubkey_from_tls_certificate(der_cert: &rustls::Certificate) -> Option<Pubkey> {
+    X509Certificate::from_der(der_cert.as_ref())
+        .ok()
+        .and_then(|(_, cert)| {
+            cert.public_key().parsed().ok().and_then(|key| match key {
+                PublicKey::Unknown(inner_key) => Some(Pubkey::new(inner_key)),
+                _ => None,
             })
-    } else {
-        None
-    }
+        })
 }
 
 #[cfg(test)]
@@ -80,10 +74,10 @@ mod tests {
     fn test_generate_tls_certificate() {
         let keypair = Keypair::new();
 
-        if let Ok((certs, _)) =
-            new_self_signed_tls_certificate_chain(&keypair, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        if let Ok((cert, _)) =
+            new_self_signed_tls_certificate(&keypair, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
         {
-            if let Some(pubkey) = get_pubkey_from_tls_certificate(&certs) {
+            if let Some(pubkey) = get_pubkey_from_tls_certificate(&cert) {
                 assert_eq!(pubkey, keypair.pubkey());
             } else {
                 panic!("Failed to get certificate pubkey");


### PR DESCRIPTION
#### Problem
QUIC client certificate code can use cleanup. It's using single self signed certificate, but the functions support certificate chains.

#### Summary of Changes
Updated the functions to use single certificate instead of a vector/slice of certificates.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
