### PR TITLE
Use Ipv4Addr constants in socketaddr!

### DIFF
--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -81,7 +81,7 @@ async fn main() {
         .into_iter()
         .collect();
 
-    let faucet_addr = socketaddr!(0, FAUCET_PORT);
+    let faucet_addr = socketaddr!(Ipv4Addr::UNSPECIFIED, FAUCET_PORT);
 
     let faucet = Arc::new(Mutex::new(Faucet::new_with_allowed_ips(
         faucet_keypair,

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -335,7 +335,7 @@ pub fn run_local_faucet_with_port(
     port: u16, // 0 => auto assign
 ) {
     thread::spawn(move || {
-        let faucet_addr = socketaddr!(0, port);
+        let faucet_addr = socketaddr!(Ipv4Addr::UNSPECIFIED, port);
         let faucet = Arc::new(Mutex::new(Faucet::new(
             faucet_keypair,
             time_input,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3623,7 +3623,7 @@ RPC Enabled Nodes: 1"#;
 
     #[test]
     fn new_with_external_ip_test_random() {
-        let ip = Ipv4Addr::from(0);
+        let ip = Ipv4Addr::UNSPECIFIED;
         let node = Node::new_with_external_ip(
             &solana_sdk::pubkey::new_rand(),
             &socketaddr!(ip, 0),
@@ -3644,11 +3644,11 @@ RPC Enabled Nodes: 1"#;
             VALIDATOR_PORT_RANGE.1 + (2 * MINIMUM_VALIDATOR_PORT_RANGE_WIDTH),
         );
 
-        let ip = IpAddr::V4(Ipv4Addr::from(0));
+        let ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let port = bind_in_range(ip, port_range).expect("Failed to bind").0;
         let node = Node::new_with_external_ip(
             &solana_sdk::pubkey::new_rand(),
-            &socketaddr!(0, port),
+            &socketaddr!(Ipv4Addr::UNSPECIFIED, port),
             port_range,
             ip,
             None,

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -723,7 +723,7 @@ mod tests {
             signature::{Keypair, Signer},
             timing::timestamp,
         },
-        std::{collections::HashSet, iter::repeat_with},
+        std::{collections::HashSet, iter::repeat_with, net::Ipv4Addr},
     };
 
     #[test]
@@ -1376,7 +1376,7 @@ mod tests {
         let v2 = VersionedCrdsValue::new(
             {
                 let mut contact_info = ContactInfo::new_localhost(&Pubkey::default(), 0);
-                contact_info.rpc = socketaddr!("0.0.0.0:0");
+                contact_info.rpc = socketaddr!(Ipv4Addr::UNSPECIFIED, 0);
                 CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(contact_info))
             },
             Cursor::default(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4677,7 +4677,7 @@ pub mod tests {
             solana_program::{program_option::COption, pubkey::Pubkey as SplTokenPubkey},
             state::{AccountState as TokenAccountState, Mint},
         },
-        std::{borrow::Cow, collections::HashMap},
+        std::{borrow::Cow, collections::HashMap, net::Ipv4Addr},
     };
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000_000;
@@ -4767,7 +4767,7 @@ pub mod tests {
             let identity = cluster_info.id();
             cluster_info.insert_info(ContactInfo::new_with_socketaddr(
                 &leader_pubkey,
-                &socketaddr!("127.0.0.1:1234"),
+                &socketaddr!(Ipv4Addr::LOCALHOST, 1234),
             ));
             let max_slots = Arc::new(MaxSlots::default());
             // note that this means that slot 0 will always be considered complete
@@ -6384,8 +6384,10 @@ pub mod tests {
         io.extend_with(rpc_full::FullImpl.to_delegate());
         let cluster_info = Arc::new({
             let keypair = Arc::new(Keypair::new());
-            let contact_info =
-                ContactInfo::new_with_socketaddr(&keypair.pubkey(), &socketaddr!("127.0.0.1:1234"));
+            let contact_info = ContactInfo::new_with_socketaddr(
+                &keypair.pubkey(),
+                &socketaddr!(Ipv4Addr::LOCALHOST, 1234),
+            );
             ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
         });
         let tpu_address = cluster_info.my_contact_info().tpu;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -91,7 +91,7 @@ impl Default for TestValidatorNodeConfig {
         let port_range = (MIN_PORT_RANGE, MAX_PORT_RANGE);
 
         Self {
-            gossip_addr: socketaddr!("127.0.0.1:0"),
+            gossip_addr: socketaddr!(Ipv4Addr::LOCALHOST, 0),
             port_range,
             bind_ip_addr,
         }


### PR DESCRIPTION
#### Problem
Code cleanup.

#### Summary of Changes
Use Ipv4Addr constants in `socketaddr!` calls.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
