### PR TITLE
add cost tracking for each bank during replay

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -614,6 +614,10 @@ pub mod delay_visibility_of_program_deployment {
     solana_sdk::declare_id!("GmuBvtFb2aHfSfMXpuFeWZGHyDeCLPS79s48fmCWCfM5");
 }
 
+pub mod apply_cost_tracker_during_replay {
+    solana_sdk::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -762,6 +766,7 @@ lazy_static! {
         (enable_request_heap_frame_ix::id(), "Enable transaction to request heap frame using compute budget instruction #30076"),
         (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30151"),
         (delay_visibility_of_program_deployment::id(), "delay visibility of program upgrades #30085"),
+        (apply_cost_tracker_during_replay::id(), "apply cost tracker to blocks during replay #29595"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Leaders use `cost_tracker` to ensure each block produced are with block limits. Same cost tracking and checking against limits should be symmetrically performed during replay, blocks exceed limits should fail replay.

#### Summary of Changes
- calling `bank.cost_tracker.try_add(tx)` during replaying, return error if block exceeds limits
- add feature gate since this change breaks consensus 

Feature Gate Issue: #29595 

**NOTE**: Until this point, cost_model and cost_tracker are exclusively used by leaders during block packing, so we enjoyed the freedom to change how it works without worrying much about breaking consensus. With this PR, future changes to `cost_model.rs`, `cost_tracker.rs`, `block_cost_limits.rs` and maybe other models that would change how transaction cost measures against block limits could break consensus, therefore need to be feature gated.