### PR TITLE
Check that halt_slot >= starting_slot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1068,7 +1068,8 @@ fn load_bank_forks(
     if let Some(halt_slot) = process_options.halt_at_slot {
         if halt_slot < starting_slot {
             eprintln!(
-                "Unable to load bank forks at slot {halt_slot} because it is less than the starting slot {starting_slot}."
+                "Unable to load bank forks at slot {halt_slot} because it is less than the starting slot {starting_slot}. \
+                The starting slot will be the latest snapshot slot, or genesis if --no-snapshot flag specified or no snapshots found."
             );
             exit(1);
         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1066,7 +1066,13 @@ fn load_bank_forks(
     };
 
     if let Some(halt_slot) = process_options.halt_at_slot {
-        // Check if we have the slot data necessary to replay from starting_slot to >= halt_slot.
+        if halt_slot < starting_slot {
+            eprintln!(
+                "Unable to load bank forks at slot {halt_slot} because it is less than the starting slot {starting_slot}."
+            );
+            exit(1);
+        }
+        // Check if we have the slot data necessary to replay from starting_slot to <= halt_slot.
         //  - This will not catch the case when loading from genesis without a full slot 0.
         if !blockstore.slot_range_connected(starting_slot, halt_slot) {
             eprintln!("Unable to load bank forks at slot {halt_slot} due to disconnected blocks.",);


### PR DESCRIPTION
#### Problem
Error message isn't clear from the connected slots check if halt_slot is specified incorrectly.

#### Summary of Changes
Add a check that `halt_slot >= starting_slot` before checking connected slots.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
