### PR TITLE
Clear parent in repair weighting when dumping from replay

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -421,7 +421,7 @@ impl HeaviestSubtreeForkChoice {
     /// Returns the subtree originating from `slot_hash_key`
     pub fn split_off(&mut self, slot_hash_key: &SlotHashKey) -> Self {
         assert_ne!(self.tree_root, *slot_hash_key);
-        let split_tree_root = {
+        let mut split_tree_root = {
             let mut node_to_split_at = self
                 .fork_infos
                 .get_mut(slot_hash_key)
@@ -464,6 +464,7 @@ impl HeaviestSubtreeForkChoice {
 
         // Update the root of the new tree with the proper info, now that we have finished
         // aggregating
+        split_tree_root.parent = None;
         split_tree_fork_infos.insert(*slot_hash_key, split_tree_root);
 
         // Split off the relevant votes to the new tree
@@ -3541,6 +3542,13 @@ mod test {
             stake,
             tree.stake_voted_subtree(&(6, Hash::default())).unwrap()
         );
+
+        assert!(tree
+            .fork_infos
+            .get(&tree.tree_root)
+            .unwrap()
+            .parent
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
When dumping slot from replay the parent info wasn't being properly cleared (although the tree was orphaned) in the repair weighting tree. This causes a panic if you have a chain of dumped slots all orphaned together that then link back in the same manner. 

```thread 'solRepairSvc' panicked at 'called `Option::unwrap()` on a `None` value', core/src/heaviest_subtree_fork_choice.rs:589:42```

#### Summary of Changes
Clear the parent + add test

Additionally this fixes the flakiness in the `test_duplicate_shreds_broadcast_leader` local-cluster test. 

Fixes #29792 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
