### PR TITLE
Banking MetricsRecorder

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -46,6 +46,9 @@ mod decision_maker;
 mod forwarder;
 mod packet_receiver;
 
+#[allow(dead_code)]
+mod metrics_reporter_service;
+
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 6;
 

--- a/core/src/banking_stage/metrics_reporter_service.rs
+++ b/core/src/banking_stage/metrics_reporter_service.rs
@@ -1,0 +1,120 @@
+//! Reporting service that reports metrics on a regular interval or when a bank is completed.
+
+use {
+    solana_poh::poh_recorder::Slot,
+    solana_runtime::leader_bank_status::LeaderBankStatus,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::JoinHandle,
+        time::{Duration, Instant},
+    },
+};
+
+/// Report metrics on a regular interval
+pub trait IntervalMetricsReporter: Send + Sync {
+    fn report(&self);
+}
+
+/// Report metrics at the end of each **leader** slot
+pub trait SlotMetricsReporter: Send + Sync {
+    fn report(&self, slot: Slot);
+}
+
+pub struct MetricsReporter {
+    /// The interval at which interval metrics are reported
+    report_interval: Duration,
+    /// Per-Slot reported metrics
+    slot_metrics_reporters: Vec<Box<dyn SlotMetricsReporter>>,
+    /// Interval reported metrics
+    interval_metrics_reporters: Vec<Box<dyn IntervalMetricsReporter>>,
+}
+
+impl MetricsReporter {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            report_interval: interval,
+            slot_metrics_reporters: vec![],
+            interval_metrics_reporters: vec![],
+        }
+    }
+
+    pub fn add_slot_metrics_reporter(&mut self, reporter: impl SlotMetricsReporter + 'static) {
+        self.slot_metrics_reporters.push(Box::new(reporter));
+    }
+
+    pub fn add_interval_metrics_reporter(
+        &mut self,
+        reporter: impl IntervalMetricsReporter + 'static,
+    ) {
+        self.interval_metrics_reporters.push(Box::new(reporter));
+    }
+
+    pub fn run(
+        self,
+        leader_bank_status: Arc<LeaderBankStatus>,
+        exit: Arc<AtomicBool>,
+    ) -> JoinHandle<()> {
+        let mut last_interval_report = Instant::now();
+        std::thread::Builder::new()
+            .name("solMetReporter".to_string())
+            .spawn(move || {
+                while !exit.load(Ordering::Relaxed) {
+                    let timeout = self.report_interval - last_interval_report.elapsed();
+                    if let Some(slot) = leader_bank_status.wait_for_next_completed_timeout(timeout)
+                    {
+                        for reporter in &self.slot_metrics_reporters {
+                            reporter.report(slot);
+                        }
+                    } else {
+                        for reporter in &self.interval_metrics_reporters {
+                            reporter.report();
+                        }
+                        last_interval_report = Instant::now();
+                    }
+                }
+            })
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::sync::atomic::AtomicU64};
+
+    #[derive(Default)]
+    struct TestSlotMetricsReporter {
+        field: AtomicU64,
+    }
+    impl SlotMetricsReporter for Arc<TestSlotMetricsReporter> {
+        fn report(&self, slot: Slot) {
+            info!("reporting slot: {slot}");
+        }
+    }
+
+    #[derive(Default)]
+    struct TestIntervalMetricsReporter {
+        field: AtomicU64,
+    }
+    impl IntervalMetricsReporter for Arc<TestIntervalMetricsReporter> {
+        fn report(&self) {
+            info!("reporting interval");
+        }
+    }
+
+    #[test]
+    fn test_metrics_reporter_add() {
+        let mut reporter = MetricsReporter::new(Duration::from_millis(100));
+        let slot_metrics_reporter = Arc::new(TestSlotMetricsReporter::default());
+        let interval_metrics_reporter = Arc::new(TestIntervalMetricsReporter::default());
+        reporter.add_slot_metrics_reporter(slot_metrics_reporter.clone());
+        reporter.add_interval_metrics_reporter(interval_metrics_reporter.clone());
+
+        slot_metrics_reporter.field.fetch_add(1, Ordering::Relaxed);
+        interval_metrics_reporter
+            .field
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/runtime/src/leader_bank_status.rs
+++ b/runtime/src/leader_bank_status.rs
@@ -1,0 +1,139 @@
+use {
+    crate::bank::Bank,
+    solana_sdk::slot_history::Slot,
+    std::{
+        sync::{Arc, Condvar, Mutex, RwLock, Weak},
+        time::{Duration, Instant},
+    },
+};
+
+/// Tracks leader status of the validator node and notifies when:
+///     1. A leader slot begins
+///     2. A leader slot completes
+#[derive(Debug, Default)]
+pub struct LeaderBankStatus {
+    /// Current state of the system
+    status: Mutex<Status>,
+    /// Weak reference to the current bank
+    bank: RwLock<Option<(Slot, Weak<Bank>)>>,
+    /// CondVar to notify status changes and waiting
+    condvar: Condvar,
+}
+
+/// Leader status state machine for the validator:
+/// [Unininitialized] -> [InProgress] -> [Completed] --|
+///                          ^-------------------------|
+#[derive(Debug, Default)]
+enum Status {
+    /// Initial state, no bank, but also not completed yet
+    #[default]
+    Uninitialized,
+    /// Slot is in progress as leader
+    InProgress,
+    /// PoH has reached the end of the slot, and the next bank as leader is not available yet
+    Completed,
+}
+
+impl LeaderBankStatus {
+    /// Set the status to `InProgress` and notify any waiting threads
+    /// if the status was not already `InProgress`.
+    pub fn set_in_progress(&self, bank: &Arc<Bank>) {
+        let mut status = self.status.lock().unwrap();
+        if matches!(*status, Status::InProgress) {
+            return;
+        }
+
+        *status = Status::InProgress;
+        *self.bank.write().unwrap() = Some((bank.slot(), Arc::downgrade(bank)));
+        self.condvar.notify_all();
+    }
+
+    /// Set the status to `Completed` and notify any waiting threads
+    /// if the status was not already `Completed`
+    /// and the slot is higher than the current slot (sanity check).
+    pub fn set_completed(&self, slot: Slot) {
+        let mut status = self.status.lock().unwrap();
+        if matches!(*status, Status::Completed) {
+            return;
+        }
+
+        if let Some((current_slot, _)) = *self.bank.read().unwrap() {
+            if slot < current_slot {
+                return;
+            }
+        }
+
+        *status = Status::Completed;
+        self.condvar.notify_all();
+    }
+
+    /// Return weak bank reference or wait for notification for an in progress bank.
+    pub fn wait_for_in_progress(&self) -> Weak<Bank> {
+        let status = self.status.lock().unwrap();
+
+        // Hold status lock until after the weak bank reference is cloned.
+        let status = self
+            .condvar
+            .wait_while(status, |status| {
+                matches!(*status, Status::Uninitialized | Status::Completed)
+            })
+            .unwrap();
+        let bank = self.bank.read().unwrap().as_ref().unwrap().1.clone();
+        drop(status);
+
+        bank
+    }
+
+    /// Wait for next notification for a completed slot.
+    /// Returns None if the timeout is reached
+    pub fn wait_for_next_completed_timeout(&self, mut timeout: Duration) -> Option<Slot> {
+        loop {
+            let start = Instant::now();
+            let status = self.status.lock().unwrap();
+            let (status, result) = self.condvar.wait_timeout(status, timeout).unwrap();
+            if result.timed_out() {
+                return None;
+            }
+
+            if matches!(*status, Status::Completed) {
+                let slot = self.bank.read().unwrap().as_ref().unwrap().0;
+                return Some(slot);
+            }
+
+            timeout = timeout.saturating_sub(start.elapsed());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_leader_bank_status_wait_for_in_progress() {
+        let leader_bank_status = Arc::new(LeaderBankStatus::default());
+        let leader_bank_status2 = leader_bank_status.clone();
+
+        let jh = std::thread::spawn(move || {
+            let _weak_bank = leader_bank_status2.wait_for_in_progress();
+        });
+        leader_bank_status.set_in_progress(&Arc::new(Bank::default_for_tests()));
+        leader_bank_status.set_completed(1);
+
+        jh.join().unwrap();
+    }
+
+    #[test]
+    fn test_leader_bank_status_wait_for_completed() {
+        let leader_bank_status = Arc::new(LeaderBankStatus::default());
+        let leader_bank_status2 = leader_bank_status.clone();
+
+        let jh = std::thread::spawn(move || {
+            let _weak_bank =
+                leader_bank_status2.wait_for_next_completed_timeout(Duration::from_secs(1));
+        });
+        leader_bank_status.set_in_progress(&Arc::new(Bank::default_for_tests()));
+
+        jh.join().unwrap();
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,6 +44,7 @@ pub mod in_mem_accounts_index;
 pub mod inline_spl_associated_token_account;
 pub mod inline_spl_token;
 pub mod inline_spl_token_2022;
+pub mod leader_bank_status;
 pub mod loader_utils;
 pub mod message_processor;
 pub mod non_circulating_supply;


### PR DESCRIPTION
#### Problem
Tx-scheduler worker threads can be entirely reactive - only wake up when there's work to do. As part of that, reporting metrics on a set interval or at slot boundaries becomes challenging.

#### Summary of Changes
Use `LeaderBankStatus` to run a separate service (thread) that reports metrics at the end of each leader slot and every `report_interval`. Intended for metrics to be accumulated by worker threads as they do work, using `Arc`-wrapped atomics, but reported/reset by this service.

Blocked by #30395 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
