### PR TITLE
metrics: datapoint macro: Allow trailing comma

### DIFF
--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -125,7 +125,7 @@ macro_rules! create_datapoint {
         $crate::create_datapoint!(@tag $point $tag_name, $tag_value);
         $crate::create_datapoint!(@fields $point $($rest)*);
     };
-    (@fields $point:ident $tag_name:expr => $tag_value:expr) => {
+    (@fields $point:ident $tag_name:expr => $tag_value:expr $(,)?) => {
         $crate::create_datapoint!(@tag $point $tag_name, $tag_value);
     };
 
@@ -134,7 +134,7 @@ macro_rules! create_datapoint {
         $crate::create_datapoint!(@field $point $name, $value, $type);
         $crate::create_datapoint!(@fields $point $($rest)*);
     };
-    (@fields $point:ident ($name:expr, $value:expr, $type:ident)) => {
+    (@fields $point:ident ($name:expr, $value:expr, $type:ident) $(,)?) => {
         $crate::create_datapoint!(@field $point $name, $value, $type);
     };
 
@@ -145,14 +145,14 @@ macro_rules! create_datapoint {
             point
         }
     };
-    (@point $name:expr) => {
+    (@point $name:expr $(,)?) => {
         $crate::datapoint::DataPoint::new(&$name)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint {
-    ($level:expr, $name:expr) => {
+    ($level:expr, $name:expr $(,)?) => {
         if log::log_enabled!($level) {
             $crate::submit($crate::create_datapoint!(@point $name), $level);
         }
@@ -165,7 +165,7 @@ macro_rules! datapoint {
 }
 #[macro_export]
 macro_rules! datapoint_error {
-    ($name:expr) => {
+    ($name:expr $(,)?) => {
         $crate::datapoint!(log::Level::Error, $name);
     };
     ($name:expr, $($fields:tt)+) => {
@@ -175,7 +175,7 @@ macro_rules! datapoint_error {
 
 #[macro_export]
 macro_rules! datapoint_warn {
-    ($name:expr) => {
+    ($name:expr $(,)?) => {
         $crate::datapoint!(log::Level::Warn, $name);
     };
     ($name:expr, $($fields:tt)+) => {


### PR DESCRIPTION
#### Problem

When I write a macro that calls one of the `datapoint` macros inside, I need to special case it, due to the `datapoint` macros not allowing trailing commas.

Rust grammar allows trailing commas in most places where a list of elements is accepted.  It simplifies cases when the list is generated by a macro, allowing the macro to avoid special cases for a one element list vs longer lists.

As such, it is a common practice to allow trailing commas in macros as well.

#### Summary of Changes

Accept and ignore a single trailing comma in all macro calls.