### PR TITLE
Refactors calculate_capitalization()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,8 +4,8 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, CalcAccountsHashDataSource, IncludeSlotInHash, LoadHint, LoadedAccount,
-            ScanStorageResult, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            BankHashInfo, IncludeSlotInHash, LoadHint, LoadedAccount, ScanStorageResult,
+            ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
             AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError, ScanResult, ZeroLamport,
@@ -759,34 +759,6 @@ impl Accounts {
             .into_iter()
             .map(|Reverse((balance, pubkey))| (pubkey, balance))
             .collect())
-    }
-
-    /// only called at startup vs steady-state runtime
-    pub fn calculate_capitalization(
-        &self,
-        ancestors: &Ancestors,
-        slot: Slot,
-        debug_verify: bool,
-        epoch_schedule: &EpochSchedule,
-        rent_collector: &RentCollector,
-        data_source: CalcAccountsHashDataSource,
-    ) -> u64 {
-        let is_startup = true;
-        self.accounts_db
-            .verify_accounts_hash_in_bg
-            .wait_for_complete();
-        self.accounts_db
-            .update_accounts_hash(
-                data_source,
-                debug_verify,
-                slot,
-                ancestors,
-                None,
-                epoch_schedule,
-                rent_collector,
-                is_startup,
-            )
-            .1
     }
 
     /// Only called from startup or test code.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6899,15 +6899,27 @@ impl Bank {
 
     /// only called from ledger-tool or tests
     fn calculate_capitalization(&self, debug_verify: bool) -> u64 {
-        self.rc.accounts.calculate_capitalization(
-            &self.ancestors,
-            self.slot(),
-            debug_verify,
-            self.epoch_schedule(),
-            &self.rent_collector,
-            // we have to use the index since the slot could be in the write cache still
-            CalcAccountsHashDataSource::IndexForTests,
-        )
+        let is_startup = true;
+        self.rc
+            .accounts
+            .accounts_db
+            .verify_accounts_hash_in_bg
+            .wait_for_complete();
+        self.rc
+            .accounts
+            .accounts_db
+            .update_accounts_hash(
+                // we have to use the index since the slot could be in the write cache still
+                CalcAccountsHashDataSource::IndexForTests,
+                debug_verify,
+                self.slot(),
+                &self.ancestors,
+                None,
+                self.epoch_schedule(),
+                &self.rent_collector,
+                is_startup,
+            )
+            .1
     }
 
     /// only called from tests or ledger tool


### PR DESCRIPTION
#### Problem

`Accounts::calculate_capitalization()` is only called in one place, by `Bank`. This family of functions is also only called from tests or ledger-tool, and the comments on the `Accounts` fn did not include this information. And one more indirection is unnecessary.


#### Summary of Changes

Move the impl into Bank, and remove the fn from Accounts.