### PR TITLE
refactor to remove additional is_simple_vote check

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,6 @@ use {
         transaction_batch::TransactionBatch,
         transaction_error_metrics::TransactionErrorMetrics,
         vote_account::{VoteAccount, VoteAccountsHashMap},
-        vote_parser,
     },
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
@@ -4671,7 +4670,7 @@ impl Bank {
                 }
             }
 
-            let is_vote = vote_parser::is_simple_vote_transaction(tx);
+            let is_vote = tx.is_simple_vote_transaction();
 
             if execution_result.was_executed() // Skip log collection for unprocessed transactions
                 && transaction_log_collector_config.filter != TransactionLogCollectorFilter::None

--- a/runtime/src/vote_parser.rs
+++ b/runtime/src/vote_parser.rs
@@ -12,24 +12,6 @@ use {
 
 pub type ParsedVote = (Pubkey, VoteTransaction, Option<Hash>, Signature);
 
-// Used for filtering out votes from the transaction log collector
-pub(crate) fn is_simple_vote_transaction(transaction: &SanitizedTransaction) -> bool {
-    if transaction.message().instructions().len() == 1 {
-        let (program_pubkey, instruction) = transaction
-            .message()
-            .program_instructions_iter()
-            .next()
-            .unwrap();
-        if program_pubkey == &solana_vote_program::id() {
-            if let Ok(vote_instruction) = limited_deserialize::<VoteInstruction>(&instruction.data)
-            {
-                return vote_instruction.is_simple_vote();
-            }
-        }
-    }
-    false
-}
-
 // Used for locally forwarding processed vote transactions to consensus
 pub fn parse_sanitized_vote_transaction(tx: &SanitizedTransaction) -> Option<ParsedVote> {
     // Check first instruction for a vote

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -117,9 +117,13 @@ impl SanitizedTransaction {
         };
 
         let is_simple_vote_tx = is_simple_vote_tx.unwrap_or_else(|| {
-            // TODO: Move to `vote_parser` runtime module
-            let mut ix_iter = message.program_instructions_iter();
-            ix_iter.next().map(|(program_id, _ix)| program_id) == Some(&crate::vote::program::id())
+            if message.instructions().len() == 1 && matches!(message, SanitizedMessage::Legacy(_)) {
+                let mut ix_iter = message.program_instructions_iter();
+                ix_iter.next().map(|(program_id, _ix)| program_id)
+                    == Some(&crate::vote::program::id())
+            } else {
+                false
+            }
         });
 
         Ok(Self {


### PR DESCRIPTION
#### Problem
sigverify checks and flags `is_simple_vote_tx` in packet.meta, all downstream should just use the flag when possible. `SanitizedTransaction.try_create()` is an exception because it may not have access to `packet` but only `VersionedTransaction`, so it might have its own implementation.

#### Summary of Changes
- removed `VoteParser.is_simple_vote_transaction`, `bank` calls `sanitized_transaction.is_simple_vote_transaction()` directly. 
- updated `sanitized_transaction.try_create()` to set is_simple_vote flag when: is legacy message && has only one vote ix

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
