### PR TITLE
chore: remove redundant packages

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -69,9 +69,6 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 anyhow = "1.0.58"
 assert_matches = { workspace = true }
-bincode = { workspace = true }
-borsh = { workspace = true }
-borsh-derive = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 


### PR DESCRIPTION
#### Problem

We have already use `bincode`, `borsh` and `borsh-derive` in [dependencies] section. It seems that we don't need to write them again in [dev-dependencies]

#### Summary of Changes

remove `bincode`, `borsh` and `borsh-derive` from [dev-dependencies]
