### PR TITLE
typos, clippy and saturating_add_assign

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1659,7 +1659,7 @@ impl SplitAncientStorages {
     }
 
     /// create once ancient slots have been identified
-    /// This is easier to test, removing SortedStorges as a type to deal with here.
+    /// This is easier to test, removing SortedStorages as a type to deal with here.
     fn new_with_ancient_info(
         range: &Range<Slot>,
         ancient_slots: Vec<Slot>,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4024,7 +4024,6 @@ impl AccountsDb {
         self.shrink_stats.report();
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn update_shrink_stats(shrink_stats: &ShrinkStats, stats_sub: ShrinkStatsSub) {
         shrink_stats
             .num_slots_shrunk
@@ -7212,7 +7211,6 @@ impl AccountsDb {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn calculate_accounts_hash_with_verify(
         &self,
         data_source: CalcAccountsHashDataSource,

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -97,7 +97,7 @@ impl AncientSlotInfos {
                 alive_bytes,
                 should_shrink,
             });
-            self.total_alive_bytes += alive_bytes;
+            saturating_add_assign!(self.total_alive_bytes, alive_bytes);
         }
     }
 
@@ -131,10 +131,10 @@ impl AncientSlotInfos {
         // shrink enough slots to write 'percent_of_alive_shrunk_data'% of the total alive data
         // from slots that exceeded the shrink threshold.
         // The goal is to limit overall i/o in this pass while making progress.
-        let threhold_bytes = self.total_alive_bytes_shrink * percent_of_alive_shrunk_data / 100;
+        let threshold_bytes = self.total_alive_bytes_shrink * percent_of_alive_shrunk_data / 100;
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
-            if bytes_to_shrink_due_to_ratio >= threhold_bytes {
+            if bytes_to_shrink_due_to_ratio >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
                 // Mark it as false for 'should_shrink' so it gets evaluated solely based on # of files.
@@ -541,7 +541,7 @@ pub enum StorageSelector {
 /// The accounts may have to be split between 2 storages (primary and overflow) if there is not enough room in the primary storage.
 /// The 'store' functions need data stored in a slice of specific type.
 /// We need 1-2 of these slices constructed based on available bytes and individual account sizes.
-/// The slice arithmetic accross both hashes and account data gets messy. So, this struct abstracts that.
+/// The slice arithmetic across both hashes and account data gets messy. So, this struct abstracts that.
 pub struct AccountsToStore<'a> {
     accounts: &'a [&'a StoredAccountMeta<'a>],
     /// if 'accounts' contains more items than can be contained in the primary storage, then we have to split these accounts.


### PR DESCRIPTION
#### Problem

fix typos, remove unnecessary clippy allow, and saturating_add_assign

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
