### PR TITLE
remove_dead_accounts uses slot instead of AppendVecId

### DIFF
--- a/runtime/src/account_storage.rs
+++ b/runtime/src/account_storage.rs
@@ -58,10 +58,15 @@ impl AccountStorage {
             })
     }
 
+    /// assert if shrink in progress is active
+    pub(crate) fn assert_no_shrink_in_progress(&self) {
+        assert!(self.shrink_in_progress_map.is_empty());
+    }
+
     /// return the append vec for 'slot' if it exists
     /// This is only ever called when shrink is not possibly running and there is a max of 1 append vec per slot.
     pub(crate) fn get_slot_storage_entry(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
     }
 
@@ -74,21 +79,21 @@ impl AccountStorage {
     }
 
     pub(crate) fn all_slots(&self) -> Vec<Slot> {
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         self.map.iter().map(|iter_item| *iter_item.key()).collect()
     }
 
     /// returns true if there is no entry for 'slot'
     #[cfg(test)]
     pub(crate) fn is_empty_entry(&self, slot: Slot) -> bool {
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         self.map.get(&slot).is_none()
     }
 
     /// initialize the storage map to 'all_storages'
     pub(crate) fn initialize(&mut self, all_storages: AccountStorageMap) {
         assert!(self.map.is_empty());
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         self.map.extend(all_storages.into_iter())
     }
 
@@ -105,12 +110,12 @@ impl AccountStorage {
 
     /// iterate through all (slot, append-vec)
     pub(crate) fn iter(&self) -> AccountStorageIter<'_> {
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         AccountStorageIter::new(self)
     }
 
     pub(crate) fn insert(&self, slot: Slot, store: Arc<AccountStorageEntry>) {
-        assert!(self.shrink_in_progress_map.is_empty());
+        self.assert_no_shrink_in_progress();
         assert!(self
             .map
             .insert(


### PR DESCRIPTION
#### Problem
We are removing `store_id` from account info.
So, slot is sufficient for figuring out which store.
While shrink is not going on, there is always only 1 store per slot. Shrink should never run in conjunction with 'remove_dead_accounts()'

#### Summary of Changes
Rework `remove_dead_accounts()` to use slot as key of a map instead of `AppendVecId`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
