### PR TITLE
simplify AccountsToCombine.accounts_keep_slots

### DIFF
--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -345,7 +345,7 @@ impl AccountsDb {
                 // there are accounts with ref_count > 1. This means this account must remain IN this slot.
                 // The same account could exist in a newer or older slot. Moving this account across slots could result
                 // in this alive version of the account now being in a slot OLDER than the non-alive instances.
-                accounts_keep_slots.insert(info.slot, (std::mem::take(many_refs), *info));
+                accounts_keep_slots.insert(info.slot, std::mem::take(many_refs));
             } else {
                 // No alive accounts in this slot have a ref_count > 1. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
@@ -418,7 +418,7 @@ struct AccountsToCombine<'a> {
     /// to any slot.
     /// We want to keep the ref_count > 1 accounts by themselves, expecting the multiple ref_counts will be resolved
     /// soon and we can clean the duplicates up (which maybe THIS one).
-    accounts_keep_slots: HashMap<Slot, (AliveAccounts<'a>, &'a SlotInfo)>,
+    accounts_keep_slots: HashMap<Slot, AliveAccounts<'a>>,
     /// all the rest of alive accounts that can move slots and should be combined
     /// This includes all accounts with ref_count = 1 from the slots in 'accounts_keep_slots'
     accounts_to_combine: Vec<ShrinkCollect<'a, ShrinkCollectAliveSeparatedByRefs<'a>>>,
@@ -605,10 +605,7 @@ pub mod tests {
         let (db, _storages, _slots, _infos) = get_sample_storages(0, None);
         let mut write_ancient_accounts = WriteAncientAccounts::default();
         db.write_ancient_accounts_to_same_slot_multiple_refs(
-            AccountsToCombine::default()
-                .accounts_keep_slots
-                .iter()
-                .map(|(_slot, (info, _slot_info))| info),
+            AccountsToCombine::default().accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
         assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
@@ -697,10 +694,7 @@ pub mod tests {
                 // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
                 let mut write_ancient_accounts = WriteAncientAccounts::default();
                 db.write_ancient_accounts_to_same_slot_multiple_refs(
-                    accounts_to_combine
-                        .accounts_keep_slots
-                        .iter()
-                        .map(|(_slot, (info, _slot_info))| info),
+                    accounts_to_combine.accounts_keep_slots.values(),
                     &mut write_ancient_accounts,
                 );
                 if two_refs {
@@ -807,7 +801,6 @@ pub mod tests {
                 .accounts_keep_slots
                 .get(&slot1)
                 .unwrap()
-                .0
                 .accounts
                 .iter()
                 .map(|meta| meta.pubkey())
@@ -844,10 +837,7 @@ pub mod tests {
         // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
         let mut write_ancient_accounts = WriteAncientAccounts::default();
         db.write_ancient_accounts_to_same_slot_multiple_refs(
-            accounts_to_combine
-                .accounts_keep_slots
-                .iter()
-                .map(|(_slot, (info, _slot_info))| info),
+            accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
         assert_eq!(write_ancient_accounts.shrinks_in_progress.len(), num_slots);


### PR DESCRIPTION
#### Problem
Building new algorithm for packing ancient storage. Packing will occur in 1 pass across multiple ancient slots.
This will be put in 1 dead code piece at a time with tests until all pieces are present. Switch between current packing algorithm and this new one is in a validator cli argument. Resulting append vecs are correct and compatible (as a set) either way. When a new storage format optimized for cold storage becomes available, it will only work with this new packing algorithm, so the change will need to be complete prior to the new storage format.

we no longer need `SlotInfo` per account to keep.

#### Summary of Changes
Remove the value from the hashmap tuple.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
