### PR TITLE
Snapshot serde test uses calculate_accounts_delta_hash()

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -174,18 +174,19 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         AccountShrinkThreshold::default(),
     );
 
+    let slot = 0;
     let mut pubkeys: Vec<Pubkey> = vec![];
-    create_test_accounts(&accounts, &mut pubkeys, 100, 0);
+    create_test_accounts(&accounts, &mut pubkeys, 100, slot);
     check_accounts(&accounts, &pubkeys, 100);
-    accounts.add_root(0);
+    accounts.add_root(slot);
 
     let mut writer = Cursor::new(vec![]);
     accountsdb_to_stream(
         serde_style,
         &mut writer,
         &accounts.accounts_db,
-        0,
-        &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=0, None).0),
+        slot,
+        &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=slot, None).0),
     )
     .unwrap();
 
@@ -208,10 +209,9 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         .unwrap(),
     );
     check_accounts(&daccounts, &pubkeys, 100);
-    assert_eq!(
-        accounts.bank_hash_info_at(0).accounts_delta_hash,
-        daccounts.bank_hash_info_at(0).accounts_delta_hash
-    );
+    let accounts_delta_hash = accounts.accounts_db.calculate_accounts_delta_hash(slot);
+    let daccounts_delta_hash = daccounts.accounts_db.calculate_accounts_delta_hash(slot);
+    assert_eq!(accounts_delta_hash, daccounts_delta_hash);
 }
 
 fn test_bank_serialize_style(


### PR DESCRIPTION
#### Problem

The serde snapshot test `test_accounts_serialize_style()` compares accounts per and post serialization/deserialization a few ways, including checking the accounts delta hash. Checking the accounts delta hash is currently using `bank_hash_info_at()`, which performs the accounts delta hash calculation internally and then returns that value within a `BankHashInfo`. I'm in the process of (re)moving/refactoring `bank_hash_info_at()`, and so I'm auditing its usage. This test just needs to calculate the accounts delta hash, so do that directly.


#### Summary of Changes

Call `calculate_accounts_delta_hash()` instead of `bank_hash_info_at()` to calculate and get the accounts delta hash.