### PR TITLE
validator: remove `--no-duplicate-instance-check`

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1283,13 +1283,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        inclusive."),
         )
         .arg(
-            Arg::with_name("no_duplicate_instance_check")
-                .long("no-duplicate-instance-check")
-                .takes_value(false)
-                .help("Disables duplicate instance check")
-                .hidden(true),
-        )
-        .arg(
             Arg::with_name("allow_private_addr")
                 .long("allow-private-addr")
                 .takes_value(false)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1594,7 +1594,7 @@ pub fn main() {
 
     let identity_keypair = Arc::new(identity_keypair);
 
-    let should_check_duplicate_instance = !matches.is_present("no_duplicate_instance_check");
+    let should_check_duplicate_instance = true;
     if !cluster_entrypoints.is_empty() {
         bootstrap::rpc_bootstrap(
             &node,


### PR DESCRIPTION
#### Problem

operators pass `--no-duplicate-instance-check` without understanding its repercussions

#### Summary of Changes

remove it, retaining plumbing in case we need it for testing