### PR TITLE
wip: use a different type for disk index persistence

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -20,7 +20,7 @@
 
 use {
     crate::{
-        account_info::{AccountInfo, StorageLocation},
+        account_info::{AccountInfo, AccountOffsetAndFlags, StorageLocation},
         account_storage::{
             meta::{
                 StorableAccountsWithHashesAndWriteVersions, StoredAccountMeta,
@@ -38,8 +38,8 @@ use {
         },
         accounts_index::{
             AccountIndexGetResult, AccountSecondaryIndexes, AccountsIndex, AccountsIndexConfig,
-            AccountsIndexRootsStats, AccountsIndexScanResult, IndexKey, IndexValue, IsCached,
-            RefCount, ScanConfig, ScanResult, SlotList, UpsertReclaim, ZeroLamport,
+            AccountsIndexRootsStats, AccountsIndexScanResult, DiskIndexValue, IndexKey, IndexValue,
+            IsCached, RefCount, ScanConfig, ScanResult, SlotList, UpsertReclaim, ZeroLamport,
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
         },
         accounts_index_storage::Startup,
@@ -676,6 +676,8 @@ impl GenerateIndexTimings {
 }
 
 impl IndexValue for AccountInfo {}
+impl DiskIndexValue for AccountInfo {}
+impl DiskIndexValue for AccountOffsetAndFlags {}
 
 impl ZeroLamport for AccountSharedData {
     fn is_zero_lamport(&self) -> bool {
@@ -1344,7 +1346,7 @@ struct RemoveUnrootedSlotsSynchronization {
     signal: Condvar,
 }
 
-type AccountInfoAccountsIndex = AccountsIndex<AccountInfo, AccountInfo>;
+type AccountInfoAccountsIndex = AccountsIndex<AccountInfo, AccountOffsetAndFlags>;
 
 // This structure handles the load/store of the accounts
 #[derive(Debug)]

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_index::{AccountsIndexConfig, IndexValue},
+        accounts_index::{AccountsIndexConfig, DiskIndexValue, IndexValue},
         bucket_map_holder::BucketMapHolder,
         in_mem_accounts_index::InMemAccountsIndex,
         waitable_condvar::WaitableCondvar,
@@ -16,7 +16,7 @@ use {
 };
 
 /// Manages the lifetime of the background processing threads.
-pub struct AccountsIndexStorage<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
+pub struct AccountsIndexStorage<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     _bg_threads: BgThreads,
 
     pub storage: Arc<BucketMapHolder<T, U>>,
@@ -27,7 +27,7 @@ pub struct AccountsIndexStorage<T: IndexValue, U: IndexValue + From<T> + Into<T>
     startup_worker_threads: Mutex<Option<BgThreads>>,
 }
 
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> Debug for AccountsIndexStorage<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for AccountsIndexStorage<T, U> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
@@ -53,7 +53,7 @@ impl Drop for BgThreads {
 }
 
 impl BgThreads {
-    fn new<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+    fn new<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         storage: &Arc<BucketMapHolder<T, U>>,
         in_mem: &[Arc<InMemAccountsIndex<T, U>>],
         threads: usize,
@@ -109,7 +109,7 @@ pub enum Startup {
     StartupWithExtraThreads,
 }
 
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> AccountsIndexStorage<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<T, U> {
     /// startup=true causes:
     ///      in mem to act in a way that flushes to disk asap
     ///      also creates some additional bg threads to facilitate flushing to disk asap

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_index::{AccountsIndexConfig, IndexLimitMb, IndexValue},
+        accounts_index::{AccountsIndexConfig, DiskIndexValue, IndexLimitMb, IndexValue},
         bucket_map_holder_stats::BucketMapHolderStats,
         in_mem_accounts_index::InMemAccountsIndex,
         waitable_condvar::WaitableCondvar,
@@ -28,7 +28,7 @@ const AGE_MS: u64 = DEFAULT_MS_PER_SLOT; // match one age per slot time
 // 10 GB limit for in-mem idx. In practice, we don't get this high. This tunes how aggressively to save items we expect to use soon.
 pub const DEFAULT_DISK_INDEX: Option<usize> = Some(10_000);
 
-pub struct BucketMapHolder<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
+pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub disk: Option<BucketMap<(Slot, U)>>,
 
     pub count_buckets_flushed: AtomicUsize,
@@ -70,14 +70,14 @@ pub struct BucketMapHolder<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
     _phantom: PhantomData<T>,
 }
 
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
 }
 
 #[allow(clippy::mutex_atomic)]
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> BucketMapHolder<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U> {
     /// is the accounts index using disk as a backing store
     pub fn is_disk_index_enabled(&self) -> bool {
         self.disk.is_some()

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{accounts_index::IndexValue, bucket_map_holder::BucketMapHolder},
+    crate::{
+        accounts_index::{DiskIndexValue, IndexValue},
+        bucket_map_holder::BucketMapHolder,
+    },
     solana_sdk::timing::AtomicInterval,
     std::{
         fmt::Debug,
@@ -99,7 +102,7 @@ impl BucketMapHolderStats {
         per_bucket.map(|stat| stat.fetch_sub(count, Ordering::Relaxed));
     }
 
-    fn ms_per_age<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+    fn ms_per_age<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         &self,
         storage: &BucketMapHolder<T, U>,
         elapsed_ms: u64,
@@ -176,7 +179,7 @@ impl BucketMapHolderStats {
         in_mem.saturating_sub(held_in_mem) as usize
     }
 
-    pub fn report_stats<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+    pub fn report_stats<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         &self,
         storage: &BucketMapHolder<T, U>,
     ) {

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         accounts_index::{
-            AccountMapEntry, AccountMapEntryInner, AccountMapEntryMeta, IndexValue,
+            AccountMapEntry, AccountMapEntryInner, AccountMapEntryMeta, DiskIndexValue, IndexValue,
             PreAllocatedAccountMapEntry, RefCount, SlotList, UpsertReclaim, ZeroLamport,
         },
         bucket_map_holder::{Age, BucketMapHolder},
@@ -83,7 +83,7 @@ impl<T: IndexValue> PossibleEvictions<T> {
 }
 
 // one instance of this represents one bin of the accounts index.
-pub struct InMemAccountsIndex<T: IndexValue, U: IndexValue + From<T> + Into<T>> {
+pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     last_age_flushed: AtomicU8,
 
     // backing store
@@ -112,7 +112,7 @@ pub struct InMemAccountsIndex<T: IndexValue, U: IndexValue + From<T> + Into<T>> 
     age_to_flush_bin_mod: Age,
 }
 
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> Debug for InMemAccountsIndex<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for InMemAccountsIndex<T, U> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
@@ -141,7 +141,7 @@ struct FlushScanResult<T> {
     evictions_random: Vec<(Pubkey, AccountMapEntry<T>)>,
 }
 
-impl<T: IndexValue, U: IndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {
     pub fn new(storage: &Arc<BucketMapHolder<T, U>>, bin: usize) -> Self {
         let ages_to_stay_in_cache = storage.ages_to_stay_in_cache;
         Self {
@@ -1397,7 +1397,7 @@ struct EvictionsGuard<'a> {
 
 impl<'a> EvictionsGuard<'a> {
     #[must_use = "if unused, this evictions lock will be immediately unlocked"]
-    fn lock<T: IndexValue, U: IndexValue + From<T> + Into<T>>(
+    fn lock<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         in_mem_accounts_index: &'a InMemAccountsIndex<T, U>,
     ) -> Self {
         Self::lock_with(


### PR DESCRIPTION
#### Problem
Working on reducing disk footprint of disk index.
in-mem and disk index account info are now different generic types.

#### Summary of Changes
Introduce a type for disk which does not store append vec id.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
