### PR TITLE
ci: make merge conflict marker sanity check more robust

### DIFF
--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -7,20 +7,47 @@ source ci/_
 
 (
   echo --- git diff --check
-  set -x
 
-  if [[ -n $CI_BASE_BRANCH ]]
-  then branch="$CI_BASE_BRANCH"
-  else branch="master"
+  if [[ -n "$CI_BASE_BRANCH" ]]; then
+    branch="$CI_BASE_BRANCH"
+    remote=origin
+  else
+    IFS='/' read -r remote branch < <(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null) || true
+    if [[ -z "$branch" ]]; then
+      branch="$remote"
+      remote=
+    fi
+  fi
+
+  if [[ -n "$remote" ]] && ! git remote | grep --quiet "^$remote\$" 2>/dev/null; then
+    echo "WARNING: Remote \`$remote\` not configured for this working directory. Assuming it is actually part of the branch name"
+    branch="$remote"/"$branch"
+    remote=
+  fi
+
+  if [[ -z "$branch" || -z "$remote" ]]; then
+    msg="Cannot determine remote target branch. Set one with \`git branch --set-upstream-to=TARGET\`"
+    if [[ -n "$CI" ]]; then
+      echo "ERROR: $msg" 1>&2
+      exit 1
+    else
+      echo "WARNING: $msg" 1>&2
+    fi
   fi
 
   # Look for failed mergify.io backports by searching leftover conflict markers
   # Also check for any trailing whitespaces!
-  git fetch origin "$branch"
-  git diff "$(git merge-base HEAD "origin/$branch")" --check --oneline
+  if [[ -n "$remote" ]]; then
+    echo "Checking remote \`$remote\` for updates to target branch \`$branch\`"
+    git fetch --quiet "$remote" "$branch"
+    target="$remote"/"$branch"
+  else
+    echo "WARNING: Target branch \`$branch\` appears to be local. No remote updates will be considered."
+    target="$branch"
+  fi
+  set -x
+  git diff "$target" --check --oneline
 )
-
-echo
 
 _ ci/check-channel-version.sh
 _ ci/nits.sh


### PR DESCRIPTION
#### Problem

the conflict marker check in `ci/test-sanity.sh` is overly presumptuous about the working tree configuration

#### Summary of Changes

- query the target branch instead of hardcoding
- various robustness and dx improvements
