### PR TITLE
get_best_weighted_repairs parameter cleanup

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -342,8 +342,8 @@ impl RepairService {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &duplicate_slot_repair_statuses,
-                    Some(&mut repair_timing),
-                    Some(&mut best_repairs_stats),
+                    &mut repair_timing,
+                    &mut best_repairs_stats,
                 );
 
                 repairs
@@ -808,8 +808,8 @@ mod test {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
-                    None,
-                    None,
+                    &mut RepairTiming::default(),
+                    &mut BestRepairsStats::default(),
                 ),
                 vec![
                     ShredRepairType::Orphan(2),
@@ -845,8 +845,8 @@ mod test {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
-                    None,
-                    None,
+                    &mut RepairTiming::default(),
+                    &mut BestRepairsStats::default(),
                 ),
                 vec![ShredRepairType::HighestShred(0, 0)]
             );
@@ -907,8 +907,8 @@ mod test {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
-                    None,
-                    None,
+                    &mut RepairTiming::default(),
+                    &mut BestRepairsStats::default(),
                 ),
                 expected
             );
@@ -923,8 +923,8 @@ mod test {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
-                    None,
-                    None,
+                    &mut RepairTiming::default(),
+                    &mut BestRepairsStats::default(),
                 )[..],
                 expected[0..expected.len() - 2]
             );
@@ -969,8 +969,8 @@ mod test {
                     MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
-                    None,
-                    None,
+                    &mut RepairTiming::default(),
+                    &mut BestRepairsStats::default(),
                 ),
                 expected
             );

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -157,8 +157,8 @@ impl RepairWeight {
         max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
         ignore_slots: &impl Contains<'a, Slot>,
-        repair_timing: Option<&mut RepairTiming>,
-        stats: Option<&mut BestRepairsStats>,
+        repair_timing: &mut RepairTiming,
+        stats: &mut BestRepairsStats,
     ) -> Vec<ShredRepairType> {
         let mut repairs = vec![];
         let mut processed_slots: HashSet<Slot> = vec![self.root].into_iter().collect();
@@ -227,24 +227,21 @@ impl RepairWeight {
         repairs.extend(closest_completion_repairs);
         get_closest_completion_elapsed.stop();
 
-        if let Some(stats) = stats {
-            stats.update(
-                num_orphan_slots as u64,
-                num_orphan_repairs as u64,
-                num_best_shreds_slots as u64,
-                num_best_shreds_repairs as u64,
-                num_unknown_last_index_slots as u64,
-                num_unknown_last_index_repairs as u64,
-                num_closest_completion_slots as u64,
-                num_closest_completion_repairs as u64,
-            );
-        }
-        if let Some(repair_timing) = repair_timing {
-            repair_timing.get_best_orphans_elapsed += get_best_orphans_elapsed.as_us();
-            repair_timing.get_best_shreds_elapsed += get_best_shreds_elapsed.as_us();
-            repair_timing.get_unknown_last_index_elapsed += get_unknown_last_index_elapsed.as_us();
-            repair_timing.get_closest_completion_elapsed += get_closest_completion_elapsed.as_us();
-        }
+        stats.update(
+            num_orphan_slots as u64,
+            num_orphan_repairs as u64,
+            num_best_shreds_slots as u64,
+            num_best_shreds_repairs as u64,
+            num_unknown_last_index_slots as u64,
+            num_unknown_last_index_repairs as u64,
+            num_closest_completion_slots as u64,
+            num_closest_completion_repairs as u64,
+        );
+        repair_timing.get_best_orphans_elapsed += get_best_orphans_elapsed.as_us();
+        repair_timing.get_best_shreds_elapsed += get_best_shreds_elapsed.as_us();
+        repair_timing.get_unknown_last_index_elapsed += get_unknown_last_index_elapsed.as_us();
+        repair_timing.get_closest_completion_elapsed += get_closest_completion_elapsed.as_us();
+
         repairs
     }
 


### PR DESCRIPTION
#### Problem
stats paramaters for `get_best_weighted_repairs` are unnecessarily wrapped in `Option`s only used for tests.

#### Summary of Changes
replace `None` instances of options in tests with `::default()` stats variants.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
