### PR TITLE
add compute budget instruction to set loaded accounts data size limit

### DIFF
--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -154,9 +154,9 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 ### Accounts data size limit
 
 A transaction should request the maximum bytes of accounts data it is
-allowed to load by including a `SetAccountsDataSizeLimit` instruction, requested
+allowed to load by including a `SetLoadedAccountsDataSizeLimit` instruction, requested
 limit is capped by `MAX_ACCOUNTS_DATA_SIZE_BYTES`. If no
-`SetAccountsDataSizeLimit` is provided, the transaction is defaulted to
+`SetLoadedAccountsDataSizeLimit` is provided, the transaction is defaulted to
 have limit of `DEFAULT_ACCOUNTS_DATA_SIZE_BYTES`.
 
 The `ComputeBudgetInstruction::set_accounts_data_size_limit` function can be used

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -60,8 +60,9 @@ to.
 As the transaction is processed compute units are consumed by its
 instruction's programs performing operations such as executing SBF instructions,
 calling syscalls, etc... When the transaction consumes its entire budget, or
-exceeds a bound such as attempting a call stack that is too deep, the runtime
-halts the transaction processing and returns an error.
+exceeds a bound such as attempting a call stack that is too deep, or loaded
+account data size exceeds limit, the runtime halts the transaction processing and
+returns an error.
 
 The following operations incur a compute cost:
 
@@ -148,6 +149,21 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_limit(300_000);
 
 ```rust
 let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
+```
+
+### Accounts data size limit
+
+A transaction should request the maximum bytes of accounts data it is
+allowed to load by including a `SetAccountsDataSizeLimit` instruction, requested
+limit is capped by `MAX_ACCOUNTS_DATA_SIZE_BYTES`. If no
+`SetAccountsDataSizeLimit` is provided, the transaction is defaulted to
+have limit of `DEFAULT_ACCOUNTS_DATA_SIZE_BYTES`.
+
+The `ComputeBudgetInstruction::set_accounts_data_size_limit` function can be used
+to create this instruction:
+
+```rust
+let instruction = ComputeBudgetInstruction::set_accounts_data_size_limit(100_000);
 ```
 
 ## New Features

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -155,9 +155,9 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 
 A transaction should request the maximum bytes of accounts data it is
 allowed to load by including a `SetLoadedAccountsDataSizeLimit` instruction, requested
-limit is capped by `MAX_ACCOUNTS_DATA_SIZE_BYTES`. If no
+limit is capped by `MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES`. If no
 `SetLoadedAccountsDataSizeLimit` is provided, the transaction is defaulted to
-have limit of `MAX_ACCOUNTS_DATA_SIZE_BYTES`.
+have limit of `MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES`.
 
 The `ComputeBudgetInstruction::set_loaded_accounts_data_size_limit` function can be used
 to create this instruction:

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -157,13 +157,13 @@ A transaction should request the maximum bytes of accounts data it is
 allowed to load by including a `SetLoadedAccountsDataSizeLimit` instruction, requested
 limit is capped by `MAX_ACCOUNTS_DATA_SIZE_BYTES`. If no
 `SetLoadedAccountsDataSizeLimit` is provided, the transaction is defaulted to
-have limit of `DEFAULT_ACCOUNTS_DATA_SIZE_BYTES`.
+have limit of `MAX_ACCOUNTS_DATA_SIZE_BYTES`.
 
