### PR TITLE
fix: correct return type of getFeeForMessage

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4464,7 +4464,7 @@ export class Connection {
     if (res.result === null) {
       throw new Error('invalid blockhash');
     }
-    return res.result as unknown as RpcResponseAndContext<number>;
+    return res.result;
   }
 
   /**

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4452,7 +4452,7 @@ export class Connection {
   async getFeeForMessage(
     message: VersionedMessage,
     commitment?: Commitment,
-  ): Promise<RpcResponseAndContext<number>> {
+  ): Promise<RpcResponseAndContext<number | null>> {
     const wireMessage = toBuffer(message.serialize()).toString('base64');
     const args = this._buildArgs([wireMessage], commitment);
     const unsafeRes = await this._rpcRequest('getFeeForMessage', args);

--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -585,7 +585,7 @@ export class Transaction {
   /**
    * Get the estimated fee associated with a transaction
    */
-  async getEstimatedFee(connection: Connection): Promise<number> {
+  async getEstimatedFee(connection: Connection): Promise<number | null> {
     return (await connection.getFeeForMessage(this.compileMessage())).value;
   }
 


### PR DESCRIPTION
#### Problem

The return type of `getFeeForMessage` did not match the implementation, which is nullable.

#### Summary of Changes

Update the typehint to reflect reality. Apologies to those of you for whom this causes your project to start failing to typecheck – please update your code to handle the possible `null` here.

Fixes #29993.