### PR TITLE
Not to tag versioned transaction as simple_vote_tx

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -362,9 +362,7 @@ fn check_for_simple_vote_transaction(
     let msg_start = (packet_offsets.msg_start as usize)
         .checked_sub(current_offset)
         .ok_or(PacketError::InvalidLen)?;
-    let message_prefix = *packet
-        .data(msg_start)
-        .ok_or(PacketError::InvalidSignatureLen)?;
+    let message_prefix = *packet.data(msg_start).ok_or(PacketError::InvalidLen)?;
     if message_prefix & MESSAGE_VERSION_PREFIX != 0 {
         return Ok(());
     }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -358,6 +358,17 @@ fn check_for_simple_vote_transaction(
         return Err(PacketError::InvalidSignatureLen);
     }
 
+    // simple vote should only be legacy message
+    let msg_start = (packet_offsets.msg_start as usize)
+        .checked_sub(current_offset)
+        .ok_or(PacketError::InvalidLen)?;
+    let message_prefix = *packet
+        .data(msg_start)
+        .ok_or(PacketError::InvalidSignatureLen)?;
+    if message_prefix & MESSAGE_VERSION_PREFIX != 0 {
+        return Ok(());
+    }
+
     let pubkey_start = (packet_offsets.pubkey_start as usize)
         .checked_sub(current_offset)
         .ok_or(PacketError::InvalidLen)?;
@@ -1377,7 +1388,7 @@ mod tests {
             assert!(!packet.meta().is_simple_vote_tx());
         }
 
-        // single vote tx is
+        // single legacy vote tx is
         {
             let mut tx = new_test_vote_tx(&mut rng);
             tx.message.instructions[0].data = vec![1, 2, 3];
@@ -1385,6 +1396,26 @@ mod tests {
             let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
             check_for_simple_vote_transaction(&mut packet, &packet_offsets, 0).ok();
             assert!(packet.meta().is_simple_vote_tx());
+        }
+
+        // single versioned vote tx is not
+        {
+            let mut tx = new_test_vote_tx(&mut rng);
+            tx.message.instructions[0].data = vec![1, 2, 3];
+            let mut packet = Packet::from_data(None, tx).unwrap();
+
+            // set messager version to v0
+            let mut packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
+            let msg_start = packet_offsets.msg_start as usize;
+            let msg_bytes = packet.data(msg_start..).unwrap().to_vec();
+            packet.buffer_mut()[msg_start] = MESSAGE_VERSION_PREFIX;
+            packet.meta_mut().size += 1;
+            let msg_end = packet.meta().size;
+            packet.buffer_mut()[msg_start + 1..msg_end].copy_from_slice(&msg_bytes);
+
+            packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
+            check_for_simple_vote_transaction(&mut packet, &packet_offsets, 0).ok();
+            assert!(!packet.meta().is_simple_vote_tx());
         }
 
         // multiple mixed tx is not
@@ -1414,22 +1445,52 @@ mod tests {
         solana_logger::setup();
         let mut rng = rand::thread_rng();
 
-        let mut current_offset = 0usize;
-        let mut batch = PacketBatch::default();
-        batch.push(Packet::from_data(None, test_tx()).unwrap());
-        let tx = new_test_vote_tx(&mut rng);
-        batch.push(Packet::from_data(None, tx).unwrap());
-        batch.iter_mut().enumerate().for_each(|(index, packet)| {
-            let packet_offsets = do_get_packet_offsets(packet, current_offset).unwrap();
-            check_for_simple_vote_transaction(packet, &packet_offsets, current_offset).ok();
-            if index == 1 {
-                assert!(packet.meta().is_simple_vote_tx());
-            } else {
-                assert!(!packet.meta().is_simple_vote_tx());
-            }
+        // batch of legacy messages
+        {
+            let mut current_offset = 0usize;
+            let mut batch = PacketBatch::default();
+            batch.push(Packet::from_data(None, test_tx()).unwrap());
+            let tx = new_test_vote_tx(&mut rng);
+            batch.push(Packet::from_data(None, tx).unwrap());
+            batch.iter_mut().enumerate().for_each(|(index, packet)| {
+                let packet_offsets = do_get_packet_offsets(packet, current_offset).unwrap();
+                check_for_simple_vote_transaction(packet, &packet_offsets, current_offset).ok();
+                if index == 1 {
+                    assert!(packet.meta().is_simple_vote_tx());
+                } else {
+                    assert!(!packet.meta().is_simple_vote_tx());
+                }
 
-            current_offset = current_offset.saturating_add(size_of::<Packet>());
-        });
+                current_offset = current_offset.saturating_add(size_of::<Packet>());
+            });
+        }
+
+        // batch of mixed legacy messages and versioned vote tx, which won't be flagged as
+        // simple_vote_tx
+        {
+            let mut current_offset = 0usize;
+            let mut batch = PacketBatch::default();
+            batch.push(Packet::from_data(None, test_tx()).unwrap());
+            // versioned vote tx
+            let tx = new_test_vote_tx(&mut rng);
+            let mut packet = Packet::from_data(None, tx).unwrap();
+            let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
+            let msg_start = packet_offsets.msg_start as usize;
+            let msg_bytes = packet.data(msg_start..).unwrap().to_vec();
+            packet.buffer_mut()[msg_start] = MESSAGE_VERSION_PREFIX;
+            packet.meta_mut().size += 1;
+            let msg_end = packet.meta().size;
+            packet.buffer_mut()[msg_start + 1..msg_end].copy_from_slice(&msg_bytes);
+            batch.push(packet);
+
+            batch.iter_mut().for_each(|packet| {
+                let packet_offsets = do_get_packet_offsets(packet, current_offset).unwrap();
+                check_for_simple_vote_transaction(packet, &packet_offsets, current_offset).ok();
+                assert!(!packet.meta().is_simple_vote_tx());
+
+                current_offset = current_offset.saturating_add(size_of::<Packet>());
+            });
+        }
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Versioned vote transaction should not be tagged as _simple_ vote tx. 

#### Summary of Changes
- filter versioned transaction out of `check_for_simple_vote_transaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