-The `ComputeBudgetInstruction::set_accounts_data_size_limit` function can be used
+The `ComputeBudgetInstruction::set_loaded_accounts_data_size_limit` function can be used
 to create this instruction:
 
 ```rust
-let instruction = ComputeBudgetInstruction::set_accounts_data_size_limit(100_000);
+let instruction = ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(100_000);
 ```
 
 ## New Features

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -700,24 +700,25 @@ mod tests {
         //     return InstructionError
         let data_size: usize = 1;
         for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
-                (
-                    Ok(PrioritizationFeeDetails::default()),
-                    ComputeBudget {
-                        compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                        loaded_accounts_data_size_limit: data_size,
-                        ..ComputeBudget::default()
-                    },
-                )
-            } else {
-                (
-                    Err(TransactionError::InstructionError(
-                        0,
-                        InstructionError::InvalidInstructionData,
-                    )),
-                    ComputeBudget::default(),
-                )
-            };
+            let (expected_result, expected_budget) =
+                if support_set_loaded_accounts_data_size_limit_ix {
+                    (
+                        Ok(PrioritizationFeeDetails::default()),
+                        ComputeBudget {
+                            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                            loaded_accounts_data_size_limit: data_size,
+                            ..ComputeBudget::default()
+                        },
+                    )
+                } else {
+                    (
+                        Err(TransactionError::InstructionError(
+                            0,
+                            InstructionError::InvalidInstructionData,
+                        )),
+                        ComputeBudget::default(),
+                    )
+                };
 
             test!(
                 &[
@@ -738,24 +739,25 @@ mod tests {
         //     return InstructionError
         let data_size: usize = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES + 1;
         for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
-                (
-                    Ok(PrioritizationFeeDetails::default()),
-                    ComputeBudget {
-                        compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                        loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-                        ..ComputeBudget::default()
-                    },
-                )
-            } else {
-                (
-                    Err(TransactionError::InstructionError(
-                        0,
-                        InstructionError::InvalidInstructionData,
-                    )),
-                    ComputeBudget::default(),
-                )
-            };
+            let (expected_result, expected_budget) =
+                if support_set_loaded_accounts_data_size_limit_ix {
+                    (
+                        Ok(PrioritizationFeeDetails::default()),
+                        ComputeBudget {
+                            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                            loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+                            ..ComputeBudget::default()
+                        },
+                    )
+                } else {
+                    (
+                        Err(TransactionError::InstructionError(
+                            0,
+                            InstructionError::InvalidInstructionData,
+                        )),
+                        ComputeBudget::default(),
+                    )
+                };
 
             test!(
                 &[
@@ -804,20 +806,21 @@ mod tests {
         //     return InstructionError
         let data_size: usize = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES;
         for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
-                (
-                    Err(TransactionError::DuplicateInstruction(2)),
-                    ComputeBudget::default(),
-                )
-            } else {
-                (
-                    Err(TransactionError::InstructionError(
-                        1,
-                        InstructionError::InvalidInstructionData,
-                    )),
-                    ComputeBudget::default(),
-                )
-            };
+            let (expected_result, expected_budget) =
+                if support_set_loaded_accounts_data_size_limit_ix {
+                    (
+                        Err(TransactionError::DuplicateInstruction(2)),
+                        ComputeBudget::default(),
+                    )
+                } else {
+                    (
+                        Err(TransactionError::InstructionError(
+                            1,
+                            InstructionError::InvalidInstructionData,
+                        )),
+                        ComputeBudget::default(),
+                    )
+                };
 
             test!(
                 &[

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -11,10 +11,8 @@ use {
 };
 
 /// The total accounts data a transaction can load is limited to 64MiB to not break
-/// anyone in Mainnet-beta today. It can be set by set_accounts_data_size_limit instruction
-pub const MAX_ACCOUNTS_DATA_SIZE_BYTES: usize = 64 * 1024 * 1024;
-/// default data size to allow one maximum sized account
-const DEFAULT_ACCOUNTS_DATA_SIZE_BYTES: usize = 10 * 1024 * 1024;
+/// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
+pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: usize = 64 * 1024 * 1024;
 
 pub const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
@@ -116,8 +114,8 @@ pub struct ComputeBudget {
     /// Big integer modular exponentiation cost
     pub big_modular_exponentiation_cost: u64,
     /// Maximum accounts data size, in bytes, that a transaction is allowed to load; The
-    /// value is capped by MAX_ACCOUNTS_DATA_SIZE_BYTES to prevent overuse of memory.
-    pub accounts_data_size_limit: usize,
+    /// value is capped by MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES to prevent overuse of memory.
+    pub loaded_accounts_data_size_limit: usize,
 }
 
 impl Default for ComputeBudget {
@@ -166,7 +164,7 @@ impl ComputeBudget {
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
             big_modular_exponentiation_cost: 33,
-            accounts_data_size_limit: DEFAULT_ACCOUNTS_DATA_SIZE_BYTES,
+            loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
         }
     }
 
@@ -176,13 +174,13 @@ impl ComputeBudget {
         default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
         enable_request_heap_frame_ix: bool,
-        support_set_accounts_data_size_limit_ix: bool,
+        support_set_loaded_accounts_data_size_limit_ix: bool,
     ) -> Result<PrioritizationFeeDetails, TransactionError> {
         let mut num_non_compute_budget_instructions: usize = 0;
         let mut updated_compute_unit_limit = None;
         let mut requested_heap_size = None;
         let mut prioritization_fee = None;
-        let mut updated_accounts_data_size_limit = None;
+        let mut updated_loaded_accounts_data_size_limit = None;
 
         for (i, (program_id, instruction)) in instructions.enumerate() {
             if compute_budget::check_id(program_id) {
@@ -227,12 +225,12 @@ impl ComputeBudget {
                             Some(PrioritizationFeeType::ComputeUnitPrice(micro_lamports));
                     }
                     Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes))
-                        if support_set_accounts_data_size_limit_ix =>
+                        if support_set_loaded_accounts_data_size_limit_ix =>
                     {
-                        if updated_accounts_data_size_limit.is_some() {
+                        if updated_loaded_accounts_data_size_limit.is_some() {
                             return Err(duplicate_instruction_error);
                         }
-                        updated_accounts_data_size_limit = Some(bytes as usize);
+                        updated_loaded_accounts_data_size_limit = Some(bytes as usize);
                     }
                     _ => return Err(invalid_instruction_data_error),
                 }
@@ -270,9 +268,9 @@ impl ComputeBudget {
         .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
         .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
 
-        self.accounts_data_size_limit = updated_accounts_data_size_limit
-            .unwrap_or(DEFAULT_ACCOUNTS_DATA_SIZE_BYTES)
-            .min(MAX_ACCOUNTS_DATA_SIZE_BYTES);
+        self.loaded_accounts_data_size_limit = updated_loaded_accounts_data_size_limit
+            .unwrap_or(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
+            .min(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
 
         Ok(prioritization_fee
             .map(|fee_type| PrioritizationFeeDetails::new(fee_type, self.compute_unit_limit))
@@ -296,7 +294,7 @@ mod tests {
     };
 
     macro_rules! test {
-        ( $instructions: expr, $expected_result: expr, $expected_budget: expr, $enable_request_heap_frame_ix: expr, $support_set_accounts_data_size_limit_ix: expr ) => {
+        ( $instructions: expr, $expected_result: expr, $expected_budget: expr, $enable_request_heap_frame_ix: expr, $support_set_loaded_accounts_data_size_limit_ix: expr ) => {
             let payer_keypair = Keypair::new();
             let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
                 &[&payer_keypair],
@@ -309,7 +307,7 @@ mod tests {
                 true,
                 false, /*not support request_units_deprecated*/
                 $enable_request_heap_frame_ix,
-                $support_set_accounts_data_size_limit_ix,
+                $support_set_loaded_accounts_data_size_limit_ix,
             );
             assert_eq!($expected_result, result);
             assert_eq!(compute_budget, $expected_budget);
@@ -677,12 +675,12 @@ mod tests {
     }
 
     #[test]
-    fn test_process_accounts_data_size_limit_instruction() {
+    fn test_process_loaded_accounts_data_size_limit_instruction() {
         let enable_request_heap_frame_ix: bool = true;
 
-        // Assert for empty instructions, change value of support_set_accounts_data_size_limit_ix
+        // Assert for empty instructions, change value of support_set_loaded_accounts_data_size_limit_ix
         // will not change results, which should all be default
-        for support_set_accounts_data_size_limit_ix in [true, false] {
+        for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
             test!(
                 &[],
                 Ok(PrioritizationFeeDetails::default()),
@@ -691,23 +689,23 @@ mod tests {
                     ..ComputeBudget::default()
                 },
                 enable_request_heap_frame_ix,
-                support_set_accounts_data_size_limit_ix
+                support_set_loaded_accounts_data_size_limit_ix
             );
         }
 
-        // Assert when set_accounts_data_size_limit presents,
-        // if support_set_accounts_data_size_limit_ix then
+        // Assert when set_loaded_accounts_data_size_limit presents,
+        // if support_set_loaded_accounts_data_size_limit_ix then
         //     budget is set with data_size
         // else
         //     return InstructionError
         let data_size: usize = 1;
-        for support_set_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+        for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
                 (
                     Ok(PrioritizationFeeDetails::default()),
                     ComputeBudget {
                         compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                        accounts_data_size_limit: data_size,
+                        loaded_accounts_data_size_limit: data_size,
                         ..ComputeBudget::default()
                     },
                 )
@@ -723,29 +721,29 @@ mod tests {
 
             test!(
                 &[
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size as u32),
                     Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
                 ],
                 expected_result,
                 expected_budget,
                 enable_request_heap_frame_ix,
-                support_set_accounts_data_size_limit_ix
+                support_set_loaded_accounts_data_size_limit_ix
             );
         }
 
-        // Assert when set_accounts_data_size_limit presents, with greater than max value
-        // if support_set_accounts_data_size_limit_ix then
+        // Assert when set_loaded_accounts_data_size_limit presents, with greater than max value
+        // if support_set_loaded_accounts_data_size_limit_ix then
         //     budget is set to max data size
         // else
         //     return InstructionError
-        let data_size: usize = MAX_ACCOUNTS_DATA_SIZE_BYTES + 1;
-        for support_set_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+        let data_size: usize = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES + 1;
+        for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
                 (
                     Ok(PrioritizationFeeDetails::default()),
                     ComputeBudget {
                         compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                        accounts_data_size_limit: MAX_ACCOUNTS_DATA_SIZE_BYTES,
+                        loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
                         ..ComputeBudget::default()
                     },
                 )
@@ -761,27 +759,27 @@ mod tests {
 
             test!(
                 &[
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size as u32),
                     Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
                 ],
                 expected_result,
                 expected_budget,
                 enable_request_heap_frame_ix,
-                support_set_accounts_data_size_limit_ix
+                support_set_loaded_accounts_data_size_limit_ix
             );
         }
 
-        // Assert when set_accounts_data_size_limit is not presented
-        // if support_set_accounts_data_size_limit_ix then
+        // Assert when set_loaded_accounts_data_size_limit is not presented
+        // if support_set_loaded_accounts_data_size_limit_ix then
         //     budget is set to default data size
         // else
         //     return
-        for support_set_accounts_data_size_limit_ix in [true, false] {
+        for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
             let (expected_result, expected_budget) = (
                 Ok(PrioritizationFeeDetails::default()),
                 ComputeBudget {
                     compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                    accounts_data_size_limit: DEFAULT_ACCOUNTS_DATA_SIZE_BYTES,
+                    loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
                     ..ComputeBudget::default()
                 },
             );
@@ -795,18 +793,18 @@ mod tests {
                 expected_result,
                 expected_budget,
                 enable_request_heap_frame_ix,
-                support_set_accounts_data_size_limit_ix
+                support_set_loaded_accounts_data_size_limit_ix
             );
         }
 
-        // Assert when set_accounts_data_size_limit presents more than once,
-        // if support_set_accounts_data_size_limit_ix then
+        // Assert when set_loaded_accounts_data_size_limit presents more than once,
+        // if support_set_loaded_accounts_data_size_limit_ix then
         //     return DuplicateInstruction
         // else
         //     return InstructionError
-        let data_size: usize = DEFAULT_ACCOUNTS_DATA_SIZE_BYTES;
-        for support_set_accounts_data_size_limit_ix in [true, false] {
-            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+        let data_size: usize = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES;
+        for support_set_loaded_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_loaded_accounts_data_size_limit_ix {
                 (
                     Err(TransactionError::DuplicateInstruction(2)),
                     ComputeBudget::default(),
@@ -824,13 +822,13 @@ mod tests {
             test!(
                 &[
                     Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
-                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size as u32),
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size as u32),
                 ],
                 expected_result,
                 expected_budget,
                 enable_request_heap_frame_ix,
-                support_set_accounts_data_size_limit_ix
+                support_set_loaded_accounts_data_size_limit_ix
             );
         }
     }

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -10,6 +10,12 @@ use {
     },
 };
 
+/// The total accounts data a transaction can load is limited to 64MiB to not break
+/// anyone in Mainnet-beta today. It can be set by set_accounts_data_size_limit instruction
+pub const MAX_ACCOUNTS_DATA_SIZE_BYTES: usize = 64 * 1024 * 1024;
+/// default data size to allow one maximum sized account
+const DEFAULT_ACCOUNTS_DATA_SIZE_BYTES: usize = 10 * 1024 * 1024;
+
 pub const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
@@ -109,6 +115,9 @@ pub struct ComputeBudget {
     pub alt_bn128_pairing_one_pair_cost_other: u64,
     /// Big integer modular exponentiation cost
     pub big_modular_exponentiation_cost: u64,
+    /// Maximum accounts data size, in bytes, that a transaction is allowed to load; The
+    /// value is capped by MAX_ACCOUNTS_DATA_SIZE_BYTES to prevent overuse of memory.
+    pub accounts_data_size_limit: usize,
 }
 
 impl Default for ComputeBudget {
@@ -157,6 +166,7 @@ impl ComputeBudget {
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
             big_modular_exponentiation_cost: 33,
+            accounts_data_size_limit: DEFAULT_ACCOUNTS_DATA_SIZE_BYTES,
         }
     }
 
@@ -166,11 +176,13 @@ impl ComputeBudget {
         default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
         enable_request_heap_frame_ix: bool,
+        support_set_accounts_data_size_limit_ix: bool,
     ) -> Result<PrioritizationFeeDetails, TransactionError> {
         let mut num_non_compute_budget_instructions: usize = 0;
         let mut updated_compute_unit_limit = None;
         let mut requested_heap_size = None;
         let mut prioritization_fee = None;
+        let mut updated_accounts_data_size_limit = None;
 
         for (i, (program_id, instruction)) in instructions.enumerate() {
             if compute_budget::check_id(program_id) {
@@ -214,6 +226,14 @@ impl ComputeBudget {
                         prioritization_fee =
                             Some(PrioritizationFeeType::ComputeUnitPrice(micro_lamports));
                     }
+                    Ok(ComputeBudgetInstruction::SetAccountsDataSizeLimit(bytes))
+                        if support_set_accounts_data_size_limit_ix =>
+                    {
+                        if updated_accounts_data_size_limit.is_some() {
+                            return Err(duplicate_instruction_error);
+                        }
+                        updated_accounts_data_size_limit = Some(bytes as usize);
+                    }
                     _ => return Err(invalid_instruction_data_error),
                 }
             } else {
@@ -250,6 +270,10 @@ impl ComputeBudget {
         .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
         .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
 
+        self.accounts_data_size_limit = updated_accounts_data_size_limit
+            .unwrap_or(DEFAULT_ACCOUNTS_DATA_SIZE_BYTES)
+            .min(MAX_ACCOUNTS_DATA_SIZE_BYTES);
+
         Ok(prioritization_fee
             .map(|fee_type| PrioritizationFeeDetails::new(fee_type, self.compute_unit_limit))
             .unwrap_or_default())
@@ -272,7 +296,7 @@ mod tests {
     };
 
     macro_rules! test {
-        ( $instructions: expr, $expected_result: expr, $expected_budget: expr, $enable_request_heap_frame_ix: expr ) => {
+        ( $instructions: expr, $expected_result: expr, $expected_budget: expr, $enable_request_heap_frame_ix: expr, $support_set_accounts_data_size_limit_ix: expr ) => {
             let payer_keypair = Keypair::new();
             let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
                 &[&payer_keypair],
@@ -285,12 +309,19 @@ mod tests {
                 true,
                 false, /*not support request_units_deprecated*/
                 $enable_request_heap_frame_ix,
+                $support_set_accounts_data_size_limit_ix,
             );
             assert_eq!($expected_result, result);
             assert_eq!(compute_budget, $expected_budget);
         };
         ( $instructions: expr, $expected_result: expr, $expected_budget: expr) => {
-            test!($instructions, $expected_result, $expected_budget, true);
+            test!(
+                $instructions,
+                $expected_result,
+                $expected_budget,
+                true,
+                false
+            );
         };
     }
 
@@ -561,6 +592,7 @@ mod tests {
                 compute_unit_limit: 0,
                 ..ComputeBudget::default()
             },
+            false,
             false
         );
 
@@ -575,6 +607,7 @@ mod tests {
                 InstructionError::InvalidInstructionData
             )),
             ComputeBudget::default(),
+            false,
             false
         );
         test!(
@@ -587,6 +620,7 @@ mod tests {
                 InstructionError::InvalidInstructionData,
             )),
             ComputeBudget::default(),
+            false,
             false
         );
         test!(
@@ -601,6 +635,7 @@ mod tests {
                 InstructionError::InvalidInstructionData,
             )),
             ComputeBudget::default(),
+            false,
             false
         );
         test!(
@@ -615,6 +650,7 @@ mod tests {
                 InstructionError::InvalidInstructionData,
             )),
             ComputeBudget::default(),
+            false,
             false
         );
 
@@ -635,7 +671,167 @@ mod tests {
                 compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64 * 7,
                 ..ComputeBudget::default()
             },
+            false,
             false
         );
+    }
+
+    #[test]
+    fn test_process_accounts_data_size_limit_instruction() {
+        let enable_request_heap_frame_ix: bool = true;
+
+        // Assert for empty instructions, change value of support_set_accounts_data_size_limit_ix
+        // will not change results, which should all be default
+        for support_set_accounts_data_size_limit_ix in [true, false] {
+            test!(
+                &[],
+                Ok(PrioritizationFeeDetails::default()),
+                ComputeBudget {
+                    compute_unit_limit: 0,
+                    ..ComputeBudget::default()
+                },
+                enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix
+            );
+        }
+
+        // Assert when set_accounts_data_size_limit presents,
+        // if support_set_accounts_data_size_limit_ix then
+        //     budget is set with data_size
+        // else
+        //     return InstructionError
+        let data_size: usize = 1;
+        for support_set_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+                (
+                    Ok(PrioritizationFeeDetails::default()),
+                    ComputeBudget {
+                        compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                        accounts_data_size_limit: data_size,
+                        ..ComputeBudget::default()
+                    },
+                )
+            } else {
+                (
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::InvalidInstructionData,
+                    )),
+                    ComputeBudget::default(),
+                )
+            };
+
+            test!(
+                &[
+                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ],
+                expected_result,
+                expected_budget,
+                enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix
+            );
+        }
+
+        // Assert when set_accounts_data_size_limit presents, with greater than max value
+        // if support_set_accounts_data_size_limit_ix then
+        //     budget is set to max data size
+        // else
+        //     return InstructionError
+        let data_size: usize = MAX_ACCOUNTS_DATA_SIZE_BYTES + 1;
+        for support_set_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+                (
+                    Ok(PrioritizationFeeDetails::default()),
+                    ComputeBudget {
+                        compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                        accounts_data_size_limit: MAX_ACCOUNTS_DATA_SIZE_BYTES,
+                        ..ComputeBudget::default()
+                    },
+                )
+            } else {
+                (
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::InvalidInstructionData,
+                    )),
+                    ComputeBudget::default(),
+                )
+            };
+
+            test!(
+                &[
+                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ],
+                expected_result,
+                expected_budget,
+                enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix
+            );
+        }
+
+        // Assert when set_accounts_data_size_limit is not presented
+        // if support_set_accounts_data_size_limit_ix then
+        //     budget is set to default data size
+        // else
+        //     return
+        for support_set_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = (
+                Ok(PrioritizationFeeDetails::default()),
+                ComputeBudget {
+                    compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+                    accounts_data_size_limit: DEFAULT_ACCOUNTS_DATA_SIZE_BYTES,
+                    ..ComputeBudget::default()
+                },
+            );
+
+            test!(
+                &[Instruction::new_with_bincode(
+                    Pubkey::new_unique(),
+                    &0_u8,
+                    vec![]
+                ),],
+                expected_result,
+                expected_budget,
+                enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix
+            );
+        }
+
+        // Assert when set_accounts_data_size_limit presents more than once,
+        // if support_set_accounts_data_size_limit_ix then
+        //     return DuplicateInstruction
+        // else
+        //     return InstructionError
+        let data_size: usize = DEFAULT_ACCOUNTS_DATA_SIZE_BYTES;
+        for support_set_accounts_data_size_limit_ix in [true, false] {
+            let (expected_result, expected_budget) = if support_set_accounts_data_size_limit_ix {
+                (
+                    Err(TransactionError::DuplicateInstruction(2)),
+                    ComputeBudget::default(),
+                )
+            } else {
+                (
+                    Err(TransactionError::InstructionError(
+                        1,
+                        InstructionError::InvalidInstructionData,
+                    )),
+                    ComputeBudget::default(),
+                )
+            };
+
+            test!(
+                &[
+                    Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                    ComputeBudgetInstruction::set_accounts_data_size_limit(data_size as u32),
+                ],
+                expected_result,
+                expected_budget,
+                enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix
+            );
+        }
     }
 }

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -226,7 +226,7 @@ impl ComputeBudget {
                         prioritization_fee =
                             Some(PrioritizationFeeType::ComputeUnitPrice(micro_lamports));
                     }
