### PR TITLE
reduce closest-completion-repairs requests

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -110,7 +110,6 @@ pub struct RepairTiming {
     pub add_votes_elapsed: u64,
     pub get_best_orphans_elapsed: u64,
     pub get_best_shreds_elapsed: u64,
-    pub get_unknown_last_index_elapsed: u64,
     pub get_closest_completion_elapsed: u64,
     pub send_repairs_elapsed: u64,
     pub build_repairs_batch_elapsed: u64,
@@ -144,8 +143,6 @@ pub struct BestRepairsStats {
     pub num_orphan_repairs: u64,
     pub num_best_shreds_slots: u64,
     pub num_best_shreds_repairs: u64,
-    pub num_unknown_last_index_slots: u64,
-    pub num_unknown_last_index_repairs: u64,
     pub num_closest_completion_slots: u64,
     pub num_closest_completion_repairs: u64,
 }
@@ -157,8 +154,6 @@ impl BestRepairsStats {
         num_orphan_repairs: u64,
         num_best_shreds_slots: u64,
         num_best_shreds_repairs: u64,
-        num_unknown_last_index_slots: u64,
-        num_unknown_last_index_repairs: u64,
         num_closest_completion_slots: u64,
         num_closest_completion_repairs: u64,
     ) {
@@ -167,8 +162,6 @@ impl BestRepairsStats {
         self.num_orphan_repairs += num_orphan_repairs;
         self.num_best_shreds_slots += num_best_shreds_slots;
         self.num_best_shreds_repairs += num_best_shreds_repairs;
-        self.num_unknown_last_index_slots += num_unknown_last_index_slots;
-        self.num_unknown_last_index_repairs += num_unknown_last_index_repairs;
         self.num_closest_completion_slots += num_closest_completion_slots;
         self.num_closest_completion_repairs += num_closest_completion_repairs;
     }
@@ -179,7 +172,6 @@ pub const MAX_REPAIR_PER_DUPLICATE: usize = 20;
 pub const MAX_DUPLICATE_WAIT_MS: usize = 10_000;
 pub const REPAIR_MS: u64 = 100;
 pub const MAX_ORPHANS: usize = 5;
-pub const MAX_UNKNOWN_LAST_INDEX_REPAIRS: usize = 10;
 pub const MAX_CLOSEST_COMPLETION_REPAIRS: usize = 100;
 
 #[derive(Clone)]
@@ -350,7 +342,6 @@ impl RepairService {
                     root_bank.epoch_schedule(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &duplicate_slot_repair_statuses,
                     &mut repair_timing,
@@ -453,11 +444,6 @@ impl RepairService {
                         i64
                     ),
                     (
-                        "get-unknown-last-index-elapsed",
-                        repair_timing.get_unknown_last_index_elapsed,
-                        i64
-                    ),
-                    (
                         "get-closest-completion-elapsed",
                         repair_timing.get_closest_completion_elapsed,
                         i64
@@ -491,16 +477,6 @@ impl RepairService {
                     (
                         "best-shreds-repairs",
                         best_repairs_stats.num_best_shreds_repairs,
-                        i64
-                    ),
-                    (
-                        "unknown-last-index-slots",
-                        best_repairs_stats.num_unknown_last_index_slots,
-                        i64
-                    ),
-                    (
-                        "unknown-last-index-repairs",
-                        best_repairs_stats.num_unknown_last_index_repairs,
                         i64
                     ),
                     (
@@ -842,7 +818,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     &mut RepairTiming::default(),
@@ -879,7 +854,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     &mut RepairTiming::default(),
@@ -940,7 +914,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     &mut RepairTiming::default(),
@@ -956,7 +929,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     expected.len() - 2,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     &mut RepairTiming::default(),
@@ -1003,7 +975,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &HashSet::default(),
                     &mut RepairTiming::default(),


### PR DESCRIPTION
#### Problem
`closest-completion-repairs` can revisit the same slots. See #30374.

#### Summary of Changes
- prevent slot from being processed multiple times in `get_closest_completion`
- stop parent traversal prior to our root slot
- remove `get-unknown-last-index` repairs. does not appear useful from mainnet data.

Validator start and catch up on mainnet:
![Screenshot 2023-02-21 at 9 30 52 PM](https://user-images.githubusercontent.com/1054614/220740327-8364f1d3-df50-4316-a3a7-f00f151872cb.png)


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
