### PR TITLE
Node identity for bench

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -372,7 +372,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .value_name("PATH")
                 .takes_value(true)
                 .requires("json_rpc_url")
-                .help("File containing a node id (keypair) to communicate with validators"),
+                .help("File containing a node id (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
         )
 }
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -373,7 +373,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .requires("json_rpc_url")
                 .validator(is_keypair)
-                .help("File containing the node id (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
+                .help("File containing the node identity (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
         )
 }
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -70,6 +70,8 @@ pub struct Config {
     pub num_conflict_groups: Option<usize>,
     pub bind_address: IpAddr,
     pub client_node_id: Keypair,
+    pub client_node_stake: u64,
+    pub client_node_total_stake: u64,
 }
 
 impl Default for Config {
@@ -103,6 +105,8 @@ impl Default for Config {
             num_conflict_groups: None,
             bind_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             client_node_id: Keypair::new(),
+            client_node_stake: 0,
+            client_node_total_stake: 0,
         }
     }
 }
@@ -372,6 +376,24 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .help("File containing a node id (keypair) to communicate with validators"),
         )
+        .arg(
+            Arg::with_name("client_node_stake")
+                .long("client-node-stake")
+                .value_name("LAMPORTS")
+                .takes_value(true)
+                .help(
+                    "Stake of the client_node_id",
+                ),
+        )
+        .arg(
+            Arg::with_name("client_node_total_stake")
+                .long("client-node-total-stake")
+                .value_name("LAMPORTS")
+                .takes_value(true)
+                .help(
+                    "Total stake of the client_node_id",
+                ),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -546,6 +568,12 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         args.client_node_id = node_id;
     } else if matches.is_present("client_node_id") {
         panic!("could not parse identity path");
+    }
+    if let Some(v) = matches.value_of("client-node-stake") {
+        args.client_node_stake = v.to_string().parse().expect("can't parse lamports");
+    }
+    if let Some(v) = matches.value_of("client-node-total-stake") {
+        args.client_node_total_stake = v.to_string().parse().expect("can't parse lamports");
     }
 
     args

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -10,7 +10,7 @@ use {
     },
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
     std::{
-        net::{Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         process::exit,
         time::Duration,
     },
@@ -68,6 +68,8 @@ pub struct Config {
     pub use_durable_nonce: bool,
     pub instruction_padding_config: Option<InstructionPaddingConfig>,
     pub num_conflict_groups: Option<usize>,
+    pub bind_address: IpAddr,
+    pub client_node_id: Keypair,
 }
 
 impl Default for Config {
@@ -99,6 +101,8 @@ impl Default for Config {
             use_durable_nonce: false,
             instruction_padding_config: None,
             num_conflict_groups: None,
+            bind_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            client_node_id: Keypair::new(),
         }
     }
 }
@@ -353,6 +357,21 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .validator(|arg| is_within_range(arg, 1..))
                 .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
         )
+        .arg(
+            Arg::with_name("bind_address")
+                .long("bind-address")
+                .value_name("HOST")
+                .takes_value(true)
+                .validator(solana_net_utils::is_host)
+                .help("IP address to use with connection cache"),
+        )
+        .arg(
+            Arg::with_name("client_node_id")
+                .long("client-node-id")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("File containing a node id (keypair) to communicate with validators"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -513,5 +532,54 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         );
     }
 
+    if let Some(addr) = matches.value_of("bind_address") {
+        args.bind_address = solana_net_utils::parse_host(addr).unwrap_or_else(|e| {
+            eprintln!("failed to parse bind_address address: {e}");
+            exit(1)
+        });
+    }
+    let (_, node_id_path) = ConfigInput::compute_keypair_path_setting(
+        matches.value_of("client_node_id").unwrap_or(""),
+        &config.keypair_path,
+    );
+    if let Ok(node_id) = read_keypair_file(node_id_path) {
+        args.client_node_id = node_id;
+    } else if matches.is_present("client_node_id") {
+        panic!("could not parse identity path");
+    }
+
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{fs::File, io::prelude::*, path::Path},
+    };
+
+    fn write_keypair_to_file(keypair: &Keypair, file_name: &str) {
+        let serialized = serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap();
+        let path = Path::new(file_name);
+        let mut file = File::create(path).unwrap();
+        file.write_all(&serialized.into_bytes()).unwrap();
+    }
+
+    #[test]
+    fn test_cli_parse() {
+        let keypair = Keypair::new();
+        let keypair_file_name = "./keypair.json";
+        write_keypair_to_file(&keypair, keypair_file_name);
+
+        let matches = build_args("1.0.0").get_matches_from(vec![
+            "solana-bench-tps",
+            "--bind-address",
+            "192.0.0.1",
+            "--client-node-id",
+            keypair_file_name,
+        ]);
+        let result = extract_args(&matches);
+        assert_eq!(result.bind_address, IpAddr::V4(Ipv4Addr::new(192, 0, 0, 1)));
+        assert_eq!(result.client_node_id, keypair);
+    }
 }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -58,7 +58,6 @@ fn find_node_activated_stake(
     let total_active_stake: u64 = vote_accounts
         .current
         .iter()
-        .chain(vote_accounts.delinquent.iter())
         .map(|vote_account| vote_account.activated_stake)
         .sum();
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -66,14 +66,6 @@ fn find_node_activated_stake(
         .map_or(Err(()), |value| {
             Ok((value.activated_stake, total_active_stake))
         })
-    /*
-    for vote_account in vote_accounts.current {
-        if Pubkey::from_str(&vote_account.node_pubkey).unwrap() == node_id {
-            return Ok(vote_account.activated_stake);
-        }
-    }
-    Err(())
-    */
 }
 
 fn create_connection_cache(
@@ -100,22 +92,6 @@ fn create_connection_cache(
         CommitmentConfig::confirmed(),
     ));
 
-    // get stake history
-    /*
-    let stake_history_account = rpc_client.get_account(&stake_history::id()).unwrap();
-    let stake_history = from_account::<StakeHistory, _>(&stake_history_account)
-        .ok_or_else(|| {
-            eprintln!("Error: failed to deserialize stake history");
-            exit(1);
-        })
-        .unwrap();
-
-    if stake_history.len() == 0 {
-        eprintln!("Error: failed to deserialize stake history");
-        exit(1);
-    }
-    //let total_stake = stake_history[0].0;
-    */
     let client_node_id = client_node_id.unwrap();
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -99,13 +99,11 @@ fn create_connection_cache(
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
     info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
-    staked_nodes.write().unwrap().total_stake = total_stake;
-    staked_nodes
-        .write()
-        .unwrap()
-        .pubkey_stake_map
-        .insert(client_node_id.pubkey(), stake);
+    let staked_nodes = Arc::new(RwLock::new(StakedNodes {
+        total_stake,
+        pubkey_stake_map: HashMap::from([(client_node_id.pubkey(), stake)]),
+        ..StakedNodes::default()
+    }));
     ConnectionCache::new_with_client_options(
         tpu_connection_pool_size,
         None,


### PR DESCRIPTION
#### Problem

Currently node_id is generated randomly, this complicates testing if we want to use staked connection with bench-tps.
~~I guess it might be possible to get `bind_address` in the code using some wrapper for `getifaddrs`, yet it looks like we usually specify this as cli argument.~~

#### Summary of Changes

* add two additional parameters `bind_address` and `client_node_id` to cli
* add code to get total active stake and stake information from the network
* use this data when constructing `ConnectionCache`
