### PR TITLE
ci: Do not produce build artifacts when run in a fork

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,9 @@ jobs:
   build_and_deploy:
     needs:
       - check
-    if: ${{ needs.check.outputs.continue == 1 }}
+    if: >
+      github.repository == 'solana-labs/solana' &&
+      needs.check.outputs.continue == 1
     # the name is used by .mergify.yml as well
     name: build & deploy docs
     runs-on: ubuntu-20.04

--- a/.github/workflows/release-artifacts-auto.yml
+++ b/.github/workflows/release-artifacts-auto.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   release-artifacts:
+    if: github.repository == 'solana-labs/solana'
     uses: ./.github/workflows/release-artifacts.yml
     with:
       commit: ${{ github.sha }}


### PR DESCRIPTION
#### Problem

My personal fork of this repo is always failing on a few specific actions, as they try to interact with the Solana Labs infrastructure that the fork does not have access to.

#### Summary of Changes

Disable these actions in forks.