### PR TITLE
chore: Use `i` over `ix` variable name when naming worker threads

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -100,7 +100,7 @@ const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(MAX_CONCURRENT_FORKS_TO_REPLAY)
-        .thread_name(|ix| format!("solReplay{ix:02}"))
+        .thread_name(|i| format!("solReplay{i:02}"))
         .build()
         .unwrap();
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -443,7 +443,7 @@ impl Validator {
         }
 
         if rayon::ThreadPoolBuilder::new()
-            .thread_name(|ix| format!("solRayonGlob{ix:02}"))
+            .thread_name(|i| format!("solRayonGlob{i:02}"))
             .build_global()
             .is_err()
         {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -47,7 +47,7 @@ use {
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_max_thread_count())
-        .thread_name(|ix| format!("solEntry{ix:02}"))
+        .thread_name(|i| format!("solEntry{i:02}"))
         .build()
         .unwrap();
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -92,12 +92,12 @@ pub use {
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_max_thread_count())
-        .thread_name(|ix| format!("solBstore{ix:02}"))
+        .thread_name(|i| format!("solBstore{i:02}"))
         .build()
         .unwrap();
     static ref PAR_THREAD_POOL_ALL_CPUS: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_cpus::get())
-        .thread_name(|ix| format!("solBstoreAll{ix:02}"))
+        .thread_name(|i| format!("solBstoreAll{i:02}"))
         .build()
         .unwrap();
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -79,7 +79,7 @@ struct ReplayEntry {
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_max_thread_count())
-        .thread_name(|ix| format!("solBstoreProc{ix:02}"))
+        .thread_name(|i| format!("solBstoreProc{i:02}"))
         .build()
         .unwrap();
 }

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -24,7 +24,7 @@ use {
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_thread_count())
-        .thread_name(|ix| format!("solShredder{ix:02}"))
+        .thread_name(|i| format!("solShredder{i:02}"))
         .build()
         .unwrap();
 }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -26,7 +26,7 @@ const SIGN_SHRED_GPU_MIN: usize = 256;
 lazy_static! {
     static ref SIGVERIFY_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_thread_count())
-        .thread_name(|ix| format!("solSvrfyShred{ix:02}"))
+        .thread_name(|i| format!("solSvrfyShred{i:02}"))
         .build()
         .unwrap();
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -36,7 +36,7 @@ pub const VERIFY_MIN_PACKETS_PER_THREAD: usize = 128;
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(get_thread_count())
-        .thread_name(|ix| format!("solSigVerify{ix:02}"))
+        .thread_name(|i| format!("solSigVerify{i:02}"))
         .build()
         .unwrap();
 }


### PR DESCRIPTION
No functional changes, just done for consistency. Additionally, the `ix` abbreviation is used to refer to instruction in other places so avoid that.