### PR TITLE
Adjust tower root after warp slot

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1147,6 +1147,11 @@ impl Tower {
         Ok(self)
     }
 
+    pub fn adjust_lockouts_after_warp(&mut self, warp_slot: Slot) {
+        self.initialize_root(warp_slot);
+        self.initialize_lockouts(|v| v.slot() > warp_slot);
+    }
+
     fn adjust_lockouts_with_slot_history(&mut self, slot_history: &SlotHistory) -> Result<()> {
         let tower_root = self.root();
         // retained slots will be consisted only from divergent slots

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1147,11 +1147,6 @@ impl Tower {
         Ok(self)
     }
 
-    pub fn adjust_lockouts_after_warp(&mut self, warp_slot: Slot) {
-        self.initialize_root(warp_slot);
-        self.initialize_lockouts(|v| v.slot() > warp_slot);
-    }
-
     fn adjust_lockouts_with_slot_history(&mut self, slot_history: &SlotHistory) -> Result<()> {
         let tower_root = self.root();
         // retained slots will be consisted only from divergent slots

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1693,8 +1693,6 @@ fn maybe_warp_slot(
     accounts_background_request_sender: &AbsRequestSender,
 ) -> Result<(), String> {
     if let Some(warp_slot) = config.warp_slot {
-        process_blockstore.process()?;
-
         let mut bank_forks = bank_forks.write().unwrap();
 
         let working_bank = bank_forks.working_bank();
@@ -1750,6 +1748,11 @@ fn maybe_warp_slot(
             "created snapshot: {}",
             full_snapshot_archive_info.path().display()
         );
+
+        drop(bank_forks);
+        // Process blockstore after warping bank forks to make sure tower and
+        // bank forks are in sync.
+        process_blockstore.process()?;
     }
     Ok(())
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1359,11 +1359,7 @@ fn post_process_restored_tower(
                 );
             }
 
-            let mut tower = Tower::new_from_bankforks(bank_forks, validator_identity, vote_account);
-            if let Some(warp_slot) = config.warp_slot {
-                tower.adjust_lockouts_after_warp(warp_slot);
-            }
-            tower
+            Tower::new_from_bankforks(bank_forks, validator_identity, vote_account)
         }
     };
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1359,7 +1359,11 @@ fn post_process_restored_tower(
                 );
             }
 
-            Tower::new_from_bankforks(bank_forks, validator_identity, vote_account)
+            let mut tower = Tower::new_from_bankforks(bank_forks, validator_identity, vote_account);
+            if let Some(warp_slot) = config.warp_slot {
+                tower.adjust_lockouts_after_warp(warp_slot);
+            }
+            tower
         }
     };
 


### PR DESCRIPTION
#### Problem
See #30258 

We are failing when running test validator and warping slots. E.g. like so:
```
$ solana-install init 1.14.16
  ✨ 1.14.16 initialized
$ solana-test-validator --reset --warp-slot 20
Ledger location: test-ledger
Log: test-ledger/validator.log
⠐ Initializing...
⠋ Initializing...
⠁ Initializing...
⠚ Initializing...
⠒ Initializing...
⠄ Initializing...
⠠ Initializing...
⠖ Initializing...
⠒ Initializing...
⠈ Initializing...
Identity: 69BsCtTFeJDzgEB12YHDWGFMe9BezypotP1CQvE4mJzR
Genesis Hash: GSB8fKhzFf89M2TZaUKqVE49WUX1QJhkv13vKqzZ3MCi
Version: 1.14.16
Shred Version: 16939
Gossip Address: 127.0.0.1:1024
TPU Address: 127.0.0.1:1027
JSON RPC URL: http://127.0.0.1:8899
⠋ 00:00:29 | Processed Slot: 20 | Confirmed Slot: 20 | Finalized Slot: 20 | Full Snapshot Slot:
^C
```
We are asserting in replay because we cannot find the root slot (0) in the ancestors list for current slot (20). If we just ignore this assert, we assume slot 20 is not locked out and everything seems to proceed just fine.

I'm thinking the REAL issue here is that the bank forks root and the tower vote state root are not in sync. Tower gets setup from bank forks before we've made bank fork changes for the warp. "proper ancestors" only includes slots after the bank forks root, so we effectively filter out the root (slot 0 in this case) from the tower vote state perspective. The tower vote state root is what we use to determine what should be in the ancestors during the assert check.

#### Summary of Changes
Update tower vote state root when warping slot