### PR TITLE
Store account_index under <ledger> folder when running creating snapshot subcommand

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3009,7 +3009,28 @@ fn main() {
                     output_directory.display()
                 );
 
+                let mut accounts_index_config = AccountsIndexConfig::default();
+                {
+                    let mut accounts_index_paths: Vec<PathBuf> =
+                        if arg_matches.is_present("accounts_index_path") {
+                            values_t_or_exit!(arg_matches, "accounts_index_path", String)
+                                .into_iter()
+                                .map(PathBuf::from)
+                                .collect()
+                        } else {
+                            vec![]
+                        };
+                    if accounts_index_paths.is_empty() {
+                        accounts_index_paths = vec![ledger_path.join("accounts_index")];
+                    }
+                    accounts_index_config.drives = Some(accounts_index_paths);
+                }
+
                 let accounts_db_config = Some(AccountsDbConfig {
+                    index: Some(accounts_index_config),
+                    accounts_hash_cache_path: Some(
+                        ledger_path.join(AccountsDb::ACCOUNTS_HASH_CACHE_DIR),
+                    ),
                     ancient_append_vec_offset: value_t!(
                         matches,
                         "accounts_db_ancient_append_vecs",

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3021,7 +3021,7 @@ fn main() {
                             vec![]
                         };
                     if accounts_index_paths.is_empty() {
-                        accounts_index_paths = vec![ledger_path.join("accounts_index")];
+                        accounts_index_paths = vec![ledger_path.join("accounts_index.ledger-tool")];
                     }
                     accounts_index_config.drives = Some(accounts_index_paths);
                 }


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/29934

`create-snapshot` subcommand in `ledger-tool` use `/tmp/` folder to store accounts index. This can fail for ledger with large number of accounts - there is not enough space to allocate in `/tmp/` directory (most linux system `tmpfs` is quite limited). 

#### Summary of Changes

Store account_index under `<ledger>` folder when running creating snapshot subcommand


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
