### PR TITLE
chore: bump bzip2 from 0.4.3 to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/solana-install"
 [dependencies]
 atty = "0.2.11"
 bincode = "1.3.3"
-bzip2 = "0.4.3"
+bzip2 = "0.4.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = { version = "2.33.1" }
 console = "0.15.0"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -583,9 +583,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,7 @@ blake3 = "1.3.1"
 bv = { version = "0.11.1", features = ["serde"] }
 bytemuck = "1.11.0"
 byteorder = "1.4.3"
-bzip2 = "0.4.3"
+bzip2 = "0.4.4"
 crossbeam-channel = "0.5"
 dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 dir-diff = "0.3.2"

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bzip2 = "0.4.3"
+bzip2 = "0.4.4"
 cargo_metadata = "0.15.0"
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { version = "0.4.14", features = ["std"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bincode = "1.3.3"
 bytes = "1.0"
-bzip2 = "0.4.3"
+bzip2 = "0.4.4"
 enum-iterator = "0.8.1"
 flate2 = "1.0.24"
 futures = "0.3.21"


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1070941749234634782
https://buildkite.com/solana-labs/solana/builds/89544#0186156a-3b08-4242-bd6e-c3fe77e544e1

```
Crate:     bzip2
Version:   0.4.3
Title:     bzip2 Denial of Service (DoS)
Date:      2023-09-01
ID:        RUSTSEC-2023-0004
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0004
Solution:  Upgrade to >=0.4.4
```
