### PR TITLE
Add docker latest tag when building stable release

### DIFF
--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -32,6 +32,10 @@ cp -f ../../fetch-spl.sh usr/bin/
 
 docker build -t solanalabs/solana:"$CHANNEL_OR_TAG" .
 
+if [[ $CHANNEL_OR_TAG = stable ]] ;then
+  docker tag solanalabs/solana:"$CHANNEL_OR_TAG" solanalabs/solana:latest
+fi
+
 maybeEcho=
 if [[ -z $CI ]]; then
   echo "Not CI, skipping |docker push|"
@@ -44,4 +48,4 @@ else
     fi
   )
 fi
-$maybeEcho docker push solanalabs/solana:"$CHANNEL_OR_TAG"
+$maybeEcho docker push --all-tags solanalabs/solana:"$CHANNEL_OR_TAG"


### PR DESCRIPTION
#### Problem

As mentioned in #22485, the `solanalabs/solana` docker image has no `latest` tag applied to it when pushed to docker hub. This prevents users from running `docker pull solanalabs/solana`, which is a common convention.

#### Summary of Changes

The best practice docker hub images is to tag the latest stable release with the `latest` tag and any additional tags as desired (see [Ubuntu official docker image](https://hub.docker.com/_/ubuntu)). These changes add an additional docker image tag of `latest` when the `$CHANNEL_OR_TAG` is equal to `stable`, and adds the `--all-tags` option to the `docker push` command in `sdk/docker-solana/build.sh`.

Fixes #22485