### PR TITLE
Replaces stable sort with unstable sort

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4989,8 +4989,10 @@ impl Bank {
         #[cfg(not(test))]
         assert!(!validator_stakes.is_empty());
 
-        // Sort first by stake and then by validator identity pubkey for determinism
-        validator_stakes.sort_by(|(pubkey1, staked1), (pubkey2, staked2)| {
+        // Sort first by stake and then by validator identity pubkey for determinism.
+        // If two items are still equal, their relative order does not matter since
+        // both refer to the same validator.
+        validator_stakes.sort_unstable_by(|(pubkey1, staked1), (pubkey2, staked2)| {
             staked2.cmp(staked1).then(pubkey2.cmp(pubkey1))
         });
 


### PR DESCRIPTION
#### Problem

The `validator_stakes` used to distribute rent to validators is sorted by stake and then pubkey. The sorting is done currently with a stable sort which is unneeded for two reasons:

1. If a `validator_stake` matches another one, then that means they are both for the same validator and thus their relative order does not matter.
2. Since `validator_stakes` is created by collecting from a HashMap, the pre-sorted vector is not deterministic across the cluster, which means the stable sort itself is not actually stable (when viewed across the cluster).

Since a stable sort is (1) not needed, and (2) not possible, we can use a faster, unstable sort instead.

#### Summary of Changes

Unstable sort `validator_stakes`.