### PR TITLE
Apply clippy fixes for future rust upgrade

### DIFF
--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -1584,7 +1584,7 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, &request).unwrap();
+            let mut packet = Packet::from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
@@ -1603,7 +1603,7 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, &request).unwrap();
+            let mut packet = Packet::from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
@@ -1625,7 +1625,7 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, &request).unwrap();
+            let mut packet = Packet::from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
@@ -1645,7 +1645,7 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, &request).unwrap();
+            let mut packet = Packet::from_data(None, request).unwrap();
             sign_packet(&mut packet, &other_keypair);
             packet
         };

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -277,7 +277,7 @@ impl CrdsGossipPull {
             filters.truncate(MAX_NUM_PULL_REQUESTS);
         }
         // Associate each pull-request filter with a randomly selected peer.
-        let dist = WeightedIndex::new(&weights).unwrap();
+        let dist = WeightedIndex::new(weights).unwrap();
         let nodes = repeat_with(|| nodes[dist.sample(&mut rng)].clone());
         Ok(nodes.zip(filters).into_group_map())
     }

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -604,7 +604,7 @@ pub mod tests {
             sample_period_secs,
         };
         let actual =
-            serde_json::to_value(&input).expect("Can convert RpcPerfSample into a JSON value");
+            serde_json::to_value(input).expect("Can convert RpcPerfSample into a JSON value");
         let expected = json!({
             "slot": slot,
             "numTransactions": num_transactions,

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -434,9 +434,9 @@ impl AccountsDb {
     /// finish shrink operation on slots where a new storage was created
     /// drop root and storage for all original slots whose contents were combined into other storages
     #[allow(dead_code)]
-    fn finish_combine_ancient_slots_packed_internal<'a>(
+    fn finish_combine_ancient_slots_packed_internal(
         &self,
-        accounts_to_combine: AccountsToCombine<'a>,
+        accounts_to_combine: AccountsToCombine<'_>,
         mut write_ancient_accounts: WriteAncientAccounts,
         metrics: &mut ShrinkStatsSub,
     ) {

--- a/sdk/program/src/alt_bn128.rs
+++ b/sdk/program/src/alt_bn128.rs
@@ -199,7 +199,7 @@ mod target_arch {
             .map_err(|_| AltBn128Error::InvalidInputData)?;
 
         let mut result_point_data = [0; ALT_BN128_MULTIPLICATION_OUTPUT_LEN + 1];
-        let result_point: G1 = p.into_projective().mul(&fr).into();
+        let result_point: G1 = p.into_projective().mul(fr).into();
         <G1 as ToBytes>::write(&result_point, &mut result_point_data[..])
             .map_err(|_| AltBn128Error::InvalidInputData)?;
         if result_point == G1::zero() {


### PR DESCRIPTION
#### Problem

In order to upgrade Rust in #29947, we must resolve new clippy lints.


#### Summary of Changes

Run `clippy --fix`