### PR TITLE
Removes checks for bank_hash_stats in test

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -17761,13 +17761,11 @@ pub mod tests {
         db.handle_dropped_roots_for_ancient(std::iter::empty::<Slot>());
         let slot0 = 0;
         let dropped_roots = vec![slot0];
-        assert!(db.get_bank_hash_stats(slot0).is_some());
         db.accounts_index.add_root(slot0);
         db.accounts_index.add_uncleaned_roots([slot0].into_iter());
         assert!(db.accounts_index.is_uncleaned_root(slot0));
         assert!(db.accounts_index.is_alive_root(slot0));
         db.handle_dropped_roots_for_ancient(dropped_roots.into_iter());
-        assert!(db.get_bank_hash_stats(slot0).is_none());
         assert!(!db.accounts_index.is_uncleaned_root(slot0));
         assert!(!db.accounts_index.is_alive_root(slot0));
     }


### PR DESCRIPTION
#### Problem

`AccountsDb::bank_hash_stats` is a map of `Slot` -> `BankHashStats`. These stats are somewhat special, in that a default value is inserted into the map whenever a new bank is created (from parent). We also have a redundant insert-default whenever `store()` is called. And lastly new AccountsDb's will insert a default value at slot 0 too. This pre-usage insert-default-value behavior has one potential use: logging an error if a new bank was created with the same slot as a pre-existing one. To check for that case, `bank_hash_stats` is consulted. This case can happen in unusual forking, and is present in the local-cluster `test_optimistic_confirmation_violation_detection` test.

Looking up the bank_hash_stats is used in `test_handle_dropped_roots_for_ancient()` as a way to check if the slot  is present or not. The test has other checks to see if the root is dropped, and the bank_hash_stats is not needed here. By using bank_hash_stats, it prevents removing the pre-usage insert-default-value behavior.

(The longer story is that these stats are also stored in snapshots, even though they aren't even used/needed, and I'd like to remove them *there* also. Incremental changes though!)


#### Summary of Changes

Remove the calls to `get_bank_hash_stats()` inside `test_handle_dropped_roots_for_ancient()`, which already has other way to assert its invariants.