### PR TITLE
Moves impl of bank_hash_info_at() into hash_internal_state()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, IncludeSlotInHash, LoadHint, LoadedAccount, ScanStorageResult,
+            IncludeSlotInHash, LoadHint, LoadedAccount, ScanStorageResult,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
@@ -1065,17 +1065,6 @@ impl Accounts {
         for k in readonly_keys {
             account_locks.unlock_readonly(k);
         }
-    }
-
-    pub fn bank_hash_info_at(&self, slot: Slot) -> BankHashInfo {
-        let accounts_delta_hash = self.accounts_db.calculate_accounts_delta_hash(slot);
-        let bank_hashes = self.accounts_db.bank_hashes.read().unwrap();
-        let mut bank_hash_info = bank_hashes
-            .get(&slot)
-            .expect("No bank hash was found for this bank, that should not be possible")
-            .clone();
-        bank_hash_info.accounts_delta_hash = accounts_delta_hash;
-        bank_hash_info
     }
 
     /// This function will prevent multiple threads from modifying the same account state at the


### PR DESCRIPTION
#### Problem

`Accounts::bank_hash_info_at()` is weird. It looks like it should/could be a simple lookup of a `BankHashInfo` in the map of bank hashes in AccountsDb. However, it is not, for a few reasons.

First, it doesn't return an Option, it calls `.expect()`. So if you lookup a slot that's not in the bank hashes, you'll crash. Luckily there is only a single usage of this function, and that behavior is correct. Since `bank_hash_info_at()` is public, it could be called by something else later that doesn't know to uphold this invariant.

Second, it is not a simple lookup. Calling it will also calculate the accounts delta hash for the input slot, which is relatively expensive compared to a lookup in a map. 

Lastly, the newly calculated accounts delta hash replaces whatever was in the looked-up BankHashInfo and then returned. This is strange because the accounts delta hash is actually never written into the bank hashes, so the accounts delta hash _field_ in the BankHashInfo is always a default hash... This is fine because the accounts delta hash is not needed anywhere else. (The bank hashes can be cleaned up in a subsequent PR.)

I'd like for this to be less strange. Since we only call this function in `Bank::hash_internal_state()`, we can get rid of `bank_hash_info_at()` by moving the contents.


#### Summary of Changes

Move the contents of `bank_hash_info_at()` into `hash_internal_state()` and then delete `bank_hash_info_at()`.