### PR TITLE
Moves BankHashInfo into serde_snapshot

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1188,13 +1188,6 @@ impl BankHashStats {
     }
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
-pub struct BankHashInfo {
-    pub accounts_delta_hash: AccountsDeltaHash,
-    pub accounts_hash: AccountsHash,
-    pub stats: BankHashStats,
-}
-
 #[derive(Default, Debug)]
 pub struct StoreAccountsTiming {
     store_accounts_elapsed: u64,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -3,9 +3,9 @@ use {
         accounts::Accounts,
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig, AppendVecId,
-            AtomicAppendVecId, BankHashInfo, IndexGenerationInfo,
+            AtomicAppendVecId, BankHashStats, IndexGenerationInfo,
         },
-        accounts_hash::AccountsHash,
+        accounts_hash::{AccountsDeltaHash, AccountsHash},
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         append_vec::{AppendVec, StoredMetaWriteVersion},
@@ -79,6 +79,13 @@ pub struct AccountsDbFields<T>(
     #[serde(deserialize_with = "default_on_eof")]
     Vec<(Slot, Hash)>,
 );
+
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+struct BankHashInfo {
+    accounts_delta_hash: AccountsDeltaHash,
+    accounts_hash: AccountsHash,
+    stats: BankHashStats,
+}
 
 /// Helper type to wrap BufReader streams when deserializing and reconstructing from either just a
 /// full snapshot, or both a full and incremental snapshot

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -5,7 +5,6 @@ use {
         *,
     },
     crate::{
-        accounts_db::BankHashInfo,
         accounts_hash::AccountsHash,
         ancestors::AncestorsForSerialization,
         stakes::{serde_stakes_enum_compat, StakesEnum},

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -718,7 +718,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "DVS6Qqzxe2w86mdaEuVnsdZqXQVXaPab54uCJG2GypT6")]
+    #[frozen_abi(digest = "Eg6gt9thiY8Sn6gDKvpyyHADtWpSt6ur9Z4Zwh1BrCgv")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem

Background context: https://github.com/solana-labs/solana/pull/30024, https://github.com/solana-labs/solana/pull/30063, https://github.com/solana-labs/solana/pull/30069, https://github.com/solana-labs/solana/pull/30071, https://github.com/solana-labs/solana/pull/30087, https://github.com/solana-labs/solana/pull/30101

BankHashInfo is not used *except* in serde_snapshot as part of AccountsDbFields, but it lives in AccountsDb.

#### Summary of Changes

Move BankHashInfo to serde_snapshot