### PR TITLE
Add link to new web3.js repo

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -1,0 +1,3 @@
+# `@solana/web3.js`
+
+Moved to its own repo @ https://github.com/solana-labs/solana-web3.js


### PR DESCRIPTION
#### Problem

Probable dead links to web3.js in the monorepo

#### Summary of Changes

Add a link to the new location at the old directory