### PR TITLE
ci: don't print 'Checking PACKAGE_NAME...' when do cargo sorting check

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -81,7 +81,13 @@ nightly_clippy_allows=()
    --deny=clippy::integer_arithmetic \
    "${nightly_clippy_allows[@]}"
 
-_ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" sort --workspace --check
+if [[ -n $CI ]]; then
+  # exclude from printing "Checking xxx ..."
+  _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" sort --workspace --check > /dev/null
+else
+  _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" sort --workspace --check
+fi
+
 _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" fmt --all -- --check
 
  _ ci/do-audit.sh


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1075566094439436298

It is not easy to read the errors which produced by `cargo sort`.

#### Summary of Changes

hide all stdout when run on CI environment. it looks like

![Screenshot 2023-02-16 at 8 33 21 PM](https://user-images.githubusercontent.com/8209234/219366065-0878c29a-4eb8-4838-8e0e-aa7cc1cd0f61.png)

the build: https://buildkite.com/solana-labs/solana/builds/90451#01865a17-95f1-4eb1-82c0-0f87b482cb77

