### PR TITLE
Fixes race in local cluster incremental snapshot test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1054,6 +1054,11 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     };
     info!("leader full snapshot archive for comparison: {leader_full_snapshot_archive_for_comparison:#?}");
 
+    // Stop the validator before we reset its snapshots
+    info!("Stopping the validator...");
+    let validator_info = cluster.exit_node(&validator_identity.pubkey());
+    info!("Stopping the validator... DONE");
+
     info!("Delete all the snapshots on the validator and restore the originals from the backup...");
     delete_files_with_remote(
         validator_snapshot_test_config
@@ -1093,15 +1098,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     info!(
         "Restarting the validator with full snapshot {validator_full_snapshot_slot_at_startup}..."
     );
-
-    // Stop the test validator
-    let validator_info = cluster.exit_node(&validator_identity.pubkey());
-
     // To restart, it is not enough to remove the old bank snapshot directories under snapshot/.
     // The old hardlinks under <account_path>/snapshot/<slot> should also be removed.
     // The purge call covers all of them.
     snapshot_utils::purge_old_bank_snapshots(validator_snapshot_test_config.bank_snapshots_dir, 0);
-
     cluster.restart_node(
         &validator_identity.pubkey(),
         validator_info,


### PR DESCRIPTION
#### Problem

`test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup` has a race where files are deleted out from under a running validator. If that validator is in the middle of archiving a snapshot, it will panic. 

The validator doesn't need to be running when the files are being deleted, but currently it is. 


#### Summary of Changes

Stop the validator before we delete the snapshot files.


Fixes #30291