### PR TITLE
Only insert default BankHashStats in Accounts::new_from_parent()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -208,7 +208,7 @@ impl Accounts {
 
     pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot) -> Self {
         let accounts_db = parent.accounts_db.clone();
-        accounts_db.insert_default_bank_hash(slot, parent_slot);
+        accounts_db.insert_default_bank_hash_stats(slot, parent_slot);
         Self {
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4884,28 +4884,16 @@ impl AccountsDb {
         }
     }
 
-    /// Insert a new bank hash for `slot`
+    /// Insert a default bank hash stats for `slot`
     ///
-    /// The new bank hash is empty/default except for the slot.  This fn is called when creating a
-    /// new bank from parent.  The bank hash for this slot is updated with real values later.
-    pub fn insert_default_bank_hash(&self, slot: Slot, parent_slot: Slot) {
+    /// This fn is called when creating a new bank from parent.
+    pub fn insert_default_bank_hash_stats(&self, slot: Slot, parent_slot: Slot) {
         let mut bank_hash_stats = self.bank_hash_stats.lock().unwrap();
         if bank_hash_stats.get(&slot).is_some() {
-            error!(
-                "set_hash: already exists; multiple forks with shared slot {} as child (parent: {})!?",
-                slot, parent_slot,
-            );
+            error!( "set_hash: already exists; multiple forks with shared slot {slot} as child (parent: {parent_slot})!?");
             return;
         }
         bank_hash_stats.insert(slot, BankHashStats::default());
-        drop(bank_hash_stats);
-
-        let old_accounts_delta_hash =
-            self.set_accounts_delta_hash(slot, AccountsDeltaHash::default());
-        assert!(old_accounts_delta_hash.is_none());
-
-        let old_accounts_hash = self.set_accounts_hash(slot, AccountsHash::default());
-        assert!(old_accounts_hash.is_none());
     }
 
     pub fn load(
@@ -11907,13 +11895,13 @@ pub mod tests {
         accounts.add_root(0);
 
         let mut current_slot = 1;
-        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash_stats(current_slot, current_slot - 1);
         accounts.store_for_tests(current_slot, &[(&pubkey, &account)]);
         accounts.calculate_accounts_delta_hash(current_slot);
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash_stats(current_slot, current_slot - 1);
         accounts.store_for_tests(current_slot, &[(&pubkey, &zero_lamport_account)]);
         accounts.calculate_accounts_delta_hash(current_slot);
         accounts.add_root_and_flush_write_cache(current_slot);
@@ -11922,7 +11910,7 @@ pub mod tests {
 
         // Otherwise slot 2 will not be removed
         current_slot += 1;
-        accounts.insert_default_bank_hash(current_slot, current_slot - 1);
+        accounts.insert_default_bank_hash_stats(current_slot, current_slot - 1);
         accounts.calculate_accounts_delta_hash(current_slot);
         accounts.add_root_and_flush_write_cache(current_slot);
 


### PR DESCRIPTION
#### Problem

Background context: https://github.com/solana-labs/solana/pull/30024

When a new bank is created, it calls `Accounts::new_from_parent()`, which in turn inserts default values for this bank's slot into the AccountsDb accounts delta hashes, accounts hashes, and bank hash stats maps. The default accounts delta hash and default accounts hash are useless though. When the bank is frozen, it will calculate its real accounts delta hash. And when a snapshot is taken, it will calculate its real accounts hash. So inserting default values for these two is not necessary.

(Still keep the default bank hash stats, because if there's not any transactions in the bank that call a `store()`, the bank hash stats for the slot are still looked up, and the default value would be correct.)

#### Summary of Changes

Do not insert default values for accounts delta hash nor accounts hash when there's a new bank.