### PR TITLE
add test_stake_account_consistency_with_rent_epoch_max_feature

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10243,8 +10243,10 @@ pub(crate) mod tests {
         let vote_id = solana_sdk::pubkey::new_rand();
         let mut vote_account =
             vote_state::create_account(&vote_id, &solana_sdk::pubkey::new_rand(), 0, 100);
-        let (stake_id1, stake_account1) = crate::stakes::tests::create_stake_account(123, &vote_id);
-        let (stake_id2, stake_account2) = crate::stakes::tests::create_stake_account(456, &vote_id);
+        let stake_id1 = solana_sdk::pubkey::new_rand();
+        let stake_account1 = crate::stakes::tests::create_stake_account(123, &vote_id, &stake_id1);
+        let stake_id2 = solana_sdk::pubkey::new_rand();
+        let stake_account2 = crate::stakes::tests::create_stake_account(456, &vote_id, &stake_id2);
 
         // set up accounts
         bank.store_account_and_update_capitalization(&stake_id1, &stake_account1);
@@ -20193,10 +20195,10 @@ pub(crate) mod tests {
             assert!(bank.rc.accounts.accounts_db.assert_stakes_cache_consistency);
             let mut pubkey_bytes_early = [0u8; 32];
             pubkey_bytes_early[31] = 2;
-            let stake_acct = Pubkey::from(pubkey_bytes_early);
+            let stake_id1 = Pubkey::from(pubkey_bytes_early);
             let vote_id = solana_sdk::pubkey::new_rand();
-            let (stake_id1, stake_account1) =
-                crate::stakes::tests::create_stake_account_with_id(12300000, &vote_id, stake_acct);
+            let stake_account1 =
+                crate::stakes::tests::create_stake_account(12300000, &vote_id, &stake_id1);
 
             // set up accounts
             bank.store_account_and_update_capitalization(&stake_id1, &stake_account1);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2496,8 +2496,7 @@ impl Bank {
                     if cached_stake_account.account() != &stake_account {
                         if self.rc.accounts.accounts_db.assert_stakes_cache_consistency {
                             panic!(
-                                "stakes cache accounts mismatch {:?} {:?}",
-                                cached_stake_account, stake_account
+                                "stakes cache accounts mismatch {cached_stake_account:?} {stake_account:?}"
                             );
                         }
                         invalid_cached_stake_accounts.fetch_add(1, Relaxed);
@@ -20195,13 +20194,13 @@ pub(crate) mod tests {
             Epoch::default()
         };
 
-            assert!(bank.rc.accounts.accounts_db.assert_stakes_cache_consistency);
-            let mut pubkey_bytes_early = [0u8; 32];
-            pubkey_bytes_early[31] = 2;
-            let stake_id1 = Pubkey::from(pubkey_bytes_early);
-            let vote_id = solana_sdk::pubkey::new_rand();
-            let stake_account1 =
-                crate::stakes::tests::create_stake_account(12300000, &vote_id, &stake_id1);
+        assert!(bank.rc.accounts.accounts_db.assert_stakes_cache_consistency);
+        let mut pubkey_bytes_early = [0u8; 32];
+        pubkey_bytes_early[31] = 2;
+        let stake_id1 = Pubkey::from(pubkey_bytes_early);
+        let vote_id = solana_sdk::pubkey::new_rand();
+        let stake_account1 =
+            crate::stakes::tests::create_stake_account(12300000, &vote_id, &stake_id1);
 
         // set up accounts
         bank.store_account_and_update_capitalization(&stake_id1, &stake_account1);

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -533,6 +533,15 @@ pub(crate) mod tests {
         vote_pubkey: &Pubkey,
     ) -> (Pubkey, AccountSharedData) {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
+        create_stake_account_with_id(stake, vote_pubkey, stake_pubkey)
+    }
+
+    //   add stake to a vote_pubkey                               (   stake    )
+    pub(crate) fn create_stake_account_with_id(
+        stake: u64,
+        vote_pubkey: &Pubkey,
+        stake_pubkey: Pubkey,
+    ) -> (Pubkey, AccountSharedData) {
         (
             stake_pubkey,
             stake_state::create_account(

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -521,9 +521,13 @@ pub(crate) mod tests {
         let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account =
             vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         (
             (vote_pubkey, vote_account),
-            create_stake_account(stake, &vote_pubkey),
+            (
+                stake_pubkey,
+                create_stake_account(stake, &vote_pubkey, &stake_pubkey),
+            ),
         )
     }
 
@@ -531,26 +535,14 @@ pub(crate) mod tests {
     pub(crate) fn create_stake_account(
         stake: u64,
         vote_pubkey: &Pubkey,
-    ) -> (Pubkey, AccountSharedData) {
-        let stake_pubkey = solana_sdk::pubkey::new_rand();
-        create_stake_account_with_id(stake, vote_pubkey, stake_pubkey)
-    }
-
-    //   add stake to a vote_pubkey                               (   stake    )
-    pub(crate) fn create_stake_account_with_id(
-        stake: u64,
-        vote_pubkey: &Pubkey,
-        stake_pubkey: Pubkey,
-    ) -> (Pubkey, AccountSharedData) {
-        (
+        stake_pubkey: &Pubkey,
+    ) -> AccountSharedData {
+        stake_state::create_account(
             stake_pubkey,
-            stake_state::create_account(
-                &stake_pubkey,
-                vote_pubkey,
-                &vote_state::create_account(vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
-                &Rent::free(),
-                stake,
-            ),
+            vote_pubkey,
+            &vote_state::create_account(vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
+            &Rent::free(),
+            stake,
         )
     }
 
@@ -624,7 +616,8 @@ pub(crate) mod tests {
             }
 
             // activate more
-            let (_stake_pubkey, mut stake_account) = create_stake_account(42, &vote_pubkey);
+            let mut stake_account =
+                create_stake_account(42, &vote_pubkey, &solana_sdk::pubkey::new_rand());
             stakes_cache.check_and_store(&stake_pubkey, &stake_account);
             let stake = stake_state::stake_from(&stake_account).unwrap();
             {
@@ -808,7 +801,8 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        let (stake_pubkey2, stake_account2) = create_stake_account(10, &vote_pubkey);
+        let stake_pubkey2 = solana_sdk::pubkey::new_rand();
+        let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account);
 


### PR DESCRIPTION
#### Problem
Add test around activation of rent_epoch max feature.
This test verifies that activating the feature keeps the stakes cache up to date.
Note that this test fails unless I remove the assert:
`test_stake_vote_account_validity`

#### Summary of Changes
Add ability to cause stakes cache mismatches to assert for testing.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
