### PR TITLE
removes staked-nodes updater service excessive locks on gossip

### DIFF
--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -128,18 +128,13 @@ impl StakedNodesUpdaterService {
         ip_to_stake_map: &mut HashMap<IpAddr, u64>,
         staked_map_overrides: &HashMap<Pubkey, u64>,
     ) {
-        for (id_override, stake_override) in staked_map_overrides.iter() {
-            if let Some(ip_override) =
-                cluster_info
-                    .all_peers()
-                    .into_iter()
-                    .find_map(|(node, _seen_time)| {
-                        if node.id == *id_override {
-                            return Some(node.tvu.ip());
-                        }
-                        None
-                    })
-            {
+        let nodes: HashMap<Pubkey, IpAddr> = cluster_info
+            .all_peers()
+            .into_iter()
+            .map(|(node, _)| (node.id, node.tvu.ip()))
+            .collect();
+        for (id_override, stake_override) in staked_map_overrides {
+            if let Some(&ip_override) = nodes.get(id_override) {
                 if let Some(previous_stake) = id_to_stake_map.get(id_override) {
                     *total_stake -= previous_stake;
                 }
@@ -148,9 +143,10 @@ impl StakedNodesUpdaterService {
                 ip_to_stake_map.insert(ip_override, *stake_override);
             } else {
                 error!(
-                        "staked nodes overrides configuration for id {} with stake {} does not match existing IP. Skipping",
-                        id_override, stake_override
-                    );
+                    "staked nodes overrides configuration for id \
+                        {id_override} with stake {stake_override} does not \
+                        match existing IP. Skipping",
+                );
             }
         }
     }


### PR DESCRIPTION
#### Problem
`staked_nodes_updater_service` is unnecessarily locking gossip repeatedly to obtain same set of nodes:
https://github.com/solana-labs/solana/blob/bd9b311c6/core/src/staked_nodes_updater_service.rs#L128-L129


#### Summary of Changes
Obtain gossip nodes only once out of the loop.