### PR TITLE
Bump chrono to v0.4.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,9 +831,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2412,7 +2412,11 @@ impl fmt::Display for CliBlock {
             self.encoded_confirmed_block.previous_blockhash
         )?;
         if let Some(block_time) = self.encoded_confirmed_block.block_time {
-            writeln!(f, "Block Time: {:?}", Local.timestamp_opt(block_time, 0).unwrap())?;
+            writeln!(
+                f,
+                "Block Time: {:?}",
+                Local.timestamp_opt(block_time, 0).unwrap()
+            )?;
         }
         if let Some(block_height) = self.encoded_confirmed_block.block_height {
             writeln!(f, "Block Height: {block_height:?}")?;

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2412,7 +2412,7 @@ impl fmt::Display for CliBlock {
             self.encoded_confirmed_block.previous_blockhash
         )?;
         if let Some(block_time) = self.encoded_confirmed_block.block_time {
-            writeln!(f, "Block Time: {:?}", Local.timestamp(block_time, 0))?;
+            writeln!(f, "Block Time: {:?}", Local.timestamp_opt(block_time, 0).unwrap())?;
         }
         if let Some(block_height) = self.encoded_confirmed_block.block_height {
             writeln!(f, "Block Height: {block_height:?}")?;

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -322,8 +322,8 @@ fn write_block_time<W: io::Write>(
 ) -> io::Result<()> {
     if let Some(block_time) = block_time {
         let block_time_output = match timezone {
-            CliTimezone::Local => format!("{:?}", Local.timestamp(block_time, 0)),
-            CliTimezone::Utc => format!("{:?}", Utc.timestamp(block_time, 0)),
+            CliTimezone::Local => format!("{:?}", Local.timestamp_opt(block_time, 0).unwrap()),
+            CliTimezone::Utc => format!("{:?}", Utc.timestamp_opt(block_time, 0).unwrap()),
         };
         writeln!(w, "{prefix}Block Time: {block_time_output}",)?;
     }

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -596,7 +596,7 @@ fn release_channel_version_url(release_channel: &str) -> String {
 }
 
 fn print_update_manifest(update_manifest: &UpdateManifest) {
-    let when = Local.timestamp(update_manifest.timestamp_secs as i64, 0);
+    let when = Local.timestamp_opt(update_manifest.timestamp_secs as i64, 0).unwrap();
     println_name_value(&format!("{BULLET}release date:"), &when.to_string());
     println_name_value(
         &format!("{BULLET}download URL:"),

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -596,7 +596,9 @@ fn release_channel_version_url(release_channel: &str) -> String {
 }
 
 fn print_update_manifest(update_manifest: &UpdateManifest) {
-    let when = Local.timestamp_opt(update_manifest.timestamp_secs as i64, 0).unwrap();
+    let when = Local
+        .timestamp_opt(update_manifest.timestamp_secs as i64, 0)
+        .unwrap();
     println_name_value(&format!("{BULLET}release date:"), &when.to_string());
     println_name_value(
         &format!("{BULLET}download URL:"),

--- a/programs/config/src/date_instruction.rs
+++ b/programs/config/src/date_instruction.rs
@@ -27,9 +27,7 @@ impl Default for DateConfig {
 }
 impl DateConfig {
     pub fn new(date_time: DateTime<Utc>) -> Self {
-        Self {
-            date_time,
-        }
+        Self { date_time }
     }
 
     pub fn deserialize(input: &[u8]) -> Option<Self> {

--- a/programs/config/src/date_instruction.rs
+++ b/programs/config/src/date_instruction.rs
@@ -5,7 +5,7 @@ use bincode::{deserialize, serialized_size};
 use {
     crate::{config_instruction, ConfigState},
     chrono::{
-        prelude::{Date, DateTime, TimeZone, Utc},
+        prelude::{DateTime, TimeZone, Utc},
         serde::ts_seconds,
     },
     serde_derive::{Deserialize, Serialize},
@@ -21,14 +21,14 @@ pub struct DateConfig {
 impl Default for DateConfig {
     fn default() -> Self {
         Self {
-            date_time: Utc.timestamp(0, 0),
+            date_time: Utc.timestamp_opt(0, 0).unwrap(),
         }
     }
 }
 impl DateConfig {
-    pub fn new(date: Date<Utc>) -> Self {
+    pub fn new(date_time: DateTime<Utc>) -> Self {
         Self {
-            date_time: date.and_hms(0, 0, 0),
+            date_time,
         }
     }
 
@@ -54,7 +54,7 @@ pub fn create_account(
 
 /// Set the date in the date account. The account pubkey must be signed in the
 /// transaction containing this instruction.
-pub fn store(date_pubkey: &Pubkey, date: Date<Utc>) -> Instruction {
-    let date_config = DateConfig::new(date);
+pub fn store(date_pubkey: &Pubkey, date_time: DateTime<Utc>) -> Instruction {
+    let date_config = DateConfig::new(date_time);
     config_instruction::store(date_pubkey, true, vec![], &date_config)
 }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-tokens"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.23", features = ["serde"] }
 clap = "2.33.0"
 console = "0.15.0"
 csv = "1.1.6"

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -218,11 +218,11 @@ mod tests {
     #[test]
     fn test_sort_transaction_infos_finalized_first() {
         let info0 = TransactionInfo {
-            finalized_date: Some(Utc.ymd(2014, 7, 8).and_hms(9, 10, 11)),
+            finalized_date: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
             ..TransactionInfo::default()
         };
         let info1 = TransactionInfo {
-            finalized_date: Some(Utc.ymd(2014, 7, 8).and_hms(9, 10, 42)),
+            finalized_date: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 42).unwrap()),
             ..TransactionInfo::default()
         };
         let info2 = TransactionInfo::default();


### PR DESCRIPTION
(no rush; no need to work on weekend)

#### Problem

#29196 is blocked on chrono version bump (via `rolling-file` crate, which is newly added there).

cc: @apfitzge 

#### Summary of Changes

Update chrono to v0.4.23: https://github.com/chronotope/chrono/releases/tag/v0.4.23

Acoompanied code change is due to `chrono`'s new deprecations. Basically, it's trying to get rid of `panic!()` even with out-of-range inputs in those deprecated API, forcing users to handle errors gracefully while relieving users from validating complex human's calendar (i think this is sensible, considering it's _time_ library) https://github.com/chronotope/chrono/issues/815. so, although I just lazily resorted to `.unwrap()` naively, it's completely non-functional-change. ;)