### PR TITLE
Add address lookup tables to minimized snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1338,7 +1338,7 @@ fn minimize_bank_for_snapshot(
     ending_slot: Slot,
 ) {
     let (transaction_account_set, transaction_accounts_measure) = measure!(
-        blockstore.get_accounts_used_in_range(snapshot_slot, ending_slot),
+        blockstore.get_accounts_used_in_range(bank, snapshot_slot, ending_slot),
         "get transaction accounts"
     );
     let total_accounts_len = transaction_account_set.len();
@@ -1918,6 +1918,7 @@ fn main() {
             .arg(&no_snapshot_arg)
             .arg(&account_paths_arg)
             .arg(&accounts_db_skip_initial_hash_calc_arg)
+            .arg(&accountsdb_skip_shrink)
             .arg(&ancient_append_vecs)
             .arg(&hard_forks_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
@@ -3015,6 +3016,7 @@ fn main() {
                         halt_at_slot: Some(snapshot_slot),
                         poh_verify: false,
                         accounts_db_config: Some(get_accounts_db_config(&ledger_path, arg_matches)),
+                        accounts_db_skip_shrink: arg_matches.is_present("accounts_db_skip_shrink"),
                         ..ProcessOptions::default()
                     },
                     snapshot_archive_path,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2855,6 +2855,11 @@ impl Blockstore {
                                     result.insert(lookup.account_key);
                                 });
                             }
+                            // howdy, anybody who reached here from the panic messsage!
+                            // the .unwrap() below could indicate there was an odd error or there
+                            // could simply be a tx with a new alt, which is just created in this
+                            // range. too bad... this edge case isn't currently supported.
+                            // for casual use, please chose different slot range.
                             let sanitized_tx = bank.fully_verify_transaction(tx).unwrap();
                             sanitized_tx
                                 .message()

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -39,7 +39,10 @@ use {
         poh_timing_point::{send_poh_timing_point, PohTimingSender, SlotPohTimingInfo},
     },
     solana_rayon_threadlimit::get_max_thread_count,
-    solana_runtime::hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    solana_runtime::{
+        bank::Bank,
+        hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    },
     solana_sdk::{
         clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, MS_PER_TICK},
         genesis_config::{GenesisConfig, DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE},
@@ -2835,6 +2838,7 @@ impl Blockstore {
     /// Used by ledger-tool to create a minimized snapshot
     pub fn get_accounts_used_in_range(
         &self,
+        bank: &Bank,
         starting_slot: Slot,
         ending_slot: Slot,
     ) -> DashSet<Pubkey> {
@@ -2844,11 +2848,21 @@ impl Blockstore {
             .into_par_iter()
             .for_each(|slot| {
                 if let Ok(entries) = self.get_slot_entries(slot, 0) {
-                    entries.par_iter().for_each(|entry| {
-                        entry.transactions.iter().for_each(|tx| {
-                            tx.message.static_account_keys().iter().for_each(|pubkey| {
-                                result.insert(*pubkey);
-                            });
+                    entries.into_par_iter().for_each(|entry| {
+                        entry.transactions.into_iter().for_each(|tx| {
+                            if let Some(lookups) = tx.message.address_table_lookups() {
+                                lookups.iter().for_each(|lookup| {
+                                    result.insert(lookup.account_key);
+                                });
+                            }
+                            let sanitized_tx = bank.fully_verify_transaction(tx).unwrap();
+                            sanitized_tx
+                                .message()
+                                .account_keys()
+                                .iter()
+                                .for_each(|&pubkey| {
+                                    result.insert(pubkey);
+                                });
                         });
                     });
                 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2857,8 +2857,9 @@ impl Blockstore {
                             }
                             // howdy, anybody who reached here from the panic messsage!
                             // the .unwrap() below could indicate there was an odd error or there
-                            // could simply be a tx with a new alt, which is just created in this
-                            // range. too bad... this edge case isn't currently supported.
+                            // could simply be a tx with a new alt, which is just created/updated
+                            // in this range. too bad... this edge case isn't currently supported.
+                            // see: https://github.com/solana-labs/solana/issues/30165
                             // for casual use, please chose different slot range.
                             let sanitized_tx = bank.fully_verify_transaction(tx).unwrap();
                             sanitized_tx

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2857,10 +2857,10 @@ impl Blockstore {
                             }
                             // howdy, anybody who reached here from the panic messsage!
                             // the .unwrap() below could indicate there was an odd error or there
-                            // could simply be a tx with a new alt, which is just created/updated
+                            // could simply be a tx with a new ALT, which is just created/updated
                             // in this range. too bad... this edge case isn't currently supported.
                             // see: https://github.com/solana-labs/solana/issues/30165
-                            // for casual use, please chose different slot range.
+                            // for casual use, please choose different slot range.
                             let sanitized_tx = bank.fully_verify_transaction(tx).unwrap();
                             sanitized_tx
                                 .message()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1912,6 +1912,7 @@ impl Bank {
             additional_builtins,
             debug_do_not_add_builtins,
         );
+        bank.fill_missing_sysvar_cache_entries();
 
         // Sanity assertions between bank snapshot and genesis config
         // Consider removing from serializable bank state
@@ -6918,6 +6919,13 @@ impl Bank {
         }
 
         Ok(sanitized_tx)
+    }
+
+    pub fn fully_verify_transaction(
+        &self,
+        tx: VersionedTransaction,
+    ) -> Result<SanitizedTransaction> {
+        self.verify_transaction(tx, TransactionVerificationMode::FullVerification)
     }
 
     /// only called from ledger-tool or tests


### PR DESCRIPTION
#### Problem

Currently, we can't create a minimized snapshot for mainnet-beta due to wide-spread use of address-lookup-table txes which is currently-unsupported for the minimized snapshot.

#### Summary of Changes

Support it. Needed bunch of seemingly unrelated changes...