### PR TITLE
fixup! lt: Reallow custom accounts path with Secondary access (#30228)

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1164,7 +1164,7 @@ fn load_bank_forks(
             if Blockstore::open_with_options(
                 blockstore.ledger_path(),
                 BlockstoreOptions {
-                    access_type: AccessType::Primary,
+                    access_type: AccessType::PrimaryForMaintenance,
                     ..BlockstoreOptions::default()
                 },
             )


### PR DESCRIPTION
#### Problem
The previous PR (#30228) used Primary access; however, it is better to use PrimaryForMaintenance in this case to disallow any potential compaction from happening.

#### Summary of Changes
Use PrimaryForMaintenance instead of Primary per [this comment](https://github.com/solana-labs/solana/pull/30228#discussion_r1102202339).