### PR TITLE
Add version and state_complete flag into bank snapshot

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4627,15 +4627,21 @@ mod tests {
         while slot < 4 {
             let bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, slot));
 
+            while !bank.is_complete() {
+                bank.fill_bank_with_ticks_for_tests();
+            }
+
+            bank.squash();
+            bank.force_flush_accounts_cache();
+
             let snapshot_storages = bank.get_snapshot_storages(None);
-            // this slot_deltas assignment causes panic  at 'Missing accounts delta hash entry for slot 1'
-            // let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
             add_bank_snapshot(
                 bank_snapshots_dir,
                 &bank,
                 &snapshot_storages,
                 snapshot_version,
-                vec![], // slot_deltas,
+                slot_deltas,
             )
             .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4630,7 +4630,7 @@ mod tests {
             let snapshot_storages = bank.get_snapshot_storages(None);
             let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
             add_bank_snapshot(
-                &bank_snapshots_dir,
+                bank_snapshots_dir,
                 &bank,
                 &snapshot_storages,
                 snapshot_version,
@@ -4638,10 +4638,10 @@ mod tests {
             )
             .unwrap();
 
-            slot = slot + 1;
+            slot += 1;
         }
 
-        let (slot, _path) = get_highest_full_snapshot_slot_and_path(&bank_snapshots_dir).unwrap();
+        let (slot, _path) = get_highest_full_snapshot_slot_and_path(bank_snapshots_dir).unwrap();
 
         assert_eq!(slot, 3);
 
@@ -4650,7 +4650,7 @@ mod tests {
             .join("state_complete");
         fs::remove_file(complete_flag_file).unwrap();
 
-        let (slot, _path) = get_highest_full_snapshot_slot_and_path(&bank_snapshots_dir).unwrap();
+        let (slot, _path) = get_highest_full_snapshot_slot_and_path(bank_snapshots_dir).unwrap();
 
         assert_eq!(slot, 2);
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4628,13 +4628,14 @@ mod tests {
             let bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, slot));
 
             let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+            // this slot_deltas assignment causes panic  at 'Missing accounts delta hash entry for slot 1'
+            // let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
             add_bank_snapshot(
                 bank_snapshots_dir,
                 &bank,
                 &snapshot_storages,
                 snapshot_version,
-                slot_deltas,
+                vec![], // slot_deltas,
             )
             .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -296,15 +296,6 @@ pub enum SnapshotError {
 
     #[error("invalid AppendVec path: {}", .0.display())]
     InvalidAppendVecPath(PathBuf),
-
-    #[error("no snapshot slot directory")]
-    NoSnapshotSlotDir,
-
-    #[error("unknown snapshot file")]
-    UnknownSnapshotFile,
-
-    #[error("missing status cache file")]
-    MissingStatusCacheFile,
 }
 pub type Result<T> = std::result::Result<T, SnapshotError>;
 
@@ -1828,22 +1819,6 @@ pub fn get_highest_incremental_snapshot_archive_slot(
         full_snapshot_slot,
     )
     .map(|incremental_snapshot_archive_info| incremental_snapshot_archive_info.slot())
-}
-
-/// There is a time window from the slot directory being created, and the content being completely
-/// filled.  Check the completion to avoid using a highest found slot directory with missing content.
-pub fn snapshot_slot_dir_check_complete(path: &Path) -> bool {
-    let completion_flag_file = path.to_path_buf().join(SNAPSHOT_COMPLETE_STATE_FILENAME);
-    fs::metadata(completion_flag_file).is_ok()
-}
-
-pub fn snapshot_slot_dir_check_version(path: &Path) -> bool {
-    let version_path = path.to_path_buf().join(SNAPSHOT_VERSION_FILENAME);
-    if let Ok(content) = fs::read_to_string(version_path) {
-        content.eq(SnapshotVersion::default().as_str())
-    } else {
-        false
-    }
 }
 
 /// Get the path (and metadata) for the full snapshot archive with the highest slot in a directory

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4614,6 +4614,7 @@ mod tests {
 
     fn test_get_highest_full_snapshot_slot_and_path() {
         solana_logger::setup();
+
         let genesis_config = GenesisConfig::default();
         let bank0 = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank0);
@@ -4621,16 +4622,17 @@ mod tests {
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let bank_snapshots_dir = tmp_dir.path();
         let collecter_id = Pubkey::new_unique();
-
         let snapshot_version = SnapshotVersion::default();
 
         for slot in 0..4 {
+            // prepare the bank
             let parent_bank = bank_forks.get(slot).unwrap();
             let bank = Bank::new_from_parent(&parent_bank, &collecter_id, slot + 1);
             bank.fill_bank_with_ticks_for_tests();
             bank.squash();
             bank.force_flush_accounts_cache();
 
+            // generate the bank snapshot directory for slot+1
             let snapshot_storages = bank.get_snapshot_storages(None);
             let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
             add_bank_snapshot(
@@ -4657,7 +4659,5 @@ mod tests {
         let (slot, _path) = get_highest_full_snapshot_slot_and_path(bank_snapshots_dir).unwrap();
 
         assert_eq!(slot, 3);
-
-        info!("done");
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1056,7 +1056,7 @@ pub fn add_bank_snapshot(
     serialize_status_cache(slot, &slot_deltas, &status_cache_path)?;
 
     let version_path = bank_snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
-    write_snapshot_version_file(version_path, SnapshotVersion::default()).unwrap();
+    write_snapshot_version_file(version_path, snapshot_version).unwrap();
 
     // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
     let state_complete_path = bank_snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -71,7 +71,7 @@ pub use archive_format::*;
 
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
-pub const SNAPSHOT_COMPLETE_STATE_FILENAME: &str = "state_complete";
+pub const SNAPSHOT_STATE_COMPLETE_FILENAME: &str = "state_complete";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 25_000;
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
@@ -1059,7 +1059,7 @@ pub fn add_bank_snapshot(
     write_snapshot_version_file(version_path, SnapshotVersion::default()).unwrap();
 
     // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
-    let state_complete_path = bank_snapshot_dir.join(SNAPSHOT_COMPLETE_STATE_FILENAME);
+    let state_complete_path = bank_snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
     fs::File::create(state_complete_path)?;
 
     // Monitor sizes because they're capped to MAX_SNAPSHOT_DATA_FILE_SIZE
@@ -2369,7 +2369,7 @@ pub fn verify_snapshot_archive<P, Q, R>(
             std::fs::remove_file(version_path).unwrap();
         }
 
-        let state_complete_path = snapshot_slot_dir.join(SNAPSHOT_COMPLETE_STATE_FILENAME);
+        let state_complete_path = snapshot_slot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
         if state_complete_path.is_file() {
             std::fs::remove_file(state_complete_path).unwrap();
         }


### PR DESCRIPTION
#### Problem

To boot faster, we want to boot from a bank snapshot directory, instead of an archive.  This requires getting meta information from the snapshot directories indicating the snapshot versions and the completion statuses, to help identify a good directory to boot from.

#### Summary of Changes
Add snapshot version file and the state_complete file flag into the bank snapshot directory.  This completes the bank snapshot directory, marks it ready for constructing a bank from it.

Add version file
Add state_complete flag
Add function to check the directory and selects the highest completed directory.

This is a split PR from https://github.com/solana-labs/solana/pull/28745

It is orthogonal to the account hardlink PR https://github.com/solana-labs/solana/pull/29496.  But it is better to be committed after that so that the state_complete flag correctly reflects that the directory state is complete with the accounts content present.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
