### PR TITLE
embeds the new gossip ContactInfo in ClusterInfo

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -740,7 +740,7 @@ pub mod test {
         let num_instructions = 2;
         let mut start = Measure::start("total accounts run");
         run_accounts_bench(
-            cluster.entry_point_info.rpc,
+            cluster.entry_point_info.rpc().unwrap(),
             faucet_addr,
             &[&cluster.funding_keypair],
             iterations,

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -80,8 +80,8 @@ fn test_bench_tps_local_cluster(config: Config) {
     cluster.transfer(&cluster.funding_keypair, &faucet_pubkey, 100_000_000);
 
     let client = Arc::new(ThinClient::new(
-        cluster.entry_point_info.rpc,
-        cluster.entry_point_info.tpu,
+        cluster.entry_point_info.rpc().unwrap(),
+        cluster.entry_point_info.tpu().unwrap(),
         cluster.connection_cache.clone(),
     ));
 

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -12,7 +12,7 @@ use {
     },
     solana_gossip::{
         cluster_info::{ClusterInfo, Node},
-        legacy_contact_info::LegacyContactInfo as ContactInfo,
+        contact_info::ContactInfo,
     },
     solana_ledger::{
         genesis_utils::{create_genesis_config, GenesisConfigInfo},

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -464,10 +464,7 @@ mod tests {
     use {
         super::*,
         rand::seq::SliceRandom,
-        solana_gossip::{
-            cluster_info::make_accounts_hashes_message,
-            legacy_contact_info::LegacyContactInfo as ContactInfo,
-        },
+        solana_gossip::{cluster_info::make_accounts_hashes_message, contact_info::ContactInfo},
         solana_sdk::{
             hash::hash,
             signature::{Keypair, Signer},

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -772,7 +772,7 @@ mod test {
         },
         solana_gossip::{
             cluster_info::{ClusterInfo, Node},
-            legacy_contact_info::LegacyContactInfo as ContactInfo,
+            contact_info::ContactInfo,
         },
         solana_ledger::{blockstore::make_many_slot_entries, get_tmp_ledger_path, shred::Nonce},
         solana_runtime::{accounts_background_service::AbsRequestSender, bank_forks::BankForks},
@@ -1151,13 +1151,13 @@ mod test {
     ) {
         let request_bytes = requester_serve_repair.ancestor_repair_request_bytes(
             &requester_cluster_info.keypair(),
-            &responder_info.id,
+            responder_info.pubkey(),
             dead_slot,
             nonce,
         );
         if let Ok(request_bytes) = request_bytes {
-            let _ =
-                ancestor_hashes_request_socket.send_to(&request_bytes, responder_info.serve_repair);
+            let socket = responder_info.serve_repair().unwrap();
+            let _ = ancestor_hashes_request_socket.send_to(&request_bytes, socket);
         }
     }
 
@@ -1225,7 +1225,7 @@ mod test {
         let packet = &mut response_packet[0];
         packet
             .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+            .set_socket_addr(&responder_info.serve_repair().unwrap());
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1239,7 +1239,7 @@ mod test {
         assert_eq!(decision, None);
 
         // Add the responder to the eligible list for requests
-        let responder_id = responder_info.id;
+        let responder_id = *responder_info.pubkey();
         cluster_slots.insert_node_id(dead_slot, responder_id);
         requester_cluster_info.insert_info(responder_info.clone());
         // Now the request should actually be made
@@ -1265,7 +1265,7 @@ mod test {
         let packet = &mut response_packet[0];
         packet
             .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+            .set_socket_addr(&responder_info.serve_repair().unwrap());
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1588,7 +1588,7 @@ mod test {
         let (dumped_slots_sender, _dumped_slots_receiver) = unbounded();
 
         // Add the responder to the eligible list for requests
-        let responder_id = responder_info.id;
+        let responder_id = *responder_info.pubkey();
         cluster_slots.insert_node_id(dead_slot, responder_id);
         requester_cluster_info.insert_info(responder_info.clone());
 
@@ -1608,7 +1608,7 @@ mod test {
         let packet = &mut response_packet[0];
         packet
             .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+            .set_socket_addr(&responder_info.serve_repair().unwrap());
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,
@@ -1670,7 +1670,7 @@ mod test {
         let packet = &mut response_packet[0];
         packet
             .meta_mut()
-            .set_socket_addr(&responder_info.serve_repair);
+            .set_socket_addr(&responder_info.serve_repair().unwrap());
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
             &ancestor_hashes_request_statuses,

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -159,7 +159,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
 mod tests {
     use {
         super::*,
-        solana_gossip::legacy_contact_info::LegacyContactInfo as ContactInfo,
+        solana_gossip::contact_info::ContactInfo,
         solana_sdk::signature::Signer,
         solana_streamer::socket::SocketAddrSpace,
         std::net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -803,9 +803,7 @@ pub(crate) fn post_shred_deferment_timestamp() -> u64 {
 mod test {
     use {
         super::*,
-        solana_gossip::{
-            cluster_info::Node, legacy_contact_info::LegacyContactInfo as ContactInfo,
-        },
+        solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
         solana_ledger::{
             blockstore::{
                 make_chaining_slot_entries, make_many_slot_entries, make_slot_entries, Blockstore,
@@ -1277,7 +1275,7 @@ mod test {
         // a valid target for repair
         let dead_slot = 9;
         let cluster_slots = ClusterSlots::default();
-        cluster_slots.insert_node_id(dead_slot, valid_repair_peer.id);
+        cluster_slots.insert_node_id(dead_slot, *valid_repair_peer.pubkey());
         cluster_info.insert_info(valid_repair_peer);
 
         // Not enough time has passed, should not update the

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -100,10 +100,12 @@ impl StakedNodesUpdaterService {
                     Some((node.tvu.ip(), *stake))
                 })
                 .collect();
-            let my_pubkey = cluster_info.my_contact_info().id;
+            let my_pubkey = *cluster_info.my_contact_info().pubkey();
             if let Some(stake) = staked_nodes.get(&my_pubkey) {
                 id_to_stake.insert(my_pubkey, *stake);
-                ip_to_stake.insert(cluster_info.my_contact_info().tvu.ip(), *stake);
+                if let Ok(tvu) = cluster_info.my_contact_info().tvu() {
+                    ip_to_stake.insert(tvu.ip(), *stake);
+                }
             }
             Self::override_stake(
                 cluster_info,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -164,7 +164,11 @@ impl Tpu {
         let (_, tpu_quic_t) = spawn_server(
             transactions_quic_sockets,
             keypair,
-            cluster_info.my_contact_info().tpu.ip(),
+            cluster_info
+                .my_contact_info()
+                .tpu_quic()
+                .expect("Operator must spin up node with valid (QUIC) TPU address")
+                .ip(),
             packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -179,7 +183,11 @@ impl Tpu {
         let (_, tpu_forwards_quic_t) = spawn_server(
             transactions_forwards_quic_sockets,
             keypair,
-            cluster_info.my_contact_info().tpu_forwards.ip(),
+            cluster_info
+                .my_contact_info()
+                .tpu_forwards_quic()
+                .expect("Operator must spin up node with valid (QUIC) TPU-forwards address")
+                .ip(),
             forwarded_packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -480,7 +480,7 @@ mod test {
     use {
         super::*,
         solana_entry::entry::{create_ticks, Entry},
-        solana_gossip::legacy_contact_info::LegacyContactInfo as ContactInfo,
+        solana_gossip::contact_info::ContactInfo,
         solana_ledger::{
             blockstore::{make_many_slot_entries, Blockstore},
             get_tmp_ledger_path,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -6,9 +6,7 @@ use {
         accounts_hash_verifier::AccountsHashVerifier,
         snapshot_packager_service::SnapshotPackagerService,
     },
-    solana_gossip::{
-        cluster_info::ClusterInfo, legacy_contact_info::LegacyContactInfo as ContactInfo,
-    },
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_runtime::{
         accounts_background_service::{
             AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -10,9 +10,7 @@ use {
         accounts_hash_verifier::AccountsHashVerifier,
         snapshot_packager_service::SnapshotPackagerService,
     },
-    solana_gossip::{
-        cluster_info::ClusterInfo, legacy_contact_info::LegacyContactInfo as ContactInfo,
-    },
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_runtime::{
         accounts_background_service::{
             AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
@@ -516,10 +514,11 @@ fn test_concurrent_snapshot_packaging(
 
     let cluster_info = Arc::new({
         let keypair = Arc::new(Keypair::new());
-        let contact_info = ContactInfo {
-            id: keypair.pubkey(),
-            ..ContactInfo::default()
-        };
+        let contact_info = ContactInfo::new(
+            keypair.pubkey(),
+            timestamp(), // wallclock
+            0u16,        // shred_version
+        );
         ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
     });
 

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -789,6 +789,7 @@ pub mod test {
         solana_client::thin_client::ThinClient,
         solana_core::validator::ValidatorConfig,
         solana_faucet::faucet::run_local_faucet,
+        solana_gossip::contact_info::LegacyContactInfo,
         solana_local_cluster::{
             cluster::Cluster,
             local_cluster::{ClusterConfig, LocalCluster},
@@ -896,7 +897,11 @@ pub mod test {
         assert_eq!(cluster.validators.len(), num_nodes);
 
         let nodes = cluster.get_node_pubkeys();
-        let node = cluster.get_contact_info(&nodes[0]).unwrap().clone();
+        let node = cluster
+            .get_contact_info(&nodes[0])
+            .map(LegacyContactInfo::try_from)
+            .unwrap()
+            .unwrap();
         let nodes_slice = [node];
 
         // send random transactions to TPU
@@ -905,7 +910,7 @@ pub mod test {
             &nodes_slice,
             10,
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 1024,
                 data_type: DataType::Random,
@@ -929,12 +934,16 @@ pub mod test {
         assert_eq!(cluster.validators.len(), num_nodes);
 
         let nodes = cluster.get_node_pubkeys();
-        let node = cluster.get_contact_info(&nodes[0]).unwrap().clone();
+        let node = cluster
+            .get_contact_info(&nodes[0])
+            .map(LegacyContactInfo::try_from)
+            .unwrap()
+            .unwrap();
         let nodes_slice = [node];
 
         let client = Arc::new(ThinClient::new(
-            cluster.entry_point_info.rpc,
-            cluster.entry_point_info.tpu,
+            cluster.entry_point_info.rpc().unwrap(),
+            cluster.entry_point_info.tpu().unwrap(),
             cluster.connection_cache.clone(),
         ));
 
@@ -944,7 +953,7 @@ pub mod test {
             10,
             Some(client.clone()),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant
                 data_type: DataType::Transaction,
@@ -971,7 +980,7 @@ pub mod test {
             10,
             Some(client.clone()),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant
                 data_type: DataType::Transaction,
@@ -998,7 +1007,7 @@ pub mod test {
             10,
             Some(client),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant
                 data_type: DataType::Transaction,
@@ -1061,12 +1070,16 @@ pub mod test {
         cluster.transfer(&cluster.funding_keypair, &faucet_pubkey, 100_000_000);
 
         let nodes = cluster.get_node_pubkeys();
-        let node = cluster.get_contact_info(&nodes[0]).unwrap().clone();
+        let node = cluster
+            .get_contact_info(&nodes[0])
+            .map(LegacyContactInfo::try_from)
+            .unwrap()
+            .unwrap();
         let nodes_slice = [node];
 
         let client = Arc::new(ThinClient::new(
-            cluster.entry_point_info.rpc,
-            cluster.entry_point_info.tpu,
+            cluster.entry_point_info.rpc().unwrap(),
+            cluster.entry_point_info.tpu().unwrap(),
             cluster.connection_cache.clone(),
         ));
 
@@ -1077,7 +1090,7 @@ pub mod test {
             10,
             Some(client.clone()),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant if not random
                 data_type: DataType::Transaction,
@@ -1106,7 +1119,7 @@ pub mod test {
             10,
             Some(client.clone()),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant if not random
                 data_type: DataType::Transaction,
@@ -1134,7 +1147,7 @@ pub mod test {
             10,
             Some(client.clone()),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant if not random
                 data_type: DataType::Transaction,
@@ -1162,7 +1175,7 @@ pub mod test {
             10,
             Some(client),
             DosClientParameters {
-                entrypoint_addr: cluster.entry_point_info.gossip,
+                entrypoint_addr: cluster.entry_point_info.gossip().unwrap(),
                 mode: Mode::Tpu,
                 data_size: 0, // irrelevant if not random
                 data_type: DataType::Transaction,

--- a/gossip/src/gossip_error.rs
+++ b/gossip/src/gossip_error.rs
@@ -1,5 +1,5 @@
 use {
-    crate::duplicate_shred,
+    crate::{contact_info, duplicate_shred},
     crossbeam_channel::{RecvTimeoutError, SendError},
     std::io,
     thiserror::Error,
@@ -11,6 +11,8 @@ pub enum GossipError {
     DuplicateNodeInstance,
     #[error(transparent)]
     DuplicateShredError(#[from] duplicate_shred::Error),
+    #[error(transparent)]
+    InvalidContactInfo(#[from] contact_info::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -331,7 +331,10 @@ pub fn make_gossip_node(
 mod tests {
     use {
         super::*,
-        crate::cluster_info::{ClusterInfo, Node},
+        crate::{
+            cluster_info::{ClusterInfo, Node},
+            contact_info::ContactInfo,
+        },
         std::sync::{atomic::AtomicBool, Arc},
     };
 
@@ -422,7 +425,7 @@ mod tests {
             None,
             TIMEOUT,
             None,
-            Some(&peer0_info.gossip),
+            Some(&peer0_info.gossip().unwrap()),
         );
         assert!(met_criteria);
 

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -163,7 +163,7 @@ fn gossip_ring() {
             let yv = &listen[y].0;
             let mut d = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
             d.wallclock = timestamp();
-            listen[x].0.insert_info(d);
+            listen[x].0.insert_legacy_info(d);
         }
     });
 }
@@ -181,7 +181,7 @@ fn gossip_ring_large() {
             let yv = &listen[y].0;
             let mut d = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
             d.wallclock = timestamp();
-            listen[x].0.insert_info(d);
+            listen[x].0.insert_legacy_info(d);
         }
     });
 }
@@ -198,7 +198,7 @@ fn gossip_star() {
             let mut yd = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
             yd.wallclock = timestamp();
             let xv = &listen[x].0;
-            xv.insert_info(yd);
+            xv.insert_legacy_info(yd);
             trace!("star leader {}", &xv.id());
         }
     });
@@ -218,7 +218,7 @@ fn gossip_rstar() {
         for n in 0..(num - 1) {
             let y = (n + 1) % listen.len();
             let yv = &listen[y].0;
-            yv.insert_info(xd.clone());
+            yv.insert_legacy_info(xd.clone());
             trace!("rstar insert {} into {}", xd.id, yv.id());
         }
     });

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -1,7 +1,7 @@
 use {
     solana_client::thin_client::ThinClient,
     solana_core::validator::{Validator, ValidatorConfig},
-    solana_gossip::{cluster_info::Node, legacy_contact_info::LegacyContactInfo as ContactInfo},
+    solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
     solana_streamer::socket::SocketAddrSpace,
     std::{path::PathBuf, sync::Arc},

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -12,8 +12,9 @@ use {
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     },
     solana_gossip::{
-        cluster_info::Node, gossip_service::discover_cluster,
-        legacy_contact_info::LegacyContactInfo as ContactInfo,
+        cluster_info::Node,
+        contact_info::{ContactInfo, LegacyContactInfo},
+        gossip_service::discover_cluster,
     },
     solana_ledger::create_new_tmp_ledger,
     solana_runtime::{
@@ -265,7 +266,10 @@ impl LocalCluster {
         let (leader_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
         let leader_contact_info = leader_node.info.clone();
         let mut leader_config = safe_clone_config(&config.validator_configs[0]);
-        leader_config.rpc_addrs = Some((leader_node.info.rpc, leader_node.info.rpc_pubsub));
+        leader_config.rpc_addrs = Some((
+            leader_node.info.rpc().unwrap(),
+            leader_node.info.rpc_pubsub().unwrap(),
+        ));
         Self::sync_ledger_path_across_nested_config_fields(&mut leader_config, &leader_ledger_path);
         let leader_keypair = Arc::new(leader_keypair.insecure_clone());
         let leader_vote_keypair = Arc::new(leader_vote_keypair.insecure_clone());
@@ -349,14 +353,14 @@ impl LocalCluster {
         });
 
         discover_cluster(
-            &cluster.entry_point_info.gossip,
+            &cluster.entry_point_info.gossip().unwrap(),
             config.node_stakes.len() + config.num_listeners as usize,
             socket_addr_space,
         )
         .unwrap();
 
         discover_cluster(
-            &cluster.entry_point_info.gossip,
+            &cluster.entry_point_info.gossip().unwrap(),
             config.node_stakes.len(),
             socket_addr_space,
         )
@@ -429,7 +433,9 @@ impl LocalCluster {
         mut voting_keypair: Option<Arc<Keypair>>,
         socket_addr_space: SocketAddrSpace,
     ) -> Pubkey {
-        let (rpc, tpu) = cluster_tests::get_client_facing_addr(&self.entry_point_info);
+        let (rpc, tpu) = LegacyContactInfo::try_from(&self.entry_point_info)
+            .map(cluster_tests::get_client_facing_addr)
+            .unwrap();
         let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
 
         // Must have enough tokens to fund vote account and set delegate
@@ -467,7 +473,10 @@ impl LocalCluster {
         }
 
         let mut config = safe_clone_config(validator_config);
-        config.rpc_addrs = Some((validator_node.info.rpc, validator_node.info.rpc_pubsub));
+        config.rpc_addrs = Some((
+            validator_node.info.rpc().unwrap(),
+            validator_node.info.rpc_pubsub().unwrap(),
+        ));
         Self::sync_ledger_path_across_nested_config_fields(&mut config, &ledger_path);
         let voting_keypair = voting_keypair.unwrap();
         let validator_server = Validator::new(
@@ -476,7 +485,7 @@ impl LocalCluster {
             &ledger_path,
             &voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![voting_keypair.clone()])),
-            vec![self.entry_point_info.clone()],
+            vec![LegacyContactInfo::try_from(&self.entry_point_info).unwrap()],
             &config,
             true, // should_check_duplicate_instance
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
@@ -517,7 +526,9 @@ impl LocalCluster {
     }
 
     pub fn transfer(&self, source_keypair: &Keypair, dest_pubkey: &Pubkey, lamports: u64) -> u64 {
-        let (rpc, tpu) = cluster_tests::get_client_facing_addr(&self.entry_point_info);
+        let (rpc, tpu) = LegacyContactInfo::try_from(&self.entry_point_info)
+            .map(cluster_tests::get_client_facing_addr)
+            .unwrap();
         let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
         Self::transfer_with_client(&client, source_keypair, dest_pubkey, lamports)
     }
@@ -536,7 +547,7 @@ impl LocalCluster {
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
         let cluster_nodes = discover_cluster(
-            &alive_node_contact_infos[0].gossip,
+            &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
             socket_addr_space,
         )
@@ -561,12 +572,12 @@ impl LocalCluster {
         let alive_node_contact_infos: Vec<_> = self
             .validators
             .values()
-            .map(|v| v.info.contact_info.clone())
+            .map(|node| &node.info.contact_info)
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
         let cluster_nodes = discover_cluster(
-            &alive_node_contact_infos[0].gossip,
+            &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
             socket_addr_space,
         )
@@ -575,7 +586,11 @@ impl LocalCluster {
         info!("{} making sure no new roots on any nodes", test_name);
         cluster_tests::check_no_new_roots(
             num_slots_to_wait,
-            &alive_node_contact_infos,
+            &alive_node_contact_infos
+                .into_iter()
+                .map(LegacyContactInfo::try_from)
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap(),
             &self.connection_cache,
             test_name,
         );
@@ -762,7 +777,9 @@ impl Cluster for LocalCluster {
 
     fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient> {
         self.validators.get(pubkey).map(|f| {
-            let (rpc, tpu) = cluster_tests::get_client_facing_addr(&f.info.contact_info);
+            let (rpc, tpu) = LegacyContactInfo::try_from(&f.info.contact_info)
+                .map(cluster_tests::get_client_facing_addr)
+                .unwrap();
             ThinClient::new(rpc, tpu, self.connection_cache.clone())
         })
     }
@@ -785,10 +802,11 @@ impl Cluster for LocalCluster {
         // Update the stored ContactInfo for this node
         let node = Node::new_localhost_with_pubkey(pubkey);
         cluster_validator_info.info.contact_info = node.info.clone();
-        cluster_validator_info.config.rpc_addrs = Some((node.info.rpc, node.info.rpc_pubsub));
+        cluster_validator_info.config.rpc_addrs =
+            Some((node.info.rpc().unwrap(), node.info.rpc_pubsub().unwrap()));
 
         let entry_point_info = {
-            if *pubkey == self.entry_point_info.id {
+            if pubkey == self.entry_point_info.pubkey() {
                 self.entry_point_info = node.info.clone();
                 None
             } else {
@@ -836,7 +854,9 @@ impl Cluster for LocalCluster {
             &validator_info.voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![validator_info.voting_keypair.clone()])),
             entry_point_info
-                .map(|entry_point_info| vec![entry_point_info])
+                .map(|entry_point_info| {
+                    vec![LegacyContactInfo::try_from(&entry_point_info).unwrap()]
+                })
                 .unwrap_or_default(),
             &safe_clone_config(&cluster_validator_info.config),
             true, // should_check_duplicate_instance

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -73,7 +73,7 @@ impl LocalCluster {
     ) -> NextSnapshotResult {
         // Get slot after which this was generated
         let client = self
-            .get_validator_client(&self.entry_point_info.id)
+            .get_validator_client(self.entry_point_info.pubkey())
             .unwrap();
         let last_slot = client
             .get_slot_with_commitment(CommitmentConfig::processed())

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -343,7 +343,7 @@ pub fn run_cluster_partition<C>(
     );
 
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         num_nodes,
         SocketAddrSpace::Unspecified,
     )

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,7 +16,7 @@ use {
         validator::ValidatorConfig,
     },
     solana_download_utils::download_snapshot_archive,
-    solana_gossip::gossip_service::discover_cluster,
+    solana_gossip::{contact_info::LegacyContactInfo, gossip_service::discover_cluster},
     solana_ledger::{
         ancestor_iterator::AncestorIterator, bank_forks_utils, blockstore::Blockstore,
         blockstore_processor::ProcessOptions,
@@ -195,11 +195,13 @@ fn test_local_cluster_signature_subscribe() {
     // Get non leader
     let non_bootstrap_id = nodes
         .into_iter()
-        .find(|id| *id != cluster.entry_point_info.id)
+        .find(|id| id != cluster.entry_point_info.pubkey())
         .unwrap();
     let non_bootstrap_info = cluster.get_contact_info(&non_bootstrap_id).unwrap();
 
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(non_bootstrap_info);
+    let (rpc, tpu) = LegacyContactInfo::try_from(non_bootstrap_info)
+        .map(cluster_tests::get_client_facing_addr)
+        .unwrap();
     let tx_client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
 
     let (blockhash, _) = tx_client
@@ -214,7 +216,10 @@ fn test_local_cluster_signature_subscribe() {
     );
 
     let (mut sig_subscribe_client, receiver) = PubsubClient::signature_subscribe(
-        &format!("ws://{}", &non_bootstrap_info.rpc_pubsub.to_string()),
+        &format!(
+            "ws://{}",
+            &non_bootstrap_info.rpc_pubsub().unwrap().to_string()
+        ),
         &transaction.signatures[0],
         Some(RpcSignatureSubscribeConfig {
             commitment: Some(CommitmentConfig::processed()),
@@ -312,7 +317,7 @@ fn test_two_unbalanced_stakes() {
         num_slots_per_epoch,
     );
     cluster.close_preserve_ledgers();
-    let leader_pubkey = cluster.entry_point_info.id;
+    let leader_pubkey = *cluster.entry_point_info.pubkey();
     let leader_ledger = cluster.validators[&leader_pubkey].info.ledger_path.clone();
     cluster_tests::verify_ledger_ticks(&leader_ledger, num_ticks_per_slot as usize);
 }
@@ -335,14 +340,14 @@ fn test_forwarding() {
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         2,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
     assert!(cluster_nodes.len() >= 2);
 
-    let leader_pubkey = cluster.entry_point_info.id;
+    let leader_pubkey = *cluster.entry_point_info.pubkey();
 
     let validator_info = cluster_nodes
         .iter()
@@ -394,7 +399,7 @@ fn test_restart_node() {
         slots_per_epoch,
     );
     cluster_tests::send_many_transactions(
-        &cluster.entry_point_info,
+        &LegacyContactInfo::try_from(&cluster.entry_point_info).unwrap(),
         &cluster.funding_keypair,
         &cluster.connection_cache,
         10,
@@ -419,14 +424,16 @@ fn test_mainnet_beta_cluster_type() {
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         1,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
     assert_eq!(cluster_nodes.len(), 1);
 
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(&cluster.entry_point_info);
+    let (rpc, tpu) = LegacyContactInfo::try_from(&cluster.entry_point_info)
+        .map(cluster_tests::get_client_facing_addr)
+        .unwrap();
     let client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
 
     // Programs that are available at epoch 0
@@ -506,7 +513,7 @@ fn test_snapshot_download() {
 
     // Download the snapshot, then boot a validator from it.
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &cluster.entry_point_info.rpc().unwrap(),
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -637,7 +644,7 @@ fn test_incremental_snapshot_download() {
 
     // Download the snapshots, then boot a validator from them.
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &cluster.entry_point_info.rpc().unwrap(),
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -665,7 +672,7 @@ fn test_incremental_snapshot_download() {
     .unwrap();
 
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &cluster.entry_point_info.rpc().unwrap(),
         &validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -813,7 +820,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     // Download the snapshots, then boot a validator from them.
     info!("Downloading full snapshot to validator...");
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &cluster.entry_point_info.rpc().unwrap(),
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .path(),
@@ -847,7 +854,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     info!("Downloading incremental snapshot to validator...");
     download_snapshot_archive(
-        &cluster.entry_point_info.rpc,
+        &cluster.entry_point_info.rpc().unwrap(),
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .path(),
@@ -1244,7 +1251,7 @@ fn test_snapshot_restart_tower() {
     let all_pubkeys = cluster.get_node_pubkeys();
     let validator_id = all_pubkeys
         .into_iter()
-        .find(|x| *x != cluster.entry_point_info.id)
+        .find(|x| x != cluster.entry_point_info.pubkey())
         .unwrap();
     let validator_info = cluster.exit_node(&validator_id);
 
@@ -1344,7 +1351,7 @@ fn test_snapshots_blockstore_floor() {
 
     // Start up a new node from a snapshot
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         1,
         SocketAddrSpace::Unspecified,
     )
@@ -1365,7 +1372,7 @@ fn test_snapshots_blockstore_floor() {
     let all_pubkeys = cluster.get_node_pubkeys();
     let validator_id = all_pubkeys
         .into_iter()
-        .find(|x| *x != cluster.entry_point_info.id)
+        .find(|x| x != cluster.entry_point_info.pubkey())
         .unwrap();
     let validator_client = cluster.get_validator_client(&validator_id).unwrap();
     let mut current_slot = 0;
@@ -1430,7 +1437,7 @@ fn test_snapshots_restart_validity() {
         // forwarded to and processed.
         trace!("Sending transactions");
         let new_balances = cluster_tests::send_many_transactions(
-            &cluster.entry_point_info,
+            &LegacyContactInfo::try_from(&cluster.entry_point_info).unwrap(),
             &cluster.funding_keypair,
             &cluster.connection_cache,
             10,
@@ -1525,7 +1532,7 @@ fn test_wait_for_max_stake() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let client = RpcClient::new_socket(cluster.entry_point_info.rpc);
+    let client = RpcClient::new_socket(cluster.entry_point_info.rpc().unwrap());
 
     assert!(client
         .wait_for_max_stake(CommitmentConfig::default(), 33.0f32)
@@ -1550,7 +1557,7 @@ fn test_no_voting() {
     };
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     let client = cluster
-        .get_validator_client(&cluster.entry_point_info.id)
+        .get_validator_client(cluster.entry_point_info.pubkey())
         .unwrap();
     loop {
         let last_slot = client
@@ -1563,7 +1570,7 @@ fn test_no_voting() {
     }
 
     cluster.close_preserve_ledgers();
-    let leader_pubkey = cluster.entry_point_info.id;
+    let leader_pubkey = *cluster.entry_point_info.pubkey();
     let ledger_path = cluster.validators[&leader_pubkey].info.ledger_path.clone();
     let ledger = Blockstore::open(&ledger_path).unwrap();
     for i in 0..2 * VOTE_THRESHOLD_DEPTH {
@@ -2481,11 +2488,11 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
 
     let on_partition_start = |cluster: &mut LocalCluster, _: &mut ()| {
         let update_client = cluster
-            .get_validator_client(&cluster.entry_point_info.id)
+            .get_validator_client(cluster.entry_point_info.pubkey())
             .unwrap();
         update_client_sender.send(update_client).unwrap();
         let scan_client = cluster
-            .get_validator_client(&cluster.entry_point_info.id)
+            .get_validator_client(cluster.entry_point_info.pubkey())
             .unwrap();
         scan_client_sender.send(scan_client).unwrap();
     };
@@ -2542,7 +2549,10 @@ fn test_rpc_block_subscribe() {
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
-        &format!("ws://{}", &cluster.entry_point_info.rpc_pubsub.to_string()),
+        &format!(
+            "ws://{}",
+            &cluster.entry_point_info.rpc_pubsub().unwrap().to_string()
+        ),
         RpcBlockSubscribeFilter::All,
         Some(RpcBlockSubscribeConfig {
             commitment: Some(CommitmentConfig::confirmed()),
@@ -2628,13 +2638,15 @@ fn test_oc_bad_signatures() {
     );
 
     // 3) Start up a spy to listen for and push votes to leader TPU
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(&cluster.entry_point_info);
+    let (rpc, tpu) = LegacyContactInfo::try_from(&cluster.entry_point_info)
+        .map(cluster_tests::get_client_facing_addr)
+        .unwrap();
     let client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
     let cluster_funding_keypair = cluster.funding_keypair.insecure_clone();
     let voter_thread_sleep_ms: usize = 100;
     let num_votes_simulated = Arc::new(AtomicUsize::new(0));
     let gossip_voter = cluster_tests::start_gossip_voter(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         &node_keypair,
         |(_label, leader_vote_tx)| {
             let vote = vote_parser::parse_vote_transaction(&leader_vote_tx)
@@ -2686,7 +2698,10 @@ fn test_oc_bad_signatures() {
     );
 
     let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
-        &format!("ws://{}", &cluster.entry_point_info.rpc_pubsub.to_string()),
+        &format!(
+            "ws://{}",
+            &cluster.entry_point_info.rpc_pubsub().unwrap().to_string()
+        ),
         RpcBlockSubscribeFilter::All,
         Some(RpcBlockSubscribeConfig {
             commitment: Some(CommitmentConfig::confirmed()),
@@ -2982,10 +2997,10 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
     let all_pubkeys = cluster.get_node_pubkeys();
     let other_validator_id = all_pubkeys
         .into_iter()
-        .find(|x| *x != cluster.entry_point_info.id)
+        .find(|x| x != cluster.entry_point_info.pubkey())
         .unwrap();
     let client = cluster
-        .get_validator_client(&cluster.entry_point_info.id)
+        .get_validator_client(cluster.entry_point_info.pubkey())
         .unwrap();
     update_client_sender.send(client).unwrap();
     let scan_client = cluster.get_validator_client(&other_validator_id).unwrap();

--- a/local-cluster/tests/local_cluster_slow_1.rs
+++ b/local-cluster/tests/local_cluster_slow_1.rs
@@ -448,14 +448,14 @@ fn test_duplicate_shreds_broadcast_leader() {
     let our_info = cluster.exit_node(&our_id);
     let node_keypair = our_info.info.keypair;
     let vote_keypair = our_info.info.voting_keypair;
-    let bad_leader_id = cluster.entry_point_info.id;
+    let bad_leader_id = *cluster.entry_point_info.pubkey();
     let bad_leader_ledger_path = cluster.validators[&bad_leader_id].info.ledger_path.clone();
     info!("our node id: {}", node_keypair.pubkey());
 
     // 3) Start up a gossip instance to listen for and push votes
     let voter_thread_sleep_ms = 100;
     let gossip_voter = cluster_tests::start_gossip_voter(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         &node_keypair,
         move |(label, leader_vote_tx)| {
             // Filter out votes not from the bad leader
@@ -721,7 +721,8 @@ fn test_switch_threshold_uses_gossip_votes() {
             cluster
                 .get_contact_info(&context.heaviest_validator_key)
                 .unwrap()
-                .gossip,
+                .gossip()
+                .unwrap(),
             &SocketAddrSpace::Unspecified,
         )
         .unwrap();
@@ -798,7 +799,7 @@ fn test_listener_startup() {
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         4,
         SocketAddrSpace::Unspecified,
     )

--- a/local-cluster/tests/local_cluster_slow_2.rs
+++ b/local-cluster/tests/local_cluster_slow_2.rs
@@ -90,7 +90,7 @@ fn test_consistency_halt() {
 
     sleep(Duration::from_millis(5000));
     let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip,
+        &cluster.entry_point_info.gossip().unwrap(),
         1,
         SocketAddrSpace::Unspecified,
     )
@@ -123,7 +123,7 @@ fn test_consistency_halt() {
     let num_nodes = 2;
     assert_eq!(
         discover_cluster(
-            &cluster.entry_point_info.gossip,
+            &cluster.entry_point_info.gossip().unwrap(),
             num_nodes,
             SocketAddrSpace::Unspecified
         )
@@ -136,7 +136,7 @@ fn test_consistency_halt() {
     let mut encountered_error = false;
     loop {
         let discover = discover_cluster(
-            &cluster.entry_point_info.gossip,
+            &cluster.entry_point_info.gossip().unwrap(),
             2,
             SocketAddrSpace::Unspecified,
         );
@@ -154,7 +154,7 @@ fn test_consistency_halt() {
             }
         }
         let client = cluster
-            .get_validator_client(&cluster.entry_point_info.id)
+            .get_validator_client(cluster.entry_point_info.pubkey())
             .unwrap();
         if let Ok(slot) = client.get_slot() {
             if slot > 210 {
@@ -187,7 +187,7 @@ fn test_leader_failure_4() {
         &local.entry_point_info,
         &local
             .validators
-            .get(&local.entry_point_info.id)
+            .get(local.entry_point_info.pubkey())
             .unwrap()
             .config
             .validator_exit,

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -59,7 +59,7 @@ impl TpuInfo for ClusterTpuInfo {
 mod test {
     use {
         super::*,
-        solana_gossip::legacy_contact_info::LegacyContactInfo as ContactInfo,
+        solana_gossip::contact_info::ContactInfo,
         solana_ledger::{
             blockstore::Blockstore, get_tmp_ledger_path, leader_schedule_cache::LeaderScheduleCache,
         },

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -377,7 +377,10 @@ impl JsonRpcService {
             LARGEST_ACCOUNTS_CACHE_DURATION,
         )));
 
-        let tpu_address = cluster_info.my_contact_info().tpu;
+        let tpu_address = cluster_info
+            .my_contact_info()
+            .tpu()
+            .map_err(|err| format!("{err}"))?;
 
         // sadly, some parts of our current rpc implemention block the jsonrpc's
         // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,

--- a/streamer/src/socket.rs
+++ b/streamer/src/socket.rs
@@ -16,6 +16,7 @@ impl SocketAddrSpace {
     }
 
     /// Returns true if the IP address is valid.
+    #[must_use]
     pub fn check(&self, addr: &SocketAddr) -> bool {
         if self == &SocketAddrSpace::Unspecified {
             return true;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -750,15 +750,16 @@ impl TestValidator {
             config.node_config.bind_ip_addr,
         );
         if let Some((rpc, rpc_pubsub)) = config.rpc_ports {
-            node.info.rpc = SocketAddr::new(node.info.gossip.ip(), rpc);
-            node.info.rpc_pubsub = SocketAddr::new(node.info.gossip.ip(), rpc_pubsub);
+            let addr = node.info.gossip().unwrap().ip();
+            node.info.set_rpc((addr, rpc)).unwrap();
+            node.info.set_rpc_pubsub((addr, rpc_pubsub)).unwrap();
         }
 
         let vote_account_address = validator_vote_account.pubkey();
-        let rpc_url = format!("http://{}", node.info.rpc);
-        let rpc_pubsub_url = format!("ws://{}/", node.info.rpc_pubsub);
-        let tpu = node.info.tpu;
-        let gossip = node.info.gossip;
+        let rpc_url = format!("http://{}", node.info.rpc().unwrap());
+        let rpc_pubsub_url = format!("ws://{}/", node.info.rpc_pubsub().unwrap());
+        let tpu = node.info.tpu().unwrap();
+        let gossip = node.info.gossip().unwrap();
 
         {
             let mut authorized_voter_keypairs = config.authorized_voter_keypairs.write().unwrap();
@@ -793,10 +794,13 @@ impl TestValidator {
         let mut validator_config = ValidatorConfig {
             geyser_plugin_config_files: config.geyser_plugin_config_files.clone(),
             rpc_addrs: Some((
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), node.info.rpc.port()),
                 SocketAddr::new(
                     IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                    node.info.rpc_pubsub.port(),
+                    node.info.rpc().unwrap().port(),
+                ),
+                SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                    node.info.rpc_pubsub().unwrap().port(),
                 ),
             )),
             rpc_config: config.rpc_config.clone(),

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -707,7 +707,7 @@ pub mod test {
         let account_keypair_refs: Vec<_> = account_keypairs.iter().collect();
         let mut start = Measure::start("total accounts run");
         run_transactions_dos(
-            cluster.entry_point_info.rpc,
+            cluster.entry_point_info.rpc().unwrap(),
             faucet_addr,
             &[&cluster.funding_keypair],
             iterations,


### PR DESCRIPTION
#### Problem
Working towards migrating to the new gossip `ContactInfo`.

#### Summary of Changes
Use the new gossip `ContactInfo` in `ClusterInfo` struct.

* Note that all unwraps are either in tests or on _my own contact-info_; and this is due to extra sanity checks on the new contact-info.
* Also this commit only uses the new `ContactInfo` internally; It does not push the type to other nodes on gossip; so the change is backward compatible.