### PR TITLE
Refactor: bank.accounts() returns reference

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6317,8 +6317,8 @@ impl Bank {
         Ok(account.lamports())
     }
 
-    pub fn accounts(&self) -> Arc<Accounts> {
-        self.rc.accounts.clone()
+    pub fn accounts(&self) -> &Arc<Accounts> {
+        &self.rc.accounts
     }
 
     fn finish_init(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -307,8 +307,7 @@ impl BankForks {
             is_root_bank_squashed = eah_bank.slot() == root;
 
             eah_bank
-                .rc
-                .accounts
+                .accounts()
                 .accounts_db
                 .epoch_accounts_hash_manager
                 .set_in_flight(eah_bank.slot());
@@ -764,8 +763,7 @@ mod tests {
                         .for_each(|snapshot_request| {
                             snapshot_request
                                 .snapshot_root_bank
-                                .rc
-                                .accounts
+                                .accounts()
                                 .accounts_db
                                 .epoch_accounts_hash_manager
                                 .set_valid(

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -30,8 +30,7 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCircu
     let clock = bank.clock();
     let config = &ScanConfig::default();
     let stake_accounts = if bank
-        .rc
-        .accounts
+        .accounts()
         .accounts_db
         .account_indexes
         .contains(&AccountIndex::ProgramId)

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -203,7 +203,7 @@ impl<'a> TypeContext<'a> for Context {
         (
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'a, Self> {
-                accounts_db: &serializable_bank.bank.rc.accounts.accounts_db,
+                accounts_db: &serializable_bank.bank.accounts().accounts_db,
                 slot: serializable_bank.bank.rc.slot,
                 account_storage_entries: serializable_bank.snapshot_storages,
                 phantom: std::marker::PhantomData::default(),
@@ -234,7 +234,7 @@ impl<'a> TypeContext<'a> for Context {
         (
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'a, Self> {
-                accounts_db: &serializable_bank.bank.rc.accounts.accounts_db,
+                accounts_db: &serializable_bank.bank.accounts().accounts_db,
                 slot: serializable_bank.bank.rc.slot,
                 account_storage_entries: serializable_bank.snapshot_storages,
                 phantom: std::marker::PhantomData::default(),

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -265,8 +265,7 @@ fn test_bank_serialize_style(
     if initial_epoch_accounts_hash {
         expected_epoch_accounts_hash = Some(Hash::new(&[7; 32]));
         bank2
-            .rc
-            .accounts
+            .accounts()
             .accounts_db
             .epoch_accounts_hash_manager
             .set_valid(
@@ -377,7 +376,7 @@ fn test_bank_serialize_style(
     // Create a directory to simulate AppendVecs unpackaged from a snapshot tar
     let copied_accounts = TempDir::new().unwrap();
     let storage_and_next_append_vec_id =
-        copy_append_vecs(&bank2.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        copy_append_vecs(&bank2.accounts().accounts_db, copied_accounts.path()).unwrap();
     let mut snapshot_streams = SnapshotStreams {
         full_snapshot_stream: &mut reader,
         incremental_snapshot_stream: None,
@@ -489,7 +488,7 @@ fn test_bank_serialize_newer() {
 }
 
 fn add_root_and_flush_write_cache(bank: &Bank) {
-    bank.rc.accounts.add_root(bank.slot());
+    bank.accounts().add_root(bank.slot());
     bank.flush_accounts_cache_slot_for_tests()
 }
 
@@ -533,7 +532,7 @@ fn test_extra_fields_eof() {
     let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
     let copied_accounts = TempDir::new().unwrap();
     let storage_and_next_append_vec_id =
-        copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        copy_append_vecs(&bank.accounts().accounts_db, copied_accounts.path()).unwrap();
     let dbank = crate::serde_snapshot::bank_from_streams(
         SerdeStyle::Newer,
         &mut snapshot_streams,
@@ -661,7 +660,7 @@ fn test_blank_extra_fields() {
     let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
     let copied_accounts = TempDir::new().unwrap();
     let storage_and_next_append_vec_id =
-        copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        copy_append_vecs(&bank.accounts().accounts_db, copied_accounts.path()).unwrap();
     let dbank = crate::serde_snapshot::bank_from_streams(
         SerdeStyle::Newer,
         &mut snapshot_streams,
@@ -703,8 +702,7 @@ mod test_bank_serialize {
         S: serde::Serializer,
     {
         let snapshot_storages = bank
-            .rc
-            .accounts
+            .accounts()
             .accounts_db
             .get_snapshot_storages(..=0, None)
             .0;

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -402,7 +402,7 @@ impl<'a> SnapshotMinimizer<'a> {
 
     /// Convenience function for getting accounts_db
     fn accounts_db(&self) -> &AccountsDb {
-        &self.bank.rc.accounts.accounts_db
+        &self.bank.accounts().accounts_db
     }
 }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -152,7 +152,7 @@ impl AccountsPackage {
             snapshot_storages,
             expected_capitalization: bank.capitalization(),
             accounts_hash_for_testing,
-            accounts: bank.accounts(),
+            accounts: bank.accounts().clone(),
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
             snapshot_info,


### PR DESCRIPTION
#### Problem
We have a ton of internal and external bank uses that use `bank.rc.accounts ...`. Potentially makes future refactors more difficult - relying on internal structure of BankRc.

Additionally, may be worth considering just adding a `bank.accounts_db()` fn since gettings accounts_db is the most common use case, and would make the code even simpler.

#### Summary of Changes
Change `bank.accounts()` to return reference (`&Arc<Accounts>`).
Change uses of `bank.rc.accounts` to `bank.accounts()`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
