### PR TITLE
break apart AccountInfo

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -87,6 +87,11 @@ pub struct AccountInfo {
     /// index identifying the append storage
     store_id: AppendVecId,
 
+    account_offset_and_flags: AccountOffsetAndFlags,
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct AccountOffsetAndFlags {
     /// offset = 'packed_offset_and_flags.offset_reduced()' * ALIGN_BOUNDARY_OFFSET into the storage
     /// Note this is a smaller type than 'Offset'
     packed_offset_and_flags: PackedOffsetAndFlags,
@@ -94,13 +99,18 @@ pub struct AccountInfo {
 
 impl ZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
-        self.packed_offset_and_flags.is_zero_lamport()
+        self.account_offset_and_flags
+            .packed_offset_and_flags
+            .is_zero_lamport()
     }
 }
 
 impl IsCached for AccountInfo {
     fn is_cached(&self) -> bool {
-        self.packed_offset_and_flags.offset_reduced() == CACHED_OFFSET
+        self.account_offset_and_flags
+            .packed_offset_and_flags
+            .offset_reduced()
+            == CACHED_OFFSET
     }
 }
 
@@ -137,9 +147,12 @@ impl AccountInfo {
             }
         };
         packed_offset_and_flags.set_is_zero_lamport(lamports == 0);
+        let account_offset_and_flags = AccountOffsetAndFlags {
+            packed_offset_and_flags,
+        };
         Self {
             store_id,
-            packed_offset_and_flags,
+            account_offset_and_flags,
         }
     }
 
@@ -154,7 +167,11 @@ impl AccountInfo {
     }
 
     pub fn offset(&self) -> Offset {
-        Self::reduced_offset_to_offset(self.packed_offset_and_flags.offset_reduced())
+        Self::reduced_offset_to_offset(
+            self.account_offset_and_flags
+                .packed_offset_and_flags
+                .offset_reduced(),
+        )
     }
 
     fn reduced_offset_to_offset(reduced_offset: OffsetReduced) -> Offset {


### PR DESCRIPTION
#### Problem
Moving to a different account info stored on disk from what is in memory. `AccountOffsetAndFlags` will be saved to disk in the near future. Note it does not contain `store_id`

#### Summary of Changes
Split `AccountInfo` into a sub struct that can be persisted to disk separately.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
