### PR TITLE
chore: Use Self in Packet/PacketBatch impl blocks

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -33,7 +33,7 @@ impl PacketBatch {
 
     pub fn with_capacity(capacity: usize) -> Self {
         let packets = PinnedVec::with_capacity(capacity);
-        PacketBatch { packets }
+        Self { packets }
     }
 
     pub fn new_pinned_with_capacity(capacity: usize) -> Self {
@@ -49,7 +49,7 @@ impl PacketBatch {
     ) -> Self {
         let mut packets = recycler.allocate(name);
         packets.reserve(capacity);
-        PacketBatch { packets }
+        Self { packets }
     }
 
     pub fn new_with_recycler(
@@ -59,7 +59,7 @@ impl PacketBatch {
     ) -> Self {
         let mut packets = recycler.allocate(name);
         packets.reserve_and_pin(capacity);
-        PacketBatch { packets }
+        Self { packets }
     }
 
     pub fn new_with_recycler_data(
@@ -77,8 +77,7 @@ impl PacketBatch {
         name: &'static str,
         dests_and_data: &[(SocketAddr, T)],
     ) -> Self {
-        let mut batch =
-            PacketBatch::new_unpinned_with_recycler(recycler, dests_and_data.len(), name);
+        let mut batch = Self::new_unpinned_with_recycler(recycler, dests_and_data.len(), name);
         batch
             .packets
             .resize(dests_and_data.len(), Packet::default());

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -123,7 +123,7 @@ impl Packet {
     }
 
     pub fn from_data<T: Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
-        let mut packet = Packet::default();
+        let mut packet = Self::default();
         Self::populate_packet(&mut packet, dest, &data)?;
         Ok(packet)
     }
@@ -170,9 +170,9 @@ impl fmt::Debug for Packet {
 
 #[allow(clippy::uninit_assumed_init)]
 impl Default for Packet {
-    fn default() -> Packet {
+    fn default() -> Self {
         let buffer = std::mem::MaybeUninit::<[u8; PACKET_DATA_SIZE]>::uninit();
-        Packet {
+        Self {
             buffer: unsafe { buffer.assume_init() },
             meta: Meta::default(),
         }
@@ -180,7 +180,7 @@ impl Default for Packet {
 }
 
 impl PartialEq for Packet {
-    fn eq(&self, other: &Packet) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.meta() == other.meta() && self.data(..) == other.data(..)
     }
 }


### PR DESCRIPTION
#### Summary of Changes
Use `Self` where we can in return types.

No functional changes, this is meant to reduce line count on a future PR that will more largely change `Packet` / `PacketBatch`