### PR TITLE
Do not populate slot 0 with default accounts delta hash/accounts hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2326,10 +2326,6 @@ impl AccountsDb {
                 .to_path_buf()
         });
 
-        let mut accounts_delta_hashes = HashMap::new();
-        accounts_delta_hashes.insert(0, AccountsDeltaHash::default());
-        let mut accounts_hashes = HashMap::new();
-        accounts_hashes.insert(0, AccountsHash::default());
         let mut bank_hash_stats = HashMap::new();
         bank_hash_stats.insert(0, BankHashStats::default());
 
@@ -2372,8 +2368,8 @@ impl AccountsDb {
                 .build()
                 .unwrap(),
             thread_pool_clean: make_min_priority_thread_pool(),
-            accounts_delta_hashes: Mutex::new(accounts_delta_hashes),
-            accounts_hashes: Mutex::new(accounts_hashes),
+            accounts_delta_hashes: Mutex::new(HashMap::new()),
+            accounts_hashes: Mutex::new(HashMap::new()),
             bank_hash_stats: Mutex::new(bank_hash_stats),
             external_purge_slots_stats: PurgeStats::default(),
             clean_accounts_stats: CleanAccountsStats::default(),
@@ -11740,9 +11736,9 @@ pub mod tests {
             );
 
             // Get the hashes for the latest slot, which should be the only hashes in the
-            // map on the deserialized AccountsDb (other than slot 0)
-            assert_eq!(daccounts.accounts_delta_hashes.lock().unwrap().len(), 2);
-            assert_eq!(daccounts.accounts_hashes.lock().unwrap().len(), 2);
+            // map on the deserialized AccountsDb
+            assert_eq!(daccounts.accounts_delta_hashes.lock().unwrap().len(), 1);
+            assert_eq!(daccounts.accounts_hashes.lock().unwrap().len(), 1);
             assert_eq!(
                 daccounts.get_accounts_delta_hash(latest_slot).unwrap(),
                 accounts.get_accounts_delta_hash(latest_slot).unwrap(),


### PR DESCRIPTION
#### Problem

Background context: https://github.com/solana-labs/solana/pull/30024, https://github.com/solana-labs/solana/pull/30063

There are places that assume there's an accounts delta hash and/or accounts hash, even if those values are default/garbage. I'm working to remove those.

Here, a new AccountsDb is populated with default values for AccountsDeltaHash and AccountsHash. These values will be computed correctly later, as needed. No point in adding them here.

Note: BankHashStats will stay here for now and may be removed in a later PR (got a few more bits to rip out before that becomes easy though).

#### Summary of Changes

Do not populate slot 0 with default values for accounts delta hash and accounts hash.