### PR TITLE
Makes AccountsDb::bank_hashes private

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1331,7 +1331,7 @@ pub struct AccountsDb {
 
     pub thread_pool_clean: ThreadPool,
 
-    pub bank_hashes: RwLock<HashMap<Slot, BankHashInfo>>,
+    bank_hashes: RwLock<HashMap<Slot, BankHashInfo>>,
 
     pub stats: AccountsStats,
 


### PR DESCRIPTION
#### Problem

`AccountsDb::bank_hashes` is public, which makes it hard to change its impl. Luckily no one outside of accounts db accesses bank_hashes directly.


#### Summary of Changes

Makes bank_hashes private