### PR TITLE
add optimization to skip no-op ancient shrink

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -442,6 +442,7 @@ pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
     pub(crate) alive_accounts: T,
     /// total size in storage of all alive accounts
     pub(crate) alive_total_bytes: usize,
+    /// # of accounts in the original storage. This includes both alive and dead accounts.
     pub(crate) total_starting_accounts: usize,
     /// true if all alive accounts are zero lamports
     pub(crate) all_are_zero_lamports: bool,


### PR DESCRIPTION
#### Problem
#30195 added function to calculate ancient slots to combine.
There is a corner case where there may be an ancient storage with all alive accounts in it having multiple refcounts and there being no dead accounts in the storage. In that case, it is a waste of time to rewrite the storage.

#### Summary of Changes
Add ability to skip ancient storages where it is a waste of time to rewrite them.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
