### PR TITLE
Cli: add `find-program-derived-address` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,6 +5279,7 @@ dependencies = [
  "criterion-stats",
  "crossbeam-channel",
  "ctrlc",
+ "hex",
  "humantime",
  "log",
  "num-traits",

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -334,6 +334,51 @@ where
         .map(|_| ())
 }
 
+pub fn is_complex_seed<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    let (prefix, value) = value
+        .as_ref()
+        .split_once(":")
+        .ok_or("Seed must contain ':' as delimiter")
+        .unwrap();
+    if prefix.is_empty() || value.is_empty() {
+        Err(String::from("Seed prefix or value is empty"))
+    } else {
+        match prefix {
+            "string" | "pubkey" | "hex" | "u8" => Ok(()),
+            _ => {
+                let len = prefix.len();
+                if len != 5 && len != 6 {
+                    Err(format!("Wrong prefix length {len} {prefix}:{value}"))
+                } else {
+                    let sign = &prefix[0..1];
+                    let type_size = &prefix[1..len - 2];
+                    let byte_order = &prefix[len - 2..len];
+                    if sign != "u" && sign != "i" {
+                        Err(format!("Wrong prefix sign {sign} {prefix}:{value}"))
+                    } else if type_size != "16"
+                        && type_size != "32"
+                        && type_size != "64"
+                        && type_size != "128"
+                    {
+                        Err(format!(
+                            "Wrong prefix type size {type_size} {prefix}:{value}"
+                        ))
+                    } else if byte_order != "le" && byte_order != "be" {
+                        Err(format!(
+                            "Wrong prefix byte order {byte_order} {prefix}:{value}"
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub fn is_derived_address_seed<T>(value: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -340,7 +340,7 @@ where
 {
     let (prefix, value) = value
         .as_ref()
-        .split_once(":")
+        .split_once(':')
         .ok_or("Seed must contain ':' as delimiter")
         .unwrap();
     if prefix.is_empty() || value.is_empty() {
@@ -354,8 +354,8 @@ where
                     Err(format!("Wrong prefix length {len} {prefix}:{value}"))
                 } else {
                     let sign = &prefix[0..1];
-                    let type_size = &prefix[1..len - 2];
-                    let byte_order = &prefix[len - 2..len];
+                    let type_size = &prefix[1..len.saturating_sub(2)];
+                    let byte_order = &prefix[len.saturating_sub(2)..len];
                     if sign != "u" && sign != "i" {
                         Err(format!("Wrong prefix sign {sign} {prefix}:{value}"))
                     } else if type_size != "16"

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -334,7 +334,7 @@ where
         .map(|_| ())
 }
 
-pub fn is_complex_seed<T>(value: T) -> Result<(), String>
+pub fn is_structured_seed<T>(value: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -328,6 +328,51 @@ where
         .map(|_| ())
 }
 
+pub fn is_structured_seed<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    let (prefix, value) = value
+        .as_ref()
+        .split_once(':')
+        .ok_or("Seed must contain ':' as delimiter")
+        .unwrap();
+    if prefix.is_empty() || value.is_empty() {
+        Err(String::from("Seed prefix or value is empty"))
+    } else {
+        match prefix {
+            "string" | "pubkey" | "hex" | "u8" => Ok(()),
+            _ => {
+                let len = prefix.len();
+                if len != 5 && len != 6 {
+                    Err(format!("Wrong prefix length {len} {prefix}:{value}"))
+                } else {
+                    let sign = &prefix[0..1];
+                    let type_size = &prefix[1..len.saturating_sub(2)];
+                    let byte_order = &prefix[len.saturating_sub(2)..len];
+                    if sign != "u" && sign != "i" {
+                        Err(format!("Wrong prefix sign {sign} {prefix}:{value}"))
+                    } else if type_size != "16"
+                        && type_size != "32"
+                        && type_size != "64"
+                        && type_size != "128"
+                    {
+                        Err(format!(
+                            "Wrong prefix type size {type_size} {prefix}:{value}"
+                        ))
+                    } else if byte_order != "le" && byte_order != "be" {
+                        Err(format!(
+                            "Wrong prefix byte order {byte_order} {prefix}:{value}"
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub fn is_derived_address_seed<T>(value: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2986,6 +2986,23 @@ impl fmt::Display for CliBalance {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliFindProgramAddress {
+    pub address: String,
+    pub bump_seed: u8,
+}
+
+impl QuietDisplay for CliFindProgramAddress {}
+impl VerboseDisplay for CliFindProgramAddress {}
+
+impl fmt::Display for CliFindProgramAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.address)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2988,15 +2988,15 @@ impl fmt::Display for CliBalance {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CliFindProgramAddress {
+pub struct CliFindProgramDerivedAddress {
     pub address: String,
     pub bump_seed: u8,
 }
 
-impl QuietDisplay for CliFindProgramAddress {}
-impl VerboseDisplay for CliFindProgramAddress {}
+impl QuietDisplay for CliFindProgramDerivedAddress {}
+impl VerboseDisplay for CliFindProgramDerivedAddress {}
 
-impl fmt::Display for CliFindProgramAddress {
+impl fmt::Display for CliFindProgramDerivedAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.address)?;
         Ok(())

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ const_format = { workspace = true }
 criterion-stats = { workspace = true }
 crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true, features = ["termination"] }
+hex = { workspace = true }
 humantime = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -59,6 +59,10 @@ pub enum CliCommand {
     Fees {
         blockhash: Option<Hash>,
     },
+    FindProgramAddress {
+        seeds: Vec<Vec<u8>>,
+        program_id: Pubkey,
+    },
     FirstAvailableBlock,
     GetBlock {
         slot: Option<Slot>,
@@ -802,6 +806,7 @@ pub fn parse_command(
         ("create-address-with-seed", Some(matches)) => {
             parse_create_address_with_seed(matches, default_signer, wallet_manager)
         }
+        ("find-program-address", Some(matches)) => parse_find_program_address(matches),
         ("decode-transaction", Some(matches)) => parse_decode_transaction(matches),
         ("resolve-signer", Some(matches)) => {
             let signer_path = resolve_signer(matches, "signer", wallet_manager)?;
@@ -887,6 +892,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Fees { ref blockhash } => process_fees(&rpc_client, config, blockhash.as_ref()),
         CliCommand::Feature(feature_subcommand) => {
             process_feature_subcommand(&rpc_client, config, feature_subcommand)
+        }
+        CliCommand::FindProgramAddress { seeds, program_id } => {
+            process_find_program_address(config, seeds, program_id)
         }
         CliCommand::FirstAvailableBlock => process_first_available_block(&rpc_client),
         CliCommand::GetBlock { slot } => process_get_block(&rpc_client, config, *slot),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -59,7 +59,7 @@ pub enum CliCommand {
     Fees {
         blockhash: Option<Hash>,
     },
-    FindProgramAddress {
+    FindProgramDerivedAddress {
         seeds: Vec<Vec<u8>>,
         program_id: Pubkey,
     },
@@ -806,7 +806,9 @@ pub fn parse_command(
         ("create-address-with-seed", Some(matches)) => {
             parse_create_address_with_seed(matches, default_signer, wallet_manager)
         }
-        ("find-program-address", Some(matches)) => parse_find_program_address(matches),
+        ("find-program-derived-address", Some(matches)) => {
+            parse_find_program_derived_address(matches)
+        }
         ("decode-transaction", Some(matches)) => parse_decode_transaction(matches),
         ("resolve-signer", Some(matches)) => {
             let signer_path = resolve_signer(matches, "signer", wallet_manager)?;
@@ -893,8 +895,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Feature(feature_subcommand) => {
             process_feature_subcommand(&rpc_client, config, feature_subcommand)
         }
-        CliCommand::FindProgramAddress { seeds, program_id } => {
-            process_find_program_address(config, seeds, program_id)
+        CliCommand::FindProgramDerivedAddress { seeds, program_id } => {
+            process_find_program_derived_address(config, seeds, program_id)
         }
         CliCommand::FirstAvailableBlock => process_first_available_block(&rpc_client),
         CliCommand::GetBlock { slot } => process_get_block(&rpc_client, config, *slot),

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -495,7 +495,7 @@ pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommand
         .map(|seeds| {
             seeds
                 .map(|value| {
-                    let (prefix, value) = value.split_once(":").unwrap();
+                    let (prefix, value) = value.split_once(':').unwrap();
                     match prefix {
                         "pubkey" => Pubkey::from_str(value).unwrap().to_bytes().to_vec(),
                         "string" => value.as_bytes().to_vec(),

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -10,6 +10,7 @@ use {
         spend_utils::{resolve_spend_tx_and_check_account_balances, SpendAmount},
     },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
+    hex::FromHex,
     solana_clap_utils::{
         compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
         fee_payer::*,
@@ -23,8 +24,9 @@ use {
     },
     solana_cli_output::{
         display::{build_balance_message, BuildBalanceMessageConfig},
-        return_signers_with_config, CliAccount, CliBalance, CliSignatureVerificationStatus,
-        CliTransaction, CliTransactionConfirmation, OutputFormat, ReturnSignersConfig,
+        return_signers_with_config, CliAccount, CliBalance, CliFindProgramAddress,
+        CliSignatureVerificationStatus, CliTransaction, CliTransactionConfirmation, OutputFormat,
+        ReturnSignersConfig,
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
@@ -45,7 +47,7 @@ use {
         EncodableWithMeta, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
         TransactionBinaryEncoding, UiTransactionEncoding,
     },
-    std::{fmt::Write as FmtWrite, fs::File, io::Write, sync::Arc},
+    std::{fmt::Write as FmtWrite, fs::File, io::Write, str::FromStr, sync::Arc},
 };
 
 pub trait WalletSubCommands {
@@ -179,6 +181,35 @@ impl WalletSubCommands for App<'_, '_> {
                         "From (base) key, [default: cli config keypair]. "),
                 ),
         )
+            .subcommand(
+                SubCommand::with_name("find-program-address")
+                    .about("Generate a program derived account address with a seed")
+                    .arg(
+                        Arg::with_name("program_id")
+                                .index(1)
+                                .value_name("PROGRAM_ID")
+                                .takes_value(true)
+                                .required(true)
+                                .help(
+                                    "The program_id that the address will ultimately be used for, \n\
+                                    or one of NONCE, STAKE, and VOTE keywords",
+                                ),
+                        )
+                    .arg(
+                        Arg::with_name("seeds")
+                            .min_values(0)
+                            .value_name("SEED")
+                            .takes_value(true)
+                            .validator(is_complex_seed)
+                            .help(
+                                "The seeds. \n\
+                                Each one must match the pattern PREFIX:VALUE. \n\
+                                PREFIX - the one of [string, pubkey, hex, u8] \n\
+                                or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) \n\
+                                where first two parts represent a number type and last one (le/be) - byte order"
+                            ),
+                    ),
+            )
         .subcommand(
             SubCommand::with_name("decode-transaction")
                 .about("Decode a serialized transaction")
@@ -454,6 +485,49 @@ pub fn parse_create_address_with_seed(
             program_id,
         },
         signers,
+    })
+}
+
+pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+    let program_id = resolve_derived_address_program_id(matches, "program_id").unwrap();
+    let seeds = matches
+        .values_of("seeds")
+        .map(|seeds| {
+            seeds
+                .map(|value| {
+                    let (prefix, value) = value.split_once(":").unwrap();
+                    match prefix {
+                        "pubkey" => Pubkey::from_str(value).unwrap().to_bytes().to_vec(),
+                        "string" => value.as_bytes().to_vec(),
+                        "hex" => Vec::<u8>::from_hex(value).unwrap(),
+                        "u8" => u8::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "u16le" => u16::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "u32le" => u32::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "u64le" => u64::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "u128le" => u128::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "i16le" => i16::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "i32le" => i32::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "i64le" => i64::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "i128le" => i128::from_str(value).unwrap().to_le_bytes().to_vec(),
+                        "u16be" => u16::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "u32be" => u32::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "u64be" => u64::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "u128be" => u128::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "i16be" => i16::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "i32be" => i32::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "i64be" => i64::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        "i128be" => i128::from_str(value).unwrap().to_be_bytes().to_vec(),
+                        // Must be unreachable due to arg validator
+                        _ => panic!("parse_find_program_address: {}:{}", prefix, value),
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(CliCommandInfo {
+        command: CliCommand::FindProgramAddress { seeds, program_id },
+        signers: vec![],
     })
 }
 
@@ -757,6 +831,23 @@ pub fn process_create_address_with_seed(
     };
     let address = Pubkey::create_with_seed(&from_pubkey, seed, program_id)?;
     Ok(address.to_string())
+}
+
+pub fn process_find_program_address(
+    config: &CliConfig,
+    seeds: &Vec<Vec<u8>>,
+    program_id: &Pubkey,
+) -> ProcessResult {
+    if config.verbose {
+        println!("Seeds: {:?}", seeds);
+    }
+    let seeds_slice = seeds.iter().map(|x| &x[..]).collect::<Vec<_>>();
+    let (address, bump_seed) = Pubkey::find_program_address(&seeds_slice[..], program_id);
+    let result = CliFindProgramAddress {
+        address: address.to_string(),
+        bump_seed,
+    };
+    Ok(config.output_format.formatted_string(&result))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -204,9 +204,15 @@ impl WalletSubCommands for App<'_, '_> {
                             .help(
                                 "The seeds. \n\
                                 Each one must match the pattern PREFIX:VALUE. \n\
-                                PREFIX - the one of [string, pubkey, hex, u8] \n\
-                                or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) \n\
-                                where first two parts represent a number type and last one (le/be) - byte order"
+                                PREFIX can be one of [string, pubkey, hex, u8] \n\
+                                or matches the pattern [u,i][16,32,64,128][le,be] (for example, u64le) \n\
+                                This pattern contains information on how a number is stored in computer memory, \n\
+                                as different computer languages/architectures can store numbers using different schemas, \n\
+                                and so it affects to derived address.\n\
+                                [u,i] - represents whether the number type includes only unsigned numbers \n\
+                                or both signed and unsigned numbers, \n\
+                                [16,32,64,128] - represents the bit length, and \n\
+                                [le,be] - represents the byte order - little endian or big endian"
                             ),
                     ),
             )

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -491,7 +491,8 @@ pub fn parse_create_address_with_seed(
 pub fn parse_find_program_derived_address(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {
-    let program_id = resolve_derived_address_program_id(matches, "program_id").unwrap();
+    let program_id = resolve_derived_address_program_id(matches, "program_id")
+        .ok_or_else(|| CliError::BadParameter("PROGRAM_ID".to_string()))?;
     let seeds = matches
         .values_of("seeds")
         .map(|seeds| {

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -24,7 +24,7 @@ use {
     },
     solana_cli_output::{
         display::{build_balance_message, BuildBalanceMessageConfig},
-        return_signers_with_config, CliAccount, CliBalance, CliFindProgramAddress,
+        return_signers_with_config, CliAccount, CliBalance, CliFindProgramDerivedAddress,
         CliSignatureVerificationStatus, CliTransaction, CliTransactionConfirmation, OutputFormat,
         ReturnSignersConfig,
     },
@@ -182,7 +182,7 @@ impl WalletSubCommands for App<'_, '_> {
                 ),
         )
             .subcommand(
-                SubCommand::with_name("find-program-address")
+                SubCommand::with_name("find-program-derived-address")
                     .about("Generate a program derived account address with a seed")
                     .arg(
                         Arg::with_name("program_id")
@@ -488,7 +488,9 @@ pub fn parse_create_address_with_seed(
     })
 }
 
-pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+pub fn parse_find_program_derived_address(
+    matches: &ArgMatches<'_>,
+) -> Result<CliCommandInfo, CliError> {
     let program_id = resolve_derived_address_program_id(matches, "program_id").unwrap();
     let seeds = matches
         .values_of("seeds")
@@ -518,7 +520,7 @@ pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommand
                         "i64be" => i64::from_str(value).unwrap().to_be_bytes().to_vec(),
                         "i128be" => i128::from_str(value).unwrap().to_be_bytes().to_vec(),
                         // Must be unreachable due to arg validator
-                        _ => unreachable!("parse_find_program_address: {prefix}:{value}"),
+                        _ => unreachable!("parse_find_program_derived_address: {prefix}:{value}"),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -526,7 +528,7 @@ pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommand
         .unwrap_or_default();
 
     Ok(CliCommandInfo {
-        command: CliCommand::FindProgramAddress { seeds, program_id },
+        command: CliCommand::FindProgramDerivedAddress { seeds, program_id },
         signers: vec![],
     })
 }
@@ -833,7 +835,7 @@ pub fn process_create_address_with_seed(
     Ok(address.to_string())
 }
 
-pub fn process_find_program_address(
+pub fn process_find_program_derived_address(
     config: &CliConfig,
     seeds: &Vec<Vec<u8>>,
     program_id: &Pubkey,
@@ -843,7 +845,7 @@ pub fn process_find_program_address(
     }
     let seeds_slice = seeds.iter().map(|x| &x[..]).collect::<Vec<_>>();
     let (address, bump_seed) = Pubkey::find_program_address(&seeds_slice[..], program_id);
-    let result = CliFindProgramAddress {
+    let result = CliFindProgramDerivedAddress {
         address: address.to_string(),
         bump_seed,
     };

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -200,7 +200,7 @@ impl WalletSubCommands for App<'_, '_> {
                             .min_values(0)
                             .value_name("SEED")
                             .takes_value(true)
-                            .validator(is_complex_seed)
+                            .validator(is_structured_seed)
                             .help(
                                 "The seeds. \n\
                                 Each one must match the pattern PREFIX:VALUE. \n\

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -208,12 +208,8 @@ impl WalletSubCommands for App<'_, '_> {
                                 "The seeds. \n\
                                 Each one must match the pattern PREFIX:VALUE. \n\
                                 PREFIX can be one of [string, pubkey, hex, u8] \n\
-                                or matches the pattern [u,i][16,32,64,128][le,be] (for example, u64le) \n\
-                                This pattern contains information on how a number is stored in computer memory, \n\
-                                as different computer languages/architectures can store numbers using different schemas, \n\
-                                and so it affects to derived address.\n\
-                                [u,i] - represents whether the number type includes only unsigned numbers \n\
-                                or both signed and unsigned numbers, \n\
+                                or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) for number values \n\
+                                [u,i] - represents whether the number is unsigned or signed, \n\
                                 [16,32,64,128] - represents the bit length, and \n\
                                 [le,be] - represents the byte order - little endian or big endian"
                             ),

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -152,7 +152,10 @@ impl WalletSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("create-address-with-seed")
-                .about("Generate a derived account address with a seed")
+                .about(
+                    "Generate a derived account address with a seed. \
+                    For program derived addresses (PDAs), use the find-program-derived-address command instead"
+                )
                 .arg(
                     Arg::with_name("seed")
                         .index(1)

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -518,7 +518,7 @@ pub fn parse_find_program_address(matches: &ArgMatches<'_>) -> Result<CliCommand
                         "i64be" => i64::from_str(value).unwrap().to_be_bytes().to_vec(),
                         "i128be" => i128::from_str(value).unwrap().to_be_bytes().to_vec(),
                         // Must be unreachable due to arg validator
-                        _ => panic!("parse_find_program_address: {}:{}", prefix, value),
+                        _ => unreachable!("parse_find_program_address: {prefix}:{value}"),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -839,7 +839,7 @@ pub fn process_find_program_address(
     program_id: &Pubkey,
 ) -> ProcessResult {
     if config.verbose {
-        println!("Seeds: {:?}", seeds);
+        println!("Seeds: {seeds:?}");
     }
     let seeds_slice = seeds.iter().map(|x| &x[..]).collect::<Vec<_>>();
     let (address, bump_seed) = Pubkey::find_program_address(&seeds_slice[..], program_id);


### PR DESCRIPTION
#### Problem

There is no tool to calculate program derived address.
Each time you need to make this for each program.

#### Summary of Changes

Add `find-program-address` command.

**Usage**
```
solana find-program-address [FLAGS] [OPTIONS] <PROGRAM_ID> [SEED]...
...
ARGS:
    <PROGRAM_ID>    The program_id that the address will ultimately be used for, 
                    or one of NONCE, STAKE, and VOTE keywords
    <SEED>...       The seeds. 
                    Each one must match the pattern PREFIX:VALUE. 
                    PREFIX - the one of [string, pubkey, hex, u8] 
                    or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) 
                    where first two parts represent a number type and last one (le/be) - byte order
```

**Samples**
To find metaplex metadata address for `9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E ` Wrapped Bitcoin:
```
solana find-program-address metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s string:metadata pubkey:metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s pubkey:9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E

F4zNPXoqasVow544cKMQTPaVW4kmxaJXiN9PG9vqcjDt
```

To find jito tip account address for validator-epoch for `GE6atKoWiQ2pt3zL7N13pjNHjdLVys8LinG8qeJLcAiL` (Laine, epoch 412):
```
solana find-program-address 4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7 string:TIP_DISTRIBUTION_ACCOUNT pubkey:GE6atKoWiQ2pt3zL7N13pjNHjdLVys8LinG8qeJLcAiL u64le:412

7uRCPZovH9HvGbmXzzKXfVBF13PE9A3UohcTHqSPNpeM
```

With `--verbose` flag it shows calculated seeds (maybe useful for debug purposes):
```
Seeds: [[84, 73, 80, 95, 68, 73, 83, 84, 82, 73, 66, 85, 84, 73, 79, 78, 95, 65, 67, 67, 79, 85, 78, 84], [226, 58, 43, 35, 182, 37, 231, 81, 57, 145, 190, 55, 10, 44, 32, 213, 197, 226, 118, 73, 29, 54, 119, 126, 242, 229, 177, 34, 127, 254, 115, 41], [156, 1, 0, 0, 0, 0, 0, 0]]
```
and with `--output json` option it also returns `bump_seed`:
```
{
  "address": "7uRCPZovH9HvGbmXzzKXfVBF13PE9A3UohcTHqSPNpeM",
  "bumpSeed": 254
}
```