### PR TITLE
Cli: expose tx slot in json output for confirm or transaction-history

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2600,7 +2600,7 @@ pub struct CliTransaction {
     pub transaction: EncodedTransaction,
     pub meta: Option<UiTransactionStatusMeta>,
     pub block_time: Option<UnixTimestamp>,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slot: Option<Slot>,
     #[serde(skip_serializing)]
     pub decoded_transaction: VersionedTransaction,


### PR DESCRIPTION
#### Problem
During #30376, I discovered that `solana confirm -v` does not return a transaction's slot in its json output, only in the human-readable display. This looks like a simple oversight.

#### Summary of Changes
Convert blanket skip_serializing to only skip if populated with None. Affects `solana confirm -v --output json` and `solana transaction-history --show-transactions --output json`
