### PR TITLE
Upgrades to Rust 1.66.1

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.65.0
+FROM solanalabs/rust:1.66.1
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/rust-version.sh to pick up the new image tag
-FROM rust:1.65.0
+FROM rust:1.66.1
 
 RUN set -x \
  && apt update \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.1"


### PR DESCRIPTION
https://blog.rust-lang.org/2023/01/10/Rust-1.66.1.html

Note, this PR only updates the stable Rust version. In Rust 1.68 (what would be the normal nightly), the layout of structs can/does change. This is manifesting in the program runtime how a few types are passed to and from the vm. These types need to be audited to see if any require a stable-layout version.

Related: #29304