### PR TITLE
faucet: Remove unused FAUCET_PORT_STR const

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -53,7 +53,6 @@ const ERROR_RESPONSE: [u8; 2] = 0u16.to_le_bytes();
 
 pub const TIME_SLICE: u64 = 60;
 pub const FAUCET_PORT: u16 = 9900;
-pub const FAUCET_PORT_STR: &str = "9900";
 
 #[derive(Error, Debug)]
 pub enum FaucetError {


### PR DESCRIPTION
#### Problem
Just a code cleanup change.

#### Summary of Changes
Remove an unused `FAUCET_PORT_STR` constant.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
