### PR TITLE
SortedStorages uses contiguous array internally

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7073,7 +7073,7 @@ impl AccountsDb {
                 let mut sort_time = Measure::start("sort_storages");
                 let min_root = self.accounts_index.min_alive_root();
                 let storages = SortedStorages::new_with_slots(
-                    combined_maps.iter().zip(slots.into_iter()),
+                    slots.into_iter().zip(combined_maps.iter()),
                     min_root,
                     Some(slot),
                 );
@@ -9223,10 +9223,6 @@ pub mod tests {
         ancestors
     }
 
-    fn empty_storages<'a>() -> SortedStorages<'a> {
-        SortedStorages::new(&[])
-    }
-
     impl AccountsDb {
         fn scan_snapshot_stores(
             &self,
@@ -9579,10 +9575,10 @@ pub mod tests {
     fn test_accountsdb_scan_snapshot_stores_illegal_range_start() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 2, end: 2 };
+        let storages = SortedStorages::new(&[]);
         let accounts_db = AccountsDb::new_single_for_tests();
-
         accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds, false)
+            .scan_snapshot_stores(&storages, &mut stats, 2, &bounds, false)
             .unwrap();
     }
     #[test]
@@ -9592,10 +9588,10 @@ pub mod tests {
     fn test_accountsdb_scan_snapshot_stores_illegal_range_end() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 1, end: 3 };
-
+        let storages = SortedStorages::new(&[]);
         let accounts_db = AccountsDb::new_single_for_tests();
         accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds, false)
+            .scan_snapshot_stores(&storages, &mut stats, 2, &bounds, false)
             .unwrap();
     }
 
@@ -9606,10 +9602,10 @@ pub mod tests {
     fn test_accountsdb_scan_snapshot_stores_illegal_range_inverse() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 1, end: 0 };
-
+        let storages = SortedStorages::new(&[]);
         let accounts_db = AccountsDb::new_single_for_tests();
         accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds, false)
+            .scan_snapshot_stores(&storages, &mut stats, 2, &bounds, false)
             .unwrap();
     }
 
