### PR TITLE
[WIP] Stop loading program accounts unnecessarily during tx processing

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -212,9 +212,6 @@ pub fn load_program_from_account(
         return Err(InstructionError::IncorrectProgramId);
     }
 
-    let (programdata_offset, deployment_slot) =
-        get_programdata_offset_and_depoyment_offset(&log_collector, program, programdata)?;
-
     if let Some(ref tx_executor_cache) = tx_executor_cache {
         if let Some(loaded_program) = tx_executor_cache.get(program.get_key()) {
             if loaded_program.is_tombstone() {
@@ -226,6 +223,9 @@ pub fn load_program_from_account(
             return Ok((loaded_program, None));
         }
     }
+
+    let (programdata_offset, deployment_slot) =
+        get_programdata_offset_and_depoyment_offset(&log_collector, program, programdata)?;
 
     let programdata_size = if programdata_offset != 0 {
         programdata.get_data().len()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11706,6 +11706,8 @@ fn test_rent_state_list_len() {
         &bank.feature_set,
         &FeeStructure::default(),
         None,
+        &HashMap::new(),
+        &HashMap::new(),
     );
 
     let compute_budget = bank.runtime_config.compute_budget.unwrap_or_else(|| {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -87,6 +87,7 @@ impl MessageProcessor {
             .zip(program_indices.iter())
             .enumerate()
         {
+            //let program_indices = &[instruction.program_id_index as IndexOfAccount];
             let is_precompile =
                 is_precompile(program_id, |id| invoke_context.feature_set.is_active(id));
 


### PR DESCRIPTION
#### Problem
The program accounts are being loaded even though the program is already in the executor cache.

#### Summary of Changes
- The executor cache gets eagerly replenished with all programs before start of the transaction batch processing
- The data from program accounts is no longer required during transaction processing. Previously it was needed for lazy loading of the programs.
- This PR removes the loading of program accounts, and their program data accounts.
- For now, the `accounts` array will contain a dummy `AccountSharedData` object for the program account. This will contain account's meta data.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
