### PR TITLE
remove unused metric

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1931,7 +1931,6 @@ pub(crate) struct ShrinkStats {
     num_slots_shrunk: AtomicUsize,
     storage_read_elapsed: AtomicU64,
     index_read_elapsed: AtomicU64,
-    find_alive_elapsed: AtomicU64,
     create_and_insert_store_elapsed: AtomicU64,
     store_accounts_elapsed: AtomicU64,
     update_index_elapsed: AtomicU64,
@@ -2073,13 +2072,6 @@ impl ShrinkAncientStats {
                     "index_read_elapsed",
                     self.shrink_stats
                         .index_read_elapsed
-                        .swap(0, Ordering::Relaxed) as i64,
-                    i64
-                ),
-                (
-                    "find_alive_elapsed",
-                    self.shrink_stats
-                        .find_alive_elapsed
                         .swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
@@ -4029,26 +4021,15 @@ impl AccountsDb {
             );
         }
 
-        Self::update_shrink_stats(
-            &self.shrink_stats,
-            0, // find_alive_elapsed
-            stats_sub,
-        );
+        Self::update_shrink_stats(&self.shrink_stats, stats_sub);
         self.shrink_stats.report();
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn update_shrink_stats(
-        shrink_stats: &ShrinkStats,
-        find_alive_elapsed_us: u64,
-        stats_sub: ShrinkStatsSub,
-    ) {
+    pub(crate) fn update_shrink_stats(shrink_stats: &ShrinkStats, stats_sub: ShrinkStatsSub) {
         shrink_stats
             .num_slots_shrunk
             .fetch_add(1, Ordering::Relaxed);
-        shrink_stats
-            .find_alive_elapsed
-            .fetch_add(find_alive_elapsed_us, Ordering::Relaxed);
         shrink_stats.create_and_insert_store_elapsed.fetch_add(
             stats_sub.create_and_insert_store_elapsed_us,
             Ordering::Relaxed,
@@ -4543,12 +4524,12 @@ impl AccountsDb {
         // split accounts in 'slot' into:
         // 'Primary', which can fit in 'current_ancient'
         // 'Overflow', which will have to go into a new ancient append vec at 'slot'
-        let (to_store, find_alive_elapsed_us) = measure_us!(AccountsToStore::new(
+        let to_store = AccountsToStore::new(
             available_bytes,
             shrink_collect.alive_accounts.alive_accounts(),
             shrink_collect.alive_total_bytes,
-            slot
-        ));
+            slot,
+        );
 
         ancient_slot_pubkeys.maybe_unref_accounts_already_in_ancient(
             slot,
@@ -4603,11 +4584,7 @@ impl AccountsDb {
         // we should not try to shrink any of the stores from this slot anymore. All shrinking for this slot is now handled by ancient append vec code.
         self.shrink_candidate_slots.lock().unwrap().remove(&slot);
 
-        Self::update_shrink_stats(
-            &self.shrink_ancient_stats.shrink_stats,
-            find_alive_elapsed_us,
-            stats_sub,
-        );
+        Self::update_shrink_stats(&self.shrink_ancient_stats.shrink_stats, stats_sub);
     }
 
     /// each slot in 'dropped_roots' has been combined into an ancient append vec.


### PR DESCRIPTION
#### Problem
over time, the shrink and ancient code has been improved. We no longer spend time reshaping the data in shrink like we used to. As a result, the metric for `find_alive_elapsed` has become unnecessary. Where we spend time is already handled by other metrics.

#### Summary of Changes
Remove metric that is not useful.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
