### PR TITLE
[explorer] Fix parsing of some Pyth transactions.

### DIFF
--- a/explorer/src/components/instruction/pyth/PythDetailsCard.tsx
+++ b/explorer/src/components/instruction/pyth/PythDetailsCard.tsx
@@ -13,6 +13,7 @@ import InitMappingDetailsCard from "./InitMappingDetailsCard";
 import AddMappingDetailsCard from "./AddMappingDetailsCard";
 import AggregatePriceDetailsCard from "./AggregatePriceDetailsCard";
 import InitPriceDetailsCard from "./InitPriceDetailsCard";
+import SetMinPublishersDetailsCard from "./SetMinPublishersDetailsCard";
 
 export function PythDetailsCard(props: {
   ix: TransactionInstruction;
@@ -106,6 +107,13 @@ export function PythDetailsCard(props: {
         return (
           <InitPriceDetailsCard
             info={PythInstruction.decodeInitPrice(ix)}
+            {...props}
+          />
+        );
+      case "SetMinPublishers":
+        return (
+          <SetMinPublishersDetailsCard
+            info={PythInstruction.decodeSetMinPublishers(ix)}
             {...props}
           />
         );

--- a/explorer/src/components/instruction/pyth/program.ts
+++ b/explorer/src/components/instruction/pyth/program.ts
@@ -402,7 +402,7 @@ export class PythInstruction {
     return {
       signerPubkey: instruction.keys[0].pubkey,
       pricePubkey: instruction.keys[1].pubkey,
-      publisherPubkey: PublicKey.decode(publisherPubkey),
+      publisherPubkey: new PublicKey(publisherPubkey),
     };
   }
 
@@ -420,7 +420,7 @@ export class PythInstruction {
     return {
       signerPubkey: instruction.keys[0].pubkey,
       pricePubkey: instruction.keys[1].pubkey,
-      publisherPubkey: PublicKey.decode(publisherPubkey),
+      publisherPubkey: new PublicKey(publisherPubkey),
     };
   }
 


### PR DESCRIPTION
#### Problem
 Some transactions related to the Pyth oracle are not displayed properly.

#### Summary of Changes
- Fix a bug where the instruction setMinimumPublishers was not recognized
- Fix a bug where the public keys in the instruction payload to AddPublisher and DeletePublisher where not deserialized properly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
