### PR TITLE
remove unnecessary clippy warning ignore

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -705,7 +705,6 @@ impl BankingStage {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn process_loop(
         packet_deserializer: &mut PacketDeserializer,
         decision_maker: &DecisionMaker,


### PR DESCRIPTION
#### Problem
#29403 and #29784 individually did not get us under the clippy limit, but together do.

#### Summary of Changes
Remove clippy warning ignore (a sign of progress 🎉 )

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
