### PR TITLE
use local for store_id in write_accounts_to_storage

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6209,12 +6209,13 @@ impl AccountsDb {
                 continue;
             }
 
+            let store_id = storage.append_vec_id();
             for (i, offsets) in rvs.unwrap().windows(2).enumerate() {
                 let stored_size = offsets[1] - offsets[0];
                 storage.add_account(stored_size);
 
                 infos.push(AccountInfo::new(
-                    StorageLocation::AppendVec(storage.append_vec_id(), offsets[0]),
+                    StorageLocation::AppendVec(store_id, offsets[0]),
                     accounts_and_meta_to_store
                         .account(i)
                         .map(|account| account.lamports())


### PR DESCRIPTION
#### Problem
Use local for store_id instead of reading it from atomic for each account.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
