### PR TITLE
Removes unnecessary derives from Accounts{Delta}Hash

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -540,10 +540,11 @@ fn test_concurrent_snapshot_packaging(
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
                 accounts_package.snapshot_links_dir(),
                 accounts_package.slot,
-                &AccountsHash::default(),
+                &AccountsHash(Hash::default()),
                 None,
             );
-            let snapshot_package = SnapshotPackage::new(accounts_package, AccountsHash::default());
+            let snapshot_package =
+                SnapshotPackage::new(accounts_package, AccountsHash(Hash::default()));
             pending_snapshot_package
                 .lock()
                 .unwrap()
@@ -570,7 +571,7 @@ fn test_concurrent_snapshot_packaging(
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         saved_snapshots_dir.path(),
         saved_slot,
-        &AccountsHash::default(),
+        &AccountsHash(Hash::default()),
         None,
     );
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1108,11 +1108,11 @@ pub enum ZeroLamportAccounts {
 }
 
 /// Hash of accounts
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, AbiExample)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct AccountsHash(pub Hash);
 
 /// Hash of accounts written in a single slot
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, AbiExample)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct AccountsDeltaHash(pub Hash);
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Builds on #30390 and #30391

Incremental Accounts Hash needs to disambiguate between a Full and an Incremental accounts hash. Using an enum (or multiple types with a trait) requires changes to serde snapshot so that ABI is maintained. There are multiple steps involved.

In order to change `AccountsHash`, we don't want it tied to ABI. Since it derives Serde and ABI traits, this is a problem at worst, and confusing at best.

#### Summary of Changes

Remove unnecessary traits from AccountsHash and AccountsDeltaHash.

Once nice safety benefit is that we can remove Default too. Since an AccountsHash/AccountsDeltaHash doesn't have a valid "default", it's nice to no longer need to support that.