### PR TITLE
ci: fix commit range in push event

### DIFF
--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get commit range (push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          echo "COMMIT_RANGE=$GITHUB_SHA" >> $GITHUB_ENV
+          echo "COMMIT_RANGE=HEAD~1..$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Get commit range (pull_request)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get commit range (push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          echo "COMMIT_RANGE=HEAD~1..$GITHUB_SHA" >> $GITHUB_ENV
+          echo "COMMIT_RANGE=${{ github.event.before }}..$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Get commit range (pull_request)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get commit range (push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          echo "COMMIT_RANGE=$GITHUB_SHA" >> $GITHUB_ENV
+          echo "COMMIT_RANGE=HEAD~1..$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Get commit range (pull_request)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get commit range (push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          echo "COMMIT_RANGE=HEAD~1..$GITHUB_SHA" >> $GITHUB_ENV
+          echo "COMMIT_RANGE=${{ github.event.before }}..$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Get commit range (pull_request)
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
#### Problem

I only set current commit for push event as COMMIT_RANGE so we got empty value when we `git diff $COMMIT_RANGE`

#### Summary of Changes

use HEAD~1..HEAD as commit range
