### PR TITLE
Add checks when constructing a BankSnapshotInfo from a directory 

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3130,6 +3130,16 @@ mod tests {
             let snapshot_filename = get_snapshot_file_name(slot);
             let snapshot_path = snapshot_dir.join(snapshot_filename);
             File::create(snapshot_path).unwrap();
+
+            let status_cache_file = snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
+            File::create(status_cache_file).unwrap();
+
+            let version_path = snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
+            write_snapshot_version_file(version_path, SnapshotVersion::default()).unwrap();
+
+            // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
+            let state_complete_path = snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
+            fs::File::create(state_complete_path).unwrap();
         }
     }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1630,10 +1630,10 @@ fn create_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Pat
 
     // The unpacked dir has a single slot dir, which is the snapshot slot dir.
     let slot_dir = fs::read_dir(&snapshots_dir)
-        .unwrap()
+        .map_err(|_| SnapshotError::NoSnapshotSlotDir(snapshots_dir.clone()))?
         .find(|entry| entry.as_ref().unwrap().path().is_dir())
-        .unwrap()
-        .unwrap()
+        .ok_or_else(|| SnapshotError::NoSnapshotSlotDir(snapshots_dir.clone()))?
+        .map_err(|_| SnapshotError::NoSnapshotSlotDir(snapshots_dir.clone()))?
         .path();
 
     let version_file = unpack_dir.as_ref().join(SNAPSHOT_VERSION_FILENAME);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1622,7 +1622,7 @@ fn streaming_unarchive_snapshot(
 /// as a valid one.  A dir unpacked from an archive lacks these files.  Fill them here to
 /// allow new_from_dir() checks to pass.  These checks are not needed for unpacked dirs,
 /// but it is not clean to add another flag to new_from_dir() to skip them.
-fn fill_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Path>) -> Result<()> {
+fn create_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Path>) -> Result<()> {
     let snapshots_dir = unpack_dir.as_ref().join("snapshots");
     if !snapshots_dir.is_dir() {
         return Err(SnapshotError::NoSnapshotSlotDir(snapshots_dir));
@@ -1696,7 +1696,7 @@ where
     );
     info!("{}", measure_untar);
 
-    fill_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
+    create_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
 
     let RebuiltSnapshotStorage {
         snapshot_version,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -323,6 +323,9 @@ pub enum SnapshotError {
     #[error("snapshot slot deltas are invalid: {0}")]
     VerifySlotDeltas(#[from] VerifySlotDeltasError),
 
+    #[error("bank_snapshot_info new_from_dir failed: {0}")]
+    NewFromDir(#[from] SnapshotNewFromDirError),
+
     #[error("invalid AppendVec path: {}", .0.display())]
     InvalidAppendVecPath(PathBuf),
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1887,9 +1887,8 @@ pub fn get_highest_incremental_snapshot_archive_slot(
 pub fn get_highest_full_snapshot(snapshots_dir: impl AsRef<Path>) -> Result<BankSnapshotInfo> {
     let bank_snapshots = get_bank_snapshots(&snapshots_dir);
 
-    do_get_highest_bank_snapshot(bank_snapshots).ok_or_else(|| SnapshotError::NoSnapshotSlotDir(
-        snapshots_dir.as_ref().to_path_buf(),
-    ))
+    do_get_highest_bank_snapshot(bank_snapshots)
+        .ok_or_else(|| SnapshotError::NoSnapshotSlotDir(snapshots_dir.as_ref().to_path_buf()))
 }
 
 pub fn get_highest_incremental_snapshot(


### PR DESCRIPTION
#### Problem
Before constructing a bank from a snapshot, we need to read the snapshot directories and find the highest correct one with the necessary meta info files.  Sometimes a directory may have partial information, not fully ready to be used for bank construction.  Only the ones passing the checks will be selected.

#### Summary of Changes
Add snapshot version into BankSnapshotInfo, fill that from the version file;
Add checks to ensure only a correct directory is used to generate a BankSnapshotInfo. 
A function to find the one with the highest slot, which is a wrapper of get_bank_snapshots and selecting the highest one.
Add the test function test_get_highest_bank_snapshot.  It removes the meta files in the directories, and check if it gets the highest correct snapshot.

This is one of the split PRs of https://github.com/solana-labs/solana/pull/28745.  It precedes https://github.com/solana-labs/solana/pull/30171

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
