### PR TITLE
Admin RPC Service: move post-init activation to before wait-for-supermajority

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -1,0 +1,17 @@
+use {
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_runtime::bank_forks::BankForks,
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        collections::HashSet,
+        sync::{Arc, RwLock},
+    },
+};
+
+#[derive(Clone)]
+pub struct AdminRpcRequestMetadataPostInit {
+    pub cluster_info: Arc<ClusterInfo>,
+    pub bank_forks: Arc<RwLock<BankForks>>,
+    pub vote_account: Pubkey,
+    pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 
 pub mod accounts_hash_verifier;
+pub mod admin_rpc_post_init;
 pub mod ancestor_hashes_service;
 pub mod banking_stage;
 pub mod banking_trace;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,6 +4,7 @@ pub use solana_perf::report_target_features;
 use {
     crate::{
         accounts_hash_verifier::AccountsHashVerifier,
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_trace::{self, BankingTracer},
         broadcast_stage::BroadcastStageType,
         cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
@@ -395,6 +396,7 @@ impl Validator {
         use_quic: bool,
         tpu_connection_pool_size: usize,
         tpu_enable_udp: bool,
+        admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     ) -> Result<Self, String> {
         let id = identity_keypair.pubkey();
         assert_eq!(&id, node.info.pubkey());
@@ -907,6 +909,13 @@ impl Validator {
             stats_reporter_sender,
             exit.clone(),
         );
+
+        *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
+            bank_forks: bank_forks.clone(),
+            cluster_info: cluster_info.clone(),
+            vote_account: *vote_account,
+            repair_whitelist: config.repair_whitelist.clone(),
+        });
 
         let waited_for_supermajority = match wait_for_supermajority(
             config,
@@ -2146,6 +2155,7 @@ mod tests {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
         assert_eq!(
@@ -2241,6 +2251,7 @@ mod tests {
                     DEFAULT_TPU_USE_QUIC,
                     DEFAULT_TPU_CONNECTION_POOL_SIZE,
                     DEFAULT_TPU_ENABLE_UDP,
+                    Arc::new(RwLock::new(None)),
                 )
                 .expect("assume successful validator start")
             })

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -288,6 +288,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
 
@@ -493,6 +494,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
 
@@ -865,6 +867,7 @@ impl Cluster for LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -5,6 +5,7 @@ use {
     solana_cli_output::CliAccount,
     solana_client::rpc_request::MAX_MULTIPLE_ACCOUNTS,
     solana_core::{
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         tower_storage::TowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     },
@@ -137,6 +138,7 @@ pub struct TestValidatorGenesis {
     pub log_messages_bytes_limit: Option<usize>,
     pub transaction_account_lock_limit: Option<usize>,
     pub tpu_enable_udp: bool,
+    admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
 }
 
 impl Default for TestValidatorGenesis {
@@ -170,6 +172,8 @@ impl Default for TestValidatorGenesis {
             log_messages_bytes_limit: Option::<usize>::default(),
             transaction_account_lock_limit: Option::<usize>::default(),
             tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+            admin_rpc_service_post_init:
+                Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
         }
     }
 }
@@ -950,6 +954,7 @@ impl TestValidator {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
+            config.admin_rpc_service_post_init.clone(),
         )?);
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -7,12 +7,13 @@ use {
     log::*,
     serde::{de::Deserializer, Deserialize, Serialize},
     solana_core::{
-        consensus::Tower, tower_storage::TowerStorage, validator::ValidatorStartProgress,
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit, consensus::Tower,
+        tower_storage::TowerStorage, validator::ValidatorStartProgress,
     },
-    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+    solana_gossip::contact_info::ContactInfo,
     solana_rpc::rpc::verify_pubkey,
     solana_rpc_client_api::{config::RpcAccountIndex, custom_error::RpcCustomError},
-    solana_runtime::{accounts_index::AccountIndex, bank_forks::BankForks},
+    solana_runtime::accounts_index::AccountIndex,
     solana_sdk::{
         exit::Exit,
         pubkey::Pubkey,
@@ -29,14 +30,6 @@ use {
         time::{Duration, SystemTime},
     },
 };
-
-#[derive(Clone)]
-pub struct AdminRpcRequestMetadataPostInit {
-    pub cluster_info: Arc<ClusterInfo>,
-    pub bank_forks: Arc<RwLock<BankForks>>,
-    pub vote_account: Pubkey,
-    pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
-}
 
 #[derive(Clone)]
 pub struct AdminRpcRequestMetadata {
@@ -643,11 +636,13 @@ mod tests {
         serde_json::Value,
         solana_account_decoder::parse_token::spl_token_pubkey,
         solana_core::tower_storage::NullTowerStorage,
+        solana_gossip::cluster_info::ClusterInfo,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_rpc::rpc::create_validator_exit,
         solana_runtime::{
             accounts_index::AccountSecondaryIndexes,
             bank::{Bank, BankTestConfig},
+            bank_forks::BankForks,
             inline_spl_token,
             secondary_index::MAX_NUM_LARGEST_INDEX_KEYS_RETURNED,
         },

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -6,7 +6,9 @@ use {
         input_parsers::{pubkey_of, pubkeys_of, value_of},
         input_validators::normalize_to_url_if_moniker,
     },
-    solana_core::tower_storage::FileTowerStorage,
+    solana_core::{
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit, tower_storage::FileTowerStorage,
+    },
     solana_faucet::faucet::run_local_faucet_with_port,
     solana_rpc::{
         rpc::{JsonRpcConfig, RpcBigtableConfig},
@@ -561,13 +563,12 @@ fn main() {
 
     match genesis.start_with_mint_address(mint_address, socket_addr_space) {
         Ok(test_validator) => {
-            *admin_service_post_init.write().unwrap() =
-                Some(admin_rpc_service::AdminRpcRequestMetadataPostInit {
-                    bank_forks: test_validator.bank_forks(),
-                    cluster_info: test_validator.cluster_info(),
-                    vote_account: test_validator.vote_account_address(),
-                    repair_whitelist: test_validator.repair_whitelist(),
-                });
+            *admin_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
+                bank_forks: test_validator.bank_forks(),
+                cluster_info: test_validator.cluster_info(),
+                vote_account: test_validator.vote_account_address(),
+                repair_whitelist: test_validator.repair_whitelist(),
+            });
             if let Some(dashboard) = dashboard {
                 dashboard.run(Duration::from_millis(250));
             }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -6,9 +6,7 @@ use {
         input_parsers::{pubkey_of, pubkeys_of, value_of},
         input_validators::normalize_to_url_if_moniker,
     },
-    solana_core::{
-        admin_rpc_post_init::AdminRpcRequestMetadataPostInit, tower_storage::FileTowerStorage,
-    },
+    solana_core::tower_storage::FileTowerStorage,
     solana_faucet::faucet::run_local_faucet_with_port,
     solana_rpc::{
         rpc::{JsonRpcConfig, RpcBigtableConfig},
@@ -409,7 +407,7 @@ fn main() {
             validator_exit: genesis.validator_exit.clone(),
             authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
             staked_nodes_overrides: genesis.staked_nodes_overrides.clone(),
-            post_init: admin_service_post_init.clone(),
+            post_init: admin_service_post_init,
             tower_storage: tower_storage.clone(),
         },
     );
@@ -563,12 +561,6 @@ fn main() {
 
     match genesis.start_with_mint_address(mint_address, socket_addr_space) {
         Ok(test_validator) => {
-            *admin_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
-                bank_forks: test_validator.bank_forks(),
-                cluster_info: test_validator.cluster_info(),
-                vote_account: test_validator.vote_account_address(),
-                repair_whitelist: test_validator.repair_whitelist(),
-            });
             if let Some(dashboard) = dashboard {
                 dashboard.run(Duration::from_millis(250));
             }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -8,6 +8,7 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
     solana_core::{
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_trace::DISABLED_BAKING_TRACE_DIR,
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         system_monitor_service::SystemMonitorService,
@@ -1692,13 +1693,12 @@ pub fn main() {
         error!("Failed to start validator: {:?}", e);
         exit(1);
     });
-    *admin_service_post_init.write().unwrap() =
-        Some(admin_rpc_service::AdminRpcRequestMetadataPostInit {
-            bank_forks: validator.bank_forks.clone(),
-            cluster_info: validator.cluster_info.clone(),
-            vote_account,
-            repair_whitelist,
-        });
+    *admin_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
+        bank_forks: validator.bank_forks.clone(),
+        cluster_info: validator.cluster_info.clone(),
+        vote_account,
+        repair_whitelist,
+    });
 
     if let Some(filename) = init_complete_file {
         File::create(filename).unwrap_or_else(|_| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -8,7 +8,6 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
     solana_core::{
-        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_trace::DISABLED_BAKING_TRACE_DIR,
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         system_monitor_service::SystemMonitorService,
@@ -1195,7 +1194,7 @@ pub fn main() {
         wait_for_supermajority: value_t!(matches, "wait_for_supermajority", Slot).ok(),
         known_validators,
         repair_validators,
-        repair_whitelist: repair_whitelist.clone(),
+        repair_whitelist,
         gossip_validators,
         wal_recovery_mode,
         poh_verify: !matches.is_present("skip_poh_verify"),
@@ -1688,16 +1687,11 @@ pub fn main() {
         tpu_use_quic,
         tpu_connection_pool_size,
         tpu_enable_udp,
+        admin_service_post_init,
     )
     .unwrap_or_else(|e| {
         error!("Failed to start validator: {:?}", e);
         exit(1);
-    });
-    *admin_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
-        bank_forks: validator.bank_forks.clone(),
-        cluster_info: validator.cluster_info.clone(),
-        vote_account,
-        repair_whitelist,
     });
 
     if let Some(filename) = init_complete_file {


### PR DESCRIPTION
#### Problem
The validator admin interface will not accept validator identities while a node is waiting for supermajority during a restart, because the post-init setting doesn't happen until after Validator::new() returns.

#### Summary of Changes
Move AdminRpcRequestMetadataPostInit to solana core so it can be used inside Validators::new(). Write admin_rpc_service_post_init just before `wait_for_supermajority()`

Fixes #30530
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
