### PR TITLE
Remove docblock that claims Mergify config can be validated using a webservice

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,3 @@
-# Validate your changes with:
-#
-#   $ curl -F 'data=@.mergify.yml' https://gh.mergify.io/validate/
-#
-# https://doc.mergify.io/
 pull_request_rules:
   - name: label changes from community
     conditions:


### PR DESCRIPTION
#### Problem

This doesn't actually work anymore.

#### Summary of Changes

Disabuse the reader of the notion that it does.