### PR TITLE
Prevent Rent-reward recipients from ending up RentPaying

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5032,7 +5032,8 @@ impl Bank {
                     let mut account = self
                         .get_account_with_fixed_root(&pubkey)
                         .unwrap_or_default();
-                    if account.checked_add_lamports(rent_to_be_paid).is_err() {
+                    let distribution = account.checked_add_lamports(rent_to_be_paid);
+                    if distribution.is_err() {
                         // overflow adding lamports
                         self.capitalization.fetch_sub(rent_to_be_paid, Relaxed);
                         error!(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -606,6 +606,10 @@ pub mod enable_request_heap_frame_ix {
     solana_sdk::declare_id!("Hr1nUA9b7NJ6eChS26o7Vi8gYYDDwWD3YeBfzJkTbU86");
 }
 
+pub mod prevent_rent_paying_rent_recipients {
+    solana_sdk::declare_id!("Fab5oP3DmsLYCiQZXdjyqT3ukFFPrsmqhXU4WU1AWVVF");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -752,6 +756,7 @@ lazy_static! {
         (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to a limit #27839"),
         (remove_congestion_multiplier_from_fee_calculation::id(), "Remove congestion multiplier from transaction fee calculation #29881"),
         (enable_request_heap_frame_ix::id(), "Enable transaction to request heap frame using compute budget instruction #30076"),
+        (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30???"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
There is still one way accounts can end up newly rent-paying: a validator identity account with a very small or zero balance may receive a sub-rent-exemption rent distribution here: https://github.com/solana-labs/solana/blob/151585e59688b4f71e2724ee353058198075f244/runtime/src/bank.rs#L5035

#### Summary of Changes
Add feature-gate that, when active, will burn attempted rent distributions that do not meet rent-state transition requirements
Piggy-backs on #16847 (which in retrospect, should have included a test. I wasted some time thinking the `test_distribute_rent_to_validators_overflow` was testing the credit-overflow checked in that PR)