### PR TITLE
Simplify some comparisons using (a1, a2).cmp(&(b1, b2))

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -559,11 +559,7 @@ impl fmt::Display for CliValidators {
             }
             CliValidatorsSortOrder::Version => {
                 sorted_validators.sort_by(|a, b| {
-                    use std::cmp::Ordering;
-                    match a.version.cmp(&b.version) {
-                        Ordering::Equal => a.activated_stake.cmp(&b.activated_stake),
-                        ordering => ordering,
-                    }
+                    (&a.version, a.activated_stake).cmp(&(&b.version, b.activated_stake))
                 });
             }
         }

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -93,10 +93,7 @@ impl PartialOrd for CliFeature {
 
 impl Ord for CliFeature {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.status.cmp(&other.status) {
-            Ordering::Equal => self.id.cmp(&other.id),
-            ordering => ordering,
-        }
+        (&self.status, &self.id).cmp(&(&other.status, &other.id))
     }
 }
 


### PR DESCRIPTION
#### Problem
None, just code cleanup.

#### Summary of Changes
Small code cleanup change using `.cmp`.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
