### PR TITLE
add second type to accounts index for disk

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -24,7 +24,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_FORKS: u64 = 16;
 
     let mut reclaims = vec![];
-    let index = AccountsIndex::<AccountInfo>::new(
+    let index = AccountsIndex::<AccountInfo, AccountInfo>::new(
         Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
         &Arc::default(),
     );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1344,7 +1344,7 @@ struct RemoveUnrootedSlotsSynchronization {
     signal: Condvar,
 }
 
-type AccountInfoAccountsIndex = AccountsIndex<AccountInfo>;
+type AccountInfoAccountsIndex = AccountsIndex<AccountInfo, AccountInfo>;
 
 // This structure handles the load/store of the accounts
 #[derive(Debug)]
@@ -13593,7 +13593,7 @@ pub mod tests {
 
     // returns the rooted entries and the storage ref count
     fn roots_and_ref_count<T: IndexValue>(
-        index: &AccountsIndex<T>,
+        index: &AccountsIndex<T, T>,
         locked_account_entry: &ReadAccountMapEntry<T>,
         max_inclusive: Option<Slot>,
     ) -> (SlotList<T>, RefCount) {

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -16,18 +16,18 @@ use {
 };
 
 /// Manages the lifetime of the background processing threads.
-pub struct AccountsIndexStorage<T: IndexValue> {
+pub struct AccountsIndexStorage<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
     _bg_threads: BgThreads,
 
-    pub storage: Arc<BucketMapHolder<T>>,
-    pub in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
+    pub storage: Arc<BucketMapHolder<T, U>>,
+    pub in_mem: Vec<Arc<InMemAccountsIndex<T, U>>>,
     exit: Arc<AtomicBool>,
 
     /// set_startup(true) creates bg threads which are kept alive until set_startup(false)
     startup_worker_threads: Mutex<Option<BgThreads>>,
 }
 
-impl<T: IndexValue> Debug for AccountsIndexStorage<T> {
+impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> Debug for AccountsIndexStorage<T, U> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
@@ -53,9 +53,9 @@ impl Drop for BgThreads {
 }
 
 impl BgThreads {
-    fn new<T: IndexValue>(
-        storage: &Arc<BucketMapHolder<T>>,
-        in_mem: &[Arc<InMemAccountsIndex<T>>],
+    fn new<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+        storage: &Arc<BucketMapHolder<T, U>>,
+        in_mem: &[Arc<InMemAccountsIndex<T, U>>],
         threads: usize,
         can_advance_age: bool,
         exit: &Arc<AtomicBool>,
@@ -109,7 +109,7 @@ pub enum Startup {
     StartupWithExtraThreads,
 }
 
-impl<T: IndexValue> AccountsIndexStorage<T> {
+impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> AccountsIndexStorage<T, U> {
     /// startup=true causes:
     ///      in mem to act in a way that flushes to disk asap
     ///      also creates some additional bg threads to facilitate flushing to disk asap

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -13,6 +13,7 @@ use {
     },
     std::{
         fmt::Debug,
+        marker::PhantomData,
         sync::{
             atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
             Arc,
@@ -27,8 +28,8 @@ const AGE_MS: u64 = DEFAULT_MS_PER_SLOT; // match one age per slot time
 // 10 GB limit for in-mem idx. In practice, we don't get this high. This tunes how aggressively to save items we expect to use soon.
 pub const DEFAULT_DISK_INDEX: Option<usize> = Some(10_000);
 
-pub struct BucketMapHolder<T: IndexValue> {
-    pub disk: Option<BucketMap<(Slot, T)>>,
+pub struct BucketMapHolder<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
+    pub disk: Option<BucketMap<(Slot, U)>>,
 
     pub count_buckets_flushed: AtomicUsize,
 
@@ -66,16 +67,17 @@ pub struct BucketMapHolder<T: IndexValue> {
     /// and writing to disk in parallel are.
     /// Note startup is an optimization and is not required for correctness.
     startup: AtomicBool,
+    _phantom: PhantomData<T>,
 }
 
-impl<T: IndexValue> Debug for BucketMapHolder<T> {
+impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
 }
 
 #[allow(clippy::mutex_atomic)]
-impl<T: IndexValue> BucketMapHolder<T> {
+impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> BucketMapHolder<T, U> {
     /// is the accounts index using disk as a backing store
     pub fn is_disk_index_enabled(&self) -> bool {
         self.disk.is_some()
@@ -256,6 +258,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
             startup: AtomicBool::default(),
             mem_budget_mb,
             threads,
+            _phantom: PhantomData::default(),
         }
     }
 
@@ -328,7 +331,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
     pub fn background(
         &self,
         exit: Vec<Arc<AtomicBool>>,
-        in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
+        in_mem: Vec<Arc<InMemAccountsIndex<T, U>>>,
         can_advance_age: bool,
     ) {
         let bins = in_mem.len();
@@ -402,7 +405,7 @@ pub mod tests {
     fn test_next_bucket_to_flush() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         let visited = (0..bins)
             .map(|_| AtomicUsize::default())
             .collect::<Vec<_>>();
@@ -425,7 +428,7 @@ pub mod tests {
     fn test_ages() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         assert_eq!(0, test.current_age());
         assert_eq!(test.ages_to_stay_in_cache, test.future_age_to_flush(false));
         assert_eq!(u8::MAX, test.future_age_to_flush(true));
@@ -445,7 +448,7 @@ pub mod tests {
     fn test_age_increment() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         for age in 0..513 {
             assert_eq!(test.current_age(), (age % 256) as Age);
 
@@ -466,7 +469,7 @@ pub mod tests {
     fn test_throttle() {
         solana_logger::setup();
         let bins = 128;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         let bins = test.bins as u64;
         let interval_ms = test.age_interval_ms();
         // 90% of time elapsed, all but 1 bins flushed, should not wait since we'll end up right on time
@@ -498,7 +501,7 @@ pub mod tests {
             index_limit_mb: IndexLimitMb::Limit(0),
             ..AccountsIndexConfig::default()
         };
-        let test = BucketMapHolder::<u64>::new(bins, &Some(config), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(config), 1);
         assert!(test.is_disk_index_enabled());
     }
 
@@ -506,7 +509,7 @@ pub mod tests {
     fn test_age_time() {
         solana_logger::setup();
         let bins = 1;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         let threads = 2;
         let time = AGE_MS * 8 / 3;
         let expected = (time / AGE_MS) as Age;
@@ -538,7 +541,7 @@ pub mod tests {
     fn test_age_broad() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         assert_eq!(test.current_age(), 0);
         for _ in 0..bins {
             assert!(!test.all_buckets_flushed_at_current_age());

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -99,7 +99,11 @@ impl BucketMapHolderStats {
         per_bucket.map(|stat| stat.fetch_sub(count, Ordering::Relaxed));
     }
 
-    fn ms_per_age<T: IndexValue>(&self, storage: &BucketMapHolder<T>, elapsed_ms: u64) -> u64 {
+    fn ms_per_age<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+        &self,
+        storage: &BucketMapHolder<T, U>,
+        elapsed_ms: u64,
+    ) -> u64 {
         let age_now = storage.current_age();
         let ages_flushed = storage.count_buckets_flushed() as u64;
         let last_age = self.last_age.swap(age_now, Ordering::Relaxed) as u64;
@@ -172,7 +176,10 @@ impl BucketMapHolderStats {
         in_mem.saturating_sub(held_in_mem) as usize
     }
 
-    pub fn report_stats<T: IndexValue>(&self, storage: &BucketMapHolder<T>) {
+    pub fn report_stats<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+        &self,
+        storage: &BucketMapHolder<T, U>,
+    ) {
         let elapsed_ms = self.last_time.elapsed_ms();
         if elapsed_ms < STATS_INTERVAL_MS {
             return;


### PR DESCRIPTION
#### Problem
Working on reducing disk footprint of disk index.
Soon, in-mem and disk index account info will be different generic types.

#### Summary of Changes
Introduce second type to accounts index. The new second type will be the type that is stored on disk. Practically, it will have no append vec field.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
