### PR TITLE
report less datapoints to block_min_prioritization_fee

### DIFF
--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -235,8 +235,8 @@ impl PrioritizationFee {
             ("entity", "block", String),
             ("min_prioritization_fee", min_transaction_fee as i64, i64),
         );
-        for (account_key, fee) in accounts_fees.iter().take(3) {
-            datapoint_info!(
+        for (account_key, fee) in accounts_fees.iter().take(10) {
+            datapoint_trace!(
                 "block_min_prioritization_fee",
                 ("slot", slot as i64, i64),
                 ("entity", account_key.to_string(), String),

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -235,7 +235,7 @@ impl PrioritizationFee {
             ("entity", "block", String),
             ("min_prioritization_fee", min_transaction_fee as i64, i64),
         );
-        for (account_key, fee) in accounts_fees.iter().take(10) {
+        for (account_key, fee) in accounts_fees.iter().take(3) {
             datapoint_info!(
                 "block_min_prioritization_fee",
                 ("slot", slot as i64, i64),


### PR DESCRIPTION
#### Problem
block min fee and top 10 most expensive accounts min fee are reported to `block_min_prioritization_fee` every slot, that's more data than we need to monitor.

#### Summary of Changes
reports top 10 accounts min fee at `datapoint_trace!` so only configured hosts reports these datapoints.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
