### PR TITLE
removes manual implementations of Default for enums

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -84,15 +84,10 @@ pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 4;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
 pub enum SnapshotVersion {
+    #[default]
     V1_2_0,
-}
-
-impl Default for SnapshotVersion {
-    fn default() -> Self {
-        SnapshotVersion::V1_2_0
-    }
 }
 
 impl fmt::Display for SnapshotVersion {

--- a/sdk/program/src/nonce/state/current.rs
+++ b/sdk/program/src/nonce/state/current.rs
@@ -67,16 +67,11 @@ impl DurableNonce {
 ///
 /// When created in memory with [`State::default`] or when deserialized from an
 /// uninitialized account, a nonce account will be [`State::Uninitialized`].
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum State {
+    #[default]
     Uninitialized,
     Initialized(Data),
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::Uninitialized
-    }
 }
 
 impl State {

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -16,9 +16,10 @@ use {
 
 pub type StakeActivationStatus = StakeHistoryEntry;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub enum StakeState {
+    #[default]
     Uninitialized,
     Initialized(Meta),
     Stake(Meta, Stake),
@@ -63,12 +64,6 @@ impl BorshSerialize for StakeState {
             }
             StakeState::RewardsPool => writer.write_all(&3u32.to_le_bytes()),
         }
-    }
-}
-
-impl Default for StakeState {
-    fn default() -> Self {
-        StakeState::Uninitialized
     }
 }
 


### PR DESCRIPTION
#### Problem
Manual `impl Default for` enums is unnecessary and verbose.

#### Summary of Changes
removed manual implementations of `Default` for enums