### PR TITLE
[ledger-tool] Allow top-accounts to sort accounts by exec/non-exec data size

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -518,13 +518,17 @@ impl<V: std::cmp::Ord> PartialEq for TopAccountsStatsEntry<V> {
 
 #[derive(PartialEq)]
 enum TopAccountsRankingField {
-    AccountDataSize,
+    DataSize,
+    ExecutableDataSize,
+    NonExecutableDataSize,
 }
 
 impl TopAccountsRankingField {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
-            "data_size" => Some(Self::AccountDataSize),
+            "data_size" => Some(Self::DataSize),
+            "exec_data_size" => Some(Self::ExecutableDataSize),
+            "non_exec_data_size" => Some(Self::NonExecutableDataSize),
             _ => None,
         }
     }
@@ -2296,11 +2300,13 @@ fn main() {
                     .long("field")
                     .takes_value(true)
                     .value_name("FIELD")
-                    .possible_values(&["data_size"])
+					.possible_values(&["data_size", "exec_data_size", "non_exec_data_size"])
                     .default_value("data_size")
                     .help("Determine which stats to print. \
                            Possible values are: \
-                           'data_size': print the top N accounts with the largest account data size.")
+                           'data_size': print the top N accounts ranked by the account data size. \
+                           'exec_data_size': print the top N accounts ranked by the executable account data size. \
+                           'non_exec_data_size': print the top N accounts ranked by the non-executable account data size.")
             )
             .arg(
                 Arg::with_name("top")
@@ -4414,8 +4420,20 @@ fn main() {
                                 min_heap.push(Reverse(TopAccountsStatsEntry {
                                     key: *account.pubkey(),
                                     value: match field {
-                                        TopAccountsRankingField::AccountDataSize => {
-                                            account.data.len()
+                                        TopAccountsRankingField::DataSize => account.data.len(),
+                                        TopAccountsRankingField::ExecutableDataSize => {
+                                            if account.account_meta.executable {
+                                                account.data.len()
+                                            } else {
+                                                0
+                                            }
+                                        }
+                                        TopAccountsRankingField::NonExecutableDataSize => {
+                                            if account.account_meta.executable {
+                                                0
+                                            } else {
+                                                account.data.len()
+                                            }
                                         }
                                     },
                                 }));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -51,6 +51,7 @@ use {
         },
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanConfig},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
+        append_vec::AppendVec,
         bank::{Bank, RewardCalculationEvent, TotalAccountsStats},
         bank_forks::BankForks,
         cost_model::CostModel,
@@ -89,7 +90,8 @@ use {
         vote_state::{self, VoteState},
     },
     std::{
-        collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+        cmp::Reverse,
+        collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
         ffi::OsStr,
         fs::File,
         io::{self, stdout, BufRead, BufReader, Write},
@@ -488,6 +490,44 @@ impl FromStr for GraphVoteAccountMode {
 struct GraphConfig {
     include_all_votes: bool,
     vote_account_mode: GraphVoteAccountMode,
+}
+
+#[derive(Debug, Eq)]
+struct TopAccountsStatsEntry<V: std::cmp::Ord> {
+    key: Pubkey,
+    value: V,
+}
+
+impl<V: std::cmp::Ord> Ord for TopAccountsStatsEntry<V> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<V: std::cmp::Ord> PartialOrd for TopAccountsStatsEntry<V> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<V: std::cmp::Ord> PartialEq for TopAccountsStatsEntry<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+#[derive(PartialEq)]
+enum TopAccountsRankingField {
+    AccountDataSize,
+}
+
+impl TopAccountsRankingField {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "data_size" => Some(Self::AccountDataSize),
+            _ => None,
+        }
+    }
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -1513,6 +1553,8 @@ fn main() {
 
     let mut measure_total_execution_time = Measure::start("ledger tool");
 
+    let default_top_accounts_file_count_limit = &std::usize::MAX.to_string();
+
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -2243,6 +2285,38 @@ fn main() {
                     .value_name("SST_FILE_NAME")
                     .help("The ledger file name (e.g. 011080.sst.) \
                            If no file name is specified, it will print the metadata of all ledger files.")
+            )
+        )
+        .subcommand(
+            SubCommand::with_name("top-accounts")
+            .about("Print the top N accounts of the specified field.")
+            .arg(&account_paths_arg)
+            .arg(
+                Arg::with_name("field")
+                    .long("field")
+                    .takes_value(true)
+                    .value_name("FIELD")
+                    .possible_values(&["data_size"])
+                    .default_value("data_size")
+                    .help("Determine which stats to print. \
+                           Possible values are: \
+                           'data_size': print the top N accounts with the largest account data size.")
+            )
+            .arg(
+                Arg::with_name("top")
+                    .long("top")
+                    .takes_value(true)
+                    .value_name("N")
+                    .default_value("30")
+                    .help("Collect the top N entries of the specified --field")
+            )
+            .arg(
+                Arg::with_name("limit")
+                    .long("limit")
+                    .takes_value(true)
+                    .value_name("LIMIT")
+                    .default_value(default_top_accounts_file_count_limit)
+                    .help("Collect stats from up to LIMIT accounts db files.")
             )
         )
         .get_matches();
@@ -4301,6 +4375,69 @@ fn main() {
                 let sst_file_name = arg_matches.value_of("file_name");
                 if let Err(err) = print_blockstore_file_metadata(&blockstore, &sst_file_name) {
                     eprintln!("{err}");
+                }
+            }
+            ("top-accounts", Some(arg_matches)) => {
+                let mut accounts_db_paths: Vec<PathBuf> =
+                    value_t_or_exit!(arg_matches, "account_paths", String)
+                        .split(',')
+                        .map(PathBuf::from)
+                        .collect();
+
+                let heap_size = value_t_or_exit!(arg_matches, "top", usize);
+                let limit = value_t_or_exit!(arg_matches, "limit", usize);
+                let field_str = value_t_or_exit!(arg_matches, "field", String);
+                let field = TopAccountsRankingField::from_str(&field_str).unwrap();
+
+                let mut min_heap = BinaryHeap::new();
+                let mut file_count = 0;
+
+                while !accounts_db_paths.is_empty() {
+                    let path = accounts_db_paths.pop();
+                    let append_vec_paths = std::fs::read_dir(path.unwrap()).unwrap();
+                    debug!("paths = {:?}", append_vec_paths);
+                    for path in append_vec_paths {
+                        debug!("Collecting stats from {:?}", path);
+                        let av_path = path.expect("success").path();
+                        let av_len = std::fs::metadata(&av_path).unwrap().len() as usize;
+                        if let Ok(mut append_vec) =
+                            AppendVec::new_from_file_unchecked(av_path.clone(), av_len)
+                        {
+                            append_vec.set_no_remove_on_drop();
+
+                            // read append-vec
+                            let mut offset = 0;
+                            while let Some((account, next_offset)) = append_vec.get_account(offset)
+                            {
+                                offset = next_offset;
+                                // data_size
+                                min_heap.push(Reverse(TopAccountsStatsEntry {
+                                    key: *account.pubkey(),
+                                    value: match field {
+                                        TopAccountsRankingField::AccountDataSize => {
+                                            account.data.len()
+                                        }
+                                    },
+                                }));
+                                if min_heap.len() > heap_size {
+                                    min_heap.pop();
+                                }
+                            }
+                            file_count += 1;
+                            if file_count >= limit {
+                                break;
+                            }
+                        } else if av_path.is_dir() {
+                            info!("discovering subdirectory {:?} as well", av_path);
+                            accounts_db_paths.push(av_path);
+                        }
+                    }
+                }
+                println!("Collected top {:?} samples", min_heap.len());
+                while !min_heap.is_empty() {
+                    if let Some(Reverse(entry)) = min_heap.pop() {
+                        println!("account: {:?}, {}: {:?}", entry.key, field_str, entry.value);
+                    }
                 }
             }
             ("", _) => {


### PR DESCRIPTION
#### Summary of Changes
Allow top-accounts subcommand in ledger-tool to sort accounts by
exec/non-exec data size

This PR depends on #29781 which introduces top-accounts subcommand.

Example:
```
$ ./solana-ledger-tool top-accounts --ledger ./ledger --accounts ./ledger/accounts --limit 10000 --top 5 --field exec_data_size
[2023-01-26T07:02:27.113853504Z INFO  solana_ledger_tool] solana-ledger-tool 1.15.0 (src:00000000; feat:2976789029, client:SolanaLabs)
Collected top 5 samples
account: 5A8EiKwp6es75QE4wUh1hpm8uKKKxXGLtdpVwRRTLv9K, exec_data_size: 397504
account: ChBvnZkQHvgUaPZCiCe9YtsR52zqCP7vU37x49cVzjg, exec_data_size: 402296
account: 3W14kvhqTAbGiJhx9aaDYoXFv4VpaVuuh4ocwhaeyeYJ, exec_data_size: 424344
account: 7nTEukWmmwLGCb9cxEGouRMg3FLVGv43o3jiGkhGEC4f, exec_data_size: 428936
account: 7mkSRhsJMnAGFngJxpJ52ikRa24TY53ZWKEjwJ4nyYGC, exec_data_size: 780248
[2023-01-26T07:02:40.260137973Z INFO  solana_ledger_tool] ledger tool took 13.2s
```

```
$ ./src/solana/target/debug/solana-ledger-tool top-accounts --ledger ./ledger --accounts ./ledger/accounts --limit 10000 --top 5 --field non_exec_data_size
[2023-01-26T07:03:30.666043263Z INFO  solana_ledger_tool] solana-ledger-tool 1.15.0 (src:00000000; feat:2976789029, client:SolanaLabs)
Collected top 5 samples
account: 2v4qnkskmnXjeYRQkdFTPLPsU42vhG1tAKbRvw7Vqjij, non_exec_data_size: 6720200
account: 5WyTBrEgvkAXjTdYTLY9PVrztjmz4edP5W9wks9KPFg5, non_exec_data_size: 6720200
account: 76npM99oWkDXdepEJLXc3chmya2n1tEZzqfU2n67nywS, non_exec_data_size: 6720200
account: 4tacGjTExC28MiAMnYD4X3pe3LzR9xovLevTk2kjQF1w, non_exec_data_size: 9000045
account: GWtkxX8VeuRfWUBvrTFukZw4jZ38PpmkoRvPGk5gupnM, non_exec_data_size: 9999721
[2023-01-26T07:03:41.707475695Z INFO  solana_ledger_tool] ledger tool took 11.0s
```
