### PR TITLE
chore: bump bincode to 1.3.3

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -11,7 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bincode = "1.3.1"
+bincode = { workspace = true }
 blake3 = { workspace = true, features = ["digest", "traits-preview"] }
 borsh = { workspace = true }
 borsh-derive = { workspace = true }
@@ -69,7 +69,7 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 anyhow = "1.0.58"
 assert_matches = { workspace = true }
-bincode = "1.3.1"
+bincode = { workspace = true }
 borsh = { workspace = true }
 borsh-derive = { workspace = true }
 serde_json = "1.0.56"

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
 arrayref = { workspace = true }
-bincode = "1"
+bincode = { workspace = true }
 byteorder = { workspace = true }
 cipher = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
#### Summary of Changes

make `sdk/program/Cargo.toml` and  `zk-token-sdk/Cargo.toml` use bincode 1.3.3.