### PR TITLE
Serde snapshot uses own types

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -54,6 +54,7 @@ use {
         read_only_accounts_cache::ReadOnlyAccountsCache,
         rent_collector::RentCollector,
         rent_paying_accounts_by_partition::RentPayingAccountsByPartition,
+        serde_snapshot::{SerdeAccountsDeltaHash, SerdeAccountsHash},
         snapshot_utils::create_accounts_run_and_snapshot_dirs,
         sorted_storages::SortedStorages,
         storable_accounts::StorableAccounts,
@@ -7325,12 +7326,13 @@ impl AccountsDb {
             .insert(slot, accounts_hash)
     }
 
+    /// After deserializing a snapshot, set the accounts hash for the new AccountsDb
     pub fn set_accounts_hash_from_snapshot(
-        &self,
+        &mut self,
         slot: Slot,
-        accounts_hash: AccountsHash,
+        accounts_hash: SerdeAccountsHash,
     ) -> Option<AccountsHash> {
-        self.set_accounts_hash(slot, accounts_hash)
+        self.set_accounts_hash(slot, accounts_hash.into())
     }
 
     /// Get the accounts hash for `slot` in the `accounts_hashes` map
@@ -7729,12 +7731,13 @@ impl AccountsDb {
             .insert(slot, accounts_delta_hash)
     }
 
+    /// After deserializing a snapshot, set the accounts delta hash for the new AccountsDb
     pub fn set_accounts_delta_hash_from_snapshot(
-        &self,
+        &mut self,
         slot: Slot,
-        accounts_delta_hash: AccountsDeltaHash,
+        accounts_delta_hash: SerdeAccountsDeltaHash,
     ) -> Option<AccountsDeltaHash> {
-        self.set_accounts_delta_hash(slot, accounts_delta_hash)
+        self.set_accounts_delta_hash(slot, accounts_delta_hash.into())
     }
 
     /// Get the accounts delta hash for `slot` in the `accounts_delta_hashes` map
@@ -7756,7 +7759,7 @@ impl AccountsDb {
     /// snapshot--the bank hash stats map is populated with a default entry at slot 0.  Remove the
     /// default entry at slot 0, and then insert the new value at `slot`.
     pub fn update_bank_hash_stats_from_snapshot(
-        &self,
+        &mut self,
         slot: Slot,
         stats: BankHashStats,
     ) -> Option<BankHashStats> {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -83,9 +83,38 @@ pub struct AccountsDbFields<T>(
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
 struct BankHashInfo {
-    accounts_delta_hash: AccountsDeltaHash,
-    accounts_hash: AccountsHash,
+    accounts_delta_hash: SerdeAccountsDeltaHash,
+    accounts_hash: SerdeAccountsHash,
     stats: BankHashStats,
+}
+
+/// Snapshot serde-safe accounts delta hash
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+pub struct SerdeAccountsDeltaHash(pub Hash);
+
+impl From<SerdeAccountsDeltaHash> for AccountsDeltaHash {
+    fn from(accounts_delta_hash: SerdeAccountsDeltaHash) -> Self {
+        Self(accounts_delta_hash.0)
+    }
+}
+impl From<AccountsDeltaHash> for SerdeAccountsDeltaHash {
+    fn from(accounts_delta_hash: AccountsDeltaHash) -> Self {
+        Self(accounts_delta_hash.0)
+    }
+}
+
+/// Snapshot serde-safe accounts hash
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+pub struct SerdeAccountsHash(pub Hash);
+impl From<SerdeAccountsHash> for AccountsHash {
+    fn from(accounts_hash: SerdeAccountsHash) -> Self {
+        Self(accounts_hash.0)
+    }
+}
+impl From<AccountsHash> for SerdeAccountsHash {
+    fn from(accounts_hash: AccountsHash) -> Self {
+        Self(accounts_hash.0)
+    }
 }
 
 /// Helper type to wrap BufReader streams when deserializing and reconstructing from either just a

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -273,6 +273,7 @@ impl<'a> TypeContext<'a> for Context {
         let accounts_delta_hash = serializable_db
             .accounts_db
             .get_accounts_delta_hash(slot)
+            .map(Into::into)
             .unwrap_or_else(|| panic!("Missing accounts delta hash entry for slot {slot}"));
         // NOTE: The accounts hash is calculated in AHV, which is *after* a bank snapshot is taken
         // (and serialized here).  Thus it is expected that an accounts hash is *not* found for
@@ -281,6 +282,7 @@ impl<'a> TypeContext<'a> for Context {
         let accounts_hash = serializable_db
             .accounts_db
             .get_accounts_hash(slot)
+            .map(Into::into)
             .unwrap_or_default();
         let stats = serializable_db
             .accounts_db
@@ -369,7 +371,7 @@ impl<'a> TypeContext<'a> for Context {
     {
         let (bank_fields, mut accounts_db_fields) =
             Self::deserialize_bank_fields(stream_reader).unwrap();
-        accounts_db_fields.3.accounts_hash = *accounts_hash;
+        accounts_db_fields.3.accounts_hash = (*accounts_hash).into();
         let mut rhs = bank_fields;
         let blockhash_queue = RwLock::new(std::mem::take(&mut rhs.blockhash_queue));
         let hard_forks = RwLock::new(std::mem::take(&mut rhs.hard_forks));

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -719,7 +719,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "Eg6gt9thiY8Sn6gDKvpyyHADtWpSt6ur9Z4Zwh1BrCgv")]
+    #[frozen_abi(digest = "FeRj6jpfB3n6FvX2edAhdwYhnBkYZgsqHufd7weFWTfx")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem

Builds on #30390

Incremental Accounts Hash needs to disambiguate between a Full and an Incremental accounts hash. Using an enum (or multiple types with a trait) requires changes to serde snapshot so that ABI is maintained. There are multiple steps involved.

When serializing/deserializing AccountsDb, we cannot change the ABI easily. We *do* want to change the Accounts Hash type to be an enum, which breaks ABI. Luckily, we can use the `BankIncrementalSnapshotPersistence` fields for the new accounts hash values. We still have to divorce the `AccountsHash` type from `AccountsDbFields` though, otherwise ABI will break.


#### Summary of Changes

Add new "Serde" types for AccountsHash and AccountsDeltaHash. This will behave similar to Bank's `BankFieldsToSerialize`/`BankFieldsToDeserialize`. By using new types just for serde snapshot, we can now guarantee ABI won't change in the snapshot, and we *can* change the original `AccountsHash` and/or `AccountsDeltaHash` behind the scenes.

With these new types, we can also make the `set_accounts_{delta}_hash_from_snapshot()` functions safer by using the Serde types as function parameters.

*And!* since #30390 updated the tests to call the test-version of the `set()` functions, we now update the `_from_snapshot()` functions to take a `&mut` to the AccountsDb instance, further narrowing where these functions can legally be called from (i.e. only when creating a new AccountsDb when deserializing a snapshot).