### PR TITLE
Abstract out AppendVec into AccountsFile enum

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -1,0 +1,163 @@
+use {
+    crate::{append_vec::*, storable_accounts::StorableAccounts},
+    solana_sdk::{account::ReadableAccount, clock::Slot, hash::Hash, pubkey::Pubkey},
+    std::{borrow::Borrow, io, path::PathBuf},
+};
+
+#[derive(Debug)]
+/// An enum for accessing an accounts file which can be implemented
+/// under different formats.
+pub enum AccountsFile {
+    AppendVec(AppendVec),
+}
+
+impl AccountsFile {
+    /// By default, all AccountsFile will remove its underlying file on
+    /// drop.  Calling this function to disable such behavior for this
+    /// instance.
+    pub fn set_no_remove_on_drop(&mut self) {
+        match self {
+            Self::AppendVec(av) => av.set_no_remove_on_drop(),
+        }
+    }
+
+    pub fn flush(&self) -> io::Result<()> {
+        match self {
+            Self::AppendVec(av) => av.flush(),
+        }
+    }
+
+    pub fn reset(&self) {
+        match self {
+            Self::AppendVec(av) => av.reset(),
+        }
+    }
+
+    pub fn remaining_bytes(&self) -> u64 {
+        match self {
+            Self::AppendVec(av) => av.remaining_bytes(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::AppendVec(av) => av.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::AppendVec(av) => av.is_empty(),
+        }
+    }
+
+    pub fn capacity(&self) -> u64 {
+        match self {
+            Self::AppendVec(av) => av.capacity(),
+        }
+    }
+
+    pub fn file_name(slot: Slot, id: impl std::fmt::Display) -> String {
+        format!("{slot}.{id}")
+    }
+
+    /// Return (account metadata, next_index) pair for the account at the
+    /// specified `index` if any.  Otherwise return None.   Also return the
+    /// index of the next entry.
+    pub fn get_account(&self, index: usize) -> Option<(StoredAccountMeta<'_>, usize)> {
+        match self {
+            Self::AppendVec(av) => av.get_account(index),
+        }
+    }
+
+    pub fn account_matches_owners(
+        &self,
+        offset: usize,
+        owners: &[&Pubkey],
+    ) -> Result<(), MatchAccountOwnerError> {
+        match self {
+            Self::AppendVec(av) => av.account_matches_owners(offset, owners),
+        }
+    }
+
+    /// Return the path of the underlying account file.
+    pub fn get_path(&self) -> PathBuf {
+        match self {
+            Self::AppendVec(av) => av.get_path(),
+        }
+    }
+
+    /// Return iterator for account metadata
+    pub fn account_iter(&self) -> AccountsFileIter {
+        AccountsFileIter::new(self)
+    }
+
+    /// Return a vector of account metadata for each account, starting from `offset`.
+    pub fn accounts(&self, offset: usize) -> Vec<StoredAccountMeta> {
+        match self {
+            Self::AppendVec(av) => av.accounts(offset),
+        }
+    }
+
+    /// Copy each account metadata, account and hash to the internal buffer.
+    /// If there is no room to write the first entry, None is returned.
+    /// Otherwise, returns the starting offset of each account metadata.
+    /// Plus, the final return value is the offset where the next entry would be appended.
+    /// So, return.len() is 1 + (number of accounts written)
+    /// After each account is appended, the internal `current_len` is updated
+    /// and will be available to other threads.
+    pub fn append_accounts<
+        'a,
+        'b,
+        T: ReadableAccount + Sync,
+        U: StorableAccounts<'a, T>,
+        V: Borrow<Hash>,
+    >(
+        &self,
+        accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
+        skip: usize,
+    ) -> Option<Vec<usize>> {
+        match self {
+            Self::AppendVec(av) => av.append_accounts(accounts, skip),
+        }
+    }
+}
+
+pub struct AccountsFileIter<'a> {
+    file_entry: &'a AccountsFile,
+    offset: usize,
+}
+
+impl<'a> AccountsFileIter<'a> {
+    pub fn new(file_entry: &'a AccountsFile) -> Self {
+        Self {
+            file_entry,
+            offset: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for AccountsFileIter<'a> {
+    type Item = StoredAccountMeta<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((account, next_offset)) = self.file_entry.get_account(self.offset) {
+            self.offset = next_offset;
+            Some(account)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::accounts_file::AccountsFile;
+    impl AccountsFile {
+        pub(crate) fn set_current_len_for_tests(&self, len: usize) {
+            match self {
+                Self::AppendVec(av) => av.set_current_len_for_tests(len),
+            }
+        }
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;
 pub mod accounts_db;
+pub mod accounts_file;
 pub mod accounts_hash;
 pub mod accounts_index;
 pub mod accounts_index_storage;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -5,6 +5,7 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig, AppendVecId,
             AtomicAppendVecId, BankHashStats, IndexGenerationInfo,
         },
+        accounts_file::AccountsFile,
         accounts_hash::{AccountsDeltaHash, AccountsHash},
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -574,11 +575,12 @@ fn reconstruct_single_storage(
     current_len: usize,
     append_vec_id: AppendVecId,
 ) -> io::Result<Arc<AccountStorageEntry>> {
-    let (accounts, num_accounts) = AppendVec::new_from_file(append_vec_path, current_len)?;
+    let (append_vec, num_accounts) = AppendVec::new_from_file(append_vec_path, current_len)?;
+    let accounts_file = AccountsFile::AppendVec(append_vec);
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
-        accounts,
+        accounts_file,
         num_accounts,
     )))
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -8,6 +8,7 @@ use {
         accounts_db::{
             get_temp_accounts_paths, test_utils::create_test_accounts, AccountShrinkThreshold,
         },
+        accounts_file::AccountsFile,
         accounts_hash::{AccountsDeltaHash, AccountsHash},
         append_vec::AppendVec,
         bank::{Bank, BankTestConfig},
@@ -56,10 +57,11 @@ fn copy_append_vecs<P: AsRef<Path>>(
         // Read new file into append-vec and build new entry
         let (append_vec, num_accounts) =
             AppendVec::new_from_file(output_path, storage_entry.accounts.len())?;
+        let accounts_file = AccountsFile::AppendVec(append_vec);
         let new_storage_entry = AccountStorageEntry::new_existing(
             storage_entry.slot(),
             storage_entry.append_vec_id(),
-            append_vec,
+            accounts_file,
             num_accounts,
         );
         next_append_vec_id = next_append_vec_id.max(new_storage_entry.append_vec_id());

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -196,6 +196,7 @@ pub mod tests {
         super::*,
         crate::{
             accounts_db::{AccountStorageEntry, AppendVecId},
+            accounts_file::AccountsFile,
             append_vec::AppendVec,
         },
         std::sync::Arc,
@@ -369,7 +370,7 @@ pub mod tests {
         let size: usize = 123;
         let slot = 0;
         let mut data = AccountStorageEntry::new(&paths[0], slot, id, size as u64);
-        let av = AppendVec::new(&tf.path, true, 1024 * 1024);
+        let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 
         Arc::new(data)


### PR DESCRIPTION
#### Summary of Changes
This PR abstracts out AppendVec into AccountsFile enum.
This will allow different implementations of AccountsFile that support the AccountsDB.
