### PR TITLE
Relax `Sized` bound for `Signers` in `Transaction` and `Client`

### DIFF
--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -198,7 +198,7 @@ impl TpuClient {
         })
     }
 
-    pub async fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub async fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -125,7 +125,7 @@ impl ThinClient {
         self.send_and_confirm_transaction(&[keypair], transaction, tries, 0)
     }
 
-    pub fn send_and_confirm_transaction<T: Signers>(
+    pub fn send_and_confirm_transaction<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         transaction: &mut Transaction,
@@ -246,7 +246,7 @@ impl Client for ThinClient {
 }
 
 impl SyncClient for ThinClient {
-    fn send_and_confirm_message<T: Signers>(
+    fn send_and_confirm_message<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         message: Message,

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -108,7 +108,7 @@ impl TpuClient {
         })
     }
 
-    pub fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -51,7 +51,7 @@ impl AsyncClient for BankClient {
 }
 
 impl SyncClient for BankClient {
-    fn send_and_confirm_message<T: Signers>(
+    fn send_and_confirm_message<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         message: Message,

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -213,7 +213,7 @@ pub mod solana_sdk {
         }
 
         impl VersionedTransaction {
-            pub fn try_new<T: Signers>(
+            pub fn try_new<T: Signers + ?Sized>(
                 message: VersionedMessage,
                 _keypairs: &T,
             ) -> std::result::Result<Self, SignerError> {
@@ -230,7 +230,7 @@ pub mod solana_sdk {
         }
 
         impl Transaction {
-            pub fn new<T: Signers>(
+            pub fn new<T: Signers + ?Sized>(
                 _from_keypairs: &T,
                 _message: Message,
                 _recent_blockhash: Hash,
@@ -252,7 +252,7 @@ pub mod solana_sdk {
                 }
             }
 
-            pub fn new_signed_with_payer<T: Signers>(
+            pub fn new_signed_with_payer<T: Signers + ?Sized>(
                 instructions: &[Instruction],
                 payer: Option<&Pubkey>,
                 signing_keypairs: &T,
@@ -262,9 +262,9 @@ pub mod solana_sdk {
                 Self::new(signing_keypairs, message, recent_blockhash)
             }
 
-            pub fn sign<T: Signers>(&mut self, _keypairs: &T, _recent_blockhash: Hash) {}
+            pub fn sign<T: Signers + ?Sized>(&mut self, _keypairs: &T, _recent_blockhash: Hash) {}
 
-            pub fn try_sign<T: Signers>(
+            pub fn try_sign<T: Signers + ?Sized>(
                 &mut self,
                 _keypairs: &T,
                 _recent_blockhash: Hash,

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -34,7 +34,7 @@ pub trait Client: SyncClient + AsyncClient {
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the
     /// server, retrying as-needed.
-    fn send_and_confirm_message<T: Signers>(
+    fn send_and_confirm_message<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         message: Message,
@@ -204,7 +204,7 @@ pub trait AsyncClient {
 
     /// Create a transaction from the given message, and send it to the
     /// server, but don't wait for to see if the server accepted it.
-    fn async_send_message<T: Signers>(
+    fn async_send_message<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         message: Message,

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -346,7 +346,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn new<T: Signers>(
+    pub fn new<T: Signers + ?Sized>(
         from_keypairs: &T,
         message: Message,
         recent_blockhash: Hash,
@@ -501,7 +501,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn new_signed_with_payer<T: Signers>(
+    pub fn new_signed_with_payer<T: Signers + ?Sized>(
         instructions: &[Instruction],
         payer: Option<&Pubkey>,
         signing_keypairs: &T,
@@ -526,7 +526,7 @@ impl Transaction {
     ///
     /// Panics when signing fails. See [`Transaction::try_sign`] and for a full
     /// description of failure conditions.
-    pub fn new_with_compiled_instructions<T: Signers>(
+    pub fn new_with_compiled_instructions<T: Signers + ?Sized>(
         from_keypairs: &T,
         keys: &[Pubkey],
         recent_blockhash: Hash,
@@ -705,7 +705,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn sign<T: Signers>(&mut self, keypairs: &T, recent_blockhash: Hash) {
+    pub fn sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_sign(keypairs, recent_blockhash) {
             panic!("Transaction::sign failed with error {e:?}");
         }
@@ -731,7 +731,7 @@ impl Transaction {
     /// handle the error. See the documentation for
     /// [`Transaction::try_partial_sign`] for a full description of failure
     /// conditions.
-    pub fn partial_sign<T: Signers>(&mut self, keypairs: &T, recent_blockhash: Hash) {
+    pub fn partial_sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_partial_sign(keypairs, recent_blockhash) {
             panic!("Transaction::partial_sign failed with error {e:?}");
         }
@@ -750,7 +750,7 @@ impl Transaction {
     ///
     /// Panics if signing fails. Use [`Transaction::try_partial_sign_unchecked`]
     /// to handle the error.
-    pub fn partial_sign_unchecked<T: Signers>(
+    pub fn partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         positions: Vec<usize>,
@@ -843,7 +843,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn try_sign<T: Signers>(
+    pub fn try_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         recent_blockhash: Hash,
@@ -906,7 +906,7 @@ impl Transaction {
     /// [`PresignerError::VerificationFailure`]: crate::signer::presigner::PresignerError::VerificationFailure
     /// [`solana-remote-wallet`]: https://docs.rs/solana-remote-wallet/latest/
     /// [`RemoteKeypair`]: https://docs.rs/solana-remote-wallet/latest/solana_remote_wallet/remote_keypair/struct.RemoteKeypair.html
-    pub fn try_partial_sign<T: Signers>(
+    pub fn try_partial_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         recent_blockhash: Hash,
@@ -932,7 +932,7 @@ impl Transaction {
     /// # Errors
     ///
     /// Returns an error if signing fails.
-    pub fn try_partial_sign_unchecked<T: Signers>(
+    pub fn try_partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         positions: Vec<usize>,

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -68,7 +68,7 @@ impl From<Transaction> for VersionedTransaction {
 impl VersionedTransaction {
     /// Signs a versioned message and if successful, returns a signed
     /// transaction.
-    pub fn try_new<T: Signers>(
+    pub fn try_new<T: Signers + ?Sized>(
         message: VersionedMessage,
         keypairs: &T,
     ) -> std::result::Result<Self, SignerError> {

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -202,7 +202,7 @@ impl<P: ConnectionPool> ThinClient<P> {
         self.send_and_confirm_transaction(&[keypair], transaction, tries, 0)
     }
 
-    pub fn send_and_confirm_transaction<T: Signers>(
+    pub fn send_and_confirm_transaction<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         transaction: &mut Transaction,
@@ -323,7 +323,7 @@ impl<P: ConnectionPool> Client for ThinClient<P> {
 }
 
 impl<P: ConnectionPool> SyncClient for ThinClient<P> {
-    fn send_and_confirm_message<T: Signers>(
+    fn send_and_confirm_message<T: Signers + ?Sized>(
         &self,
         keypairs: &T,
         message: Message,

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -421,7 +421,7 @@ impl<P: ConnectionPool> TpuClient<P> {
     }
 
     #[cfg(feature = "spinner")]
-    pub async fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub async fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -145,7 +145,7 @@ impl<P: ConnectionPool> TpuClient<P> {
     }
 
     #[cfg(feature = "spinner")]
-    pub fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,


### PR DESCRIPTION
Continuation of previously auto-closed PR: #28536 
@joncinque could take a look please?

I've added some more `?Sized` relaxations to client, thin-client, and tpu-client as you asked. I also added it to runtime (https://github.com/solana-labs/solana/blob/master/runtime/src/bank_client.rs#L54) because it was an implementation of the relaxed trait, so it was required.

There are still some locations where it could be added though:

1. https://github.com/solana-labs/solana/blob/master/ledger/src/staking_utils.rs#L36
    - Looks like a local function, so no actual need for it, but it might help with consistency
2. https://github.com/solana-labs/solana/blob/master/runtime/src/accounts.rs#L1362
    - It's only used in tests, not really needed
3. https://github.com/solana-labs/solana/blob/master/stake-accounts/src/main.rs#L203 and https://github.com/solana-labs/solana/blob/master/stake-accounts/src/main.rs#L221
    - Looks useful to add it here, what do you think?

I'll work on the tests in the meantime