### PR TITLE
[docs] style: prettier force line length to 80 chars

### DIFF
--- a/docs/.prettierrc.json
+++ b/docs/.prettierrc.json
@@ -2,5 +2,7 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": false
+  "singleQuote": false,
+  "proseWrap": "always",
+  "printWidth": 80
 }


### PR DESCRIPTION
#### Problem

The doc's markdown files often have line lengths >80 characters, resulting in inconsistent formatting of the files and difficulty in reading on screen.

#### Summary of Changes

Updated prettier config file to force line lengths to 80 characters within the markdown files. This will enable auto format on save.