### PR TITLE
Remove recursive read lock that could deadlock Blockstore

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2878,8 +2878,6 @@ impl Blockstore {
         slot: Slot,
         start_index: u64,
     ) -> Result<(CompletedRanges, Option<SlotMeta>)> {
-        let _lock = self.check_lowest_cleanup_slot(slot)?;
-
         let slot_meta_cf = self.db.column::<cf::SlotMeta>();
         let slot_meta = slot_meta_cf.get(slot)?;
         if slot_meta.is_none() {


### PR DESCRIPTION
#### Problem
This deadlock could only occur on nodes that call
Blockstore::get_rooted_block(). Regular validators don't call this function, RPC nodes and nodes that have BigTableUploadService enabled do.

Blockstore::get_rooted_block() grabs a read lock on lowest_cleanup_slot right at the start to check if the block has been cleaned up, and to ensure it doesn't get cleaned up during execution. As part of the callstack of get_rooted_block(), Blockstore::get_completed_ranges() will get called, which also grabs a read lock on lowest_cleanup_slot.

If LedgerCleanupService attempts to grab a write lock between the read lock calls, we could hit a deadlock if priority is given to the write lock request in this scenario.

#### Summary of Changes
This change removes the call to get the read lock in get_completed_ranges(). The lock is only held for the scope of this function, which is a single rocksdb read and thus not needed. This does mean that a different error will be returned if the requested slot was below lowest_cleanup_slot. Previously, a BlockstoreError::SlotCleanedUp would have been thrown; the rocksdb error will be bubbled up now. Note that callers of get_rooted_block() will still get the SlotCleanedUp error when appropriate because get_rooted_block() grabs the lock. If the slot is unavailable, it will return immediately. If the slot is available, get_rooted_block() holding the lock means the slot will remain available.

https://github.com/solana-labs/solana/issues/29901 has more information on when the issue was first observed, as well as some additional information such as actually observed callstacks from deadlocked warehouse (using bigtable) node.

#### Callstack That Could Hit Deadlock
```
+ Blockstore::get_rooted_block()
+!!! Blockstore::check_lowest_cleanup_slot() (line 1926) to obtain read lock
+--+ Blockstore:: get_complete_block() (line 1929)
   +--+ Blockstore::get_slot_entries() (line 1948)
      +--+ Blockstore::get_slot_entries_with_shred_info() (line 2778)
         +--+ Blockstore::get_completed_ranges() (line 2790)
            +!!! Blockstore::check_lowest_cleanup_slot() (line 2856) to obtain read lock
```

```
// RPC Thread                       |  // LedgerCleanupService Thread
                                    |
// First call that gets read lock   |
let _ = lowest_cleanup_slot.read(); |
                                    |  // LCS gets write lock next
                                    |  let _ = lowest_cleanup_slot.write();
// Second read lock that could      |
// deadlock us                      |
let _ = lowest_cleanup_slot.read(); |
```

In regards
- Rust < 1.62 behavior would allow the second read-lock to go before the write-lock, given that read-locks could go in parallel. This could hypothetically starve the writer, but with our workload, I don't think this was happening in any meaningful way (ie probably seconds at most of starvation)
- Rust >= 1.62 behavior will prevent the second read lock since there was a write lock request ahead of it.

One thing that isn't 100% to me is that the behavior to make [RwLock favor writers on Linux was added in Rust 1.62](https://twitter.com/m_ou_se/status/1526211117651050497?lang=en). However, the report came in from Jito where they were rebased on top of v1.13 or v1.14 (which have older Rust versions). @segfaultdoc confirmed that they were using the `./cargo` script to build, so they were using the "supported" Rust version.

Additionally, segfaultdoc mentioned that he saw the issue with Jito v1.13.5+ and v1.14.13 (they rebase their commits on top of our tags). But, the issue didn't show in Jito v1.13.4 for them ... this is pretty peculiar as the diff between v1.13.4 and v1.13.5 isn't too big:
```
$ git log v1.13.4 v1.13.5 --pretty=oneline
9138494335acec3e5406e77587607aaba30ab95e (tag: v1.13.5) MultiIteratorScanner - improve banking stage performance with high contention
88c87d12d9c85f508e4e83528a68567b8e3c095c Delete files older than the lowest_cleanup_slot in LedgerCleanupService::cleanup_ledger (backport #26651) (#28721)
f3471e54560388a10cc56d7a0990fafaf967132d Backport timeout async send tasks to v1.13 (#28750)
959b760ca89ff192107d4a1115fc5a69ed071c8b chore: bump tj-actions/changed-files to v34 (backport #28674) (#28675)
3d4a5f69998fee65a65fb94b6a7cc94e72223fcc clean_dead_slots_from_accounts_index unrefs correctly (backport #2746… (#28582)
2e69d6d6426422f90a96edbf30fd72006a40a274 Limit async tasks spawn to runtime for quic transaction send (backport #28452) (#28603)
9d211065cc4ffc3d3b85a50a8425da0dc82df7f9 Backport of #28599 to v1.13 (#28602)
40920b4ebe9f73cecad28ac93910d677f86f0bcb chore: fix solana-private pipeline (#28609)
bf2acd04846538cd8926459891f8a7e6e072905f stats for staked/unstaked repair requests (backport #28215) (#28598)
9382e90c08613be460d77cce6118882f0ada1a3c make ping cache rate limit delay configurable (backport #27955) (#28595)
dcf4cc6471ce96f08a6c3ae4957721a17238869b ledger-tool: remove inefficient base58 encoding options (backport #28488) (#28494)
c090a6b446ac4da7fd3063fac0eee73eb4abb5b2 Bump Version to 1.13.5 (#28506)
3b81ee9c2602620ca4904df20bdf098bff47aaf9 (tag: v1.13.4) Fixes typo in bootstrap log (backport #28483) (#28491)
```
88c87d12d9c85f508e4e83528a68567b8e3c095c obviously sticks out as it changes LedgerCleanupService behavior, but that commit didn't change the locking behavior. Not observing the issue on a given version isn't definitive (not seeing it doesn't mean it couldn't happen), so maybe that is the case or maybe there is some nth-order effect from one of these other changes.

Fixes #29901 
