### PR TITLE
Remove unnecessary Sigverifier trait

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -12,9 +12,8 @@ use {
         thread_rng, Rng,
     },
     solana_core::{
-        banking_trace::BankingTracer,
-        sigverify::TransactionSigVerifier,
-        sigverify_stage::{SigVerifier, SigVerifyStage},
+        banking_trace::BankingTracer, sigverify::TransactionSigVerifier,
+        sigverify_stage::SigVerifyStage,
     },
     solana_measure::measure::Measure,
     solana_perf::{


### PR DESCRIPTION
#### Problem
This trait was previously in place to support a configuration option that allowed bypassing signature verification of packets. That config option has long since been removed, so remove the trait that supported it.

#### Summary of Changes
Remove the extra trait abstraction that is no longer used.