### PR TITLE
ci: group check steps into an individual queue

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -114,7 +114,7 @@ command_step() {
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:
-      queue: "solana"
+      queue: ${4:-solana}
 EOF
 }
 
@@ -139,7 +139,7 @@ wait_step() {
 }
 
 all_test_steps() {
-  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20 check
   wait_step
 
   # Coverage...
@@ -308,12 +308,12 @@ EOF
 }
 
 pull_or_push_steps() {
-  command_step sanity "ci/test-sanity.sh" 5
+  command_step sanity "ci/test-sanity.sh" 5 check
   wait_step
 
   # Check for any .sh file changes
   if affects .sh$; then
-    command_step shellcheck "ci/shellcheck.sh" 5
+    command_step shellcheck "ci/shellcheck.sh" 5 check
     wait_step
   fi
 

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -114,7 +114,7 @@ command_step() {
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:
-      queue: ${4:-solana}
+      queue: "${4:-solana}"
 EOF
 }
 


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1074785045107196066

#### Summary of Changes

made these steps run on bk agent which queue is `check` (has already set up them on bk)

- sanity (about 15s)
- shellcheck (about 19 s)
- checks (about 5~7 mins)

