### PR TITLE
[explorer] Add Account Compression Program to searchable programs on explorer

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -37,6 +37,7 @@ export enum PROGRAM_NAMES {
 
   // spl
   ASSOCIATED_TOKEN = "Associated Token Program",
+  ACCOUNT_COMPRESSION = "Account Compression Program",
   FEATURE_PROPOSAL = "Feature Proposal Program",
   LENDING = "Lending Program",
   MEMO = "Memo Program",
@@ -158,6 +159,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
   ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL: {
     name: PROGRAM_NAMES.ASSOCIATED_TOKEN,
     deployments: ALL_CLUSTERS,
+  },
+  cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK: {
+    name: PROGRAM_NAMES.ACCOUNT_COMPRESSION,
+    deployments: [Cluster.Devnet, Cluster.MainnetBeta],
   },
   Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse: {
     name: PROGRAM_NAMES.FEATURE_PROPOSAL,


### PR DESCRIPTION
#### Problem

Account Compression is SPL program on Mainnet & Devnet, but it's hard to find on explorer

#### Summary of Changes

Make it show up in search bar when typing "Account Compression Program"

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
