### PR TITLE
ledger: Mark `process_entries_for_tests` as `#[cfg(test)]`

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -399,9 +399,10 @@ fn execute_batches(
 /// 3. Register the `Tick` if it's available
 /// 4. Update the leader scheduler, goto 1
 ///
-/// This method is for use testing against a single Bank, and assumes `Bank::transaction_count()`
-/// represents the number of transactions executed in this Bank
-pub fn process_entries_for_tests(
+/// This method is used in testing against a single Bank, and assumes `Bank::transaction_count()`
+/// represents the number of transactions executed in this Bank.
+#[cfg(test)]
+fn process_entries_for_tests(
     bank: &Arc<Bank>,
     entries: Vec<Entry>,
     randomize: bool,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4549,6 +4549,7 @@ pub fn create_test_transaction_entries(
     (vec![entry_1, entry_2], signatures)
 }
 
+#[cfg(test)]
 pub fn populate_blockstore_for_tests(
     entries: Vec<Entry>,
     bank: Arc<Bank>,


### PR DESCRIPTION
This way, the compiler will ensure that the function is indeed only called from the testing code.