### PR TITLE
Default solana-test-validator --bpf-programs to upgradeable loader

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -69,6 +69,7 @@ pub struct AccountInfo<'a> {
     pub filename: &'a str,
 }
 
+#[deprecated(since = "1.16.0", note = "Please use `UpgradeableProgramInfo` instead")]
 #[derive(Clone)]
 pub struct ProgramInfo {
     pub program_id: Pubkey,
@@ -118,6 +119,7 @@ pub struct TestValidatorGenesis {
     warp_slot: Option<Slot>,
     no_bpf_jit: bool,
     accounts: HashMap<Pubkey, AccountSharedData>,
+    #[allow(deprecated)]
     programs: Vec<ProgramInfo>,
     upgradeable_programs: Vec<UpgradeableProgramInfo>,
     ticks_per_slot: Option<u64>,
@@ -150,6 +152,7 @@ impl Default for TestValidatorGenesis {
             warp_slot: Option::<Slot>::default(),
             no_bpf_jit: bool::default(),
             accounts: HashMap::<Pubkey, AccountSharedData>::default(),
+            #[allow(deprecated)]
             programs: Vec::<ProgramInfo>::default(),
             upgradeable_programs: Vec::<UpgradeableProgramInfo>::default(),
             ticks_per_slot: Option::<u64>::default(),
@@ -492,6 +495,11 @@ impl TestValidatorGenesis {
     }
 
     /// Add a list of programs to the test environment.
+    #[deprecated(
+        since = "1.16.0",
+        note = "Please use `add_upgradeable_programs_with_path()` instead"
+    )]
+    #[allow(deprecated)]
     pub fn add_programs_with_path(&mut self, programs: &[ProgramInfo]) -> &mut Self {
         for program in programs {
             self.programs.push(program.clone());
@@ -681,6 +689,7 @@ impl TestValidator {
         for (address, account) in solana_program_test::programs::spl_programs(&config.rent) {
             accounts.entry(address).or_insert(account);
         }
+        #[allow(deprecated)]
         for program in &config.programs {
             let data = solana_program_test::read_file(&program.program_path);
             accounts.insert(

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -482,9 +482,10 @@ impl TestValidatorGenesis {
         let program_path = solana_program_test::find_file(&format!("{program_name}.so"))
             .unwrap_or_else(|| panic!("Unable to locate program {program_name}"));
 
-        self.programs.push(ProgramInfo {
+        self.upgradeable_programs.push(UpgradeableProgramInfo {
             program_id,
-            loader: solana_sdk::bpf_loader::id(),
+            loader: solana_sdk::bpf_loader_upgradeable::id(),
+            upgrade_authority: Pubkey::default(),
             program_path,
         });
         self

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -201,7 +201,7 @@ fn main() {
         program_path
     };
 
-    let mut programs_to_load = vec![];
+    let mut upgradeable_programs_to_load = vec![];
     if let Some(values) = matches.values_of("bpf_program") {
         let values: Vec<&str> = values.collect::<Vec<_>>();
         for address_program in values.chunks(2) {
@@ -210,9 +210,10 @@ fn main() {
                     let address = parse_address(address, "address");
                     let program_path = parse_program_path(program);
 
-                    programs_to_load.push(ProgramInfo {
+                    upgradeable_programs_to_load.push(UpgradeableProgramInfo {
                         program_id: address,
-                        loader: solana_sdk::bpf_loader::id(),
+                        loader: solana_sdk::bpf_loader_upgradeable::id(),
+                        upgrade_authority: Pubkey::default(),
                         program_path,
                     });
                 }
@@ -221,7 +222,6 @@ fn main() {
         }
     }
 
-    let mut upgradeable_programs_to_load = vec![];
     if let Some(values) = matches.values_of("upgradeable_program") {
         let values: Vec<&str> = values.collect::<Vec<_>>();
         for address_program_upgrade_authority in values.chunks(3) {
@@ -452,7 +452,6 @@ fn main() {
         })
         .bpf_jit(!matches.is_present("no_bpf_jit"))
         .rpc_port(rpc_port)
-        .add_programs_with_path(&programs_to_load)
         .add_upgradeable_programs_with_path(&upgradeable_programs_to_load)
         .add_accounts_from_json_files(&accounts_to_load)
         .unwrap_or_else(|e| {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2016,7 +2016,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .number_of_values(2)
                 .multiple(true)
                 .help(
-                    "Add a SBF program to the genesis configuration. \
+                    "Add a SBF program to the genesis configuration with upgrades disabled. \
                        If the ledger already exists then this parameter is silently ignored. \
                        First argument can be a pubkey string or path to a keypair",
                 ),


### PR DESCRIPTION
#### Problem
As discussed in #30412 and #29051, `solana deploy` has been deprecated, so users probably don't intend to use the immutable bpf loader with solana-test-validator either.

#### Summary of Changes
Use the upgradeable loader under the hood for `--bpf-program` inputs
Deprecate public non-upgradeable program interfaces
