### PR TITLE
removes dynamic cast and dynamic dispatch from connection-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,6 +4904,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
+ "solana-connection-cache",
  "solana-core",
  "solana-faucet",
  "solana-genesis",

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -19,6 +19,7 @@ serde_yaml = "0.9.13"
 solana-clap-utils = { path = "../clap-utils", version = "=1.16.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.16.0" }
 solana-client = { path = "../client", version = "=1.16.0" }
+solana-connection-cache = { path = "../connection-cache", version = "=1.16.0" }
 solana-core = { path = "../core", version = "=1.16.0" }
 solana-faucet = { path = "../faucet", version = "=1.16.0" }
 solana-genesis = { path = "../genesis", version = "=1.16.0" }

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -1,13 +1,21 @@
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_client::tpu_client::TpuClient,
+    solana_connection_cache::connection_cache::{
+        ConnectionManager, ConnectionPool, NewConnectionConfig,
+    },
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
         message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
     },
 };
 
-impl BenchTpsClient for TpuClient {
+impl<R, S, T> BenchTpsClient for TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
         let signature = transaction.signatures[0];
         self.try_send_transaction(&transaction)?;

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -110,19 +110,32 @@ fn create_client(
                 true => ConnectionCache::new(tpu_connection_pool_size),
                 false => ConnectionCache::with_udp(tpu_connection_pool_size),
             };
-
-            Arc::new(
-                TpuClient::new_with_connection_cache(
-                    rpc_client,
-                    websocket_url,
-                    TpuClientConfig::default(),
-                    Arc::new(connection_cache.into()),
-                )
-                .unwrap_or_else(|err| {
-                    eprintln!("Could not create TpuClient {err:?}");
-                    exit(1);
-                }),
-            )
+            match connection_cache {
+                ConnectionCache::Udp(cache) => Arc::new(
+                    TpuClient::new_with_connection_cache(
+                        rpc_client,
+                        websocket_url,
+                        TpuClientConfig::default(),
+                        Arc::new(cache),
+                    )
+                    .unwrap_or_else(|err| {
+                        eprintln!("Could not create TpuClient {err:?}");
+                        exit(1);
+                    }),
+                ),
+                ConnectionCache::Quic(cache) => Arc::new(
+                    TpuClient::new_with_connection_cache(
+                        rpc_client,
+                        websocket_url,
+                        TpuClientConfig::default(),
+                        Arc::new(cache),
+                    )
+                    .unwrap_or_else(|err| {
+                        eprintln!("Could not create TpuClient {err:?}");
+                        exit(1);
+                    }),
+                ),
+            }
         }
     }
 }

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -9,7 +9,6 @@ use {
         spl_convert::FromOtherSolana,
     },
     solana_client::{
-        connection_cache::ConnectionCache,
         thin_client::ThinClient,
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -131,17 +130,8 @@ fn test_bench_tps_test_validator(config: Config) {
         CommitmentConfig::processed(),
     ));
     let websocket_url = test_validator.rpc_pubsub_url();
-    let connection_cache = ConnectionCache::default();
-
-    let client = Arc::new(
-        TpuClient::new_with_connection_cache(
-            rpc_client,
-            &websocket_url,
-            TpuClientConfig::default(),
-            Arc::new(connection_cache.into()),
-        )
-        .unwrap(),
-    );
+    let client =
+        Arc::new(TpuClient::new(rpc_client, &websocket_url, TpuClientConfig::default()).unwrap());
 
     let lamports_per_account = 1000;
 

