### PR TITLE
docs: fix order of positional `start_slot` and `end_slot` in `getBlocks` API docs

### DIFF
--- a/docs/src/api/methods/_getBlocks.mdx
+++ b/docs/src/api/methods/_getBlocks.mdx
@@ -21,11 +21,11 @@ Returns a list of confirmed blocks between two slots
 ### Parameters:
 
 <Parameter type={"u64"} required={true}>
-  end_slot, as <code>u64</code> integer
+  start_slot, as <code>u64</code> integer
 </Parameter>
 
 <Parameter type={"u64"} optional={true}>
-  start_slot, as <code>u64</code> integer (must be no more than 500,000 blocks
+  end_slot, as <code>u64</code> integer (must be no more than 500,000 blocks
   higher than the `start_slot`)
 </Parameter>
 


### PR DESCRIPTION
#### Problem

I'm pretty sure these are backwards.

#### Summary of Changes

Note, in the docs, that `start_slot` comes first and `end_slot` (optionally) comes next.