### PR TITLE
add http to the url in remote-client script

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -72,10 +72,10 @@ solana-bench-tps)
 
   if ${TPU_CLIENT}; then
     args+=(--use-tpu-client)
-    args+=(--url "$entrypointIp:8899")
+    args+=(--url "http://$entrypointIp:8899")
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
-    args+=(--url "$entrypointIp:8899")
+    args+=(--url "http://$entrypointIp:8899")
   else
     args+=(--entrypoint "$entrypointIp:8001")
   fi


### PR DESCRIPTION
#### Problem

Some time ago a new option was added to net script which allows to specify different types of clients.
For example: `./net/net.sh start --client-type [thin-client, tpu-client, rpc-client]` but the problem is that there is `http` missing in the url.

#### Summary of Changes

Add http to url