### PR TITLE
impl default version of contains_multiple_slots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9387,9 +9387,6 @@ pub mod tests {
         fn len(&self) -> usize {
             self.1.len()
         }
-        fn contains_multiple_slots(&self) -> bool {
-            false
-        }
         fn include_slot_in_hash(&self) -> IncludeSlotInHash {
             INCLUDE_SLOT_IN_HASH_TESTS
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1189,9 +1189,6 @@ impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward], I
     fn len(&self) -> usize {
         self.1.len()
     }
-    fn contains_multiple_slots(&self) -> bool {
-        false
-    }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.2
     }

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -31,7 +31,9 @@ pub trait StorableAccounts<'a, T: ReadableAccount + Sync>: Sync {
     fn len(&self) -> usize;
     /// are there accounts from multiple slots
     /// only used for an assert
-    fn contains_multiple_slots(&self) -> bool;
+    fn contains_multiple_slots(&self) -> bool {
+        false
+    }
     /// true iff hashing these accounts should include the slot
     fn include_slot_in_hash(&self) -> IncludeSlotInHash;
 
@@ -87,9 +89,6 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a, T> for StorableAccounts
     fn len(&self) -> usize {
         self.accounts.len()
     }
-    fn contains_multiple_slots(&self) -> bool {
-        false
-    }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.include_slot_in_hash
     }
@@ -116,9 +115,6 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a, T>
     fn len(&self) -> usize {
         self.1.len()
     }
-    fn contains_multiple_slots(&self) -> bool {
-        false
-    }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.2
     }
@@ -144,9 +140,6 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
     }
     fn len(&self) -> usize {
         self.1.len()
-    }
-    fn contains_multiple_slots(&self) -> bool {
-        false
     }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.2
@@ -187,9 +180,6 @@ impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
     }
     fn len(&self) -> usize {
         self.1.len()
-    }
-    fn contains_multiple_slots(&self) -> bool {
-        false
     }
     fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         self.2


### PR DESCRIPTION
#### Problem
There are multiple impls of `StorableAccounts`. Almost all of them do NOT contain multiple slots.

#### Summary of Changes
Provide default impl of `contains_multiple_slots()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
