### PR TITLE
Fix transactions counts stored by SamplePerformanceService

### DIFF
--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -56,6 +56,9 @@ impl SamplePerformanceService {
             (forks.root_bank(), forks.highest_slot())
         };
 
+        // Store the absolute transaction counts to that we can compute the
+        // difference between these values at points in time to figure out
+        // how many transactions occurred in that timespan.
         let mut snapshot = SamplePerformanceSnapshot {
             num_transactions: bank.transaction_count(),
             num_non_vote_transactions: bank.non_vote_transaction_count_since_restart(),
@@ -96,9 +99,11 @@ impl SamplePerformanceService {
                     error!("write_perf_sample failed: slot {:?} {:?}", highest_slot, e);
                 }
 
+                // Same as above, store the absolute transaction counts to use
+                // as comparison for the next iteration of this loop.
                 snapshot = SamplePerformanceSnapshot {
-                    num_transactions,
-                    num_non_vote_transactions,
+                    num_transactions: bank.transaction_count(),
+                    num_non_vote_transactions: bank.non_vote_transaction_count_since_restart(),
                     highest_slot,
                 };
             }


### PR DESCRIPTION
#### Problem
A recent change to this service to store the number of non-vote transactions introduced a bug in the computation of the number of transactions during the time interval. This resulted in bogus values being stored in Blockstore and eventually getting served through RPC for the TPS chart on explorer.

#### Summary of Changes
`Bank::transaction_count()` returns the total number of transactions all time up to whatever slot that `Bank` is at. So, if we want to compute how many transactions occur in a time window (as SamplePerformanceService does), we need to call `Bank::transaction_count()` at the start and end of the time window. The number of transactions during that period is the difference in the two counts.

We had pre-existing behavior to save the total transaction count from one sample to use as comparison for our next sample. But, we introduced a bug where we started storing the number of transactions in the 60-second interval instead of the total counts from `Bank`. This led to bad math when we tried to compute the transaction count in the next interval (`snapshot.num_transactions` contained the wrong value here):
https://github.com/solana-labs/solana/blob/f4fe5500040bffbfeb6dd2199757230b695432ed/core/src/sample_performance_service.rs#L81-L83

The bug was introduced here:
https://github.com/solana-labs/solana/pull/29404/files#diff-65bb3c028302211b6b87741af7f24b648cc1e4949a3d1ef7c8e6f5ee28744b22L93-R102