### PR TITLE
collect_sort_filter_ancient_slots takes tuning by ref

### DIFF
--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -239,11 +239,11 @@ impl AccountsDb {
     fn collect_sort_filter_ancient_slots(
         &self,
         slots: Vec<Slot>,
-        tuning: PackedAncientStorageTuning,
+        tuning: &PackedAncientStorageTuning,
     ) -> AncientSlotInfos {
         let mut ancient_slot_infos = self.calc_ancient_slot_info(slots, tuning.can_randomly_shrink);
 
-        ancient_slot_infos.filter_ancient_slots(&tuning);
+        ancient_slot_infos.filter_ancient_slots(tuning);
         ancient_slot_infos
     }
 
@@ -953,7 +953,7 @@ pub mod tests {
                             ideal_storage_size: NonZeroU64::new(1).unwrap(),
                             can_randomly_shrink,
                         };
-                        infos = db.collect_sort_filter_ancient_slots(vec![slot1], tuning);
+                        infos = db.collect_sort_filter_ancient_slots(vec![slot1], &tuning);
                     }
                 }
                 assert_eq!(infos.all_infos.len(), 1);
@@ -1110,7 +1110,7 @@ pub mod tests {
                                 ideal_storage_size: NonZeroU64::new(1).unwrap(),
                                 can_randomly_shrink,
                             };
-                            db.collect_sort_filter_ancient_slots(slot_vec.clone(), tuning)
+                            db.collect_sort_filter_ancient_slots(slot_vec.clone(), &tuning)
                         }
                     };
                     assert_eq!(infos.all_infos.len(), 1, "method: {method:?}");
@@ -1402,7 +1402,7 @@ pub mod tests {
                             can_randomly_shrink,
                         };
                         // note this can sort infos.all_infos
-                        db.collect_sort_filter_ancient_slots(slot_vec.clone(), tuning)
+                        db.collect_sort_filter_ancient_slots(slot_vec.clone(), &tuning)
                     }
                 };
 


### PR DESCRIPTION
#### Problem
Building new algorithm for packing ancient storage. Packing will occur in 1 pass across multiple ancient slots.
This will be put in 1 dead code piece at a time with tests until all pieces are present. Switch between current packing algorithm and this new one is in a validator cli argument. Resulting append vecs are correct and compatible (as a set) either way. When a new storage format optimized for cold storage becomes available, it will only work with this new packing algorithm, so the change will need to be complete prior to the new storage format.

The tuning parameters need to be reused by other functions.

#### Summary of Changes
Pass by ref.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
