### PR TITLE
Adds symmetric tests for all cases of un-/re-/deployment inside the same transaction

### DIFF
--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -167,9 +167,6 @@ pub fn load_upgradeable_program(
     authority_keypair: &Keypair,
     name: &str,
 ) {
-    let program_pubkey = executable_keypair.pubkey();
-    let authority_pubkey = authority_keypair.pubkey();
-
     let program = load_upgradeable_buffer(
         bank_client,
         from_keypair,
@@ -181,9 +178,9 @@ pub fn load_upgradeable_program(
     let message = Message::new(
         &bpf_loader_upgradeable::deploy_with_max_program_len(
             &from_keypair.pubkey(),
-            &program_pubkey,
+            &executable_keypair.pubkey(),
             &buffer_keypair.pubkey(),
-            &authority_pubkey,
+            &authority_keypair.pubkey(),
             1.max(
                 bank_client
                     .get_minimum_balance_for_rent_exemption(


### PR DESCRIPTION
#### Problem

The state of the madness is currently neither documented nor covered by test cases (except for redeployment). Here is the effect of a top-level upgradeable loader instruction on subsequent instructions in the same transaction:

| Action | top-level-instruction | CPI-instruction |
| --- | --- | --- |
| deployment | invisible | visible |
| redeployment (upgrade) | visible | visible |
| undeployment (close) | invisible | invisible |

CPI-instructions themselves can not invoke the upgradeable loader to perform these actions.

#### Summary of Changes
- Unifies `test_program_sbf_upgrade_and_invoke_in_same_tx()` and `test_program_sbf_upgrade_self_via_cpi()` into `test_program_sbf_invoke_in_same_tx_as_redeployment()`.
- Adds `test_program_sbf_invoke_in_same_tx_as_deployment()` and `test_program_sbf_invoke_in_same_tx_as_undeployment()`.