--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -1,7 +1,11 @@
 pub use solana_tpu_client::nonblocking::tpu_client::{LeaderTpuService, TpuSenderError};
 use {
     crate::{connection_cache::ConnectionCache, tpu_client::TpuClientConfig},
-    solana_connection_cache::connection_cache::ConnectionCache as BackendConnectionCache,
+    solana_connection_cache::connection_cache::{
+        ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
+        NewConnectionConfig,
+    },
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_sdk::{
         message::Message,
@@ -15,11 +19,20 @@ use {
 
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
-pub struct TpuClient {
-    tpu_client: BackendTpuClient,
+pub struct TpuClient<
+    R, // ConnectionPool
+    S, // ConnectionManager
+    T, // NewConnectionConfig
+> {
+    tpu_client: BackendTpuClient<R, S, T>,
 }
 
-impl TpuClient {
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     pub async fn send_transaction(&self, transaction: &Transaction) -> bool {
@@ -62,23 +75,39 @@ impl TpuClient {
             .try_send_wire_transaction_batch(wire_transactions)
             .await
     }
+}
 
+impl TpuClient<QuicPool, QuicConnectionManager, QuicConfig> {
     /// Create a new client that disconnects when dropped
     pub async fn new(
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let connection_cache = Arc::new(ConnectionCache::default().into());
+        let connection_cache = match ConnectionCache::default() {
+            ConnectionCache::Quic(cache) => Arc::new(cache),
+            ConnectionCache::Udp(_) => {
+                return Err(TpuSenderError::Custom(String::from(
+                    "Invalid default connection cache",
+                )))
+            }
+        };
         Self::new_with_connection_cache(rpc_client, websocket_url, config, connection_cache).await
     }
+}
 
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Create a new client that disconnects when dropped
     pub async fn new_with_connection_cache(
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_cache: Arc<BackendConnectionCache>,
+        connection_cache: Arc<BackendConnectionCache<R, S, T>>,
     ) -> Result<Self> {
         Ok(Self {
             tpu_client: BackendTpuClient::new_with_connection_cache(
@@ -91,10 +120,10 @@ impl TpuClient {
         })
     }
 
-    pub async fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub async fn send_and_confirm_messages_with_spinner<K: Signers>(
         &self,
         messages: &[Message],
-        signers: &T,
+        signers: &K,
     ) -> Result<Vec<Option<TransactionError>>> {
         self.tpu_client
             .send_and_confirm_messages_with_spinner(messages, signers)

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -7,6 +7,7 @@ use {
     crate::connection_cache::ConnectionCache,
     log::*,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
+    solana_connection_cache::client_connection::ClientConnection,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{config::RpcProgramAccountsConfig, response::Response},
     solana_sdk::{

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -1,6 +1,10 @@
 use {
     crate::connection_cache::ConnectionCache,
-    solana_connection_cache::connection_cache::ConnectionCache as BackendConnectionCache,
+    solana_connection_cache::connection_cache::{
+        ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
+        NewConnectionConfig,
+    },
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
         message::Message,
@@ -19,11 +23,20 @@ pub use {
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
 /// This is just a thin wrapper over the "BackendTpuClient", use that directly for more efficiency.
-pub struct TpuClient {
-    tpu_client: BackendTpuClient,
+pub struct TpuClient<
+    R, // ConnectionPool
+    S, // ConnectionManager
+    T, // NewConnectionConfig
+> {
+    tpu_client: BackendTpuClient<R, S, T>,
 }
 
-impl TpuClient {
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     pub fn send_transaction(&self, transaction: &Transaction) -> bool {
@@ -54,28 +67,39 @@ impl TpuClient {
     pub fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
         self.tpu_client.try_send_wire_transaction(wire_transaction)
     }
+}
 
+impl TpuClient<QuicPool, QuicConnectionManager, QuicConfig> {
     /// Create a new client that disconnects when dropped
     pub fn new(
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let connection_cache = ConnectionCache::default();
-        Self::new_with_connection_cache(
-            rpc_client,
-            websocket_url,
-            config,
-            Arc::new(connection_cache.into()),
-        )
+        let connection_cache = match ConnectionCache::default() {
+            ConnectionCache::Quic(cache) => Arc::new(cache),
+            ConnectionCache::Udp(_) => {
+                return Err(TpuSenderError::Custom(String::from(
+                    "Invalid default connection cache",
+                )))
+            }
+        };
+        Self::new_with_connection_cache(rpc_client, websocket_url, config, connection_cache)
     }
+}
 
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Create a new client that disconnects when dropped
     pub fn new_with_connection_cache(
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_cache: Arc<BackendConnectionCache>,
+        connection_cache: Arc<BackendConnectionCache<R, S, T>>,
     ) -> Result<Self> {
         Ok(Self {
             tpu_client: BackendTpuClient::new_with_connection_cache(
@@ -87,10 +111,10 @@ impl TpuClient {
         })
     }
 
-    pub fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub fn send_and_confirm_messages_with_spinner<K: Signers>(
         &self,
         messages: &[Message],
-        signers: &T,
+        signers: &K,
     ) -> Result<Vec<Option<TransactionError>>> {
         self.tpu_client
             .send_and_confirm_messages_with_spinner(messages, signers)

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -9,7 +9,6 @@ use {
     solana_measure::measure::Measure,
     solana_sdk::timing::AtomicInterval,
     std::{
-        any::Any,
         net::SocketAddr,
         sync::{atomic::Ordering, Arc, RwLock},
     },
@@ -17,38 +16,40 @@ use {
 };
 
 // Should be non-zero
-pub static MAX_CONNECTIONS: usize = 1024;
+const MAX_CONNECTIONS: usize = 1024;
 
 /// Default connection pool size per remote address
 pub const DEFAULT_CONNECTION_POOL_SIZE: usize = 4;
 
-/// Defines the protocol types of an implementation supports.
-pub enum ProtocolType {
-    UDP,
-    QUIC,
-}
+pub trait ConnectionManager {
+    type ConnectionPool: ConnectionPool;
+    type NewConnectionConfig: NewConnectionConfig;
 
-pub trait ConnectionManager: Sync + Send {
-    fn new_connection_pool(&self) -> Box<dyn ConnectionPool>;
-    fn new_connection_config(&self) -> Box<dyn NewConnectionConfig>;
+    fn new_connection_pool(&self) -> Self::ConnectionPool;
+    fn new_connection_config(&self) -> Self::NewConnectionConfig;
     fn get_port_offset(&self) -> u16;
-    fn get_protocol_type(&self) -> ProtocolType;
 }
 
-pub struct ConnectionCache {
-    pub map: RwLock<IndexMap<SocketAddr, Box<dyn ConnectionPool>>>,
-    pub connection_manager: Box<dyn ConnectionManager>,
-    pub stats: Arc<ConnectionCacheStats>,
-    pub last_stats: AtomicInterval,
-    pub connection_pool_size: usize,
-    pub connection_config: Box<dyn NewConnectionConfig>,
+pub struct ConnectionCache<
+    R, // ConnectionPool
+    S, // ConnectionManager
+    T, // NewConnectionConfig
+> {
+    map: RwLock<IndexMap<SocketAddr, /*ConnectionPool:*/ R>>,
+    connection_manager: S,
+    stats: Arc<ConnectionCacheStats>,
+    last_stats: AtomicInterval,
+    connection_pool_size: usize,
+    connection_config: T,
 }
 
-impl ConnectionCache {
-    pub fn new(
-        connection_manager: Box<dyn ConnectionManager>,
-        connection_pool_size: usize,
-    ) -> Result<Self, ClientError> {
+impl<R, S, T> ConnectionCache<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
+    pub fn new(connection_manager: S, connection_pool_size: usize) -> Result<Self, ClientError> {
         let config = connection_manager.new_connection_config();
         Ok(Self::new_with_config(
             connection_pool_size,
@@ -59,8 +60,8 @@ impl ConnectionCache {
 
     pub fn new_with_config(
         connection_pool_size: usize,
-        connection_config: Box<dyn NewConnectionConfig>,
-        connection_manager: Box<dyn ConnectionManager>,
+        connection_config: T,
+        connection_manager: S,
     ) -> Self {
         Self {
             map: RwLock::new(IndexMap::with_capacity(MAX_CONNECTIONS)),
@@ -79,7 +80,7 @@ impl ConnectionCache {
         &self,
         lock_timing_ms: &mut u64,
         addr: &SocketAddr,
-    ) -> CreateConnectionResult {
+    ) -> CreateConnectionResult<<R as ConnectionPool>::BaseClientConnection> {
         let mut get_connection_map_lock_measure = Measure::start("get_connection_map_lock_measure");
         let mut map = self.map.write().unwrap();
         get_connection_map_lock_measure.stop();
@@ -113,11 +114,11 @@ impl ConnectionCache {
 
             map.entry(*addr)
                 .and_modify(|pool| {
-                    pool.add_connection(&*self.connection_config, addr);
+                    pool.add_connection(&self.connection_config, addr);
                 })
                 .or_insert_with(|| {
                     let mut pool = self.connection_manager.new_connection_pool();
-                    pool.add_connection(&*self.connection_config, addr);
+                    pool.add_connection(&self.connection_config, addr);
                     pool
                 });
             (
@@ -141,7 +142,10 @@ impl ConnectionCache {
         }
     }
 
-    fn get_or_add_connection(&self, addr: &SocketAddr) -> GetConnectionResult {
+    fn get_or_add_connection(
+        &self,
+        addr: &SocketAddr,
+    ) -> GetConnectionResult<<R as ConnectionPool>::BaseClientConnection> {
         let mut get_connection_map_lock_measure = Measure::start("get_connection_map_lock_measure");
         let map = self.map.read().unwrap();
         get_connection_map_lock_measure.stop();
@@ -207,7 +211,10 @@ impl ConnectionCache {
     fn get_connection_and_log_stats(
         &self,
         addr: &SocketAddr,
-    ) -> (Arc<dyn BaseClientConnection>, Arc<ConnectionCacheStats>) {
+    ) -> (
+        Arc<<R as ConnectionPool>::BaseClientConnection>,
+        Arc<ConnectionCacheStats>,
+    ) {
         let mut get_connection_measure = Measure::start("get_connection_measure");
         let GetConnectionResult {
             connection,
@@ -257,7 +264,7 @@ impl ConnectionCache {
         (connection, connection_cache_stats)
     }
 
-    pub fn get_connection(&self, addr: &SocketAddr) -> Arc<dyn BlockingClientConnection> {
+    pub fn get_connection(&self, addr: &SocketAddr) -> Arc<<<R as ConnectionPool>::BaseClientConnection as BaseClientConnection>::BlockingClientConnection>{
         let (connection, connection_cache_stats) = self.get_connection_and_log_stats(addr);
         connection.new_blocking_connection(*addr, connection_cache_stats)
     }
@@ -265,13 +272,9 @@ impl ConnectionCache {
     pub fn get_nonblocking_connection(
         &self,
         addr: &SocketAddr,
-    ) -> Arc<dyn NonblockingClientConnection> {
+    ) -> Arc<<<R as ConnectionPool>::BaseClientConnection as BaseClientConnection>::NonblockingClientConnection>{
         let (connection, connection_cache_stats) = self.get_connection_and_log_stats(addr);
         connection.new_nonblocking_connection(*addr, connection_cache_stats)
-    }
-
-    pub fn get_protocol_type(&self) -> ProtocolType {
-        self.connection_manager.get_protocol_type()
     }
 }
 
@@ -290,28 +293,26 @@ pub enum ClientError {
     IoError(#[from] std::io::Error),
 }
 
-pub trait NewConnectionConfig: Sync + Send {
-    fn new() -> Result<Self, ClientError>
-    where
-        Self: Sized;
-    fn as_any(&self) -> &dyn Any;
-
-    fn as_mut_any(&mut self) -> &mut dyn Any;
+pub trait NewConnectionConfig: Sized {
+    fn new() -> Result<Self, ClientError>;
 }
 
-pub trait ConnectionPool: Sync + Send {
+pub trait ConnectionPool {
+    type NewConnectionConfig: NewConnectionConfig;
+    type BaseClientConnection: BaseClientConnection;
+
     /// Add a connection to the pool
-    fn add_connection(&mut self, config: &dyn NewConnectionConfig, addr: &SocketAddr);
+    fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr);
 
     /// Get the number of current connections in the pool
     fn num_connections(&self) -> usize;
 
     /// Get a connection based on its index in the pool, without checking if the
-    fn get(&self, index: usize) -> Result<Arc<dyn BaseClientConnection>, ConnectionPoolError>;
+    fn get(&self, index: usize) -> Result<Arc<Self::BaseClientConnection>, ConnectionPoolError>;
 
     /// Get a connection from the pool. It must have at least one connection in the pool.
     /// This randomly picks a connection in the pool.
-    fn borrow_connection(&self) -> Arc<dyn BaseClientConnection> {
+    fn borrow_connection(&self) -> Arc<Self::BaseClientConnection> {
         let mut rng = thread_rng();
         let n = rng.gen_range(0, self.num_connections());
         self.get(n).expect("index is within num_connections")
@@ -324,27 +325,30 @@ pub trait ConnectionPool: Sync + Send {
 
     fn create_pool_entry(
         &self,
-        config: &dyn NewConnectionConfig,
+        config: &Self::NewConnectionConfig,
         addr: &SocketAddr,
-    ) -> Arc<dyn BaseClientConnection>;
+    ) -> Arc<Self::BaseClientConnection>;
 }
 
-pub trait BaseClientConnection: Sync + Send {
+pub trait BaseClientConnection {
+    type BlockingClientConnection: BlockingClientConnection;
+    type NonblockingClientConnection: NonblockingClientConnection;
+
     fn new_blocking_connection(
         &self,
         addr: SocketAddr,
         stats: Arc<ConnectionCacheStats>,
-    ) -> Arc<dyn BlockingClientConnection>;
+    ) -> Arc<Self::BlockingClientConnection>;
 
     fn new_nonblocking_connection(
         &self,
         addr: SocketAddr,
         stats: Arc<ConnectionCacheStats>,
-    ) -> Arc<dyn NonblockingClientConnection>;
+    ) -> Arc<Self::NonblockingClientConnection>;
 }
 
-struct GetConnectionResult {
-    connection: Arc<dyn BaseClientConnection>,
+struct GetConnectionResult<T> {
+    connection: Arc</*BaseClientConnection:*/ T>,
     cache_hit: bool,
     report_stats: bool,
     map_timing_ms: u64,
@@ -354,8 +358,8 @@ struct GetConnectionResult {
     eviction_timing_ms: u64,
 }
 
-struct CreateConnectionResult {
-    connection: Arc<dyn BaseClientConnection>,
+struct CreateConnectionResult<T> {
+    connection: Arc</*BaseClientConnection:*/ T>,
     cache_hit: bool,
     connection_cache_stats: Arc<ConnectionCacheStats>,
     num_evictions: u64,
@@ -382,11 +386,14 @@ mod tests {
 
     const MOCK_PORT_OFFSET: u16 = 42;
 
-    pub struct MockUdpPool {
-        connections: Vec<Arc<dyn BaseClientConnection>>,
+    struct MockUdpPool {
+        connections: Vec<Arc<MockUdp>>,
     }
     impl ConnectionPool for MockUdpPool {
-        fn add_connection(&mut self, config: &dyn NewConnectionConfig, addr: &SocketAddr) {
+        type NewConnectionConfig = MockUdpConfig;
+        type BaseClientConnection = MockUdp;
+
+        fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr) {
             let connection = self.create_pool_entry(config, addr);
             self.connections.push(connection);
         }
@@ -395,7 +402,10 @@ mod tests {
             self.connections.len()
         }
 
-        fn get(&self, index: usize) -> Result<Arc<dyn BaseClientConnection>, ConnectionPoolError> {
+        fn get(
+            &self,
+            index: usize,
+        ) -> Result<Arc<Self::BaseClientConnection>, ConnectionPoolError> {
             self.connections
                 .get(index)
                 .cloned()
@@ -404,19 +414,14 @@ mod tests {
 
         fn create_pool_entry(
             &self,
-            config: &dyn NewConnectionConfig,
+            config: &Self::NewConnectionConfig,
             _addr: &SocketAddr,
-        ) -> Arc<dyn BaseClientConnection> {
-            let config: &MockUdpConfig = match config.as_any().downcast_ref::<MockUdpConfig>() {
-                Some(b) => b,
-                None => panic!("Expecting a MockUdpConfig!"),
-            };
-
+        ) -> Arc<Self::BaseClientConnection> {
             Arc::new(MockUdp(config.udp_socket.clone()))
         }
     }
 
-    pub struct MockUdpConfig {
+    struct MockUdpConfig {
         udp_socket: Arc<UdpSocket>,
     }
 
@@ -440,23 +445,18 @@ mod tests {
                 ),
             })
         }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn as_mut_any(&mut self) -> &mut dyn Any {
-            self
-        }
     }
 
-    pub struct MockUdp(Arc<UdpSocket>);
+    struct MockUdp(Arc<UdpSocket>);
     impl BaseClientConnection for MockUdp {
+        type BlockingClientConnection = MockUdpConnection;
+        type NonblockingClientConnection = MockUdpConnection;
+
         fn new_blocking_connection(
             &self,
             addr: SocketAddr,
             _stats: Arc<ConnectionCacheStats>,
-        ) -> Arc<dyn BlockingClientConnection> {
+        ) -> Arc<Self::BlockingClientConnection> {
             Arc::new(MockUdpConnection {
                 _socket: self.0.clone(),
                 addr,
@@ -467,7 +467,7 @@ mod tests {
             &self,
             addr: SocketAddr,
             _stats: Arc<ConnectionCacheStats>,
-        ) -> Arc<dyn NonblockingClientConnection> {
+        ) -> Arc<Self::NonblockingClientConnection> {
             Arc::new(MockUdpConnection {
                 _socket: self.0.clone(),
                 addr,
@@ -475,31 +475,30 @@ mod tests {
         }
     }
 
-    pub struct MockUdpConnection {
+    struct MockUdpConnection {
         _socket: Arc<UdpSocket>,
         addr: SocketAddr,
     }
 
     #[derive(Default)]
-    pub struct MockConnectionManager {}
+    struct MockConnectionManager {}
 
     impl ConnectionManager for MockConnectionManager {
-        fn new_connection_pool(&self) -> Box<dyn ConnectionPool> {
-            Box::new(MockUdpPool {
+        type ConnectionPool = MockUdpPool;
+        type NewConnectionConfig = MockUdpConfig;
+
+        fn new_connection_pool(&self) -> Self::ConnectionPool {
+            MockUdpPool {
                 connections: Vec::default(),
-            })
+            }
         }
 
-        fn new_connection_config(&self) -> Box<dyn NewConnectionConfig> {
-            Box::new(MockUdpConfig::new().unwrap())
+        fn new_connection_config(&self) -> Self::NewConnectionConfig {
+            MockUdpConfig::new().unwrap()
         }
 
         fn get_port_offset(&self) -> u16 {
             MOCK_PORT_OFFSET
-        }
-
-        fn get_protocol_type(&self) -> ProtocolType {
-            ProtocolType::UDP
         }
     }
 
@@ -560,7 +559,7 @@ mod tests {
         // we can actually connect to those addresses - ClientConnection implementations should either
         // be lazy and not connect until first use or handle connection errors somehow
         // (without crashing, as would be required in a real practical validator)
-        let connection_manager = Box::<MockConnectionManager>::default();
+        let connection_manager = MockConnectionManager::default();
         let connection_cache =
             ConnectionCache::new(connection_manager, DEFAULT_CONNECTION_POOL_SIZE).unwrap();
         let port_offset = MOCK_PORT_OFFSET;
@@ -583,7 +582,14 @@ mod tests {
 
                 let conn = &map.get(addr).expect("Address not found").get(0).unwrap();
                 let conn = conn.new_blocking_connection(*addr, connection_cache.stats.clone());
-                assert!(addr.ip() == conn.server_addr().ip());
+                assert_eq!(
+                    BlockingClientConnection::server_addr(&*conn).ip(),
+                    addr.ip(),
+                );
+                assert_eq!(
+                    NonblockingClientConnection::server_addr(&*conn).ip(),
+                    addr.ip(),
+                );
             });
         }
 
@@ -608,14 +614,18 @@ mod tests {
         let port = u16::MAX - MOCK_PORT_OFFSET + 1;
         assert!(port.checked_add(MOCK_PORT_OFFSET).is_none());
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-        let connection_manager = Box::<MockConnectionManager>::default();
+        let connection_manager = MockConnectionManager::default();
         let connection_cache = ConnectionCache::new(connection_manager, 1).unwrap();
 
         let conn = connection_cache.get_connection(&addr);
         // We (intentionally) don't have an interface that allows us to distinguish between
         // UDP and Quic connections, so check instead that the port is valid (non-zero)
         // and is the same as the input port (falling back on UDP)
-        assert!(conn.server_addr().port() != 0);
-        assert!(conn.server_addr().port() == port);
+        assert_ne!(port, 0u16);
+        assert_eq!(BlockingClientConnection::server_addr(&*conn).port(), port);
+        assert_eq!(
+            NonblockingClientConnection::server_addr(&*conn).port(),
+            port
+        );
     }
 }

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -7,7 +7,7 @@ use {
         tracer_packet_stats::TracerPacketStats,
         unprocessed_transaction_storage::UnprocessedTransactionStorage,
     },
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::{connection_cache::ConnectionCache, tpu_connection::TpuConnection},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_perf::{data_budget::DataBudget, packet::Packet},

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -3,7 +3,7 @@
 
 use {
     rand::{thread_rng, Rng},
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::{connection_cache::ConnectionCache, tpu_connection::TpuConnection},
     solana_gossip::cluster_info::ClusterInfo,
     solana_poh::poh_recorder::PohRecorder,
     std::{

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -45,7 +45,7 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     solana_bench_tps::{bench::generate_and_fund_keypairs, bench_tps_client::BenchTpsClient},
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::{connection_cache::ConnectionCache, tpu_connection::TpuConnection},
     solana_core::serve_repair::{RepairProtocol, RepairRequestHeader, ServeRepair},
     solana_dos::cli::*,
     solana_gossip::{

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -2,7 +2,7 @@ use {
     crate::tpu_info::TpuInfo,
     crossbeam_channel::{Receiver, RecvTimeoutError},
     log::*,
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::{connection_cache::ConnectionCache, tpu_connection::TpuConnection},
     solana_measure::measure::Measure,
     solana_metrics::datapoint_warn,
     solana_runtime::{bank::Bank, bank_forks::BankForks},

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -11,8 +11,12 @@ use {
     bincode::serialize,
     futures_util::{future::join_all, stream::StreamExt},
     log::*,
-    solana_connection_cache::connection_cache::{
-        ConnectionCache, ConnectionManager, DEFAULT_CONNECTION_POOL_SIZE,
+    solana_connection_cache::{
+        connection_cache::{
+            ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig,
+            DEFAULT_CONNECTION_POOL_SIZE,
+        },
+        nonblocking::client_connection::ClientConnection,
     },
     solana_pubsub_client::nonblocking::pubsub_client::{PubsubClient, PubsubClientError},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
@@ -250,33 +254,52 @@ impl LeaderTpuCache {
 
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
-pub struct TpuClient {
+pub struct TpuClient<
+    R, // ConnectionPool
+    S, // ConnectionManager
+    T, // NewConnectionConfig
+> {
     fanout_slots: u64,
     leader_tpu_service: LeaderTpuService,
     exit: Arc<AtomicBool>,
     rpc_client: Arc<RpcClient>,
-    connection_cache: Arc<ConnectionCache>,
+    connection_cache: Arc<ConnectionCache<R, S, T>>,
 }
 
-async fn send_wire_transaction_to_addr(
-    connection_cache: &ConnectionCache,
+async fn send_wire_transaction_to_addr<R, S, T>(
+    connection_cache: &ConnectionCache<R, S, T>,
     addr: &SocketAddr,
     wire_transaction: Vec<u8>,
-) -> TransportResult<()> {
+) -> TransportResult<()>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     let conn = connection_cache.get_nonblocking_connection(addr);
     conn.send_data(&wire_transaction).await
 }
 
-async fn send_wire_transaction_batch_to_addr(
-    connection_cache: &ConnectionCache,
+async fn send_wire_transaction_batch_to_addr<R, S, T>(
+    connection_cache: &ConnectionCache<R, S, T>,
     addr: &SocketAddr,
     wire_transactions: &[Vec<u8>],
-) -> TransportResult<()> {
+) -> TransportResult<()>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     let conn = connection_cache.get_nonblocking_connection(addr);
     conn.send_data_batch(wire_transactions).await
 }
 
-impl TpuClient {
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     pub async fn send_transaction(&self, transaction: &Transaction) -> bool {
@@ -391,7 +414,7 @@ impl TpuClient {
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_manager: Box<dyn ConnectionManager>,
+        connection_manager: S,
     ) -> Result<Self> {
         let connection_cache = Arc::new(
             ConnectionCache::new(connection_manager, DEFAULT_CONNECTION_POOL_SIZE).unwrap(),
@@ -404,7 +427,7 @@ impl TpuClient {
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_cache: Arc<ConnectionCache>,
+        connection_cache: Arc<ConnectionCache<R, S, T>>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
         let leader_tpu_service =
@@ -420,10 +443,10 @@ impl TpuClient {
     }
 
     #[cfg(feature = "spinner")]
-    pub async fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub async fn send_and_confirm_messages_with_spinner<K: Signers>(
         &self,
         messages: &[Message],
-        signers: &T,
+        signers: &K,
     ) -> Result<Vec<Option<TransactionError>>> {
         let mut expired_blockhash_retries = 5;
         let progress_bar = spinner::new_progress_bar();
@@ -553,7 +576,7 @@ impl TpuClient {
     }
 }
 
-impl Drop for TpuClient {
+impl<R, S, T> Drop for TpuClient<R, S, T> {
     fn drop(&mut self) {
         self.exit.store(true, Ordering::Relaxed);
     }

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -2,7 +2,9 @@ pub use crate::nonblocking::tpu_client::TpuSenderError;
 use {
     crate::nonblocking::tpu_client::TpuClient as NonblockingTpuClient,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
-    solana_connection_cache::connection_cache::{ConnectionCache, ConnectionManager},
+    solana_connection_cache::connection_cache::{
+        ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig,
+    },
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{clock::Slot, transaction::Transaction, transport::Result as TransportResult},
     std::{
@@ -59,14 +61,23 @@ impl Default for TpuClientConfig {
 
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
-pub struct TpuClient {
+pub struct TpuClient<
+    R, // ConnectionPool
+    S, // ConnectionManager
+    T, // NewConnectionConfig
+> {
     _deprecated: UdpSocket, // TpuClient now uses the connection_cache to choose a send_socket
     //todo: get rid of this field
     rpc_client: Arc<RpcClient>,
-    tpu_client: Arc<NonblockingTpuClient>,
+    tpu_client: Arc<NonblockingTpuClient<R, S, T>>,
 }
 
-impl TpuClient {
+impl<R, S, T> TpuClient<R, S, T>
+where
+    R: ConnectionPool<NewConnectionConfig = T>,
+    S: ConnectionManager<ConnectionPool = R, NewConnectionConfig = T>,
+    T: NewConnectionConfig,
+{
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     pub fn send_transaction(&self, transaction: &Transaction) -> bool {
@@ -110,7 +121,7 @@ impl TpuClient {
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_manager: Box<dyn ConnectionManager>,
+        connection_manager: S,
     ) -> Result<Self> {
         let create_tpu_client = NonblockingTpuClient::new(
             rpc_client.get_inner_client().clone(),
@@ -133,7 +144,7 @@ impl TpuClient {
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: TpuClientConfig,
-        connection_cache: Arc<ConnectionCache>,
+        connection_cache: Arc<ConnectionCache<R, S, T>>,
     ) -> Result<Self> {
         let create_tpu_client = NonblockingTpuClient::new_with_connection_cache(
             rpc_client.get_inner_client().clone(),
@@ -152,10 +163,10 @@ impl TpuClient {
     }
 
     #[cfg(feature = "spinner")]
-    pub fn send_and_confirm_messages_with_spinner<T: Signers>(
+    pub fn send_and_confirm_messages_with_spinner<K: Signers>(
         &self,
         messages: &[Message],
-        signers: &T,
+        signers: &K,
     ) -> Result<Vec<Option<TransactionError>>> {
         self.invoke(
             self.tpu_client
@@ -167,7 +178,7 @@ impl TpuClient {
         &self.rpc_client
     }
 
-    fn invoke<T, F: std::future::Future<Output = T>>(&self, f: F) -> T {
+    fn invoke<O, F: std::future::Future<Output = O>>(&self, f: F) -> O {
         // `block_on()` panics if called within an asynchronous execution context. Whereas
         // `block_in_place()` only panics if called from a current_thread runtime, which is the
         // lesser evil.


### PR DESCRIPTION



#### Problem
Dynamic dispatch forces heap allocation and adds extra overhead.
Dynamic casting as in the ones below, lacks compile-time type safety:
https://github.com/solana-labs/solana/blob/eeb622c4e/quic-client/src/lib.rs#L172-L175
https://github.com/solana-labs/solana/blob/eeb622c4e/udp-client/src/lib.rs#L52-L55



#### Summary of Changes
The commit removes all instances of `Any`, `Box<dyn ...>`, and `Arc<dyn ...>`,
and instead uses generic and associated types.

There are only two protocols QUIC and UDP; and the code which has to
work with both protocols can use a trivial thin enum wrapper.

With respect to connection-cache specifically:
* `connection-cache/ConnectionCache` is a single protocol cache which
  allows to use either QUIC or UDP without any build dependency on the
  other protocol.
* `client/ConnectionCache` is an enum wrapper around both protocols and
  can be used in the code which has to work with both QUIC and UDP.