### PR TITLE
Add comment on the closure

### DIFF
--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -33,6 +33,7 @@ impl PacketReceiver {
                     recv_timeout,
                     unprocessed_transaction_storage.max_receive_size(),
                 )
+                // Consumes results if Ok, otherwise we keep the Err
                 .map(|receive_packet_results| {
                     Self::buffer_packets(
                         receive_packet_results,


### PR DESCRIPTION
#### Problem
Follow-up to comment here: https://github.com/solana-labs/solana/pull/29784#discussion_r1094529924

#### Summary of Changes
Returning unit makes clippy unhappy, so I opted for a comment instead:
```
36 |                 .map(|receive_packet_results| -> () {
   |                                              ^^^^^^ help: remove the `-> ()`
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
