### PR TITLE
Explorer: Fix crash on failed anchor account parsing

### DIFF
--- a/explorer/src/components/account/AnchorAccountCard.tsx
+++ b/explorer/src/components/account/AnchorAccountCard.tsx
@@ -27,7 +27,11 @@ export function AnchorAccountCard({ account }: { account: Account }) {
       );
       if (accountDefTmp) {
         accountDef = accountDefTmp;
-        decodedAccountData = coder.decode(accountDef.name, rawData);
+        try {
+          decodedAccountData = coder.decode(accountDef.name, rawData);
+        } catch (err) {
+          console.log(err);
+        }
       }
     }
 


### PR DESCRIPTION
#### Problem
In the explorer, the `/anchor-account` card throws an unhandled error and crashes in case the anchor account parsing fails.

Example: https://explorer.solana.com/address/5VsCBvW7CswQfYe5rQdP9W5tSWb2rEZBQZ2C8wU7qrnL/anchor-account

#### Summary of Changes
Add error handling to print the error out to the console and have the card display the `ErrorCard` instead of crashing the explorer.

Fixes #29294 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
