### PR TITLE
Asserts new bank doesn't already exist with different parent

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4944,12 +4944,15 @@ impl AccountsDb {
     ///
     /// This fn is called when creating a new bank from parent.
     pub fn insert_default_bank_hash_stats(&self, slot: Slot, parent_slot: Slot) {
-        let mut bank_hash_stats = self.bank_hash_stats.lock().unwrap();
-        if bank_hash_stats.get(&slot).is_some() {
-            error!( "set_hash: already exists; multiple forks with shared slot {slot} as child (parent: {parent_slot})!?");
-            return;
-        }
-        bank_hash_stats.insert(slot, BankHashStats::default());
+        let old_bank_hash_stats = self
+            .bank_hash_stats
+            .lock()
+            .unwrap()
+            .insert(slot, BankHashStats::default());
+        assert!(
+            old_bank_hash_stats.is_none(),
+            "set_hash: already exists; multiple forks with shared slot {slot} as child (parent: {parent_slot})!?",
+        );
     }
 
     pub fn load(


### PR DESCRIPTION
#### Problem

It should be illegal to create a new bank with an existing slot.


#### Summary of Changes

Change error log to an assert.