### PR TITLE
ci: extract vercel scope as an env

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,7 @@ jobs:
           ./build.sh
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
 
   error_reporting:
     needs:

--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -28,7 +28,7 @@ fi
 cat > "$CONFIG_FILE" <<EOF
 {
   "name": "$PROJECT_NAME",
-  "scope": "solana-labs",
+  "scope": "$VERCEL_SCOPE",
   "redirects": [
     { "source": "/apps", "destination": "/developers" },
     { "source": "/developing/programming-model/overview", "destination": "/developers" },


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/actions/runs/4245534288/jobs/7381468172
![Screenshot 2023-02-23 at 3 36 28 AM](https://user-images.githubusercontent.com/8209234/220740043-7326fb30-86ea-4284-b164-cd10541cff2e.png)

I think we changed the Vercel team slug about weeks ago. sorry for the late response 😢 

#### Summary of Changes

extract Vercel scope as an env `VERCEL_SCOPE` which has already setup in this repo.

