### PR TITLE
Include own node in stake table

### DIFF
--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -100,6 +100,11 @@ impl StakedNodesUpdaterService {
                     Some((node.tvu.ip(), *stake))
                 })
                 .collect();
+            let my_pubkey = cluster_info.my_contact_info().id;
+            if let Some(stake) = staked_nodes.get(&my_pubkey) {
+                id_to_stake.insert(my_pubkey, *stake);
+                ip_to_stake.insert(cluster_info.my_contact_info().tvu.ip(), *stake);
+            }
             Self::override_stake(
                 cluster_info,
                 total_stake,


### PR DESCRIPTION
#### Problem
We do not currently include the Pubkey/stake for our own node in the shared stake node table. This table can be queried with our pubkey for determining things like connection/packet priority for TPU transactions. There are a couple places where we could send transactions to ourself:
1. In rpc when using send-transaction-service. If the leader is itself, it can send to itself.
2. When handling transaction as a leader and forwarding the excessive transactions to the next leader and that next leader happens to be itself. I think this happens relatively easily in smaller cluster like in the bench-tps. But in large cluster like MNB, chance of that happening is small.

This also has impact on local cluster testing where connection to our own node gets put in same connection table entry as client connections because we don't find the pubkey in the staked node table and all clients/validators share the same IP for local cluster testing. This has lead to things like exceeding max connections errors.

#### Summary of Changes
Include Pubkey/stake for our own node in the shared stake node table.