### PR TITLE
ci: suppress dep trees by default in `ci/do-audit.sh`

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -7,6 +7,16 @@ src_root="$(readlink -f "${here}/..")"
 
 cd "${src_root}"
 
+# `cargo-audit` doesn't give us a way to do this nicely, so hammer it is...
+dep_tree_filter="grep -Ev '│|└|├|─'"
+
+while [[ -n $1 ]]; do
+  if [[ $1 = "--display-dependency-trees" ]]; then
+    dep_tree_filter="cat"
+    shift
+  fi
+done
+
 cargo_audit_ignores=(
   # Potential segfault in the time crate
   #
@@ -19,4 +29,4 @@ cargo_audit_ignores=(
   # https://github.com/solana-labs/solana/issues/29586
   --ignore RUSTSEC-2023-0001
 )
-scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}"
+scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter


### PR DESCRIPTION
#### Problem

`cargo-audit` displays (obnoxiously long in our case) dependency trees for each flagged advisory, frequently leading to missed/or misidentified vulnerable crates.  conveniently, it offers a `--quiet` that does _not_ suppress these trees :facepalm: 

#### Summary of Changes

`grep` out the dependency trees in the `ci/do-audit.sh` wrapper by default.

introduce a `--display-dependency-trees` arg to get them back if/when needed