### PR TITLE
stop get_unrepaired_path at root slot

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -111,6 +111,7 @@ fn get_unrepaired_path(
 pub fn get_closest_completion(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
+    root_slot: Slot,
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
@@ -169,7 +170,7 @@ pub fn get_closest_completion(
     }
     v.sort_by(|(_, d1), (_, d2)| d1.cmp(d2));
 
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::from([root_slot]);
     let mut repairs = Vec::new();
     for (slot, _) in v {
         if repairs.len() >= limit {
@@ -235,6 +236,7 @@ pub mod test {
         let repairs = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
+            0, // root_slot
             &mut slot_meta_cache,
             &mut processed_slots,
             10,
@@ -259,14 +261,12 @@ pub mod test {
         let repairs = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
+            0, // root_slot
             &mut slot_meta_cache,
             &mut processed_slots,
-            2,
+            1,
         );
-        assert_eq!(
-            repairs,
-            [ShredRepairType::Shred(0, 3), ShredRepairType::Shred(1, 3)]
-        );
+        assert_eq!(repairs, [ShredRepairType::Shred(1, 3)]);
     }
 
     fn add_tree_with_missing_shreds(

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -473,6 +473,7 @@ impl RepairWeight {
             let new_repairs = get_closest_completion(
                 tree,
                 blockstore,
+                self.root,
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),


### PR DESCRIPTION
#### Problem
`get_unrepaired_path` can follow parent slot to include the root slot.

#### Summary of Changes
add root slot to visited list 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
