### PR TITLE
program-test: Use "max" for program account lamports

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -616,7 +616,7 @@ impl ProgramTest {
             this.add_account(
                 program_id,
                 Account {
-                    lamports: Rent::default().minimum_balance(data.len()).min(1),
+                    lamports: Rent::default().minimum_balance(data.len()).max(1),
                     data,
                     owner: solana_sdk::bpf_loader::id(),
                     executable: true,

--- a/program-test/src/programs.rs
+++ b/program-test/src/programs.rs
@@ -40,7 +40,7 @@ pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, AccountSharedData)> {
             (
                 *program_id,
                 AccountSharedData::from(Account {
-                    lamports: rent.minimum_balance(elf.len()).min(1),
+                    lamports: rent.minimum_balance(elf.len()).max(1),
                     data: elf.to_vec(),
                     owner: solana_sdk::bpf_loader::id(),
                     executable: true,


### PR DESCRIPTION
#### Problem

While working on #29878, I noticed that the lamports for accounts are using `rent.minimum_balance(...).min(1)`, which will just put 1 lamport in the account, which won't reflect what's on mainnet.

#### Summary of Changes

Use `max` instead of `min`, which I think is the intended behavior.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
