### PR TITLE
cleanup get_closeset_completion

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -117,13 +117,11 @@ pub fn get_closest_completion(
     limit: usize,
 ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
     let mut slot_dists: Vec<(Slot, u64)> = Vec::default();
-    let mut explored_slots: HashSet<Slot> = HashSet::default();
     let iter = GenericTraversal::new(tree);
     for slot in iter {
-        if processed_slots.contains(&slot) || explored_slots.contains(&slot) {
+        if processed_slots.contains(&slot) {
             continue;
         }
-        explored_slots.insert(slot);
         let slot_meta = slot_meta_cache
             .entry(slot)
             .or_insert_with(|| blockstore.meta(slot).unwrap());


### PR DESCRIPTION
#### Problem
`explored_slots` is unnecessary. Slots added to `HeaviestSubtreeForkChoice` in repair are not differentiated by hash with `SlotHashKey`.

#### Summary of Changes
Remove `explored_slots`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
