### PR TITLE
ledger-tool: Reallow custom accounts path with Secondary access

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1143,11 +1143,31 @@ fn load_bank_forks(
     }
 
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {
+        // If this blockstore access is Primary, no other process (solana-validator) can hold
+        // Primary access. So, allow a custom accounts path without worry of wiping the accounts
+        // of solana-validator.
         if !blockstore.is_primary_access() {
-            // Be defensive, when default account dir is explicitly specified, it's still possible
-            // to wipe the dir possibly shared by the running validator!
-            eprintln!("Error: custom accounts path is not supported under secondary access");
-            exit(1);
+            // Attempt to open the Blockstore in Primary access; if successful, no other process
+            // was holding Primary so allow things to proceed with custom accounts path. Release
+            // the Primary access instead of holding it to give priority to solana-validator over
+            // solana-ledger-tool should solana-validator start before we've finished.
+            info!(
+                "Checking if another process currently holding Primary access to {:?}",
+                blockstore.ledger_path()
+            );
+            if Blockstore::open_with_options(
+                blockstore.ledger_path(),
+                BlockstoreOptions {
+                    access_type: AccessType::Primary,
+                    ..BlockstoreOptions::default()
+                },
+            )
+            .is_err()
+            {
+                // Couldn't get Primary access, error out to be defensive.
+                eprintln!("Error: custom accounts path is not supported under secondary access");
+                exit(1);
+            }
         }
         account_paths.split(',').map(PathBuf::from).collect()
     } else if blockstore.is_primary_access() {


### PR DESCRIPTION
#### Problem
Previously, ledger-tool had a guardrail to disallow a custom accounts path when access mode to the blockstore was Secondary. This was to avoid potentially pulling the accounts out from underneath solana-validator. When ledger-tool switched over to use Secondary blockstore access for all commands that do not need write access, this removed the ability to use custom accounts paths with ledger-tool at all for these commands. Custom accounts paths are desirable, especially if that custom path is in tmpfs to speed up processing.

#### Summary of Changes
With this change, when a custom accounts path is passed for a command using Secondary access, ledger-tool now checks if Primary access is being held by another process. If not, allow processing to proceed with the custom accounts path.

The above check isn't fullproof, but it is about equal to the check that previously existed when ledger-tool would run in Primary access mode when it didn't need to.

This change made as an alternative to https://github.com/solana-labs/solana/pull/29672, as I didn't like the idea of having to pass an extra arg all the time.

#### Testing
On a ledger where no validator running, things proceed as expected:
```
$ cargo run --release --bin solana-ledger-tool -- verify --ledger ~/gh30060/ledger/ --accounts ~/gh30060/test

[2023-02-09T20:56:20.223437294Z INFO  solana_ledger::blockstore] Opening database at "/home/sol/gh30060/ledger/rocksdb"
[2023-02-09T20:56:20.223446812Z INFO  solana_ledger::blockstore_db] Disabling rocksdb's automatic compactions...
[2023-02-09T20:56:20.226821688Z INFO  solana_ledger::blockstore_db] Opening Rocks with secondary (read only) access at: "/home/sol/gh30060/ledger/rocksdb/solana-secondary"
...
[2023-02-09T20:56:20.246619843Z INFO  solana_ledger_tool] Checking if another process currently holding Primary access to "/home/sol/gh30060/ledger"
[2023-02-09T20:56:20.246632517Z INFO  solana_ledger::blockstore] Maximum open file descriptors: 1048576
[2023-02-09T20:56:20.246636444Z INFO  solana_ledger::blockstore] Opening database at "/home/sol/gh30060/ledger/rocksdb"
[2023-02-09T20:56:20.284909919Z INFO  solana_ledger::blockstore] "/home/sol/gh30060/ledger/rocksdb" open took 38ms
...
[2023-02-09T20:56:20.297050387Z INFO  solana_runtime::snapshot_utils] Loading bank from full snapshot: /home/sol/gh30060/ledger/snapshot-175475895-8NKW33DgSnH7SPVXFgaUXFvG8NscigB38xnnCBzSWkhX.tar.zst, and incremental snapshot: None
```
But on a ledger where the validator is running, the tool disallows us to use the custom path:
```
$ cargo run --release --bin solana-ledger-tool -- verify --ledger ~/ledger/ --accounts ~/gh30060/test

[2023-02-09T20:57:06.966037874Z INFO  solana_ledger::blockstore] Opening database at "/home/sol/ledger/rocksdb"
[2023-02-09T20:57:06.966046871Z INFO  solana_ledger::blockstore_db] Disabling rocksdb's automatic compactions...
[2023-02-09T20:57:06.970389977Z INFO  solana_ledger::blockstore_db] Opening Rocks with secondary (read only) access at: "/home/sol/ledger/rocksdb/solana-secondary"
...
[2023-02-09T20:57:13.885983249Z INFO  solana_ledger::blockstore] "/home/sol/ledger/rocksdb" open took 6.9s
[2023-02-09T20:57:13.886436641Z INFO  solana_ledger_tool] Checking if another process currently holding Primary access to "/home/sol/ledger"
[2023-02-09T20:57:13.886448464Z INFO  solana_ledger::blockstore] Maximum open file descriptors: 1048576
[2023-02-09T20:57:13.886452151Z INFO  solana_ledger::blockstore] Opening database at "/home/sol/ledger/rocksdb"
Error: custom accounts path is not supported under secondary access
```