### PR TITLE
refactor: remove obsoleted function

### DIFF
--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -74,15 +74,11 @@ impl TransactionCost {
     }
 
     pub fn sum(&self) -> u64 {
-        self.sum_without_bpf()
-            .saturating_add(self.bpf_execution_cost)
-    }
-
-    pub fn sum_without_bpf(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)
             .saturating_add(self.data_bytes_cost)
             .saturating_add(self.builtins_execution_cost)
+            .saturating_add(self.bpf_execution_cost)
     }
 }
 


### PR DESCRIPTION
#### Problem
function `sum_without_bpf()` is not used externally.

#### Summary of Changes
remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
