### PR TITLE
ledger-tool: Remove unnecessary function to parse ledger path arg

### DIFF
--- a/ledger-tool/src/ledger_path.rs
+++ b/ledger-tool/src/ledger_path.rs
@@ -1,21 +1,8 @@
-use {
-    clap::{value_t, ArgMatches},
-    std::{
-        fs,
-        path::{Path, PathBuf},
-        process::exit,
-    },
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::exit,
 };
-
-pub fn parse_ledger_path(matches: &ArgMatches<'_>, name: &str) -> PathBuf {
-    PathBuf::from(value_t!(matches, name, String).unwrap_or_else(|_err| {
-        eprintln!(
-            "Error: Missing --ledger <DIR> argument.\n\n{}",
-            matches.usage()
-        );
-        exit(1);
-    }))
-}
 
 // Canonicalize ledger path to avoid issues with symlink creation
 pub fn canonicalize_ledger_path(ledger_path: &Path) -> PathBuf {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2249,8 +2249,7 @@ fn main() {
 
     info!("{} {}", crate_name!(), solana_version::version!());
 
-    let ledger_path = parse_ledger_path(&matches, "ledger_path");
-
+    let ledger_path = PathBuf::from(value_t_or_exit!(matches, "ledger_path", String));
     let snapshot_archive_path = value_t!(matches, "snapshot_archive_path", String)
         .ok()
         .map(PathBuf::from);


### PR DESCRIPTION
#### Problem
The function reports an error if ledger_path is not found in argument matches; however, ledger_path has a default value so a value will always be present. The check that actually matters is provided by canonicalize_ledger_path() which checks that a path is actually valid.

#### Summary of Changes
Rip out the unnecessary function.

Here is the tool's output from running without ledger path specified when a `ledger` directory doesn't exist in the current working directory. Note this is the error from `canonicalize_ledger_path()`, not `parse_ledger_path()`.
```
$ solana-ledger-tool bounds
...
Unable to access ledger path 'ledger': No such file or directory (os error 2)
```
And for completeness, here is output when `ledger` is a valid sub-directory in current working directory:
```
$ ~/src/solana/target/release/solana-ledger-tool bounds
...
Ledger has data for 165601 slots 174451279 to 174622838
  with 156635 rooted slots from 174451279 to 174622701
  and 130 slots past the last root
```