### PR TITLE
Removes full_snapshot from CalcAccountsHashConfig

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -233,7 +233,6 @@ impl AccountsHashVerifier {
                     epoch_schedule: &accounts_package.epoch_schedule,
                     rent_collector: &accounts_package.rent_collector,
                     store_detailed_debug_info_on_failure: false,
-                    full_snapshot: None,
                 },
                 &sorted_storages,
                 timings,
@@ -255,7 +254,6 @@ impl AccountsHashVerifier {
                         epoch_schedule: &accounts_package.epoch_schedule,
                         rent_collector: &accounts_package.rent_collector,
                         store_detailed_debug_info_on_failure: false,
-                        full_snapshot: None,
                     },
                 );
             info!(
@@ -274,7 +272,6 @@ impl AccountsHashVerifier {
                         rent_collector: &accounts_package.rent_collector,
                         // now that we've failed, store off the failing contents that produced a bad capitalization
                         store_detailed_debug_info_on_failure: true,
-                        full_snapshot: None,
                     },
                     &sorted_storages,
                     HashStats::default(),

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -323,7 +323,6 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                         epoch_schedule: bank.epoch_schedule(),
                         rent_collector: bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
-                        full_snapshot: None,
                     },
                 )
                 .unwrap();

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -331,7 +331,6 @@ impl SnapshotRequestHandler {
                         epoch_schedule: snapshot_root_bank.epoch_schedule(),
                         rent_collector: snapshot_root_bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
-                        full_snapshot: None,
                     },
                 )
                 .unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7117,7 +7117,6 @@ impl AccountsDb {
                     epoch_schedule,
                     rent_collector,
                     store_detailed_debug_info_on_failure: false,
-                    full_snapshot: None,
                 },
                 expected_capitalization,
             )
@@ -7406,7 +7405,6 @@ impl AccountsDb {
                     epoch_schedule,
                     rent_collector,
                     store_detailed_debug_info_on_failure: store_hash_raw_data_for_debug,
-                    full_snapshot: None,
                 },
                 None,
             )?;
@@ -12111,7 +12109,6 @@ pub mod tests {
                 epoch_schedule: &EPOCH_SCHEDULE,
                 rent_collector: &RENT_COLLECTOR,
                 store_detailed_debug_info_on_failure: false,
-                full_snapshot: None,
             }
         }
     }

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -95,15 +95,6 @@ impl AccountHashesFile {
     }
 }
 
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct FullSnapshotAccountsHashInfo {
-    /// accounts hash over all accounts when the full snapshot was taken
-    hash: AccountsHash,
-    /// slot where full snapshot was taken
-    slot: Slot,
-}
-
 /// parameters to calculate accounts hash
 #[derive(Debug)]
 pub struct CalcAccountsHashConfig<'a> {
@@ -120,8 +111,6 @@ pub struct CalcAccountsHashConfig<'a> {
     pub rent_collector: &'a RentCollector,
     /// used for tracking down hash mismatches after the fact
     pub store_detailed_debug_info_on_failure: bool,
-    /// `Some` if this is an incremental snapshot which only hashes slots since the base full snapshot
-    pub full_snapshot: Option<FullSnapshotAccountsHashInfo>,
 }
 
 impl<'a> CalcAccountsHashConfig<'a> {


### PR DESCRIPTION
#### Problem

This field is never used. Incremental accounts hash calculations will take in this information as a parameter to the function, so no need to put it in the config for all callers.

#### Summary of Changes

Remove it.