### PR TITLE
defer repair for turbine propagation

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -1,10 +1,12 @@
 use {
     crate::{
-        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairService,
-        serve_repair::ShredRepairType, tree_diff::TreeDiff,
+        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
+        repair_service::{RepairService, RepairStats},
+        serve_repair::ShredRepairType,
+        tree_diff::TreeDiff,
     },
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
-    solana_sdk::{clock::Slot, hash::Hash},
+    solana_sdk::{clock::Slot, genesis_config::ClusterType, hash::Hash},
     std::collections::{HashMap, HashSet},
 };
 
@@ -114,6 +116,8 @@ pub fn get_closest_completion(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
+    stats: &mut RepairStats,
+    cluster_type: ClusterType,
 ) -> Vec<ShredRepairType> {
     let mut v: Vec<(Slot, u64)> = Vec::default();
     let iter = GenericTraversal::new(tree);
@@ -187,6 +191,8 @@ pub fn get_closest_completion(
                 slot,
                 slot_meta,
                 limit - repairs.len(),
+                stats,
+                cluster_type,
             );
             repairs.extend(new_repairs);
         }
@@ -241,6 +247,8 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             10,
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(repairs, []);
 
@@ -265,6 +273,8 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             2,
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,

--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -1,11 +1,13 @@
 use {
     crate::{
-        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairService,
-        serve_repair::ShredRepairType, tree_diff::TreeDiff,
+        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
+        repair_service::{RepairService, RepairStats},
+        serve_repair::ShredRepairType,
+        tree_diff::TreeDiff,
     },
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
     solana_runtime::contains::Contains,
-    solana_sdk::{clock::Slot, hash::Hash},
+    solana_sdk::{clock::Slot, genesis_config::ClusterType, hash::Hash},
     std::collections::{HashMap, HashSet},
 };
 
@@ -80,6 +82,8 @@ pub fn get_best_repair_shreds<'a>(
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
     ignore_slots: &impl Contains<'a, Slot>,
+    stats: &mut RepairStats,
+    cluster_type: ClusterType,
 ) {
     let initial_len = repairs.len();
     let max_repairs = initial_len + max_new_shreds;
@@ -106,6 +110,8 @@ pub fn get_best_repair_shreds<'a>(
                             slot,
                             slot_meta,
                             max_repairs - repairs.len(),
+                            stats,
+                            cluster_type,
                         );
                         repairs.extend(new_repairs);
                     }
@@ -127,6 +133,8 @@ pub fn get_best_repair_shreds<'a>(
                                 max_repairs,
                                 *new_child_slot,
                                 ignore_slots,
+                                stats,
+                                cluster_type,
                             );
                         }
                         visited_set.insert(*new_child_slot);
@@ -232,6 +240,8 @@ pub mod test {
             &mut repairs,
             6,
             &HashSet::default(),
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -261,6 +271,8 @@ pub mod test {
             &mut repairs,
             6,
             &HashSet::default(),
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -301,6 +313,8 @@ pub mod test {
             &mut repairs,
             4,
             &HashSet::default(),
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -322,6 +336,8 @@ pub mod test {
             &mut repairs,
             4,
             &HashSet::default(),
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -347,6 +363,8 @@ pub mod test {
             &mut repairs,
             std::usize::MAX,
             &HashSet::default(),
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
         assert_eq!(
@@ -375,6 +393,8 @@ pub mod test {
             &mut repairs,
             std::usize::MAX,
             &ignore_set,
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -397,6 +417,8 @@ pub mod test {
             &mut repairs,
             std::usize::MAX,
             &ignore_set,
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,
@@ -418,6 +440,8 @@ pub mod test {
             &mut repairs,
             std::usize::MAX,
             &ignore_set,
+            &mut RepairStats::default(),
+            ClusterType::Development,
         );
         assert_eq!(
             repairs,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -105,8 +105,7 @@ lazy_static! {
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 pub const MAX_TURBINE_PROPAGATION: Duration = Duration::from_millis(200);
-pub const MAX_TURBINE_DELAY_IN_TICKS: u64 =
-    MAX_TURBINE_PROPAGATION.as_millis() as u64 / MS_PER_TICK;
+const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION.as_millis() as u64 / MS_PER_TICK;
 
 // An upper bound on maximum number of data shreds we can handle in a slot
 // 32K shreds would allow ~320K peak TPS


### PR DESCRIPTION
#### Problem
Draft for repair propagation delay changes.

Should propagation delay be implemented in repair rather than blockstore?

#### Summary of Changes
- introduce a propagation delay in `repair_service`
- use propagation delay for `HighestShred` shred repairs

propagation delay is currently enforced in `blockstore`: #29742.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
