### PR TITLE
Uses set_accounts_{delta,}_hash_for_tests() in serde tests

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9501,6 +9501,15 @@ pub mod tests {
         pub fn set_accounts_hash_for_tests(&self, slot: Slot, accounts_hash: AccountsHash) {
             self.set_accounts_hash(slot, accounts_hash);
         }
+
+        // used by serde_snapshot tests
+        pub fn set_accounts_delta_hash_for_tests(
+            &self,
+            slot: Slot,
+            accounts_delta_hash: AccountsDeltaHash,
+        ) {
+            self.set_accounts_delta_hash(slot, accounts_delta_hash);
+        }
     }
 
     /// This impl exists until this feature is activated:

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -188,7 +188,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     let accounts_hash = AccountsHash(Hash::new_unique());
     accounts
         .accounts_db
-        .set_accounts_hash_from_snapshot(slot, accounts_hash);
+        .set_accounts_hash_for_tests(slot, accounts_hash);
 
     let mut writer = Cursor::new(vec![]);
     accountsdb_to_stream(
@@ -521,11 +521,11 @@ fn test_extra_fields_eof() {
     bank.rc
         .accounts
         .accounts_db
-        .set_accounts_delta_hash_from_snapshot(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
+        .set_accounts_delta_hash_for_tests(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
     bank.rc
         .accounts
         .accounts_db
-        .set_accounts_hash_from_snapshot(bank.slot(), AccountsHash(Hash::new_unique()));
+        .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
 
     // Set extra fields
     bank.fee_rate_governor.lamports_per_signature = 7000;
@@ -657,11 +657,11 @@ fn test_blank_extra_fields() {
     bank.rc
         .accounts
         .accounts_db
-        .set_accounts_delta_hash_from_snapshot(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
+        .set_accounts_delta_hash_for_tests(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
     bank.rc
         .accounts
         .accounts_db
-        .set_accounts_hash_from_snapshot(bank.slot(), AccountsHash(Hash::new_unique()));
+        .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
 
     // Set extra fields
     bank.fee_rate_governor.lamports_per_signature = 7000;
@@ -733,14 +733,11 @@ mod test_bank_serialize {
         bank.rc
             .accounts
             .accounts_db
-            .set_accounts_delta_hash_from_snapshot(
-                bank.slot(),
-                AccountsDeltaHash(Hash::new_unique()),
-            );
+            .set_accounts_delta_hash_for_tests(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
         bank.rc
             .accounts
             .accounts_db
-            .set_accounts_hash_from_snapshot(bank.slot(), AccountsHash(Hash::new_unique()));
+            .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
         let snapshot_storages = bank
             .rc
             .accounts


### PR DESCRIPTION
#### Problem

Incremental Accounts Hash needs to disambiguate between a Full and an Incremental accounts hash. Using an enum (or multiple types with a trait) requires changes to serde snapshot so that ABI is maintained. There are multiple steps involved.

In this PR, serde snapshot tests set the accounts hash and accounts delta hash. They are using methods intended for "normal" accounts db deserialization that will be changing in the next PR. Those changes will break the serde tests. Instead, we proactively add/use test-only methods to set the accounts hash/accounts delta hash.


#### Summary of Changes

Add/use test-only methods to set the accounts delta hash/accounts hash in serde_snapshot tests.