### PR TITLE
docs: prioritization fees

### DIFF
--- a/docs/src/api/methods/_getRecentPrioritizationFees.mdx
+++ b/docs/src/api/methods/_getRecentPrioritizationFees.mdx
@@ -39,7 +39,7 @@ An array of `RpcPrioritizationFee<object>` with the following fields:
 
 - `slot: <u64>` - slot in which the fee was observed
 - `prioritizationFee: <u64>` - the per-compute-unit fee paid by at least
-  one successfully landed transaction, specified in increments of 0.000001 lamports
+  one successfully landed transaction, specified in increments of micro-lamports (0.000001 lamports)
 
 </CodeParams>
 

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -116,40 +116,19 @@ for more information.
 
 ### Prioritization fees
 
-A transaction may set the maximum number of compute units it is allowed to
-consume and the compute unit price by including a `SetComputeUnitLimit` and a
-`SetComputeUnitPrice`
-[Compute budget instructions](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L22)
-respectively.
+As part of the Compute Budget, the runtime supports transactions including an
+**optional** fee to prioritize itself against others known as a
+[prioritization fee](./../../transaction_fees.md#prioritization-fee).
 
-If no `SetComputeUnitLimit` is provided the limit will be calculated as the
-product of the number of instructions in the transaction (excluding the [Compute
-budget instructions](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L22)) and the default per-instruction units, which is currently 200k.
+This _prioritization fee_ is calculated by multiplying the number
+of _compute units_ by the _compute unit price_ (measured in micro-lamports).
+These values may be set via the Compute Budget instructions `SetComputeUnitLimit`
+and `SetComputeUnitPrice` once per transaction.
 
-> **NOTE:** A transaction's [prioritization fee](./../../terminology.md#prioritization-fee) is calculated by multiplying the
-> number of _compute units_ by the _compute unit price_ (measured in micro-lamports)
-> set by the transaction via compute budget instructions.
-
-Transactions should request the minimum amount of compute units required for execution to minimize
-fees. Also note that fees are not adjusted when the number of requested compute
-units exceeds the number of compute units actually consumed by an executed
-transaction.
-
-Compute Budget instructions don't require any accounts and don't consume any
-compute units to process. Transactions can only contain one of each type of
-compute budget instruction, duplicate types will result in an error.
-
-The `ComputeBudgetInstruction::set_compute_unit_limit` and
-`ComputeBudgetInstruction::set_compute_unit_price` functions can be used to
-create these instructions:
-
-```rust
-let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
-```
-
-```rust
-let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
-```
+:::info
+You can learn more of the specifics of _how_ and _when_ to set a prioritization fee
+on the [transaction fees](./../../transaction_fees.md#prioritization-fee) page.
+:::
 
 ### Accounts data size limit
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -169,6 +169,10 @@ A [public key](#public-key-pubkey) and corresponding [private key](#private-key)
 
 A fractional [native token](#native-token) with the value of 0.000000001 [sol](#sol).
 
+:::info
+Within the compute budget, a quantity of _[micro-lamports](https://github.com/solana-labs/solana/blob/ced8f6a512c61e0dd5308095ae8457add4a39e94/program-runtime/src/prioritization_fee.rs#L1-L2)_ is used in the calculation of [prioritization fees](#prioritization-fee).
+:::
+
 ## leader
 
 The role of a [validator](#validator) when it is appending [entries](#entry) to the [ledger](#ledger).

--- a/docs/src/transaction_fees.md
+++ b/docs/src/transaction_fees.md
@@ -1,6 +1,9 @@
 ---
 title: Transaction Fees
-description: "Transaction fees are the small fees paid to process instructions on the network. These fees are based on computation and an optional prioritization fee."
+description:
+  "Transaction fees are the small fees paid to process instructions on the
+  network. These fees are based on computation and an optional prioritization
+  fee."
 keywords:
   - instruction fee
   - processing fee
@@ -12,46 +15,73 @@ keywords:
   - affordable blockchain
 ---
 
-The small fees paid to process [instructions](./terminology.md#instruction) on the Solana blockchain are known as "_transaction fees_".
+The small fees paid to process [instructions](./terminology.md#instruction) on
+the Solana blockchain are known as "_transaction fees_".
 
-As each transaction (which contains one or more instructions) is sent through the network, it gets processed by the current leader validation-client. Once confirmed as a global state transaction, this _transaction fee_ is paid to the network to help support the [economic design](#economic-design) of the Solana blockchain.
+As each transaction (which contains one or more instructions) is sent through
+the network, it gets processed by the current leader validation-client. Once
+confirmed as a global state transaction, this _transaction fee_ is paid to the
+network to help support the [economic design](#economic-design) of the Solana
+blockchain.
 
-> **NOTE:** Transaction fees are different from [account rent](./terminology.md#rent)!
-> While transaction fees are paid to process instructions on the Solana network, rent is paid to store data on the blockchain.
+> **NOTE:** Transaction fees are different from
+> [account rent](./terminology.md#rent)! While transaction fees are paid to
+> process instructions on the Solana network, rent is paid to store data on the
+> blockchain.
 
-> You can learn more about rent here: [What is rent?](./developing/intro/rent.md)
+> You can learn more about rent here:
+> [What is rent?](./developing/intro/rent.md)
 
 ## Why pay transaction fees?
 
-Transaction fees offer many benefits in the Solana [economic design](#basic-economic-design) described below. Mainly:
+Transaction fees offer many benefits in the Solana
+[economic design](#basic-economic-design) described below. Mainly:
 
-- they provide compensation to the validator network for the CPU/GPU resources necessary to process transactions,
+- they provide compensation to the validator network for the CPU/GPU resources
+  necessary to process transactions,
 - reduce network spam by introducing real cost to transactions,
-- and provide long-term economic stability to the network through a protocol-captured minimum fee amount per transaction
+- and provide long-term economic stability to the network through a
+  protocol-captured minimum fee amount per transaction
 
-> **NOTE:** Network consensus votes are sent as normal system transfers, which means that validators pay transaction fees to participate in consensus.
+> **NOTE:** Network consensus votes are sent as normal system transfers, which
+> means that validators pay transaction fees to participate in consensus.
 
 ## Basic economic design
 
-Many blockchain networks \(e.g. Bitcoin and Ethereum\), rely on inflationary _protocol-based rewards_ to secure the network in the short-term. Over the long-term, these networks will increasingly rely on _transaction fees_ to sustain security.
+Many blockchain networks \(e.g. Bitcoin and Ethereum\), rely on inflationary
+_protocol-based rewards_ to secure the network in the short-term. Over the
+long-term, these networks will increasingly rely on _transaction fees_ to
+sustain security.
 
 The same is true on Solana. Specifically:
 
-- A fixed proportion (initially 50%) of each transaction fee is _burned_ (destroyed), with the remaining going to the current [leader](./terminology.md#leader) processing the transaction.
-- A scheduled global inflation rate provides a source for [rewards](./implemented-proposals/staking-rewards.md) distributed to [Solana Validators](../src/running-validator.md).
+- A fixed proportion (initially 50%) of each transaction fee is _burned_
+  (destroyed), with the remaining going to the current
+  [leader](./terminology.md#leader) processing the transaction.
+- A scheduled global inflation rate provides a source for
+  [rewards](./implemented-proposals/staking-rewards.md) distributed to
+  [Solana Validators](../src/running-validator.md).
 
 ### Why burn some fees?
 
-As mentioned above, a fixed proportion of each transaction fee is _burned_ (destroyed). This is intended to cement the economic value of SOL and thus sustain the network's security. Unlike a scheme where transactions fees are completely burned, leaders are still incentivized to include as many transactions as possible in their slots.
+As mentioned above, a fixed proportion of each transaction fee is _burned_
+(destroyed). This is intended to cement the economic value of SOL and thus
+sustain the network's security. Unlike a scheme where transactions fees are
+completely burned, leaders are still incentivized to include as many
+transactions as possible in their slots.
 
-Burnt fees can also help prevent malicious validators from censoring transactions by being considered in [fork](./terminology.md#fork) selection.
+Burnt fees can also help prevent malicious validators from censoring
+transactions by being considered in [fork](./terminology.md#fork) selection.
 
 #### Example of an attack:
 
-In the case of a [Proof of History (PoH)](./terminology.md#proof-of-history-poh) fork with a malicious, censoring leader:
+In the case of a [Proof of History (PoH)](./terminology.md#proof-of-history-poh)
+fork with a malicious, censoring leader:
 
-- due to the fees lost from censoring, we would expect the total fees burned to be **_less than_** a comparable honest fork
-- if the censoring leader is to compensate for these lost protocol fees, they would have to replace the burnt fees on their fork themselves
+- due to the fees lost from censoring, we would expect the total fees burned to
+  be **_less than_** a comparable honest fork
+- if the censoring leader is to compensate for these lost protocol fees, they
+  would have to replace the burnt fees on their fork themselves
 - thus potentially reducing the incentive to censor in the first place
 
 ## Calculating transaction fees
@@ -59,28 +89,146 @@ In the case of a [Proof of History (PoH)](./terminology.md#proof-of-history-poh)
 Transactions fees are calculated based on two main parts:
 
 - a statically set base fee per signature, and
-- the computational resources used during the transaction, measured in "[_compute units_](./terminology.md#compute-units)"
+- the computational resources used during the transaction, measured in
+  "[_compute units_](./terminology.md#compute-units)"
 
-Since each transaction may require a different amount of computational resources, they are alloted a maximum number of _compute units_ per transaction known as the "[_compute budget_](./terminology.md#compute-budget)".
+Since each transaction may require a different amount of computational
+resources, they are alloted a maximum number of _compute units_ per transaction
+known as the "[_compute budget_](./terminology.md#compute-budget)".
 
-The execution of each instruction within a transaction consumes a different number of _compute units_. After the maximum number of _compute units_ has been consumed (aka compute budget exhaustion), the runtime will halt the transaction and return an error. This results in a failed transaction.
+The execution of each instruction within a transaction consumes a different
+number of _compute units_. After the maximum number of _compute units_ has been
+consumed (aka compute budget exhaustion), the runtime will halt the transaction
+and return an error. This results in a failed transaction.
 
-> **Learn more:** compute units and the [Compute Budget](./developing/programming-model/runtime#compute-budget) in the Runtime and [requesting a fee estimate](../api/http#getfeeformessage) from the RPC.
+> **Learn more:** compute units and the
+> [Compute Budget](./developing/programming-model/runtime#compute-budget) in the
+> Runtime and [requesting a fee estimate](../api/http#getfeeformessage) from the
+> RPC.
 
 ## Prioritization fee
 
-Recently, Solana has introduced an optional fee called the "_[prioritization fee](./terminology.md#prioritization-fee)_". This additional fee can be paid to help boost how a transaction is prioritized against others, resulting in faster transaction execution times.
+A Solana transaction can include an **optional** fee to prioritize itself
+against others known as a
+"_[prioritization fee](./terminology.md#prioritization-fee)_". Paying this
+additional fee helps boost how a transaction is prioritized against others,
+resulting in faster execution times.
 
-The prioritization fee is calculated by multiplying the requested maximum _compute units_ by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
+### How the prioritization fee is calculated
 
-You can read more about the [compute budget instruction](./developing/programming-model/runtime.md#compute-budget) here.
+A transaction's [prioritization fee](./terminology.md#prioritization-fee) is
+calculated by multiplying the maximum number of **_compute units_** by the
+**_compute unit price_** (measured in _micro-lamports_).
+
+Each transaction can set the maximum number of compute units it is allowed to
+consume and the compute unit price by including a `SetComputeUnitLimit` and
+`SetComputeUnitPrice` compute budget instruction respectively.
+
+:::info
+[Compute Budget instructions](https://github.com/solana-labs/solana/blob/master/sdk/src/compute_budget.rs)
+do **not** require any accounts. :::
+
+If no `SetComputeUnitLimit` instruction is provided, the limit will be
+calculated as the product of the number of instructions in the transaction and
+the default per-instruction units, which is currently
+[200k](https://github.com/solana-labs/solana/blob/4293f11cf13fc1e83f1baa2ca3bb2f8ea8f9a000/program-runtime/src/compute_budget.rs#L13).
+
+If no `SetComputeUnitPrice` instruction is provided, the transaction will
+default to no additional elevated fee and the lowest priority.
+
+### How to set the prioritization fee
+
+A transaction's prioritization fee is set by including a `SetComputeUnitPrice`
+instruction, and optionally a `SetComputeUnitLimit` instruction. The runtime
+will use these values to calculate the prioritization fee, which will be used to
+prioritize the given transaction within the block.
+
+You can craft each of these instructions via their `rust` or `@solana/web3.js`
+functions. Each of these instructions can then be included in the transaction
+and sent to the cluster like normal. See also the
+[best practices](#prioritization-fee-best-practices) below.
+
+:::caution Transactions can only contain **one of each type** of compute budget
+instruction. Duplicate types will result in an
+[`TransactionError::DuplicateInstruction`](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction/error.rs#L144-145)
+error, and ultimately transaction failure. :::
+
+#### Rust
+
+The rust `solana-sdk` crate includes functions within
+[`ComputeBudgetInstruction`](https://docs.rs/solana-sdk/latest/solana_sdk/compute_budget/enum.ComputeBudgetInstruction.html)
+to craft instructions for setting the _compute unit limit_ and _compute unit
+price_:
+
+```rust
+let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
+```
+
+```rust
+let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
+```
+
+#### Javascript
+
+The `@solana/web3.js` library includes functions within the
+[`ComputeBudgetProgram`](https://solana-labs.github.io/solana-web3.js/classes/ComputeBudgetProgram.html)
+class to craft instructions for setting the _compute unit limit_ and _compute
+unit price_:
+
+```js
+const instruction = ComputeBudgetProgram.setComputeUnitLimit({
+  units: 300_000,
+});
+```
+
+```js
+const instruction = ComputeBudgetProgram.setComputeUnitPrice({
+  microLamports: 1,
+});
+```
+
+### Prioritization fee best practices
+
+#### Request the minimum compute units
+
+Transactions should request the minimum amount of compute units required for
+execution to minimize fees. Also note that fees are not adjusted when the number
+of requested compute units exceeds the number of compute units actually consumed
+by an executed transaction.
+
+#### Get recent prioritization fees
+
+Prior to sending a transaction to the cluster, you can use the
+[`getRecentPrioritizationFees`](/api/http#getrecentprioritizationfees) RPC
+method to get a list of the recent paid prioritization fees within the recent
+blocks processed by the node.
+
+You could then use this data to estimate an appropriate prioritization fee for
+your transaction to both (a) better ensure it gets processed by the cluster and
+(b) minimize the fees paid.
 
 ## Fee Collection
 
-Transactions are required to have at least one account which has signed the transaction and is writable. Writable signer accounts are serialized first in the list of transaction accounts and the first of these accounts is always used as the "fee payer".
+Transactions are required to have at least one account which has signed the
+transaction and is writable. Writable signer accounts are serialized first in
+the list of transaction accounts and the first of these accounts is always used
+as the "fee payer".
 
-Before any transaction instructions are processed, the fee payer account balance will be deducted to pay for transaction fees. If the fee payer balance is not sufficient to cover transaction fees, the transaction will be dropped by the cluster. If the balance was sufficient, the fees will be deducted whether the transaction is processed successfully or not. In fact, if any of the transaction instructions return an error or violate runtime restrictions, all account changes _except_ the transaction fee deduction will be rolled back.
+Before any transaction instructions are processed, the fee payer account balance
+will be deducted to pay for transaction fees. If the fee payer balance is not
+sufficient to cover transaction fees, the transaction will be dropped by the
+cluster. If the balance was sufficient, the fees will be deducted whether the
+transaction is processed successfully or not. In fact, if any of the transaction
+instructions return an error or violate runtime restrictions, all account
+changes _except_ the transaction fee deduction will be rolled back.
 
 ## Fee Distribution
 
-Transaction fees are partially burned and the remaining fees are collected by the validator that produced the block that the corresponding transactions were included in. The transaction fee burn rate was initialized as 50% when inflation rewards were enabled at the beginning of 2021 and has not changed so far. These fees incentivize a validator to process as many transactions as possible during its slots in the leader schedule. Collected fees are deposited in the validator's account (listed in the leader schedule for the current slot) after processing all of the transactions included in a block.
+Transaction fees are partially burned and the remaining fees are collected by
+the validator that produced the block that the corresponding transactions were
+included in. The transaction fee burn rate was initialized as 50% when inflation
+rewards were enabled at the beginning of 2021 and has not changed so far. These
+fees incentivize a validator to process as many transactions as possible during
+its slots in the leader schedule. Collected fees are deposited in the
+validator's account (listed in the leader schedule for the current slot) after
+processing all of the transactions included in a block.

--- a/docs/src/transaction_fees.md
+++ b/docs/src/transaction_fees.md
@@ -109,6 +109,7 @@ and return an error. This results in a failed transaction.
 ## Prioritization fee
 
 A Solana transaction can include an **optional** fee to prioritize itself
+<<<<<<< HEAD
 against others known as a
 "_[prioritization fee](./terminology.md#prioritization-fee)_". Paying this
 additional fee helps boost how a transaction is prioritized against others,
@@ -118,6 +119,16 @@ resulting in faster execution times.
 
 A transaction's [prioritization fee](./terminology.md#prioritization-fee) is
 calculated by multiplying the maximum number of **_compute units_** by the
+=======
+against others known as a "_[prioritization fee](./terminology.md#prioritization-fee)_".
+Paying this additional fee helps boost how a transaction is prioritized against
+others, resulting in faster execution times.
+
+### How the prioritization fee is calculated
+
+A transaction's [prioritization fee](./terminology.md#prioritization-fee)
+is calculated by multiplying the maximum number of **_compute units_** by the
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 **_compute unit price_** (measured in _micro-lamports_).
 
 Each transaction can set the maximum number of compute units it is allowed to
@@ -125,6 +136,7 @@ consume and the compute unit price by including a `SetComputeUnitLimit` and
 `SetComputeUnitPrice` compute budget instruction respectively.
 
 :::info
+<<<<<<< HEAD
 [Compute Budget instructions](https://github.com/solana-labs/solana/blob/master/sdk/src/compute_budget.rs)
 do **not** require any accounts. :::
 
@@ -135,11 +147,24 @@ the default per-instruction units, which is currently
 
 If no `SetComputeUnitPrice` instruction is provided, the transaction will
 default to no additional elevated fee and the lowest priority.
+=======
+[Compute Budget instructions](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L22) do **not** require any accounts and do **not**
+consume any compute units to process.
+:::
+
+If no `SetComputeUnitLimit` instruction is provided, the limit will be
+calculated as the product of the number of instructions in the transaction and
+the default per-instruction units, which is currently [200k](https://github.com/solana-labs/solana/blob/4293f11cf13fc1e83f1baa2ca3bb2f8ea8f9a000/program-runtime/src/compute_budget.rs#L13).
+
+If no `SetComputeUnitPrice` instruction is provided, the transaction will
+effectively have a default priority.
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ### How to set the prioritization fee
 
 A transaction's prioritization fee is set by including a `SetComputeUnitPrice`
 instruction, and optionally a `SetComputeUnitLimit` instruction. The runtime
+<<<<<<< HEAD
 will use these values to calculate the prioritization fee, which will be used to
 prioritize the given transaction within the block.
 
@@ -152,13 +177,30 @@ and sent to the cluster like normal. See also the
 instruction. Duplicate types will result in an
 [`TransactionError::DuplicateInstruction`](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction/error.rs#L144-145)
 error, and ultimately transaction failure. :::
+=======
+will use these values to calculate the prioritization fee, which will be used
+to prioritize the given transaction within the block.
+
+You can craft each of these instructions via their `rust` or `@solana/web3.js`
+functions. Each of these instructions can then be included in the transaction
+and sent to the cluster like normal. See also the [best practices](#prioritization-fee-best-practices) below.
+
+:::caution
+Transactions can only contain **one of each type** of compute budget instruction.
+Duplicate types will result in an error, and ultimately transaction failure.
+:::
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 #### Rust
 
 The rust `solana-sdk` crate includes functions within
 [`ComputeBudgetInstruction`](https://docs.rs/solana-sdk/latest/solana_sdk/compute_budget/enum.ComputeBudgetInstruction.html)
+<<<<<<< HEAD
 to craft instructions for setting the _compute unit limit_ and _compute unit
 price_:
+=======
+to craft instructions for setting the _compute unit limit_ and _compute unit price_:
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ```rust
 let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
@@ -172,8 +214,12 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 
 The `@solana/web3.js` library includes functions within the
 [`ComputeBudgetProgram`](https://solana-labs.github.io/solana-web3.js/classes/ComputeBudgetProgram.html)
+<<<<<<< HEAD
 class to craft instructions for setting the _compute unit limit_ and _compute
 unit price_:
+=======
+class to craft instructions for setting the _compute unit limit_ and _compute unit price_:
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ```js
 const instruction = ComputeBudgetProgram.setComputeUnitLimit({
@@ -192,9 +238,15 @@ const instruction = ComputeBudgetProgram.setComputeUnitPrice({
 #### Request the minimum compute units
 
 Transactions should request the minimum amount of compute units required for
+<<<<<<< HEAD
 execution to minimize fees. Also note that fees are not adjusted when the number
 of requested compute units exceeds the number of compute units actually consumed
 by an executed transaction.
+=======
+execution to minimize fees. Also note that fees are not adjusted when the
+number of requested compute units exceeds the number of compute units actually
+consumed by an executed transaction.
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 #### Get recent prioritization fees
 
@@ -204,8 +256,13 @@ method to get a list of the recent paid prioritization fees within the recent
 blocks processed by the node.
 
 You could then use this data to estimate an appropriate prioritization fee for
+<<<<<<< HEAD
 your transaction to both (a) better ensure it gets processed by the cluster and
 (b) minimize the fees paid.
+=======
+your transaction to both (a) better ensure it gets processed by the cluster
+and (b) minimize the fees paid.
+>>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ## Fee Collection
 

--- a/docs/src/transaction_fees.md
+++ b/docs/src/transaction_fees.md
@@ -109,7 +109,6 @@ and return an error. This results in a failed transaction.
 ## Prioritization fee
 
 A Solana transaction can include an **optional** fee to prioritize itself
-<<<<<<< HEAD
 against others known as a
 "_[prioritization fee](./terminology.md#prioritization-fee)_". Paying this
 additional fee helps boost how a transaction is prioritized against others,
@@ -119,16 +118,6 @@ resulting in faster execution times.
 
 A transaction's [prioritization fee](./terminology.md#prioritization-fee) is
 calculated by multiplying the maximum number of **_compute units_** by the
-=======
-against others known as a "_[prioritization fee](./terminology.md#prioritization-fee)_".
-Paying this additional fee helps boost how a transaction is prioritized against
-others, resulting in faster execution times.
-
-### How the prioritization fee is calculated
-
-A transaction's [prioritization fee](./terminology.md#prioritization-fee)
-is calculated by multiplying the maximum number of **_compute units_** by the
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 **_compute unit price_** (measured in _micro-lamports_).
 
 Each transaction can set the maximum number of compute units it is allowed to
@@ -136,7 +125,6 @@ consume and the compute unit price by including a `SetComputeUnitLimit` and
 `SetComputeUnitPrice` compute budget instruction respectively.
 
 :::info
-<<<<<<< HEAD
 [Compute Budget instructions](https://github.com/solana-labs/solana/blob/master/sdk/src/compute_budget.rs)
 do **not** require any accounts. :::
 
@@ -147,24 +135,11 @@ the default per-instruction units, which is currently
 
 If no `SetComputeUnitPrice` instruction is provided, the transaction will
 default to no additional elevated fee and the lowest priority.
-=======
-[Compute Budget instructions](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L22) do **not** require any accounts and do **not**
-consume any compute units to process.
-:::
-
-If no `SetComputeUnitLimit` instruction is provided, the limit will be
-calculated as the product of the number of instructions in the transaction and
-the default per-instruction units, which is currently [200k](https://github.com/solana-labs/solana/blob/4293f11cf13fc1e83f1baa2ca3bb2f8ea8f9a000/program-runtime/src/compute_budget.rs#L13).
-
-If no `SetComputeUnitPrice` instruction is provided, the transaction will
-effectively have a default priority.
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ### How to set the prioritization fee
 
 A transaction's prioritization fee is set by including a `SetComputeUnitPrice`
 instruction, and optionally a `SetComputeUnitLimit` instruction. The runtime
-<<<<<<< HEAD
 will use these values to calculate the prioritization fee, which will be used to
 prioritize the given transaction within the block.
 
@@ -177,30 +152,13 @@ and sent to the cluster like normal. See also the
 instruction. Duplicate types will result in an
 [`TransactionError::DuplicateInstruction`](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction/error.rs#L144-145)
 error, and ultimately transaction failure. :::
-=======
-will use these values to calculate the prioritization fee, which will be used
-to prioritize the given transaction within the block.
-
-You can craft each of these instructions via their `rust` or `@solana/web3.js`
-functions. Each of these instructions can then be included in the transaction
-and sent to the cluster like normal. See also the [best practices](#prioritization-fee-best-practices) below.
-
-:::caution
-Transactions can only contain **one of each type** of compute budget instruction.
-Duplicate types will result in an error, and ultimately transaction failure.
-:::
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 #### Rust
 
 The rust `solana-sdk` crate includes functions within
 [`ComputeBudgetInstruction`](https://docs.rs/solana-sdk/latest/solana_sdk/compute_budget/enum.ComputeBudgetInstruction.html)
-<<<<<<< HEAD
 to craft instructions for setting the _compute unit limit_ and _compute unit
 price_:
-=======
-to craft instructions for setting the _compute unit limit_ and _compute unit price_:
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ```rust
 let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
@@ -214,12 +172,8 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 
 The `@solana/web3.js` library includes functions within the
 [`ComputeBudgetProgram`](https://solana-labs.github.io/solana-web3.js/classes/ComputeBudgetProgram.html)
-<<<<<<< HEAD
 class to craft instructions for setting the _compute unit limit_ and _compute
 unit price_:
-=======
-class to craft instructions for setting the _compute unit limit_ and _compute unit price_:
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ```js
 const instruction = ComputeBudgetProgram.setComputeUnitLimit({
@@ -238,15 +192,9 @@ const instruction = ComputeBudgetProgram.setComputeUnitPrice({
 #### Request the minimum compute units
 
 Transactions should request the minimum amount of compute units required for
-<<<<<<< HEAD
 execution to minimize fees. Also note that fees are not adjusted when the number
 of requested compute units exceeds the number of compute units actually consumed
 by an executed transaction.
-=======
-execution to minimize fees. Also note that fees are not adjusted when the
-number of requested compute units exceeds the number of compute units actually
-consumed by an executed transaction.
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 #### Get recent prioritization fees
 
@@ -256,13 +204,8 @@ method to get a list of the recent paid prioritization fees within the recent
 blocks processed by the node.
 
 You could then use this data to estimate an appropriate prioritization fee for
-<<<<<<< HEAD
 your transaction to both (a) better ensure it gets processed by the cluster and
 (b) minimize the fees paid.
-=======
-your transaction to both (a) better ensure it gets processed by the cluster
-and (b) minimize the fees paid.
->>>>>>> b80f49b775 (docs: updated prioritization fees docs)
 
 ## Fee Collection
 


### PR DESCRIPTION
#### Problem

The docs lack complete information on how to use prioritization fees and what they are

#### Summary of Changes

- moved prioritization fees info from `runtime` to `transaction_fees` (left a brief explainer and internal link)
- added more information and examples of how to use prioritization fees to the `transaction_fees` page
- added elaboration of `micro-lamports` to the terminology page

