### PR TITLE
Abstract out StoredAccountMeta as an Enum

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7976,7 +7976,7 @@ impl AccountsDb {
                 );
                 let offset = account_info.offset();
                 let account = store.accounts.get_account(offset).unwrap();
-                let stored_size = account.0.stored_size;
+                let stored_size = account.0.stored_size();
                 let count = store.remove_account(stored_size, reset_accounts);
                 if count == 0 {
                     self.dirty_stores.insert(*slot, store.clone());
@@ -9454,7 +9454,7 @@ pub mod tests {
                 tests::*, AccountIndex, AccountSecondaryIndexes,
                 AccountSecondaryIndexesIncludeExclude, ReadAccountMapEntry, RefCount,
             },
-            append_vec::test_utils::TempFile,
+            append_vec::{test_utils::TempFile, AppendVecStoredAccountMeta},
             cache_hash_data_stats::CacheHashDataStats,
             inline_spl_token,
             secondary_index::MAX_NUM_LARGEST_INDEX_KEYS_RETURNED,
@@ -9664,7 +9664,7 @@ pub mod tests {
             pubkey,
             data_len: 43,
         };
-        let account = StoredAccountMeta {
+        let account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &stored_meta,
             /// account data
             account_meta: &account_meta,
@@ -9672,7 +9672,7 @@ pub mod tests {
             offset,
             stored_size: account_size,
             hash: &hash,
-        };
+        });
         let map = vec![&account];
         let alive_total_bytes = account.stored_size();
         let to_store = AccountsToStore::new(available_bytes, &map, alive_total_bytes, slot0);
@@ -9760,38 +9760,38 @@ pub mod tests {
         let offset = 99;
         let stored_size = 101;
         let hash = Hash::new_unique();
-        let stored_account = StoredAccountMeta {
+        let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
-        let stored_account2 = StoredAccountMeta {
+        });
+        let stored_account2 = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta2,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
-        let stored_account3 = StoredAccountMeta {
+        });
+        let stored_account3 = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta3,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
-        let stored_account4 = StoredAccountMeta {
+        });
+        let stored_account4 = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta4,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
+        });
         let mut existing_ancient_pubkeys = HashSet::default();
         let accounts = [&stored_account];
         // pubkey NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
@@ -12382,14 +12382,14 @@ pub mod tests {
         let offset = 99;
         let stored_size = 101;
         let hash = Hash::new_unique();
-        let stored_account = StoredAccountMeta {
+        let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
+        });
         assert!(accounts_equal(&account, &stored_account));
     }
 
@@ -12426,14 +12426,14 @@ pub mod tests {
         let (slot, meta, account_meta, data, offset, hash): InputTuple =
             unsafe { std::mem::transmute::<InputBlob, InputTuple>(blob) };
 
-        let stored_account = StoredAccountMeta {
+        let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size: CACHE_VIRTUAL_STORED_SIZE as usize,
             hash: &hash,
-        };
+        });
         let account = stored_account.clone_account();
 
         let expected_account_hash = if cfg!(debug_assertions) {

--- a/runtime/src/accounts_db/geyser_plugin_utils.rs
+++ b/runtime/src/accounts_db/geyser_plugin_utils.rs
@@ -138,9 +138,9 @@ impl AccountsDb {
             // Passing 0 for everyone's write_version is sufficiently correct.
             let meta = StoredMeta {
                 write_version_obsolete: local_write_version,
-                ..*account.meta
+                ..*account.meta()
             };
-            account.meta = &meta;
+            account.set_meta(&meta);
             let mut measure_pure_notify = Measure::start("accountsdb-plugin-notifying-accounts");
             notifier.notify_account_restore_from_snapshot(slot, &account);
             measure_pure_notify.stop();

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -770,7 +770,7 @@ pub mod tests {
                 },
                 INCLUDE_SLOT_IN_HASH_TESTS,
             },
-            append_vec::{aligned_stored_size, AppendVec},
+            append_vec::{aligned_stored_size, AppendVec, AppendVecStoredAccountMeta},
             storable_accounts::StorableAccountsBySlot,
         },
         solana_sdk::{
@@ -1618,7 +1618,7 @@ pub mod tests {
             pubkey,
             data_len: 43,
         };
-        let account = StoredAccountMeta {
+        let account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &stored_meta,
             /// account data
             account_meta: &account_meta,
@@ -1626,7 +1626,7 @@ pub mod tests {
             offset,
             stored_size: account_size,
             hash: &hash,
-        };
+        });
         let map = vec![&account];
         for (selector, available_bytes) in [
             (StorageSelector::Primary, account_size),

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -306,6 +306,7 @@ pub mod tests {
         crate::{
             account_storage::meta::{AccountMeta, StoredAccountMeta, StoredMeta},
             accounts_db::INCLUDE_SLOT_IN_HASH_TESTS,
+            append_vec::AppendVecStoredAccountMeta,
         },
         solana_sdk::{
             account::{accounts_equal, AccountSharedData, WritableAccount},
@@ -353,14 +354,14 @@ pub mod tests {
         let offset = 99;
         let stored_size = 101;
         let hash = Hash::new_unique();
-        let stored_account = StoredAccountMeta {
+        let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
             hash: &hash,
-        };
+        });
 
         let test3 = (
             slot,
@@ -411,14 +412,14 @@ pub mod tests {
                     for entry in 0..entries {
                         let offset = 99;
                         let stored_size = 101;
-                        raw2.push(StoredAccountMeta {
+                        raw2.push(StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
                             meta: &raw[entry as usize].3,
                             account_meta: &raw[entry as usize].4,
                             data: &data,
                             offset,
                             stored_size,
                             hash: &hash,
-                        });
+                        }));
                     }
 
                     let mut two = Vec::new();
@@ -508,14 +509,14 @@ pub mod tests {
             for entry in 0..entries {
                 let offset = 99;
                 let stored_size = 101;
-                raw2.push(StoredAccountMeta {
+                raw2.push(StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
                     meta: &raw[entry as usize].2,
                     account_meta: &raw[entry as usize].3,
                     data: &data,
                     offset,
                     stored_size,
                     hash: &hashes[entry as usize],
-                });
+                }));
             }
             let raw2_refs = raw2.iter().collect::<Vec<_>>();
 


### PR DESCRIPTION
#### Problem
The existing StoredAccountMeta requires the file and in-memory layout of
account metadata to match StoredMeta and AccountMeta.  This limits the
flexibility to implement different accounts storage file formats.

#### Summary of Changes
This PR abstracts out StoredAccountMeta as an Enum.

This PR depends on https://github.com/solana-labs/solana/pull/30571.