### PR TITLE
Revert "Do not exclude failed simple vote transactions from consensus"

### DIFF
--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -43,8 +43,8 @@ pub fn find_and_send_votes(
         sanitized_txs
             .iter()
             .zip(execution_results.iter())
-            .for_each(|(tx, _result)| {
-                if tx.is_simple_vote_transaction() {
+            .for_each(|(tx, result)| {
+                if tx.is_simple_vote_transaction() && result.was_executed_successfully() {
                     if let Some(parsed_vote) = vote_parser::parse_sanitized_vote_transaction(tx) {
                         if parsed_vote.1.last_voted_slot().is_some() {
                             let _ = vote_sender.send(parsed_vote);


### PR DESCRIPTION
This reverts commit b4237f3f2cbdacc06ca9b81f54e6b096cc3b4110.

#### Problem
Usually votes ingested from gossip for optimistic confirmation are verified in `ClusterInfoVoteListener` via `verify_votes` in `recv_loop()`: https://github.com/solana-labs/solana/blob/b1340d77a2166448b18b7c6042261fac07599f8b/core/src/cluster_info_vote_listener.rs#L320-L323

However, votes sent from `BankingStage` and `ReplayStage` to `ClusterInfoVoteListener` are ingested via a separate loop https://github.com/solana-labs/solana/blob/b1340d77a2166448b18b7c6042261fac07599f8b/core/src/cluster_info_vote_listener.rs#L291
`process_votes_loop()`, where it's assumed that those votes have been verified by `BankingStage` and `ReplayStage`.

Thus signatures of authorized voters sent from `ReplayStage` and `BankingStage` are not verified in `ClusterInfoVoteListener` for optimistic confirmation.

Because the commit removed the `was_executed_successfully` check in  from `ReplayStage` and `BankingStage` then this means optimistic confirmation can be fooled by bad votes.

This has been verified by local cluster test: https://github.com/carllin/solana/commit/160dbaffc71b50e648a08c1805f338416ebe7810 where we see an invalid vote make it into optimistic confirmation.

```
BankingStage transaction from EbPnteLdv3FegMSG8sWprQiNffhCSeaba8CqS2eX12YX was success: false, slots: [0, 1]
Optimistic conf got vote pubkey from EbPnteLdv3FegMSG8sWprQiNffhCSeaba8CqS2eX12YX for slots [0, 1]
```

Thanks @ryoqun for the find!

#### Summary of Changes
Change is only on testnet in 1.14, so revert change that allowed invalid votes to be sent from replay and bankingstage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
