### PR TITLE
is_cached_store, bool -> Storage enum

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -161,6 +161,14 @@ pub enum CreateAncientStorage {
     Pack,
 }
 
+#[derive(Copy, Clone)]
+enum Storage {
+    /// write to cache
+    Cache,
+    /// write to storage
+    Storage,
+}
+
 #[derive(Default)]
 /// hold alive accounts and bytes used by those accounts
 /// alive means in the accounts index
@@ -6561,7 +6569,7 @@ impl AccountsDb {
         hashes: Option<Vec<impl Borrow<Hash>>>,
         storage_finder: F,
         mut write_version_producer: P,
-        is_cached_store: bool,
+        is_cached_store: Storage,
         txn_signatures: Option<&[Option<&'a Signature>]>,
     ) -> Vec<AccountInfo> {
         let mut calc_stored_meta_time = Measure::start("calc_stored_meta");
@@ -6575,7 +6583,7 @@ impl AccountsDb {
             .calc_stored_meta
             .fetch_add(calc_stored_meta_time.as_us(), Ordering::Relaxed);
 
-        if is_cached_store {
+        if matches!(is_cached_store, Storage::Cache) {
             let signature_iter: Box<dyn std::iter::Iterator<Item = &Option<&Signature>>> =
                 match txn_signatures {
                     Some(txn_signatures) => {
@@ -8032,7 +8040,12 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a, T>,
         txn_signatures: Option<&'a [Option<&'a Signature>]>,
     ) {
-        self.store(accounts, true, txn_signatures, StoreReclaims::Default);
+        self.store(
+            accounts,
+            Storage::Cache,
+            txn_signatures,
+            StoreReclaims::Default,
+        );
     }
 
     /// Store the account update.
@@ -8040,7 +8053,7 @@ impl AccountsDb {
     pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         self.store(
             (slot, accounts, INCLUDE_SLOT_IN_HASH_TESTS),
-            false,
+            Storage::Storage,
             None,
             StoreReclaims::Default,
         );
@@ -8049,7 +8062,7 @@ impl AccountsDb {
     fn store<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
-        is_cached_store: bool,
+        is_cached_store: Storage,
         txn_signatures: Option<&'a [Option<&'a Signature>]>,
         reclaim: StoreReclaims,
     ) {
@@ -8218,7 +8231,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a, T>,
         hashes: Option<Vec<impl Borrow<Hash>>>,
-        is_cached_store: bool,
+        is_cached_store: Storage,
         txn_signatures: Option<&'a [Option<&'a Signature>]>,
         reclaim: StoreReclaims,
     ) {
@@ -8254,7 +8267,7 @@ impl AccountsDb {
         // the append vec so that hashing could happen on the store
         // and accounts in the append_vec can be unrefed correctly
         let reset_accounts = false;
-        let is_cached_store = false;
+        let is_cached_store = Storage::Storage;
         self.store_accounts_custom(
             accounts,
             hashes,
@@ -8273,7 +8286,7 @@ impl AccountsDb {
         hashes: Option<Vec<impl Borrow<Hash>>>,
         storage: Option<&Arc<AccountStorageEntry>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
-        is_cached_store: bool,
+        is_cached_store: Storage,
         reset_accounts: bool,
         txn_signatures: Option<&[Option<&Signature>]>,
         reclaim: StoreReclaims,
@@ -8314,7 +8327,7 @@ impl AccountsDb {
 
         let reclaim = if matches!(reclaim, StoreReclaims::Ignore) {
             UpsertReclaim::IgnoreReclaims
-        } else if is_cached_store {
+        } else if matches!(is_cached_store, Storage::Cache) {
             UpsertReclaim::PreviousSlotEntryWasCached
         } else {
             UpsertReclaim::PopulateReclaims
@@ -8337,7 +8350,7 @@ impl AccountsDb {
         // entries
         reclaims.retain(|(_, r)| !r.is_cached());
 
-        if is_cached_store {
+        if matches!(is_cached_store, Storage::Cache) {
             assert!(reclaims.is_empty());
         }
 
@@ -12235,7 +12248,7 @@ pub mod tests {
         db.store_accounts_unfrozen(
             (some_slot, &[(&key, &account)][..]),
             Some(vec![&Hash::default()]),
-            false,
+            Storage::Storage,
             None,
             StoreReclaims::Default,
         );
@@ -12514,7 +12527,7 @@ pub mod tests {
         db.store_accounts_unfrozen(
             (some_slot, accounts),
             Some(vec![&some_hash]),
-            false,
+            Storage::Storage,
             None,
             StoreReclaims::Default,
         );
@@ -15935,7 +15948,7 @@ pub mod tests {
         pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
             self.store(
                 (slot, accounts, INCLUDE_SLOT_IN_HASH_TESTS),
-                true,
+                Storage::Cache,
                 None,
                 StoreReclaims::Default,
             );


### PR DESCRIPTION
#### Problem
writes to cache know a storage is never needed.
Writes NOT using cache have to look up a storage deep in the bowels of the code.
Writes NOT using cache are either shrink, flush, or tests.
shrink and flush create the storage ahead of time.
Tests often do not, but they use specific test apis.
Ideally, we never lookup a storage deep in the bowels of writing accounts.
This allows us to simplify and improve performance of account writing.
Further changes will include the required storage in the `Storage` enum value so that it doesn't have to be looked up deeper.
Overall, changing this to an enum makes it trivial to find all places which are not using the cache.

#### Summary of Changes
Add enum to replace bool.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
