### PR TITLE
measure_us! use Instant and duration_to_us internally

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -3,7 +3,7 @@ use {
     solana_ledger::{
         blockstore_processor::TransactionStatusSender, token_balances::collect_token_balances,
     },
-    solana_measure::{measure, measure_us},
+    solana_measure::measure_us,
     solana_runtime::{
         accounts::TransactionLoadResult,
         bank::{

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -9,7 +9,7 @@ use {
         unprocessed_transaction_storage::UnprocessedTransactionStorage,
     },
     crossbeam_channel::RecvTimeoutError,
-    solana_measure::{measure, measure::Measure, measure_us},
+    solana_measure::{measure::Measure, measure_us},
     solana_sdk::{saturating_add_assign, timing::timestamp},
     std::{sync::atomic::Ordering, time::Duration},
 };

--- a/measure/src/macros.rs
+++ b/measure/src/macros.rs
@@ -83,8 +83,9 @@ macro_rules! measure {
 #[macro_export]
 macro_rules! measure_us {
     ($val:expr) => {{
-        let (result, measure) = measure!($val);
-        (result, measure.as_us())
+        let start = std::time::Instant::now();
+        let result = $val;
+        (result, solana_sdk::timing::duration_as_us(&start.elapsed()))
     }};
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -68,7 +68,7 @@ use {
     rand::{thread_rng, Rng},
     rayon::{prelude::*, ThreadPool},
     serde::{Deserialize, Serialize},
-    solana_measure::{measure, measure::Measure, measure_us},
+    solana_measure::{measure::Measure, measure_us},
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -17,7 +17,7 @@ use {
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
     },
     rand::{thread_rng, Rng},
-    solana_measure::{measure, measure_us},
+    solana_measure::measure_us,
     solana_sdk::{account::ReadableAccount, clock::Slot, hash::Hash, saturating_add_assign},
     std::{
         collections::HashMap,


### PR DESCRIPTION
#### Problem
Unlikely to have significant impact, but this is slightly more efficient way of doing `measure_us`. 

measure_us! was using a `Measure` internally:

Flow in the current macro:
1. Create `std::time::Instant` (in `Measure::start`)
2. Do $val (what we're measuring)
3. Store `duration: u64` on `Measure` from `duration_as_ns(&self.start.elapsed())`
4. Return result and `duration / 1000`

#### Summary of Changes
Micro-optimizations:
Just directly calculate the `us` from duration using `duration_as_us`. Can skip the `ns` store and extra division. Also bypass the `Measure` struct which holds a `&str`.

More specific namespacing also lets me get rid of now unused imports of `measure!`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
