### PR TITLE
Add solana-test-validator --upgradeable-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6765,6 +6765,7 @@ name = "solana-test-validator"
 version = "1.16.0"
 dependencies = [
  "base64 0.13.0",
+ "bincode",
  "log",
  "serde_derive",
  "serde_json",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6042,6 +6042,7 @@ name = "solana-test-validator"
 version = "1.16.0"
 dependencies = [
  "base64 0.13.0",
+ "bincode",
  "log",
  "serde_derive",
  "serde_json",

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 base64 = { workspace = true }
+bincode = { workspace = true }
 log = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2022,6 +2022,20 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 ),
         )
         .arg(
+            Arg::with_name("upgradeable_program")
+                .long("upgradeable-program")
+                .value_names(&["ADDRESS_OR_KEYPAIR", "SBF_PROGRAM.SO", "UPGRADE_AUTHORITY"])
+                .takes_value(true)
+                .number_of_values(3)
+                .multiple(true)
+                .help(
+                    "Add an upgradeable SBF program to the genesis configuration. \
+                       If the ledger already exists then this parameter is silently ignored. \
+                       First and third arguments can be a pubkey string or path to a keypair. \
+                       Upgrade authority set to \"none\" disables upgrades",
+                ),
+        )
+        .arg(
             Arg::with_name("account")
                 .long("account")
                 .value_names(&["ADDRESS", "DUMP.JSON"])


### PR DESCRIPTION
#### Problem
#29051 attempted to default `solana-test-validator --bpf-program` to use the upgradeable loader, but had to be reverted. But the issue remains that most people want to use the upgradeable loader, and the only way to do that with solana-test-validator is [clone from another cluster](https://github.com/solana-labs/solana/pull/30279).

#### Summary of Changes
Add `--upgradeable-program` flag to automatically initialize solana-test-validator with an upgradeable program. Parallels #29994
I added this as a separate path from the existing param because I thought it would be cool to support an optional upgrade authority, which would break the existing `--bpf-program` interface. However, we could make `--bpf-program` an alias for `--upgradeable-program <PROGRAM_ID> <PROGRAM.SO> none`. What do you think?
If you like that idea, I can remove a bunch of the duplication here, and switch from `ProgramInfo` to `UpgradeableProgramInfo` everywhere.