### PR TITLE
ci: disable program-2022 and token-cli in ci downstream build

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -44,8 +44,8 @@ spl() {
     PROGRAMS=(
       instruction-padding/program
       token/program
-      token/program-2022
-      token/program-2022-test
+      # token/program-2022
+      # token/program-2022-test
       associated-token-account/program
       token-upgrade/program
       feature-proposal/program
@@ -78,8 +78,8 @@ spl() {
     # TODO better: `build.rs` for spl-token-cli doesn't seem to properly build
     # the required programs to run the tests, so instead we run the tests
     # after we know programs have been built
-    cargo build
-    cargo test
+    cargo build --workspace --exclude "spl-token-cli"
+    cargo test --workspace --exclude "spl-token-cli"
   )
 }
 


### PR DESCRIPTION
#### Problem
- Due to circular dependency on token-cli and `account-decoder`, the downstream project ci test fails (https://github.com/solana-labs/solana/pull/30353)
- There is a change to the `ZkTokenProof` program that breaks the token-2022 program (https://github.com/solana-labs/solana/pull/29996)

#### Summary of Changes
Temporarily disable token-2022 and token-cli in the downstream build ci tests for token-2022 program and token-cli until these PRs are merged and the crates in spl are updated accordingly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
