### PR TITLE
refactor update_shrink_stats

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3921,7 +3921,7 @@ impl AccountsDb {
             Measure::start("ignored"), // find_alive_elapsed
             create_and_insert_store_elapsed_us,
             store_accounts_timing,
-            rewrite_elapsed,
+            rewrite_elapsed.as_us(),
             remove_old_stores_shrink_us,
         );
         self.shrink_stats.report();
@@ -3933,7 +3933,7 @@ impl AccountsDb {
         find_alive_elapsed: Measure,
         create_and_insert_store_elapsed_us: u64,
         store_accounts_timing: StoreAccountsTiming,
-        rewrite_elapsed: Measure,
+        rewrite_elapsed_us: u64,
         remove_old_stores_shrink_us: u64,
     ) {
         shrink_stats
@@ -3962,7 +3962,7 @@ impl AccountsDb {
             .fetch_add(remove_old_stores_shrink_us, Ordering::Relaxed);
         shrink_stats
             .rewrite_elapsed
-            .fetch_add(rewrite_elapsed.as_us(), Ordering::Relaxed);
+            .fetch_add(rewrite_elapsed_us, Ordering::Relaxed);
     }
 
     /// get stores for 'slot'
@@ -4497,7 +4497,7 @@ impl AccountsDb {
             find_alive_elapsed,
             create_and_insert_store_elapsed_us,
             store_accounts_timing,
-            rewrite_elapsed,
+            rewrite_elapsed.as_us(),
             remove_old_stores_shrink.as_us(),
         );
     }


### PR DESCRIPTION
#### Problem
Reworking ancient append vecs to create in a single shot instead of appending.

#### Summary of Changes
Refactor `update_shrink_stats` to allow multiple passes of `rewrite_elapsed` to accumulate stats.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
