### PR TITLE
Rename remaining ones to replay_vote_{sender,receiver}

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2034,7 +2034,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, None, None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2087,7 +2087,7 @@ mod tests {
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
             let (verified_gossip_vote_sender, verified_gossip_vote_receiver) = unbounded();
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2165,7 +2165,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2300,7 +2300,7 @@ mod tests {
         let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let entry_receiver = {
                 // start a banking_stage to eat verified receiver
@@ -2634,7 +2634,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -2771,7 +2771,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -2845,7 +2845,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let qos_service = QosService::new(1);
 
@@ -3000,7 +3000,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3078,7 +3078,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let process_transactions_summary = BankingStage::process_transactions(
                 &bank,
@@ -3145,7 +3145,7 @@ mod tests {
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-        let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
         let process_transactions_summary = BankingStage::process_transactions(
             &bank,
@@ -3373,7 +3373,7 @@ mod tests {
                 &Arc::new(AtomicBool::new(false)),
             );
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let _ = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3542,7 +3542,7 @@ mod tests {
                 &Arc::new(AtomicBool::new(false)),
             );
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let _ = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3663,7 +3663,7 @@ mod tests {
                     ThreadType::Transactions,
                 );
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
             assert!(!poh_recorder.read().unwrap().has_bank());
@@ -3721,7 +3721,7 @@ mod tests {
                     ThreadType::Transactions,
                 );
 
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             // When the working bank in poh_recorder is None, no packets should be processed
             assert!(!poh_recorder.read().unwrap().has_bank());
@@ -3772,7 +3772,7 @@ mod tests {
             let poh_recorder_ = poh_recorder.clone();
             let recorder = poh_recorder_.read().unwrap().recorder();
             let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
             // Start up thread to process the banks
             let t_consume = Builder::new()
                 .name("consume-buffered-packets".to_string())
@@ -4094,7 +4094,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -389,7 +389,7 @@ impl BankingStage {
         tpu_verified_vote_receiver: BankingPacketReceiver,
         verified_vote_receiver: BankingPacketReceiver,
         transaction_status_sender: Option<TransactionStatusSender>,
-        gossip_vote_sender: ReplayVoteSender,
+        replay_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -402,7 +402,7 @@ impl BankingStage {
             verified_vote_receiver,
             Self::num_threads(),
             transaction_status_sender,
-            gossip_vote_sender,
+            replay_vote_sender,
             log_messages_bytes_limit,
             connection_cache,
             bank_forks,
@@ -418,7 +418,7 @@ impl BankingStage {
         verified_vote_receiver: BankingPacketReceiver,
         num_threads: u32,
         transaction_status_sender: Option<TransactionStatusSender>,
-        gossip_vote_sender: ReplayVoteSender,
+        replay_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -487,7 +487,7 @@ impl BankingStage {
                 let cluster_info = cluster_info.clone();
                 let mut recv_start = Instant::now();
                 let transaction_status_sender = transaction_status_sender.clone();
-                let gossip_vote_sender = gossip_vote_sender.clone();
+                let replay_vote_sender = replay_vote_sender.clone();
                 let data_budget = data_budget.clone();
                 let connection_cache = connection_cache.clone();
                 let bank_forks = bank_forks.clone();
@@ -501,7 +501,7 @@ impl BankingStage {
                             &mut recv_start,
                             i,
                             transaction_status_sender,
-                            gossip_vote_sender,
+                            replay_vote_sender,
                             &data_budget,
                             log_messages_bytes_limit,
                             connection_cache,
@@ -616,7 +616,7 @@ impl BankingStage {
         payload: &mut ConsumeScannerPayload,
         recorder: &TransactionRecorder,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         banking_stage_stats: &BankingStageStats,
         qos_service: &QosService,
         log_messages_bytes_limit: Option<usize>,
@@ -637,7 +637,7 @@ impl BankingStage {
                 recorder,
                 &payload.sanitized_transactions,
                 transaction_status_sender,
-                gossip_vote_sender,
+                replay_vote_sender,
                 banking_stage_stats,
                 qos_service,
                 payload.slot_metrics_tracker,
@@ -692,7 +692,7 @@ impl BankingStage {
         bank_start: &BankStart,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         test_fn: Option<impl Fn()>,
         banking_stage_stats: &BankingStageStats,
         recorder: &TransactionRecorder,
@@ -715,7 +715,7 @@ impl BankingStage {
                     payload,
                     recorder,
                     transaction_status_sender,
-                    gossip_vote_sender,
+                    replay_vote_sender,
                     banking_stage_stats,
                     qos_service,
                     log_messages_bytes_limit,
@@ -827,7 +827,7 @@ impl BankingStage {
         cluster_info: &ClusterInfo,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         banking_stage_stats: &BankingStageStats,
         recorder: &TransactionRecorder,
         data_budget: &DataBudget,
@@ -858,7 +858,7 @@ impl BankingStage {
                         &bank_start,
                         unprocessed_transaction_storage,
                         transaction_status_sender,
-                        gossip_vote_sender,
+                        replay_vote_sender,
                         None::<Box<dyn Fn()>>,
                         banking_stage_stats,
                         recorder,
@@ -1023,7 +1023,7 @@ impl BankingStage {
         recv_start: &mut Instant,
         id: u32,
         transaction_status_sender: Option<TransactionStatusSender>,
-        gossip_vote_sender: ReplayVoteSender,
+        replay_vote_sender: ReplayVoteSender,
         data_budget: &DataBudget,
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Arc<ConnectionCache>,
@@ -1052,7 +1052,7 @@ impl BankingStage {
                         cluster_info,
                         &mut unprocessed_transaction_storage,
                         &transaction_status_sender,
-                        &gossip_vote_sender,
+                        &replay_vote_sender,
                         &banking_stage_stats,
                         &recorder,
                         data_budget,
@@ -1175,7 +1175,7 @@ impl BankingStage {
         pre_balance_info: &mut PreBalanceInfo,
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         signature_count: u64,
         executed_transactions_count: usize,
         executed_non_vote_transactions_count: usize,
@@ -1228,7 +1228,7 @@ impl BankingStage {
                 bank_utils::find_and_send_votes(
                     sanitized_txs,
                     &tx_results,
-                    Some(gossip_vote_sender),
+                    Some(replay_vote_sender),
                 );
                 Self::collect_balances_and_send_status_batch(
                     transaction_status_sender,
@@ -1295,7 +1295,7 @@ impl BankingStage {
         poh: &TransactionRecorder,
         batch: &TransactionBatch,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
     ) -> ExecuteAndCommitTransactionsOutput {
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
@@ -1410,7 +1410,7 @@ impl BankingStage {
                 &mut pre_balance_info,
                 &mut execute_and_commit_timings,
                 transaction_status_sender,
-                gossip_vote_sender,
+                replay_vote_sender,
                 signature_count,
                 executed_transactions_count,
                 executed_non_vote_transactions_count,
@@ -1461,7 +1461,7 @@ impl BankingStage {
         poh: &TransactionRecorder,
         chunk_offset: usize,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         qos_service: &QosService,
         log_messages_bytes_limit: Option<usize>,
     ) -> ProcessTransactionBatchOutput {
@@ -1486,7 +1486,7 @@ impl BankingStage {
                 poh,
                 &batch,
                 transaction_status_sender,
-                gossip_vote_sender,
+                replay_vote_sender,
                 log_messages_bytes_limit,
             );
 
@@ -1559,7 +1559,7 @@ impl BankingStage {
         transactions: &[SanitizedTransaction],
         poh: &TransactionRecorder,
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &ReplayVoteSender,
+        replay_vote_sender: &ReplayVoteSender,
         qos_service: &QosService,
         log_messages_bytes_limit: Option<usize>,
     ) -> ProcessTransactionsSummary {
@@ -1591,7 +1591,7 @@ impl BankingStage {
                 poh,
                 chunk_start,
                 transaction_status_sender,
-                gossip_vote_sender,
+                replay_vote_sender,
                 qos_service,
                 log_messages_bytes_limit,
             );
@@ -1734,7 +1734,7 @@ impl BankingStage {
         poh: &'a TransactionRecorder,
         sanitized_transactions: &[SanitizedTransaction],
         transaction_status_sender: &Option<TransactionStatusSender>,
-        gossip_vote_sender: &'a ReplayVoteSender,
+        replay_vote_sender: &'a ReplayVoteSender,
         banking_stage_stats: &'a BankingStageStats,
         qos_service: &'a QosService,
         slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
@@ -1748,7 +1748,7 @@ impl BankingStage {
                 sanitized_transactions,
                 poh,
                 transaction_status_sender,
-                gossip_vote_sender,
+                replay_vote_sender,
                 qos_service,
                 log_messages_bytes_limit,
             ),
@@ -2034,7 +2034,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, None, None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2043,7 +2043,7 @@ mod tests {
                 tpu_vote_receiver,
                 gossip_verified_vote_receiver,
                 None,
-                gossip_vote_sender,
+                replay_vote_sender,
                 None,
                 Arc::new(ConnectionCache::default()),
                 bank_forks,
@@ -2087,7 +2087,7 @@ mod tests {
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
             let (verified_gossip_vote_sender, verified_gossip_vote_receiver) = unbounded();
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2096,7 +2096,7 @@ mod tests {
                 tpu_vote_receiver,
                 verified_gossip_vote_receiver,
                 None,
-                gossip_vote_sender,
+                replay_vote_sender,
                 None,
                 Arc::new(ConnectionCache::default()),
                 bank_forks,
@@ -2165,7 +2165,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -2174,7 +2174,7 @@ mod tests {
                 tpu_vote_receiver,
                 gossip_verified_vote_receiver,
                 None,
-                gossip_vote_sender,
+                replay_vote_sender,
                 None,
                 Arc::new(ConnectionCache::default()),
                 bank_forks,
@@ -2300,7 +2300,7 @@ mod tests {
         let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let entry_receiver = {
                 // start a banking_stage to eat verified receiver
@@ -2329,7 +2329,7 @@ mod tests {
                     vote_receiver,
                     3,
                     None,
-                    gossip_vote_sender,
+                    replay_vote_sender,
                     None,
                     Arc::new(ConnectionCache::default()),
                     bank_forks,
@@ -2634,7 +2634,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -2642,7 +2642,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -2695,7 +2695,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -2771,7 +2771,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -2779,7 +2779,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -2845,7 +2845,7 @@ mod tests {
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.write().unwrap().set_bank(&bank, false);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let qos_service = QosService::new(1);
 
@@ -2871,7 +2871,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &qos_service,
                 None,
             );
@@ -2911,7 +2911,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &qos_service,
                 None,
             );
@@ -3000,7 +3000,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let process_transactions_batch_output = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3008,7 +3008,7 @@ mod tests {
                 &recorder,
                 0,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -3078,7 +3078,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let process_transactions_summary = BankingStage::process_transactions(
                 &bank,
@@ -3086,7 +3086,7 @@ mod tests {
                 &transactions,
                 &recorder,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -3145,7 +3145,7 @@ mod tests {
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-        let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+        let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
         let process_transactions_summary = BankingStage::process_transactions(
             &bank,
@@ -3153,7 +3153,7 @@ mod tests {
             &transactions,
             &recorder,
             &None,
-            &gossip_vote_sender,
+            &replay_vote_sender,
             &QosService::new(1),
             None,
         );
@@ -3373,7 +3373,7 @@ mod tests {
                 &Arc::new(AtomicBool::new(false)),
             );
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let _ = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3383,7 +3383,7 @@ mod tests {
                 &Some(TransactionStatusSender {
                     sender: transaction_status_sender,
                 }),
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -3542,7 +3542,7 @@ mod tests {
                 &Arc::new(AtomicBool::new(false)),
             );
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let _ = BankingStage::process_and_record_transactions(
                 &bank,
@@ -3552,7 +3552,7 @@ mod tests {
                 &Some(TransactionStatusSender {
                     sender: transaction_status_sender,
                 }),
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 &QosService::new(1),
                 None,
             );
@@ -3663,7 +3663,7 @@ mod tests {
                     ThreadType::Transactions,
                 );
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
             assert!(!poh_recorder.read().unwrap().has_bank());
@@ -3676,7 +3676,7 @@ mod tests {
                 &bank_start,
                 &mut buffered_packet_batches,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
@@ -3721,7 +3721,7 @@ mod tests {
                     ThreadType::Transactions,
                 );
 
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             // When the working bank in poh_recorder is None, no packets should be processed
             assert!(!poh_recorder.read().unwrap().has_bank());
@@ -3734,7 +3734,7 @@ mod tests {
                 &bank_start,
                 &mut buffered_packet_batches,
                 &None,
-                &gossip_vote_sender,
+                &replay_vote_sender,
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
@@ -3772,7 +3772,7 @@ mod tests {
             let poh_recorder_ = poh_recorder.clone();
             let recorder = poh_recorder_.read().unwrap().recorder();
             let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
             // Start up thread to process the banks
             let t_consume = Builder::new()
                 .name("consume-buffered-packets".to_string())
@@ -3796,7 +3796,7 @@ mod tests {
                         &bank_start,
                         &mut buffered_packet_batches,
                         &None,
-                        &gossip_vote_sender,
+                        &replay_vote_sender,
                         test_fn,
                         &BankingStageStats::default(),
                         &recorder,
@@ -4094,7 +4094,7 @@ mod tests {
                 create_test_recorder(&bank, &blockstore, Some(poh_config), None);
             let cluster_info = new_test_cluster_info(Node::new_localhost().info);
             let cluster_info = Arc::new(cluster_info);
-            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+            let (replay_vote_sender, _repaly_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
                 &cluster_info,
@@ -4103,7 +4103,7 @@ mod tests {
                 tpu_vote_receiver,
                 gossip_verified_vote_receiver,
                 None,
-                gossip_vote_sender,
+                replay_vote_sender,
                 None,
                 Arc::new(ConnectionCache::default()),
                 bank_forks,


### PR DESCRIPTION
(no rush; no need to work on weekend)

#### Problem

There's remaining instances of stale variable names for the type of `ReplayVote{Sender/Receiver}`.

hmm, actually, i found that it's not _stale_ after some `git log` unfolding.... it seems that the var name and type name were inconsistent since the beginning...: https://github.com/solana-labs/solana/pull/11434/files#r1070596384 (#11434).... 

(

I think it's a bit off that we call this type as `*Replay*Vote{Sender,Receiver}` considering its usage inside BankingStage. yet again `*gossip*_vote_{sender,receiver}` is misnomer too, considering it's not only gossip but all of committed votes in banking stage is sent over the channel (including vote tpu, non-vote tpu origins).... Fixing this is out of scope, I'll just align all to type names.... cc: @carllin

hehe, it's so tempting to rename them all to `CommittedVote{Sender,Receiver}`. but I'm quite deep at buffered prs. T_T

)

Namely, I want to use `gossip_vote_sender` in #29196, but it's currently squatted by the stale variables here and there.


#### Summary of Changes

Rename 'em all with this  preparatory pr to ease review of #29196.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
