### PR TITLE
Bugfix: bank-hash optionally takes halt_at_slot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1737,6 +1737,7 @@ fn main() {
             SubCommand::with_name("bank-hash")
             .about("Prints the hash of the working bank after reading the ledger")
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(&halt_at_slot_arg)
         )
         .subcommand(
             SubCommand::with_name("bounds")
@@ -2473,7 +2474,7 @@ fn main() {
             ("bank-hash", Some(arg_matches)) => {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
-                    halt_at_slot: Some(0),
+                    halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                     poh_verify: false,
                     ..ProcessOptions::default()
                 };


### PR DESCRIPTION
#### Problem
`bank-hash` subcommand sets `halt_at_slot` to 0 which goes against the meaning of `halt_at_slot`, as well as not doing what the description of `bank-hash` does: "Prints the hash of the working bank after reading the ledger".

#### Summary of Changes
Don't set `halt_at_slot` for `bank-hash` subcommand.

Fixes #29799 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
