### PR TITLE
Add terminology entry for SBF

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -231,6 +231,10 @@ A [block](#block) or [slot](#slot) that has reached maximum [lockout](#lockout) 
 
 The component of a [validator](#validator) responsible for [program](#program) execution.
 
+## SBF / Solana Bytecode Format
+
+Solana's variation of the Berkeley Packet Filter (BPF) bytecode used for on-chain programs. SBF allows arbitrary memory access, indirect jumps, loops, and other useful behavior, and also removes unused BPF features.
+
 ## Sealevel
 
 Solana's parallel smart contracts run-time.


### PR DESCRIPTION
Solana Bytecode Format, not the fraudster. 😛 Please check my work, I'm not a Rust engineer. I used https://bpf.wtf/sol-0x00-intro/ for my research.

#### Problem

I had an error on my local validator referencing SBF and it was missing from the terminology.

#### Summary of Changes

As above.

