### PR TITLE
Remove the specific QUIC connection entry that disconnected

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1262,7 +1262,7 @@ pub mod test {
         let default_keypair = Keypair::new();
         endpoint.set_default_client_config(get_client_config(&default_keypair));
         let conn1 = endpoint
-            .connect(server_address.clone(), "localhost")
+            .connect(server_address, "localhost")
             .expect("Failed in connecting")
             .await
             .expect("Failed in waiting");


### PR DESCRIPTION
#### Problem
Multiple QUIC connections can originate from the same client endpoint. All of them will have the same peer address, port and pubkey. When a connection disconnects (due to close, timeout or any other error), the server calls `remove_connection()` to remove the entry from its connection table. The current code is removing all the connections that match the peer IP/Pubkey, and  port). This will result in removing the connections that might still be active.

#### Summary of Changes
Each QUIC connection has a `stable_id` that's specific to the connection (and doesn't change over the lifetime of the connection). This PR updates the `remove_connection()` code to match the `stable_id` of the connection that's being removed with the connections in the table. It also adds a test to make sure the specific connection is removed from the table.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
