### PR TITLE
Uses a channel for AHV -> SPS

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,9 @@
 use {
+    crossbeam_channel::{Receiver, Sender},
     solana_gossip::cluster_info::{
         ClusterInfo, MAX_INCREMENTAL_SNAPSHOT_HASHES, MAX_SNAPSHOT_HASHES,
     },
+    solana_measure::measure_us,
     solana_perf::thread::renice_this_thread,
     solana_runtime::{
         snapshot_archive_info::SnapshotArchiveInfoGetter,
@@ -10,7 +12,7 @@ use {
             FullSnapshotHash, FullSnapshotHashes, IncrementalSnapshotHash,
             IncrementalSnapshotHashes, StartingSnapshotHashes,
         },
-        snapshot_package::{retain_max_n_elements, PendingSnapshotPackage, SnapshotType},
+        snapshot_package::{self, retain_max_n_elements, SnapshotPackage, SnapshotType},
         snapshot_utils,
     },
     solana_sdk::{clock::Slot, hash::Hash},
@@ -29,8 +31,12 @@ pub struct SnapshotPackagerService {
 }
 
 impl SnapshotPackagerService {
+    /// If there are no snapshot packages to handle, limit how often we re-check
+    const LOOP_LIMITER: Duration = Duration::from_millis(100);
+
     pub fn new(
-        pending_snapshot_package: PendingSnapshotPackage,
+        snapshot_package_sender: Sender<SnapshotPackage>,
+        snapshot_package_receiver: Receiver<SnapshotPackage>,
         starting_snapshot_hashes: Option<StartingSnapshotHashes>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
@@ -72,32 +78,55 @@ impl SnapshotPackagerService {
                         break;
                     }
 
-                    let snapshot_package = pending_snapshot_package.lock().unwrap().take();
-                    if snapshot_package.is_none() {
-                        std::thread::sleep(Duration::from_millis(100));
+                    let Some((
+                        snapshot_package,
+                        num_outstanding_snapshot_packages,
+                        num_re_enqueued_snapshot_packages,
+                    )) = Self::get_next_snapshot_package(&snapshot_package_sender, &snapshot_package_receiver) else {
+                        std::thread::sleep(Self::LOOP_LIMITER);
                         continue;
-                    }
-                    let snapshot_package = snapshot_package.unwrap();
+                    };
+                    info!("handling snapshot package: {snapshot_package:?}");
+                    let enqueued_time = snapshot_package.enqueued.elapsed();
 
-                    // Archiving the snapshot package is not allowed to fail.
-                    // AccountsBackgroundService calls `clean_accounts()` with a value for
-                    // last_full_snapshot_slot that requires this archive call to succeed.
-                    snapshot_utils::archive_snapshot_package(
-                        &snapshot_package,
-                        &snapshot_config.full_snapshot_archives_dir,
-                        &snapshot_config.incremental_snapshot_archives_dir,
-                        snapshot_config.maximum_full_snapshot_archives_to_retain,
-                        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
-                    )
-                    .expect("failed to archive snapshot package");
+                    let (_, handling_time_us) = measure_us!({
+                        // Archiving the snapshot package is not allowed to fail.
+                        // AccountsBackgroundService calls `clean_accounts()` with a value for
+                        // last_full_snapshot_slot that requires this archive call to succeed.
+                        snapshot_utils::archive_snapshot_package(
+                            &snapshot_package,
+                            &snapshot_config.full_snapshot_archives_dir,
+                            &snapshot_config.incremental_snapshot_archives_dir,
+                            snapshot_config.maximum_full_snapshot_archives_to_retain,
+                            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
+                        )
+                        .expect("failed to archive snapshot package");
 
-                    if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
-                        snapshot_gossip_manager.push_snapshot_hash(
-                            snapshot_package.snapshot_type,
-                            (snapshot_package.slot(), snapshot_package.hash().0),
-                        );
-                    }
+                        if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
+                            snapshot_gossip_manager.push_snapshot_hash(
+                                snapshot_package.snapshot_type,
+                                (snapshot_package.slot(), snapshot_package.hash().0),
+                            );
+                        }
+                    });
+
+                    datapoint_info!(
+                        "snapshot_packager_service",
+                        (
+                            "num-outstanding-snapshot-packages",
+                            num_outstanding_snapshot_packages,
+                            i64
+                        ),
+                        (
+                            "num-re-enqueued-snapshot-packages",
+                            num_re_enqueued_snapshot_packages,
+                            i64
+                        ),
+                        ("enqueued-time-us", enqueued_time.as_micros(), i64),
+                        ("handling-time-us", handling_time_us, i64),
+                    );
                 }
+                info!("Snapshot Packager Service has stopped");
             })
             .unwrap();
 
