### PR TITLE
Fix the return type of AccountsFile::account_matches_owners()

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -74,7 +74,7 @@ impl AccountsFile {
         &self,
         offset: usize,
         owners: &[&Pubkey],
-    ) -> Result<(), MatchAccountOwnerError> {
+    ) -> Result<usize, MatchAccountOwnerError> {
         match self {
             Self::AppendVec(av) => av.account_matches_owners(offset, owners),
         }


### PR DESCRIPTION
#### Problem
The API conflict wasn't detected in the auto-merge.

#### Summary of Changes
Fix the AccountsFile::account_matches_owners() to include the matched index
