### PR TITLE
doc: Fix documentation warnings and add some links

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -173,7 +173,7 @@ impl Faucet {
     /// Checks per-request and per-time-ip limits; if both pass, this method returns a signed
     /// SystemProgram::Transfer transaction from the faucet keypair to the requested recipient. If
     /// the request exceeds this per-request limit, this method returns a signed SPL Memo
-    /// transaction with the memo: "request too large; req: <REQUEST> SOL cap: <CAP> SOL"
+    /// transaction with the memo: `"request too large; req: <REQUEST> SOL cap: <CAP> SOL"`
     pub fn build_airdrop_transaction(
         &mut self,
         req: FaucetRequest,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -229,14 +229,14 @@ pub mod columns {
     /// The shred data column
     ///
     /// index type: (u64, u64)
-    /// value type: Vec<u8>
+    /// value type: [`Vec<u8>`]
     pub struct ShredData;
 
     #[derive(Debug)]
     /// The shred erasure code column
     ///
     /// index type: (u64, u64)
-    /// value type: Vec<u8>
+    /// value type: [`Vec<u8>`]
     pub struct ShredCode;
 
     #[derive(Debug)]

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -228,7 +228,8 @@ pub trait RemoteWallet<T> {
         unimplemented!();
     }
 
-    /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
+    /// Sign transaction data with wallet managing pubkey at derivation path
+    /// `m/44'/501'/<account>'/<change>'`.
     fn sign_message(
         &self,
         derivation_path: &DerivationPath,
@@ -237,7 +238,8 @@ pub trait RemoteWallet<T> {
         unimplemented!();
     }
 
-    /// Sign off-chain message with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
+    /// Sign off-chain message with wallet managing pubkey at derivation path
+    /// `m/44'/501'/<account>'/<change>'`.
     fn sign_offchain_message(
         &self,
         derivation_path: &DerivationPath,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1,5 +1,5 @@
-//! Persistent accounts are stored in below path location:
-//!  <path>/<pid>/data/
+//! Persistent accounts are stored at this path location:
+//!  `<path>/<pid>/data/`
 //!
 //! The persistent store would allow for this mode of operation:
 //!  - Concurrent single thread append with many concurrent readers.
@@ -12,8 +12,8 @@
 //! The only required in memory data structure with a write lock is the index,
 //! which should be fast to update.
 //!
-//! AppendVec's only store accounts for single slots.  To bootstrap the
-//! index from a persistent store of AppendVec's, the entries include
+//! [`AppendVec`]'s only store accounts for single slots.  To bootstrap the
+//! index from a persistent store of [`AppendVec`]'s, the entries include
 //! a "write_version".  A single global atomic `AccountsDb::write_version`
 //! tracks the number of commits to the entire data store. So the latest
 //! commit for each slot entry would be indexed.

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -29,7 +29,7 @@ impl<'a> SortedStorages<'a> {
         }
     }
 
-    /// primary method of retrieving (Slot, Arc<AccountStorageEntry>)
+    /// primary method of retrieving [`(Slot, Arc<AccountStorageEntry>)`]
     pub fn iter_range<R>(&'a self, range: &R) -> SortedStoragesIter<'a>
     where
         R: RangeBounds<Slot>,
@@ -70,9 +70,9 @@ impl<'a> SortedStorages<'a> {
         Self::new_with_slots(source.iter().zip(slots.into_iter()), None, None)
     }
 
-    /// create `SortedStorages` from 'source' iterator.
-    /// 'source' contains a Arc<AccountStorageEntry> and its associated slot
-    /// 'source' does not have to be sorted in any way, but is assumed to not have duplicate slot #s
+    /// create [`SortedStorages`] from `source` iterator.
+    /// `source` contains a [`Arc<AccountStorageEntry>`] and its associated slot
+    /// `source` does not have to be sorted in any way, but is assumed to not have duplicate slot #s
     pub fn new_with_slots(
         source: impl Iterator<Item = (&'a Arc<AccountStorageEntry>, Slot)> + Clone,
         // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -159,9 +159,9 @@ impl StakesCache {
 }
 
 /// The generic type T is either Delegation or StakeAccount.
-/// Stake<Delegation> is equivalent to the old code and is used for backward
-/// compatibility in BankFieldsToDeserialize.
-/// But banks cache Stakes<StakeAccount> which includes the entire stake
+/// [`Stakes<Delegation>`] is equivalent to the old code and is used for backward
+/// compatibility in [`crate::bank::BankFieldsToDeserialize`].
+/// But banks cache [`Stakes<StakeAccount>`] which includes the entire stake
 /// account and StakeState deserialized from the account. Doing so, will remove
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -70,7 +70,7 @@ impl Keypair {
     /// Note that the `Clone` trait is intentionally unimplemented because making a
     /// second copy of sensitive secret keys in memory is usually a bad idea.
     ///
-    /// Only use this in tests or when strictly required. Consider using Arc<Keypair>
+    /// Only use this in tests or when strictly required. Consider using [`std::sync::Arc<Keypair>`]
     /// instead.
     pub fn insecure_clone(&self) -> Self {
         Self(ed25519_dalek::Keypair {

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -790,7 +790,7 @@ impl<'a> BorrowedAccount<'a> {
     /// Call this when you have an owned buffer and want to replace the account
     /// data with it.
     ///
-    /// If you have a slice, use set_data_from_slice().
+    /// If you have a slice, use [`Self::set_data_from_slice()`].
     #[cfg(not(target_os = "solana"))]
     pub fn set_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;
@@ -807,7 +807,7 @@ impl<'a> BorrowedAccount<'a> {
     /// Call this when you have a slice of data you do not own and want to
     /// replace the account data with it.
     ///
-    /// If you have an owned buffer (eg Vec<u8>), use set_data().
+    /// If you have an owned buffer (eg [`Vec<u8>`]), use [`Self::set_data()`].
     #[cfg(not(target_os = "solana"))]
     pub fn set_data_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;


### PR DESCRIPTION
#### Problem

`cargo +nightly doc` generates a number of warnings.

#### Summary of Changes

Quote type references and some text that should be treated as code.