### PR TITLE
reduces MAX_CODE_SHREDS_PER_SLOT

### DIFF
--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -442,7 +442,7 @@ mod test {
             shred.common_header.index = MAX_CODE_SHREDS_PER_SLOT as u32;
             assert_matches!(
                 shred.sanitize(),
-                Err(Error::InvalidShredIndex(ShredType::Code, 557_056))
+                Err(Error::InvalidShredIndex(ShredType::Code, 32_768))
             );
         }
         // pos >= num_coding is invalid.

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -1,20 +1,17 @@
 use {
-    crate::{
-        shred::{
-            common::dispatch,
-            legacy, merkle,
-            traits::{Shred, ShredCode as ShredCodeTrait},
-            CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
-            DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
-        },
-        shredder::ERASURE_BATCH_SIZE,
+    crate::shred::{
+        common::dispatch,
+        legacy, merkle,
+        traits::{Shred, ShredCode as ShredCodeTrait},
+        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
+        DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
     solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
 };
 
-const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768 * 17);
-pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT * (ERASURE_BATCH_SIZE[1] - 1);
+const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768);
+pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -1231,7 +1231,7 @@ mod tests {
 
     #[test]
     fn test_max_shreds_per_slot() {
-        for num_data_shreds in 0..128 {
+        for num_data_shreds in 32..128 {
             let num_coding_shreds = get_erasure_batch_size(num_data_shreds)
                 .checked_sub(num_data_shreds)
                 .unwrap();


### PR DESCRIPTION

#### Problem
https://github.com/solana-labs/solana/pull/26070 introduced `MAX_CODE_SHREDS_PER_SLOT` which because of how coding shreds are generated was later set larger than `MAX_DATA_SHREDS_PER_SLOT`.

The old code was discarding: `index >= MAX_DATA_SHREDS_PER_SLOT` regardless of if the shred is code or data:
https://github.com/solana-labs/solana/blob/v1.13.6/core/src/window_service.rs#L193-L195

This might allow more load on the cluster for slots which don't get rooted anyways.

#### Summary of Changes
Since that many code (or data) shreds will probably never result in a rooted slot anyways, the commit reduces `MAX_CODE_SHREDS_PER_SLOT` to what previously was the effective limit.
