### PR TITLE
AccountStorage only holds a single append vec

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -9,7 +9,10 @@ use {
 
 #[derive(Clone, Debug)]
 pub struct AccountStorageReference {
+    /// the single storage for a given slot
     pub(crate) storage: SnapshotStorageOne,
+    /// id can be read from 'storage', but it is an atomic read.
+    /// id will never change while a storage is held, so we store it separately here for faster runtime lookup in 'get_account_storage_entry'
     pub(crate) id: AppendVecId,
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10724,11 +10724,11 @@ pub mod tests {
         }
 
         let mut append_vec_histogram = HashMap::new();
-        let mut all_storages = vec![];
+        let mut all_slots = vec![];
         for slot_storage in accounts.storage.iter() {
-            all_storages.push(slot_storage.0)
+            all_slots.push(slot_storage.0)
         }
-        for slot in all_storages {
+        for slot in all_slots {
             *append_vec_histogram.entry(slot).or_insert(0) += 1;
         }
         for count in append_vec_histogram.values() {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10726,10 +10726,10 @@ pub mod tests {
         let mut append_vec_histogram = HashMap::new();
         let mut all_storages = vec![];
         for slot_storage in accounts.storage.iter() {
-            all_storages.push(slot_storage.1)
+            all_storages.push(slot_storage.0)
         }
-        for storage in all_storages {
-            *append_vec_histogram.entry(storage.slot()).or_insert(0) += 1;
+        for slot in all_storages {
+            *append_vec_histogram.entry(slot).or_insert(0) += 1;
         }
         for count in append_vec_histogram.values() {
             assert!(*count >= 2);
@@ -17184,7 +17184,6 @@ pub mod tests {
             .write()
             .unwrap()
             .insert(slot0, BankHashInfo::default());
-        db.storage.insert_empty_at_slot(slot0);
         assert!(!db.bank_hashes.read().unwrap().is_empty());
         db.accounts_index.add_root(slot0);
         db.accounts_index.add_uncleaned_roots([slot0].into_iter());

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -605,9 +605,6 @@ pub type SnapshotStorages = Vec<Vec<SnapshotStorageOne>>;
 /// exactly 1 append vec per slot
 pub type SnapshotStoragesOne = Vec<SnapshotStorageOne>;
 
-// Each slot has a set of storage entries.
-pub(crate) type SlotStores = Arc<RwLock<HashMap<AppendVecId, Arc<AccountStorageEntry>>>>;
-
 type AccountSlots = HashMap<Pubkey, HashSet<Slot>>;
 type AppendVecOffsets = HashMap<AppendVecId, HashSet<usize>>;
 type ReclaimResult = (AccountSlots, AppendVecOffsets);
@@ -3915,12 +3912,9 @@ impl AccountsDb {
             // shrink is in progress, so 1 new append vec to keep, 1 old one to throw away
             not_retaining_store(shrink_in_progress.old_storage());
             // dropping 'shrink_in_progress' removes the old append vec that was being shrunk from db's storage
-        } else if let Some(slot_stores) = self.storage.get_slot_stores(slot) {
+        } else if let Some(store) = self.storage.remove(&slot) {
             // no shrink in progress, so all append vecs in this slot are dead
-            let mut list = slot_stores.write().unwrap();
-            list.drain().for_each(|(_key, store)| {
-                not_retaining_store(&store);
-            });
+            not_retaining_store(&store);
         }
 
         dead_storages

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -714,7 +714,6 @@ where
     // discard any slots with no storage entries
     // this can happen if a non-root slot was serialized
     // but non-root stores should not be included in the snapshot
-    storage.retain(|_slot, stores| !stores.read().unwrap().is_empty());
     assert!(
         !storage.is_empty(),
         "At least one storage entry must exist from deserializing stream"

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -711,9 +711,6 @@ where
         next_append_vec_id,
     } = storage_and_next_append_vec_id;
 
-    // discard any slots with no storage entries
-    // this can happen if a non-root slot was serialized
-    // but non-root stores should not be included in the snapshot
     assert!(
         !storage.is_empty(),
         "At least one storage entry must exist from deserializing stream"

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -3,7 +3,7 @@
 use {
     super::*,
     crate::{
-        account_storage::AccountStorageMap,
+        account_storage::{AccountStorageMap, AccountStorageReference},
         accounts::Accounts,
         accounts_db::{
             get_temp_accounts_paths, test_utils::create_test_accounts, AccountShrinkThreshold,
@@ -60,15 +60,13 @@ fn copy_append_vecs<P: AsRef<Path>>(
             num_accounts,
         );
         next_append_vec_id = next_append_vec_id.max(new_storage_entry.append_vec_id());
-        storage
-            .entry(new_storage_entry.slot())
-            .or_default()
-            .write()
-            .unwrap()
-            .insert(
-                new_storage_entry.append_vec_id(),
-                Arc::new(new_storage_entry),
-            );
+        storage.insert(
+            new_storage_entry.slot(),
+            AccountStorageReference {
+                id: new_storage_entry.append_vec_id(),
+                storage: Arc::new(new_storage_entry),
+            },
+        );
     }
 
     Ok(StorageAndNextAppendVecId {

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -317,6 +317,7 @@ impl SnapshotStorageRebuilder {
             })
             .collect::<Result<HashMap<AppendVecId, Arc<AccountStorageEntry>>, std::io::Error>>()?;
 
+        assert_eq!(slot_stores.len(), 1);
         let (id, storage) = slot_stores.drain().next().unwrap();
         self.storage
             .insert(slot, AccountStorageReference { id, storage });

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -1,11 +1,9 @@
 //! Provides interfaces for rebuilding snapshot storages
 
-use crate::account_storage::AccountStorageReference;
-
 use {
     super::{get_io_error, snapshot_version_from_file, SnapshotError, SnapshotVersion},
     crate::{
-        account_storage::AccountStorageMap,
+        account_storage::{AccountStorageMap, AccountStorageReference},
         accounts_db::{AccountStorageEntry, AppendVecId, AtomicAppendVecId},
         serde_snapshot::{
             self, remap_and_reconstruct_single_storage, snapshot_storage_lengths_from_fields,


### PR DESCRIPTION
#### Problem
Moving to 1 append vec per slot.

#### Summary of Changes
Change data type in `AccountStorage` to a single `Arc<AccountStorageEntry>` instead of `Vec<Arc<AccountStorageEntry>>`
It will now no longer be possible to have anything but 1 append vec per slot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
