### PR TITLE
Improves RPC path sanitation

### DIFF
--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -136,7 +136,7 @@ impl RpcRequestMiddleware {
         }
 
         let Some(path) = Self::strip_leading_slash(path) else {
-            return false
+            return false;
         };
 
         self.full_snapshot_archive_path_regex.is_match(path)


### PR DESCRIPTION
#### Problem

RPC path sanitization is inconsistent between checking if the path is valid and then getting the file from the path.

#### Summary of Changes

Create a new shared fn to handle the path sanitation.