### PR TITLE
Update SamplePerformanceService to use bank (root) slot to calculate elapsed slots

### DIFF
--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -51,9 +51,9 @@ impl SamplePerformanceService {
         blockstore: &Arc<Blockstore>,
         exit: Arc<AtomicBool>,
     ) {
-        let (bank, highest_slot) = {
+        let bank = {
             let forks = bank_forks.read().unwrap();
-            (forks.root_bank(), forks.highest_slot())
+            forks.root_bank()
         };
 
         // Store the absolute transaction counts to that we can compute the
@@ -62,7 +62,7 @@ impl SamplePerformanceService {
         let mut snapshot = SamplePerformanceSnapshot {
             num_transactions: bank.transaction_count(),
             num_non_vote_transactions: bank.non_vote_transaction_count_since_restart(),
-            highest_slot,
+            highest_slot: bank.slot(),
         };
 
         let mut now = Instant::now();
@@ -75,10 +75,11 @@ impl SamplePerformanceService {
 
             if elapsed.as_secs() >= SAMPLE_INTERVAL {
                 now = Instant::now();
-                let (bank, highest_slot) = {
+                let bank = {
                     let bank_forks = bank_forks.read().unwrap();
-                    (bank_forks.root_bank(), bank_forks.highest_slot())
+                    bank_forks.root_bank()
                 };
+                let highest_slot = bank.slot();
 
                 let num_slots = highest_slot.saturating_sub(snapshot.highest_slot);
                 let num_transactions = bank


### PR DESCRIPTION
#### Problem
The first implementation of the SamplePerformanceService used the `BankForks::working_bank()` (now called `BankForks::highest_slot()` to track tx counts. The impl was changed to use root banks (https://github.com/solana-labs/solana/pull/12251/commits/460cdce5e9fbc87a1b4829eaa3e1c15bd5d299cc), but the calculation for the number of elapsed slots continued to use the working_bank slot. I believe this was simply an oversight.
The result is that the `num_slots` in a sample may be inaccurate, particularly at times of high forking, since the highest_slot will advance quickly, while the root (and hence number of transactions) will not. This may not matter to any callers, but let's fix while we're in here.

#### Summary of Changes
Use root-bank slot to calculate `num_slots`
Commit 2 is a tiny refactor
Commit 3 is only renaming.
