### PR TITLE
Scope SamplePerformanceService Bank only for initial sample snapshot

### DIFF
--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -52,10 +52,9 @@ impl SamplePerformanceService {
         exit: Arc<AtomicBool>,
     ) {
         let mut snapshot = {
-            let (bank, highest_slot) = {
-                let forks = bank_forks.read().unwrap();
-                (forks.root_bank(), forks.highest_slot())
-            };
+            let forks = bank_forks.read().unwrap();
+            let bank = forks.root_bank();
+            let highest_slot = forks.highest_slot();
 
             // Store the absolute transaction counts to that we can compute the
             // difference between these values at points in time to figure out

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -51,18 +51,20 @@ impl SamplePerformanceService {
         blockstore: &Arc<Blockstore>,
         exit: Arc<AtomicBool>,
     ) {
-        let (bank, highest_slot) = {
-            let forks = bank_forks.read().unwrap();
-            (forks.root_bank(), forks.highest_slot())
-        };
+        let mut snapshot = {
+            let (bank, highest_slot) = {
+                let forks = bank_forks.read().unwrap();
+                (forks.root_bank(), forks.highest_slot())
+            };
 
-        // Store the absolute transaction counts to that we can compute the
-        // difference between these values at points in time to figure out
-        // how many transactions occurred in that timespan.
-        let mut snapshot = SamplePerformanceSnapshot {
-            num_transactions: bank.transaction_count(),
-            num_non_vote_transactions: bank.non_vote_transaction_count_since_restart(),
-            highest_slot,
+            // Store the absolute transaction counts to that we can compute the
+            // difference between these values at points in time to figure out
+            // how many transactions occurred in that timespan.
+            SamplePerformanceSnapshot {
+                num_transactions: bank.transaction_count(),
+                num_non_vote_transactions: bank.non_vote_transaction_count_since_restart(),
+                highest_slot,
+            }
         };
 
         let mut now = Instant::now();


### PR DESCRIPTION
#### Problem
The initial Bank reference in the SamplePerformanceService is held for the life of the service, even though it's only used to query some sample-snapshot data at boot.

#### Summary of Changes
Only hold the Bank reference while generating the initial sample snapshot.
https://github.com/solana-labs/solana/pull/30297 will also fix this issue, but this is a more lightweight change to consider for backporting. Wdyt @steviez ?

Fixes #30312
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
