### PR TITLE
vote: encapsulate `Lockout`

### DIFF
--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -22,8 +22,8 @@ pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
         .votes
         .iter()
         .map(|lockout| UiLockout {
-            slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            slot: lockout.slot(),
+            confirmation_count: lockout.confirmation_count(),
         })
         .collect();
     let authorized_voters = vote_state
@@ -92,8 +92,8 @@ struct UiLockout {
 impl From<&Lockout> for UiLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
-            slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            slot: lockout.slot(),
+            confirmation_count: lockout.confirmation_count(),
         }
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1536,8 +1536,8 @@ pub struct CliLockout {
 impl From<&Lockout> for CliLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
-            slot: lockout.slot,
-            confirmation_count: lockout.confirmation_count,
+            slot: lockout.slot(),
+            confirmation_count: lockout.confirmation_count(),
         }
     }
 }

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -227,11 +227,11 @@ impl AggregateCommitmentService {
         }
 
         for vote in &vote_state.votes {
-            while ancestors[ancestors_index] <= vote.slot {
+            while ancestors[ancestors_index] <= vote.slot() {
                 commitment
                     .entry(ancestors[ancestors_index])
                     .or_insert_with(BlockCommitment::default)
-                    .increase_confirmation_stake(vote.confirmation_count as usize, lamports);
+                    .increase_confirmation_stake(vote.confirmation_count() as usize, lamports);
                 ancestors_index += 1;
 
                 if ancestors_index == ancestors.len() {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2840,7 +2840,7 @@ impl ReplayStage {
                                         bank_vote_state.root_slot = Some(local_root);
                                         bank_vote_state
                                             .votes
-                                            .retain(|lockout| lockout.slot > local_root);
+                                            .retain(|lockout| lockout.slot() > local_root);
                                         info!(
                                             "Local root is larger than on chain root,
                                             overwrote bank root {:?} and updated votes {:?}",
@@ -2849,7 +2849,7 @@ impl ReplayStage {
 
                                         if let Some(first_vote) = bank_vote_state.votes.front() {
                                             assert!(ancestors
-                                                .get(&first_vote.slot)
+                                                .get(&first_vote.slot())
                                                 .expect(
                                                     "Ancestors map must contain an
                                                         entry for all slots on this fork

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -713,9 +713,8 @@ mod tests {
         // Now send some new votes
         for i in 101..201 {
             let slots = std::iter::zip((i - 30)..(i + 1), (1..32).rev())
-                .map(|(slot, confirmation_count)| Lockout {
-                    slot,
-                    confirmation_count,
+                .map(|(slot, confirmation_count)| {
+                    Lockout::new_with_confirmation_count(slot, confirmation_count)
                 })
                 .collect::<VecDeque<Lockout>>();
             let vote = VoteTransaction::from(VoteStateUpdate::new(

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -111,7 +111,7 @@ impl VoteSimulator {
                         .unwrap()
                         .votes
                         .iter()
-                        .any(|lockout| lockout.slot == parent));
+                        .any(|lockout| lockout.slot() == parent));
                 }
             }
             while new_bank.tick_height() < new_bank.max_tick_height() {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -516,13 +516,13 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
             let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
             if let Some(last_vote) = vote_state.votes.iter().last() {
                 let entry = last_votes.entry(vote_state.node_pubkey).or_insert((
-                    last_vote.slot,
+                    last_vote.slot(),
                     vote_state.clone(),
                     *stake,
                     total_stake,
                 ));
-                if entry.0 < last_vote.slot {
-                    *entry = (last_vote.slot, vote_state.clone(), *stake, total_stake);
+                if entry.0 < last_vote.slot() {
+                    *entry = (last_vote.slot(), vote_state.clone(), *stake, total_stake);
                 }
             }
         }
@@ -558,7 +558,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                 if let Some(last_vote) = vote_state.votes.iter().last() {
                     let validator_votes = all_votes.entry(vote_state.node_pubkey).or_default();
                     validator_votes
-                        .entry(last_vote.slot)
+                        .entry(last_vote.slot())
                         .or_insert_with(|| vote_state.clone());
                 }
             }
@@ -662,7 +662,8 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                             .iter()
                             .map(|vote| format!(
                                 "slot {} (conf={})",
-                                vote.slot, vote.confirmation_count
+                                vote.slot(),
+                                vote.confirmation_count()
                             ))
                             .collect::<Vec<_>>()
                             .join("\n")
@@ -673,7 +674,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                         vote_state
                             .votes
                             .back()
-                            .map(|vote| vote.slot.to_string())
+                            .map(|vote| vote.slot().to_string())
                             .unwrap_or_else(|| "none".to_string())
                     )
                 };
@@ -721,7 +722,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                     vote_state
                         .votes
                         .iter()
-                        .map(|vote| format!("slot {} (conf={})", vote.slot, vote.confirmation_count))
+                        .map(|vote| format!("slot {} (conf={})", vote.slot(), vote.confirmation_count()))
                         .collect::<Vec<_>>()
                         .join("\n")
                 ));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -936,7 +936,7 @@ impl JsonRpcRequestProcessor {
                 let vote_state = account.vote_state();
                 let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
                 let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
-                    vote.slot
+                    vote.slot()
                 } else {
                     0
                 };

--- a/runtime/src/vote_transaction.rs
+++ b/runtime/src/vote_transaction.rs
@@ -19,7 +19,7 @@ impl VoteTransaction {
             VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update
                 .lockouts
                 .iter()
-                .map(|lockout| lockout.slot)
+                .map(|lockout| lockout.slot())
                 .collect(),
         }
     }
@@ -51,7 +51,7 @@ impl VoteTransaction {
         match self {
             VoteTransaction::Vote(vote) => vote.slots.last().copied(),
             VoteTransaction::VoteStateUpdate(vote_state_update) => {
-                Some(vote_state_update.lockouts.back()?.slot)
+                Some(vote_state_update.lockouts.back()?.slot())
             }
         }
     }


### PR DESCRIPTION
#### Problem

lack of encapsulation in `vote_state::Lockout` clutters https://github.com/solana-labs/solana/pull/29524 with unnecessary plumbing

#### Summary of Changes

encapsulate it

this should be purely cosmetic aside from the note below