### PR TITLE
Eliminate unchecked arithmetic in vote program

### DIFF
--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
 
 pub mod vote_processor;
 pub mod vote_state;

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -483,10 +483,10 @@ mod tests {
         vote_state.authorized_withdrawer = vote_pubkey;
         vote_state.epoch_credits = Vec::new();
 
-        let mut current_epoch_credits = 0;
+        let mut current_epoch_credits: u64 = 0;
         let mut previous_epoch_credits = 0;
         for (epoch, credits) in credits_to_append.iter().enumerate() {
-            current_epoch_credits += credits;
+            current_epoch_credits = current_epoch_credits.saturating_add(*credits);
             vote_state.epoch_credits.push((
                 u64::try_from(epoch).unwrap(),
                 current_epoch_credits,


### PR DESCRIPTION
#### Problem
Still some lingering uses of `#![allow(clippy::integer_arithmetic)]` in the vote program.

#### Summary of Changes
Eliminate them by using checked or saturating arithmetic.
Left `vote_state_0_23_5` alone since it's not in use anymore. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
