### PR TITLE
shred-version has optional halt_at_slot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1726,6 +1726,7 @@ fn main() {
             .about("Prints the ledger's shred hash")
             .arg(&hard_forks_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(&halt_at_slot_arg)
         )
         .subcommand(
             SubCommand::with_name("shred-meta")
@@ -2380,7 +2381,7 @@ fn main() {
             ("shred-version", Some(arg_matches)) => {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
-                    halt_at_slot: Some(0),
+                    halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                     poh_verify: false,
                     ..ProcessOptions::default()
                 };


### PR DESCRIPTION
#### Problem
shred-version specified halt_at_slot as Some(0) which will break in the connected slots check unless there is no snapshot.

#### Summary of Changes
Give user option to specify halt slot, defaults to replaying all available slots.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
