### PR TITLE
records outdated gossip crds upserts in received-cache

### DIFF
--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -184,14 +184,12 @@ impl CrdsGossip {
         pings: &mut Vec<(SocketAddr, Ping)>,
         socket_addr_space: &SocketAddrSpace,
     ) {
-        let network_size = self.crds.read().unwrap().num_nodes();
         self.push.refresh_push_active_set(
             &self.crds,
             stakes,
             gossip_validators,
             self_keypair,
             self_shred_version,
-            network_size,
             ping_cache,
             pings,
             socket_addr_space,

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -13,6 +13,7 @@ const NUM_PUSH_ACTIVE_SET_ENTRIES: usize = 25;
 //     min stake of { this node, crds value owner }
 // The entry represents set of gossip nodes to actively
 // push to for crds values belonging to the bucket.
+#[derive(Default)]
 pub(crate) struct PushActiveSet([PushActiveSetEntry; NUM_PUSH_ACTIVE_SET_ENTRIES]);
 
 // Keys are gossip nodes to push messages to.
@@ -162,12 +163,6 @@ impl PushActiveSetEntry {
         while self.0.len() > size {
             self.0.shift_remove_index(0);
         }
-    }
-}
-
-impl Default for PushActiveSet {
-    fn default() -> Self {
-        Self(std::array::from_fn(|_| PushActiveSetEntry::default()))
     }
 }
 

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -83,6 +83,9 @@ impl ReceivedCacheEntry {
             *score = score.saturating_add(1);
         } else if self.nodes.len() < Self::CAPACITY {
             // Ensure that node is inserted into the cache for later pruning.
+            // This intentionally does not negatively impact node's score, in
+            // order to prevent replayed messages with spoofed addresses force
+            // pruning a good node.
             let _ = self.nodes.entry(node).or_default();
         }
     }


### PR DESCRIPTION
#### Problem
Outdated gossip crds upserts from push messages should also be recorded in received-cache for later pruning.

#### Summary of Changes
Record outdated gossip crds upserts from push messages in received-cache