### PR TITLE
restore timestamp() in find_missing_indexes

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -114,7 +114,6 @@ pub fn get_closest_completion(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
-    now_timestamp: u64,
 ) -> Vec<ShredRepairType> {
     let mut v: Vec<(Slot, u64)> = Vec::default();
     let iter = GenericTraversal::new(tree);
@@ -188,7 +187,6 @@ pub fn get_closest_completion(
                 slot,
                 slot_meta,
                 limit - repairs.len(),
-                now_timestamp,
             );
             repairs.extend(new_repairs);
         }
@@ -201,9 +199,9 @@ pub fn get_closest_completion(
 pub mod test {
     use {
         super::*,
-        crate::repair_service::post_shred_deferment_timestamp,
+        crate::repair_service::sleep_shred_deferment_period,
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
-        solana_sdk::{hash::Hash, timing::timestamp},
+        solana_sdk::hash::Hash,
         trees::{tr, Tree, TreeWalk},
     };
 
@@ -240,7 +238,6 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             10,
-            timestamp(),
         );
         assert_eq!(repairs, []);
 
@@ -258,13 +255,13 @@ pub mod test {
         let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
+        sleep_shred_deferment_period();
         let repairs = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut processed_slots,
             2,
-            post_shred_deferment_timestamp(),
         );
         assert_eq!(
             repairs,

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -157,7 +157,6 @@ impl RepairWeight {
         max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
         ignore_slots: &impl Contains<'a, Slot>,
-        now_timestamp: u64,
         repair_timing: &mut RepairTiming,
         stats: &mut BestRepairsStats,
     ) -> Vec<ShredRepairType> {
@@ -188,7 +187,6 @@ impl RepairWeight {
             &mut best_shreds_repairs,
             max_new_shreds,
             ignore_slots,
-            now_timestamp,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
         let repair_slots_set: HashSet<Slot> =
@@ -223,7 +221,6 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut processed_slots,
             max_closest_completion_repairs,
-            now_timestamp,
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
         let num_closest_completion_slots = processed_slots.len() - pre_num_slots;
@@ -353,7 +350,6 @@ impl RepairWeight {
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
         ignore_slots: &impl Contains<'a, Slot>,
-        now_timestamp: u64,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
         repair_weighted_traversal::get_best_repair_shreds(
@@ -363,7 +359,6 @@ impl RepairWeight {
             repairs,
             max_new_shreds,
             ignore_slots,
-            now_timestamp,
         );
     }
 
@@ -472,7 +467,6 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
-        now_timestamp: u64,
     ) -> Vec<ShredRepairType> {
         let mut repairs = Vec::default();
         for (_slot, tree) in self.trees.iter() {
@@ -485,7 +479,6 @@ impl RepairWeight {
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),
-                now_timestamp,
             );
             repairs.extend(new_repairs);
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1801,7 +1801,6 @@ impl Blockstore {
     fn find_missing_indexes<C>(
         db_iterator: &mut DBRawIterator,
         slot: Slot,
-        now_timestamp: u64,
         first_timestamp: u64,
         defer_threshold_ticks: u64,
         start_index: u64,
@@ -1816,8 +1815,9 @@ impl Blockstore {
         }
 
         let mut missing_indexes = vec![];
+        // System time is not monotonic
         let ticks_since_first_insert =
-            DEFAULT_TICKS_PER_SECOND * (now_timestamp - first_timestamp) / 1000;
+            DEFAULT_TICKS_PER_SECOND * timestamp().saturating_sub(first_timestamp) / 1000;
 
         // Seek to the first shred with index >= start_index
         db_iterator.seek(&C::key((slot, start_index)));
@@ -1877,7 +1877,6 @@ impl Blockstore {
     pub fn find_missing_data_indexes(
         &self,
         slot: Slot,
-        now_timestamp: u64,
         first_timestamp: u64,
         defer_threshold_ticks: u64,
         start_index: u64,
@@ -1891,7 +1890,6 @@ impl Blockstore {
             Self::find_missing_indexes::<cf::ShredData>(
                 &mut db_iterator,
                 slot,
-                now_timestamp,
                 first_timestamp,
                 defer_threshold_ticks,
                 start_index,
@@ -5916,7 +5914,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,            // first_timestamp
                 0,            // defer_threshold_ticks
                 0,            // start_index
@@ -5928,7 +5925,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,                  // first_timestamp
                 0,                  // defer_threshold_ticks
                 1,                  // start_index
@@ -5940,7 +5936,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,                  // first_timestmap
                 0,                  // defer_threshold_ticks
                 0,                  // start_index
@@ -5952,7 +5947,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,            // first_timestmap
                 0,            // defer_threshold_ticks
                 gap - 2,      // start_index
@@ -5964,7 +5958,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,       // first_timestamp
                 0,       // defer_threshold_ticks
                 gap - 2, // start_index
@@ -5975,9 +5968,7 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0,   // first_timestamp
+                slot, 0,   // first_timestamp
                 0,   // defer_threshold_ticks
                 0,   // start_index
                 gap, // end_index
@@ -5993,7 +5984,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,                  // first_timestamp
                 0,                  // defer_threshold_ticks
                 0,                  // start_index
@@ -6005,7 +5995,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 0,                  // first_timestamp
                 0,                  // defer_threshold_ticks
                 0,                  // start_index
@@ -6027,7 +6016,6 @@ pub mod tests {
                 assert_eq!(
                     blockstore.find_missing_data_indexes(
                         slot,
-                        timestamp(),
                         0,                        // first_timestamp
                         0,                        // defer_threshold_ticks
                         j * gap,                  // start_index
@@ -6068,7 +6056,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 timestamp(), // first_timestamp
                 0,           // defer_threshold_ticks
                 0,           // start_index
@@ -6081,7 +6068,6 @@ pub mod tests {
         assert_eq!(
             blockstore.find_missing_data_indexes(
                 slot,
-                timestamp(),
                 timestamp() - 400, // first_timestamp
                 0,                 // defer_threshold_ticks
                 0,                 // start_index
@@ -6103,9 +6089,7 @@ pub mod tests {
         let empty: Vec<u64> = vec![];
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0, // first_timestamp
+                slot, 0, // first_timestamp
                 0, // defer_threshold_ticks
                 0, // start_index
                 0, // end_index
@@ -6115,9 +6099,7 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0, // first_timestamp
+                slot, 0, // first_timestamp
                 0, // defer_threshold_ticks
                 5, // start_index
                 5, // end_index
@@ -6127,9 +6109,7 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0, // first_timestamp
+                slot, 0, // first_timestamp
                 0, // defer_threshold_ticks
                 4, // start_index
                 3, // end_index
@@ -6139,9 +6119,7 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0, // first_timestamp
+                slot, 0, // first_timestamp
                 0, // defer_threshold_ticks
                 1, // start_index
                 2, // end_index
@@ -6173,9 +6151,7 @@ pub mod tests {
         // [i, first_index - 1]
         for start in 0..STARTS {
             let result = blockstore.find_missing_data_indexes(
-                slot,
-                timestamp(),
-                0,     // first_timestamp
+                slot, 0,     // first_timestamp
                 0,     // defer_threshold_ticks
                 start, // start_index
                 END,   // end_index
@@ -6207,7 +6183,6 @@ pub mod tests {
                 assert_eq!(
                     blockstore.find_missing_data_indexes(
                         slot,
-                        timestamp(),
                         0,                // first_timestamp
                         0,                // defer_threshold_ticks
                         j,                // start_index

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5957,7 +5957,7 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot,
+                slot,    // slot
                 0,       // first_timestamp
                 0,       // defer_threshold_ticks
                 gap - 2, // start_index
@@ -5968,11 +5968,12 @@ pub mod tests {
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot, 0,   // first_timestamp
-                0,   // defer_threshold_ticks
-                0,   // start_index
-                gap, // end_index
-                1,   // max_missing
+                slot, // slot
+                0,    // first_timestamp
+                0,    // defer_threshold_ticks
+                0,    // start_index
+                gap,  // end_index
+                1,    // max_missing
             ),
             vec![1],
         );
@@ -6089,41 +6090,45 @@ pub mod tests {
         let empty: Vec<u64> = vec![];
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot, 0, // first_timestamp
-                0, // defer_threshold_ticks
-                0, // start_index
-                0, // end_index
-                1, // max_missing
+                slot, // slot
+                0,    // first_timestamp
+                0,    // defer_threshold_ticks
+                0,    // start_index
+                0,    // end_index
+                1,    // max_missing
             ),
             empty
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot, 0, // first_timestamp
-                0, // defer_threshold_ticks
-                5, // start_index
-                5, // end_index
-                1, // max_missing
+                slot, // slot
+                0,    // first_timestamp
+                0,    // defer_threshold_ticks
+                5,    // start_index
+                5,    // end_index
+                1,    // max_missing
             ),
             empty
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot, 0, // first_timestamp
-                0, // defer_threshold_ticks
-                4, // start_index
-                3, // end_index
-                1, // max_missing
+                slot, // slot
+                0,    // first_timestamp
+                0,    // defer_threshold_ticks
+                4,    // start_index
+                3,    // end_index
+                1,    // max_missing
             ),
             empty
         );
         assert_eq!(
             blockstore.find_missing_data_indexes(
-                slot, 0, // first_timestamp
-                0, // defer_threshold_ticks
-                1, // start_index
-                2, // end_index
-                0, // max_missing
+                slot, // slot
+                0,    // first_timestamp
+                0,    // defer_threshold_ticks
+                1,    // start_index
+                2,    // end_index
+                0,    // max_missing
             ),
             empty
         );
@@ -6151,7 +6156,8 @@ pub mod tests {
         // [i, first_index - 1]
         for start in 0..STARTS {
             let result = blockstore.find_missing_data_indexes(
-                slot, 0,     // first_timestamp
+                slot,  // slot
+                0,     // first_timestamp
                 0,     // defer_threshold_ticks
                 start, // start_index
                 END,   // end_index


### PR DESCRIPTION
#### Problem
- race between timestamp passed to `get_best_weighted_repairs` and newly inserted shred `first_shred_timestamp`
- `find_missing_indexes` timestamp calculation should use `saturating_sub`

#### Summary of Changes
restore `timestamp()` call to `find_missing_indexes` and use saturating math.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
