### PR TITLE
Explorer - Improve token display name in detail view

### DIFF
--- a/explorer/src/components/account/OwnedTokensCard.tsx
+++ b/explorer/src/components/account/OwnedTokensCard.tsx
@@ -127,10 +127,10 @@ function HoldingsDetailTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
           </td>
         )}
         <td>
-          <Address pubkey={tokenAccount.pubkey} link truncate />
+          <Address pubkey={tokenAccount.info.mint} link truncate useMetadata />
         </td>
         <td>
-          <Address pubkey={tokenAccount.info.mint} link truncate />
+          <Address pubkey={tokenAccount.pubkey} link truncate />
         </td>
         <td>
           {tokenAccount.info.tokenAmount.uiAmountString}{" "}
@@ -148,8 +148,8 @@ function HoldingsDetailTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
             {showLogos && (
               <th className="text-muted w-1 p-0 text-center">Logo</th>
             )}
-            <th className="text-muted">Account Address</th>
             <th className="text-muted">Mint Address</th>
+            <th className="text-muted">Account Address</th>
             <th className="text-muted">Balance</th>
           </tr>
         </thead>


### PR DESCRIPTION
#### Problem
Solana Explorer Token Details tab loses known token names for some tokens (my hunch is those with newer Metaplex metadata post token registry).
Example: Can be seen [here](https://explorer.solana.com/address/FgrpCC6E1xXH5E4nFM4mBvCvmocJHcm2hf6Fdbz9xFtX/tokens?display=detail) where SAMO maintains token name but others do not: 
![image](https://user-images.githubusercontent.com/85324096/215295051-f121be9e-e1e9-4d93-b52c-e1e2c26eaa2e.png)


#### Summary of Changes

1. Add `useMetadata` to the `mint` display so that newer tokens' display name is shown (not just those in the registry) 
2. Shift column order so mint/name column is always first and does not change when toggling from `Summary` to `Detailed`

Achieved outcome--all tokens 

https://user-images.githubusercontent.com/85324096/215294960-dcd98af2-0d41-4175-bb13-29305c42f9f0.mov



Fixes #
[Issue 29604](https://github.com/solana-labs/explorer/issues/207)
<!-- Don't forget to add the "feature-gate" label -->
