### PR TITLE
Validator default stake

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -31,7 +31,7 @@ use {
         stake::{instruction::LockupArgs, state::Lockup},
         transaction::{TransactionError, VersionedTransaction},
     },
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
+    solana_tpu_client::tpu_connection_cache::{DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP},
     solana_vote_program::vote_state::VoteAuthorize,
     std::{collections::HashMap, error, io::stdout, str::FromStr, sync::Arc, time::Duration},
     thiserror::Error,
@@ -509,6 +509,7 @@ pub struct CliConfig<'a> {
     pub confirm_transaction_initial_timeout: Duration,
     pub address_labels: HashMap<String, String>,
     pub use_quic: bool,
+    pub default_stake: Option<u64>,
 }
 
 impl CliConfig<'_> {
@@ -557,6 +558,7 @@ impl Default for CliConfig<'_> {
             ),
             address_labels: HashMap::new(),
             use_quic: !DEFAULT_TPU_ENABLE_UDP,
+            default_stake: DEFAULT_TPU_DEFAULT_STAKE,
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
+    solana_tpu_client::tpu_connection_cache::{DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP},
     std::{collections::HashMap, error, path::PathBuf, sync::Arc, time::Duration},
 };
 
@@ -211,6 +211,8 @@ pub fn parse_args<'a>(
         !DEFAULT_TPU_ENABLE_UDP
     };
 
