### PR TITLE
serde-snapshot uses methods to access AccountsDb::bank_hashes

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7565,6 +7565,28 @@ impl AccountsDb {
         self.bank_hashes.read().unwrap().get(&slot).cloned()
     }
 
+    /// When reconstructing AccountsDb from a snapshot, insert the `bank_hash_info` into the
+    /// internal bank hashses map.
+    ///
+    /// This fn is only called when loading from a snapshot, which means AccountsDb is new and its
+    /// bank hashes is unpopulated.  Therefore, a bank hash must not already exist at `slot` [^1].
+    ///
+    /// [^1] Slot 0 is a special case, however.  When a new AccountsDb is created--like when
+    /// loading from a snapshot--the bank hashes map is populated with a default entry at slot 0.
+    /// It is valid to have a snapshot at slot 0, so it must be handled accordingly.
+    pub fn set_bank_hash_info_from_snapshot(&self, slot: Slot, bank_hash_info: BankHashInfo) {
+        let old_bank_hash_info = self
+            .bank_hashes
+            .write()
+            .unwrap()
+            .insert(slot, bank_hash_info);
+        assert!(
+            old_bank_hash_info.is_none()
+                || (slot == 0 && old_bank_hash_info == Some(BankHashInfo::default())),
+            "There should not already be a BankHashInfo at slot {slot}: {old_bank_hash_info:?}",
+        );
+    }
+
     fn update_index<'a, T: ReadableAccount + Sync>(
         &self,
         infos: Vec<AccountInfo>,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -718,11 +718,7 @@ where
     );
 
     // Process deserialized data, set necessary fields in self
-    accounts_db
-        .bank_hashes
-        .write()
-        .unwrap()
-        .insert(snapshot_slot, snapshot_bank_hash_info);
+    accounts_db.set_bank_hash_info_from_snapshot(snapshot_slot, snapshot_bank_hash_info);
     accounts_db.storage.initialize(storage);
     accounts_db
         .next_id

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -270,14 +270,10 @@ impl<'a> TypeContext<'a> for Context {
                 )
             }));
         let slot = serializable_db.slot;
-        let bank_hash_info: BankHashInfo = serializable_db
+        let bank_hash_info = serializable_db
             .accounts_db
-            .bank_hashes
-            .read()
-            .unwrap()
-            .get(&serializable_db.slot)
-            .unwrap_or_else(|| panic!("No bank_hashes entry for slot {}", serializable_db.slot))
-            .clone();
+            .get_bank_hash_info(serializable_db.slot)
+            .unwrap_or_else(|| panic!("No bank_hashes entry for slot {}", serializable_db.slot));
 
         let historical_roots = serializable_db
             .accounts_db


### PR DESCRIPTION
#### Problem

`AccountsDb::bank_hashes` is public, and only used within `accounts_db.rs` _except_ for two uses in `serde_snapshot.rs` when reconstructing the accounts db fields from a snapshot (and then taking the snapshot of accounts db). This usage of `bank_hashes` inhibits an effort to make `bank_hashes` private (and then change its representation).


#### Summary of Changes

* Access to bank hashes from serde snapshot go through methods on AccountsDb.
    * Add a method for serde snapshot to insert into bank hashes when reconstructing accounts db from a snapshot.