### PR TITLE
prevent duplicated processing for closest-completion-repairs

### DIFF
--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -473,6 +473,7 @@ impl RepairWeight {
             let new_repairs = get_closest_completion(
                 tree,
                 blockstore,
+                self.root,
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),


### PR DESCRIPTION
#### Problem
`closest-completion-repairs` can revisit the same slots.

changes split from #30433.

#### Summary of Changes
- prevent slot from being processed multiple times in get_closest_completion
- stop parent traversal at root slot

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
