### PR TITLE
hide commonly misused `--no-port-check` validator arg

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -431,12 +431,6 @@ solana-validator ..."); otherwise, when logrotate sends its signal to the
 validator, the enclosing script will die and take the validator process with
 it.
 
-### Disable port checks to speed up restarts
-
-Once your validator is operating normally, you can reduce the time it takes to
-restart your validator by adding the `--no-port-check` flag to your
-`solana-validator` command-line.
-
 ### Using a ramdisk with spill-over into swap for the accounts database to reduce SSD wear
 
 If your machine has plenty of RAM, a tmpfs ramdisk

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -195,6 +195,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("no_port_check")
                 .long("no-port-check")
                 .takes_value(false)
+                .hidden(true)
                 .help("Do not perform TCP/UDP reachable port checks at start-up")
         )
         .arg(


### PR DESCRIPTION
#### Problem

followup to #30250. missed the worst one due to #30303 :facepalm: 

#### Summary of Changes

hide `--no-port-check`