### PR TITLE
solana-genesis: fix bpf-program value_name

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -370,7 +370,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .arg(
             Arg::with_name("bpf_program")
                 .long("bpf-program")
-                .value_name("ADDRESS BPF_PROGRAM.SO")
+                .value_name("ADDRESS LOADER BPF_PROGRAM.SO")
                 .takes_value(true)
                 .number_of_values(3)
                 .multiple(true)


### PR DESCRIPTION
#### Problem
While investigating adding upgradeable programs to solana-genesis, I got confused by the existing `--bpf-program` parameter, as the `value_name` is inconsistent with actual usage.

#### Summary of Changes
Fix it
