### PR TITLE
Add accounts-index disk/mem arguments to create-snapshot command

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1606,6 +1606,9 @@ fn main() {
             .about("Create a new ledger snapshot")
             .arg(&no_snapshot_arg)
             .arg(&account_paths_arg)
+            .arg(&accounts_index_limit)
+            .arg(&disable_disk_index)
+            .arg(&enable_disk_index)
             .arg(&skip_rewrites_arg)
             .arg(&accounts_db_skip_initial_hash_calc_arg)
             .arg(&ancient_append_vecs)
@@ -2727,7 +2730,24 @@ fn main() {
                     output_directory.display()
                 );
 
+                let accounts_index_config = AccountsIndexConfig {
+                    index_limit_mb: if let Some(limit) =
+                        value_t!(matches, "accounts_index_memory_limit_mb", usize).ok()
+                    {
+                        IndexLimitMb::Limit(limit)
+                    } else if matches.is_present("enable_accounts_disk_index") {
+                        IndexLimitMb::Unspecified
+                    } else {
+                        if matches.is_present("disable_accounts_disk_index") {
+                            warn!("ignoring `--disable-accounts-disk-index` as it specifies default behavior");
+                        }
+                        IndexLimitMb::InMemOnly
+                    },
+                    ..AccountsIndexConfig::default()
+                };
+
                 let accounts_db_config = Some(AccountsDbConfig {
+                    index: Some(accounts_index_config),
                     skip_rewrites: arg_matches.is_present("accounts_db_skip_rewrites"),
                     ancient_append_vecs: arg_matches.is_present("accounts_db_ancient_append_vecs"),
                     skip_initial_hash_calc: arg_matches


### PR DESCRIPTION
#### Problem
The v1.14 branch was initially supposed to have the accounts-index on disk. In constrast, v1.13 and previous branches had the accounts-index in memory. However, high disk i/o during validator startup with v1.14 prompted a change to revert to in-memory accounts-index by default. This default behavior was enforced at the level of command line argument parsing, not defaults of the underlying config structs.

The create-snapshot command did not previously have any of the arguments to configure the accounts-index mem/disk usage, so it implicitly used the default AccountsIndexConfig and IndexLimitMb value. As a result, create-snapshot has been running with accounts, accounts-index and the created snapshot all on disk. This shows the similar disk contention whcih results in the create-snapshot command running quite slowly.

#### Summary of Changes
This change makes the create-snapshot command consistent with solana-validator to have the accounts-index in memory. This should make the command run much quicker.

#### Testing
On a machine with all of the ledger contents striped across 2 NVMe's through a logical volume, I created a snapshot that advanced one slot beyond the latest incremental.
- Without patch: `ledger tool took 2375.3s` (39+ min)
- With patch: `ledger tool took 1477.2s` (24+ min)