### PR TITLE
ledger-tool: Fix argument matching for accounts_db_ancient_append_vecs

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2746,7 +2746,7 @@ fn main() {
                     ),
                     filler_accounts_config,
                     ancient_append_vec_offset: value_t!(
-                        matches,
+                        arg_matches,
                         "accounts_db_ancient_append_vecs",
                         i64
                     )
@@ -3011,7 +3011,7 @@ fn main() {
 
                 let accounts_db_config = Some(AccountsDbConfig {
                     ancient_append_vec_offset: value_t!(
-                        matches,
+                        arg_matches,
                         "accounts_db_ancient_append_vecs",
                         i64
                     )


### PR DESCRIPTION
#### Problem
The logic was searching for argument in global argument matches when it should have been searching in the subcommand matches.

#### Summary of Changes
Match `accounts_db_ancient_append_vecs` from subcommand matches.

To illustrate, I applied this change to the tip of master immediately after the arg was matched in the `AccountsDbConfig` creation:
```rust
+                if !accounts_db_config.as_ref().unwrap().ancient_append_vec_offset.is_some() {
+                    panic!("Didn't match ancient_append_vec_offset");
+                }
```
and then ran:
```
$ cargo run --release --bin solana-ledger-tool -- verify --ledger ~/empty_ledger/ --accounts-db-ancient-append-vecs 5
```
which yielded:
```
thread 'main' panicked at 'Didn't match ancient_append_vec_offset', ledger-tool/src/main.rs:2761:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
With this PR applied and running the same command, I now see the failure later on since I passed a ledger path with no snapshots or slots.
