### PR TITLE
local-cluster test: Do not delete files that are in use by node

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1187,18 +1187,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         num_account_paths,
     );
 
-    // Copy over the snapshots to the new node, but need to remove the tmp snapshot dir so it
-    // doesn't break the simple copy_files closure.
-    snapshot_utils::remove_tmp_snapshot_archives(
-        validator_snapshot_test_config
-            .full_snapshot_archives_dir
-            .path(),
-    );
-    snapshot_utils::remove_tmp_snapshot_archives(
-        validator_snapshot_test_config
-            .incremental_snapshot_archives_dir
-            .path(),
-    );
+    // Copy over the snapshots to the new node that it will boot from
     copy_files(
         validator_snapshot_test_config
             .full_snapshot_archives_dir


### PR DESCRIPTION
#### Problem

Original problem: https://github.com/solana-labs/solana/pull/30291
Partial fix: https://github.com/solana-labs/solana/pull/30340

Remaining issue:
https://github.com/solana-labs/solana/pull/30340#issuecomment-1433535391

Possible fixes:
https://github.com/solana-labs/solana/pull/30340#issuecomment-1433740383

Tl;dr: We are deleting tmp snapshot archives from underneath a running validator. If that validator is in the middle of archiving a snapshot, it will fail since its working-files will just have been rugged.


#### Summary of Changes

There's no need to remove the tmp snapshot archives from the validator *before* we copy snapshot archives over to the final validator. So don't 😄 

Fixes #30291


#### Testing

I ran this modification in a tight loop for approximately 550 iterations without a failure. Hopefully this will fix the last issue in this test? If we sure further issues here, the validator can be stopped *before* we copy the snapshot archives to the final validator.