### PR TITLE
Cli: support json output for transaction-history

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -842,10 +842,10 @@ pub struct CliHistoryVerbose {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CliHistoryTransactionVec(Vec<CliHistoryTransaction>);
+pub struct CliHistoryTransactionVec(Vec<CliTransactionConfirmation>);
 
 impl CliHistoryTransactionVec {
-    pub fn new(list: Vec<CliHistoryTransaction>) -> Self {
+    pub fn new(list: Vec<CliTransactionConfirmation>) -> Self {
         Self(list)
     }
 }
@@ -856,34 +856,10 @@ impl VerboseDisplay for CliHistoryTransactionVec {}
 impl fmt::Display for CliHistoryTransactionVec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for transaction in &self.0 {
-            write!(f, "{transaction}")?;
+            VerboseDisplay::write_str(transaction, f)?;
             writeln!(f)?;
         }
         writeln!(f, "{} transactions found", self.0.len())
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CliHistoryTransaction {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<CliTransaction>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_msg: Option<String>,
-}
-
-impl QuietDisplay for CliHistoryTransaction {}
-impl VerboseDisplay for CliHistoryTransaction {}
-
-impl fmt::Display for CliHistoryTransaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(transaction) = &self.transaction {
-            write!(f, "{transaction}")
-        } else if let Some(error) = &self.error_msg {
-            writeln!(f, "{error}")
-        } else {
-            Ok(())
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem
`solana transaction-history` still doesn't support `--output json`

#### Summary of Changes
Implement support
I changed the `--show-transactions` output for humans slightly: `-v` now does nothing, since it just replicates data in the transaction. I will include before/after examples in comments.
Also, the `--show-transactions` variant will now wait until all transactions have been queried to print anything, since we don't support streaming output via `config.output_format.formatted_string`. Just realizing I should probably add a spinner for stderr while this is processing... will do in a small follow-up.

Fixes #14509
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
