### PR TITLE
Makes AccountInfo repr(C)

### DIFF
--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -15,23 +15,24 @@ use {
 
 /// Account information
 #[derive(Clone)]
+#[repr(C)]
 pub struct AccountInfo<'a> {
     /// Public key of the account
     pub key: &'a Pubkey,
-    /// Was the transaction signed by this account's public key?
-    pub is_signer: bool,
-    /// Is the account writable?
-    pub is_writable: bool,
     /// The lamports in the account.  Modifiable by programs.
     pub lamports: Rc<RefCell<&'a mut u64>>,
     /// The data held in this account.  Modifiable by programs.
     pub data: Rc<RefCell<&'a mut [u8]>>,
     /// Program that owns this account
     pub owner: &'a Pubkey,
-    /// This account's data contains a loaded program (and is now read-only)
-    pub executable: bool,
     /// The epoch at which this account will next owe rent
     pub rent_epoch: Epoch,
+    /// Was the transaction signed by this account's public key?
+    pub is_signer: bool,
+    /// Is the account writable?
+    pub is_writable: bool,
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
 }
 
 impl<'a> fmt::Debug for AccountInfo<'a> {


### PR DESCRIPTION
#### Problem

Please see https://github.com/solana-labs/solana/issues/29852.

Since AccountInfo does not contain any `Vec`s, we can move the fields around and add `repr(C)` to ensure its layout remains stable. (This assumes that the layouts for `Rc`,`RefCell`, and `slice` do not change, which is verified in the `check_type_assumptions` test.)


#### Summary of Changes

Add `repr(C)` to `AccountInfo`