### PR TITLE
Error if cannot find peers and system clock drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6934,6 +6934,7 @@ dependencies = [
 name = "solana-validator"
 version = "1.16.0"
 dependencies = [
+ "byteorder",
  "chrono",
  "clap 2.33.3",
  "console",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6142,6 +6142,7 @@ dependencies = [
 name = "solana-validator"
 version = "1.16.0"
 dependencies = [
+ "byteorder 1.4.3",
  "chrono",
  "clap 2.33.3",
  "console",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/solana-validator"
 default-run = "solana-validator"
 
 [dependencies]
+byteorder = "1.4.3"
 chrono = { version = "0.4.22", features = ["serde"] }
 clap = "2.33.1"
 console = "0.15.0"


### PR DESCRIPTION
#### Problem
If system clock drifts far enough, Gossip messages can get dropped and bad things can happen.

#### Summary of Changes
If we are unable to connect to any RPC peers, check system clock against external server time protocol and print an error if they have diverged significantly.