### PR TITLE
web3.js: Adds lastValidBlockHeight to VersionedTransaction

### DIFF
--- a/web3.js/src/transaction/versioned.ts
+++ b/web3.js/src/transaction/versioned.ts
@@ -17,12 +17,13 @@ export type TransactionVersion = 'legacy' | 0;
 export class VersionedTransaction {
   signatures: Array<Uint8Array>;
   message: VersionedMessage;
+  lastValidBlockHeight?: number;
 
   get version(): TransactionVersion {
     return this.message.version;
   }
 
-  constructor(message: VersionedMessage, signatures?: Array<Uint8Array>) {
+  constructor(message: VersionedMessage, signatures?: Array<Uint8Array>, lastValidBlockHeight?: number) {
     if (signatures !== undefined) {
       assert(
         signatures.length === message.header.numRequiredSignatures,
@@ -37,6 +38,7 @@ export class VersionedTransaction {
       this.signatures = defaultSignatures;
     }
     this.message = message;
+    this.lastValidBlockHeight = lastValidBlockHeight;
   }
 
   serialize(): Uint8Array {


### PR DESCRIPTION
#### Problem
Unlike `Transaction`, `VersionedTransaction` doesn't hold the `lastValidBlockHeight`

#### Summary of Changes
Just for developer convenience, allowing us to store the `lastValidBlockHeight` makes it easier to pass around the transaction and use when we need to confirm the transaction

I've maintained the previous api surface by not changing the constructor args into an object, but its kind of ugly to have to initialize like `new VersionedTransaction(message, undefined, 696969)`, so i'd be open to changing to an object instead
