### PR TITLE
removes wallclock from duplicate-shreds handler

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1203,7 +1203,6 @@ impl ClusterInfo {
     }
 
     /// Returns duplicate-shreds inserted since the given cursor.
-    #[allow(dead_code)]
     pub(crate) fn get_duplicate_shreds(&self, cursor: &mut Cursor) -> Vec<DuplicateShred> {
         let gossip_crds = self.gossip.crds.read().unwrap();
         gossip_crds

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -43,9 +43,12 @@ pub struct DuplicateShred {
 }
 
 impl DuplicateShred {
+    #[inline]
     pub(crate) fn num_chunks(&self) -> u8 {
         self.num_chunks
     }
+
+    #[inline]
     pub(crate) fn chunk_index(&self) -> u8 {
         self.chunk_index
     }


### PR DESCRIPTION

#### Problem
Duplicate-shred handler relies on all chunks within a duplicate-shred proof having the same wallclock. But this is only an implementation detail and does not need to be the case.


#### Summary of Changes
Removed wallclock from duplicate-shreds handler.