### PR TITLE
Use halt-at-slot to specify getting bank-hash for slot 0

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -266,7 +266,7 @@ EOF
       solana-ledger-tool -l config/bootstrap-validator shred-version --max-genesis-archive-unpacked-size 1073741824 | tee config/shred-version
 
       if [[ -n "$maybeWaitForSupermajority" ]]; then
-        bankHash=$(solana-ledger-tool -l config/bootstrap-validator bank-hash)
+        bankHash=$(solana-ledger-tool -l config/bootstrap-validator bank-hash --halt-at-slot 0)
         extraNodeArgs="$extraNodeArgs --expected-bank-hash $bankHash"
         echo "$bankHash" > config/bank-hash
       fi


### PR DESCRIPTION
#### Problem
The bootstrap node creates the bootstrap snapshot at slot 0 so we do indeed want the bank hash at slot 0. However, stricter error checking in solana-ledger-tool made it such that the bank-hash command would error.

#### Summary of Changes
Specify slot 0 as the slot we want bank hash for. See https://github.com/solana-labs/solana/issues/29799 for more context; this must go in after https://github.com/solana-labs/solana/pull/29865