### PR TITLE
faucet: Expose time-slice, per-time-cap, and per-request-cap in test validator

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -330,16 +330,18 @@ pub fn request_airdrop_transaction(
 pub fn run_local_faucet_with_port(
     faucet_keypair: Keypair,
     sender: Sender<Result<SocketAddr, String>>,
+    time_input: Option<u64>,
     per_time_cap: Option<u64>,
+    per_request_cap: Option<u64>,
     port: u16, // 0 => auto assign
 ) {
     thread::spawn(move || {
         let faucet_addr = socketaddr!(0, port);
         let faucet = Arc::new(Mutex::new(Faucet::new(
             faucet_keypair,
-            None,
+            time_input,
             per_time_cap,
-            None,
+            per_request_cap,
         )));
         let runtime = Runtime::new().unwrap();
         runtime.block_on(run_faucet(faucet, faucet_addr, Some(sender)));
@@ -349,7 +351,7 @@ pub fn run_local_faucet_with_port(
 // For integration tests. Listens on random open port and reports port to Sender.
 pub fn run_local_faucet(faucet_keypair: Keypair, per_time_cap: Option<u64>) -> SocketAddr {
     let (sender, receiver) = unbounded();
-    run_local_faucet_with_port(faucet_keypair, sender, per_time_cap, 0);
+    run_local_faucet_with_port(faucet_keypair, sender, None, per_time_cap, None, 0);
     receiver
         .recv()
         .expect("run_local_faucet")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -10,7 +10,7 @@ use {
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
-    solana_faucet::faucet::FAUCET_PORT,
+    solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
@@ -2165,6 +2165,38 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 ),
         )
         .arg(
+            Arg::with_name("faucet_time_slice_secs")
+                .long("faucet-time-slice-secs")
+                .takes_value(true)
+                .value_name("SECS")
+                .default_value(default_args.faucet_time_slice_secs.as_str())
+                .help(
+                    "Time slice (in secs) over which to limit faucet requests",
+                ),
+        )
+        .arg(
+            Arg::with_name("faucet_per_time_sol_cap")
+                .long("faucet-per-time-sol-cap")
+                .takes_value(true)
+                .value_name("SOL")
+                .min_values(0)
+                .max_values(1)
+                .help(
+                    "Per-time slice limit for faucet requests, in SOL",
+                ),
+        )
+        .arg(
+            Arg::with_name("faucet_per_request_sol_cap")
+                .long("faucet-per-request-sol-cap")
+                .takes_value(true)
+                .value_name("SOL")
+                .min_values(0)
+                .max_values(1)
+                .help(
+                    "Per-request limit for faucet requests, in SOL",
+                ),
+        )
+        .arg(
             Arg::with_name("geyser_plugin_config")
                 .long("geyser-plugin-config")
                 .alias("accountsdb-plugin-config")
@@ -2214,6 +2246,7 @@ pub struct DefaultTestArgs {
     pub faucet_port: String,
     pub limit_ledger_size: String,
     pub faucet_sol: String,
+    pub faucet_time_slice_secs: String,
 }
 
 impl DefaultTestArgs {
@@ -2227,6 +2260,7 @@ impl DefaultTestArgs {
              */
             limit_ledger_size: 10_000.to_string(),
             faucet_sol: (1_000_000.).to_string(),
+            faucet_time_slice_secs: (faucet::TIME_SLICE).to_string(),
         }
     }
 }


### PR DESCRIPTION
#### Problem

Some of the faucet flags are not present in the test-validator.

#### Summary of Changes

Expose more of the faucet flags in the test-validator. I kept these in SOL to keep this consistent with the `faucet-sol` flag.