### PR TITLE
Add clarifying comments to SamplePerformanceService

### DIFF
--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -66,6 +66,10 @@ impl SamplePerformanceService {
                 snapshot = new_snapshot;
 
                 let perf_sample = PerfSampleV2 {
+                    // Note: since num_slots is computed from the highest slot and not the bank
+                    // slot, this value should not be used in conjunction with num_transactions or
+                    // num_non_vote_transactions to draw any conclusions about number of
+                    // transactions per slot.
                     num_slots,
                     num_transactions,
                     num_non_vote_transactions,

--- a/docs/src/api/methods/_getRecentPerformanceSamples.mdx
+++ b/docs/src/api/methods/_getRecentPerformanceSamples.mdx
@@ -31,11 +31,11 @@ number of samples to return (maximum 720)
 An array of `RpcPerfSample<object>` with the following fields:
 
 - `slot: <u64>` - Slot in which sample was taken at
-- `numTransactions: <u64>` - Number of transactions in sample
-- `numSlots: <u64>` - Number of slots in sample
+- `numTransactions: <u64>` - Number of transactions processed during the sample period
+- `numSlots: <u64>` - Number of slots completed during the sample period
 - `samplePeriodSecs: <u16>` - Number of seconds in a sample window
-- `numNonVoteTransaction: <u64>` - Number of non-vote transactions in
-  sample.
+- `numNonVoteTransaction: <u64>` - Number of non-vote transactions processed during the
+  sample period.
 
 :::info
 `numNonVoteTransaction` is present starting with v1.15.


### PR DESCRIPTION
#### Problem
It's not immediately obvious why we're querying `BankForks::highest_slot()` in SamplePerformanceService, instead of using the same bank slot that we query for transaction counts.

#### Summary of Changes
Add comments to SamplePerformanceService
Also update jsonrpc docs to be more correct.
