### PR TITLE
ledger-tool: Move shred storage type inference next to Blockstore::open

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -17,9 +17,8 @@ use {
         OutputFormat,
     },
     solana_ledger::{
-        bigtable_upload::ConfirmedBlockUploadConfig,
-        blockstore::Blockstore,
-        blockstore_options::{AccessType, ShredStorageType},
+        bigtable_upload::ConfirmedBlockUploadConfig, blockstore::Blockstore,
+        blockstore_options::AccessType,
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
     solana_storage_bigtable::CredentialType,
@@ -985,11 +984,7 @@ fn get_global_subcommand_arg<T: FromStr>(
     }
 }
 
-pub fn bigtable_process_command(
-    ledger_path: &Path,
-    matches: &ArgMatches<'_>,
-    shred_storage_type: &ShredStorageType,
-) {
+pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let verbose = matches.is_present("verbose");
@@ -1019,7 +1014,6 @@ pub fn bigtable_process_command(
                 &canonicalize_ledger_path(ledger_path),
                 AccessType::Secondary,
                 None,
-                shred_storage_type,
                 force_update_to_open,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {


### PR DESCRIPTION
#### Problem
The shred storage type (ie compaction) only needs to be known for opening the blockstore, so move the discovery next to open instead of having to pass around as an arg in a bunch of places.

#### Summary of Changes
Shift the call to determine shred storage type. Note that this change will also avoid the warn (now info) when we won't even open the blockstore at all, such as in some of the upcoming `accounts` commands.