### PR TITLE
ThreadAwareAccountLocks

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -46,6 +46,9 @@ mod decision_maker;
 mod forwarder;
 mod packet_receiver;
 
+#[allow(dead_code)]
+mod thread_aware_account_locks;
+
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 6;
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -323,12 +323,12 @@ impl ThreadSet {
 
     #[inline(always)]
     pub fn any(num_threads: usize) -> Self {
-        Self((1 << num_threads) - 1)
+        Self(Self::as_flag(num_threads) - 1)
     }
 
     #[inline(always)]
     pub fn only(thread_id: ThreadId) -> Self {
-        Self(1 << thread_id)
+        Self(Self::as_flag(thread_id))
     }
 
     #[inline(always)]
@@ -348,22 +348,27 @@ impl ThreadSet {
 
     #[inline(always)]
     pub fn contains(&self, thread_id: ThreadId) -> bool {
-        self.0 & (1 << thread_id) != 0
+        self.0 & (Self::as_flag(thread_id)) != 0
     }
 
     #[inline(always)]
     pub fn insert(&mut self, thread_id: ThreadId) {
-        self.0 |= 1 << thread_id;
+        self.0 |= Self::as_flag(thread_id);
     }
 
     #[inline(always)]
     pub fn remove(&mut self, thread_id: ThreadId) {
-        self.0 &= !(1 << thread_id);
+        self.0 &= !Self::as_flag(thread_id);
     }
 
     #[inline(always)]
     pub fn threads_iter(self) -> impl Iterator<Item = ThreadId> {
         (0..MAX_THREADS).filter(move |thread_id| self.contains(*thread_id))
+    }
+
+    #[inline(always)]
+    fn as_flag(thread_id: ThreadId) -> u64 {
+        1 << thread_id
     }
 }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -369,7 +369,7 @@ mod tests {
             ThreadSet::any(TEST_NUM_THREADS)
         );
 
-        locks.read_lock_account(&pk2, 0);
+        locks.read_lock_account(&pk1, 0);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::none()
@@ -400,18 +400,6 @@ mod tests {
     }
 
     #[test]
-    fn test_locks() {
-        let pk1 = Pubkey::new_unique();
-        let pk2 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.write_lock_account(&pk1, 0);
-        locks.write_lock_account(&pk1, 0);
-
-        locks.read_lock_account(&pk2, 1);
-        locks.write_lock_account(&pk2, 1);
-    }
-
-    #[test]
     #[should_panic]
     fn test_write_lock_account_write_conflict_panic() {
         let pk1 = Pubkey::new_unique();
@@ -431,7 +419,15 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_write_unlock_account_panic() {
+    fn test_write_unlock_account_not_locked() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.write_unlock_account(&pk1, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_write_unlock_account_thread_mismatch() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
         locks.write_lock_account(&pk1, 1);
@@ -449,7 +445,15 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_read_unlock_account_panic() {
+    fn test_read_unlock_account_not_locked() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.read_unlock_account(&pk1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_read_unlock_account_thread_mismatch() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
         locks.read_lock_account(&pk1, 0);

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -14,7 +14,6 @@ pub type ThreadId = usize; // 0..MAX_THREADS-1
 
 /// A bit-set of threads an account is scheduled or can be scheduled for.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(transparent)]
 pub struct ThreadSet(u64);
 
 /// Thread-aware account locks which allows for scheduling on threads

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -26,10 +26,10 @@ pub(crate) struct ThreadAwareAccountLocks {
     /// Number of threads.
     num_threads: usize, // 0..MAX_THREADS
     /// Limit on the number of sequentially-queued transactions per account.
-    sequential_queue_limit: u32,
+    sequential_queue_limit: LockCount,
     /// Write locks - only on thread can hold a write lock at a time.
     /// Contains how many write locks are held by the thread.
-    write_locks: HashMap<Pubkey, (ThreadId, u32)>,
+    write_locks: HashMap<Pubkey, (ThreadId, LockCount)>,
     /// Read locks - multiple threads can hold a read lock at a time.
     /// Contains thread-set for easily checking which threads are scheduled.
     /// Contains how many read locks are held by each thread.

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -9,7 +9,7 @@ use {
 pub const MAX_THREADS: usize = 64;
 
 /// Identifier for a thread
-pub type ThreadId = u8; // 0..MAX_THREADS-1
+pub type ThreadId = usize; // 0..MAX_THREADS-1
 
 /// A bit-set of threads an account is scheduled or can be scheduled for.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -36,9 +36,9 @@ impl BitAnd for ThreadSet {
 /// is still being executed on the thread, up to a queue limit.
 pub struct ThreadAwareAccountLocks {
     /// Number of threads.
-    num_threads: u8, // 0..MAX_THREADS
-    /// Limit on the number of write-queued transactions per account.
-    write_queue_limit: u32,
+    num_threads: usize, // 0..MAX_THREADS
+    /// Limit on the number of sequentially-queued transactions per account.
+    sequential_queue_limit: u32,
     /// Write locks - only on thread can hold a write lock at a time.
     /// Contains how many write locks are held by the thread.
     write_locks: HashMap<Pubkey, (ThreadId, u32)>,
@@ -51,11 +51,11 @@ pub struct ThreadAwareAccountLocks {
 impl ThreadAwareAccountLocks {
     /// Creates a new `ThreadAwareAccountLocks` with the given number of threads
     /// and queue limit.
-    pub fn new(num_threads: u8, write_queue_limit: u32) -> Self {
-        assert!(num_threads <= MAX_THREADS as u8);
+    pub fn new(num_threads: usize, write_queue_limit: u32) -> Self {
+        assert!(num_threads > 0 && num_threads <= MAX_THREADS);
         Self {
             num_threads,
-            write_queue_limit,
+            sequential_queue_limit: write_queue_limit,
             write_locks: HashMap::new(),
             read_locks: HashMap::new(),
         }
@@ -69,27 +69,87 @@ impl ThreadAwareAccountLocks {
     ) -> ThreadSet {
         let mut schedulable_threads = ThreadSet::any(self.num_threads);
 
-        // Write accounts conflict with read and write locks.
         for account in write_account_locks {
-            if let Some((thread_id, count)) = self.write_locks.get(account) {
-                if count == &self.write_queue_limit {
-                    return ThreadSet::none();
-                }
-                schedulable_threads &= ThreadSet::only(*thread_id);
-            }
-            if let Some((thread_set, _)) = self.read_locks.get(account) {
-                schedulable_threads &= *thread_set;
-            }
+            schedulable_threads &= self.write_schedulable_threads(account);
         }
 
-        // Read accounts conflict with write locks.
         for account in read_account_locks {
-            if let Some((thread_id, _)) = self.write_locks.get(account) {
-                schedulable_threads &= ThreadSet::only(*thread_id);
-            }
+            schedulable_threads &= self.read_schedulable_threads(account);
         }
 
         schedulable_threads
+    }
+
+    /// Returns `ThreadSet` of schedulable threads for the given readable account.
+    /// If the account is not locked, then all threads are schedulable.
+    /// If only read locked, then all threads are schedulable.
+    /// If write-locked, then only the thread holding the write lock is schedulable.
+    /// The sequential limit is checked, and a thread will not be returned as schedulable
+    /// if the limit is reached.
+    fn read_schedulable_threads(&self, account: &Pubkey) -> ThreadSet {
+        // If the account is only read locked, then a read lock can be taken on any thread
+        // that is not at the sequential limit.
+        self.schedulable_threads_with_read_only_handler(account, |thread_set, counts| {
+            let mut schedulable_threads = ThreadSet::any(self.num_threads);
+            for thread_id in thread_set.threads_iter() {
+                if counts[thread_id] == self.sequential_queue_limit {
+                    schedulable_threads.remove(thread_id);
+                }
+            }
+            schedulable_threads
+        })
+    }
+
+    /// Returns `ThreadSet` of schedulable threads for the given writable account.
+    /// If the account is not locked, then all threads are schedulable.
+    /// If read-locked on a single thread, then only that thread is schedulable.
+    /// If write-locked, then only that thread is schedulable.
+    /// In all other cases, no threads are schedulable.
+    /// The sequential limit is checked, and a thread will not be returned as schedulable
+    /// if the limit is reached.
+    fn write_schedulable_threads(&self, account: &Pubkey) -> ThreadSet {
+        // If the account is only read locked, then a write lock can only be taken
+        // if the read lock is held by a single thread, and the limit is not exceeded.
+        self.schedulable_threads_with_read_only_handler(account, |thread_set, counts| {
+            thread_set
+                .only_one_scheduled()
+                .filter(|thread_id| counts[*thread_id] < self.sequential_queue_limit)
+                .map_or_else(ThreadSet::none, ThreadSet::only)
+        })
+    }
+
+    /// Returns `ThreadSet` of schedulable threads, given the read-only lock handler.
+    /// Helper function, since the only difference between read and write schedulable threads
+    /// is in how the case where only read locks are held is handled.
+    /// If there are no locks, then all threads are schedulable.
+    /// If only write-locked, then only the thread holding the write lock is schedulable.
+    /// If a mix of locks, then only the write thread is schedulable.
+    /// The sequential limit is checked, and a thread will not be returned as schedulable
+    /// if the limit is reached.
+    fn schedulable_threads_with_read_only_handler(
+        &self,
+        account: &Pubkey,
+        read_only_handler: impl Fn(&ThreadSet, &[u32]) -> ThreadSet,
+    ) -> ThreadSet {
+        match (self.write_locks.get(account), self.read_locks.get(account)) {
+            (None, None) => ThreadSet::any(self.num_threads),
+            (None, Some((thread_set, counts))) => read_only_handler(thread_set, counts),
+            (Some((thread_id, count)), None) => {
+                if count == &self.sequential_queue_limit {
+                    ThreadSet::none()
+                } else {
+                    ThreadSet::only(*thread_id)
+                }
+            }
+            (Some((thread_id, count)), Some((thread_set, counts))) => {
+                debug_assert_eq!(Some(*thread_id), thread_set.only_one_scheduled());
+                if count + counts[*thread_id] == self.sequential_queue_limit {
+                    ThreadSet::none()
+                } else {
+                    ThreadSet::only(*thread_id)
+                }
+            }
+        }
     }
 
     /// Add locks for all writable and readable accounts on `thread_id`.
@@ -100,24 +160,24 @@ impl ThreadAwareAccountLocks {
         thread_id: ThreadId,
     ) {
         for account in write_account_locks {
-            self.lock_write_account(account, thread_id);
+            self.write_lock_account(account, thread_id);
         }
 
         for account in read_account_locks {
-            self.lock_read_account(account, thread_id);
+            self.read_lock_account(account, thread_id);
         }
     }
 
     /// Locks the given `account` for writing on `thread_id`.
     /// Panics if the account is already locked for writing on another thread.
-    fn lock_write_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+    fn write_lock_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
         match self.write_locks.entry(*account) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (lock_thread_id, lock_count) = entry.get_mut();
                 assert_eq!(*lock_thread_id, thread_id);
 
                 *lock_count += 1;
-                assert!(*lock_count <= self.write_queue_limit);
+                assert!(*lock_count <= self.sequential_queue_limit);
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert((thread_id, 1));
@@ -132,7 +192,7 @@ impl ThreadAwareAccountLocks {
 
     /// Unlocks the given `account` for writing on `thread_id`.
     /// Panics if the account is not locked for writing on `thread_id`.
-    fn unlock_write_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+    fn write_unlock_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
         match self.write_locks.entry(*account) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (lock_thread_id, lock_count) = entry.get_mut();
@@ -150,17 +210,17 @@ impl ThreadAwareAccountLocks {
 
     /// Locks the given `account` for reading on `thread_id`.
     /// Panics if the account is already locked for writing on another thread.
-    fn lock_read_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+    fn read_lock_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
         match self.read_locks.entry(*account) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (thread_set, lock_counts) = entry.get_mut();
                 assert!(thread_set.contains(thread_id));
 
-                lock_counts[thread_id as usize] += 1;
+                lock_counts[thread_id] += 1;
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 let mut lock_counts = [0; MAX_THREADS];
-                lock_counts[thread_id as usize] = 1;
+                lock_counts[thread_id] = 1;
                 entry.insert((ThreadSet::only(thread_id), lock_counts));
             }
         }
@@ -173,13 +233,13 @@ impl ThreadAwareAccountLocks {
 
     /// Unlocks the given `account` for reading on `thread_id`.
     /// Panics if the account is not locked for reading on `thread_id`.
-    fn unlock_read_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+    fn read_unlock_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
         match self.read_locks.entry(*account) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (thread_set, lock_counts) = entry.get_mut();
                 assert!(thread_set.contains(thread_id));
-                lock_counts[thread_id as usize] -= 1;
-                if lock_counts[thread_id as usize] == 0 {
+                lock_counts[thread_id] -= 1;
+                if lock_counts[thread_id] == 0 {
                     thread_set.remove(thread_id);
                     if thread_set.is_empty() {
                         entry.remove();
@@ -200,7 +260,7 @@ impl ThreadSet {
     }
 
     #[inline(always)]
-    pub fn any(num_threads: u8) -> Self {
+    pub fn any(num_threads: usize) -> Self {
         Self((1 << num_threads) - 1)
     }
 
@@ -249,10 +309,22 @@ impl ThreadSet {
 mod tests {
     use super::*;
 
-    const TEST_NUM_THREADS: u8 = 4;
+    const TEST_NUM_THREADS: usize = 4;
 
     #[test]
-    fn accounts_schedulable_threads() {
+    #[should_panic]
+    fn test_too_few_num_threads() {
+        ThreadAwareAccountLocks::new(0, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_too_many_num_threads() {
+        ThreadAwareAccountLocks::new(MAX_THREADS + 1, 1);
+    }
+
+    #[test]
+    fn test_accounts_schedulable_threads() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
@@ -264,30 +336,30 @@ mod tests {
         );
 
         // Write lock on pk1 on thread 0 - now only thread 0 is schedulable
-        locks.lock_write_account(&pk1, 0);
+        locks.write_lock_account(&pk1, 0);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::only(0)
         );
 
         // Write lock pk2 on thread 0 - can still schedule on thread 0
-        locks.lock_write_account(&pk2, 0);
+        locks.write_lock_account(&pk2, 0);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::only(0)
         );
 
         // Move pk2 lock to thread 1 - cannot schedule on any threads
-        locks.unlock_write_account(&pk2, 0);
-        locks.lock_write_account(&pk2, 1);
+        locks.write_unlock_account(&pk2, 0);
+        locks.write_lock_account(&pk2, 1);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::none()
         );
 
-        // Remove pj2 lock, add another lock for pk1 on thread 0 - at `write_queue_limit` so cannot schedule on any threads
-        locks.unlock_write_account(&pk2, 1);
-        locks.lock_write_account(&pk1, 0);
+        // Remove pk2 lock, add another lock for pk1 on thread 0 - at `write_queue_limit` so cannot schedule on any threads
+        locks.write_unlock_account(&pk2, 1);
+        locks.write_lock_account(&pk1, 0);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::none()
@@ -295,48 +367,60 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_lock_write_account_write_conflict_panic() {
+    fn test_locks() {
         let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.lock_write_account(&pk1, 0);
-        locks.lock_write_account(&pk1, 1);
+        locks.write_lock_account(&pk1, 0);
+        locks.write_lock_account(&pk1, 0);
+
+        locks.read_lock_account(&pk2, 1);
+        locks.write_lock_account(&pk2, 1);
     }
 
     #[test]
     #[should_panic]
-    fn test_lock_write_account_read_conflict_panic() {
+    fn test_write_lock_account_write_conflict_panic() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.lock_read_account(&pk1, 0);
-        locks.lock_write_account(&pk1, 1);
+        locks.write_lock_account(&pk1, 0);
+        locks.write_lock_account(&pk1, 1);
     }
 
     #[test]
     #[should_panic]
-    fn test_unlock_write_account_panic() {
+    fn test_write_lock_account_read_conflict_panic() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.lock_write_account(&pk1, 1);
-        locks.unlock_write_account(&pk1, 0);
+        locks.read_lock_account(&pk1, 0);
+        locks.write_lock_account(&pk1, 1);
     }
 
     #[test]
     #[should_panic]
-    fn test_lock_read_account_write_conflict_panic() {
+    fn test_write_unlock_account_panic() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.lock_write_account(&pk1, 0);
-        locks.lock_read_account(&pk1, 1);
+        locks.write_lock_account(&pk1, 1);
+        locks.write_unlock_account(&pk1, 0);
     }
 
     #[test]
     #[should_panic]
-    fn test_unlock_read_account_panic() {
+    fn test_read_lock_account_write_conflict_panic() {
         let pk1 = Pubkey::new_unique();
         let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
-        locks.lock_read_account(&pk1, 0);
-        locks.unlock_read_account(&pk1, 1);
+        locks.write_lock_account(&pk1, 0);
+        locks.read_lock_account(&pk1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_read_unlock_account_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.read_lock_account(&pk1, 0);
+        locks.read_unlock_account(&pk1, 1);
     }
 
     #[test]
@@ -346,7 +430,7 @@ mod tests {
         assert_eq!(thread_set.num_threads(), 0);
         assert_eq!(thread_set.only_one_scheduled(), None);
         for idx in 0..MAX_THREADS {
-            assert!(!thread_set.contains(idx as ThreadId));
+            assert!(!thread_set.contains(idx));
         }
 
         thread_set.insert(4);
@@ -354,7 +438,7 @@ mod tests {
         assert_eq!(thread_set.num_threads(), 1);
         assert_eq!(thread_set.only_one_scheduled(), Some(4));
         for idx in 0..MAX_THREADS {
-            assert_eq!(thread_set.contains(idx as ThreadId), idx == 4);
+            assert_eq!(thread_set.contains(idx), idx == 4);
         }
 
         thread_set.insert(2);
@@ -362,7 +446,7 @@ mod tests {
         assert_eq!(thread_set.num_threads(), 2);
         assert_eq!(thread_set.only_one_scheduled(), None);
         for idx in 0..MAX_THREADS {
-            assert_eq!(thread_set.contains(idx as ThreadId), idx == 2 || idx == 4);
+            assert_eq!(thread_set.contains(idx), idx == 2 || idx == 4);
         }
 
         thread_set.remove(4);
@@ -370,7 +454,7 @@ mod tests {
         assert_eq!(thread_set.num_threads(), 1);
         assert_eq!(thread_set.only_one_scheduled(), Some(2));
         for idx in 0..MAX_THREADS {
-            assert_eq!(thread_set.contains(idx as ThreadId), idx == 2);
+            assert_eq!(thread_set.contains(idx), idx == 2);
         }
     }
 }

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -73,6 +73,22 @@ impl ThreadAwareAccountLocks {
         })
     }
 
+    /// Unlocks the accounts for the given thread.
+    pub(crate) fn unlock_accounts<'a>(
+        &mut self,
+        write_account_locks: impl Iterator<Item = &'a Pubkey>,
+        read_account_locks: impl Iterator<Item = &'a Pubkey>,
+        thread_id: ThreadId,
+    ) {
+        for account in write_account_locks {
+            self.write_unlock_account(account, thread_id);
+        }
+
+        for account in read_account_locks {
+            self.read_unlock_account(account, thread_id);
+        }
+    }
+
     /// Returns `ThreadSet` that the given accounts can be scheduled on.
     fn accounts_schedulable_threads<'a>(
         &self,

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -530,10 +530,10 @@ mod tests {
     fn test_accounts_schedulable_threads_outstanding_mixed() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 3);
 
         locks.read_lock_account(&pk1, 2);
-        locks.write_lock_account(&pk2, 2);
+        locks.write_lock_account(&pk1, 2);
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
             ThreadSet::only(2)

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -138,7 +138,8 @@ impl ThreadAwareAccountLocks {
             thread_set
                 .only_one_contained()
                 .filter(|thread_id| counts[*thread_id] < self.sequential_queue_limit)
-                .map_or_else(ThreadSet::none, ThreadSet::only)
+                .map(ThreadSet::only)
+                .unwrap_or_else(ThreadSet::none)
         })
     }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -1,9 +1,6 @@
 use {
     solana_sdk::pubkey::Pubkey,
-    std::{
-        collections::HashMap,
-        ops::{BitAnd, BitAndAssign},
-    },
+    std::{collections::HashMap, ops::BitAndAssign},
 };
 
 pub const MAX_THREADS: usize = 64;
@@ -19,14 +16,6 @@ pub struct ThreadSet(u64);
 impl BitAndAssign for ThreadSet {
     fn bitand_assign(&mut self, rhs: Self) {
         self.0 &= rhs.0;
-    }
-}
-
-impl BitAnd for ThreadSet {
-    type Output = Self;
-
-    fn bitand(self, rhs: Self) -> Self::Output {
-        Self(self.0 & rhs.0)
     }
 }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -2,7 +2,7 @@ use {
     solana_sdk::pubkey::Pubkey,
     std::{
         collections::HashMap,
-        fmt::Display,
+        fmt::{Debug, Display},
         ops::{BitAndAssign, Sub},
     },
 };
@@ -283,9 +283,9 @@ impl Display for ThreadSet {
     }
 }
 
-impl std::fmt::Debug for ThreadSet {
+impl Debug for ThreadSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self}")
+        Display::fmt(self, f)
     }
 }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -12,6 +12,8 @@ pub(crate) const MAX_THREADS: usize = u64::BITS as usize;
 /// Identifier for a thread
 pub(crate) type ThreadId = usize; // 0..MAX_THREADS-1
 
+type LockCount = u32;
+
 /// A bit-set of threads an account is scheduled or can be scheduled for.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) struct ThreadSet(u64);
@@ -31,7 +33,7 @@ pub(crate) struct ThreadAwareAccountLocks {
     /// Read locks - multiple threads can hold a read lock at a time.
     /// Contains thread-set for easily checking which threads are scheduled.
     /// Contains how many read locks are held by each thread.
-    read_locks: HashMap<Pubkey, (ThreadSet, [u32; MAX_THREADS])>,
+    read_locks: HashMap<Pubkey, (ThreadSet, [LockCount; MAX_THREADS])>,
 }
 
 impl ThreadAwareAccountLocks {

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -300,17 +300,18 @@ mod tests {
     use super::*;
 
     const TEST_NUM_THREADS: usize = 4;
+    const TEST_SEQ_LIMIT: u32 = 2;
 
     #[test]
     #[should_panic]
     fn test_too_few_num_threads() {
-        ThreadAwareAccountLocks::new(0, 1);
+        ThreadAwareAccountLocks::new(0, TEST_SEQ_LIMIT);
     }
 
     #[test]
     #[should_panic]
     fn test_too_many_num_threads() {
-        ThreadAwareAccountLocks::new(MAX_THREADS + 1, 1);
+        ThreadAwareAccountLocks::new(MAX_THREADS + 1, TEST_SEQ_LIMIT);
     }
 
     #[test]
@@ -322,7 +323,7 @@ mod tests {
     #[test]
     fn test_accounts_schedulable_threads_no_outstanding_locks() {
         let pk1 = Pubkey::new_unique();
-        let locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
 
         assert_eq!(
             locks.accounts_schedulable_threads([&pk1].into_iter(), std::iter::empty()),
@@ -339,7 +340,7 @@ mod tests {
     fn test_accounts_schedulable_threads_outstanding_write_only() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.write_lock_account(&pk1, 2);
 
         assert_eq!(
@@ -357,7 +358,7 @@ mod tests {
     fn test_accounts_schedulable_threads_outstanding_read_only() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.read_lock_account(&pk1, 2);
 
         assert_eq!(
@@ -384,7 +385,7 @@ mod tests {
     fn test_accounts_schedulable_threads_outstanding_mixed() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.read_lock_account(&pk1, 2);
         locks.write_lock_account(&pk2, 2);
 
@@ -403,7 +404,7 @@ mod tests {
     #[should_panic]
     fn test_write_lock_account_write_conflict_panic() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.write_lock_account(&pk1, 0);
         locks.write_lock_account(&pk1, 1);
     }
@@ -412,7 +413,7 @@ mod tests {
     #[should_panic]
     fn test_write_lock_account_read_conflict_panic() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.read_lock_account(&pk1, 0);
         locks.write_lock_account(&pk1, 1);
     }
@@ -421,7 +422,7 @@ mod tests {
     #[should_panic]
     fn test_write_unlock_account_not_locked() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.write_unlock_account(&pk1, 0);
     }
 
@@ -429,7 +430,7 @@ mod tests {
     #[should_panic]
     fn test_write_unlock_account_thread_mismatch() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.write_lock_account(&pk1, 1);
         locks.write_unlock_account(&pk1, 0);
     }
@@ -438,7 +439,7 @@ mod tests {
     #[should_panic]
     fn test_read_lock_account_write_conflict_panic() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.write_lock_account(&pk1, 0);
         locks.read_lock_account(&pk1, 1);
     }
@@ -447,7 +448,7 @@ mod tests {
     #[should_panic]
     fn test_read_unlock_account_not_locked() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.read_unlock_account(&pk1, 1);
     }
 
@@ -455,7 +456,7 @@ mod tests {
     #[should_panic]
     fn test_read_unlock_account_thread_mismatch() {
         let pk1 = Pubkey::new_unique();
-        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, TEST_SEQ_LIMIT);
         locks.read_lock_account(&pk1, 0);
         locks.read_unlock_account(&pk1, 1);
     }

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -303,11 +303,9 @@ impl Sub for ThreadSet {
     }
 }
 
-#[cfg(test)]
-static_assertions::assert_eq_size!(ThreadSet, u64); // Formatting must change if size changes
 impl Display for ThreadSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ThreadSet({:#064b})", self.0)
+        write!(f, "ThreadSet({:#0width$b})", self.0, width = MAX_THREADS)
     }
 }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -221,7 +221,7 @@ impl ThreadAwareAccountLocks {
         match self.read_locks.entry(*account) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (thread_set, lock_counts) = entry.get_mut();
-                assert!(thread_set.contains(thread_id));
+                thread_set.insert(thread_id);
 
                 lock_counts[thread_id] += 1;
             }
@@ -478,7 +478,13 @@ mod tests {
         );
         assert_eq!(
             locks.accounts_schedulable_threads(std::iter::empty(), [&pk1, &pk2].into_iter()),
-            ThreadSet::any(TEST_NUM_THREADS) - ThreadSet::only(2)
+            ThreadSet::any(TEST_NUM_THREADS)
+        );
+
+        locks.read_lock_account(&pk1, 0); // at limit
+        assert_eq!(
+            locks.accounts_schedulable_threads(std::iter::empty(), [&pk1, &pk2].into_iter()),
+            ThreadSet::any(TEST_NUM_THREADS) - ThreadSet::only(0)
         );
     }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -158,7 +158,7 @@ impl ThreadAwareAccountLocks {
                 }
             }
             (Some((thread_id, count)), Some((thread_set, counts))) => {
-                debug_assert_eq!(Some(*thread_id), thread_set.only_one_contained());
+                assert_eq!(Some(*thread_id), thread_set.only_one_contained());
                 if count + counts[*thread_id] == self.sequential_queue_limit {
                     ThreadSet::none()
                 } else {

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -40,11 +40,12 @@ pub struct ThreadAwareAccountLocks {
 impl ThreadAwareAccountLocks {
     /// Creates a new `ThreadAwareAccountLocks` with the given number of threads
     /// and queue limit.
-    pub fn new(num_threads: usize, write_queue_limit: u32) -> Self {
+    pub fn new(num_threads: usize, sequential_queue_limit: u32) -> Self {
         assert!(num_threads > 0 && num_threads <= MAX_THREADS);
+        assert!(sequential_queue_limit > 0);
         Self {
             num_threads,
-            sequential_queue_limit: write_queue_limit,
+            sequential_queue_limit,
             write_locks: HashMap::new(),
             read_locks: HashMap::new(),
         }
@@ -310,6 +311,12 @@ mod tests {
     #[should_panic]
     fn test_too_many_num_threads() {
         ThreadAwareAccountLocks::new(MAX_THREADS + 1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_sequential_limit() {
+        ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 0);
     }
 
     #[test]

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -137,7 +137,7 @@ impl ThreadAwareAccountLocks {
     }
 
     /// Add locks for all writable and readable accounts on `thread_id`.
-    pub(crate) fn lock_accounts<'a>(
+    fn lock_accounts<'a>(
         &mut self,
         write_account_locks: impl Iterator<Item = &'a Pubkey>,
         read_account_locks: impl Iterator<Item = &'a Pubkey>,

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -1,0 +1,376 @@
+use {
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        collections::HashMap,
+        ops::{BitAnd, BitAndAssign},
+    },
+};
+
+pub const MAX_THREADS: usize = 64;
+
+/// Identifier for a thread
+pub type ThreadId = u8; // 0..MAX_THREADS-1
+
+/// A bit-set of threads an account is scheduled or can be scheduled for.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct ThreadSet(u64);
+
+impl BitAndAssign for ThreadSet {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl BitAnd for ThreadSet {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+/// Thread-aware account locks which allows for scheduling on threads
+/// that already hold locks on the account. This is useful for allowing
+/// queued transactions to be scheduled on a thread while the transaction
+/// is still being executed on the thread, up to a queue limit.
+pub struct ThreadAwareAccountLocks {
+    /// Number of threads.
+    num_threads: u8, // 0..MAX_THREADS
+    /// Limit on the number of write-queued transactions per account.
+    write_queue_limit: u32,
+    /// Write locks - only on thread can hold a write lock at a time.
+    /// Contains how many write locks are held by the thread.
+    write_locks: HashMap<Pubkey, (ThreadId, u32)>,
+    /// Read locks - multiple threads can hold a read lock at a time.
+    /// Contains thread-set for easily checking which threads are scheduled.
+    /// Contains how many read locks are held by each thread.
+    read_locks: HashMap<Pubkey, (ThreadSet, [u32; MAX_THREADS])>,
+}
+
+impl ThreadAwareAccountLocks {
+    /// Creates a new `ThreadAwareAccountLocks` with the given number of threads
+    /// and queue limit.
+    pub fn new(num_threads: u8, write_queue_limit: u32) -> Self {
+        assert!(num_threads <= MAX_THREADS as u8);
+        Self {
+            num_threads,
+            write_queue_limit,
+            write_locks: HashMap::new(),
+            read_locks: HashMap::new(),
+        }
+    }
+
+    /// Returns `ThreadSet` that the given accounts can be scheduled on.
+    pub fn accounts_schedulable_threads<'a>(
+        &self,
+        write_account_locks: impl Iterator<Item = &'a Pubkey>,
+        read_account_locks: impl Iterator<Item = &'a Pubkey>,
+    ) -> ThreadSet {
+        let mut schedulable_threads = ThreadSet::any(self.num_threads);
+
+        // Write accounts conflict with read and write locks.
+        for account in write_account_locks {
+            if let Some((thread_id, count)) = self.write_locks.get(account) {
+                if count == &self.write_queue_limit {
+                    return ThreadSet::none();
+                }
+                schedulable_threads &= ThreadSet::only(*thread_id);
+            }
+            if let Some((thread_set, _)) = self.read_locks.get(account) {
+                schedulable_threads &= *thread_set;
+            }
+        }
+
+        // Read accounts conflict with write locks.
+        for account in read_account_locks {
+            if let Some((thread_id, _)) = self.write_locks.get(account) {
+                schedulable_threads &= ThreadSet::only(*thread_id);
+            }
+        }
+
+        schedulable_threads
+    }
+
+    /// Add locks for all writable and readable accounts on `thread_id`.
+    pub fn lock_accounts<'a>(
+        &mut self,
+        write_account_locks: impl Iterator<Item = &'a Pubkey>,
+        read_account_locks: impl Iterator<Item = &'a Pubkey>,
+        thread_id: ThreadId,
+    ) {
+        for account in write_account_locks {
+            self.lock_write_account(account, thread_id);
+        }
+
+        for account in read_account_locks {
+            self.lock_read_account(account, thread_id);
+        }
+    }
+
+    /// Locks the given `account` for writing on `thread_id`.
+    /// Panics if the account is already locked for writing on another thread.
+    fn lock_write_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+        match self.write_locks.entry(*account) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (lock_thread_id, lock_count) = entry.get_mut();
+                assert_eq!(*lock_thread_id, thread_id);
+
+                *lock_count += 1;
+                assert!(*lock_count <= self.write_queue_limit);
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert((thread_id, 1));
+            }
+        }
+
+        // Check for outstanding read-locks
+        if let Some((read_thread_set, _)) = self.read_locks.get(account) {
+            assert_eq!(read_thread_set, &ThreadSet::only(thread_id));
+        }
+    }
+
+    /// Unlocks the given `account` for writing on `thread_id`.
+    /// Panics if the account is not locked for writing on `thread_id`.
+    fn unlock_write_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+        match self.write_locks.entry(*account) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (lock_thread_id, lock_count) = entry.get_mut();
+                assert_eq!(*lock_thread_id, thread_id);
+                *lock_count -= 1;
+                if *lock_count == 0 {
+                    entry.remove();
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(_) => {
+                panic!("Write lock not found for account: {account}");
+            }
+        }
+    }
+
+    /// Locks the given `account` for reading on `thread_id`.
+    /// Panics if the account is already locked for writing on another thread.
+    fn lock_read_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+        match self.read_locks.entry(*account) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (thread_set, lock_counts) = entry.get_mut();
+                assert!(thread_set.contains(thread_id));
+
+                lock_counts[thread_id as usize] += 1;
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let mut lock_counts = [0; MAX_THREADS];
+                lock_counts[thread_id as usize] = 1;
+                entry.insert((ThreadSet::only(thread_id), lock_counts));
+            }
+        }
+
+        // Check for outstanding write-locks
+        if let Some((write_thread_id, _)) = self.write_locks.get(account) {
+            assert_eq!(write_thread_id, &thread_id);
+        }
+    }
+
+    /// Unlocks the given `account` for reading on `thread_id`.
+    /// Panics if the account is not locked for reading on `thread_id`.
+    fn unlock_read_account(&mut self, account: &Pubkey, thread_id: ThreadId) {
+        match self.read_locks.entry(*account) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (thread_set, lock_counts) = entry.get_mut();
+                assert!(thread_set.contains(thread_id));
+                lock_counts[thread_id as usize] -= 1;
+                if lock_counts[thread_id as usize] == 0 {
+                    thread_set.remove(thread_id);
+                    if thread_set.is_empty() {
+                        entry.remove();
+                    }
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(_) => {
+                panic!("Read lock not found for account: {account}");
+            }
+        }
+    }
+}
+
+impl ThreadSet {
+    #[inline(always)]
+    pub fn none() -> Self {
+        Self(0)
+    }
+
+    #[inline(always)]
+    pub fn any(num_threads: u8) -> Self {
+        Self((1 << num_threads) - 1)
+    }
+
+    #[inline(always)]
+    pub fn only(thread_id: ThreadId) -> Self {
+        Self(1 << thread_id)
+    }
+
+    #[inline(always)]
+    pub fn num_threads(&self) -> u8 {
+        self.0.count_ones() as u8
+    }
+
+    #[inline(always)]
+    pub fn only_one_scheduled(&self) -> Option<ThreadId> {
+        (self.num_threads() == 1).then_some(self.0.trailing_zeros() as ThreadId)
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    #[inline(always)]
+    pub fn contains(&self, thread_id: ThreadId) -> bool {
+        self.0 & (1 << thread_id) != 0
+    }
+
+    #[inline(always)]
+    pub fn insert(&mut self, thread_id: ThreadId) {
+        self.0 |= 1 << thread_id;
+    }
+
+    #[inline(always)]
+    pub fn remove(&mut self, thread_id: ThreadId) {
+        self.0 &= !(1 << thread_id);
+    }
+
+    #[inline(always)]
+    pub fn threads_iter(self) -> impl Iterator<Item = ThreadId> {
+        (0..MAX_THREADS as ThreadId).filter(move |thread_id| self.contains(*thread_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_NUM_THREADS: u8 = 4;
+
+    #[test]
+    fn accounts_schedulable_threads() {
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+
+        // No locks - all threads are schedulable
+        assert_eq!(
+            locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
+            ThreadSet::any(TEST_NUM_THREADS)
+        );
+
+        // Write lock on pk1 on thread 0 - now only thread 0 is schedulable
+        locks.lock_write_account(&pk1, 0);
+        assert_eq!(
+            locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
+            ThreadSet::only(0)
+        );
+
+        // Write lock pk2 on thread 0 - can still schedule on thread 0
+        locks.lock_write_account(&pk2, 0);
+        assert_eq!(
+            locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
+            ThreadSet::only(0)
+        );
+
+        // Move pk2 lock to thread 1 - cannot schedule on any threads
+        locks.unlock_write_account(&pk2, 0);
+        locks.lock_write_account(&pk2, 1);
+        assert_eq!(
+            locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
+            ThreadSet::none()
+        );
+
+        // Remove pj2 lock, add another lock for pk1 on thread 0 - at `write_queue_limit` so cannot schedule on any threads
+        locks.unlock_write_account(&pk2, 1);
+        locks.lock_write_account(&pk1, 0);
+        assert_eq!(
+            locks.accounts_schedulable_threads([&pk1, &pk2].into_iter(), std::iter::empty()),
+            ThreadSet::none()
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lock_write_account_write_conflict_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.lock_write_account(&pk1, 0);
+        locks.lock_write_account(&pk1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lock_write_account_read_conflict_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.lock_read_account(&pk1, 0);
+        locks.lock_write_account(&pk1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unlock_write_account_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.lock_write_account(&pk1, 1);
+        locks.unlock_write_account(&pk1, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lock_read_account_write_conflict_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.lock_write_account(&pk1, 0);
+        locks.lock_read_account(&pk1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unlock_read_account_panic() {
+        let pk1 = Pubkey::new_unique();
+        let mut locks = ThreadAwareAccountLocks::new(TEST_NUM_THREADS, 2);
+        locks.lock_read_account(&pk1, 0);
+        locks.unlock_read_account(&pk1, 1);
+    }
+
+    #[test]
+    fn test_thread_set() {
+        let mut thread_set = ThreadSet::none();
+        assert!(thread_set.is_empty());
+        assert_eq!(thread_set.num_threads(), 0);
+        assert_eq!(thread_set.only_one_scheduled(), None);
+        for idx in 0..MAX_THREADS {
+            assert!(!thread_set.contains(idx as ThreadId));
+        }
+
+        thread_set.insert(4);
+        assert!(!thread_set.is_empty());
+        assert_eq!(thread_set.num_threads(), 1);
+        assert_eq!(thread_set.only_one_scheduled(), Some(4));
+        for idx in 0..MAX_THREADS {
+            assert_eq!(thread_set.contains(idx as ThreadId), idx == 4);
+        }
+
+        thread_set.insert(2);
+        assert!(!thread_set.is_empty());
+        assert_eq!(thread_set.num_threads(), 2);
+        assert_eq!(thread_set.only_one_scheduled(), None);
+        for idx in 0..MAX_THREADS {
+            assert_eq!(thread_set.contains(idx as ThreadId), idx == 2 || idx == 4);
+        }
+
+        thread_set.remove(4);
+        assert!(!thread_set.is_empty());
+        assert_eq!(thread_set.num_threads(), 1);
+        assert_eq!(thread_set.only_one_scheduled(), Some(2));
+        for idx in 0..MAX_THREADS {
+            assert_eq!(thread_set.contains(idx as ThreadId), idx == 2);
+        }
+    }
+}

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -343,8 +343,8 @@ impl ThreadSet {
     }
 
     #[inline(always)]
-    pub(crate) fn num_threads(&self) -> u8 {
-        self.0.count_ones() as u8
+    pub(crate) fn num_threads(&self) -> u32 {
+        self.0.count_ones()
     }
 
     #[inline(always)]

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -115,7 +115,7 @@ impl ThreadAwareAccountLocks {
         // that is not at the sequential limit.
         self.schedulable_threads_with_read_only_handler(account, |thread_set, counts| {
             let mut schedulable_threads = ThreadSet::any(self.num_threads);
-            for thread_id in thread_set.threads_iter() {
+            for thread_id in thread_set.contained_threads_iter() {
                 if counts[thread_id] == self.sequential_queue_limit {
                     schedulable_threads.remove(thread_id);
                 }
@@ -373,7 +373,7 @@ impl ThreadSet {
     }
 
     #[inline(always)]
-    pub(crate) fn threads_iter(self) -> impl Iterator<Item = ThreadId> {
+    pub(crate) fn contained_threads_iter(self) -> impl Iterator<Item = ThreadId> {
         (0..MAX_THREADS).filter(move |thread_id| self.contains(*thread_id))
     }
 
@@ -392,7 +392,7 @@ mod tests {
 
     // Simple thread selector to select the first schedulable thread
     fn test_thread_selector(thread_set: ThreadSet) -> ThreadId {
-        thread_set.threads_iter().next().unwrap()
+        thread_set.contained_threads_iter().next().unwrap()
     }
 
     #[test]

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -345,7 +345,7 @@ impl ThreadSet {
 
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.0 == 0
+        self == &Self::none()
     }
 
     #[inline(always)]

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -363,7 +363,7 @@ impl ThreadSet {
 
     #[inline(always)]
     pub fn threads_iter(self) -> impl Iterator<Item = ThreadId> {
-        (0..MAX_THREADS as ThreadId).filter(move |thread_id| self.contains(*thread_id))
+        (0..MAX_THREADS).filter(move |thread_id| self.contains(*thread_id))
     }
 }
 

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -177,10 +177,10 @@ impl ThreadAwareAccountLocks {
         }
 
         // Check for outstanding read-locks
-        if let Some((read_thread_set, _)) = self.read_locks.get(account) {
+        if let Some(&(read_thread_set, _)) = self.read_locks.get(account) {
             assert_eq!(
                 read_thread_set,
-                &ThreadSet::only(thread_id),
+                ThreadSet::only(thread_id),
                 "outstanding read lock must be on same thread"
             );
         }

--- a/core/src/banking_stage/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/thread_aware_account_locks.rs
@@ -2,6 +2,7 @@ use {
     solana_sdk::pubkey::Pubkey,
     std::{
         collections::HashMap,
+        fmt::Display,
         ops::{BitAndAssign, Sub},
     },
 };
@@ -12,7 +13,7 @@ pub const MAX_THREADS: usize = 64;
 pub type ThreadId = usize; // 0..MAX_THREADS-1
 
 /// A bit-set of threads an account is scheduled or can be scheduled for.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ThreadSet(u64);
 
@@ -270,6 +271,20 @@ impl Sub for ThreadSet {
 
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0 & !rhs.0)
+    }
+}
+
+#[cfg(test)]
+static_assertions::assert_eq_size!(ThreadSet, u64); // Formatting must change if size changes
+impl Display for ThreadSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ThreadSet({:#064b})", self.0)
+    }
+}
+
+impl std::fmt::Debug for ThreadSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
     }
 }
 


### PR DESCRIPTION
#### Problem
With transaction batch scheduling, we end up with inefficieny if we wait to schedule conflicting txs until we receive a completed signal. Want a way of queueing up conflicting transactions onto the same thread - to do so we need to track the what locks are on which thread.

#### Summary of Changes
Account locks that track per-thread usage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
