### PR TITLE
fix alive_bytes test fn

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10397,10 +10397,11 @@ pub mod tests {
                 vec![&hash],
                 vec![write_version],
             );
+        let old_written = storage.written_bytes();
         storage.accounts.append_accounts(&storable_accounts, 0);
         if mark_alive {
-            // updates 'alive_bytes'
-            storage.add_account(storage.accounts.len());
+            // updates 'alive_bytes' on the storage
+            storage.add_account((storage.written_bytes() - old_written) as usize);
         }
     }
 


### PR DESCRIPTION
#### Problem
when adding test accounts, test can request alive_bytes be updated on the storage. The # of bytes added was incorrectly calculated.

#### Summary of Changes
set the correct # of alive bytes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
