### PR TITLE
defer HighestShred repairs during shred propagation threshold

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
-        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairService,
-        serve_repair::ShredRepairType, tree_diff::TreeDiff,
+        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
+        repair_service::{RepairService, DEFER_REPAIR_THRESHOLD},
+        serve_repair::ShredRepairType,
+        tree_diff::TreeDiff,
     },
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
     solana_sdk::{clock::Slot, hash::Hash},
@@ -187,6 +189,7 @@ pub fn get_closest_completion(
                 slot,
                 slot_meta,
                 limit - repairs.len(),
+                DEFER_REPAIR_THRESHOLD,
             );
             repairs.extend(new_repairs);
         }
@@ -199,10 +202,8 @@ pub fn get_closest_completion(
 pub mod test {
     use {
         super::*,
-        solana_ledger::{
-            blockstore::{Blockstore, MAX_TURBINE_PROPAGATION},
-            get_tmp_ledger_path,
-        },
+        crate::repair_service::DEFER_REPAIR_THRESHOLD,
+        solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
         solana_sdk::hash::Hash,
         std::thread::sleep,
         trees::{tr, Tree, TreeWalk},
@@ -256,7 +257,7 @@ pub mod test {
             Hash::default(),
         );
         let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
-        sleep(MAX_TURBINE_PROPAGATION);
+        sleep(DEFER_REPAIR_THRESHOLD);
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
         let repairs = get_closest_completion(

--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -1,9 +1,7 @@
 use {
     crate::{
-        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-        repair_service::{RepairService, DEFER_REPAIR_THRESHOLD_TICKS},
-        serve_repair::ShredRepairType,
-        tree_diff::TreeDiff,
+        heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairService,
+        serve_repair::ShredRepairType, tree_diff::TreeDiff,
     },
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
     solana_sdk::{clock::Slot, hash::Hash, timing::timestamp},
@@ -190,7 +188,6 @@ pub fn get_closest_completion(
                 slot_meta,
                 limit - repairs.len(),
                 timestamp(),
-                DEFER_REPAIR_THRESHOLD_TICKS,
             );
             repairs.extend(new_repairs);
         }

--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-        repair_service::{RepairService, DEFER_REPAIR_THRESHOLD},
+        repair_service::{RepairService, DEFER_REPAIR_THRESHOLD_TICKS},
         serve_repair::ShredRepairType,
         tree_diff::TreeDiff,
     },
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
-    solana_sdk::{clock::Slot, hash::Hash},
+    solana_sdk::{clock::Slot, hash::Hash, timing::timestamp},
     std::collections::{HashMap, HashSet},
 };
 
@@ -189,7 +189,8 @@ pub fn get_closest_completion(
                 slot,
                 slot_meta,
                 limit - repairs.len(),
-                DEFER_REPAIR_THRESHOLD,
+                timestamp(),
+                DEFER_REPAIR_THRESHOLD_TICKS,
             );
             repairs.extend(new_repairs);
         }

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -45,8 +45,7 @@ use {solana_ledger::shred::Nonce, solana_sdk::clock::DEFAULT_MS_PER_SLOT};
 
 // Time to defer repair requests to allow for turbine propagation
 pub(crate) const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(200);
-pub(crate) const DEFER_REPAIR_THRESHOLD_TICKS: u64 =
-    DEFER_REPAIR_THRESHOLD.as_millis() as u64 / MS_PER_TICK;
+const DEFER_REPAIR_THRESHOLD_TICKS: u64 = DEFER_REPAIR_THRESHOLD.as_millis() as u64 / MS_PER_TICK;
 
 pub type DuplicateSlotsResetSender = CrossbeamSender<Vec<(Slot, Hash)>>;
 pub type DuplicateSlotsResetReceiver = CrossbeamReceiver<Vec<(Slot, Hash)>>;

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -544,9 +544,11 @@ impl RepairService {
                 .map(u64::from)
             {
                 let ticks_since_first_insert = DEFAULT_TICKS_PER_SECOND
-                    * (now_timestamp.saturating_sub(slot_meta.first_shred_timestamp))
+                    * now_timestamp.saturating_sub(slot_meta.first_shred_timestamp)
                     / 1_000;
-                if ticks_since_first_insert < reference_tick + DEFER_REPAIR_THRESHOLD_TICKS {
+                if ticks_since_first_insert
+                    < reference_tick.saturating_add(DEFER_REPAIR_THRESHOLD_TICKS)
+                {
                     return vec![];
                 }
             }

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -355,7 +355,6 @@ impl RepairService {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &duplicate_slot_repair_statuses,
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut repair_timing,
                     &mut best_repairs_stats,
                 );
@@ -533,7 +532,6 @@ impl RepairService {
         slot_meta: &SlotMeta,
         max_repairs: usize,
         now_timestamp: u64,
-        defer_threshold_ticks: u64,
     ) -> Vec<ShredRepairType> {
         if max_repairs == 0 || slot_meta.is_full() {
             vec![]
@@ -549,7 +547,7 @@ impl RepairService {
                 let ticks_since_first_insert = DEFAULT_TICKS_PER_SECOND
                     * (now_timestamp.saturating_sub(slot_meta.first_shred_timestamp))
                     / 1_000;
-                if ticks_since_first_insert < reference_tick + defer_threshold_ticks {
+                if ticks_since_first_insert < reference_tick + DEFER_REPAIR_THRESHOLD_TICKS {
                     return vec![];
                 }
             }
@@ -579,7 +577,6 @@ impl RepairService {
         slot: Slot,
         duplicate_slot_repair_statuses: &impl Contains<'a, Slot>,
         now_timestamp: u64,
-        defer_threshold_ticks: u64,
     ) {
         let mut pending_slots = vec![slot];
         while repairs.len() < max_repairs && !pending_slots.is_empty() {
@@ -595,7 +592,6 @@ impl RepairService {
                     &slot_meta,
                     max_repairs - repairs.len(),
                     now_timestamp,
-                    defer_threshold_ticks,
                 );
                 repairs.extend(new_repairs);
                 let next_slots = slot_meta.next_slots;
@@ -634,7 +630,6 @@ impl RepairService {
                 &meta,
                 max_repairs - repairs.len(),
                 timestamp(),
-                DEFER_REPAIR_THRESHOLD_TICKS,
             );
             repairs.extend(new_repairs);
         }
@@ -658,7 +653,6 @@ impl RepairService {
                     &slot_meta,
                     MAX_REPAIR_PER_DUPLICATE,
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                 ))
             }
         } else {
@@ -857,7 +851,6 @@ mod test {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
                 ),
@@ -896,7 +889,6 @@ mod test {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
                 ),
@@ -960,7 +952,6 @@ mod test {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
                 ),
@@ -978,7 +969,6 @@ mod test {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
                 )[..],
@@ -1026,7 +1016,6 @@ mod test {
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     post_shred_deferment_timestamp(),
-                    DEFER_REPAIR_THRESHOLD_TICKS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
                 ),

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -797,7 +797,7 @@ impl RepairService {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use {
         super::*,
         solana_gossip::{
@@ -820,6 +820,11 @@ mod test {
         solana_streamer::socket::SocketAddrSpace,
         std::collections::HashSet,
     };
+
+    pub(crate) fn post_shred_deferment_timestamp() -> u64 {
+        // adjust timestamp to bypass shred deferment window
+        timestamp() + DEFAULT_MS_PER_SLOT + DEFER_REPAIR_THRESHOLD.as_millis() as u64
+    }
 
     fn new_test_cluster_info() -> ClusterInfo {
         let keypair = Arc::new(Keypair::new());
@@ -979,11 +984,6 @@ mod test {
             );
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
-    }
-
-    fn post_shred_deferment_timestamp() -> u64 {
-        // adjust timestamp to bypass shred deferment window
-        timestamp() + DEFAULT_MS_PER_SLOT + DEFER_REPAIR_THRESHOLD.as_millis() as u64
     }
 
     #[test]

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
         repair_generic_traversal::{get_closest_completion, get_unknown_last_index},
-        repair_service::{BestRepairsStats, RepairTiming, DEFER_REPAIR_THRESHOLD},
+        repair_service::{BestRepairsStats, RepairTiming},
         repair_weighted_traversal,
         serve_repair::ShredRepairType,
         tree_diff::TreeDiff,
@@ -157,6 +157,8 @@ impl RepairWeight {
         max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
         ignore_slots: &impl Contains<'a, Slot>,
+        now_timestamp: u64,
+        defer_threshold_ticks: u64,
         repair_timing: &mut RepairTiming,
         stats: &mut BestRepairsStats,
     ) -> Vec<ShredRepairType> {
@@ -187,6 +189,8 @@ impl RepairWeight {
             &mut best_shreds_repairs,
             max_new_shreds,
             ignore_slots,
+            now_timestamp,
+            defer_threshold_ticks,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
         let repair_slots_set: HashSet<Slot> =
@@ -350,6 +354,8 @@ impl RepairWeight {
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
         ignore_slots: &impl Contains<'a, Slot>,
+        now_timestamp: u64,
+        defer_threshold_ticks: u64,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
         repair_weighted_traversal::get_best_repair_shreds(
@@ -359,7 +365,8 @@ impl RepairWeight {
             repairs,
             max_new_shreds,
             ignore_slots,
-            DEFER_REPAIR_THRESHOLD,
+            now_timestamp,
+            defer_threshold_ticks,
         );
     }
 

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
         repair_generic_traversal::{get_closest_completion, get_unknown_last_index},
-        repair_service::{BestRepairsStats, RepairTiming},
+        repair_service::{BestRepairsStats, RepairTiming, DEFER_REPAIR_THRESHOLD},
         repair_weighted_traversal,
         serve_repair::ShredRepairType,
         tree_diff::TreeDiff,
@@ -359,6 +359,7 @@ impl RepairWeight {
             repairs,
             max_new_shreds,
             ignore_slots,
+            DEFER_REPAIR_THRESHOLD,
         );
     }
 

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -158,7 +158,6 @@ impl RepairWeight {
         max_closest_completion_repairs: usize,
         ignore_slots: &impl Contains<'a, Slot>,
         now_timestamp: u64,
-        defer_threshold_ticks: u64,
         repair_timing: &mut RepairTiming,
         stats: &mut BestRepairsStats,
     ) -> Vec<ShredRepairType> {
@@ -190,7 +189,6 @@ impl RepairWeight {
             max_new_shreds,
             ignore_slots,
             now_timestamp,
-            defer_threshold_ticks,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
         let repair_slots_set: HashSet<Slot> =
@@ -355,7 +353,6 @@ impl RepairWeight {
         max_new_shreds: usize,
         ignore_slots: &impl Contains<'a, Slot>,
         now_timestamp: u64,
-        defer_threshold_ticks: u64,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
         repair_weighted_traversal::get_best_repair_shreds(
@@ -366,7 +363,6 @@ impl RepairWeight {
             max_new_shreds,
             ignore_slots,
             now_timestamp,
-            defer_threshold_ticks,
         );
     }
 

--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -147,9 +147,7 @@ pub fn get_best_repair_shreds<'a>(
 pub mod test {
     use {
         super::*,
-        crate::repair_service::{
-            test::post_shred_deferment_timestamp, DEFER_REPAIR_THRESHOLD_TICKS,
-        },
+        crate::repair_service::{post_shred_deferment_timestamp, DEFER_REPAIR_THRESHOLD_TICKS},
         solana_ledger::{
             get_tmp_ledger_path,
             shred::{Shred, ShredFlags},

--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -147,17 +147,15 @@ pub fn get_best_repair_shreds<'a>(
 pub mod test {
     use {
         super::*,
-        crate::repair_service::{DEFER_REPAIR_THRESHOLD, DEFER_REPAIR_THRESHOLD_TICKS},
+        crate::repair_service::{
+            test::post_shred_deferment_timestamp, DEFER_REPAIR_THRESHOLD_TICKS,
+        },
         solana_ledger::{
             get_tmp_ledger_path,
             shred::{Shred, ShredFlags},
         },
         solana_runtime::bank_utils,
-        solana_sdk::{
-            clock::{DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SECOND},
-            hash::Hash,
-            timing::timestamp,
-        },
+        solana_sdk::{clock::DEFAULT_TICKS_PER_SECOND, hash::Hash, timing::timestamp},
         trees::tr,
     };
 
@@ -225,11 +223,6 @@ pub mod test {
                 Visit::Visited(0)
             ]
         );
-    }
-
-    fn post_shred_deferment_timestamp() -> u64 {
-        // adjust timestamp to bypass shred deferment window
-        timestamp() + DEFAULT_MS_PER_SLOT + DEFER_REPAIR_THRESHOLD.as_millis() as u64
     }
 
     #[test]

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -668,7 +668,7 @@ pub mod layout {
         (offsets.end <= shred.len()).then_some(offsets)
     }
 
-    pub(crate) fn get_reference_tick(shred: &[u8]) -> Result<u8, Error> {
+    pub fn get_reference_tick(shred: &[u8]) -> Result<u8, Error> {
         if get_shred_type(shred)? != ShredType::Data {
             return Err(Error::InvalidShredType);
         }


### PR DESCRIPTION
#### Problem
Turbine propagation delay is not considered before creating a `HighestShred` request.

#### Summary of Changes
- use propagation delay and the reference tick of the last shred we have received for the slot to determine if a `HighestShred` repair request should be sent.
- moves network propagation delay value from blockstore to repair.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
