### PR TITLE
add cost to additional built-in programs

### DIFF
--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -3,8 +3,8 @@
 use {
     lazy_static::lazy_static,
     solana_sdk::{
-        bpf_loader_upgradeable, compute_budget, ed25519_program, feature, incinerator,
-        native_loader, pubkey::Pubkey, secp256k1_program, system_program,
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, ed25519_program,
+        feature, incinerator, native_loader, pubkey::Pubkey, secp256k1_program, system_program,
     },
     std::collections::HashMap,
 };
@@ -44,7 +44,9 @@ lazy_static! {
         (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
         (compute_budget::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
         (solana_address_lookup_table_program::id(), COMPUTE_UNIT_TO_US_RATIO * 25),
-        (bpf_loader_upgradeable::id(), COMPUTE_UNIT_TO_US_RATIO * 775),
+        (bpf_loader_upgradeable::id(), COMPUTE_UNIT_TO_US_RATIO * 79),
+        (bpf_loader_deprecated::id(), COMPUTE_UNIT_TO_US_RATIO * 38),
+        (bpf_loader::id(), COMPUTE_UNIT_TO_US_RATIO * 19),
     ]
     .iter()
     .cloned()

--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -3,8 +3,8 @@
 use {
     lazy_static::lazy_static,
     solana_sdk::{
-        ed25519_program, feature, incinerator, native_loader, pubkey::Pubkey, secp256k1_program,
-        system_program,
+        bpf_loader_upgradeable, compute_budget, ed25519_program, feature, incinerator,
+        native_loader, pubkey::Pubkey, secp256k1_program, system_program,
     },
     std::collections::HashMap,
 };
@@ -42,6 +42,9 @@ lazy_static! {
         (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (ed25519_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
+        (compute_budget::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
+        (solana_address_lookup_table_program::id(), COMPUTE_UNIT_TO_US_RATIO * 25),
+        (bpf_loader_upgradeable::id(), COMPUTE_UNIT_TO_US_RATIO * 775),
     ]
     .iter()
     .cloned()

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -388,7 +388,12 @@ mod tests {
             &token_transaction,
             &FeatureSet::all_enabled(),
         );
-        assert_eq!(0, tx_cost.builtins_execution_cost);
+        assert_eq!(
+            *BUILT_IN_INSTRUCTION_COSTS
+                .get(&compute_budget::id())
+                .unwrap(),
+            tx_cost.builtins_execution_cost
+        );
         assert_eq!(12_345, tx_cost.bpf_execution_cost);
         assert_eq!(1, tx_cost.data_bytes_cost);
     }


### PR DESCRIPTION
#### Problem
These three built-in programs have no cost defined. 

Replayed a random set of mainnet-beta snapshots, collected the program's executing time, compare to `system` program, the results are: 

|built-in | times of system program |
|------|------|
|ComputeBudget111111111111111111111111111111| 1 |
|AddressLookupTab1e1111111111111111111111111| 5 |
|BPFLoaderUpgradeab1e11111111111111111111111| 155|

#### Summary of Changes
Add static costs for them

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
