### PR TITLE
fix bug in test fn compare_all_accounts

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -17294,7 +17294,7 @@ pub mod tests {
             for i in 0..two_indexes.len() {
                 let pubkey2 = two[two_indexes[i]].0;
                 if pubkey2 == *pubkey {
-                    assert!(accounts_equal(account, &two[i].1));
+                    assert!(accounts_equal(account, &two[two_indexes[i]].1));
                     two_indexes.remove(i);
                     break;
                 }


### PR DESCRIPTION
#### Problem
test code compares sets of accounts after clean/shrink operations.
The indexing was off and new tests were giving false positives.
The test code was equivalent as long as everything was in the same order.

#### Summary of Changes
Fix test code comparison indexes.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