@@ -108,6 +137,58 @@ impl SnapshotPackagerService {
 
     pub fn join(self) -> thread::Result<()> {
         self.t_snapshot_packager.join()
+    }
+
+    /// Get the next snapshot package to handle
+    ///
+    /// Look through the snapshot package channel to find the highest priority one to handle next.
+    /// If there are no snapshot packages in the channel, return None.  Otherwise return the
+    /// highest priority one.  Unhandled snapshot packages with slots GREATER-THAN the handled one
+    /// will be re-enqueued.  The remaining will be dropped.
+    ///
+    /// Also return the number of snapshot packages initially in the channel, and the number of
+    /// ones re-enqueued.
+    fn get_next_snapshot_package(
+        snapshot_package_sender: &Sender<SnapshotPackage>,
+        snapshot_package_receiver: &Receiver<SnapshotPackage>,
+    ) -> Option<(
+        SnapshotPackage,
+        /*num outstanding snapshot packages*/ usize,
+        /*num re-enqueued snapshot packages*/ usize,
+    )> {
+        let mut snapshot_packages: Vec<_> = snapshot_package_receiver.try_iter().collect();
+        // `select_nth()` panics if the slice is empty, so return if that's the case
+        if snapshot_packages.is_empty() {
+            return None;
+        }
+        let snapshot_packages_len = snapshot_packages.len();
+        debug!("outstanding snapshot packages ({snapshot_packages_len}): {snapshot_packages:?}");
+
+        snapshot_packages.select_nth_unstable_by(
+            snapshot_packages_len - 1,
+            snapshot_package::cmp_snapshot_packages_by_priority,
+        );
+        // SAFETY: We know `snapshot_packages` is not empty, so its len is >= 1,
+        // therefore there is always an element to pop.
+        let snapshot_package = snapshot_packages.pop().unwrap();
+        let handled_snapshot_package_slot = snapshot_package.slot();
+        // re-enqueue any remaining snapshot packages for slots GREATER-THAN the snapshot package
+        // that will be handled
+        let num_re_enqueued_snapshot_packages = snapshot_packages
+            .into_iter()
+            .filter(|snapshot_package| snapshot_package.slot() > handled_snapshot_package_slot)
+            .map(|snapshot_package| {
+                snapshot_package_sender
+                    .try_send(snapshot_package)
+                    .expect("re-enqueue snapshot package")
+            })
+            .count();
+
+        Some((
+            snapshot_package,
+            snapshot_packages_len,
+            num_re_enqueued_snapshot_packages,
+        ))
     }
 }
 
