### PR TITLE
WIP: new_from_parent() no longer inserts default BankHashStats

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2627,7 +2627,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        assert!(accounts.accounts_db.get_bank_hash_stats(0).is_some());
+        assert!(accounts.accounts_db.get_bank_hash_stats(0).is_none());
         assert!(accounts.accounts_db.get_bank_hash_stats(1).is_none());
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -770,8 +770,8 @@ where
         old_accounts_hash.is_none(),
         "There should not already be an AccountsHash at slot {snapshot_slot}: {old_accounts_hash:?}",
     );
-    let old_stats = accounts_db
-        .update_bank_hash_stats_from_snapshot(snapshot_slot, snapshot_bank_hash_info.stats);
+    let old_stats =
+        accounts_db.set_bank_hash_stats_from_snapshot(snapshot_slot, snapshot_bank_hash_info.stats);
     assert!(
         old_stats.is_none(),
         "There should not already be a BankHashStats at slot {snapshot_slot}: {old_stats:?}",


### PR DESCRIPTION
#### Problem

`AccountsDb::bank_hash_stats` is a map of `Slot` -> `BankHashStats`. These stats are somewhat special, in that a default value is inserted into the map whenever a new bank is created (from parent). We also have a redundant insert-default whenever `store()` is called. And lastly new AccountsDb's will insert a default value at slot 0 too. This pre-usage insert-default-value behavior has one potential use: logging an error if a new bank was created with the same slot as a pre-existing one. To check for that case, `bank_hash_stats` is consulted. This case can happen in unusual forking, and is present in the local-cluster `test_optimistic_confirmation_violation_detection` test.

(The longer story is that these stats are also stored in snapshots, even though they aren't even used/needed, and I'd like to remove them *there* also. Incremental changes though!)


#### Summary of Changes

No longer insert a default `BankHashStats` in `Bank::new_from_parent()`.

Since `store()` will insert a BankHashStats if one is not present, I *think* this will cover the current use-case where `bank_hash_stats` is queried to check if there's already a bank at this slot. (The only way this *doesn't* work if if the preexisting bank *never* called `store()` *and* hasn't been frozen.)