+    let default_stake = DEFAULT_TPU_DEFAULT_STAKE;
+
     Ok((
         CliConfig {
             command,
@@ -230,6 +232,7 @@ pub fn parse_args<'a>(
             confirm_transaction_initial_timeout,
             address_labels,
             use_quic,
+            default_stake,
         },
         signers,
     ))

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -1,5 +1,6 @@
 pub use solana_tpu_client::tpu_connection_cache::{
-    DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+    DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP,
+    DEFAULT_TPU_USE_QUIC,
 };
 use {
     crate::{
@@ -667,6 +668,7 @@ mod tests {
             10,
             response_recv_stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -103,6 +103,7 @@ impl Tpu {
         banking_tracer: Arc<BankingTracer>,
         tracer_thread_hdl: TracerThread,
         tpu_enable_udp: bool,
+        default_stake: Option<u64>,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -173,6 +174,7 @@ impl Tpu {
             MAX_UNSTAKED_CONNECTIONS,
             stats.clone(),
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            default_stake,
         )
         .unwrap();
 
@@ -188,6 +190,7 @@ impl Tpu {
             0, // Prevent unstaked nodes from forwarding transactions
             stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -382,6 +382,7 @@ impl Validator {
         use_quic: bool,
         tpu_connection_pool_size: usize,
         tpu_enable_udp: bool,
+        default_stake: Option<u64>,
     ) -> Result<Self, String> {
         let id = identity_keypair.pubkey();
         assert_eq!(id, node.info.id);
@@ -1039,6 +1040,7 @@ impl Validator {
             banking_tracer,
             tracer_thread,
             tpu_enable_udp,
+            default_stake,
         );
 
         datapoint_info!(
@@ -2070,6 +2072,8 @@ pub fn is_snapshot_config_valid(
 
 #[cfg(test)]
 mod tests {
+    use solana_client::connection_cache::DEFAULT_TPU_DEFAULT_STAKE;
+
     use {
         super::*,
         crossbeam_channel::{bounded, RecvTimeoutError},
@@ -2114,6 +2118,7 @@ mod tests {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            DEFAULT_TPU_DEFAULT_STAKE,
         )
         .expect("assume successful validator start");
         assert_eq!(
@@ -2206,6 +2211,7 @@ mod tests {
                     DEFAULT_TPU_USE_QUIC,
                     DEFAULT_TPU_CONNECTION_POOL_SIZE,
                     DEFAULT_TPU_ENABLE_UDP,
+                    DEFAULT_TPU_DEFAULT_STAKE,
                 )
                 .expect("assume successful validator start")
             })

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -44,7 +44,8 @@ use {
     solana_stake_program::{config::create_account as create_stake_config_account, stake_state},
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP,
+        DEFAULT_TPU_USE_QUIC,
     },
     solana_vote_program::{
         vote_instruction,
@@ -279,6 +280,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            DEFAULT_TPU_DEFAULT_STAKE,
         )
         .expect("assume successful validator start");
 
@@ -479,6 +481,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            DEFAULT_TPU_DEFAULT_STAKE,
         )
         .expect("assume successful validator start");
 
@@ -840,6 +843,7 @@ impl Cluster for LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            DEFAULT_TPU_DEFAULT_STAKE,
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -86,6 +86,7 @@ mod tests {
             10,
             stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 
@@ -133,6 +134,7 @@ mod tests {
             10,
             stats,
             1000,
+            None,
         )
         .unwrap();
 
@@ -190,6 +192,7 @@ mod tests {
             10,
             request_recv_stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 
@@ -219,6 +222,7 @@ mod tests {
             10,
             response_recv_stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -309,6 +309,7 @@ pub fn spawn_server(
     max_unstaked_connections: usize,
     stats: Arc<StreamStats>,
     wait_for_chunk_timeout_ms: u64,
+    default_stake: Option<u64>,
 ) -> Result<(Endpoint, thread::JoinHandle<()>), QuicServerError> {
     let runtime = rt();
     let (endpoint, task) = {
@@ -325,6 +326,7 @@ pub fn spawn_server(
             max_unstaked_connections,
             stats,
             wait_for_chunk_timeout_ms,
+            default_stake,
         )
     }?;
     let handle = thread::Builder::new()
@@ -373,6 +375,7 @@ mod test {
             MAX_UNSTAKED_CONNECTIONS,
             stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
         (t, exit, receiver, server_address)
@@ -429,6 +432,7 @@ mod test {
             MAX_UNSTAKED_CONNECTIONS,
             stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 
@@ -472,6 +476,7 @@ mod test {
             0, // Do not allow any connection from unstaked clients/nodes
             stats,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT_MS,
+            None,
         )
         .unwrap();
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -45,7 +45,8 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_connection_cache::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP,
+        DEFAULT_TPU_USE_QUIC,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -841,6 +842,7 @@ impl TestValidator {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
+            DEFAULT_TPU_DEFAULT_STAKE,
         )?);
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/tpu-client/src/tpu_connection_cache.rs
+++ b/tpu-client/src/tpu_connection_cache.rs
@@ -27,6 +27,8 @@ pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 
+pub const DEFAULT_TPU_DEFAULT_STAKE: Option<u64> = None;
+
 pub struct TpuConnectionCache<P: ConnectionPool> {
     pub map: RwLock<IndexMap<SocketAddr, P>>,
     pub stats: Arc<ConnectionCacheStats>,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -786,6 +786,14 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                             Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}"),
         )
         .arg(
+            Arg::with_name("default_stake")
+                .long("default-stake")
+                .takes_value(true)
+                .value_name("NUMBER")
+                .validator(is_parsable::<u64>)
+                .help("If set, makes all connections to be staked with specified stake value"),
+        )
+        .arg(
             Arg::with_name("bind_address")
                 .long("bind-address")
                 .value_name("HOST")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -46,7 +46,7 @@ use {
     },
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::socket::SocketAddrSpace,
-    solana_tpu_client::tpu_connection_cache::DEFAULT_TPU_ENABLE_UDP,
+    solana_tpu_client::tpu_connection_cache::{DEFAULT_TPU_DEFAULT_STAKE, DEFAULT_TPU_ENABLE_UDP},
     solana_validator::{
         admin_rpc_service,
         admin_rpc_service::{load_staked_nodes_overrides, StakedNodesOverrides},
@@ -910,6 +910,8 @@ pub fn main() {
         DEFAULT_TPU_ENABLE_UDP
     };
 
+    let default_stake = DEFAULT_TPU_DEFAULT_STAKE;
+
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
@@ -1656,6 +1658,7 @@ pub fn main() {
         tpu_use_quic,
         tpu_connection_pool_size,
         tpu_enable_udp,
+        default_stake,
     )
     .unwrap_or_else(|e| {
         error!("Failed to start validator: {:?}", e);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -910,7 +910,11 @@ pub fn main() {
         DEFAULT_TPU_ENABLE_UDP
     };
 
-    let default_stake = DEFAULT_TPU_DEFAULT_STAKE;
+    let default_stake = if matches.is_present("default_stake") {
+        Some(value_t_or_exit!(matches, "default_stake", u64))
+    } else {
+        DEFAULT_TPU_DEFAULT_STAKE
+    };
 
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 


### PR DESCRIPTION
#### Problem

Add cli argument `default_stake` to validator to use always staked connections with provided stake value.
Why: for benchmarking on private cluster.

While in some discussions it was proposed to use `max_stake` instead of provided value, I've found that `max_stake` is 0 in my experiments (not sure if this is supposed to be like that or it is due to my setup parameters).

#### Summary of Changes

Most of the changes are about adding cli argument (separate commit) and propagating this value to the `fn get_connection_stake` where the real work is done.
