### PR TITLE
get stored_size from StoredAccountMeta

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7929,7 +7929,7 @@ impl AccountsDb {
                 );
                 let offset = account_info.offset();
                 let account = store.accounts.get_account(offset).unwrap();
-                let stored_size = account.1.saturating_sub(offset);
+                let stored_size = account.0.stored_size;
                 let count = store.remove_account(stored_size, reset_accounts);
                 if count == 0 {
                     self.dirty_stores


### PR DESCRIPTION
#### Problem
stored_size is already calculated and stored in `StoredAccountMeta`

#### Summary of Changes
use `StoredAccountMeta.stored_size`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
