### PR TITLE
Adds AccountsDb::get_bank_hash_info()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2443,7 +2443,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_accounts_empty_bank_hash() {
         let accounts = Accounts::new_with_config_for_tests(
             Vec::new(),
@@ -2451,7 +2450,8 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        accounts.bank_hash_info_at(1);
+        assert!(accounts.accounts_db.get_bank_hash_info(0).is_some());
+        assert!(accounts.accounts_db.get_bank_hash_info(1).is_none());
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7547,6 +7547,11 @@ impl AccountsDb {
         accounts_delta_hash
     }
 
+    /// Get the bank hash info for `slot`
+    pub fn get_bank_hash_info(&self, slot: Slot) -> Option<BankHashInfo> {
+        self.bank_hashes.read().unwrap().get(&slot).cloned()
+    }
+
     fn update_index<'a, T: ReadableAccount + Sync>(
         &self,
         infos: Vec<AccountInfo>,


### PR DESCRIPTION
#### Problem

The Accounts test, `test_accounts_empty_bank_hash()` uses `bank_hash_info_at()` to ensure there's not a bank hash at a slot where it shouldn't be. The `bank_hash_info_at()` fn does return the bank hash info, but it also calculates the accounts delta hash, which is not needed for this test.

I'm in the process of (re)moving/refactoring `bank_hash_info_at()`, and so I'm auditing its usage. This test just needs to return the bank hash info, so do that directly.


#### Summary of Changes

Add a fn to get the bank hash info, and use that in the test.