### PR TITLE
Changes AccountsHash into an enum

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
             }
             println!(
                 "hash,{},{},{},{}%",
-                results.0 .0,
+                results.0.as_hash(),
                 time,
                 time_store,
                 (time_store.as_us() as f64 / time.as_us() as f64 * 100.0f64) as u32

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -314,7 +314,8 @@ impl AccountsHashVerifier {
         if accounts_package.package_type == AccountsPackageType::EpochAccountsHash {
             info!(
                 "saving epoch accounts hash, slot: {}, hash: {}",
-                accounts_package.slot, accounts_hash.0,
+                accounts_package.slot,
+                accounts_hash.as_hash(),
             );
             let epoch_accounts_hash = EpochAccountsHash::from(accounts_hash);
             accounts_package
@@ -349,11 +350,11 @@ impl AccountsHashVerifier {
             && accounts_package.slot % fault_injection_rate_slots == 0
         {
             // For testing, publish an invalid hash to gossip.
-            let fault_hash = Self::generate_fault_hash(&accounts_hash.0);
+            let fault_hash = Self::generate_fault_hash(accounts_hash.as_hash());
             warn!("inserting fault at slot: {}", accounts_package.slot);
             hashes.push((accounts_package.slot, fault_hash));
         } else {
-            hashes.push((accounts_package.slot, accounts_hash.0));
+            hashes.push((accounts_package.slot, accounts_hash.to_hash()));
         }
 
         retain_max_n_elements(hashes, MAX_SNAPSHOT_HASHES);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -529,10 +529,11 @@ fn test_concurrent_snapshot_packaging(
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
                 accounts_package.snapshot_links_dir(),
                 accounts_package.slot,
-                &AccountsHash::default(),
+                &AccountsHash::Full(Hash::default()),
                 None,
             );
-            let snapshot_package = SnapshotPackage::new(accounts_package, AccountsHash::default());
+            let snapshot_package =
+                SnapshotPackage::new(accounts_package, AccountsHash::Full(Hash::default()));
             pending_snapshot_package
                 .lock()
                 .unwrap()
@@ -573,7 +574,7 @@ fn test_concurrent_snapshot_packaging(
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         saved_snapshots_dir.path(),
         saved_slot,
-        &AccountsHash::default(),
+        &AccountsHash::Full(Hash::default()),
         None,
     );
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1117,8 +1117,24 @@ pub enum ZeroLamportAccounts {
 }
 
 /// Hash of accounts
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, AbiExample)]
-pub struct AccountsHash(pub Hash);
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, AbiExample)]
+pub enum AccountsHash {
+    Full(Hash),
+    Incremental(Hash),
+}
+
+impl AccountsHash {
+    pub const fn as_hash(&self) -> &Hash {
+        match self {
+            AccountsHash::Full(hash) | AccountsHash::Incremental(hash) => hash,
+        }
+    }
+    pub const fn to_hash(self) -> Hash {
+        match self {
+            AccountsHash::Full(hash) | AccountsHash::Incremental(hash) => hash,
+        }
+    }
+}
 
 #[cfg(test)]
 pub mod tests {

--- a/runtime/src/epoch_accounts_hash.rs
+++ b/runtime/src/epoch_accounts_hash.rs
@@ -35,6 +35,9 @@ impl EpochAccountsHash {
 
 impl From<AccountsHash> for EpochAccountsHash {
     fn from(accounts_hash: AccountsHash) -> EpochAccountsHash {
-        Self::new(accounts_hash.0)
+        match accounts_hash {
+            AccountsHash::Full(hash) => Self::new(hash),
+            _ => panic!("an epoch accounts hash *must* come from a full accounts hash"),
+        }
     }
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -284,7 +284,7 @@ fn test_bank_serialize_style(
     .unwrap();
 
     let accounts_hash = if update_accounts_hash {
-        let accounts_hash = AccountsHash(Hash::new(&[1; 32]));
+        let accounts_hash = AccountsHash::Full(Hash::new(&[1; 32]));
         bank2
             .accounts()
             .accounts_db

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -61,10 +61,10 @@ impl SnapshotHash {
         epoch_accounts_hash: Option<&EpochAccountsHash>,
     ) -> Self {
         let snapshot_hash = match epoch_accounts_hash {
-            None => accounts_hash.0,
+            None => *accounts_hash.as_hash(),
             Some(epoch_accounts_hash) => {
                 let mut hasher = Hasher::default();
-                hasher.hash(accounts_hash.0.as_ref());
+                hasher.hash(accounts_hash.as_hash().as_ref());
                 hasher.hash(epoch_accounts_hash.as_ref().as_ref());
                 hasher.result()
             }


### PR DESCRIPTION
#### Problem

There is not a way to disambiguate between a full accounts hash and an incremental accounts hash _in the type system_. This could lead to inadvertent issues where a full accounts hash is used in place of an incremental accounts hash, or vice-versa.


#### Summary of Changes

Change AccountsHash into an enum with Full and Incremental variants.