### PR TITLE
ci: set -e for .buildkite/scripts/build-downstream-projects.sh

### DIFF
--- a/.buildkite/scripts/build-downstream-projects.sh
+++ b/.buildkite/scripts/build-downstream-projects.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 here=$(dirname "$0")
 
 # shellcheck source=.buildkite/scripts/common.sh


### PR DESCRIPTION
#### Problem

the build doesn't return error although jq cmd not found
https://buildkite.com/solana-labs/solana/builds/90948#01868484-f36c-4355-9551-1b770c65c511

#### Summary of Changes

set -e for `.buildkite/scripts/build-downstream-projects.sh`

