### PR TITLE
remove congestion multiplier from transaction fee calculation

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3587,6 +3587,7 @@ fn test_program_fees() {
         &fee_structure,
         true,
         false,
+        true,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3609,6 +3610,7 @@ fn test_program_fees() {
         &fee_structure,
         true,
         false,
+        true,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -31,8 +31,8 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot},
         feature_set::{
-            self, remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation,
-            FeatureSet,
+            self, remove_congestion_multiplier_from_fee_calculation,
+            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
@@ -600,6 +600,7 @@ impl Accounts {
                             fee_structure,
                             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
+                            feature_set.is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1638,6 +1639,7 @@ mod tests {
             lamports_per_signature,
             &FeeStructure::default(),
             true,
+            false,
             false,
         );
         assert_eq!(fee, lamports_per_signature);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1640,7 +1640,7 @@ mod tests {
             &FeeStructure::default(),
             true,
             false,
-            false,
+            true,
         );
         assert_eq!(fee, lamports_per_signature);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4667,20 +4667,12 @@ impl Bank {
     /// Calculate fee for `SanitizedMessage`
     pub fn calculate_fee(
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
+        _lamports_per_signature: u64,
         fee_structure: &FeeStructure,
         use_default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
-        const BASE_CONGESTION: f64 = 5_000.0;
-        let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
-        } else {
-            BASE_CONGESTION / current_congestion
-        };
-
         let mut compute_budget = ComputeBudget::default();
         let prioritization_fee_details = compute_budget
             .process_instructions(
@@ -4707,11 +4699,10 @@ impl Bank {
                     .unwrap_or_default()
             });
 
-        ((prioritization_fee
+        (prioritization_fee
             .saturating_add(signature_fee)
             .saturating_add(write_lock_fee)
             .saturating_add(compute_fee) as f64)
-            * congestion_multiplier)
             .round() as u64
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4679,16 +4679,14 @@ impl Bank {
         remove_congestion_multiplier: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
-        let congestion_multiplier = if remove_congestion_multiplier {
+        let congestion_multiplier = if lamports_per_signature == 0 {
+            0.0 // test only
+        } else if remove_congestion_multiplier {
             1.0 // multiplier that has no effect
         } else {
             const BASE_CONGESTION: f64 = 5_000.0;
             let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
-            if lamports_per_signature == 0 {
-                0.0 // test only
-            } else {
-                BASE_CONGESTION / current_congestion
-            }
+            BASE_CONGESTION / current_congestion
         };
 
         let mut compute_budget = ComputeBudget::default();
@@ -10891,7 +10889,7 @@ pub(crate) mod tests {
             &FeeStructure::default(),
             true,
             false,
-            false,
+            true,
         );
 
         let (expected_fee_collected, expected_fee_burned) =
@@ -11073,7 +11071,7 @@ pub(crate) mod tests {
             &FeeStructure::default(),
             true,
             false,
-            false,
+            true,
         );
         assert_eq!(
             bank.get_balance(&mint_keypair.pubkey()),
@@ -11092,7 +11090,7 @@ pub(crate) mod tests {
             &FeeStructure::default(),
             true,
             false,
-            false,
+            true,
         );
         assert_eq!(
             bank.get_balance(&mint_keypair.pubkey()),
@@ -11209,7 +11207,7 @@ pub(crate) mod tests {
                             &FeeStructure::default(),
                             true,
                             false,
-                            false,
+                            true,
                         ) * 2
                     )
                     .0
@@ -18411,7 +18409,7 @@ pub(crate) mod tests {
                 },
                 true,
                 false,
-                false,
+                true,
             ),
             0
         );
@@ -18427,7 +18425,7 @@ pub(crate) mod tests {
                 },
                 true,
                 false,
-                false,
+                true,
             ),
             1
         );
@@ -18448,7 +18446,7 @@ pub(crate) mod tests {
                 },
                 true,
                 false,
-                false,
+                true,
             ),
             4
         );
@@ -18468,7 +18466,7 @@ pub(crate) mod tests {
         let message =
             SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true, false, false),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, false, true),
             max_fee + lamports_per_signature
         );
 
@@ -18480,7 +18478,7 @@ pub(crate) mod tests {
             SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique())))
                 .unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true, false, false),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, false, true),
             max_fee + 3 * lamports_per_signature
         );
 
@@ -18513,7 +18511,7 @@ pub(crate) mod tests {
                 Some(&Pubkey::new_unique()),
             ))
             .unwrap();
-            let fee = Bank::calculate_fee(&message, 1, &fee_structure, true, false, false);
+            let fee = Bank::calculate_fee(&message, 1, &fee_structure, true, false, true);
             assert_eq!(
                 fee,
                 lamports_per_signature + prioritization_fee_details.get_fee()
@@ -18552,7 +18550,7 @@ pub(crate) mod tests {
         ))
         .unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true, false, false),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, false, true),
             2
         );
 
@@ -18564,7 +18562,7 @@ pub(crate) mod tests {
         ))
         .unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true, false, false),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, false, true),
             11
         );
     }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -598,6 +598,10 @@ pub mod cap_transaction_accounts_data_size {
     solana_sdk::declare_id!("DdLwVYuvDz26JohmgSbA7mjpJFgX5zP2dkp8qsF2C33V");
 }
 
+pub mod remove_congestion_multiplier_from_fee_calculation {
+    solana_sdk::declare_id!("A8xyMHZovGXFkorFqEmVH2PKGLiBip5JD7jt4zsUWo4H");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -742,6 +746,7 @@ lazy_static! {
         (enable_big_mod_exp_syscall::id(), "add big_mod_exp syscall #28503"),
         (disable_builtin_loader_ownership_chains::id(), "disable builtin loader ownership chains #29956"),
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to a limit #27839"),
+        (remove_congestion_multiplier_from_fee_calculation::id(), "Remove congestion multiplier from transaction fee calculation #29881"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

`congestion multiplier` in transaction fee calculation is rarely used; at several occasions, it had been suggested for removal. Thought to open a PR to get discussion going.

#### Summary of Changes
- remove `congestion_multiplier` from transaction fee calculation
- add feature to gate the change

Feature Gate Issue: Remove congestion multiplier from transaction fee calculation #29881
