### PR TITLE
Metrics for repair trees & closest completion slots

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -114,7 +114,7 @@ pub fn get_closest_completion(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
-) -> Vec<ShredRepairType> {
+) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
     let mut v: Vec<(Slot, u64)> = Vec::default();
     let iter = GenericTraversal::new(tree);
     for slot in iter {
@@ -171,6 +171,7 @@ pub fn get_closest_completion(
 
     let mut visited = HashSet::new();
     let mut repairs = Vec::new();
+    let mut total_processed_slots = 0;
     for (slot, _) in v {
         if repairs.len() >= limit {
             break;
@@ -189,10 +190,11 @@ pub fn get_closest_completion(
                 limit - repairs.len(),
             );
             repairs.extend(new_repairs);
+            total_processed_slots += 1;
         }
     }
 
-    repairs
+    (repairs, total_processed_slots)
 }
 
 #[cfg(test)]
@@ -232,7 +234,7 @@ pub mod test {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
-        let repairs = get_closest_completion(
+        let (repairs, _) = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
@@ -256,7 +258,7 @@ pub mod test {
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
         sleep_shred_deferment_period();
-        let repairs = get_closest_completion(
+        let (repairs, _) = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -149,7 +149,9 @@ pub struct BestRepairsStats {
     pub num_unknown_last_index_slots: u64,
     pub num_unknown_last_index_repairs: u64,
     pub num_closest_completion_slots: u64,
+    pub num_closest_completion_slots_path: u64,
     pub num_closest_completion_repairs: u64,
+    pub num_repair_trees: u64,
 }
 
 impl BestRepairsStats {
@@ -162,7 +164,9 @@ impl BestRepairsStats {
         num_unknown_last_index_slots: u64,
         num_unknown_last_index_repairs: u64,
         num_closest_completion_slots: u64,
+        num_closest_completion_slots_path: u64,
         num_closest_completion_repairs: u64,
+        num_repair_trees: u64,
     ) {
         self.call_count += 1;
         self.num_orphan_slots += num_orphan_slots;
@@ -172,7 +176,9 @@ impl BestRepairsStats {
         self.num_unknown_last_index_slots += num_unknown_last_index_slots;
         self.num_unknown_last_index_repairs += num_unknown_last_index_repairs;
         self.num_closest_completion_slots += num_closest_completion_slots;
+        self.num_closest_completion_slots_path += num_closest_completion_slots_path;
         self.num_closest_completion_repairs += num_closest_completion_repairs;
+        self.num_repair_trees += num_repair_trees;
     }
 }
 
@@ -508,8 +514,18 @@ impl RepairService {
                         i64
                     ),
                     (
+                        "closest-completion-slots-path",
+                        best_repairs_stats.num_closest_completion_slots_path,
+                        i64
+                    ),
+                    (
                         "closest-completion-repairs",
                         best_repairs_stats.num_closest_completion_repairs,
+                        i64
+                    ),
+                    (
+                        "repair-trees",
+                        best_repairs_stats.num_repair_trees,
                         i64
                     ),
                 );

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -155,6 +155,7 @@ pub struct BestRepairsStats {
 }
 
 impl BestRepairsStats {
+    #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
         num_orphan_slots: u64,
@@ -523,11 +524,7 @@ impl RepairService {
                         best_repairs_stats.num_closest_completion_repairs,
                         i64
                     ),
-                    (
-                        "repair-trees",
-                        best_repairs_stats.num_repair_trees,
-                        i64
-                    ),
+                    ("repair-trees", best_repairs_stats.num_repair_trees, i64),
                 );
                 repair_stats = RepairStats::default();
                 repair_timing = RepairTiming::default();

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -223,7 +223,8 @@ impl RepairWeight {
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
         let num_closest_completion_slots = processed_slots.len() - pre_num_slots;
-        let num_closest_completion_slots_path = total_slots_processed.saturating_sub(num_closest_completion_slots);
+        let num_closest_completion_slots_path =
+            total_slots_processed.saturating_sub(num_closest_completion_slots);
         repairs.extend(closest_completion_repairs);
         get_closest_completion_elapsed.stop();
 

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -215,7 +215,7 @@ impl RepairWeight {
 
         let mut get_closest_completion_elapsed = Measure::start("get_closest_completion");
         let pre_num_slots = processed_slots.len();
-        let closest_completion_repairs = self.get_best_closest_completion(
+        let (closest_completion_repairs, total_slots_processed) = self.get_best_closest_completion(
             blockstore,
             &mut slot_meta_cache,
             &mut processed_slots,
@@ -223,6 +223,7 @@ impl RepairWeight {
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
         let num_closest_completion_slots = processed_slots.len() - pre_num_slots;
+        let num_closest_completion_slots_path = total_slots_processed.saturating_sub(num_closest_completion_slots);
         repairs.extend(closest_completion_repairs);
         get_closest_completion_elapsed.stop();
 
@@ -234,7 +235,9 @@ impl RepairWeight {
             num_unknown_last_index_slots as u64,
             num_unknown_last_index_repairs as u64,
             num_closest_completion_slots as u64,
+            num_closest_completion_slots_path as u64,
             num_closest_completion_repairs as u64,
+            self.trees.len() as u64,
         );
         repair_timing.get_best_orphans_elapsed += get_best_orphans_elapsed.as_us();
         repair_timing.get_best_shreds_elapsed += get_best_shreds_elapsed.as_us();
@@ -464,13 +467,14 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
-    ) -> Vec<ShredRepairType> {
+    ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
         let mut repairs = Vec::default();
+        let mut total_processed_slots = 0;
         for (_slot, tree) in self.trees.iter() {
             if repairs.len() >= max_new_repairs {
                 break;
             }
-            let new_repairs = get_closest_completion(
+            let (new_repairs, new_processed_slots) = get_closest_completion(
                 tree,
                 blockstore,
                 slot_meta_cache,
@@ -478,8 +482,9 @@ impl RepairWeight {
                 max_new_repairs - repairs.len(),
             );
             repairs.extend(new_repairs);
+            total_processed_slots += new_processed_slots;
         }
-        repairs
+        (repairs, total_processed_slots)
     }
 
     /// Attempts to chain the orphan subtree rooted at `orphan_tree_root`


### PR DESCRIPTION
#### Problem
It is hard to tell what might be causing a spike in closest completion repair type between:
1. More shreds requiring repair on given slot(s)
2. Large ancestor path of slots being pulled in for repair
3. Large number of repair trees to iterate across

See #30374 

#### Summary of Changes
Add metrics to better understand how many repair trees are being looked at and the number of ancestor slots being repaired as part of closest completion slots