### PR TITLE
alt_bn128: Use as_slice() instead of as_ref()

### DIFF
--- a/sdk/program/src/alt_bn128.rs
+++ b/sdk/program/src/alt_bn128.rs
@@ -158,13 +158,13 @@ mod target_arch {
         input.resize(ALT_BN128_ADDITION_INPUT_LEN, 0);
 
         let p: G1 = PodG1(
-            convert_edianness_64(&input[..64])
+            convert_endianness_64(&input[..64])
                 .try_into()
                 .map_err(AltBn128Error::TryIntoVecError)?,
         )
         .try_into()?;
         let q: G1 = PodG1(
-            convert_edianness_64(&input[64..ALT_BN128_ADDITION_INPUT_LEN])
+            convert_endianness_64(&input[64..ALT_BN128_ADDITION_INPUT_LEN])
                 .try_into()
                 .map_err(AltBn128Error::TryIntoVecError)?,
         )
@@ -178,7 +178,7 @@ mod target_arch {
         if result_point == G1::zero() {
             return Ok([0u8; ALT_BN128_ADDITION_OUTPUT_LEN].to_vec());
         }
-        Ok(convert_edianness_64(&result_point_data[..ALT_BN128_ADDITION_OUTPUT_LEN]).to_vec())
+        Ok(convert_endianness_64(&result_point_data[..ALT_BN128_ADDITION_OUTPUT_LEN]).to_vec())
     }
 
     pub fn alt_bn128_multiplication(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
@@ -190,12 +190,12 @@ mod target_arch {
         input.resize(ALT_BN128_MULTIPLICATION_INPUT_LEN, 0);
 
         let p: G1 = PodG1(
-            convert_edianness_64(&input[..64])
+            convert_endianness_64(&input[..64])
                 .try_into()
                 .map_err(AltBn128Error::TryIntoVecError)?,
         )
         .try_into()?;
-        let fr = <BigInteger256 as FromBytes>::read(convert_edianness_64(&input[64..96]).as_ref())
+        let fr = <BigInteger256 as FromBytes>::read(convert_endianness_64(&input[64..96]).as_ref())
             .map_err(|_| AltBn128Error::InvalidInputData)?;
 
         let mut result_point_data = [0; ALT_BN128_MULTIPLICATION_OUTPUT_LEN + 1];
@@ -206,7 +206,7 @@ mod target_arch {
             return Ok([0u8; ALT_BN128_MULTIPLICATION_OUTPUT_LEN].to_vec());
         }
         Ok(
-            convert_edianness_64(&result_point_data[..ALT_BN128_MULTIPLICATION_OUTPUT_LEN])
+            convert_endianness_64(&result_point_data[..ALT_BN128_MULTIPLICATION_OUTPUT_LEN])
                 .to_vec(),
         )
     }
@@ -224,7 +224,7 @@ mod target_arch {
         let mut vec_pairs: Vec<(G1Prepared<Parameters>, G2Prepared<Parameters>)> = Vec::new();
         for i in 0..ele_len {
             let g1: G1 = PodG1(
-                convert_edianness_64(
+                convert_endianness_64(
                     &input[i.saturating_mul(ALT_BN128_PAIRING_ELEMENT_LEN)
                         ..i.saturating_mul(ALT_BN128_PAIRING_ELEMENT_LEN)
                             .saturating_add(ALT_BN128_POINT_SIZE)],
@@ -234,7 +234,7 @@ mod target_arch {
             )
             .try_into()?;
             let g2: G2 = PodG2(
-                convert_edianness_128(
+                convert_endianness_128(
                     &input[i
                         .saturating_mul(ALT_BN128_PAIRING_ELEMENT_LEN)
                         .saturating_add(ALT_BN128_POINT_SIZE)
@@ -260,14 +260,14 @@ mod target_arch {
         Ok(output)
     }
 
-    fn convert_edianness_64(bytes: &[u8]) -> Vec<u8> {
+    fn convert_endianness_64(bytes: &[u8]) -> Vec<u8> {
         bytes
             .chunks(32)
             .flat_map(|b| b.iter().copied().rev().collect::<Vec<u8>>())
             .collect::<Vec<u8>>()
     }
 
-    fn convert_edianness_128(bytes: &[u8]) -> Vec<u8> {
+    fn convert_endianness_128(bytes: &[u8]) -> Vec<u8> {
         bytes
             .chunks(64)
             .flat_map(|b| b.iter().copied().rev().collect::<Vec<u8>>())

--- a/sdk/program/src/alt_bn128.rs
+++ b/sdk/program/src/alt_bn128.rs
@@ -195,8 +195,9 @@ mod target_arch {
                 .map_err(AltBn128Error::TryIntoVecError)?,
         )
         .try_into()?;
-        let fr = <BigInteger256 as FromBytes>::read(convert_endianness_64(&input[64..96]).as_ref())
-            .map_err(|_| AltBn128Error::InvalidInputData)?;
+        let fr =
+            <BigInteger256 as FromBytes>::read(convert_endianness_64(&input[64..96]).as_slice())
+                .map_err(|_| AltBn128Error::InvalidInputData)?;
 
         let mut result_point_data = [0; ALT_BN128_MULTIPLICATION_OUTPUT_LEN + 1];
         let result_point: G1 = p.into_projective().mul(&fr).into();


### PR DESCRIPTION
#### Problem
`AsRef` trait and its `as_ref()` method can confuse inference, which is reproducible when using solana-program as a dependency. 

#### Summary of Changes
To avoid that issue, use `as_slice()` instead.

Fixes #29971
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
