### PR TITLE
[WIP] keygen: improve grind when starts with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-st"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b428d1a595e7ea6e853401f52e452c7afc281a2335b6115525e1a3002aa3a4f6"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5683,6 +5689,7 @@ dependencies = [
  "bs58",
  "clap 3.1.8",
  "dirs-next",
+ "lazy-st",
  "num_cpus",
  "solana-clap-v3-utils",
  "solana-cli-config",

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 bs58 = "0.4.0"
 clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = "2.0.0"
+lazy-st = "0.2.2"
 num_cpus = "1.13.1"
 solana-clap-v3-utils = { path = "../clap-v3-utils", version = "=1.16.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.16.0" }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -752,9 +752,10 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         let attempts = attempts.fetch_add(1, Ordering::Relaxed);
                         if attempts % 1_000_000 == 0 {
                             println!(
-                                "Searched {} keypairs in {}s. {} matches found.",
+                                "Searched {} keypairs in {}s (avg: {:.3} Mkps). {} matches found.",
                                 attempts,
                                 start.elapsed().as_secs(),
+                                attempts as f64 / start.elapsed().as_micros() as f64,
                                 found.load(Ordering::Relaxed),
                             );
                         }


### PR DESCRIPTION
#### Problem

While grinding for start characters it's possible to compare bytes first, and then characters. Converting pubkey to address is expensive, so it can be done as late as possible.

#### Summary of Changes

 - Add a cache of possible bytes that represent the start of addresses
 - First compare bytes
 - Make pubkey-to-address conversion lazy

#### Results
5950x:
Before: 1.045 Mkps (kps - keypair per second)
After: 1.121 Mkps
