### PR TITLE
Flushes accounts cache before warping

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1709,6 +1709,13 @@ fn maybe_warp_slot(
         info!("warping to slot {}", warp_slot);
 
         let root_bank = bank_forks.root_bank();
+
+        // An accounts hash calculation from storages will occur in warp_from_parent() below.  This
+        // requires that the accounts cache has been flushed, which requires the parent slot to be
+        // rooted.
+        root_bank.squash();
+        root_bank.force_flush_accounts_cache();
+
         bank_forks.insert(Bank::warp_from_parent(
             &root_bank,
             &Pubkey::default(),


### PR DESCRIPTION
#### Problem

While investigating https://github.com/solana-labs/solana/issues/30258, running `solana-test-validator` *and warping* [1], the test-validator would panic/crash due to accounts hash calculation mismatch.

Calculating the accounts hash when warping was added to support Epoch Accounts Hash [2]. When `solana-test-validator` warps, it calculates the accounts hash from storages, which requires that the accounts cache has been flushed. Unfortunately the accounts cache has not been flushed.

[1]
```
solana-test-validator --reset --warp-slot 400
```

[2] https://github.com/solana-labs/solana/pull/28809 and https://github.com/solana-labs/solana/pull/28459



#### Summary of Changes

Flush the accounts cache before warping.