-                    Ok(ComputeBudgetInstruction::SetAccountsDataSizeLimit(bytes))
+                    Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes))
                         if support_set_accounts_data_size_limit_ix =>
                     {
                         if updated_accounts_data_size_limit.is_some() {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3590,6 +3590,7 @@ fn test_program_fees() {
         false,
         true,
         true,
+        true,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3612,6 +3613,7 @@ fn test_program_fees() {
         &fee_structure,
         true,
         false,
+        true,
         true,
         true,
     );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -31,8 +31,9 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot},
         feature_set::{
-            self, enable_request_heap_frame_ix, remove_congestion_multiplier_from_fee_calculation,
-            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
+            self, add_set_tx_data_size_instruction, enable_request_heap_frame_ix,
+            remove_congestion_multiplier_from_fee_calculation, remove_deprecated_request_unit_ix,
+            use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
@@ -646,6 +647,7 @@ impl Accounts {
                             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                             feature_set.is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                             feature_set.is_active(&enable_request_heap_frame_ix::id()) || self.accounts_db.expected_cluster_type() != ClusterType::MainnetBeta,
+                            feature_set.is_active(&add_set_tx_data_size_instruction::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1671,6 +1673,7 @@ mod tests {
             &FeeStructure::default(),
             true,
             false,
+            true,
             true,
             true,
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -31,7 +31,7 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot},
         feature_set::{
-            self, add_set_tx_data_size_instruction, enable_request_heap_frame_ix,
+            self, add_set_tx_loaded_accounts_data_size_instruction, enable_request_heap_frame_ix,
             remove_congestion_multiplier_from_fee_calculation, remove_deprecated_request_unit_ix,
             use_default_units_in_fee_calculation, FeatureSet,
         },
@@ -647,7 +647,7 @@ impl Accounts {
                             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                             feature_set.is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                             feature_set.is_active(&enable_request_heap_frame_ix::id()) || self.accounts_db.expected_cluster_type() != ClusterType::MainnetBeta,
-                            feature_set.is_active(&add_set_tx_data_size_instruction::id()),
+                            feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -118,9 +118,10 @@ use {
         epoch_schedule::EpochSchedule,
         feature,
         feature_set::{
-            self, disable_fee_calculator, enable_early_verification_of_account_modifications,
-            enable_request_heap_frame_ix, remove_congestion_multiplier_from_fee_calculation,
-            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
+            self, add_set_tx_data_size_instruction, disable_fee_calculator,
+            enable_early_verification_of_account_modifications, enable_request_heap_frame_ix,
+            remove_congestion_multiplier_from_fee_calculation, remove_deprecated_request_unit_ix,
+            use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -3462,6 +3463,8 @@ impl Bank {
             self.feature_set
                 .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
             self.enable_request_heap_frame_ix(),
+            self.feature_set
+                .is_active(&add_set_tx_data_size_instruction::id()),
         ))
     }
 
@@ -3509,6 +3512,8 @@ impl Bank {
             self.feature_set
                 .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
             self.enable_request_heap_frame_ix(),
+            self.feature_set
+                .is_active(&add_set_tx_data_size_instruction::id()),
         )
     }
 
@@ -4520,6 +4525,8 @@ impl Bank {
                                     .feature_set
                                     .is_active(&remove_deprecated_request_unit_ix::id()),
                                 true, // don't reject txs that use request heap size ix
+                                self.feature_set
+                                    .is_active(&add_set_tx_data_size_instruction::id()),
                             );
                             compute_budget_process_transaction_time.stop();
                             saturating_add_assign!(
@@ -4800,6 +4807,7 @@ impl Bank {
         support_request_units_deprecated: bool,
         remove_congestion_multiplier: bool,
         enable_request_heap_frame_ix: bool,
+        support_set_accounts_data_size_limit_ix: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
         let congestion_multiplier = if lamports_per_signature == 0 {
@@ -4819,6 +4827,7 @@ impl Bank {
                 use_default_units_per_instruction,
                 support_request_units_deprecated,
                 enable_request_heap_frame_ix,
+                support_set_accounts_data_size_limit_ix,
             )
             .unwrap_or_default();
         let prioritization_fee = prioritization_fee_details.get_fee();
@@ -4890,6 +4899,8 @@ impl Bank {
                     self.feature_set
                         .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                     self.enable_request_heap_frame_ix(),
+                    self.feature_set
+                        .is_active(&add_set_tx_data_size_instruction::id()),
                 );
 
                 // In case of instruction error, even though no accounts

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -13,7 +13,8 @@ use {
     },
     solana_sdk::{
         feature_set::{
-            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
+            add_set_tx_data_size_instruction, remove_deprecated_request_unit_ix,
+            use_default_units_in_fee_calculation, FeatureSet,
         },
         instruction::CompiledInstruction,
         program_utils::limited_deserialize,
@@ -155,6 +156,7 @@ impl CostModel {
             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
             enable_request_heap_frame_ix,
+            feature_set.is_active(&add_set_tx_data_size_instruction::id()),
         );
 
         // if tx contained user-space instructions and a more accurate estimate available correct it

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_sdk::{
         feature_set::{
-            add_set_tx_data_size_instruction, remove_deprecated_request_unit_ix,
+            add_set_tx_loaded_accounts_data_size_instruction, remove_deprecated_request_unit_ix,
             use_default_units_in_fee_calculation, FeatureSet,
         },
         instruction::CompiledInstruction,
@@ -156,7 +156,7 @@ impl CostModel {
             feature_set.is_active(&use_default_units_in_fee_calculation::id()),
             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
             enable_request_heap_frame_ix,
-            feature_set.is_active(&add_set_tx_data_size_instruction::id()),
+            feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
         );
 
         // if tx contained user-space instructions and a more accurate estimate available correct it

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -26,6 +26,7 @@ pub trait GetTransactionPriorityDetails {
                 true,  // use default units per instruction
                 false, // stop supporting prioritization by request_units_deprecated instruction
                 true,  // enable request heap frame instruction
+                true,  // enable support set accounts data size instruction
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -69,7 +69,7 @@ impl ComputeBudgetInstruction {
     }
 
     /// Create a `ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit` `Instruction`
-    pub fn set_accounts_data_size_limit(bytes: u32) -> Instruction {
+    pub fn set_loaded_accounts_data_size_limit(bytes: u32) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::SetLoadedAccountsDataSizeLimit(bytes), vec![])
     }
 }

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -41,8 +41,8 @@ pub enum ComputeBudgetInstruction {
     /// Set a compute unit price in "micro-lamports" to pay a higher transaction
     /// fee for higher transaction prioritization.
     SetComputeUnitPrice(u64),
-    /// Set a specific transaction-wide account data size limit, in bytes, is allowed to allocate.
-    SetAccountsDataSizeLimit(u32),
+    /// Set a specific transaction-wide account data size limit, in bytes, is allowed to load.
+    SetLoadedAccountsDataSizeLimit(u32),
 }
 
 impl ComputeBudgetInstruction {
@@ -68,8 +68,8 @@ impl ComputeBudgetInstruction {
         self.try_to_vec()
     }
 
-    /// Create a `ComputeBudgetInstruction::SetAccountsDataSizeLimit` `Instruction`
+    /// Create a `ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit` `Instruction`
     pub fn set_accounts_data_size_limit(bytes: u32) -> Instruction {
-        Instruction::new_with_borsh(id(), &Self::SetAccountsDataSizeLimit(bytes), vec![])
+        Instruction::new_with_borsh(id(), &Self::SetLoadedAccountsDataSizeLimit(bytes), vec![])
     }
 }

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -41,6 +41,8 @@ pub enum ComputeBudgetInstruction {
     /// Set a compute unit price in "micro-lamports" to pay a higher transaction
     /// fee for higher transaction prioritization.
     SetComputeUnitPrice(u64),
+    /// Set a specific transaction-wide account data size limit, in bytes, is allowed to allocate.
+    SetAccountsDataSizeLimit(u32),
 }
 
 impl ComputeBudgetInstruction {
@@ -64,5 +66,10 @@ impl ComputeBudgetInstruction {
     // #[cfg(test)]
     pub fn pack(self) -> Result<Vec<u8>, std::io::Error> {
         self.try_to_vec()
+    }
+
+    /// Create a `ComputeBudgetInstruction::SetAccountsDataSizeLimit` `Instruction`
+    pub fn set_accounts_data_size_limit(bytes: u32) -> Instruction {
+        Instruction::new_with_borsh(id(), &Self::SetAccountsDataSizeLimit(bytes), vec![])
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -618,6 +618,10 @@ pub mod apply_cost_tracker_during_replay {
     solana_sdk::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 
+pub mod add_set_tx_data_size_instruction {
+    solana_sdk::declare_id!("G6vbf1UBok8MWb8m25ex86aoQHeKTzDKzuZADHkShqm6");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -767,6 +771,7 @@ lazy_static! {
         (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30151"),
         (delay_visibility_of_program_deployment::id(), "delay visibility of program upgrades #30085"),
         (apply_cost_tracker_during_replay::id(), "apply cost tracker to blocks during replay #29595"),
+        (add_set_tx_data_size_instruction::id(), "add compute budget instruction for setting account data size per transaction #30366"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -618,7 +618,7 @@ pub mod apply_cost_tracker_during_replay {
     solana_sdk::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 
-pub mod add_set_tx_data_size_instruction {
+pub mod add_set_tx_loaded_accounts_data_size_instruction {
     solana_sdk::declare_id!("G6vbf1UBok8MWb8m25ex86aoQHeKTzDKzuZADHkShqm6");
 }
 
@@ -771,7 +771,7 @@ lazy_static! {
         (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30151"),
         (delay_visibility_of_program_deployment::id(), "delay visibility of program upgrades #30085"),
         (apply_cost_tracker_during_replay::id(), "apply cost tracker to blocks during replay #29595"),
-        (add_set_tx_data_size_instruction::id(), "add compute budget instruction for setting account data size per transaction #30366"),
+        (add_set_tx_loaded_accounts_data_size_instruction::id(), "add compute budget instruction for setting account data size per transaction #30366"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Need instruction for users to set per transaction accounts data size limit

#### Summary of Changes
- add compute budget instruction, with 64MB as Max (current hard coded limit)
- feature gated
- updated call sites 

Feature Gate Issue: #30366 
<!-- Don't forget to add the "feature-gate" label -->
