### PR TITLE
add bank progress stats

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1499,7 +1499,7 @@ impl BankCreationFreezingProgress {
                     "difference",
                     self.bank_creation_count
                         .load(Ordering::Acquire)
-                        .saturating_sub(
+                        .wrapping_sub(
                             self.bank_freeze_or_destruction_count
                                 .load(Ordering::Acquire)
                         ),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1486,6 +1486,43 @@ pub struct AccountsDb {
     /// Some time later (to allow for slow calculation time), the bank hash at a slot calculated using 'M' includes the full accounts hash.
     /// Thus, the state of all accounts on a validator is known to be correct at least once per epoch.
     pub epoch_accounts_hash_manager: EpochAccountsHashManager,
+
+    pub bank_progress: BankCreationFreezingProgress,
+}
+
+impl BankCreationFreezingProgress {
+    fn report(&self) {
+        if self.last_report.should_update(60_000) {
+            datapoint_info!(
+                "bank_progress",
+                (
+                    "difference",
+                    self.bank_creation_count
+                        .load(Ordering::Acquire)
+                        .saturating_sub(
+                            self.bank_freeze_or_destruction_count
+                                .load(Ordering::Acquire)
+                        ),
+                    i64
+                )
+            );
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+/// Keeps track of when all banks that were started as of a known point in time have been frozen or otherwise destroyed.
+/// When 'bank_freeze_or_destruction_count' exceeds a prior value of 'bank_creation_count',
+/// this means that we can know all banks that began loading accounts have completed as of the prior value of 'bank_creation_count'.
+pub struct BankCreationFreezingProgress {
+    /// Incremented each time a bank is created.
+    /// Starting now, this bank could be finding accounts in the index and loading them from accounts db.
+    pub bank_creation_count: AtomicU32,
+    /// Incremented each time a bank is frozen or destroyed.
+    /// At this point, this bank has completed all account loading.
+    pub bank_freeze_or_destruction_count: AtomicU32,
+
+    last_report: AtomicInterval,
 }
 
 #[derive(Debug, Default)]
@@ -2396,6 +2433,7 @@ impl AccountsDb {
 
         AccountsDb {
             assert_stakes_cache_consistency: false,
+            bank_progress: BankCreationFreezingProgress::default(),
             create_ancient_storage: CreateAncientStorage::Append,
             verify_accounts_hash_in_bg: VerifyAccountsHashInBackground::default(),
             filler_accounts_per_slot: AtomicU64::default(),
@@ -4041,6 +4079,7 @@ impl AccountsDb {
 
         Self::update_shrink_stats(&self.shrink_stats, stats_sub);
         self.shrink_stats.report();
+        self.bank_progress.report();
     }
 
     pub(crate) fn update_shrink_stats(shrink_stats: &ShrinkStats, stats_sub: ShrinkStatsSub) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1337,6 +1337,7 @@ impl Bank {
             loaded_programs_cache: Arc::<RwLock<LoadedPrograms>>::default(),
         };
 
+        bank.bank_created();
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
         bank.accounts_data_size_initial = accounts_data_size_initial;
 
@@ -1548,14 +1549,8 @@ impl Bank {
         let (feature_set, feature_set_time_us) = measure_us!(parent.feature_set.clone());
 
         let accounts_data_size_initial = parent.load_accounts_data_size();
-        parent
-            .rc
-            .accounts
-            .accounts_db
-            .bank_progress
-            .bank_creation_count
-            .fetch_add(1, Release);
-        let mut new = Bank {
+        parent.bank_created();
+        let mut new = Self {
             bank_freeze_or_destruction_incremented: AtomicBool::default(),
             incremental_snapshot_persistence: None,
             rc,
@@ -1790,6 +1785,15 @@ impl Bank {
         self.vote_only_bank
     }
 
+    fn bank_created(&self) {
+        self.rc
+            .accounts
+            .accounts_db
+            .bank_progress
+            .bank_creation_count
+            .fetch_add(1, Release);
+    }
+
     fn bank_frozen_or_destroyed(&self) {
         if !self
             .bank_freeze_or_destruction_incremented
@@ -1949,6 +1953,8 @@ impl Bank {
             fee_structure: FeeStructure::default(),
             loaded_programs_cache: Arc::<RwLock<LoadedPrograms>>::default(),
         };
+        bank.bank_created();
+
         bank.finish_init(
             genesis_config,
             additional_builtins,


### PR DESCRIPTION
#### Problem
To reduce the contents of the accounts index, we need to be able to identify when all bank account loads that started are completed.

#### Summary of Changes
Introduce two atomics that are incremented when banks are created and frozen/destroyed. Currently these are reported as stats. Later, they will be relied upon to know that all account loads in the foreground as of a certain point have completed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
