### PR TITLE
Use Into in Hash::result() instead of TryFrom

### DIFF
--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -61,9 +61,7 @@ impl Hasher {
         }
     }
     pub fn result(self) -> Hash {
-        // At the time of this writing, the sha2 library is stuck on an old version
-        // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
+        Hash(self.hasher.finalize().into())
     }
 }
 


### PR DESCRIPTION
#### Problem

Hash::result() converts the Sha256 Hash to the Solana Hash by using TryFrom. Since both hashes are `[u8; 32]`, we know this conversion is infallible.


#### Summary of Changes

Use `Into` instead of `TryFrom`.