### PR TITLE
pass shrink_can_be_active through shrink fns

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -386,6 +386,7 @@ impl<'a> SnapshotMinimizer<'a> {
             slot,
             true, // add_dirty_stores
             shrink_in_progress,
+            false,
         );
         dead_storages
             .lock()


### PR DESCRIPTION
#### Problem
Building new algorithm for packing ancient storage. Packing will occur in 1 pass across multiple ancient slots.
This will be put in 1 dead code piece at a time with tests until all pieces are present. Switch between current packing algorithm and this new one is in a validator cli argument. Resulting append vecs are correct and compatible (as a set) either way. When a new storage format optimized for cold storage becomes available, it will only work with this new packing algorithm, so the change will need to be complete prior to the new storage format.

Now that we shrink multiple slots concurrently, when we remove a slot indicating that we shouldn't, we hit an assert that there is not a shrink in progress. There is correctly a shrink in progress.

#### Summary of Changes
pass `shrink_can_be_active` through a few functions to indicate it is ok for a shrink to be active or not.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
