### PR TITLE
Support monikers in solana-tokens

### DIFF
--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -8,7 +8,7 @@ use {
     },
     solana_clap_utils::{
         input_parsers::{pubkey_of_signer, value_of},
-        input_validators::{is_amount, is_valid_pubkey, is_valid_signer},
+        input_validators::{is_amount, is_url_or_moniker, is_valid_pubkey, is_valid_signer},
         keypair::{pubkey_from_path, signer_from_path},
     },
     solana_cli_config::CONFIG_FILE,
@@ -28,6 +28,7 @@ where
         .version(solana_version::version!())
         .arg(
             Arg::with_name("config_file")
+                .short("C")
                 .long("config")
                 .takes_value(true)
                 .value_name("FILEPATH")
@@ -35,12 +36,17 @@ where
                 .help("Config file"),
         )
         .arg(
-            Arg::with_name("url")
+            Arg::with_name("json_rpc_url")
+                .short("u")
                 .long("url")
-                .global(true)
+                .value_name("URL_OR_MONIKER")
                 .takes_value(true)
-                .value_name("URL")
-                .help("RPC entrypoint address. i.e. http://api.devnet.solana.com"),
+                .global(true)
+                .validator(is_url_or_moniker)
+                .help(
+                    "URL for Solana's JSON RPC or moniker (or their first letter): \
+                       [mainnet-beta, testnet, devnet, localhost]",
+                ),
         )
         .subcommand(
             SubCommand::with_name("distribute-tokens")

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -1,4 +1,5 @@
 use {
+    solana_clap_utils::input_validators::normalize_to_url_if_moniker,
     solana_cli_config::{Config, CONFIG_FILE},
     solana_rpc_client::rpc_client::RpcClient,
     solana_tokens::{arg_parser::parse_args, args::Command, commands, spl_token},
@@ -26,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         Config::default()
     };
-    let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
+    let json_rpc_url = normalize_to_url_if_moniker(command_args.url.unwrap_or(config.json_rpc_url));
     let client = RpcClient::new(json_rpc_url);
 
     let exit = Arc::new(AtomicBool::default());


### PR DESCRIPTION
#### Problem
Confusing error:
```
$ solana-tokens distribute-spl-tokens --db-path db.db --fee-payer payer.json --input-csv /dist.csv  --from <TOKEN_ACCOUNT> --owner payer.json --url mainnet-beta
Error: ProgramError(InvalidAccountData)
```
This is being thrown because `solana-tokens` doesn't know about monikers, and is trying to query account states from a non-existent cluster. Arguably, the error should be more descriptive, but also, it would be nice to support monikers, and the short `-u` for url.

#### Summary of Changes
Add short flag for url and config
Support parsing monikers in url parameter

cc @danpaul000 
