### PR TITLE
Revert "change test validator from non upgradable bpf loader to upgra…

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -204,7 +204,7 @@ fn main() {
 
                     programs_to_load.push(ProgramInfo {
                         program_id: address,
-                        loader: solana_sdk::bpf_loader_upgradeable::id(),
+                        loader: solana_sdk::bpf_loader::id(),
                         program_path,
                     });
                 }


### PR DESCRIPTION
…dable bpf loader (#29051)"

This reverts commit b43eabaa47430529195f708f6722afb7af15ad0c.

#### Problem
#29051 broke `solana-test-validator --bpf-program`. To use the upgradeable bpf loader, a program must have a separate programdata account; simply changing the owning program is not enough.


#### Summary of Changes
Revert

Will follow with proper TestValidator support for the upgradeable loader.

Fixes #30402 