### PR TITLE
Manual backport of #29599 for consistent metric name

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1676,7 +1676,7 @@ impl Bank {
                             apply_feature_activations_time.as_us(),
                             i64
                         ),
-                        ("activate_epoch_Us", activate_epoch_time.as_us(), i64),
+                        ("activate_epoch_us", activate_epoch_time.as_us(), i64),
                         (
                             "update_epoch_stakes_us",
                             update_epoch_stakes_time.as_us(),


### PR DESCRIPTION
#### Problem
As Behzad pointed out, I change the name of a metric field in an unobvious way in https://github.com/solana-labs/solana/pull/29599. Changing a metric name creates a split between datapoints in metrics db between versions; old versions reports old field and new version reports new field.

#### Summary of Changes
Backport the field name change to v1.14 so we'll be able to view datapoints for all nodes (v1.14 and v1.15+) under one field.

Additionally, I double checked the rest of the fields as well as another PR that moved some metrics around; this was the only rename