### PR TITLE
Remove duplicate bank frozen log from ReplayStage

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2565,7 +2565,6 @@ impl ReplayStage {
                     r_replay_stats.execute_timings
                     );
                 did_complete_bank = true;
-                info!("bank frozen: {}", bank.slot());
                 let _ = cluster_slots_update_sender.send(vec![bank_slot]);
                 if let Some(transaction_status_sender) = transaction_status_sender {
                     transaction_status_sender.send_transaction_status_freeze_message(bank);


### PR DESCRIPTION
#### Problem
We emit a similar log with more information shortly after from Bank, so this logline is extra that occurs for every slot.

```
[2023-01-22T00:00:30.373085940Z INFO  solana_core::replay_stage] bank frozen: 173717829
[2023-01-22T00:00:30.382211976Z INFO  solana_runtime::bank] bank frozen: 173717829 hash: DVZoobrBKXLr5c5fuLSDKexwN5sJkPQc4RwZR4vttziT accounts_delta: AMUUEc9pCK6tTYujYsQgQ7imkkBUZP9DxxWxX7YvK6ot signature_count: 2823 last_blockhash: AYoJHoD9cU83f4ysG8ttyZ4CRSnop3z4KfFuzJGRfVBy capitalization: 539127927997816978
[2023-01-22T00:00:30.714653459Z INFO  solana_core::replay_stage] bank frozen: 173717830
[2023-01-22T00:00:30.719940414Z INFO  solana_runtime::bank] bank frozen: 173717830 hash: 9U3azf5wb41xoa8DNctK8bRN5SPiFnWnmNx7YojtJPup accounts_delta: GUX4XCqjTQZnsx8FGDJ8xXWYM3sai7HMEwsYRQ54Swsb signature_count: 3477 last_blockhash: 4xQ1xantEF6kdKjtg8r8kwYUFyYYpW7EXXpDYvzhX7c2 capitalization: 539127927986439540
```

#### Summary of Changes
This removes the log line that just prints out the slot.