@@ -9817,10 +9813,10 @@ pub mod tests {
         let bins = 1;
         let slot = MAX_ITEMS_PER_CHUNK as Slot;
         let (storages, raw_expected) = sample_storages_and_account_in_slot(slot, &accounts_db);
-        let storage_data = vec![(&storages[0], slot)];
+        let storage_data = vec![(slot, &storages[0])];
 
         let sorted_storages =
-            SortedStorages::new_debug(&storage_data[..], 0, MAX_ITEMS_PER_CHUNK as usize + 1);
+            SortedStorages::new_debug(&storage_data, 0, MAX_ITEMS_PER_CHUNK as usize + 1);
 
         let mut stats = HashStats::default();
         let result = accounts_db
@@ -9954,10 +9950,10 @@ pub mod tests {
         let bins = 256;
         let slot = MAX_ITEMS_PER_CHUNK as Slot;
         let (storages, raw_expected) = sample_storages_and_account_in_slot(slot, &accounts_db);
-        let storage_data = vec![(&storages[0], slot)];
+        let storage_data = vec![(slot, &storages[0])];
 
         let sorted_storages =
-            SortedStorages::new_debug(&storage_data[..], 0, MAX_ITEMS_PER_CHUNK as usize + 1);
+            SortedStorages::new_debug(&storage_data, 0, MAX_ITEMS_PER_CHUNK as usize + 1);
 
         let mut stats = HashStats::default();
         let range = 1;
@@ -16097,7 +16093,7 @@ pub mod tests {
 
     #[test]
     fn test_split_storages_ancient_chunks() {
-        let storages = SortedStorages::empty();
+        let storages = SortedStorages::new(&[]);
         assert_eq!(storages.max_slot_inclusive(), 0);
         let result = SplitAncientStorages::new(0, &storages);
         assert_eq!(result, SplitAncientStorages::default());
@@ -16473,7 +16469,7 @@ pub mod tests {
                     non_ancient_storage,
                     Arc::clone(ancient3.new_storage()),
                 ];
-                let snapshot_storages = SortedStorages::new(&raw_storages[..]);
+                let snapshot_storages = SortedStorages::new(&raw_storages);
                 let one_epoch_old_slot = 0;
                 let ancient_slots =
                     SplitAncientStorages::get_ancient_slots(one_epoch_old_slot, &snapshot_storages);

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -1,56 +1,101 @@
 use {
     crate::accounts_db::AccountStorageEntry,
     log::*,
-    solana_measure::measure::Measure,
+    solana_measure::measure,
     solana_sdk::clock::Slot,
     std::{
-        collections::HashMap,
         ops::{Bound, Range, RangeBounds},
         sync::Arc,
     },
 };
 
+/// bprumo TODO: docs, talk about providing contiguous sorted-by-slot access
 /// Provide access to SnapshotStorageOnes by slot
+#[derive(Debug)]
 pub struct SortedStorages<'a> {
     /// range of slots where storages exist (likely sparse)
-    range: Range<Slot>,
+    /// bprumo note: could be looked up with .first() and .last() in the array, but the .slot() is an atomic lookup in the appendvec, so just cache it here
+    slots: Range<Slot>,
     /// the actual storages
     /// A HashMap allows sparse storage and fast lookup of Slot -> Storage.
     /// We expect ~432k slots.
-    storages: HashMap<Slot, &'a Arc<AccountStorageEntry>>,
+    //storages: HashMap<Slot, &'a Arc<AccountStorageEntry>>,
+    storages: Box<[(Slot, &'a Arc<AccountStorageEntry>)]>,
 }
 
 impl<'a> SortedStorages<'a> {
-    /// containing nothing
-    pub fn empty() -> Self {
-        SortedStorages {
-            range: Range::default(),
-            storages: HashMap::default(),
-        }
+    /// bprumo TODO: doc
+    pub fn new(source: &'a [Arc<AccountStorageEntry>]) -> Self {
+        let source_with_slots = source.into_iter().map(|storage| (storage.slot(), storage));
+        Self::new_with_slots(source_with_slots, None, None)
+    }
+
+    /// bprumo TODO: doc
+    pub fn new_with_slots(
+        source: impl IntoIterator<Item = (Slot, &'a Arc<AccountStorageEntry>)>,
+        // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator
+        min_slot: Option<Slot>,
+        // highest valid slot. Only matters if source array does not contain a slot >= max_slot_inclusive.
+        // An example is a slot that has accounts in the write cache at slots <= 'max_slot_inclusive' but no storages at those slots.
+        // None => self.range.end = source.1.max() + 1
+        // Some(slot) => self.range.end = std::cmp::max(slot, source.1.max())
+        max_slot_inclusive: Option<Slot>,
+    ) -> Self {
+        let (storages, time) = measure!({
+            let slots = match (min_slot, max_slot_inclusive) {
+                (Some(min), Some(max)) => min..=max,
+                (Some(min), None) => min..=Slot::MAX,
+                (None, Some(max)) => Slot::MIN..=max,
+                (None, None) => Slot::MIN..=Slot::MAX,
+            };
+            let source = source.into_iter().filter(|(slot, _)| slots.contains(slot));
+            let mut storages = Box::from_iter(source);
+            storages.sort_unstable_by_key(|(slot, _)| *slot);
+            storages
+        });
+        error!("bprumo DEBUG: making sorted storages took: {time}");
+
+        // ensure all slots are unique
+        // (since all storages are sorted by slot, we only need to check our neighbor to ensure uniqueness)
+        let neighbors_are_unique = |neighbors: &[(Slot, _)]| -> bool {
+            debug_assert_eq!(neighbors.len(), 2);
+            let a = neighbors[0];
+            let b = neighbors[1];
+            a.0 != b.0
+        };
+        assert!(
+            storages.windows(2).all(neighbors_are_unique),
+            "slots are not unique",
+        );
+
+        let slots = if storages.is_empty() {
+            Range::default()
+        } else {
+            // SAFETY: We've ensured `storages` is *not* empty, so `first`/`last` will always be `Some`
+            // bprumo TODO: should the input params min/max_slot ALSO change the slots range here?
+            let min_slot = storages.first().unwrap().0;
+            let max_slot = storages.last().unwrap().0;
+            min_slot..max_slot + 1
+        };
+
+        Self { slots, storages }
     }
 
     /// primary method of retrieving [`(Slot, Arc<AccountStorageEntry>)`]
-    pub fn iter_range<R>(&'a self, range: &R) -> SortedStoragesIter<'a>
-    where
-        R: RangeBounds<Slot>,
-    {
-        SortedStoragesIter::new(self, range)
-    }
-
-    fn get(&self, slot: Slot) -> Option<&Arc<AccountStorageEntry>> {
-        self.storages.get(&slot).copied()
+    pub fn iter_range(&'a self, slots: &impl RangeBounds<Slot>) -> SortedStoragesIter<'a> {
+        SortedStoragesIter::new(self, slots)
     }
 
     pub fn range_width(&self) -> Slot {
-        self.range.end - self.range.start
+        self.slots.end - self.slots.start
     }
 
     pub fn range(&self) -> &Range<Slot> {
-        &self.range
+        &self.slots
     }
 
     pub fn max_slot_inclusive(&self) -> Slot {
-        self.range.end.saturating_sub(1)
+        self.slots.end.saturating_sub(1)
     }
 
     pub fn slot_count(&self) -> usize {
@@ -63,115 +108,144 @@ impl<'a> SortedStorages<'a> {
 
     // assumption:
     // source.slot() is unique from all other items in 'source'
-    pub fn new(source: &'a [Arc<AccountStorageEntry>]) -> Self {
-        let slots = source.iter().map(|storage| {
-            storage.slot() // this must be unique. Will be enforced in new_with_slots
-        });
-        Self::new_with_slots(source.iter().zip(slots.into_iter()), None, None)
-    }
+    /*
+     * pub fn new(source: &'a [Arc<AccountStorageEntry>]) -> Self {
+     *     let slots = source.iter().map(|storage| {
+     *         storage.slot() // this must be unique. Will be enforced in new_with_slots
+     *     });
+     *     Self::new_with_slots(source.iter().zip(slots.into_iter()), None, None)
+     * }
+     */
 
-    /// create [`SortedStorages`] from `source` iterator.
-    /// `source` contains a [`Arc<AccountStorageEntry>`] and its associated slot
-    /// `source` does not have to be sorted in any way, but is assumed to not have duplicate slot #s
-    pub fn new_with_slots(
-        source: impl Iterator<Item = (&'a Arc<AccountStorageEntry>, Slot)> + Clone,
-        // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator
-        min_slot: Option<Slot>,
-        // highest valid slot. Only matters if source array does not contain a slot >= max_slot_inclusive.
-        // An example is a slot that has accounts in the write cache at slots <= 'max_slot_inclusive' but no storages at those slots.
-        // None => self.range.end = source.1.max() + 1
-        // Some(slot) => self.range.end = std::cmp::max(slot, source.1.max())
-        max_slot_inclusive: Option<Slot>,
-    ) -> Self {
-        let mut min = Slot::MAX;
-        let mut max = Slot::MIN;
-        let mut adjust_min_max = |slot| {
-            min = std::cmp::min(slot, min);
-            max = std::cmp::max(slot + 1, max);
-        };
-        // none, either, or both of min/max could be specified
-        if let Some(slot) = min_slot {
-            adjust_min_max(slot);
-        }
-        if let Some(slot) = max_slot_inclusive {
-            adjust_min_max(slot);
-        }
-
-        let mut slot_count = 0;
-        let mut time = Measure::start("get slot");
-        let source_ = source.clone();
-        let mut storage_count = 0;
-        source_.for_each(|(_, slot)| {
-            storage_count += 1;
-            slot_count += 1;
-            adjust_min_max(slot);
-        });
-        time.stop();
-        let mut time2 = Measure::start("sort");
-        let range;
-        let mut storages = HashMap::default();
-        if min > max {
-            range = Range::default();
-        } else {
-            range = Range {
-                start: min,
-                end: max,
-            };
-            source.for_each(|(original_storages, slot)| {
-                assert!(
-                    storages.insert(slot, original_storages).is_none(),
-                    "slots are not unique"
-                ); // we should not encounter the same slot twice
-            });
-        }
-        time2.stop();
-        debug!("SortedStorages, times: {}, {}", time.as_us(), time2.as_us());
-        Self { range, storages }
-    }
+    /*
+     * /// create [`SortedStorages`] from `source` iterator.
+     * /// `source` contains a [`Arc<AccountStorageEntry>`] and its associated slot
+     * /// `source` does not have to be sorted in any way, but is assumed to not have duplicate slot #s
+     */
+    /*
+     *     pub fn new_with_slots(
+     *         source: impl Iterator<Item = (&'a Arc<AccountStorageEntry>, Slot)> + Clone,
+     *         // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator
+     *         min_slot: Option<Slot>,
+     *         // highest valid slot. Only matters if source array does not contain a slot >= max_slot_inclusive.
+     *         // An example is a slot that has accounts in the write cache at slots <= 'max_slot_inclusive' but no storages at those slots.
+     *         // None => self.range.end = source.1.max() + 1
+     *         // Some(slot) => self.range.end = std::cmp::max(slot, source.1.max())
+     *         max_slot_inclusive: Option<Slot>,
+     *     ) -> Self {
+     *         let mut min = Slot::MAX;
+     *         let mut max = Slot::MIN;
+     *         let mut adjust_min_max = |slot| {
+     *             min = std::cmp::min(slot, min);
+     *             max = std::cmp::max(slot + 1, max);
+     *         };
+     *         // none, either, or both of min/max could be specified
+     *         if let Some(slot) = min_slot {
+     *             adjust_min_max(slot);
+     *         }
+     *         if let Some(slot) = max_slot_inclusive {
+     *             adjust_min_max(slot);
+     *         }
+     *
+     *         let mut slot_count = 0;
+     *         let mut time = Measure::start("get slot");
+     *         let source_ = source.clone();
+     *         let mut storage_count = 0;
+     *         source_.for_each(|(_, slot)| {
+     *             storage_count += 1;
+     *             slot_count += 1;
+     *             adjust_min_max(slot);
+     *         });
+     *         time.stop();
+     *         let mut time2 = Measure::start("sort");
+     *         let range;
+     *         let mut storages = HashMap::default();
+     *         if min > max {
+     *             range = Range::default();
+     *         } else {
+     *             range = Range {
+     *                 start: min,
+     *                 end: max,
+     *             };
+     *             source.for_each(|(original_storages, slot)| {
+     *                 assert!(
+     *                     storages.insert(slot, original_storages).is_none(),
+     *                     "slots are not unique"
+     *                 ); // we should not encounter the same slot twice
+     *             });
+     *         }
+     *         time2.stop();
+     *         debug!("SortedStorages, times: {}, {}", time.as_us(), time2.as_us());
+     *         Self {
+     *             range,
+     *             storages,
+     *             bprumo_storages: Box::default(),
+     *         }
+     *     }
+     */
 }
 
 /// Iterator over successive slots in 'storages' within 'range'.
 /// This enforces sequential access so that random access does not have to be implemented.
 /// Random access could be expensive with large sparse sets.
+#[derive(Debug)]
 pub struct SortedStoragesIter<'a> {
-    /// range for the iterator to iterate over (start_inclusive..end_exclusive)
-    range: Range<Slot>,
     /// the data to return per slot
-    storages: &'a SortedStorages<'a>,
+    sorted_storages: &'a SortedStorages<'a>,
+
+    /// range for the iterator to iterate over (start_inclusive..end_exclusive)
+    slots: Range<Slot>,
     /// the slot to be returned the next time 'Next' is called
     next_slot: Slot,
+
+    /// bprumo TODO: doc
+    indices: Range<usize>,
+    /// bprumo TODO: doc
+    next_index: usize,
 }
 
 impl<'a> Iterator for SortedStoragesIter<'a> {
     type Item = (Slot, Option<&'a Arc<AccountStorageEntry>>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let slot = self.next_slot;
-        if slot < self.range.end {
-            // iterator is still in range. Storage may or may not exist at this slot, but the iterator still needs to return the slot
-            self.next_slot += 1;
-            Some((slot, self.storages.get(slot)))
-        } else {
-            // iterator passed the end of the range, so from now on it returns None
-            None
+        if !self.slots.contains(&self.next_slot) {
+            //error!("bprumo DEBUG: SortedStoragesIter::next() done next slot not in slots! next index: {} (range: {:?}), next slot: {} (range: {:?}), ", self.next_index, self.indices, self.next_slot, self.slots);
+            return None;
         }
+
+        let mut result = (self.next_slot, None);
+
+        if let Some(&(slot, storage)) = self.sorted_storages.storages.get(self.next_index) {
+            if slot == self.next_slot {
+                //error!("bprumo DEBUG: SortedStoragesIter::next() found slot {}! next index: {} (range: {:?}), next slot: {} (range: {:?}), ", slot, self.next_index, self.indices, self.next_slot, self.slots);
+                result.1 = Some(storage);
+                self.next_index += 1;
+            } else {
+                //error!("bprumo DEBUG: SortedStoragesIter::next() did not find slot {}! next index: {} (range: {:?}), next slot: {} (range: {:?}), ", slot, self.next_index, self.indices, self.next_slot, self.slots);
+            }
+        } else {
+            //error!("bprumo DEBUG: SortedStoragesIter::next() done next index not in indices! next index: {} (range: {:?}), next slot: {} (range: {:?}), ", self.next_index, self.indices, self.next_slot, self.slots);
+        }
+
+        self.next_slot += 1;
+        Some(result)
     }
 }
 
 impl<'a> SortedStoragesIter<'a> {
     pub fn new<R: RangeBounds<Slot>>(
-        storages: &'a SortedStorages<'a>,
+        sorted_storages: &'a SortedStorages<'a>,
         range: &R,
     ) -> SortedStoragesIter<'a> {
-        let storage_range = storages.range();
-        let next_slot = match range.start_bound() {
+        let storage_range = sorted_storages.range();
+        let slot_start = match range.start_bound() {
             Bound::Unbounded => {
                 storage_range.start // unbounded beginning starts with the min known slot (which is inclusive)
             }
             Bound::Included(x) => *x,
             Bound::Excluded(x) => *x + 1, // make inclusive
         };
-        let end_exclusive_slot = match range.end_bound() {
+        let slot_end = match range.end_bound() {
             Bound::Unbounded => {
                 storage_range.end // unbounded end ends with the max known slot (which is exclusive)
             }
@@ -181,11 +255,31 @@ impl<'a> SortedStoragesIter<'a> {
         // Note that the range can be outside the range of known storages.
         // This is because the storages may not be the only source of valid slots.
         // The write cache is another source of slots that 'storages' knows nothing about.
-        let range = next_slot..end_exclusive_slot;
+        // bprumo TODO: remove?
+        let _slots = slot_start..slot_end;
+
+        // bprumo TODO: need to find the index to start iterating from; can binary search
+        // find index with slot >= range.begin
+        //
+        // maybe also find end index too? then next() will be faster
+        //
+        // Oh! get a *slice* into our storages to iterate over!
+
+        let index_start = sorted_storages
+            .storages
+            .partition_point(|(slot, _)| slot < &slot_start);
+        let index_end = sorted_storages
+            .storages
+            .partition_point(|(slot, _)| slot < &slot_end);
+        //let slice_to_iterate = &storages.bprumo_storages[index_begin..index_end];
+
+        //error!("bprumo DEBUG: SortedStoragesIter::new() slot start: {}, slot end: {}, index start: {}, index end: {}, storages slots: {:?}, storages len: {}, storages: {:?}", slot_start, slot_end, index_start, index_end, sorted_storages.slots, sorted_storages.storages.len(), sorted_storages);
         SortedStoragesIter {
-            range,
-            storages,
-            next_slot,
+            sorted_storages,
+            slots: slot_start..slot_end,
+            next_slot: slot_start,
+            indices: index_start..index_end,
+            next_index: index_start,
         }
     }
 }
@@ -194,43 +288,35 @@ impl<'a> SortedStoragesIter<'a> {
 pub mod tests {
     use {
         super::*,
-        crate::{
-            accounts_db::{AccountStorageEntry, AppendVecId},
-            append_vec::AppendVec,
-        },
-        std::sync::Arc,
+        crate::{accounts_db::AppendVecId, append_vec::AppendVec},
     };
+
     impl<'a> SortedStorages<'a> {
         pub fn new_debug(
-            source: &[(&'a Arc<AccountStorageEntry>, Slot)],
+            source: &[(Slot, &'a Arc<AccountStorageEntry>)],
             min: Slot,
             len: usize,
         ) -> Self {
-            let mut storages = HashMap::default();
-            let range = Range {
-                start: min,
-                end: min + len as Slot,
-            };
-            for (storage, slot) in source {
-                storages.insert(*slot, *storage);
+            Self {
+                slots: min..min + len as Slot,
+                ..Self::new_for_tests(source)
             }
-
-            Self { range, storages }
         }
-
-        pub fn new_for_tests(storages: &[&'a Arc<AccountStorageEntry>], slots: &[Slot]) -> Self {
-            assert_eq!(storages.len(), slots.len());
-            SortedStorages::new_with_slots(
-                storages.iter().cloned().zip(slots.iter().cloned()),
-                None,
-                None,
-            )
+        pub fn new_for_tests(storages: &[(Slot, &'a Arc<AccountStorageEntry>)]) -> Self {
+            SortedStorages::new_with_slots(storages.iter().cloned(), None, None)
+        }
+        fn get(&self, slot: Slot) -> Option<&AccountStorageEntry> {
+            self.storages
+                .iter()
+                .find(|storage| slot == storage.0)
+                .map(|(_, storage)| storage.as_ref())
         }
     }
 
     #[test]
     fn test_sorted_storages_range_iter() {
-        let storages = SortedStorages::empty();
+        solana_logger::setup();
+        let storages = SortedStorages::new(&[]);
         let check = |(slot, storages): (Slot, Option<&Arc<AccountStorageEntry>>)| {
             assert!(storages.is_none());
             slot
@@ -254,7 +340,7 @@ pub mod tests {
 
         // only item is slot 3
         let s1 = create_sample_store(1);
-        let storages = SortedStorages::new_for_tests(&[&s1], &[3]);
+        let storages = SortedStorages::new_for_tests(&[(3, &s1)]);
         let check = |(slot, storages): (Slot, Option<&Arc<AccountStorageEntry>>)| {
             assert!(
                 (slot != 3) ^ storages.is_some(),
@@ -290,7 +376,7 @@ pub mod tests {
         let store2 = create_sample_store(2);
         let store4 = create_sample_store(4);
 
-        let storages = SortedStorages::new_for_tests(&[&store2, &store4], &[2, 4]);
+        let storages = SortedStorages::new_for_tests(&[(2, &store2), (4, &store4)]);
         let check = |(slot, storage): (Slot, Option<&Arc<AccountStorageEntry>>)| {
             assert!(
                 (slot != 2 && slot != 4)
@@ -327,16 +413,57 @@ pub mod tests {
     }
 
     #[test]
+    fn test_sorted_storages_new() {
+        let store = create_sample_store(1);
+        {
+            let storages = SortedStorages::new_with_slots(
+                [(44, &store), (33, &store)].iter().cloned(),
+                Some(13),
+                Some(66),
+            );
+            assert_eq!(storages.storages.len(), 2);
+            assert_eq!(storages.slots, 33..45);
+        }
+        {
+            let storages = SortedStorages::new_with_slots(
+                [(44, &store), (33, &store)].iter().cloned(),
+                Some(37),
+                Some(66),
+            );
+            assert_eq!(storages.storages.len(), 1);
+            assert_eq!(storages.slots, 44..45);
+        }
+        {
+            let storages = SortedStorages::new_with_slots(
+                [(44, &store), (33, &store)].iter().cloned(),
+                Some(13),
+                Some(41),
+            );
+            assert_eq!(storages.storages.len(), 1);
+            assert_eq!(storages.slots, 33..34);
+        }
+        {
+            let storages = SortedStorages::new_with_slots(
+                [(44, &store), (33, &store)].iter().cloned(),
+                Some(37),
+                Some(41),
+            );
+            assert_eq!(storages.storages.len(), 0);
+            assert_eq!(storages.slots, Range::default());
+        }
+    }
+
+    #[test]
     #[should_panic(expected = "slots are not unique")]
     fn test_sorted_storages_duplicate_slots() {
         let store = create_sample_store(1);
-        SortedStorages::new_for_tests(&[&store, &store], &[0, 0]);
+        SortedStorages::new_for_tests(&[(0, &store), (0, &store)]);
     }
 
     #[test]
     fn test_sorted_storages_none() {
-        let result = SortedStorages::empty();
-        assert_eq!(result.range, Range::default());
+        let result = SortedStorages::new(&[]);
+        assert_eq!(result.slots, Range::default());
         assert_eq!(result.slot_count(), 0);
         assert_eq!(result.storages.len(), 0);
         assert!(result.get(0).is_none());
@@ -346,15 +473,8 @@ pub mod tests {
     fn test_sorted_storages_1() {
         let store = create_sample_store(1);
         let slot = 4;
-        let vecs = [&store];
-        let result = SortedStorages::new_for_tests(&vecs, &[slot]);
-        assert_eq!(
-            result.range,
-            Range {
-                start: slot,
-                end: slot + 1
-            }
-        );
+        let result = SortedStorages::new_for_tests(&[(slot, &store)]);
+        assert_eq!(result.slots, slot..slot + 1);
         assert_eq!(result.slot_count(), 1);
         assert_eq!(result.storages.len(), 1);
         assert_eq!(
@@ -379,16 +499,8 @@ pub mod tests {
     fn test_sorted_storages_2() {
         let store = create_sample_store(1);
         let store2 = create_sample_store(2);
-        let slots = [4, 7];
-        let vecs = [&store, &store2];
-        let result = SortedStorages::new_for_tests(&vecs, &slots);
-        assert_eq!(
-            result.range,
-            Range {
-                start: slots[0],
-                end: slots[1] + 1,
-            }
-        );
+        let result = SortedStorages::new_for_tests(&[(4, &store), (7, &store2)]);
+        assert_eq!(result.slots, 4..8);
         assert_eq!(result.slot_count(), 2);
         assert_eq!(result.storages.len(), 2);
         assert!(result.get(0).is_none());
@@ -397,11 +509,11 @@ pub mod tests {
         assert!(result.get(6).is_none());
         assert!(result.get(8).is_none());
         assert_eq!(
-            result.get(slots[0]).unwrap().append_vec_id(),
+            result.get(4).unwrap().append_vec_id(),
             store.append_vec_id()
         );
         assert_eq!(
-            result.get(slots[1]).unwrap().append_vec_id(),
+            result.get(7).unwrap().append_vec_id(),
             store2.append_vec_id()
         );
     }


### PR DESCRIPTION
- wip: SortedStorages uses a (sorted) Vec internally
- change how SortedStorages::new() handles the min and max params, plus doc/log cleanup

#### Problem

SortedStorages uses a HashMap to store the links to Storages. Commonly this type is used to iterate in slot-order over the storages. A HashMap does not have contiguous memory, so iterating in slot order is slow (due to indirection), and likely bad for a pre-fetcher since Values are not stored contiguous/in a set pattern/stride/offset.


#### Summary of Changes

Replace HashMap with contiguous array


#### Notes

The internal array needs to be sorted. Running this code against an mnb snapshot shows inconclusive results vs the current (i.e. HashMap) impl. Maybe it's the sorting? Maybe the I/O on the storages is what's bounding calculating the accounts hash. Whatever the case, more testing/benchmarking is required.