### PR TITLE
Account path add run parent with old path cleanup

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -268,7 +268,7 @@ mod tests {
 
     fn create_and_verify_snapshot(temp_dir: &Path) {
         let accounts_dir = temp_dir.join("accounts");
-        let accounts_dir = create_accounts_run_and_snapshot_dirs(accounts_dir.as_path())
+        let accounts_dir = create_accounts_run_and_snapshot_dirs(accounts_dir)
             .unwrap()
             .0;
 

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -228,7 +228,7 @@ mod tests {
             snapshot_hash::SnapshotHash,
             snapshot_package::{SnapshotPackage, SnapshotType},
             snapshot_utils::{
-                self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+                self, create_accounts_run_and_snapshot_dirs, ArchiveFormat, SnapshotVersion,
                 SNAPSHOT_STATUS_CACHE_FILENAME,
             },
         },
@@ -268,7 +268,9 @@ mod tests {
 
     fn create_and_verify_snapshot(temp_dir: &Path) {
         let accounts_dir = temp_dir.join("accounts");
-        let accounts_dir = setup_accounts_run_and_snapshot_paths(accounts_dir.as_path()).unwrap();
+        let accounts_dir = create_accounts_run_and_snapshot_dirs(accounts_dir.as_path())
+            .unwrap()
+            .0;
 
         let snapshots_dir = temp_dir.join("snapshots");
         let full_snapshot_archives_dir = temp_dir.join("full_snapshot_archives");

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -228,7 +228,8 @@ mod tests {
             snapshot_hash::SnapshotHash,
             snapshot_package::{SnapshotPackage, SnapshotType},
             snapshot_utils::{
-                self, ArchiveFormat, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILENAME,
+                self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+                SNAPSHOT_STATUS_CACHE_FILENAME,
             },
         },
         solana_sdk::hash::Hash,
@@ -267,6 +268,8 @@ mod tests {
 
     fn create_and_verify_snapshot(temp_dir: &Path) {
         let accounts_dir = temp_dir.join("accounts");
+        let accounts_dir = setup_accounts_run_and_snapshot_paths(accounts_dir.as_path()).unwrap();
+
         let snapshots_dir = temp_dir.join("snapshots");
         let full_snapshot_archives_dir = temp_dir.join("full_snapshot_archives");
         let incremental_snapshot_archives_dir = temp_dir.join("incremental_snapshot_archives");

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -445,7 +445,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
 
             let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
             let deserialized_bank = snapshot_utils::bank_from_snapshot_archives(
-                &[accounts_dir.as_path().to_path_buf()],
+                &[accounts_dir],
                 &snapshot_config.bank_snapshots_dir,
                 &full_snapshot_archive_info,
                 None,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 use {
+    crate::snapshot_utils::generate_test_tmp_account_path,
     log::*,
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier,
@@ -442,9 +443,9 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
                 std::thread::sleep(Duration::from_secs(1));
             };
 
-            let accounts_dir = TempDir::new().unwrap();
+            let accounts_dir = generate_test_tmp_account_path();
             let deserialized_bank = snapshot_utils::bank_from_snapshot_archives(
-                &[accounts_dir.path().to_path_buf()],
+                &[accounts_dir.as_path().to_path_buf()],
                 &snapshot_config.bank_snapshots_dir,
                 &full_snapshot_archive_info,
                 None,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 use {
-    crate::snapshot_utils::generate_test_tmp_account_path,
+    crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
     log::*,
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier,
@@ -443,7 +443,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
                 std::thread::sleep(Duration::from_secs(1));
             };
 
-            let accounts_dir = generate_test_tmp_account_path();
+            let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
             let deserialized_bank = snapshot_utils::bank_from_snapshot_archives(
                 &[accounts_dir.as_path().to_path_buf()],
                 &snapshot_config.bank_snapshots_dir,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -828,7 +828,7 @@ fn test_bank_forks_incremental_snapshot(
             restore_from_snapshots_and_check_banks_are_equal(
                 &bank,
                 &snapshot_test_config.snapshot_config,
-                temporary_accounts_dir.as_path().to_path_buf(),
+                temporary_accounts_dir,
                 &snapshot_test_config.genesis_config_info.genesis_config,
             )
             .unwrap();

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -75,8 +75,8 @@ struct SnapshotTestConfig {
     incremental_snapshot_archives_dir: TempDir,
     full_snapshot_archives_dir: TempDir,
     bank_snapshots_dir: TempDir,
-    _accounts_tmp_dir: TempDir,
     accounts_dir: PathBuf,
+    _accounts_tmp_dir: TempDir,
 }
 
 impl SnapshotTestConfig {
@@ -132,8 +132,8 @@ impl SnapshotTestConfig {
             incremental_snapshot_archives_dir,
             full_snapshot_archives_dir,
             bank_snapshots_dir,
-            _accounts_tmp_dir,
             accounts_dir,
+            _accounts_tmp_dir,
         }
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1113,7 +1113,7 @@ fn load_bank_forks(
             match create_accounts_run_and_snapshot_dirs(&account_path) {
                 Ok((account_run_path, _account_snapshot_path)) => account_run_path,
                 Err(err) => {
-                    eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
+                    eprintln!("Unable to create account run and snapshot sub directories: {}, err: {err:?}", account_path.display());
                     exit(1);
                 }
             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -62,8 +62,8 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_minimizer::SnapshotMinimizer,
         snapshot_utils::{
-            self, move_and_async_delete_path, ArchiveFormat, SnapshotVersion,
-            DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
+            self, move_and_async_delete_path, setup_accounts_run_and_snapshot_paths, ArchiveFormat,
+            SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
     solana_sdk::{
@@ -1106,6 +1106,22 @@ fn load_bank_forks(
         );
         vec![non_primary_accounts_path]
     };
+
+    // For all account_paths, set up the run/ and snapshot/ sub directories.
+    let account_run_paths: Vec<PathBuf> = account_paths.into_iter().map(
+        |account_path| {
+            match setup_accounts_run_and_snapshot_paths(&account_path) {
+                Ok(account_run_path) => account_run_path,
+                Err(err) => {
+                    eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
+                    exit(1);
+                }
+            }
+        }).collect();
+
+    // From now on, use run/ paths in the same way as the previous account_paths.
+    let account_paths = account_run_paths;
+
     info!("Cleaning contents of account paths: {:?}", account_paths);
     let mut measure = Measure::start("clean_accounts_paths");
     account_paths.iter().for_each(|path| {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -62,7 +62,7 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_minimizer::SnapshotMinimizer,
         snapshot_utils::{
-            self, move_and_async_delete_path, setup_accounts_run_and_snapshot_paths, ArchiveFormat,
+            self, create_accounts_run_and_snapshot_dirs, move_and_async_delete_path, ArchiveFormat,
             SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
@@ -1110,8 +1110,8 @@ fn load_bank_forks(
     // For all account_paths, set up the run/ and snapshot/ sub directories.
     let account_run_paths: Vec<PathBuf> = account_paths.into_iter().map(
         |account_path| {
-            match setup_accounts_run_and_snapshot_paths(&account_path) {
-                Ok(account_run_path) => account_run_path,
+            match create_accounts_run_and_snapshot_dirs(&account_path) {
+                Ok((account_run_path, _account_snapshot_path)) => account_run_path,
                 Err(err) => {
                     eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
                     exit(1);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1108,6 +1108,7 @@ fn load_bank_forks(
     };
 
     // For all account_paths, set up the run/ and snapshot/ sub directories.
+    // If the sub directories do not exist, the account_path will be cleaned because older version put account files there
     let account_run_paths: Vec<PathBuf> = account_paths.into_iter().map(
         |account_path| {
             match create_accounts_run_and_snapshot_dirs(&account_path) {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -22,7 +22,7 @@ use {
             ValidatorVoteKeypairs,
         },
         snapshot_config::SnapshotConfig,
-        snapshot_utils::setup_accounts_run_and_snapshot_paths,
+        snapshot_utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -148,8 +148,11 @@ impl LocalCluster {
         config: &mut ValidatorConfig,
         ledger_path: &Path,
     ) {
-        config.account_paths =
-            vec![setup_accounts_run_and_snapshot_paths(ledger_path.join("accounts")).unwrap()];
+        config.account_paths = vec![
+            create_accounts_run_and_snapshot_dirs(ledger_path.join("accounts"))
+                .unwrap()
+                .0,
+        ];
         config.tower_storage = Arc::new(FileTowerStorage::new(ledger_path.to_path_buf()));
 
         let snapshot_config = &mut config.snapshot_config;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -22,6 +22,7 @@ use {
             ValidatorVoteKeypairs,
         },
         snapshot_config::SnapshotConfig,
+        snapshot_utils::setup_accounts_run_and_snapshot_paths,
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -147,7 +148,8 @@ impl LocalCluster {
         config: &mut ValidatorConfig,
         ledger_path: &Path,
     ) {
-        config.account_paths = vec![ledger_path.join("accounts")];
+        config.account_paths =
+            vec![setup_accounts_run_and_snapshot_paths(ledger_path.join("accounts")).unwrap()];
         config.tower_storage = Arc::new(FileTowerStorage::new(ledger_path.to_path_buf()));
 
         let snapshot_config = &mut config.snapshot_config;

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -21,7 +21,9 @@ use {
         validator_configs::*,
     },
     solana_rpc_client::rpc_client::RpcClient,
-    solana_runtime::snapshot_config::SnapshotConfig,
+    solana_runtime::{
+        snapshot_config::SnapshotConfig, snapshot_utils::setup_accounts_run_and_snapshot_paths,
+    },
     solana_sdk::{
         account::AccountSharedData,
         clock::{self, Slot, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
@@ -436,7 +438,7 @@ pub fn generate_account_paths(num_account_paths: usize) -> (Vec<TempDir>, Vec<Pa
         .collect();
     let account_storage_paths: Vec<_> = account_storage_dirs
         .iter()
-        .map(|a| a.path().to_path_buf())
+        .map(|a| setup_accounts_run_and_snapshot_paths(a.path()).unwrap())
         .collect();
     (account_storage_dirs, account_storage_paths)
 }

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -22,7 +22,7 @@ use {
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::{
-        snapshot_config::SnapshotConfig, snapshot_utils::setup_accounts_run_and_snapshot_paths,
+        snapshot_config::SnapshotConfig, snapshot_utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_sdk::{
         account::AccountSharedData,
@@ -438,7 +438,7 @@ pub fn generate_account_paths(num_account_paths: usize) -> (Vec<TempDir>, Vec<Pa
         .collect();
     let account_storage_paths: Vec<_> = account_storage_dirs
         .iter()
-        .map(|a| setup_accounts_run_and_snapshot_paths(a.path()).unwrap())
+        .map(|a| create_accounts_run_and_snapshot_dirs(a.path()).unwrap().0)
         .collect();
     (account_storage_dirs, account_storage_paths)
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -39,7 +39,7 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_package::SnapshotType,
         snapshot_utils::{
-            self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+            self, create_accounts_run_and_snapshot_dirs, ArchiveFormat, SnapshotVersion,
         },
     },
     solana_sdk::{
@@ -2154,7 +2154,11 @@ fn create_snapshot_to_hard_fork(
     let (bank_forks, ..) = bank_forks_utils::load(
         &genesis_config,
         blockstore,
-        vec![setup_accounts_run_and_snapshot_paths(ledger_path.join("accounts")).unwrap()],
+        vec![
+            create_accounts_run_and_snapshot_dirs(ledger_path.join("accounts"))
+                .unwrap()
+                .0,
+        ],
         None,
         snapshot_config.as_ref(),
         process_options,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -38,7 +38,9 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_package::SnapshotType,
-        snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
+        snapshot_utils::{
+            self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+        },
     },
     solana_sdk::{
         account::AccountSharedData,
@@ -2152,7 +2154,7 @@ fn create_snapshot_to_hard_fork(
     let (bank_forks, ..) = bank_forks_utils::load(
         &genesis_config,
         blockstore,
-        vec![ledger_path.join("accounts")],
+        vec![setup_accounts_run_and_snapshot_paths(ledger_path.join("accounts")).unwrap()],
         None,
         snapshot_config.as_ref(),
         process_options,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1116,7 +1116,7 @@ pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBu
     let temp_dirs = temp_dirs?;
     let paths = temp_dirs
         .iter()
-        .map(|t: &TempDir| -> PathBuf {
+        .map(|t| -> PathBuf {
             let (run_dir, _snapshot_dir) = create_accounts_run_and_snapshot_dirs(t.path())
                 .expect("failed to create the run and snapshot sub-directories for an ccount path");
             run_dir

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1117,7 +1117,9 @@ pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBu
     let paths = temp_dirs
         .iter()
         .map(|t: &TempDir| -> PathBuf {
-            create_accounts_run_and_snapshot_dirs(t.path()).unwrap().0
+            let (run_dir, _snapshot_dir) = create_accounts_run_and_snapshot_dirs(t.path())
+                .expect("failed to create the run and snapshot sub-directories for an ccount path");
+            run_dir
         })
         .collect();
     Ok((temp_dirs, paths))

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1114,7 +1114,7 @@ impl AccountStorageEntry {
 pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBuf>)> {
     let temp_dirs: IoResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
     let temp_dirs = temp_dirs?;
-    let paths: Vec<PathBuf> = temp_dirs
+    let paths = temp_dirs
         .iter()
         .map(|t: &TempDir| -> PathBuf {
             create_accounts_run_and_snapshot_dirs(t.path()).unwrap().0

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1114,14 +1114,14 @@ impl AccountStorageEntry {
 pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBuf>)> {
     let temp_dirs: IoResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
     let temp_dirs = temp_dirs?;
-    let paths = temp_dirs
+
+    let paths: IoResult<Vec<_>> = temp_dirs
         .iter()
-        .map(|t| -> PathBuf {
-            let (run_dir, _snapshot_dir) = create_accounts_run_and_snapshot_dirs(t.path())
-                .expect("failed to create the run and snapshot sub-directories for an ccount path");
-            run_dir
+        .map(|temp_dir| {
+            create_accounts_run_and_snapshot_dirs(temp_dir).map(|(run_dir, _snapshot_dir)| run_dir)
         })
         .collect();
+    let paths = paths?;
     Ok((temp_dirs, paths))
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -53,6 +53,7 @@ use {
         read_only_accounts_cache::ReadOnlyAccountsCache,
         rent_collector::RentCollector,
         rent_paying_accounts_by_partition::RentPayingAccountsByPartition,
+        snapshot_utils::setup_accounts_run_and_snapshot_paths,
         sorted_storages::SortedStorages,
         storable_accounts::StorableAccounts,
         verify_accounts_hash_in_background::VerifyAccountsHashInBackground,
@@ -1113,7 +1114,10 @@ impl AccountStorageEntry {
 pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBuf>)> {
     let temp_dirs: IoResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
     let temp_dirs = temp_dirs?;
-    let paths: Vec<PathBuf> = temp_dirs.iter().map(|t| t.path().to_path_buf()).collect();
+    let paths: Vec<PathBuf> = temp_dirs
+        .iter()
+        .map(|t: &TempDir| -> PathBuf { setup_accounts_run_and_snapshot_paths(t.path()).unwrap() })
+        .collect();
     Ok((temp_dirs, paths))
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -53,7 +53,7 @@ use {
         read_only_accounts_cache::ReadOnlyAccountsCache,
         rent_collector::RentCollector,
         rent_paying_accounts_by_partition::RentPayingAccountsByPartition,
-        snapshot_utils::setup_accounts_run_and_snapshot_paths,
+        snapshot_utils::create_accounts_run_and_snapshot_dirs,
         sorted_storages::SortedStorages,
         storable_accounts::StorableAccounts,
         verify_accounts_hash_in_background::VerifyAccountsHashInBackground,
@@ -1116,7 +1116,9 @@ pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBu
     let temp_dirs = temp_dirs?;
     let paths: Vec<PathBuf> = temp_dirs
         .iter()
-        .map(|t: &TempDir| -> PathBuf { setup_accounts_run_and_snapshot_paths(t.path()).unwrap() })
+        .map(|t: &TempDir| -> PathBuf {
+            create_accounts_run_and_snapshot_dirs(t.path()).unwrap().0
+        })
         .collect();
     Ok((temp_dirs, paths))
 }

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -133,7 +133,7 @@ where
 
         let parts: Vec<_> = parts.map(|p| p.unwrap()).collect();
         let account_filename =
-            (parts.len() == 2 && parts[0] == "accounts").then_some(PathBuf::from(parts[1]));
+            (parts.len() == 2 && parts[0] == "accounts").then(|| PathBuf::from(parts[1]));
         let unpack_dir = match entry_checker(parts.as_slice(), kind) {
             UnpackPath::Invalid => {
                 return Err(UnpackError::Archive(format!(

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -132,11 +132,8 @@ where
         }
 
         let parts: Vec<_> = parts.map(|p| p.unwrap()).collect();
-        let account_filename: Option<PathBuf> = if parts.len() == 2 && parts[0] == "accounts" {
-            Some(PathBuf::from(parts[1]))
-        } else {
-            None
-        };
+        let account_filename =
+            (parts.len() == 2 && parts[0] == "accounts").then_some(PathBuf::from(parts[1]));
         let unpack_dir = match entry_checker(parts.as_slice(), kind) {
             UnpackPath::Invalid => {
                 return Err(UnpackError::Archive(format!(

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -132,6 +132,11 @@ where
         }
 
         let parts: Vec<_> = parts.map(|p| p.unwrap()).collect();
+        let account_filename: Option<PathBuf> = if parts.len() == 2 && parts[0] == "accounts" {
+            Some(PathBuf::from(parts[1]))
+        } else {
+            None
+        };
         let unpack_dir = match entry_checker(parts.as_slice(), kind) {
             UnpackPath::Invalid => {
                 return Err(UnpackError::Archive(format!(
@@ -175,8 +180,16 @@ where
         let entry_path_buf = unpack_dir.join(entry.path()?);
         set_perms(&entry_path_buf, mode)?;
 
+        let entry_path = if let Some(account_filename) = account_filename {
+            let stripped_path = unpack_dir.join(account_filename); // strip away "accounts"
+            fs::rename(&entry_path_buf, &stripped_path)?;
+            stripped_path
+        } else {
+            entry_path_buf
+        };
+
         // Process entry after setting permissions
-        entry_processor(entry_path_buf);
+        entry_processor(entry_path);
 
         total_entries += 1;
         let now = Instant::now();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -14,7 +14,7 @@ use {
         epoch_accounts_hash,
         genesis_utils::{self, activate_all_features, activate_feature},
         snapshot_utils::{
-            generate_test_tmp_account_path, get_storages_to_serialize, ArchiveFormat,
+            create_tmp_accounts_dir_for_tests, get_storages_to_serialize, ArchiveFormat,
         },
         status_cache::StatusCache,
     },
@@ -577,7 +577,7 @@ fn test_extra_fields_full_snapshot_archive() {
     // Set extra field
     bank.fee_rate_governor.lamports_per_signature = 7000;
 
-    let accounts_dir = generate_test_tmp_account_path();
+    let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
     let bank_snapshots_dir = TempDir::new().unwrap();
     let full_snapshot_archives_dir = TempDir::new().unwrap();
     let incremental_snapshot_archives_dir = TempDir::new().unwrap();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -13,7 +13,9 @@ use {
         bank::{Bank, BankTestConfig},
         epoch_accounts_hash,
         genesis_utils::{self, activate_all_features, activate_feature},
-        snapshot_utils::{get_storages_to_serialize, ArchiveFormat},
+        snapshot_utils::{
+            generate_test_tmp_account_path, get_storages_to_serialize, ArchiveFormat,
+        },
         status_cache::StatusCache,
     },
     bincode::serialize_into,
@@ -575,7 +577,7 @@ fn test_extra_fields_full_snapshot_archive() {
     // Set extra field
     bank.fee_rate_governor.lamports_per_signature = 7000;
 
-    let accounts_dir = TempDir::new().unwrap();
+    let accounts_dir = generate_test_tmp_account_path();
     let bank_snapshots_dir = TempDir::new().unwrap();
     let full_snapshot_archives_dir = TempDir::new().unwrap();
     let incremental_snapshot_archives_dir = TempDir::new().unwrap();
@@ -595,7 +597,7 @@ fn test_extra_fields_full_snapshot_archive() {
 
     // Deserialize
     let (dbank, _) = snapshot_utils::bank_from_snapshot_archives(
-        &[PathBuf::from(accounts_dir.path())],
+        &[accounts_dir],
         bank_snapshots_dir.path(),
         &snapshot_archive_info,
         None,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -851,7 +851,9 @@ pub fn create_accounts_run_and_snapshot_dirs(
         // to this new version using run and snapshot directories.
         // The run/ content cleanup will be done at a later point.  The snapshot/ content persists
         // accross the process boot, and will be purged by the account_background_service.
-        fs::remove_dir_all(account_dir.as_ref())?;
+        if fs::remove_dir_all(&account_dir).is_err() {
+            delete_contents_of_path(&account_dir);
+        }
         fs::create_dir_all(&run_path)?;
         fs::create_dir_all(&snapshot_path)?;
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2166,9 +2166,9 @@ pub fn verify_snapshot_archive<P, Q, R>(
     // In the unarchiving case, there is an extra empty "accounts" directory. The account
     // files in the archive accounts/ have been expanded to [account_paths].
     // Remove the empty "accounts" directory for the directory comparison below.
-    // In some test cases the directory to compare do not come from unchiving.  Use
+    // In some test cases the directory to compare do not come from unarchiving.  Use
     // unwarp_or_default to ignore the error if this directory does not exist.
-    std::fs::remove_dir(account_dir.join("accounts")).unwrap_or_default();
+    _ = std::fs::remove_dir(account_dir.join("accounts"));
     // Check the account entries are the same
     assert!(!dir_diff::is_different(&storages_to_verify, account_dir).unwrap());
 }
@@ -2427,11 +2427,12 @@ pub fn should_take_incremental_snapshot(
         && last_full_snapshot_slot.is_some()
 }
 
-pub fn generate_test_tmp_account_path() -> PathBuf {
-    let accounts_dir = tempfile::TempDir::new().unwrap();
-    create_accounts_run_and_snapshot_dirs(accounts_dir.path())
+pub fn create_tmp_accounts_dir_for_tests() -> (TempDir, PathBuf) {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let account_dir = create_accounts_run_and_snapshot_dirs(tmp_dir.path())
         .unwrap()
-        .0
+        .0;
+    (tmp_dir, account_dir)
 }
 
 #[cfg(test)]
@@ -3352,7 +3353,7 @@ mod tests {
             original_bank.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = generate_test_tmp_account_path();
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3464,7 +3465,7 @@ mod tests {
             bank4.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = generate_test_tmp_account_path();
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3555,7 +3556,7 @@ mod tests {
             bank1.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = generate_test_tmp_account_path();
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3677,7 +3678,7 @@ mod tests {
             bank1.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = generate_test_tmp_account_path();
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3790,7 +3791,7 @@ mod tests {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 
-        let accounts_dir = generate_test_tmp_account_path();
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2166,8 +2166,8 @@ pub fn verify_snapshot_archive<P, Q, R>(
     // In the unarchiving case, there is an extra empty "accounts" directory. The account
     // files in the archive accounts/ have been expanded to [account_paths].
     // Remove the empty "accounts" directory for the directory comparison below.
-    // In some test cases the directory to compare do not come from unarchiving.  Use
-    // unwarp_or_default to ignore the error if this directory does not exist.
+    // In some test cases the directory to compare do not come from unarchiving.
+    // Ignore the error when this directory does not exist.
     _ = std::fs::remove_dir(account_dir.join("accounts"));
     // Check the account entries are the same
     assert!(!dir_diff::is_different(&storages_to_verify, account_dir).unwrap());

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -833,6 +833,19 @@ where
     Ok(())
 }
 
+/// To allow generating a bank snapshot directory with full state information, we need to
+/// hardlink account appendvec files from the runtime operation directory to a snapshot
+/// hardlink directory.  This is to create the run/ and snapshot sub directories for an
+/// account_path provided by the user.  These two sub directories are on the same file
+/// system partition to allow hard-linking.
+pub fn setup_accounts_run_and_snapshot_paths<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
+    let run_path = path.as_ref().join("run");
+    let snapshot_path = path.as_ref().join("snapshot");
+    fs::create_dir_all(&run_path)?;
+    fs::create_dir_all(snapshot_path)?;
+    Ok(run_path)
+}
+
 /// Serialize a bank to a snapshot
 ///
 /// **DEVELOPER NOTE** Any error that is returned from this function may bring down the node!  This
@@ -2123,10 +2136,11 @@ pub fn verify_snapshot_archive<P, Q, R>(
 {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let unpack_dir = temp_dir.path();
+    let account_dir = setup_accounts_run_and_snapshot_paths(unpack_dir).unwrap();
     untar_snapshot_in(
         snapshot_archive,
         unpack_dir,
-        &[unpack_dir.to_path_buf()],
+        &[account_dir.clone()],
         archive_format,
         1,
     )
@@ -2147,9 +2161,11 @@ pub fn verify_snapshot_archive<P, Q, R>(
 
     assert!(!dir_diff::is_different(&snapshots_to_verify, unpacked_snapshots).unwrap());
 
+    // The account files in the archive accounts/ have been expanded to [account_paths].
+    // Remove the empty "accounts" directory for the directory comparison below.
+    std::fs::remove_dir(account_dir.join("accounts")).unwrap();
     // Check the account entries are the same
-    let unpacked_accounts = unpack_dir.join("accounts");
-    assert!(!dir_diff::is_different(&storages_to_verify, unpacked_accounts).unwrap());
+    assert!(!dir_diff::is_different(&storages_to_verify, account_dir).unwrap());
 }
 
 /// Remove outdated bank snapshots
@@ -2404,6 +2420,11 @@ pub fn should_take_incremental_snapshot(
 ) -> bool {
     block_height % incremental_snapshot_archive_interval_slots == 0
         && last_full_snapshot_slot.is_some()
+}
+
+pub fn generate_test_tmp_account_path() -> PathBuf {
+    let accounts_dir = tempfile::TempDir::new().unwrap();
+    setup_accounts_run_and_snapshot_paths(accounts_dir.path()).unwrap()
 }
 
 #[cfg(test)]
@@ -3324,7 +3345,7 @@ mod tests {
             original_bank.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = tempfile::TempDir::new().unwrap();
+        let accounts_dir = generate_test_tmp_account_path();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3343,7 +3364,7 @@ mod tests {
         .unwrap();
 
         let (roundtrip_bank, _) = bank_from_snapshot_archives(
-            &[PathBuf::from(accounts_dir.path())],
+            &[accounts_dir],
             bank_snapshots_dir.path(),
             &snapshot_archive_info,
             None,
@@ -3436,7 +3457,7 @@ mod tests {
             bank4.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = tempfile::TempDir::new().unwrap();
+        let accounts_dir = generate_test_tmp_account_path();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3455,7 +3476,7 @@ mod tests {
         .unwrap();
 
         let (roundtrip_bank, _) = bank_from_snapshot_archives(
-            &[PathBuf::from(accounts_dir.path())],
+            &[accounts_dir],
             bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             None,
@@ -3527,7 +3548,7 @@ mod tests {
             bank1.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = tempfile::TempDir::new().unwrap();
+        let accounts_dir = generate_test_tmp_account_path();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3587,7 +3608,7 @@ mod tests {
         .unwrap();
 
         let (roundtrip_bank, _) = bank_from_snapshot_archives(
-            &[PathBuf::from(accounts_dir.path())],
+            &[accounts_dir],
             bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),
@@ -3649,7 +3670,7 @@ mod tests {
             bank1.register_tick(&Hash::new_unique());
         }
 
-        let accounts_dir = tempfile::TempDir::new().unwrap();
+        let accounts_dir = generate_test_tmp_account_path();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3712,7 +3733,7 @@ mod tests {
             &bank_snapshots_dir,
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
-            &[accounts_dir.as_ref().to_path_buf()],
+            &[accounts_dir],
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -3762,7 +3783,7 @@ mod tests {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 
-        let accounts_dir = tempfile::TempDir::new().unwrap();
+        let accounts_dir = generate_test_tmp_account_path();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
@@ -3774,7 +3795,7 @@ mod tests {
         let bank0 = Arc::new(Bank::new_with_paths_for_tests(
             &genesis_config,
             Arc::<RuntimeConfig>::default(),
-            vec![accounts_dir.path().to_path_buf()],
+            vec![accounts_dir.clone()],
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         ));
@@ -3848,7 +3869,7 @@ mod tests {
         )
         .unwrap();
         let (deserialized_bank, _) = bank_from_snapshot_archives(
-            &[accounts_dir.path().to_path_buf()],
+            &[accounts_dir.as_path().to_path_buf()],
             bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),
@@ -3913,7 +3934,7 @@ mod tests {
         .unwrap();
 
         let (deserialized_bank, _) = bank_from_snapshot_archives(
-            &[accounts_dir.path().to_path_buf()],
+            &[accounts_dir.as_path().to_path_buf()],
             bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2429,9 +2429,7 @@ pub fn should_take_incremental_snapshot(
 
 pub fn create_tmp_accounts_dir_for_tests() -> (TempDir, PathBuf) {
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let account_dir = create_accounts_run_and_snapshot_dirs(tmp_dir.path())
-        .unwrap()
-        .0;
+    let account_dir = create_accounts_run_and_snapshot_dirs(&tmp_dir).unwrap().0;
     (tmp_dir, account_dir)
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2161,9 +2161,12 @@ pub fn verify_snapshot_archive<P, Q, R>(
 
     assert!(!dir_diff::is_different(&snapshots_to_verify, unpacked_snapshots).unwrap());
 
-    // The account files in the archive accounts/ have been expanded to [account_paths].
+    // In the unarchiving case, there is an extra empty "accounts" directory. The account
+    // files in the archive accounts/ have been expanded to [account_paths].
     // Remove the empty "accounts" directory for the directory comparison below.
-    std::fs::remove_dir(account_dir.join("accounts")).unwrap();
+    // In some test cases the directory to compare do not come from unchiving.  Use
+    // unwarp_or_default to ignore the error if this directory does not exist.
+    std::fs::remove_dir(account_dir.join("accounts")).unwrap_or_default();
     // Check the account entries are the same
     assert!(!dir_diff::is_different(&storages_to_verify, account_dir).unwrap());
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -843,7 +843,7 @@ pub fn create_accounts_run_and_snapshot_dirs(
 ) -> std::io::Result<(PathBuf, PathBuf)> {
     let run_path = account_dir.as_ref().join("run");
     let snapshot_path = account_dir.as_ref().join("snapshot");
-    if fs::metadata(&run_path).is_err() || fs::metadata(&snapshot_path).is_err() {
+    if run_path.try_exists().is_err() || snapshot_path.try_exists().is_err() {
         // If the "run/" or "snapshot" sub directories do not exist, the directory may be from
         // an older version for which the appendvec files are at this directory.  Clean up
         // them first.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -843,7 +843,7 @@ pub fn create_accounts_run_and_snapshot_dirs(
 ) -> std::io::Result<(PathBuf, PathBuf)> {
     let run_path = account_dir.as_ref().join("run");
     let snapshot_path = account_dir.as_ref().join("snapshot");
-    if run_path.try_exists().is_err() || snapshot_path.try_exists().is_err() {
+    if (!run_path.is_dir()) || (!snapshot_path.is_dir()) {
         // If the "run/" or "snapshot" sub directories do not exist, the directory may be from
         // an older version for which the appendvec files are at this directory.  Clean up
         // them first.
@@ -851,7 +851,7 @@ pub fn create_accounts_run_and_snapshot_dirs(
         // to this new version using run and snapshot directories.
         // The run/ content cleanup will be done at a later point.  The snapshot/ content persists
         // accross the process boot, and will be purged by the account_background_service.
-        move_and_async_delete_path(account_dir.as_ref());
+        fs::remove_dir_all(account_dir.as_ref())?;
         fs::create_dir_all(&run_path)?;
         fs::create_dir_all(&snapshot_path)?;
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -840,7 +840,7 @@ where
 /// system partition to allow hard-linking.
 pub fn create_accounts_run_and_snapshot_dirs(
     account_dir: impl AsRef<Path>,
-) -> Result<(PathBuf, PathBuf)> {
+) -> std::io::Result<(PathBuf, PathBuf)> {
     let run_path = account_dir.as_ref().join("run");
     let snapshot_path = account_dir.as_ref().join("snapshot");
     fs::create_dir_all(&run_path)?;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -25,7 +25,7 @@ use {
         accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig, bank_forks::BankForks,
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, runtime_config::RuntimeConfig,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::SnapshotConfig, snapshot_utils::setup_accounts_run_and_snapshot_paths,
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -802,7 +802,10 @@ impl TestValidator {
             rpc_config: config.rpc_config.clone(),
             pubsub_config: config.pubsub_config.clone(),
             accounts_hash_interval_slots: 100,
-            account_paths: vec![ledger_path.join("accounts")],
+            account_paths: vec![setup_accounts_run_and_snapshot_paths(
+                ledger_path.join("accounts"),
+            )
+            .unwrap()],
             poh_verify: false, // Skip PoH verification of ledger on startup for speed
             snapshot_config: SnapshotConfig {
                 full_snapshot_archive_interval_slots: 100,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -25,7 +25,7 @@ use {
         accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig, bank_forks::BankForks,
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, runtime_config::RuntimeConfig,
-        snapshot_config::SnapshotConfig, snapshot_utils::setup_accounts_run_and_snapshot_paths,
+        snapshot_config::SnapshotConfig, snapshot_utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -802,10 +802,11 @@ impl TestValidator {
             rpc_config: config.rpc_config.clone(),
             pubsub_config: config.pubsub_config.clone(),
             accounts_hash_interval_slots: 100,
-            account_paths: vec![setup_accounts_run_and_snapshot_paths(
-                ledger_path.join("accounts"),
-            )
-            .unwrap()],
+            account_paths: vec![
+                create_accounts_run_and_snapshot_dirs(ledger_path.join("accounts"))
+                    .unwrap()
+                    .0,
+            ],
             poh_verify: false, // Skip PoH verification of ledger on startup for speed
             snapshot_config: SnapshotConfig {
                 full_snapshot_archive_interval_slots: 100,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -35,7 +35,9 @@ use {
         },
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
-        snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
+        snapshot_utils::{
+            self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+        },
     },
     solana_sdk::{
         clock::{Slot, DEFAULT_S_PER_SLOT},
@@ -1267,7 +1269,7 @@ pub fn main() {
             .ok();
 
     // Create and canonicalize account paths to avoid issues with symlink creation
-    validator_config.account_paths = account_paths
+    let account_run_paths: Vec<PathBuf> = account_paths
         .into_iter()
         .map(|account_path| {
             match fs::create_dir_all(&account_path).and_then(|_| fs::canonicalize(&account_path)) {
@@ -1277,8 +1279,20 @@ pub fn main() {
                     exit(1);
                 }
             }
-        })
-        .collect();
+        }).map(
+        |account_path| {
+            // For all account_paths, set up the run/ and snapshot/ sub directories.
+            match setup_accounts_run_and_snapshot_paths(&account_path) {
+                Ok(account_run_path) => account_run_path,
+                Err(err) => {
+                    eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
+                    exit(1);
+                }
+            }
+        }).collect();
+
+    // From now on, use run/ paths in the same way as the previous account_paths.
+    validator_config.account_paths = account_run_paths;
 
     validator_config.account_shrink_paths = account_shrink_paths.map(|paths| {
         paths

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1282,6 +1282,7 @@ pub fn main() {
         }).map(
         |account_path| {
             // For all account_paths, set up the run/ and snapshot/ sub directories.
+            // If the sub directories do not exist, the account_path will be cleaned because older version put account files there
             match create_accounts_run_and_snapshot_dirs(&account_path) {
                 Ok((account_run_path, _account_snapshot_path)) => account_run_path,
                 Err(err) => {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -36,7 +36,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
-            self, setup_accounts_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+            self, create_accounts_run_and_snapshot_dirs, ArchiveFormat, SnapshotVersion,
         },
     },
     solana_sdk::{
@@ -1282,8 +1282,8 @@ pub fn main() {
         }).map(
         |account_path| {
             // For all account_paths, set up the run/ and snapshot/ sub directories.
-            match setup_accounts_run_and_snapshot_paths(&account_path) {
-                Ok(account_run_path) => account_run_path,
+            match create_accounts_run_and_snapshot_dirs(&account_path) {
+                Ok((account_run_path, _account_snapshot_path)) => account_run_path,
                 Err(err) => {
                     eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
                     exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1285,7 +1285,7 @@ pub fn main() {
             match create_accounts_run_and_snapshot_dirs(&account_path) {
                 Ok((account_run_path, _account_snapshot_path)) => account_run_path,
                 Err(err) => {
-                    eprintln!("Unable to set up account run and snapshot sub directories: {account_path:?}, err: {err:?}");
+                    eprintln!("Unable to create account run and snapshot sub directories: {}, err: {err:?}", account_path.display());
                     exit(1);
                 }
             }


### PR DESCRIPTION
#### Problem
PR https://github.com/solana-labs/solana/pull/29794 was reverted because of OOM.  This is the resubmission with the fix.

The new image uses the run/ sub directory for the appendvec files.  When transitioning from an old image to this new image, the appendvec files in the old account_path should be cleaned up to avoid taking the space.  In the ramfs case, it was taking the memory, causing OOM.

All commits have passed the review in PR 29794 except the last one [f8f58f2](https://github.com/solana-labs/solana/pull/29942/commits/f8f58f2907406f61205988ebad45f4c0892d99c8) 

#### Summary of Changes
The fix is to clean up the files in the old path.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
