### PR TITLE
Fix mergify, vis-a-vis missing dont-squash-my-commits team

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -38,7 +38,6 @@ pull_request_rules:
         - status-success=ci-gate
         - label=automerge
         - label!=no-automerge
-        - author≠@dont-squash-my-commits
         - or:
           # only require docs checks if docs files changed
           - -files~=^docs/
@@ -56,30 +55,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-  # Join the dont-squash-my-commits group if you won't like your commits squashed
-  - name: automatic merge (rebase) on CI success
-    conditions:
-      - and:
-        - status-success=buildkite/solana
-        - status-success=ci-gate
-        - label=automerge
-        - label!=no-automerge
-        - author=@dont-squash-my-commits
-        - or:
-          # only require docs checks if docs files changed
-          - -files~=^docs/
-          - status-success=build & deploy docs
-        - or:
-          # only require explorer checks if explorer files changed
-          - status-success=check-explorer
-          - -files~=^explorer/
-        - or:
-          # only require web3 checks if web3.js files changed
-          - status-success=all-web3-checks
-          - -files~=^web3.js/
-    actions:
-      merge:
-        method: rebase
   - name: remove automerge label on CI failure
     conditions:
       - label=automerge


### PR DESCRIPTION
#### Problem
The `automerge` label doesn't work, eg: https://github.com/solana-labs/solana/pull/29903/checks?check_run_id=10882505832

#### Summary of Changes
Fix by removing references to non-existent dont-squash-my-commits team

@yihau , sorry I can't remember... will this need to be backported, or is having the change in master enough to fix automerge for stable and beta branches?
