### PR TITLE
ci: use wasm-pack latest version

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -35,6 +35,6 @@ RUN set -x \
  && cargo install mdbook \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \
- && cargo install wasm-pack \
+ && cargo install --git https://github.com/rustwasm/wasm-pack --rev b4e619c8a13a8441b804895348afbfd4fb1a68a3 \
  && rustc --version \
  && cargo --version


### PR DESCRIPTION
#### Problem

#29893 is stuck for a month cuz I'm waiting for wasm-pack releases their new version which including workspace inheritance. (the thread: https://www.github.com/rustwasm/wasm-pack/pull/1185)
it seems that it won't happen soon. It makes me need to resolve conflict for #29893 again and again if the PR stuck there 😢 

#### Summary of Changes

Use wasm-pack latest version in our docker. 
(there is a success build: https://buildkite.com/solana-labs/solana/builds/89556#01866265-2a8e-4148-817e-fccff680a70b)
