### PR TITLE
Add `Eq` for `Keypair`

### DIFF
--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -113,6 +113,8 @@ where
     }
 }
 
+impl Eq for Keypair {}
+
 /// Reads a JSON-encoded `Keypair` from a `Reader` implementor
 pub fn read_keypair<R: Read>(reader: &mut R) -> Result<Keypair, Box<dyn error::Error>> {
     let bytes: Vec<u8> = serde_json::from_reader(reader)?;


### PR DESCRIPTION
#### Problem

No `Eq` instance for `Keypair`.

#### Summary of Changes

Considering that `PartialEq` for `Keypair` forwards to `pubkey()`, which does implement `Eq`, it seems reasonable to implement `Eq` for `Keypair` as well.