### PR TITLE
record slot propagation for retransmitted slots

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -163,7 +163,7 @@ impl ValidatorStakeInfo {
 pub const RETRANSMIT_BASE_DELAY_MS: u64 = 5_000;
 pub const RETRANSMIT_BACKOFF_CAP: u32 = 6;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RetransmitInfo {
     pub retry_time: Option<Instant>,
     pub retry_iteration: u32,


### PR DESCRIPTION
#### Problem
slot leaders will attempt to rebroadcast slots which they have determined have not been propagated. How effective is this retransmission?

#### Summary of Changes
Adds metric to record when a previously retransmitted slot has been determined to have been propagated.

See #30127

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
