### PR TITLE
Fix duplicate broadcast test

### DIFF
--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -391,20 +391,17 @@ pub fn test_faulty_node(
 ) -> (LocalCluster, Vec<Arc<Keypair>>) {
     solana_logger::setup_with_default("solana_local_cluster=info");
     let num_nodes = node_stakes.len();
-
     let mut validator_keys = Vec::with_capacity(num_nodes);
     validator_keys.resize_with(num_nodes, || (Arc::new(Keypair::new()), true));
-
     assert_eq!(node_stakes.len(), num_nodes);
     assert_eq!(validator_keys.len(), num_nodes);
 
-    let bad_leader_pubkey = validator_keys[0].0.as_ref().pubkey();
+    // Use a fixed leader schedule so that only the faulty node gets leader slots.
     let validator_to_slots = vec![(
-        bad_leader_pubkey,
+        validator_keys[0].0.as_ref().pubkey(),
         solana_sdk::clock::DEFAULT_DEV_SLOTS_PER_EPOCH as usize,
     )];
     let leader_schedule = create_custom_leader_schedule(validator_to_slots.into_iter());
-
     let fixed_leader_schedule = Some(FixedSchedule {
         leader_schedule: Arc::new(leader_schedule),
     });

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -392,21 +392,36 @@ pub fn test_faulty_node(
     solana_logger::setup_with_default("solana_local_cluster=info");
     let num_nodes = node_stakes.len();
 
+    let mut validator_keys = Vec::with_capacity(num_nodes);
+    validator_keys.resize_with(num_nodes, || (Arc::new(Keypair::new()), true));
+
+    assert_eq!(node_stakes.len(), num_nodes);
+    assert_eq!(validator_keys.len(), num_nodes);
+
+    let bad_leader_pubkey = validator_keys[0].0.as_ref().pubkey();
+    let validator_to_slots = vec![(
+        bad_leader_pubkey,
+        solana_sdk::clock::DEFAULT_DEV_SLOTS_PER_EPOCH as usize,
+    )];
+    let leader_schedule = create_custom_leader_schedule(validator_to_slots.into_iter());
+
+    let fixed_leader_schedule = Some(FixedSchedule {
+        leader_schedule: Arc::new(leader_schedule),
+    });
+
     let error_validator_config = ValidatorConfig {
         broadcast_stage_type: faulty_node_type,
+        fixed_leader_schedule: fixed_leader_schedule.clone(),
         ..ValidatorConfig::default_for_test()
     };
     let mut validator_configs = Vec::with_capacity(num_nodes);
 
     // First validator is the bootstrap leader with the malicious broadcast logic.
     validator_configs.push(error_validator_config);
-    validator_configs.resize_with(num_nodes, ValidatorConfig::default_for_test);
-
-    let mut validator_keys = Vec::with_capacity(num_nodes);
-    validator_keys.resize_with(num_nodes, || (Arc::new(Keypair::new()), true));
-
-    assert_eq!(node_stakes.len(), num_nodes);
-    assert_eq!(validator_keys.len(), num_nodes);
+    validator_configs.resize_with(num_nodes, || ValidatorConfig {
+        fixed_leader_schedule: fixed_leader_schedule.clone(),
+        ..ValidatorConfig::default_for_test()
+    });
 
     let mut cluster_config = ClusterConfig {
         cluster_lamports: 10_000,


### PR DESCRIPTION
#### Problem
See #29917 

#### Summary of Changes
Use a fixed leader schedule for this test so that only the faulty leader gets scheduled and we don't skip half the leader slots.