### PR TITLE
ledger: Remove `clippy::wrong_self_convention`

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -606,7 +606,6 @@ pub trait Column {
     fn index(key: &[u8]) -> Self::Index;
     // this return Slot or some u64
     fn primary_index(index: Self::Index) -> u64;
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(slot: Slot) -> Self::Index;
     fn slot(index: Self::Index) -> Slot {
         Self::primary_index(index)
@@ -666,7 +665,6 @@ impl<T: SlotColumn> Column for T {
         index
     }
 
-    #[allow(clippy::wrong_self_convention)]
     /// Converts a Slot to its u64 Index.
     fn as_index(slot: Slot) -> u64 {
         slot
@@ -703,7 +701,6 @@ impl Column for columns::TransactionStatus {
         index.2
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(index: u64) -> Self::Index {
         (index, Signature::default(), 0)
     }
@@ -743,7 +740,6 @@ impl Column for columns::AddressSignatures {
         index.2
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(index: u64) -> Self::Index {
         (index, Pubkey::default(), 0, Signature::default())
     }
@@ -773,7 +769,6 @@ impl Column for columns::TransactionMemos {
         unimplemented!()
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(_index: u64) -> Self::Index {
         Signature::default()
     }
@@ -803,7 +798,6 @@ impl Column for columns::TransactionStatusIndex {
         unimplemented!()
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(slot: u64) -> u64 {
         slot
     }
@@ -868,7 +862,6 @@ impl Column for columns::ProgramCosts {
         unimplemented!()
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(_index: u64) -> Self::Index {
         Pubkey::default()
     }
@@ -889,7 +882,6 @@ impl Column for columns::ShredCode {
         index.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(slot: Slot) -> Self::Index {
         (slot, 0)
     }
@@ -918,7 +910,6 @@ impl Column for columns::ShredData {
         index.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(slot: Slot) -> Self::Index {
         (slot, 0)
     }
@@ -1004,7 +995,6 @@ impl Column for columns::ErasureMeta {
         index.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn as_index(slot: Slot) -> Self::Index {
         (slot, 0)
     }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -273,7 +273,6 @@ impl ElGamalPubkey {
         &self.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
     }
@@ -433,7 +432,6 @@ impl ElGamalCiphertext {
         }
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 64] {
         let mut bytes = [0u8; 64];
         bytes[..32].copy_from_slice(&self.commitment.to_bytes());
@@ -556,7 +554,6 @@ impl DecryptHandle {
         &self.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
     }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -78,12 +78,10 @@ impl PedersenOpening {
         PedersenOpening(Scalar::random(&mut OsRng))
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn as_bytes(&self) -> &[u8; 32] {
         self.0.as_bytes()
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
@@ -171,7 +169,6 @@ impl PedersenCommitment {
         &self.0
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
     }


### PR DESCRIPTION
#### Problem

Clippy warning exception is no longer necessary.

#### Summary of Changes

Clippy does not seem to be complaining anymore.  It looks like this rule is now only applied to methods that take `self` as the first argument:

https://github.com/rust-lang/rust-clippy/blob/a9c251f11d2a07ec57ca4b8e17674f7f29daf249/clippy_lints/src/methods/wrong_self_convention.rs#L106