### PR TITLE
Improve cli args parsing in bench-tps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,6 +4926,7 @@ dependencies = [
  "solana-tpu-client",
  "solana-version",
  "spl-instruction-padding",
+ "tempfile",
  "thiserror",
 ]
 

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = { workspace = true }
 serial_test = { workspace = true }
 solana-local-cluster = { workspace = true }
 solana-test-validator = { workspace = true }
+tempfile = "3.3.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -593,6 +593,10 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 }
 
 mod tests {
+    // without it make_tmp_path is claimed to be dead
+    #![allow(dead_code)]
+    // without it read_keypair_file, write_keypair_file are claimed to be unused
+    #![allow(unused_imports)]
     use {
         super::*,
         solana_sdk::signature::{read_keypair_file, write_keypair_file, Keypair, Signer},

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -17,7 +17,7 @@ use {
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum ExternalClientType {
     // Submits transactions to an Rpc node using an RpcClient
     RpcClient,
@@ -35,7 +35,7 @@ impl Default for ExternalClientType {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct InstructionPaddingConfig {
     pub program_id: Pubkey,
     pub data_size: u32,
@@ -73,6 +73,8 @@ pub struct Config {
     pub bind_address: IpAddr,
     pub client_node_id: Option<Keypair>,
 }
+
+impl Eq for Config {}
 
 impl Default for Config {
     fn default() -> Config {
@@ -426,7 +428,7 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
         args.tpu_connection_pool_size = v
             .to_string()
             .parse::<usize>()
-            .map_err(|_| "can't parse tpu_connection_pool_size")?;
+            .map_err(|_| "can't parse tpu-connection-pool-size")?;
     }
 
     if let Some(addr) = matches.value_of("entrypoint") {
@@ -485,8 +487,10 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
     }
 
     if let Some(v) = matches.value_of("target_lamports_per_signature") {
-        args.target_lamports_per_signature =
-            v.to_string().parse().map_err(|_| "can't parse lamports")?;
+        args.target_lamports_per_signature = v
+            .to_string()
+            .parse()
+            .map_err(|_| "can't parse target-lamports-per-signature")?;
     }
 
     args.multi_client = !matches.is_present("no-multi-client");
@@ -552,7 +556,7 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 #[cfg(test)]
 mod tests {
     use {
-        crate::cli::{build_args, parse_args, Config, ExternalClientType},
+        super::*,
         solana_sdk::signature::{read_keypair_file, write_keypair_file, Keypair, Signer},
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -520,13 +520,12 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
             .value_of("instruction_padding_program_id")
             .map(|target_str| target_str.parse().unwrap())
             .unwrap_or_else(|| FromOtherSolana::from(spl_instruction_padding::ID));
-        let parsed_data_size = data_size
-            .to_string()
+        let data_size = data_size
             .parse()
             .map_err(|_| "Can't parse padded instruction data size")?;
         args.instruction_padding_config = Some(InstructionPaddingConfig {
             program_id,
-            data_size: parsed_data_size,
+            data_size,
         });
     }
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -496,18 +496,22 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
     args.multi_client = !matches.is_present("no-multi-client");
     args.target_node = matches
         .value_of("target_node")
-        .map(|target_str| target_str.parse::<Pubkey>().unwrap());
+        .map(|target_str| target_str.parse::<Pubkey>())
+        .transpose()
+        .map_err(|_| "Failed to parse target-node")?;
 
     if let Some(v) = matches.value_of("num_lamports_per_account") {
-        args.num_lamports_per_account =
-            v.to_string().parse().map_err(|_| "can't parse lamports")?;
+        args.num_lamports_per_account = v
+            .to_string()
+            .parse()
+            .map_err(|_| "can't parse num-lamports-per-account")?;
     }
 
     if let Some(t) = matches.value_of("target_slots_per_epoch") {
         args.target_slots_per_epoch = t
             .to_string()
             .parse()
-            .map_err(|_| "can't parse target slots per epoch")?;
+            .map_err(|_| "can't parse target-slots-per-epoch")?;
     }
 
     if matches.is_present("use_randomized_compute_unit_price") {
@@ -535,13 +539,13 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
     if let Some(num_conflict_groups) = matches.value_of("num_conflict_groups") {
         let parsed_num_conflict_groups = num_conflict_groups
             .parse()
-            .map_err(|_| "Can't parse conflict groups")?;
+            .map_err(|_| "Can't parse num-conflict-groups")?;
         args.num_conflict_groups = Some(parsed_num_conflict_groups);
     }
 
     if let Some(addr) = matches.value_of("bind_address") {
         args.bind_address =
-            solana_net_utils::parse_host(addr).map_err(|_| "Failed to parse bind_address")?;
+            solana_net_utils::parse_host(addr).map_err(|_| "Failed to parse bind-address")?;
     }
 
     if let Some(client_node_id_filename) = matches.value_of("client_node_id") {

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -563,28 +563,19 @@ mod tests {
             net::{Ipv4Addr, SocketAddr},
             time::Duration,
         },
+        tempfile::tempdir,
     };
-
-    fn make_tmp_path(name: &str) -> String {
-        let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
-        let keypair = Keypair::new();
-
-        let path = format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey());
-
-        // whack any possible collision
-        let _ = std::fs::remove_dir_all(&path);
-        // whack any possible collision
-        let _ = std::fs::remove_file(&path);
-
-        path
-    }
 
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_cli_parse() {
         // always specify identity in these tests because otherwise a random one will be used
         let keypair = Keypair::new();
-        let keypair_file_name = make_tmp_path("keypair_file");
+        let out_dir = tempdir().unwrap();
+        let file_path = out_dir
+            .path()
+            .join(format!("keypair_file-{}", keypair.pubkey()));
+        let keypair_file_name = file_path.into_os_string().into_string().unwrap();
         write_keypair_file(&keypair, &keypair_file_name).unwrap();
 
         // parse provided rpc address, check that default ws address is correct

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -215,7 +215,12 @@ fn main() {
     solana_metrics::set_panic_hook("bench-tps", /*version:*/ None);
 
     let matches = cli::build_args(solana_version::version!()).get_matches();
-    let cli_config = cli::extract_args(&matches);
+    let cli_config = cli::parse_args(&matches);
+    if let Err(error) = cli_config {
+        eprintln!("{error}");
+        exit(1);
+    }
+    let cli_config = cli_config.unwrap();
 
     let cli::Config {
         entrypoint_addr,

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -69,7 +69,7 @@ fn find_node_activated_stake(
     match find_result {
         Some(value) => Ok((value.activated_stake, total_active_stake)),
         None => {
-            error!("failed to find stake for requested node");
+            error!("Failed to find stake for requested node");
             Err(())
         }
     }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -215,12 +215,13 @@ fn main() {
     solana_metrics::set_panic_hook("bench-tps", /*version:*/ None);
 
     let matches = cli::build_args(solana_version::version!()).get_matches();
-    let cli_config = cli::parse_args(&matches);
-    if let Err(error) = cli_config {
-        eprintln!("{error}");
-        exit(1);
-    }
-    let cli_config = cli_config.unwrap();
+    let cli_config = match cli::parse_args(&matches) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("{error}");
+            exit(1);
+        }
+    };
 
     let cli::Config {
         entrypoint_addr,


### PR DESCRIPTION
#### Problem

Parsing cli args is different from other places (due to exit, panic, println), it also makes it more difficult to test.
Added a basic unit test for cli.
This is preliminary work to migrate it to clap-v3, most of the things will be rewritten during migration to clap-v3

#### Summary of Changes

* Rename parse function
* Get rid of panics, exit and println
* Add basic unit tests

