### PR TITLE
Update geyser interface to not require write locks

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -268,7 +268,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// the account is updated during transaction processing.
     #[allow(unused_variables)]
     fn update_account(
-        &mut self,
+        &self,
         account: ReplicaAccountInfoVersions,
         slot: u64,
         is_startup: bool,
@@ -277,25 +277,20 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     }
 
     /// Called when all accounts are notified of during startup.
-    fn notify_end_of_startup(&mut self) -> Result<()> {
+    fn notify_end_of_startup(&self) -> Result<()> {
         Ok(())
     }
 
     /// Called when a slot status is updated
     #[allow(unused_variables)]
-    fn update_slot_status(
-        &mut self,
-        slot: u64,
-        parent: Option<u64>,
-        status: SlotStatus,
-    ) -> Result<()> {
+    fn update_slot_status(&self, slot: u64, parent: Option<u64>, status: SlotStatus) -> Result<()> {
         Ok(())
     }
 
     /// Called when a transaction is updated at a slot.
     #[allow(unused_variables)]
     fn notify_transaction(
-        &mut self,
+        &self,
         transaction: ReplicaTransactionInfoVersions,
         slot: u64,
     ) -> Result<()> {
@@ -304,7 +299,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
 
     /// Called when block's metadata is updated.
     #[allow(unused_variables)]
-    fn notify_block_metadata(&mut self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
+    fn notify_block_metadata(&self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -68,12 +68,12 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
     }
 
     fn notify_end_of_restore_from_snapshot(&self) {
-        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
-        for plugin in plugin_manager.plugins.iter_mut() {
+        for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-end-of-restore-from-snapshot");
             match plugin.notify_end_of_startup() {
                 Err(err) => {
@@ -146,12 +146,12 @@ impl AccountsUpdateNotifierImpl {
         is_startup: bool,
     ) {
         let mut measure2 = Measure::start("geyser-plugin-notify_plugins_of_account_update");
-        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        let plugin_manager = self.plugin_manager.read().unwrap();
 
         if plugin_manager.plugins.is_empty() {
             return;
         }
-        for plugin in plugin_manager.plugins.iter_mut() {
+        for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-account");
             match plugin.update_account(
                 ReplicaAccountInfoVersions::V0_0_3(&account),

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -32,13 +32,13 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
     ) {
-        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
             return;
         }
         let rewards = Self::build_rewards(rewards);
 
-        for plugin in plugin_manager.plugins.iter_mut() {
+        for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             let block_info = Self::build_replica_block_info(
                 parent_slot,

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -45,12 +45,12 @@ impl SlotStatusNotifierImpl {
     }
 
     pub fn notify_slot_status(&self, slot: Slot, parent: Option<Slot>, slot_status: SlotStatus) {
-        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
-        for plugin in plugin_manager.plugins.iter_mut() {
+        for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             match plugin.update_slot_status(slot, parent, slot_status) {
                 Err(err) => {

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -38,13 +38,13 @@ impl TransactionNotifier for TransactionNotifierImpl {
             transaction,
         );
 
-        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        let plugin_manager = self.plugin_manager.read().unwrap();
 
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
-        for plugin in plugin_manager.plugins.iter_mut() {
+        for plugin in plugin_manager.plugins.iter() {
             if !plugin.transaction_notifications_enabled() {
                 continue;
             }


### PR DESCRIPTION
#### Problem
The current geyser plugin interface requires a mutable reference. This creates a massive bottleneck on plugins running geyser plugins that can cause nodes to slow down and fall behind the network. 

#### Summary of Changes
- In `geyser-plugin-interface`, it removes the `mut` reference on `update_account`, `update_slot_status`, `notify_end_of_startup`, `notification_transaction`, and `notify_block_metadata`.
- In `geyser-plugin-manager`, it replaces write locks with read locks on the plugin manager and changes plugin references to be non-mutable. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
