### PR TITLE
install: support config upgrade from serde_yaml v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,6 +5675,7 @@ dependencies = [
  "scopeguard",
  "semver 1.0.16",
  "serde",
+ "serde_yaml 0.8.26",
  "serde_yaml 0.9.13",
  "solana-clap-utils",
  "solana-config-program",

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -27,6 +27,7 @@ scopeguard = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
+serde_yaml_08 = { package = "serde_yaml", version = "0.8.26" }
 solana-clap-utils = { workspace = true }
 solana-config-program = { workspace = true }
 solana-logger = { workspace = true }


### PR DESCRIPTION
#### Problem

when the `serde_yaml` crate was bumped to v0.9 in #28388, `solana-install` lost the ability to load existing config files written by prior versions. this is operationally... annoying and will likely create a support burden when we start upgrading clusters to v1.15

#### Summary of Changes

* reintroduce `serde_yaml` v0.8
* attempt to migrate the config file when load fails with the appropriate error
