### PR TITLE
Rewrite accumulate_execute_units_and_time without allocation

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -662,18 +662,15 @@ impl Consumer {
     }
 
     fn accumulate_execute_units_and_time(execute_timings: &ExecuteTimings) -> (u64, u64) {
-        let (units, times): (Vec<_>, Vec<_>) = execute_timings
-            .details
-            .per_program_timings
-            .values()
-            .map(|program_timings| {
+        execute_timings.details.per_program_timings.values().fold(
+            (0, 0),
+            |(units, times), program_timings| {
                 (
-                    program_timings.accumulated_units,
-                    program_timings.accumulated_us,
+                    units + program_timings.accumulated_units,
+                    times + program_timings.accumulated_us,
                 )
-            })
-            .unzip();
-        (units.iter().sum(), times.iter().sum())
+            },
+        )
     }
 
     /// This function filters pending packets that are still valid


### PR DESCRIPTION
#### Problem
Noticed this was needlessly allocating when doing #30253 but thought it was separate enough to justify a separate PR.

#### Summary of Changes
Rewrite of `accumulate_execute_units_and_time` to accumulate without allocating temporary vectors.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
