### PR TITLE
Cleanup tempoary pub modules

### DIFF
--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -13,7 +13,7 @@ use {
         transaction::{Transaction, TransactionError},
         transport::Result as TransportResult,
     },
-    solana_tpu_client::nonblocking::tpu_client::{temporary_pub::*, TpuClient as BackendTpuClient},
+    solana_tpu_client::nonblocking::tpu_client::{Result, TpuClient as BackendTpuClient},
     std::sync::Arc,
 };
 

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -12,7 +12,7 @@ use {
         transaction::{Transaction, TransactionError},
         transport::Result as TransportResult,
     },
-    solana_tpu_client::tpu_client::{temporary_pub::Result, TpuClient as BackendTpuClient},
+    solana_tpu_client::tpu_client::{Result, TpuClient as BackendTpuClient},
     std::sync::Arc,
 };
 pub use {

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -1,11 +1,4 @@
-#[cfg(feature = "spinner")]
-use {
-    crate::tpu_client::temporary_pub::{SEND_TRANSACTION_INTERVAL, TRANSACTION_RESEND_INTERVAL},
-    indicatif::ProgressBar,
-    solana_rpc_client::spinner,
-    solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
-    solana_sdk::{message::Message, signers::Signers, transaction::TransactionError},
-};
+pub use crate::tpu_client::Result;
 use {
     crate::tpu_client::{RecentLeaderSlots, TpuClientConfig, MAX_FANOUT_SLOTS},
     bincode::serialize,
@@ -48,37 +41,38 @@ use {
         time::{sleep, timeout, Duration, Instant},
     },
 };
+#[cfg(feature = "spinner")]
+use {
+    crate::tpu_client::{SEND_TRANSACTION_INTERVAL, TRANSACTION_RESEND_INTERVAL},
+    indicatif::ProgressBar,
+    solana_rpc_client::spinner,
+    solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
+    solana_sdk::{message::Message, signers::Signers, transaction::TransactionError},
+};
 
-pub mod temporary_pub {
-    use super::*;
-
-    pub type Result<T> = std::result::Result<T, TpuSenderError>;
-
-    #[cfg(feature = "spinner")]
-    pub fn set_message_for_confirmed_transactions(
-        progress_bar: &ProgressBar,
-        confirmed_transactions: u32,
-        total_transactions: usize,
-        block_height: Option<u64>,
-        last_valid_block_height: u64,
-        status: &str,
-    ) {
-        progress_bar.set_message(format!(
-            "{:>5.1}% | {:<40}{}",
-            confirmed_transactions as f64 * 100. / total_transactions as f64,
-            status,
-            match block_height {
-                Some(block_height) => format!(
-                    " [block height {}; re-sign in {} blocks]",
-                    block_height,
-                    last_valid_block_height.saturating_sub(block_height),
-                ),
-                None => String::new(),
-            },
-        ));
-    }
+#[cfg(feature = "spinner")]
+fn set_message_for_confirmed_transactions(
+    progress_bar: &ProgressBar,
+    confirmed_transactions: u32,
+    total_transactions: usize,
+    block_height: Option<u64>,
+    last_valid_block_height: u64,
+    status: &str,
+) {
+    progress_bar.set_message(format!(
+        "{:>5.1}% | {:<40}{}",
+        confirmed_transactions as f64 * 100. / total_transactions as f64,
+        status,
+        match block_height {
+            Some(block_height) => format!(
+                " [block height {}; re-sign in {} blocks]",
+                block_height,
+                last_valid_block_height.saturating_sub(block_height),
+            ),
+            None => String::new(),
+        },
+    ));
 }
-use temporary_pub::*;
 
 #[derive(Error, Debug)]
 pub enum TpuSenderError {

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -23,19 +23,14 @@ pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_TPU_USE_QUIC: bool = true;
 pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;
 
-pub mod temporary_pub {
-    use super::*;
+pub type Result<T> = std::result::Result<T, TpuSenderError>;
 
-    pub type Result<T> = std::result::Result<T, TpuSenderError>;
-
-    /// Send at ~100 TPS
-    #[cfg(feature = "spinner")]
-    pub const SEND_TRANSACTION_INTERVAL: Duration = Duration::from_millis(10);
-    /// Retry batch send after 4 seconds
-    #[cfg(feature = "spinner")]
-    pub const TRANSACTION_RESEND_INTERVAL: Duration = Duration::from_secs(4);
-}
-use temporary_pub::*;
+/// Send at ~100 TPS
+#[cfg(feature = "spinner")]
+pub(crate) const SEND_TRANSACTION_INTERVAL: Duration = Duration::from_millis(10);
+/// Retry batch send after 4 seconds
+#[cfg(feature = "spinner")]
+pub(crate) const TRANSACTION_RESEND_INTERVAL: Duration = Duration::from_secs(4);
 
 /// Default number of slots used to build TPU socket fanout set
 pub const DEFAULT_FANOUT_SLOTS: u64 = 12;


### PR DESCRIPTION
#### Problem

A number of temporary_pub modules in tpu_client and thin_client can now be safely removed or really made public as duplicate code is removed.

#### Summary of Changes

Remove temporary_pub code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
