### PR TITLE
docs: Update on --limit-ledger-size and ledger disk usage

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -323,15 +323,23 @@ the validator to ports 11000-11020.
 
 The `--limit-ledger-size` parameter allows you to specify how many ledger
 [shreds](../terminology.md#shred) your node retains on disk. If you do not
-include this parameter, the validator will keep the entire ledger until it runs
-out of disk space.
+include this parameter, the validator will keep all received ledger data
+until it runs out of disk space. Otherwise, the validator will continually
+purge the oldest data once to stay under the specified `--limit-ledger-size`
+value.
 
-The default value attempts to keep the ledger disk usage under 500GB. More or
-less disk usage may be requested by adding an argument to `--limit-ledger-size`
-if desired. Check `solana-validator --help` for the default limit value used by
-`--limit-ledger-size`. More information about
-selecting a custom limit value is [available
-here](https://github.com/solana-labs/solana/blob/36167b032c03fc7d1d8c288bb621920aaf903311/core/src/ledger_cleanup_service.rs#L23-L34).
+The default value attempts to keep the blockstore (data within the rocksdb
+directory) disk usage under 500 GB. More or less disk usage may be requested
+by adding an argument to `--limit-ledger-size` if desired. More information
+about selecting a custom limit value is [available
+here](https://github.com/solana-labs/solana/blob/aa72aa87790277619d12c27f1ebc864d23739557/core/src/ledger_cleanup_service.rs#L26-L37).
+
+Note that the above target of 500 GB does not account for other items that
+may reside in the `ledger` directory, depending on validator configuration.
+These items may include (but are not limited to):
+- Persistent accounts data
+- Persistent accounts index
+- Snapshots
 
 ### Systemd Unit
 


### PR DESCRIPTION
#### Problem
The current documentation fails to call out that some items go under the ledger directory by default. If this is the case, then the stated 500 GB number will most certainly be exceeded.

#### Summary of Changes
Add some additional details so that operators aren't immediately given false expectations about disk footprint of the ledger.

https://github.com/solana-labs/solana/pull/26651 made it so space used by blockstore is kept in check better; but it is arguable that https://github.com/solana-labs/solana/issues/23248 is still an issue given that with default args, ledger will grow past 500 GB with blockstore / accounts / accounts index / snapshots.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
