### PR TITLE
Find and load missing programs in LoadedPrograms cache

### DIFF
--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -43,7 +43,7 @@ impl TransactionExecutorCache {
 
     pub fn set_tombstone(&mut self, key: Pubkey) {
         self.visible
-            .insert(key, Arc::new(LoadedProgram::new_tombstone()));
+            .insert(key, Arc::new(LoadedProgram::new_tombstone(0)));
     }
 
     pub fn set(

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -52,13 +52,13 @@ impl TransactionExecutorCache {
         executor: Arc<LoadedProgram>,
         upgrade: bool,
         delay_visibility_of_program_deployment: bool,
-        slot: Slot,
+        current_slot: Slot,
     ) {
         if upgrade {
             if delay_visibility_of_program_deployment {
                 // Place a tombstone in the cache so that
                 // we don't load the new version from the database as it should remain invisible
-                self.set_tombstone(key, slot);
+                self.set_tombstone(key, current_slot);
             } else {
                 self.visible.insert(key, executor.clone());
             }

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -41,9 +41,9 @@ impl TransactionExecutorCache {
         self.visible.get(key).cloned()
     }
 
-    pub fn set_tombstone(&mut self, key: Pubkey) {
+    pub fn set_tombstone(&mut self, key: Pubkey, slot: Slot) {
         self.visible
-            .insert(key, Arc::new(LoadedProgram::new_tombstone(0)));
+            .insert(key, Arc::new(LoadedProgram::new_tombstone(slot)));
     }
 
     pub fn set(
@@ -52,12 +52,13 @@ impl TransactionExecutorCache {
         executor: Arc<LoadedProgram>,
         upgrade: bool,
         delay_visibility_of_program_deployment: bool,
+        slot: Slot,
     ) {
         if upgrade {
             if delay_visibility_of_program_deployment {
                 // Place a tombstone in the cache so that
                 // we don't load the new version from the database as it should remain invisible
-                self.set_tombstone(key);
+                self.set_tombstone(key, slot);
             } else {
                 self.visible.insert(key, executor.clone());
             }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -219,8 +219,12 @@ pub enum LoadedProgramEntry {
 }
 
 impl LoadedPrograms {
-    /// Inserts a single entry
-    pub fn insert_entry(&mut self, key: Pubkey, entry: LoadedProgram) -> LoadedProgramEntry {
+    /// Inserts a single entry wrapped in an Arc
+    pub fn insert_entry_arc(
+        &mut self,
+        key: Pubkey,
+        entry: Arc<LoadedProgram>,
+    ) -> LoadedProgramEntry {
         let second_level = self.entries.entry(key).or_insert_with(Vec::new);
         let index = second_level
             .iter()
@@ -235,9 +239,13 @@ impl LoadedPrograms {
                 return LoadedProgramEntry::WasOccupied(existing.clone());
             }
         }
-        let new_entry = Arc::new(entry);
-        second_level.insert(index.unwrap_or(second_level.len()), new_entry.clone());
-        LoadedProgramEntry::WasVacant(new_entry)
+        second_level.insert(index.unwrap_or(second_level.len()), entry.clone());
+        LoadedProgramEntry::WasVacant(entry)
+    }
+
+    /// Inserts a single entry
+    pub fn insert_entry(&mut self, key: Pubkey, entry: LoadedProgram) -> LoadedProgramEntry {
+        self.insert_entry_arc(key, Arc::new(entry))
     }
 
     /// Before rerooting the blockstore this removes all programs of orphan forks

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -329,12 +329,12 @@ impl LoadedPrograms {
 
 #[cfg(test)]
 mod tests {
-    use solana_rbpf::vm::BuiltInProgram;
     use {
         crate::loaded_programs::{
             BlockRelation, ForkGraph, LoadedProgram, LoadedProgramEntry, LoadedProgramType,
             LoadedPrograms, WorkingSlot,
         },
+        solana_rbpf::vm::BuiltInProgram,
         solana_sdk::{clock::Slot, pubkey::Pubkey},
         std::{
             collections::HashMap,
@@ -370,9 +370,12 @@ mod tests {
         let mut cache = LoadedPrograms::default();
         let program1 = Pubkey::new_unique();
         let tombstone = cache.set_tombstone(program1, 10);
-        let second_level = &cache.entries[&program1];
+        let second_level = &cache
+            .entries
+            .get(&program1)
+            .expect("Failed to find the entry");
         assert_eq!(second_level.len(), 1);
-        assert!(second_level[0].is_tombstone());
+        assert!(second_level.get(0).unwrap().is_tombstone());
         assert_eq!(tombstone.deployment_slot, 10);
         assert_eq!(tombstone.effective_slot, 10);
 
@@ -382,25 +385,34 @@ mod tests {
             cache.insert_entry(program2, new_test_builtin_program(50, 51)),
             LoadedProgramEntry::WasVacant(_)
         ));
-        let second_level = &cache.entries[&program2];
+        let second_level = &cache
+            .entries
+            .get(&program2)
+            .expect("Failed to find the entry");
         assert_eq!(second_level.len(), 1);
-        assert!(!second_level[0].is_tombstone());
+        assert!(!second_level.get(0).unwrap().is_tombstone());
 
         let tombstone = cache.set_tombstone(program2, 60);
-        let second_level = &cache.entries[&program2];
+        let second_level = &cache
+            .entries
+            .get(&program2)
+            .expect("Failed to find the entry");
         assert_eq!(second_level.len(), 2);
-        assert!(!second_level[0].is_tombstone());
-        assert!(second_level[1].is_tombstone());
+        assert!(!second_level.get(0).unwrap().is_tombstone());
+        assert!(second_level.get(1).unwrap().is_tombstone());
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 60);
         assert_eq!(tombstone.effective_slot, 60);
 
         // Replace the program at slot 50 with a tombstone
         let tombstone = cache.set_tombstone(program2, 50);
-        let second_level = &cache.entries[&program2];
+        let second_level = &cache
+            .entries
+            .get(&program2)
+            .expect("Failed to find the entry");
         assert_eq!(second_level.len(), 2);
-        assert!(second_level[0].is_tombstone());
-        assert!(second_level[1].is_tombstone());
+        assert!(second_level.get(0).unwrap().is_tombstone());
+        assert!(second_level.get(0).unwrap().is_tombstone());
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 50);
         assert_eq!(tombstone.effective_slot, 50);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -258,6 +258,7 @@ pub fn load_program_from_account(
             loaded_program.clone(),
             false,
             feature_set.is_active(&delay_visibility_of_program_deployment::id()),
+            deployment_slot,
         );
     }
 
@@ -291,6 +292,7 @@ macro_rules! deploy_program {
             Arc::new(executor),
             true,
             delay_visibility_of_program_deployment,
+            $slot,
         );
     }};
 }
@@ -1183,10 +1185,11 @@ fn process_loader_upgradeable_instruction(
                                 .feature_set
                                 .is_active(&delay_visibility_of_program_deployment::id())
                             {
+                                let clock = invoke_context.get_sysvar_cache().get_clock()?;
                                 invoke_context
                                     .tx_executor_cache
                                     .borrow_mut()
-                                    .set_tombstone(program_key);
+                                    .set_tombstone(program_key, clock.slot);
                             }
                         }
                         _ => {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4375,7 +4375,7 @@ impl Bank {
                         .loaded_programs_cache
                         .write()
                         .unwrap()
-                        .insert_entry(*pubkey, program)
+                        .replenish(*pubkey, program)
                     {
                         LoadedProgramEntry::WasOccupied(entry) => {
                             loaded_programs_for_txs.insert(*pubkey, entry);
@@ -4393,7 +4393,7 @@ impl Bank {
                         .loaded_programs_cache
                         .write()
                         .unwrap()
-                        .set_tombstone(*pubkey, self.slot);
+                        .assign_program(*pubkey, Arc::new(LoadedProgram::new_tombstone(self.slot)));
                     loaded_programs_for_txs.insert(*pubkey, tombstone);
                 }
             });

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -94,7 +94,7 @@ use {
         compute_budget::{self, ComputeBudget},
         executor_cache::{BankExecutorCache, TransactionExecutorCache, MAX_CACHED_EXECUTORS},
         invoke_context::{BuiltinProgram, ProcessInstructionWithContext},
-        loaded_programs::{LoadedProgram, LoadedPrograms, WorkingSlot},
+        loaded_programs::{LoadedProgram, LoadedProgramEntry, LoadedPrograms, WorkingSlot},
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
@@ -105,6 +105,7 @@ use {
             AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
         },
         account_utils::StateMut,
+        bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{
             BankId, Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_HASHES_PER_TICK,
@@ -4338,6 +4339,68 @@ impl Bank {
             || self.cluster_type() != ClusterType::MainnetBeta
     }
 
+    #[allow(dead_code)] // Preparation for BankExecutorCache rework
+    fn load_and_get_programs_from_cache<'a>(
+        &self,
+        program_owners: &[&'a Pubkey],
+        sanitized_txs: &[SanitizedTransaction],
+        check_results: &mut [TransactionCheckResult],
+    ) -> (
+        HashMap<Pubkey, &'a Pubkey>,
+        HashMap<Pubkey, Arc<LoadedProgram>>,
+    ) {
+        let mut filter_programs_time = Measure::start("filter_programs_accounts");
+        let program_accounts_map = self.rc.accounts.filter_executable_program_accounts(
+            &self.ancestors,
+            sanitized_txs,
+            check_results,
+            program_owners,
+            &self.blockhash_queue.read().unwrap(),
+        );
+        filter_programs_time.stop();
+
+        let mut filter_missing_programs_time = Measure::start("filter_missing_programs_accounts");
+        let (mut loaded_programs, missing_programs) = self
+            .loaded_programs_cache
+            .read()
+            .unwrap()
+            .extract(self, program_accounts_map.keys().cloned());
+        filter_missing_programs_time.stop();
+
+        missing_programs
+            .iter()
+            .for_each(|pubkey| match self.load_program(pubkey) {
+                Ok(program) => {
+                    match self
+                        .loaded_programs_cache
+                        .write()
+                        .unwrap()
+                        .insert_entry_arc(*pubkey, program)
+                    {
+                        LoadedProgramEntry::WasOccupied(entry) => {
+                            loaded_programs.insert(*pubkey, entry);
+                        }
+                        LoadedProgramEntry::WasVacant(new_entry) => {
+                            loaded_programs.insert(*pubkey, new_entry);
+                        }
+                    }
+                }
+
+                Err(e) => {
+                    // Create a tombstone for the program in the cache??
+                    debug!("Failed to load program {}, error {:?}", pubkey, e);
+                    let tombstone = Arc::new(LoadedProgram::new_tombstone());
+                    self.loaded_programs_cache
+                        .write()
+                        .unwrap()
+                        .insert_entry_arc(*pubkey, tombstone.clone());
+                    loaded_programs.insert(*pubkey, tombstone);
+                }
+            });
+
+        (program_accounts_map, loaded_programs)
+    }
+
     #[allow(clippy::type_complexity)]
     pub fn load_and_execute_transactions(
         &self,
@@ -4399,6 +4462,24 @@ impl Bank {
             &mut error_counters,
         );
         check_time.stop();
+
+        let program_owners: Vec<Pubkey> = vec![
+            bpf_loader_upgradeable::id(),
+            bpf_loader::id(),
+            bpf_loader_deprecated::id(),
+            native_loader::id(),
+        ];
+
+        let _program_owners_refs: Vec<&Pubkey> = program_owners.iter().collect();
+        // The following code is currently commented out. This is how the new cache will
+        // finally be used, once rest of the code blocks are in place.
+        /*
+        let (program_accounts_map, loaded_programs_map) = self.load_and_get_programs_from_cache(
+            &program_owners_refs,
+            sanitized_txs,
+            &check_results,
+        );
+        */
 
         let mut load_time = Measure::start("accounts_load");
         let mut loaded_transactions = self.rc.accounts.load_accounts(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7705,10 +7705,10 @@ fn test_bank_executor_cache() {
     // do work
     let mut executors =
         TransactionExecutorCache::new((2..3).map(|i| (accounts[i].0, executor.clone())));
-    executors.set(key1, executor.clone(), false, true);
-    executors.set(key2, executor.clone(), false, true);
-    executors.set(key3, executor.clone(), true, true);
-    executors.set(key4, executor, false, true);
+    executors.set(key1, executor.clone(), false, true, bank.slot());
+    executors.set(key2, executor.clone(), false, true, bank.slot());
+    executors.set(key3, executor.clone(), true, true, bank.slot());
+    executors.set(key4, executor, false, true, bank.slot());
     let executors = Rc::new(RefCell::new(executors));
 
     // store Missing
@@ -7847,7 +7847,7 @@ fn test_bank_executor_cow() {
 
     // add one to root bank
     let mut executors = TransactionExecutorCache::default();
-    executors.set(key1, executor.clone(), false, true);
+    executors.set(key1, executor.clone(), false, true, root.slot());
     let executors = Rc::new(RefCell::new(executors));
     root.store_executors_which_added_to_the_cache(&executors);
     let executors = root.get_tx_executor_cache(accounts);
@@ -7862,7 +7862,7 @@ fn test_bank_executor_cow() {
     assert_eq!(executors.borrow().visible.len(), 1);
 
     let mut executors = TransactionExecutorCache::default();
-    executors.set(key2, executor, false, true);
+    executors.set(key2, executor, false, true, fork1.slot());
     let executors = Rc::new(RefCell::new(executors));
     fork1.store_executors_which_added_to_the_cache(&executors);
 


### PR DESCRIPTION
#### Problem
LoadedProgram cache is currently unused.

#### Summary of Changes

Find and load missing programs in LoadedPrograms cache
- filter program accounts in a transaction batch
- filter the accounts that are missing in LoadedPrograms cache
- load the programs before processing the transactions


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
