### PR TITLE
Reduce TPU connection pool size for test

### DIFF
--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -320,6 +320,7 @@ pub fn run_cluster_partition<C>(
         skip_warmup_slots: true,
         additional_accounts,
         ticks_per_slot: ticks_per_slot.unwrap_or(DEFAULT_TICKS_PER_SLOT),
+        tpu_connection_pool_size: 2,
         ..ClusterConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
QUIC server may close connection when max peer connections is exceeded. See #29602 for an example of a failing test that encounters this case intermittently.

#### Summary of Changes
Restrict the TPU connection pool size to 2 (down from current default value of 4) to limit number of parallel connections coming from clients and eliminate possibility of exceeding max peer connections