### PR TITLE
test-validator: clone upgradeable programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,6 +6763,7 @@ name = "solana-test-validator"
 version = "1.16.0"
 dependencies = [
  "base64 0.13.0",
+ "bincode",
  "log",
  "serde_derive",
  "serde_json",

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
+bincode = "1.3.3"
 log = "0.4.17"
 serde_derive = "1.0.103"
 serde_json = "1.0.83"

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -248,6 +248,11 @@ fn main() {
         .map(|v| v.into_iter().collect())
         .unwrap_or_default();
 
+    let upgradeable_programs_to_clone: HashSet<_> =
+        pubkeys_of(&matches, "clone_upgradeable_program")
+            .map(|v| v.into_iter().collect())
+            .unwrap_or_default();
+
     let warp_slot = if matches.is_present("warp_slot") {
         Some(match matches.value_of("warp_slot") {
             Some(_) => value_t_or_exit!(matches, "warp_slot", Slot),
@@ -445,6 +450,18 @@ fn main() {
                 .as_ref()
                 .expect("bug: --url argument missing?"),
             true,
+        ) {
+            println!("Error: clone_accounts failed: {e}");
+            exit(1);
+        }
+    }
+
+    if !upgradeable_programs_to_clone.is_empty() {
+        if let Err(e) = genesis.clone_upgradeable_programs(
+            upgradeable_programs_to_clone,
+            cluster_rpc_client
+                .as_ref()
+                .expect("bug: --url argument missing?"),
         ) {
             println!("Error: clone_accounts failed: {e}");
             exit(1);

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2163,6 +2163,20 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 ),
         )
         .arg(
+            Arg::with_name("clone_upgradeable_program")
+                .long("clone-upgradeable-program")
+                .value_name("ADDRESS")
+                .takes_value(true)
+                .validator(is_pubkey_or_keypair)
+                .multiple(true)
+                .requires("json_rpc_url")
+                .help(
+                    "Copy an upgradeable program and its executable data from the cluster \
+                     referenced by the --url argument the genesis configuration. \
+                     If the ledger already exists then this parameter is silently ignored",
+                ),
+        )
+        .arg(
             Arg::with_name("warp_slot")
                 .required(false)
                 .long("warp-slot")


### PR DESCRIPTION
#### Problem
When cloning upgradeable programs accounts with `solana-test-validator --clone` for cpi, it is necessary to specify both the program account and the executable data account, i.e. `solana-test-validator --clone PROGRAM_ACCOUNT --clone PROGRAM_EXECUTABLE_DATA_ACCOUNT`

#### Summary of Changes
Add the flag `--clone-upgradeable-program` that finds the executable data account of a given program and clones it as well: `solana-test-validator --clone-upgradeable-program PROGRAM_ACCOUNT`