### PR TITLE
Refactors Accounts::new_from_parent()

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -199,17 +199,11 @@ impl Accounts {
         ))
     }
 
-    pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot) -> Self {
-        let accounts_db = parent.accounts_db.clone();
-        accounts_db.insert_default_bank_hash_stats(slot, parent_slot);
-        Self::new(accounts_db)
-    }
-
     pub(crate) fn new_empty(accounts_db: AccountsDb) -> Self {
         Self::new(Arc::new(accounts_db))
     }
 
-    fn new(accounts_db: Arc<AccountsDb>) -> Self {
+    pub(crate) fn new(accounts_db: Arc<AccountsDb>) -> Self {
         Self {
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4943,10 +4943,10 @@ impl AccountsDb {
     /// Insert a default bank hash stats for `slot`
     ///
     /// This fn is called when creating a new bank from parent.
-    pub fn insert_default_bank_hash_stats(&self, slot: Slot, parent_slot: Slot) {
+    pub(crate) fn insert_default_bank_hash_stats(&self, slot: Slot, parent_slot: Slot) {
         let mut bank_hash_stats = self.bank_hash_stats.lock().unwrap();
         if bank_hash_stats.get(&slot).is_some() {
-            error!( "set_hash: already exists; multiple forks with shared slot {slot} as child (parent: {parent_slot})!?");
+            error!("set_hash: already exists; multiple forks with shared slot {slot} as child (parent: {parent_slot})!?");
             return;
         }
         bank_hash_stats.insert(slot, BankHashStats::default());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1486,15 +1486,15 @@ impl Bank {
         let epoch_schedule = parent.epoch_schedule;
         let epoch = epoch_schedule.get_epoch(slot);
 
-        let (rc, bank_rc_creation_time_us) = measure_us!(BankRc {
-            accounts: Arc::new(Accounts::new_from_parent(
-                &parent.rc.accounts,
+        let (rc, bank_rc_creation_time_us) = measure_us!({
+            let accounts_db = Arc::clone(&parent.rc.accounts.accounts_db);
+            accounts_db.insert_default_bank_hash_stats(slot, parent.slot());
+            BankRc {
+                accounts: Arc::new(Accounts::new(accounts_db)),
+                parent: RwLock::new(Some(Arc::clone(parent))),
                 slot,
-                parent.slot(),
-            )),
-            parent: RwLock::new(Some(parent.clone())),
-            slot,
-            bank_id_generator: parent.rc.bank_id_generator.clone(),
+                bank_id_generator: Arc::clone(&parent.rc.bank_id_generator),
+            }
         });
 
         let (status_cache, status_cache_time_us) = measure_us!(Arc::clone(&parent.status_cache));


### PR DESCRIPTION
#### Problem

`AccountsDb::bank_hash_stats` is a map of `Slot` -> `BankHashStats`. These stats are somewhat special, in that a default value is inserted into the map whenever a new bank is created (from parent). We also have a redundant insert-default whenever `store()` is called. And lastly new AccountsDb's will insert a default value at slot 0 too. This pre-usage insert-default-value behavior has one potential use: logging an error if a new bank was created with the same slot as a pre-existing one. To check for that case, `bank_hash_stats` is consulted. This case can happen in unusual forking, and is present in the local-cluster `test_optimistic_confirmation_violation_detection` test. I'd like to remove this pre-use insert, and to make that more clear I'm removing indirection of where `bank_hash_stats` has that pre-use insertion.

(The longer story is that these stats are also stored in snapshots, even though they aren't even used/needed, and I'd like to remove them *there* also. Incremental changes though!)

#### Summary of Changes

For this PR, `Accounts` has a `new_from_parent()` function, even though "parent" is only really a concept for `Bank`. And `Accounts::new_from_parent()` is the only caller of the `bank_hash_stats` pre-use insertion. So refactor these functions to put the pre-use insertion into `Bank::new_from_parent()` instead, and the `Accounts::new_from_parent()` can be removed.