### PR TITLE
API to match account owner against a set of owners

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -822,7 +822,7 @@ impl<'a> LoadedAccountAccessor<'a> {
                 cached_account.as_ref().map(|cached_account| AccountMeta {
                     lamports: cached_account.account.lamports(),
                     rent_epoch: cached_account.account.rent_epoch(),
-                    owner: cached_account.account.owner().clone(),
+                    owner: *cached_account.account.owner(),
                     executable: cached_account.account.executable(),
                 })
             }
@@ -4951,7 +4951,7 @@ impl AccountsDb {
                 return Some(AccountMeta {
                     lamports: account.lamports(),
                     rent_epoch: account.rent_epoch(),
-                    owner: account.owner().clone(),
+                    owner: *account.owner(),
                     executable: account.executable(),
                 });
             }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -18,7 +18,6 @@
 //! tracks the number of commits to the entire data store. So the latest
 //! commit for each slot entry would be indexed.
 
-use crate::append_vec::AccountMeta;
 use {
     crate::{
         account_info::{AccountInfo, Offset, StorageLocation, StoredSize},
@@ -43,9 +42,9 @@ use {
             get_ancient_append_vec_capacity, is_ancient, AccountsToStore, StorageSelector,
         },
         append_vec::{
-            aligned_stored_size, AppendVec, StorableAccountsWithHashesAndWriteVersions,
-            StoredAccountMeta, StoredMetaWriteVersion, APPEND_VEC_MMAPPED_FILES_OPEN,
-            STORE_META_OVERHEAD,
+            aligned_stored_size, AccountMeta, AppendVec,
+            StorableAccountsWithHashesAndWriteVersions, StoredAccountMeta, StoredMetaWriteVersion,
+            APPEND_VEC_MMAPPED_FILES_OPEN, STORE_META_OVERHEAD,
         },
         cache_hash_data::{CacheHashData, CacheHashDataFile},
         contains::Contains,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -603,7 +603,7 @@ impl AppendVec {
         ))
     }
 
-    fn get_account_meta<'a>(&'a self, offset: usize) -> Option<&'a AccountMeta> {
+    fn get_account_meta<'a>(&self, offset: usize) -> Option<&'a AccountMeta> {
         // Skip over StoredMeta data in the account
         let offset = offset.checked_add(mem::size_of::<StoredMeta>())?;
         // u64_align! does an unchecked add for alignment. Check that it won't cause an overflow.
@@ -623,8 +623,7 @@ impl AppendVec {
         let account_meta = self
             .get_account_meta(offset)
             .ok_or(MatchAccountOwnerError::UnableToLoad)?;
-        owners
-            .contains(&&account_meta.owner)
+        (account_meta.lamports != 0 && owners.contains(&&account_meta.owner))
             .then_some(())
             .ok_or(MatchAccountOwnerError::NoMatch)
     }


### PR DESCRIPTION
#### Problem
The runtime V2 needs an API to filter executable/program accounts in a transaction, without reading the whole account in the memory. We don't currently have such an API.

An API that can match account's owner with a set of pubkeys (loader pubkeys) will be ideal.

#### Summary of Changes
Add API to `account_matches_owners` in `append_vec.rs` and `accounts_db.rs`. Also, add unit tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
