### PR TITLE
wip: iter storable accounts

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1211,14 +1211,14 @@ impl Accounts {
             lamports_per_signature,
         );
         self.accounts_db.store_cached(
-            (slot, &accounts_to_store[..], include_slot_in_hash),
+            &(slot, &accounts_to_store[..], include_slot_in_hash),
             Some(&transactions),
         );
     }
 
-    pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
+    pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport + 'a, I: Iterator<Item=(&'a Pubkey, &'a T)> + 'a>(
         &self,
-        accounts: impl StorableAccounts<'a, T>,
+        accounts:&'a impl StorableAccounts<'a, T, I>,
     ) {
         self.accounts_db.store_cached(accounts, None)
     }

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -368,7 +368,7 @@ impl<'a> SnapshotMinimizer<'a> {
             shrink_in_progress = Some(self.accounts_db().get_store_for_shrink(slot, aligned_total));
             let new_storage = shrink_in_progress.as_ref().unwrap().new_storage();
             self.accounts_db().store_accounts_frozen(
-                (
+                &(
                     slot,
                     &accounts[..],
                     crate::accounts_db::INCLUDE_SLOT_IN_HASH_IRRELEVANT_APPEND_VEC_OPERATION,


### PR DESCRIPTION
#### Problem
everyone who writes to an appendvec uses iter today to get all accounts to write.
random access is expensive for some data formats.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
