### PR TITLE
includes rent_epoch in vote-accounts sanity checks

### DIFF
--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -235,18 +235,9 @@ impl Stakes<StakeAccount> {
                 None => return Err(Error::VoteAccountNotFound(*pubkey)),
                 Some(account) => account,
             };
-            // Ignoring rent_epoch until the feature for
-            // preserve_rent_epoch_for_rent_exempt_accounts is activated.
             let vote_account = vote_account.account();
-            if vote_account.lamports() != account.lamports()
-                || vote_account.owner() != account.owner()
-                || vote_account.executable() != account.executable()
-                || vote_account.data() != account.data()
-            {
-                error!(
-                    "vote account mismatch: {}, {:?}, {:?}",
-                    pubkey, vote_account, account
-                );
+            if vote_account != &account {
+                error!("vote account mismatch: {pubkey}, {vote_account:?}, {account:?}");
                 return Err(Error::VoteAccountMismatch(*pubkey));
             }
         }
@@ -266,7 +257,7 @@ impl Stakes<StakeAccount> {
             if VoteState::is_correct_size_and_initialized(account.data())
                 && VoteAccount::try_from(account.clone()).is_ok()
             {
-                error!("vote account not cached: {}, {:?}", pubkey, account);
+                error!("vote account not cached: {pubkey}, {account:?}");
                 return Err(Error::VoteAccountNotCached(pubkey));
             }
         }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/26479 preserves rent epoch for rent-exempt accounts; since the feature got activated, vote accounts in stakes cache have identical `rent_epoch` field as the accounts in accounts-db. The commit verifies this in stakes-cache sanity checks.

#### Summary of Changes
includes `rent_epoch` in vote-accounts sanity checks