### PR TITLE
hold items with ref count != 1 in memory

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -12,6 +12,7 @@ const STATS_INTERVAL_MS: u64 = 10_000;
 
 #[derive(Debug, Default)]
 pub struct BucketMapHolderStats {
+    pub held_in_mem_ref_count: AtomicU64,
     pub held_in_mem_slot_list_len: AtomicU64,
     pub held_in_mem_slot_list_cached: AtomicU64,
     pub get_mem_us: AtomicU64,
@@ -250,6 +251,11 @@ impl BucketMapHolderStats {
                 (
                     "held_in_mem_slot_list_len",
                     self.held_in_mem_slot_list_len.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "held_in_mem_ref_count",
+                    self.held_in_mem_ref_count.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1458,12 +1458,41 @@ mod tests {
     }
 
     #[test]
+    fn test_should_evict_from_mem_ref_count() {
+        for ref_count in [0, 1, 2] {
+            let bucket = new_for_test::<u64>();
+            let startup = false;
+            let current_age = 0;
+            let one_element_slot_list = vec![(0, 0)];
+            let one_element_slot_list_entry = Arc::new(AccountMapEntryInner::new(
+                one_element_slot_list,
+                ref_count,
+                AccountMapEntryMeta::default(),
+            ));
+
+            // exceeded budget
+            assert_eq!(
+                bucket
+                    .should_evict_from_mem(
+                        current_age,
+                        &one_element_slot_list_entry,
+                        startup,
+                        false,
+                        false,
+                    )
+                    .0,
+                ref_count == 1
+            );
+        }
+    }
+
+    #[test]
     fn test_should_evict_from_mem() {
         solana_logger::setup();
         let bucket = new_for_test::<u64>();
         let mut startup = false;
         let mut current_age = 0;
-        let ref_count = 0;
+        let ref_count = 1;
         let one_element_slot_list = vec![(0, 0)];
         let one_element_slot_list_entry = Arc::new(AccountMapEntryInner::new(
             one_element_slot_list,


### PR DESCRIPTION
#### Problem
Trying to simplify on disk index.

#### Summary of Changes
Hold items with ref count != 1 in memory. This allows us to not have to store refcount in the disk index.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
