### PR TITLE
refactor rent payment order cmp

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4990,10 +4990,7 @@ impl Bank {
 
         // Sort first by stake and then by validator identity pubkey for determinism
         validator_stakes.sort_by(|(pubkey1, staked1), (pubkey2, staked2)| {
-            match staked2.cmp(staked1) {
-                std::cmp::Ordering::Equal => pubkey2.cmp(pubkey1),
-                other => other,
-            }
+            staked2.cmp(staked1).then(pubkey2.cmp(pubkey1))
         });
 
         let enforce_fix = self.no_overflow_rent_distribution_enabled();


### PR DESCRIPTION
#### Problem
use rust `then` idiom for multi-key ordering compare.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
