### PR TITLE
remove get_best_unknown_last_index

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -112,7 +112,6 @@ pub struct RepairTiming {
     pub add_votes_elapsed: u64,
     pub get_best_orphans_elapsed: u64,
     pub get_best_shreds_elapsed: u64,
-    pub get_unknown_last_index_elapsed: u64,
     pub get_closest_completion_elapsed: u64,
     pub send_repairs_elapsed: u64,
     pub build_repairs_batch_elapsed: u64,
@@ -146,8 +145,6 @@ pub struct BestRepairsStats {
     pub num_orphan_repairs: u64,
     pub num_best_shreds_slots: u64,
     pub num_best_shreds_repairs: u64,
-    pub num_unknown_last_index_slots: u64,
-    pub num_unknown_last_index_repairs: u64,
     pub num_closest_completion_slots: u64,
     pub num_closest_completion_slots_path: u64,
     pub num_closest_completion_repairs: u64,
@@ -162,8 +159,6 @@ impl BestRepairsStats {
         num_orphan_repairs: u64,
         num_best_shreds_slots: u64,
         num_best_shreds_repairs: u64,
-        num_unknown_last_index_slots: u64,
-        num_unknown_last_index_repairs: u64,
         num_closest_completion_slots: u64,
         num_closest_completion_slots_path: u64,
         num_closest_completion_repairs: u64,
@@ -174,8 +169,6 @@ impl BestRepairsStats {
         self.num_orphan_repairs += num_orphan_repairs;
         self.num_best_shreds_slots += num_best_shreds_slots;
         self.num_best_shreds_repairs += num_best_shreds_repairs;
-        self.num_unknown_last_index_slots += num_unknown_last_index_slots;
-        self.num_unknown_last_index_repairs += num_unknown_last_index_repairs;
         self.num_closest_completion_slots += num_closest_completion_slots;
         self.num_closest_completion_slots_path += num_closest_completion_slots_path;
         self.num_closest_completion_repairs += num_closest_completion_repairs;
@@ -188,7 +181,6 @@ pub const MAX_REPAIR_PER_DUPLICATE: usize = 20;
 pub const MAX_DUPLICATE_WAIT_MS: usize = 10_000;
 pub const REPAIR_MS: u64 = 100;
 pub const MAX_ORPHANS: usize = 5;
-pub const MAX_UNKNOWN_LAST_INDEX_REPAIRS: usize = 10;
 pub const MAX_CLOSEST_COMPLETION_REPAIRS: usize = 100;
 
 #[derive(Clone)]
@@ -357,7 +349,6 @@ impl RepairService {
                     root_bank.epoch_schedule(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut repair_timing,
                     &mut best_repairs_stats,
@@ -459,11 +450,6 @@ impl RepairService {
                         i64
                     ),
                     (
-                        "get-unknown-last-index-elapsed",
-                        repair_timing.get_unknown_last_index_elapsed,
-                        i64
-                    ),
-                    (
                         "get-closest-completion-elapsed",
                         repair_timing.get_closest_completion_elapsed,
                         i64
@@ -497,16 +483,6 @@ impl RepairService {
                     (
                         "best-shreds-repairs",
                         best_repairs_stats.num_best_shreds_repairs,
-                        i64
-                    ),
-                    (
-                        "unknown-last-index-slots",
-                        best_repairs_stats.num_unknown_last_index_slots,
-                        i64
-                    ),
-                    (
-                        "unknown-last-index-repairs",
-                        best_repairs_stats.num_unknown_last_index_repairs,
                         i64
                     ),
                     (
@@ -849,7 +825,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
@@ -885,7 +860,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
@@ -945,7 +919,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
@@ -960,7 +933,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     expected.len() - 2,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),
@@ -1006,7 +978,6 @@ mod test {
                     &EpochSchedule::default(),
                     MAX_ORPHANS,
                     MAX_REPAIR_LENGTH,
-                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                     MAX_CLOSEST_COMPLETION_REPAIRS,
                     &mut RepairTiming::default(),
                     &mut BestRepairsStats::default(),

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-        repair_generic_traversal::{get_closest_completion, get_unknown_last_index},
+        repair_generic_traversal::get_closest_completion,
         repair_service::{BestRepairsStats, RepairTiming},
         repair_weighted_traversal,
         serve_repair::ShredRepairType,
@@ -154,7 +154,6 @@ impl RepairWeight {
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         max_new_shreds: usize,
-        max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
         repair_timing: &mut RepairTiming,
         stats: &mut BestRepairsStats,
@@ -197,22 +196,8 @@ impl RepairWeight {
 
         // Although we have generated repairs for orphan roots and slots in the rooted subtree,
         // if we have space we should generate repairs for slots in orphan trees in preparation for
-        // when they are no longer rooted. Here we generate repairs for slots with unknown last
-        // indices as well as slots that are close to completion.
-
-        let mut get_unknown_last_index_elapsed = Measure::start("get_unknown_last_index");
-        let pre_num_slots = processed_slots.len();
-        let unknown_last_index_repairs = self.get_best_unknown_last_index(
-            blockstore,
-            &mut slot_meta_cache,
-            &mut processed_slots,
-            max_unknown_last_index_repairs,
-        );
-        let num_unknown_last_index_repairs = unknown_last_index_repairs.len();
-        let num_unknown_last_index_slots = processed_slots.len() - pre_num_slots;
-        repairs.extend(unknown_last_index_repairs);
-        get_unknown_last_index_elapsed.stop();
-
+        // when they are no longer rooted. Here we generate repairs for slots that are close to
+        // completion.
         let mut get_closest_completion_elapsed = Measure::start("get_closest_completion");
         let pre_num_slots = processed_slots.len();
         let (closest_completion_repairs, total_slots_processed) = self.get_best_closest_completion(
@@ -233,8 +218,6 @@ impl RepairWeight {
             num_orphan_repairs as u64,
             num_best_shreds_slots as u64,
             num_best_shreds_repairs as u64,
-            num_unknown_last_index_slots as u64,
-            num_unknown_last_index_repairs as u64,
             num_closest_completion_slots as u64,
             num_closest_completion_slots_path as u64,
             num_closest_completion_repairs as u64,
@@ -242,7 +225,6 @@ impl RepairWeight {
         );
         repair_timing.get_best_orphans_elapsed += get_best_orphans_elapsed.as_us();
         repair_timing.get_best_shreds_elapsed += get_best_shreds_elapsed.as_us();
-        repair_timing.get_unknown_last_index_elapsed += get_unknown_last_index_elapsed.as_us();
         repair_timing.get_closest_completion_elapsed += get_closest_completion_elapsed.as_us();
 
         repairs
@@ -430,32 +412,6 @@ impl RepairWeight {
                 }
             }
         }
-    }
-
-    /// For all remaining trees (orphan and rooted), generate repairs for slots missing last_index info
-    /// prioritized by # shreds received.
-    fn get_best_unknown_last_index(
-        &mut self,
-        blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
-        processed_slots: &mut HashSet<Slot>,
-        max_new_repairs: usize,
-    ) -> Vec<ShredRepairType> {
-        let mut repairs = Vec::default();
-        for (_slot, tree) in self.trees.iter() {
-            if repairs.len() >= max_new_repairs {
-                break;
-            }
-            let new_repairs = get_unknown_last_index(
-                tree,
-                blockstore,
-                slot_meta_cache,
-                processed_slots,
-                max_new_repairs - repairs.len(),
-            );
-            repairs.extend(new_repairs);
-        }
-        repairs
     }
 
     /// For all remaining trees (orphan and rooted), generate repairs for subtrees that have last


### PR DESCRIPTION
#### Problem
`get_best_unknown_last_index` does not seem to be generating enough repairs to justify its expense.

#### Summary of Changes
remove `get_best_unknown_last_index` and associated metrics/tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
