### PR TITLE
bucket map try_write takes iter

### DIFF
--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -137,6 +137,9 @@ impl<T: Clone + Copy> BucketApi<T> {
         value: (&[T], RefCount),
     ) -> Result<(), BucketMapError> {
         let mut bucket = self.get_write_bucket();
-        bucket.as_mut().unwrap().try_write(pubkey, value.0, value.1)
+        bucket
+            .as_mut()
+            .unwrap()
+            .try_write(pubkey, value.0.iter(), value.0.len(), value.1)
     }
 }


### PR DESCRIPTION
#### Problem
Working on reducing disk footprint of disk index.
Soon, in-mem and disk index account info will be different generic types.
This change makes decoupling the two types more straightforward.

#### Summary of Changes
`try_write()` takes an iter(&T) and len instead of a `&[T]`. Source data is not shaped as `[T]`, it will be `[U]`.
We also expect the len to be always 1 in the near future. In fact, only random flushes at the moment cause us to ever write a slot list with len != 1.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
