### PR TITLE
add combine_ancient_slots_packed

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4024,7 +4024,6 @@ impl AccountsDb {
         self.shrink_stats.report();
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn update_shrink_stats(shrink_stats: &ShrinkStats, stats_sub: ShrinkStatsSub) {
         shrink_stats
             .num_slots_shrunk
@@ -4288,10 +4287,17 @@ impl AccountsDb {
         }
 
         let can_randomly_shrink = true;
-        self.combine_ancient_slots(
-            self.get_sorted_potential_ancient_slots(),
-            can_randomly_shrink,
-        );
+        if matches!(self.create_ancient_storage, CreateAncientStorage::Append) {
+            self.combine_ancient_slots(
+                self.get_sorted_potential_ancient_slots(),
+                can_randomly_shrink,
+            );
+        } else {
+            self.combine_ancient_slots_new(
+                self.get_sorted_potential_ancient_slots(),
+                can_randomly_shrink,
+            );
+        }
     }
 
     #[cfg(test)]
@@ -17253,7 +17259,7 @@ pub mod tests {
         }
     }
 
-    const CAN_RANDOMLY_SHRINK_FALSE: bool = false;
+    pub(crate) const CAN_RANDOMLY_SHRINK_FALSE: bool = false;
 
     #[test]
     fn test_combine_ancient_slots_empty() {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4293,7 +4293,7 @@ impl AccountsDb {
                 can_randomly_shrink,
             );
         } else {
-            self.combine_ancient_slots_new(
+            self.combine_ancient_slots_packed(
                 self.get_sorted_potential_ancient_slots(),
                 can_randomly_shrink,
             );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -153,7 +153,7 @@ pub enum IncludeSlotInHash {
     IrrelevantAssertOnUse,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum CreateAncientStorage {
     /// ancient storages are created by appending
     #[default]
@@ -4287,7 +4287,7 @@ impl AccountsDb {
         }
 
         let can_randomly_shrink = true;
-        if matches!(self.create_ancient_storage, CreateAncientStorage::Append) {
+        if self.create_ancient_storage == CreateAncientStorage::Append {
             self.combine_ancient_slots(
                 self.get_sorted_potential_ancient_slots(),
                 can_randomly_shrink,

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -230,7 +230,12 @@ struct WriteAncientAccounts<'a> {
 
 impl AccountsDb {
     #[allow(dead_code)]
-    pub(crate) fn combine_ancient_slots_new(
+    /// Combine account data from storages in 'sorted_slots' into packed storages.
+    /// This keeps us from accumulating storages for each slot older than an epoch.
+    /// Ater this function the number of alive roots is <= # alive roots when it was called.
+    /// In practice, the # of alive roots after will be significantly less than # alive roots when called.
+    /// Trying to reduce # roots and storages (one per root) required to store all the data in ancient slots
+    pub(crate) fn combine_ancient_slots_packed(
         &self,
         sorted_slots: Vec<Slot>,
         can_randomly_shrink: bool,
@@ -248,8 +253,11 @@ impl AccountsDb {
 
         let mut stats_sub = ShrinkStatsSub::default();
 
-        let (_, total_us) =
-            measure_us!(self.combine_ancient_slots_packed(sorted_slots, tuning, &mut stats_sub));
+        let (_, total_us) = measure_us!(self.combine_ancient_slots_packed_internal(
+            sorted_slots,
+            tuning,
+            &mut stats_sub
+        ));
 
         Self::update_shrink_stats(&self.shrink_ancient_stats.shrink_stats, stats_sub);
         self.shrink_ancient_stats
@@ -263,13 +271,8 @@ impl AccountsDb {
         }
     }
 
-    /// Combine account data from storages in 'sorted_slots' into packed storages.
-    /// This keeps us from accumulating storages for each slot older than an epoch.
-    /// Ater this function the number of alive roots is <= # alive roots when it was called.
-    /// In practice, the # of alive roots after will be significantly less than # alive roots when called.
-    /// Trying to reduce # roots and storages (one per root) required to store all the data in ancient slots
     #[allow(dead_code)]
-    fn combine_ancient_slots_packed(
+    fn combine_ancient_slots_packed_internal(
         &self,
         sorted_slots: Vec<Slot>,
         tuning: PackedAncientStorageTuning,
@@ -302,7 +305,7 @@ impl AccountsDb {
 
         let write_ancient_accounts = self.write_packed_storages(&accounts_to_combine, pack);
 
-        self.finish_combine_ancient_slots_packed(
+        self.finish_combine_ancient_slots_packed_internal(
             accounts_to_combine,
             write_ancient_accounts,
             metrics,
@@ -430,7 +433,7 @@ impl AccountsDb {
     /// finish shrink operation on slots where a new storage was created
     /// drop root and storage for all original slots whose contents were combined into other storages
     #[allow(dead_code)]
-    fn finish_combine_ancient_slots_packed<'a>(
+    fn finish_combine_ancient_slots_packed_internal<'a>(
         &self,
         accounts_to_combine: AccountsToCombine<'a>,
         mut write_ancient_accounts: WriteAncientAccounts,
@@ -1163,7 +1166,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_finish_combine_ancient_slots_packed() {
+    fn test_finish_combine_ancient_slots_packed_internal() {
         // n storages
         // 1 account each
         // all accounts have 1 ref
@@ -1208,7 +1211,7 @@ pub mod tests {
                     });
                 }
 
-                db.finish_combine_ancient_slots_packed(
+                db.finish_combine_ancient_slots_packed_internal(
                     accounts_to_combine,
                     write_ancient_accounts,
                     &mut stats,
@@ -1681,7 +1684,7 @@ pub mod tests {
         let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
         let created_accounts = db.get_unique_accounts_from_storage(&storage);
 
-        db.combine_ancient_slots_new(vec![slot1], CAN_RANDOMLY_SHRINK_FALSE);
+        db.combine_ancient_slots_packed(vec![slot1], CAN_RANDOMLY_SHRINK_FALSE);
         assert!(db.storage.get_slot_storage_entry(slot1).is_some());
         let after_store = db.storage.get_slot_storage_entry(slot1).unwrap();
         let GetUniqueAccountsResult {
@@ -2474,7 +2477,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_combine_ancient_slots_packed() {
+    fn test_combine_ancient_slots_packed_internal() {
         let can_randomly_shrink = false;
         let alive = true;
         for num_slots in 0..4 {
@@ -2492,9 +2495,9 @@ pub mod tests {
                     percent_of_alive_shrunk_data: 0,
                     max_ancient_slots,
                     can_randomly_shrink,
-                    ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(), // todo
+                    ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
                 };
-                db.combine_ancient_slots_packed(
+                db.combine_ancient_slots_packed_internal(
                     (0..num_slots).map(|slot| (slot as Slot) + slot1).collect(),
                     tuning,
                     &mut ShrinkStatsSub::default(),
@@ -2506,14 +2509,8 @@ pub mod tests {
                 }
                 // any of the several slots could have been chosen to be re-used
                 let active_slots = (0..num_slots)
-                    .map(|slot| {
-                        usize::from(
-                            db.storage
-                                .get_slot_storage_entry((slot as Slot) + slot1)
-                                .is_some(),
-                        )
-                    })
-                    .sum::<usize>();
+                    .filter_map(|slot| db.storage.get_slot_storage_entry((slot as Slot) + slot1))
+                    .count();
                 let mut expected_slots = max_ancient_slots.min(num_slots);
                 if max_ancient_slots == 0 {
                     expected_slots = 1;
@@ -2580,7 +2577,7 @@ pub mod tests {
         );
 
         // combine normal append vec(s) into existing ancient append vec
-        db.combine_ancient_slots_new(
+        db.combine_ancient_slots_packed(
             (ancient_slot..=max_slot_inclusive).collect(),
             CAN_RANDOMLY_SHRINK_FALSE,
         );
@@ -2601,7 +2598,7 @@ pub mod tests {
             &get_all_accounts(&db, ancient_slot..(max_slot_inclusive + 1)),
         );
 
-        db.combine_ancient_slots_new(
+        db.combine_ancient_slots_packed(
             (next_slot..=max_slot_inclusive).collect(),
             CAN_RANDOMLY_SHRINK_FALSE,
         );
@@ -2610,47 +2607,5 @@ pub mod tests {
             &initial_accounts,
             &get_all_accounts(&db, ancient_slot..(max_slot_inclusive + 1)),
         );
-
-        /*
-        // now, shrink the second ancient append vec into the first one
-        let mut current_ancient = CurrentAncientAppendVec::new(
-            ancient_slot,
-            db.get_storage_for_slot(ancient_slot).unwrap(),
-        );
-        let mut dropped_roots = Vec::default();
-        db.combine_one_store_into_ancient(
-            next_slot,
-            &db.get_storage_for_slot(next_slot).unwrap(),
-            &mut current_ancient,
-            &mut AncientSlotPubkeys::default(),
-            &mut dropped_roots,
-        );
-        assert!(db.storage.is_empty_entry(next_slot));
-        // this removes the storages entry completely from the hashmap for 'next_slot'.
-        // Otherwise, we have a zero length vec in that hashmap
-        db.handle_dropped_roots_for_ancient(dropped_roots);
-        assert!(db.storage.get_slot_storage_entry(next_slot).is_none());
-
-        // include all the slots we put into the ancient append vec - they should contain nothing
-        compare_all_accounts(
-            &initial_accounts,
-            &get_all_accounts(&db, ancient_slot..(max_slot_inclusive + 1)),
-        );
-        // look at just the ancient append vec
-        compare_all_accounts(
-            &initial_accounts,
-            &get_all_accounts(&db, ancient_slot..(ancient_slot + 1)),
-        );
-        // make sure there is only 1 ancient append vec at the ancient slot
-        assert!(db.storage.get_slot_storage_entry(ancient_slot).is_some());
-        assert!(is_ancient(
-            &db.storage
-                .get_slot_storage_entry(ancient_slot)
-                .unwrap()
-                .accounts
-        ));
-        ((ancient_slot + 1)..=max_slot_inclusive)
-            .for_each(|slot| assert!(db.storage.get_slot_storage_entry(slot).is_none()));
-            */
     }
 }


### PR DESCRIPTION
#### Problem
Building new algorithm for packing ancient storage. Packing will occur in 1 pass across multiple ancient slots.
This will be put in 1 dead code piece at a time with tests until all pieces are present. Switch between current packing algorithm and this new one is in a validator cli argument. Resulting append vecs are correct and compatible (as a set) either way. When a new storage format optimized for cold storage becomes available, it will only work with this new packing algorithm, so the change will need to be complete prior to the new storage format.

#### Summary of Changes
finally adding top level fn `combine_ancient_slots_packed` to pack ancient storages with new algorithm.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
