### PR TITLE
Clear upstream code after removed congestion multiplierr feature activated

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -407,7 +407,7 @@ impl Banks for BanksServer {
     ) -> Option<u64> {
         let bank = self.bank(commitment);
         let sanitized_message = SanitizedMessage::try_from(message).ok()?;
-        bank.get_fee_for_message(&sanitized_message)
+        Some(bank.get_fee_for_message(&sanitized_message))
     }
 }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3977,7 +3977,7 @@ pub mod rpc_full {
                 .map_err(|err| {
                     Error::invalid_params(format!("invalid transaction message: {err}"))
                 })?;
-            let fee = bank.get_fee_for_message(&sanitized_message);
+            let fee = Some(bank.get_fee_for_message(&sanitized_message));
             Ok(new_response(bank, fee))
         }
 

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -106,20 +106,7 @@ impl TransactionStatusService {
                             executed_units,
                             ..
                         } = details;
-                        let lamports_per_signature = match durable_nonce_fee {
-                            Some(DurableNonceFee::Valid(lamports_per_signature)) => {
-                                Some(lamports_per_signature)
-                            }
-                            Some(DurableNonceFee::Invalid) => None,
-                            None => bank.get_lamports_per_signature_for_blockhash(
-                                transaction.message().recent_blockhash(),
-                            ),
-                        }
-                        .expect("lamports_per_signature must be available");
-                        let fee = bank.get_fee_for_message_with_lamports_per_signature(
-                            transaction.message(),
-                            lamports_per_signature,
-                        );
+                        let fee = bank.get_fee_for_message(transaction.message());
                         let tx_account_locks = transaction.get_account_locks_unchecked();
 
                         let inner_instructions = inner_instructions.map(|inner_instructions| {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -31,8 +31,8 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot},
         feature_set::{
-            self, remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation,
-            FeatureSet,
+            self, remove_congestion_multiplier_from_fee_calculation,
+            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
@@ -561,6 +561,7 @@ impl Accounts {
                             fee_structure,
                             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
+                            feature_set.is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1610,6 +1611,7 @@ mod tests {
             lamports_per_signature,
             &FeeStructure::default(),
             true,
+            false,
             false,
         );
         assert_eq!(fee, lamports_per_signature);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4662,20 +4662,12 @@ impl Bank {
     /// Calculate fee for `SanitizedMessage`
     pub fn calculate_fee(
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
+        _lamports_per_signature: u64,
         fee_structure: &FeeStructure,
         use_default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
-        const BASE_CONGESTION: f64 = 5_000.0;
-        let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
-        } else {
-            BASE_CONGESTION / current_congestion
-        };
-
         let mut compute_budget = ComputeBudget::default();
         let prioritization_fee_details = compute_budget
             .process_instructions(
@@ -4702,11 +4694,10 @@ impl Bank {
                     .unwrap_or_default()
             });
 
-        ((prioritization_fee
+        (prioritization_fee
             .saturating_add(signature_fee)
             .saturating_add(write_lock_fee)
             .saturating_add(compute_fee) as f64)
-            * congestion_multiplier)
             .round() as u64
     }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -286,7 +286,7 @@ impl SyncClient for BankClient {
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
         SanitizedMessage::try_from(message.clone())
             .ok()
-            .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
+            .and_then(|sanitized_message| Some(self.bank.get_fee_for_message(&sanitized_message)))
             .ok_or_else(|| {
                 TransportError::IoError(io::Error::new(
                     io::ErrorKind::Other,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3843,7 +3843,7 @@ mod tests {
             lamports_to_transfer,
             blockhash,
         ));
-        let fee = bank2.get_fee_for_message(tx.message()).unwrap();
+        let fee = bank2.get_fee_for_message(tx.message());
         let tx = system_transaction::transfer(
             &key1,
             &key2.pubkey(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -590,6 +590,10 @@ pub mod enable_big_mod_exp_syscall {
     solana_sdk::declare_id!("EBq48m8irRKuE7ZnMTLvLg2UuGSqhe8s8oMqnmja1fJw");
 }
 
+pub mod remove_congestion_multiplier_from_fee_calculation {
+    solana_sdk::declare_id!("A8xyMHZovGXFkorFqEmVH2PKGLiBip5JD7jt4zsUWo4H");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -732,6 +736,7 @@ lazy_static! {
         (move_serialized_len_ptr_in_cpi::id(), "cpi ignore serialized_len_ptr #29592"),
         (update_hashes_per_tick::id(), "Update desired hashes per tick on epoch boundary"),
         (enable_big_mod_exp_syscall::id(), "add big_mod_exp syscall #28503"),
+        (remove_congestion_multiplier_from_fee_calculation::id(), "Remove congestion multiplier from transaction fee calculation #29881"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Once the feature #29881 is activated, should clean up the upstream code relate to the removed `congestion_multiplier`

#### Summary of Changes
- remove the feature gate code
- remove `lamports_per_signature` as input param to `calculate_fee()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
