### PR TITLE
Increase turbine propagation const

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -200,11 +200,11 @@ pub mod test {
     use {
         super::*,
         solana_ledger::{
-            blockstore::{Blockstore, MAX_TURBINE_PROPAGATION_IN_MS},
+            blockstore::{Blockstore, MAX_TURBINE_PROPAGATION},
             get_tmp_ledger_path,
         },
         solana_sdk::hash::Hash,
-        std::{thread::sleep, time::Duration},
+        std::thread::sleep,
         trees::{tr, Tree, TreeWalk},
     };
 
@@ -256,7 +256,7 @@ pub mod test {
             Hash::default(),
         );
         let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
-        sleep(Duration::from_millis(MAX_TURBINE_PROPAGATION_IN_MS));
+        sleep(MAX_TURBINE_PROPAGATION);
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
         let repairs = get_closest_completion(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -70,6 +70,7 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc, Mutex, RwLock, RwLockWriteGuard,
         },
+        time::Duration,
     },
     tempfile::{Builder, TempDir},
     thiserror::Error,
@@ -103,8 +104,9 @@ lazy_static! {
 
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
-pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 200;
-pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_PER_TICK;
+pub const MAX_TURBINE_PROPAGATION: Duration = Duration::from_millis(200);
+pub const MAX_TURBINE_DELAY_IN_TICKS: u64 =
+    MAX_TURBINE_PROPAGATION.as_millis() as u64 / MS_PER_TICK;
 
 // An upper bound on maximum number of data shreds we can handle in a slot
 // 32K shreds would allow ~320K peak TPS

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -103,7 +103,7 @@ lazy_static! {
 
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
-pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 100;
+pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 200;
 pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_PER_TICK;
 
 // An upper bound on maximum number of data shreds we can handle in a slot


### PR DESCRIPTION
#### Problem
`MAX_TURBINE_PROPAGATION_IN_MS` is used as a delay threshold for issuing shred repairs and analysis (see #28638) is showing we are overly aggressive in requesting repairs. Shreds show up via turbine before the repair completes the vast majority of the time

#### Summary of Changes
Increase constant from 100ms to 200ms. This value was shown to significantly reduce the number of repairs requested without impacting block 'is_full' times