### PR TITLE
Ledger tool print account size and load us

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -184,6 +184,11 @@ fn execute_batch(
         timings,
     );
 
+    info!(
+        " ==TAOTAOTAO== bank {} executed a batch, {:?}",
+        bank.slot(), timings
+    );
+
     if bank
         .feature_set
         .is_active(&feature_set::gate_large_block::id())

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -136,6 +136,9 @@ pub struct ExecuteAccessoryTimings {
     pub process_message_us: u64,
     pub update_executors_us: u64,
     pub process_instructions: ExecuteProcessInstructionTimings,
+    // accumulate total number of accounts specified in TXs
+    pub writable_accounts_count: u64,
+    pub readonly_accounts_count: u64,
 }
 
 impl ExecuteAccessoryTimings {
@@ -153,6 +156,8 @@ impl ExecuteAccessoryTimings {
         saturating_add_assign!(self.update_executors_us, other.update_executors_us);
         self.process_instructions
             .accumulate(&other.process_instructions);
+        saturating_add_assign!(self.writable_accounts_count, other.writable_accounts_count);
+        saturating_add_assign!(self.readonly_accounts_count, other.readonly_accounts_count);
     }
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -542,7 +542,7 @@ impl Accounts {
                     if should_accumulate_program_account_size {
                         loaded_account_total_size =
                             loaded_account_total_size.saturating_add(program_account.data().len());
-            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable size {:?}", ancestors.max_slot(), tx.signature(), program_id, program_account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable size {:?} depth {}", ancestors.max_slot(), tx.signature(), program_id, program_account.data().len(), depth); 
                     }
 
                     accounts.push((program_id, program_account));
@@ -588,7 +588,7 @@ impl Accounts {
                             if should_accumulate_program_account_size {
                                 loaded_account_total_size = loaded_account_total_size
                                     .saturating_add(programdata_account.data().len());
-            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable_programdata, size {:?}", ancestors.max_slot(), tx.signature(), programdata_address, programdata_account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable_programdata size {:?} depth {}", ancestors.max_slot(), tx.signature(), programdata_address, programdata_account.data().len(), depth); 
                             }
                             accounts.push((programdata_address, programdata_account));
                             account_index

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -320,7 +320,7 @@ impl Accounts {
 
                             load_time.stop();
         // only print for selected slot
-        if ancestors.max_slot() == 170618236 {
+        if ancestors.max_slot() == 170618236000 {
             info!(" ==TAOTAOTAO== load_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), key, load_time.as_us());
         }
                             act
@@ -366,7 +366,7 @@ impl Accounts {
                                         )
                                     {
                                         Self::accumulate_loaded_account_data_size(&mut accumulated_accounts_data_size, programdata_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account_programdata, size {:?}", tx.signature(), programdata_address, programdata_account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type account_programdata size {:?}", ancestors.max_slot(), tx.signature(), programdata_address, programdata_account.data().len()); 
 
                                         account_deps
                                             .push((programdata_address, programdata_account));
@@ -377,7 +377,7 @@ impl Accounts {
 
                                     load_time.stop();
         // only print for selected slot
-        if ancestors.max_slot() == 170618236 {
+        if ancestors.max_slot() == 170618236000 {
             info!(" ==TAOTAOTAO== load_programdata_account slot {} tx {:?} proogramdata_account {:?} load_us {}", ancestors.max_slot(), tx.signature(), programdata_address, load_time.as_us());
         }
                                 } else {
@@ -397,7 +397,7 @@ impl Accounts {
                     }
                 };
                 Self::accumulate_loaded_account_data_size(&mut accumulated_accounts_data_size, account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account, size {:?}", tx.signature(), key, account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type account size {:?}", ancestors.max_slot(), tx.signature(), key, account.data().len()); 
 
                 accounts.push((*key, account));
             }
@@ -542,7 +542,7 @@ impl Accounts {
                     if should_accumulate_program_account_size {
                         loaded_account_total_size =
                             loaded_account_total_size.saturating_add(program_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program, size {:?}", tx.signature(), program_id, program_account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable size {:?}", ancestors.max_slot(), tx.signature(), program_id, program_account.data().len()); 
                     }
 
                     accounts.push((program_id, program_account));
@@ -556,7 +556,7 @@ impl Accounts {
 
             load_time.stop();
         // only print for selected slot
-        if ancestors.max_slot() == 170618236 {
+        if ancestors.max_slot() == 170618236000 {
             info!(" ==TAOTAOTAO== load_program_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), program_id, load_time.as_us());
         }
 
@@ -588,7 +588,7 @@ impl Accounts {
                             if should_accumulate_program_account_size {
                                 loaded_account_total_size = loaded_account_total_size
                                     .saturating_add(programdata_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program_programdata, size {:?}", tx.signature(), programdata_address, programdata_account.data().len()); 
+            info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type executable_programdata, size {:?}", ancestors.max_slot(), tx.signature(), programdata_address, programdata_account.data().len()); 
                             }
                             accounts.push((programdata_address, programdata_account));
                             account_index
@@ -602,7 +602,7 @@ impl Accounts {
 
                     load_time.stop();
         // only print for selected slot
-        if ancestors.max_slot() == 170618236 {
+        if ancestors.max_slot() == 170618236000 {
             info!(" ==TAOTAOTAO== load_program_programdata_ccount slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), programdata_address, load_time.as_us());
         }
                 } else {
@@ -740,10 +740,11 @@ impl Accounts {
 
         load_time.stop();
         // only print for selected slot
-        if ancestors.max_slot() == 170618236 {
+        if ancestors.max_slot() == 170618236000 {
             info!(" ==TAOTAOTAO== load_lookup_table_addresses slot {} load_us {}", ancestors.max_slot(), load_time.as_us());
         }
 
+        info!(" ==TAOTAO== slot {} transaction {:?} account {:?} type lookup_table_account size {:?}", ancestors.max_slot(), "nil", address_table_lookup.account_key, table_account.data().len()); 
         res
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -321,7 +321,7 @@ impl Accounts {
                             load_time.stop();
         // only print for selected slot
         if ancestors.max_slot() == 170618236 {
-            info!(" ==TAOTAOTAO== load_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signatures(), key, load_time.as_us());
+            info!(" ==TAOTAOTAO== load_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), key, load_time.as_us());
         }
                             act
                         };
@@ -366,7 +366,7 @@ impl Accounts {
                                         )
                                     {
                                         Self::accumulate_loaded_account_data_size(&mut accumulated_accounts_data_size, programdata_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account_programdata, size {:?}", tx.signatures(), programdata_address, programdata_account.data().len()); 
+            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account_programdata, size {:?}", tx.signature(), programdata_address, programdata_account.data().len()); 
 
                                         account_deps
                                             .push((programdata_address, programdata_account));
@@ -378,7 +378,7 @@ impl Accounts {
                                     load_time.stop();
         // only print for selected slot
         if ancestors.max_slot() == 170618236 {
-            info!(" ==TAOTAOTAO== load_programdata_account slot {} tx {:?} proogramdata_account {:?} load_us {}", ancestors.max_slot(), tx.signatures(), programdata_address, load_time.as_us());
+            info!(" ==TAOTAOTAO== load_programdata_account slot {} tx {:?} proogramdata_account {:?} load_us {}", ancestors.max_slot(), tx.signature(), programdata_address, load_time.as_us());
         }
                                 } else {
                                     error_counters.invalid_program_for_execution += 1;
@@ -397,7 +397,7 @@ impl Accounts {
                     }
                 };
                 Self::accumulate_loaded_account_data_size(&mut accumulated_accounts_data_size, account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account, size {:?}", tx.signatures(), key, account.data().len()); 
+            info!(" ==TAOTAO== transaction {:?}, account {:?}, type account, size {:?}", tx.signature(), key, account.data().len()); 
 
                 accounts.push((*key, account));
             }
@@ -441,7 +441,7 @@ impl Accounts {
                 Err(TransactionError::AccountNotFound)
             };
 
-            info!(" ==TAO== transaction {:?}, loaded account size {:?}", tx.signatures(), accumulated_accounts_data_size); 
+            info!(" ==TAO== transaction {:?}, loaded account size {:?}", tx.signature(), accumulated_accounts_data_size); 
             res
         }
     }
@@ -542,7 +542,7 @@ impl Accounts {
                     if should_accumulate_program_account_size {
                         loaded_account_total_size =
                             loaded_account_total_size.saturating_add(program_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program, size {:?}", tx.signatures(), program_id, program_account.data().len()); 
+            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program, size {:?}", tx.signature(), program_id, program_account.data().len()); 
                     }
 
                     accounts.push((program_id, program_account));
@@ -557,7 +557,7 @@ impl Accounts {
             load_time.stop();
         // only print for selected slot
         if ancestors.max_slot() == 170618236 {
-            info!(" ==TAOTAOTAO== load_program_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signatures(), program_id, load_time.as_us());
+            info!(" ==TAOTAOTAO== load_program_account slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), program_id, load_time.as_us());
         }
 
 
@@ -588,7 +588,7 @@ impl Accounts {
                             if should_accumulate_program_account_size {
                                 loaded_account_total_size = loaded_account_total_size
                                     .saturating_add(programdata_account.data().len());
-            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program_programdata, size {:?}", tx.signatures(), programdata_address, programdata_account.data().len()); 
+            info!(" ==TAOTAO== transaction {:?}, account {:?}, type program_programdata, size {:?}", tx.signature(), programdata_address, programdata_account.data().len()); 
                             }
                             accounts.push((programdata_address, programdata_account));
                             account_index
@@ -603,7 +603,7 @@ impl Accounts {
                     load_time.stop();
         // only print for selected slot
         if ancestors.max_slot() == 170618236 {
-            info!(" ==TAOTAOTAO== load_program_programdata_ccount slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signatures(), programdata_address, load_time.as_us());
+            info!(" ==TAOTAOTAO== load_program_programdata_ccount slot {} tx {:?} account {:?} load_us {}", ancestors.max_slot(), tx.signature(), programdata_address, load_time.as_us());
         }
                 } else {
                     error_counters.invalid_program_for_execution += 1;


### PR DESCRIPTION
#### Problem
Hack ledger tool to replay MNB snapshots to investigate slow loading issue. 

Slow loading issue: blocks, or transactions, spent a lot of timing in loading accounts, result `load_us`in replay metrics spike. (example slots: `[170618100, 170618350]`)
Possible causes: 
1. certain type accounts might be slow to load, say large size
2. too many accounts in a TX, and too many such TXs, cause overall load time spikes. 

ran hacked ledger-tool on above slots range's snapshot, not finding evidences for case #1. In fact, the slowest laoded accounts are just random program accounts (including vote, ComputeBudget etc builtin programs).


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
