### PR TITLE
Add retransmit slot metrics

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -397,6 +397,12 @@ impl ProgressMap {
             .map(|fork_progress| &mut fork_progress.propagated_stats)
     }
 
+    pub fn has_attempted_retransmit(&self, slot: Slot) -> Option<bool> {
+        self.progress_map
+            .get(&slot)
+            .map(|fork_progress| fork_progress.retransmit_info.retry_iteration > 0)
+    }
+
     pub fn get_propagated_stats_must_exist(&self, slot: Slot) -> &PropagatedStats {
         self.get_propagated_stats(slot)
             .unwrap_or_else(|| panic!("slot={slot} must exist in ProgressMap"))

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -10,7 +10,7 @@ use {
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
         latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
         progress_map::{ForkProgress, ProgressMap},
-        replay_stage::{HeaviestForkFailures, ReplayStage},
+        replay_stage::{HeaviestForkFailures, ReplayStage, RetransmittedSlotsMetrics},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
     crossbeam_channel::unbounded,
@@ -164,6 +164,7 @@ impl VoteSimulator {
             &self.bank_forks,
             &mut self.heaviest_subtree_fork_choice,
             &mut self.latest_validator_votes_for_frozen_banks,
+            &mut RetransmittedSlotsMetrics::default(),
         );
 
         let vote_bank = self


### PR DESCRIPTION
#### Problem
It's not clear if the code to have leader retransmit its slot when it detects it hasn't been propagated is helping at all.

#### Summary of Changes
Add metrics to understand if any retransmitted slots are getting confirmed.