### PR TITLE
ci: cancel previous Windows build when start a new one

### DIFF
--- a/.github/workflows/release-artifacts-auto.yml
+++ b/.github/workflows/release-artifacts-auto.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-artifacts:
     uses: ./.github/workflows/release-artifacts.yml


### PR DESCRIPTION
#### Problem

In the same branch, we should cancel previous Windows building when a new one starts.

This PR can cancel previous running. It looks like this: 
![Screenshot 2023-02-02 at 7 20 12 PM](https://user-images.githubusercontent.com/8209234/216311241-2b57793a-3702-4583-b9fb-9d6c57e52a92.png)

