### PR TITLE
patches bug in sigverify-shreds when identity is hot-swapped

### DIFF
--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -1,11 +1,12 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
+    solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache, shred, sigverify_shreds::verify_shreds_gpu,
     },
     solana_perf::{self, packet::PacketBatch, recycler_cache::RecyclerCache},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_sdk::{clock::Slot, pubkey::Pubkey},
+    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signer},
     std::{
         collections::HashMap,
         sync::{
@@ -25,8 +26,7 @@ enum Error {
 }
 
 pub(crate) fn spawn_shred_sigverify(
-    // TODO: Hot swap will change pubkey.
-    self_pubkey: Pubkey,
+    cluster_info: Arc<ClusterInfo>,
     bank_forks: Arc<RwLock<BankForks>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     shred_fetch_receiver: Receiver<PacketBatch>,
@@ -39,6 +39,9 @@ pub(crate) fn spawn_shred_sigverify(
     Builder::new()
         .name("solShredVerifr".to_string())
         .spawn(move || loop {
+            // We can't store the pubkey outside the loop
+            // because the identity might be hot swapped.
+            let self_pubkey = cluster_info.keypair().pubkey();
             match run_shred_sigverify(
                 &self_pubkey,
                 &bank_forks,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -165,7 +165,7 @@ impl Tvu {
         let (verified_sender, verified_receiver) = unbounded();
         let (retransmit_sender, retransmit_receiver) = unbounded();
         let shred_sigverify = sigverify_shreds::spawn_shred_sigverify(
-            cluster_info.id(),
+            cluster_info.clone(),
             bank_forks.clone(),
             leader_schedule_cache.clone(),
             fetch_receiver,

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -82,6 +82,7 @@ impl Keypair {
 }
 
 impl Signer for Keypair {
+    #[inline]
     fn pubkey(&self) -> Pubkey {
         Pubkey::from(self.0.public.to_bytes())
     }


### PR DESCRIPTION

#### Problem
Sigverify-shreds discards shreds from node's own leader slot:
https://github.com/solana-labs/solana/blob/6baab92ab/core/src/sigverify_shreds.rs#L153-L154

But if the identity is hot-swapped the pubkey would be wrong since it is instantiated only once at startup:
https://github.com/solana-labs/solana/blob/6baab92ab/core/src/tvu.rs#L168


#### Summary of Changes
Don't store the pubkey but instead read it directly from cluster-info.