### PR TITLE
sdk: Make `declare_id` mostly const

### DIFF
--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -44,16 +44,18 @@ fn id_to_tokens(
     tokens: &mut proc_macro2::TokenStream,
 ) {
     tokens.extend(quote! {
-        /// The static program ID.
-        pub static ID: #pubkey_type = #id;
+        /// The const program ID.
+        pub const ID: #pubkey_type = #id;
 
         /// Returns `true` if given pubkey is the program ID.
+        // TODO make this const once `derive_const` makes it out of nightly
+        // and we can `derive_const(PartialEq)` on `Pubkey`.
         pub fn check_id(id: &#pubkey_type) -> bool {
             id == &ID
         }
 
         /// Returns the program ID.
-        pub fn id() -> #pubkey_type {
+        pub const fn id() -> #pubkey_type {
             ID
         }
 


### PR DESCRIPTION
#### Problem

The functions and ID created with `declare_id` could be const, but they're not, limiting their usage in other const situations, for example, as associated items on traits, where `static` is not allowed.  For example, this is not allowed:

```
trait Id {
    static ID: Pubkey;
}
```

#### Summary of Changes

Mark `id()` and `ID` as `const`, so we can do things like:

```
trait Id {
    const ID: Pubkey;
}
impl Id on Struct {
    const ID: Pubkey = system_program::ID;
}
```

Fun side note: I don't think this will break anyone! It currently isn't possible to do something like

```
static SYSTEM_ID: &str = "11111111111111111111111111111111";
crate::declare_id!(SYSTEM_ID);
```

So this only makes things better.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
