### PR TITLE
Explorer: Add toggle for raw tx logs

### DIFF
--- a/explorer/src/components/transaction/ProgramLogSection.tsx
+++ b/explorer/src/components/transaction/ProgramLogSection.tsx
@@ -4,8 +4,10 @@ import { useTransactionDetails } from "providers/transactions";
 import { ProgramLogsCardBody } from "components/ProgramLogsCardBody";
 import { parseProgramLogs } from "utils/program-logs";
 import { useCluster } from "providers/cluster";
+import { TableCardBody } from "components/common/TableCardBody";
 
 export function ProgramLogSection({ signature }: SignatureProps) {
+  const [showRaw, setShowRaw] = React.useState(false);
   const { cluster, url } = useCluster();
   const details = useTransactionDetails(signature);
 
@@ -26,14 +28,27 @@ export function ProgramLogSection({ signature }: SignatureProps) {
       <div className="card">
         <div className="card-header">
           <h3 className="card-header-title">Program Instruction Logs</h3>
+          <button
+            className={`btn btn-sm d-flex ${
+              showRaw ? "btn-black active" : "btn-white"
+            }`}
+            onClick={() => setShowRaw((r) => !r)}
+          >
+            <span className="fe fe-code me-1"></span>
+            Raw
+          </button>
         </div>
         {prettyLogs !== null ? (
-          <ProgramLogsCardBody
-            message={message}
-            logs={prettyLogs}
-            cluster={cluster}
-            url={url}
-          />
+          showRaw ? (
+            <RawProgramLogs raw={logMessages!} />
+          ) : (
+            <ProgramLogsCardBody
+              message={message}
+              logs={prettyLogs}
+              cluster={cluster}
+              url={url}
+            />
+          )
         ) : (
           <div className="card-body">
             Logs not supported for this transaction
@@ -43,3 +58,15 @@ export function ProgramLogSection({ signature }: SignatureProps) {
     </>
   );
 }
+
+const RawProgramLogs = ({ raw }: { raw: string[] }) => {
+  return (
+    <TableCardBody>
+      <tr>
+        <td>
+          <pre className="text-start">{JSON.stringify(raw, null, 2)}</pre>
+        </td>
+      </tr>
+    </TableCardBody>
+  );
+};


### PR DESCRIPTION
#### Problem
There is no way to view raw program instruction logs of historical data for debugging purposes on the explorer

The following screenshots are from the following transaction on devnet: https://explorer.solana.com/tx/3x661bDMK811eRhrZ1uNXRKBm963qREKdhve1bKzoSE572N6v5P4oRCXiHb5PL3oeU9QxcjgDN3XtN3qW8JmXSn8?cluster=devnet

Before the changes:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/50625504/213325200-b07e051c-a544-41c4-bac9-630b8e12d520.png">

After the changes:
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/50625504/213325252-42e04822-796c-414f-863b-816376eb50e3.png">

After the changes, on clicking the `<> Raw` button:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/50625504/213324219-17af5250-4130-41ad-b841-2285a05a147d.png">

#### Summary of Changes
Add the `<> Raw` button to the program instruction logs like it is done for the instruction and have it display the raw logs



Fixes #23784
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
