### PR TITLE
new ancient append vec packing

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1343,7 +1343,7 @@ impl<T: IndexValue> AccountsIndex<T> {
     ///   apply 'avoid_callback_result' if specified.
     ///   otherwise, call `callback`
     pub(crate) fn scan<'a, F, I>(
-        &'a self,
+        &self,
         pubkeys: I,
         mut callback: F,
         avoid_callback_result: Option<AccountsIndexScanResult>,

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -81,7 +81,8 @@ pub fn get_ancient_append_vec_capacity() -> u64 {
     use crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE;
     // smaller than max by a bit just in case
     // some functions add slop on allocation
-    // temporarily smaller to force ancient append vec operations to occur more often to flush out any bugs
+    // The bigger an append vec is, the more unwieldy it becomes to shrink, create, write.
+    // 1/10 of max is a reasonable size in practice.
     MAXIMUM_APPEND_VEC_FILE_SIZE / 10 - 2048
 }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1183,6 +1183,18 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                       This option is for use during testing."),
         )
         .arg(
+            Arg::with_name("accounts_db_skip_shrink")
+                .long("accounts-db-skip-shrink")
+                .help("Enables faster starting of validators by skipping shrink. \
+                      This option is for use during testing."),
+        )
+        .arg(
+            Arg::with_name("accounts_db_create_ancient_storage_packed")
+                .long("accounts-db-create-ancient-storage-packed")
+                .help("Create ancient storages in one shot instead of appending.")
+                .hidden(true),
+            )
+        .arg(
             Arg::with_name("accounts_db_ancient_append_vecs")
                 .long("accounts-db-ancient-append-vecs")
                 .value_name("SLOT-OFFSET")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1046,6 +1046,8 @@ pub fn main() {
             .map(|mb| mb * MB as u64),
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
+        create_ancient_storage_packed: matches
+            .is_present("accounts_db_create_ancient_storage_packed"),
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
We need to change the way we create and pack ancient append vecs to store them at one time. We currently append one slot at a time.

#### Summary of Changes
Add a separate code path to pack differently.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
