### PR TITLE
Add timeout for getting bootstrap RPC peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6985,6 +6985,7 @@ dependencies = [
  "solana-vote-program",
  "spl-token-2022",
  "symlink",
+ "thiserror",
  "tikv-jemallocator",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6191,6 +6191,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "symlink",
+ "thiserror",
  "tikv-jemallocator",
 ]
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -58,6 +58,7 @@ solana-tpu-client = { path = "../tpu-client", version = "=1.16.0", default-featu
 solana-version = { path = "../version", version = "=1.16.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.16.0" }
 symlink = "0.1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 solana-account-decoder = { path = "../account-decoder", version = "=1.16.0" }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -528,18 +528,21 @@ pub fn rpc_bootstrap(
         }
 
         while vetted_rpc_nodes.is_empty() {
-            let rpc_node_details_vec = get_rpc_nodes(
+            let rpc_node_details = match get_rpc_nodes(
                 &gossip.as_ref().unwrap().0,
                 cluster_entrypoints,
                 validator_config,
                 &mut blacklisted_rpc_nodes.write().unwrap(),
                 &bootstrap_config,
-            );
-            if rpc_node_details_vec.is_empty() {
-                return;
-            }
+            ) {
+                Ok(rpc_node_details) => rpc_node_details,
+                Err(err) => {
+                    error!("Failed to get RPC nodes: {}", err);
+                    exit(1);
+                }
+            };
 
-            vetted_rpc_nodes = rpc_node_details_vec
+            vetted_rpc_nodes = rpc_node_details
                 .into_par_iter()
                 .map(|rpc_node_details| {
                     let GetRpcNodeResult {
@@ -628,7 +631,7 @@ fn get_rpc_nodes(
     validator_config: &ValidatorConfig,
     blacklisted_rpc_nodes: &mut HashSet<Pubkey>,
     bootstrap_config: &RpcBootstrapConfig,
-) -> Vec<GetRpcNodeResult> {
+) -> Result<Vec<GetRpcNodeResult>, String> {
     let mut blacklist_timeout = Instant::now();
     let mut get_rpc_peers_timout = Instant::now();
     let mut newer_cluster_snapshot_timeout = None;
@@ -649,21 +652,20 @@ fn get_rpc_nodes(
         );
         if rpc_peers.is_empty() {
             if get_rpc_peers_timout.elapsed() > GET_RPC_PEERS_TIMEOUT {
-                error!("Unable to find any RPC peers");
-                return vec![];
+                return Err("Unable to find any RPC peers".to_string());
             }
             continue;
         }
-        let rpc_peers = rpc_peers.unwrap();
+
         // Reset timeouts if we found any viable RPC peers.
         blacklist_timeout = Instant::now();
         get_rpc_peers_timout = Instant::now();
         if bootstrap_config.no_snapshot_fetch {
             let random_peer = &rpc_peers[thread_rng().gen_range(0, rpc_peers.len())];
-            return vec![GetRpcNodeResult {
+            return Ok(vec![GetRpcNodeResult {
                 rpc_contact_info: random_peer.clone(),
                 snapshot_hash: None,
-            }];
+            }]);
         }
 
         let known_validators_to_wait_for = if newer_cluster_snapshot_timeout
@@ -687,8 +689,9 @@ fn get_rpc_nodes(
                 None => newer_cluster_snapshot_timeout = Some(Instant::now()),
                 Some(newer_cluster_snapshot_timeout) => {
                     if newer_cluster_snapshot_timeout.elapsed() > NEWER_SNAPSHOT_THRESHOLD {
-                        warn!("Giving up, did not get newer snapshots from the cluster.");
-                        return vec![];
+                        return Err(
+                            "Giving up, did not get newer snapshots from the cluster.".to_string()
+                        );
                     }
                 }
             }
@@ -718,7 +721,7 @@ fn get_rpc_nodes(
                 })
                 .take(MAX_RPC_CONNECTIONS_EVALUATED_PER_ITERATION)
                 .collect();
-            return rpc_node_results;
+            return Ok(rpc_node_results);
         }
     }
 }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -547,7 +547,11 @@ pub fn rpc_bootstrap(
             ) {
                 Ok(rpc_node_details) => rpc_node_details,
                 Err(err) => {
-                    error!("Failed to get RPC nodes: {}", err);
+                    error!(
+                        "Failed to get RPC nodes: {err}. Consider checking system \
+                        clock, removing `--no-port-check`, or adjusting \
+                        `--known-validator ...` arguments as applicable"
+                    );
                     exit(1);
                 }
             };


### PR DESCRIPTION
#### Problem
We can hang indefinitely if we don't find any viable RPC peers in `get_rpc_peers`

#### Summary of Changes
1. Add a 5 minute timeout to give up searching for RPC peers
2. Return error when no peers are found instead of inferring error from empty vector
3. Rename `rpc_node_details_vec` to `rpc_node_details`