### PR TITLE
Use RangeBounds for is_within_range

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -348,7 +348,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
             Arg::with_name("num_conflict_groups")
                 .long("num-conflict-groups")
                 .takes_value(true)
-                .validator(|arg| is_within_range(arg, 1, usize::MAX - 1))
+                .validator(|arg| is_within_range(arg, 1..))
                 .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
         )
 }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -7,7 +7,7 @@ use {
         pubkey::{Pubkey, MAX_SEED_LEN},
         signature::{read_keypair_file, Signature},
     },
-    std::{fmt::Display, str::FromStr},
+    std::{fmt::Display, ops::RangeBounds, str::FromStr},
 };
 
 fn is_parsable_generic<U, T>(string: T) -> Result<(), String>
@@ -35,18 +35,16 @@ where
 
 // Return an error if string cannot be parsed as numeric type T, and value not within specified
 // range
-pub fn is_within_range<T>(string: String, range_min: T, range_max: T) -> Result<(), String>
+pub fn is_within_range<T, R>(string: String, range: R) -> Result<(), String>
 where
     T: FromStr + Copy + std::fmt::Debug + PartialOrd + std::ops::Add<Output = T> + From<usize>,
     T::Err: Display,
+    R: RangeBounds<T> + std::fmt::Debug,
 {
     match string.parse::<T>() {
         Ok(input) => {
-            let range = range_min..range_max + 1.into();
             if !range.contains(&input) {
-                Err(format!(
-                    "input '{input:?}' out of range ({range_min:?}..{range_max:?}]"
-                ))
+                Err(format!("input '{input:?}' out of range {range:?}"))
             } else {
                 Ok(())
             }

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -7,7 +7,7 @@ use {
         pubkey::{Pubkey, MAX_SEED_LEN},
         signature::{read_keypair_file, Signature},
     },
-    std::{fmt::Display, str::FromStr},
+    std::{fmt::Display, ops::RangeBounds, str::FromStr},
 };
 
 fn is_parsable_generic<U, T>(string: T) -> Result<(), String>
@@ -35,18 +35,16 @@ where
 
 // Return an error if string cannot be parsed as numeric type T, and value not within specified
 // range
-pub fn is_within_range<T>(string: String, range_min: T, range_max: T) -> Result<(), String>
+pub fn is_within_range<T, R>(string: String, range: R) -> Result<(), String>
 where
     T: FromStr + Copy + std::fmt::Debug + PartialOrd + std::ops::Add<Output = T> + From<usize>,
     T::Err: Display,
+    R: RangeBounds<T> + std::fmt::Debug,
 {
     match string.parse::<T>() {
         Ok(input) => {
-            let range = range_min..range_max + 1.into();
             if !range.contains(&input) {
-                Err(format!(
-                    "input '{input:?}' out of range ({range_min:?}..{range_max:?}]"
-                ))
+                Err(format!("input '{input:?}' out of range {range:?}"))
             } else {
                 Ok(())
             }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -686,7 +686,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .long("num-rewards-epochs")
                         .takes_value(true)
                         .value_name("NUM")
-                        .validator(|s| is_within_range(s, 1, 10))
+                        .validator(|s| is_within_range(s, 1..=10))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -338,7 +338,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .long("num-rewards-epochs")
                         .takes_value(true)
                         .value_name("NUM")
-                        .validator(|s| is_within_range(s, 1, 10))
+                        .validator(|s| is_within_range(s, 1..=10))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -963,7 +963,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MILLISECS")
                 .hidden(true)
                 .takes_value(true)
-                .validator(|s| is_within_range(s, 1, MAX_BATCH_SEND_RATE_MS))
+                .validator(|s| is_within_range(s, 1..=MAX_BATCH_SEND_RATE_MS))
                 .default_value(&default_args.rpc_send_transaction_batch_ms)
                 .help("The rate at which transactions sent via rpc service are sent in batch."),
         )
@@ -999,7 +999,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .hidden(true)
                 .takes_value(true)
-                .validator(|s| is_within_range(s, 1, MAX_TRANSACTION_BATCH_SIZE))
+                .validator(|s| is_within_range(s, 1..=MAX_TRANSACTION_BATCH_SIZE))
                 .default_value(&default_args.rpc_send_transaction_batch_size)
                 .help("The size of transactions to be sent in batch."),
         )


### PR DESCRIPTION
#### Problem
Wanted to re-use this validator code in #29513 to check the value is in the range `1..`.

#### Summary of Changes
Made `is_within_range` more generic. This does change formatting of the range on error (looks like rust ranges: `input '0' out of range 1..`) 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