@@ -221,6 +302,7 @@ mod tests {
     use {
         super::*,
         bincode::serialize_into,
+        rand::seq::SliceRandom,
         solana_runtime::{
             accounts_db::AccountStorageEntry,
             bank::BankSlotDelta,
@@ -232,11 +314,12 @@ mod tests {
                 SNAPSHOT_STATUS_CACHE_FILENAME,
             },
         },
-        solana_sdk::hash::Hash,
+        solana_sdk::{clock::Slot, hash::Hash},
         std::{
             fs::{self, remove_dir_all, OpenOptions},
             io::Write,
             path::{Path, PathBuf},
+            time::Instant,
         },
         tempfile::TempDir,
     };
@@ -335,6 +418,7 @@ mod tests {
             snapshot_storages: storage_entries,
             snapshot_version: SnapshotVersion::default(),
             snapshot_type: SnapshotType::FullSnapshot,
+            enqueued: Instant::now(),
         };
 
         // Make tarball from packageable snapshot
@@ -368,5 +452,96 @@ mod tests {
             archive_format,
             snapshot_utils::VerifyBank::Deterministic,
         );
+    }
+
+    /// Ensure that unhandled snapshot packages are properly re-enqueued or dropped
+    ///
+    /// The snapshot package handler should re-enqueue unhandled snapshot packages, if those
+    /// unhandled snapshot packages are for slots GREATER-THAN the last handled snapshot package.
+    /// Otherwise, they should be dropped.
+    #[test]
+    fn test_get_next_snapshot_package() {
+        fn new(snapshot_type: SnapshotType, slot: Slot) -> SnapshotPackage {
+            SnapshotPackage {
+                snapshot_archive_info: SnapshotArchiveInfo {
+                    path: PathBuf::default(),
+                    slot,
+                    hash: SnapshotHash(Hash::default()),
+                    archive_format: ArchiveFormat::Tar,
+                },
+                block_height: slot,
+                snapshot_links: TempDir::new().unwrap(),
+                snapshot_storages: Vec::default(),
+                snapshot_version: SnapshotVersion::default(),
+                snapshot_type,
+                enqueued: Instant::now(),
+            }
+        }
+        fn new_full(slot: Slot) -> SnapshotPackage {
+            new(SnapshotType::FullSnapshot, slot)
+        }
+        fn new_incr(slot: Slot, base: Slot) -> SnapshotPackage {
+            new(SnapshotType::IncrementalSnapshot(base), slot)
+        }
+
+        let (snapshot_package_sender, snapshot_package_receiver) = crossbeam_channel::unbounded();
+
+        // Populate the channel so that re-enqueueing and dropping will be tested
+        let mut snapshot_packages = [
+            new_full(100),
+            new_incr(110, 100),
+            new_incr(210, 100),
+            new_full(300),
+            new_incr(310, 300),
+            new_full(400), // <-- handle 1st
+            new_incr(410, 400),
+            new_incr(420, 400), // <-- handle 2nd
+        ];
+        // Shuffle the snapshot packages to simulate receiving new snapshot packages from AHV
+        // simultaneously as SPS is handling them.
+        snapshot_packages.shuffle(&mut rand::thread_rng());
+        snapshot_packages
+            .into_iter()
+            .for_each(|snapshot_package| snapshot_package_sender.send(snapshot_package).unwrap());
+
+        // The Full Snapshot from slot 400 is handled 1st
+        // (the older full snapshots are skipped and dropped)
+        let (
+            snapshot_package,
+            _num_outstanding_snapshot_packages,
+            num_re_enqueued_snapshot_packages,
+        ) = SnapshotPackagerService::get_next_snapshot_package(
+            &snapshot_package_sender,
+            &snapshot_package_receiver,
+        )
+        .unwrap();
+        assert_eq!(snapshot_package.snapshot_type, SnapshotType::FullSnapshot,);
+        assert_eq!(snapshot_package.slot(), 400);
+        assert_eq!(num_re_enqueued_snapshot_packages, 2);
+
+        // The Incremental Snapshot from slot 420 is handled 2nd
+        // (the older incremental snapshot from slot 410 is skipped and dropped)
+        let (
+            snapshot_package,
+            _num_outstanding_snapshot_packages,
+            num_re_enqueued_snapshot_packages,
+        ) = SnapshotPackagerService::get_next_snapshot_package(
+            &snapshot_package_sender,
+            &snapshot_package_receiver,
+        )
+        .unwrap();
+        assert_eq!(
+            snapshot_package.snapshot_type,
+            SnapshotType::IncrementalSnapshot(400),
+        );
+        assert_eq!(snapshot_package.slot(), 420);
+        assert_eq!(num_re_enqueued_snapshot_packages, 0);
+
+        // And now the snapshot package channel is empty!
+        assert!(SnapshotPackagerService::get_next_snapshot_package(
+            &snapshot_package_sender,
+            &snapshot_package_receiver
+        )
+        .is_none());
     }
 }

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -22,7 +22,6 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
-        snapshot_package::PendingSnapshotPackage,
         snapshot_utils,
     },
     solana_sdk::{
@@ -180,9 +179,10 @@ impl BackgroundServices {
     ) -> Self {
         info!("Starting background services...");
 
-        let pending_snapshot_package = PendingSnapshotPackage::default();
+        let (snapshot_package_sender, snapshot_package_receiver) = crossbeam_channel::unbounded();
         let snapshot_packager_service = SnapshotPackagerService::new(
-            pending_snapshot_package.clone(),
+            snapshot_package_sender.clone(),
+            snapshot_package_receiver,
             None,
             &exit,
             &cluster_info,
@@ -194,7 +194,7 @@ impl BackgroundServices {
         let accounts_hash_verifier = AccountsHashVerifier::new(
             accounts_package_sender.clone(),
             accounts_package_receiver,
-            Some(pending_snapshot_package),
+            Some(snapshot_package_sender),
             &exit,
             &cluster_info,
             None,


### PR DESCRIPTION
#### Problem

SnapshotPackager service doesn't have a lot of insight available for seeing how long items wait to be processed, or if any are dropped/replaced and *not* processed.

Additionally, `PendingSnapshotPackage` can only hold a single element. So if SPS already has a pending full snapshot, but hasn't taken it yet, AHV cannot queue up the next incremental snapshot. Instead, that incremental snapshot would be dropped. This can occur in tests/CI where SPS isn't schedule to run as often.

#### Summary of Changes

Similar to https://github.com/solana-labs/solana/pull/28352, convert `PendingSnapshotPackage` to a channel.

Also add metrics to SPS and each SnapshotPackage in the queue.


#### Notes

This PR is quite large due to the number of pieces this code touches. I've tried to call out the main/important parts; please let me know if anything needs more clarification! Ignoring whitespace in the diff may be beneficial too.