### PR TITLE
Fix camelCase response for RpcPrioritizationFee

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -546,6 +546,7 @@ pub struct RpcSnapshotSlotInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcPrioritizationFee {
     pub slot: Slot,
     pub prioritization_fee: u64,


### PR DESCRIPTION
#### Problem
Current response for ```getRecentPrioritizationFee``` is ```snake_case```  but as of docs it should be ```camelCase ```
eg:
```
{
   "slot": 348125,
   "prioritizationFee": 0
}
```

#### Summary of Changes
use ```[serde(rename_all = "camelCase")]``` for ```RpcPrioritizationFee``` struct

https://github.com/solana-labs/solana/blob/d387f15587b3a1d9ec2ae1cb5d0d14e04e901644/rpc-client-api/src/response.rs#L549
