### PR TITLE
add shrink_can_be_active to remove

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -92,8 +92,12 @@ impl AccountStorage {
 
     /// remove the append vec at 'slot'
     /// returns the current contents
-    pub(crate) fn remove(&self, slot: &Slot) -> Option<Arc<AccountStorageEntry>> {
-        assert!(self.shrink_in_progress_map.is_empty());
+    pub(crate) fn remove(
+        &self,
+        slot: &Slot,
+        shrink_can_be_active: bool,
+    ) -> Option<Arc<AccountStorageEntry>> {
+        assert!(shrink_can_be_active || self.shrink_in_progress_map.is_empty());
         self.map.remove(slot).map(|(_, entry)| entry.storage)
     }
 
@@ -374,7 +378,7 @@ pub(crate) mod tests {
         storage
             .shrink_in_progress_map
             .insert(0, storage.get_test_storage());
-        storage.remove(&0);
+        storage.remove(&0, false);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4085,7 +4085,7 @@ impl AccountsDb {
             // shrink is in progress, so 1 new append vec to keep, 1 old one to throw away
             not_retaining_store(shrink_in_progress.old_storage());
             // dropping 'shrink_in_progress' removes the old append vec that was being shrunk from db's storage
-        } else if let Some(store) = self.storage.remove(&slot) {
+        } else if let Some(store) = self.storage.remove(&slot, false) {
             // no shrink in progress, so all append vecs in this slot are dead
             not_retaining_store(&store);
         }
@@ -4610,7 +4610,7 @@ impl AccountsDb {
                 .clean_dead_slot(slot, &mut AccountsIndexRootsStats::default());
             self.remove_bank_hash_info(&slot);
             // the storage has been removed from this slot and recycled or dropped
-            assert!(self.storage.remove(&slot).is_none());
+            assert!(self.storage.remove(&slot, false).is_none());
         });
     }
 
@@ -5777,7 +5777,7 @@ impl AccountsDb {
         let mut remove_storage_entries_elapsed = Measure::start("remove_storage_entries_elapsed");
         for remove_slot in removed_slots {
             // Remove the storage entries and collect some metrics
-            if let Some(store) = self.storage.remove(remove_slot) {
+            if let Some(store) = self.storage.remove(remove_slot, false) {
                 {
                     total_removed_storage_entries += 1;
                     total_removed_stored_bytes += store.accounts.capacity();
@@ -12708,7 +12708,7 @@ pub mod tests {
             db.store_for_tests(base_slot, &[(&key, &account)]);
             if pass == 0 {
                 db.add_root_and_flush_write_cache(base_slot);
-                db.storage.remove(&base_slot);
+                db.storage.remove(&base_slot, false);
                 assert!(db.get_snapshot_storages(..=after_slot, None).0.is_empty());
                 continue;
             }


### PR DESCRIPTION
#### Problem
Building new algorithm for packing ancient storage. Packing will occur in 1 pass across multiple ancient slots.
This will be put in 1 dead code piece at a time with tests until all pieces are present. Switch between current packing algorithm and this new one is in a validator cli argument. Resulting append vecs are correct and compatible (as a set) either way. When a new storage format optimized for cold storage becomes available, it will only work with this new packing algorithm, so the change will need to be complete prior to the new storage format.

Currently, ancient append vec 'shrink' occurs on a single slot at a time. Thus, when we are done with that slot and call `remove`, there is never another shrink active. However, with the new packing algorithm, many slots are actively shrinking simultaneously. As a result, the assert inside `remove` gets triggered. It is a legal use case for shrink to identify other shrinks going on concurrently.

#### Summary of Changes
Allow passing `shrink_can_be_active` to `remove` to avoid the assert in the new code (which is coming soon).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
