### PR TITLE
geyser: add parent slot/blockhash to block

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2639,6 +2639,8 @@ impl ReplayStage {
                 if let Some(ref block_metadata_notifier) = block_metadata_notifier {
                     let block_metadata_notifier = block_metadata_notifier.read().unwrap();
                     block_metadata_notifier.notify_block_metadata(
+                        bank.parent_slot(),
+                        &bank.parent_hash().to_string(),
                         bank.slot(),
                         &bank.last_blockhash().to_string(),
                         &bank.rewards,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -136,6 +136,8 @@ pub struct ReplicaBlockInfo<'a> {
 /// Extending ReplicaBlockInfo by sending the transaction_entries_count.
 #[derive(Clone, Debug)]
 pub struct ReplicaBlockInfoV2<'a> {
+    pub parent_slot: u64,
+    pub parent_blockhash: &'a str,
     pub slot: u64,
     pub blockhash: &'a str,
     pub rewards: &'a [Reward],

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -23,6 +23,8 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
     /// Notify the block metadata
     fn notify_block_metadata(
         &self,
+        parent_slot: u64,
+        parent_blockhash: &str,
         slot: u64,
         blockhash: &str,
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
@@ -39,6 +41,8 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         for plugin in plugin_manager.plugins.iter_mut() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             let block_info = Self::build_replica_block_info(
+                parent_slot,
+                parent_blockhash,
                 slot,
                 blockhash,
                 &rewards,
@@ -91,6 +95,8 @@ impl BlockMetadataNotifierImpl {
     }
 
     fn build_replica_block_info<'a>(
+        parent_slot: u64,
+        parent_blockhash: &'a str,
         slot: u64,
         blockhash: &'a str,
         rewards: &'a [Reward],
@@ -99,6 +105,8 @@ impl BlockMetadataNotifierImpl {
         executed_transaction_count: u64,
     ) -> ReplicaBlockInfoV2<'a> {
         ReplicaBlockInfoV2 {
+            parent_slot,
+            parent_blockhash,
             slot,
             blockhash,
             rewards,

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -9,6 +9,8 @@ pub trait BlockMetadataNotifier {
     /// Notify the block metadata
     fn notify_block_metadata(
         &self,
+        parent_slot: u64,
+        parent_blockhash: &str,
         slot: u64,
         blockhash: &str,
         rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,


### PR DESCRIPTION
#### Problem

Ability to construct full block with geyser interface.

https://docs.rs/solana-storage-proto/1.14.13/solana_storage_proto/convert/generated/struct.ConfirmedBlock.html
Currently we can construct all transactions from `notify_transaction` but we still need `previous_blockhash` + `parent_slot`.

There also a question, do I understand correctly that number of transactions in the block should be equal to `executed_transaction_count`?

#### Summary of Changes

Add `previous_blockhash` + `parent_slot` to `ReplicaBlockInfoV2`