### PR TITLE
wip: throttle correctly

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -175,7 +175,8 @@ impl BucketMapHolderStats {
     pub fn get_remaining_items_to_flush_estimate(&self) -> usize {
         let in_mem = self.count_in_mem.load(Ordering::Relaxed) as u64;
         let held_in_mem = self.held_in_mem_slot_list_cached.load(Ordering::Relaxed)
-            + self.held_in_mem_slot_list_len.load(Ordering::Relaxed);
+            + self.held_in_mem_slot_list_len.load(Ordering::Relaxed)
+            + self.held_in_mem_ref_count.load(Ordering::Relaxed);
         in_mem.saturating_sub(held_in_mem) as usize
     }
 


### PR DESCRIPTION
#### Problem
throttling index generation at startup needs to take into account items held because of refcount != 1.
Throttling occurs at startup to keep us from running out of memory while initially populating the disk index.

#### Summary of Changes
include the count of items with refcount != 1 in the excluded list of items to use in throttling calculations.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
