### PR TITLE
remove recommendations to skip validator startup tests on failure

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -405,9 +405,7 @@ impl Validator {
 
         if !config.no_os_network_stats_reporting {
             if let Err(e) = verify_net_stats_access() {
-                return Err(format!(
-                    "Failed to access Network stats: {e}. Bypass check with --no-os-network-stats-reporting.",
-                ));
+                return Err(format!("Failed to access Network stats: {e}",));
             }
         }
 
@@ -1267,8 +1265,7 @@ fn check_poh_speed(
             info!("PoH speed check: Will sleep {}ns per slot.", extra_ns);
         } else {
             return Err(format!(
-                "PoH is slower than cluster target tick rate! mine: {my_ns_per_slot} cluster: {target_ns_per_slot}. \
-                If you wish to continue, try --no-poh-speed-test",
+                "PoH is slower than cluster target tick rate! mine: {my_ns_per_slot} cluster: {target_ns_per_slot}.",
             ));
         }
     }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -486,6 +486,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("no_poh_speed_test")
                 .long("no-poh-speed-test")
+                .hidden(true)
                 .help("Skip the check for PoH speed."),
         )
         .arg(
@@ -497,21 +498,25 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("no_os_memory_stats_reporting")
                 .long("no-os-memory-stats-reporting")
+                .hidden(true)
                 .help("Disable reporting of OS memory statistics.")
         )
         .arg(
             Arg::with_name("no_os_network_stats_reporting")
                 .long("no-os-network-stats-reporting")
+                .hidden(true)
                 .help("Disable reporting of OS network statistics.")
         )
         .arg(
             Arg::with_name("no_os_cpu_stats_reporting")
                 .long("no-os-cpu-stats-reporting")
+                .hidden(true)
                 .help("Disable reporting of OS CPU statistics.")
         )
         .arg(
             Arg::with_name("no_os_disk_stats_reporting")
                 .long("no-os-disk-stats-reporting")
+                .hidden(true)
                 .help("Disable reporting of OS disk statistics.")
         )
         .arg(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1503,7 +1503,7 @@ pub fn main() {
         if SystemMonitorService::check_os_network_limits() {
             info!("OS network limits test passed.");
         } else {
-            eprintln!("OS network limit test failed. solana-sys-tuner may be used to configure OS network limits. Bypass check with --no-os-network-limits-test.");
+            eprintln!("OS network limit test failed. See: https://docs.solana.com/running-validator/validator-start#system-tuning");
             exit(1);
         }
     }


### PR DESCRIPTION
#### Problem

rampant use of various `--no-*-test` flags by validator operators creating unnecessary and difficult to debug support requests

#### Summary of Changes

remove suggestions to use them from failure logs