### PR TITLE
Improve keygen grind algo by 10%

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -40,7 +40,7 @@ use {
 mod smallest_length_44_public_key {
     use solana_sdk::declare_id;
 
-    declare_id!("21111111111111111111111111111111111111111111");
+    pubkey!("21111111111111111111111111111111111111111111");
 
     #[test]
     fn assert_length() {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -796,7 +796,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         } else {
                             (Keypair::new(), "".to_string())
                         };
-                        // Skip keypairs that will never match the user specified prefix 
+                        // Skip keypairs that will never match the user specified prefix
                         if skip_len_44_pubkeys && keypair.pubkey() >= smallest_length_44_public_key::id() {
                             continue;
                         }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -39,7 +39,14 @@ use {
 
 mod smallest_length_44_public_key {
     use solana_sdk::declare_id;
+
     declare_id!("21111111111111111111111111111111111111111111");
+
+    #[test]
+    fn assert_length() {
+        use crate::smallest_length_44_public_key;
+        assert_eq!(smallest_length_44_public_key::id().to_string().len(), 44);
+    }
 }
 
 const NO_PASSPHRASE: &str = "";
@@ -763,7 +770,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                     let passphrase = passphrase.clone();
                     let passphrase_message = passphrase_message.clone();
                     let derivation_path = derivation_path.clone();
-                    let skip_len_44_pubkeys = skip_len_44_pubkeys.clone();
+                    let skip_len_44_pubkeys = skip_len_44_pubkeys;
 
                     thread::spawn(move || loop {
                         if done.load(Ordering::Relaxed) {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -742,14 +742,19 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let no_outfile = matches.is_present(NO_OUTFILE_ARG.name);
 
             // The vast majority of base58 encoded public keys have length 44, but
-            // these only enacapsulate prefixes 1-9 and A-H.  If the user is searching
+            // these only encapsulate prefixes 1-9 and A-H.  If the user is searching
             // for a keypair that starts with a prefix of J-Z or a-z, then there is no
             // reason to waste time searching for a keypair that will never match
             let skip_len_44_pubkeys = grind_matches
                 .iter()
                 .map(|g| {
-                    let target_key = g.starts.clone()
-                        + &(0..44 - g.starts.len()).map(|_| "1").collect::<String>();
+                    let target_key = if ignore_case {
+                        g.starts.to_ascii_uppercase()
+                    } else {
+                        g.starts.clone()
+                    };
+                    let target_key =
+                        target_key + &(0..44 - g.starts.len()).map(|_| "1").collect::<String>();
                     bs58::decode(target_key).into_vec()
                 })
                 .filter_map(|s| s.ok())

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -38,14 +38,14 @@ use {
 };
 
 mod smallest_length_44_public_key {
-    use solana_sdk::declare_id;
+    use solana_sdk::{pubkey, pubkey::Pubkey};
 
-    pubkey!("21111111111111111111111111111111111111111111");
+    pub(super) static PUBKEY: Pubkey = pubkey!("21111111111111111111111111111111111111111111");
 
     #[test]
     fn assert_length() {
         use crate::smallest_length_44_public_key;
-        assert_eq!(smallest_length_44_public_key::id().to_string().len(), 44);
+        assert_eq!(smallest_length_44_public_key::PUBKEY.to_string().len(), 44);
     }
 }
 
@@ -797,7 +797,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                             (Keypair::new(), "".to_string())
                         };
                         // Skip keypairs that will never match the user specified prefix
-                        if skip_len_44_pubkeys && keypair.pubkey() >= smallest_length_44_public_key::id() {
+                        if skip_len_44_pubkeys && keypair.pubkey() >= smallest_length_44_public_key::PUBKEY {
                             continue;
                         }
                         let mut pubkey = bs58::encode(keypair.pubkey()).into_string();

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -37,6 +37,11 @@ use {
     },
 };
 
+mod smallest_length_44_public_key {
+    use solana_sdk::declare_id;
+    declare_id!("21111111111111111111111111111111111111111111");
+}
+
 const NO_PASSPHRASE: &str = "";
 const DEFAULT_DERIVATION_PATH: &str = "m/44'/501'/0'/0'";
 
@@ -729,6 +734,20 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             };
             let no_outfile = matches.is_present(NO_OUTFILE_ARG.name);
 
+            // The vast majority of base58 encoded public keys have length 44, but
+            // these only enacapsulate prefixes 1-9 and A-H.  If the user is searching
+            // for a keypair that starts with a prefix of J-Z or a-z, then there is no
+            // reason to waste time searching for a keypair that will never match
+            let skip_len_44_pubkeys = grind_matches
+                .iter()
+                .map(|g| {
+                    let target_key = g.starts.clone()
+                        + &(0..44 - g.starts.len()).map(|_| "1").collect::<String>();
+                    bs58::decode(target_key).into_vec()
+                })
+                .filter_map(|s| s.ok())
+                .all(|s| s.len() > 32);
+
             let grind_matches_thread_safe = Arc::new(grind_matches);
             let attempts = Arc::new(AtomicU64::new(1));
             let found = Arc::new(AtomicU64::new(0));
@@ -744,6 +763,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                     let passphrase = passphrase.clone();
                     let passphrase_message = passphrase_message.clone();
                     let derivation_path = derivation_path.clone();
+                    let skip_len_44_pubkeys = skip_len_44_pubkeys.clone();
 
                     thread::spawn(move || loop {
                         if done.load(Ordering::Relaxed) {
@@ -769,6 +789,10 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         } else {
                             (Keypair::new(), "".to_string())
                         };
+                        // Skip keypairs that will never match the user specified prefix 
+                        if skip_len_44_pubkeys && keypair.pubkey() >= smallest_length_44_public_key::id() {
+                            continue;
+                        }
                         let mut pubkey = bs58::encode(keypair.pubkey()).into_string();
                         if ignore_case {
                             pubkey = pubkey.to_lowercase();


### PR DESCRIPTION
#### Problem
`solana-keygen grind` is slightly inefficient in that it checks a few too many keys when searching for prefixes. The largest pubkey is `JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG` and has 44 characters. If the starting ascii character for the grind is between K and z, this means that it is impossible for the resulting pubkey to match if the sampled key has 44 characters.

The smallest key with 44 characters is `21111111111111111111111111111111111111111111`, we can short circuit the main loop if the sampled key >= `21111111111111111111111111111111111111111111` depending on the supplied prefixes.

#### Summary of Changes
Efficiency improvement is admittedly marginal:

Original:
```
Searched 40000000 keypairs in 93s. 0 matches found.
```

Updated:
```
Searched 40000000 keypairs in 81s. 0 matches found.
```

I guess bs58 encode is faster than i expected and most of the bottleneck is probably in `ed25519_dalek::Keypair::generate`. Still a reasonably fun/quick 30 min project 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
