### PR TITLE
introduce bucket map with single data entry

### DIFF
--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
-        bucket::Bucket, bucket_item::BucketItem, bucket_map::BucketMapError,
-        bucket_stats::BucketMapStats, MaxSearch, RefCount,
+        bucket::{Bucket, BucketSingle},
+        bucket_item::BucketItem,
+        bucket_map::BucketMapError,
+        bucket_stats::BucketMapStats,
+        MaxSearch, RefCount,
     },
     solana_sdk::pubkey::Pubkey,
     std::{
@@ -15,7 +18,7 @@ use {
 };
 
 type LockedBucket<T> = RwLock<Option<Bucket<T>>>;
-
+type LockedBucketSingle<T> = RwLock<Option<BucketSingle<T>>>;
 pub struct BucketApi<T: Clone + Copy> {
     drives: Arc<Vec<PathBuf>>,
     max_search: MaxSearch,
@@ -141,5 +144,130 @@ impl<T: Clone + Copy> BucketApi<T> {
             .as_mut()
             .unwrap()
             .try_write(pubkey, value.0.iter(), value.0.len(), value.1)
+    }
+}
+
+pub struct BucketApiSingle<T: Clone + Copy> {
+    drives: Arc<Vec<PathBuf>>,
+    max_search: MaxSearch,
+    pub stats: Arc<BucketMapStats>,
+
+    bucket: LockedBucketSingle<T>,
+    count: Arc<AtomicU64>,
+}
+
+impl<T: Clone + Copy> BucketApiSingle<T> {
+    pub fn new(
+        drives: Arc<Vec<PathBuf>>,
+        max_search: MaxSearch,
+        stats: Arc<BucketMapStats>,
+    ) -> Self {
+        Self {
+            drives,
+            max_search,
+            stats,
+            bucket: RwLock::default(),
+            count: Arc::default(),
+        }
+    }
+
+    /// Get the items for bucket
+    pub fn items_in_range<R>(&self, range: &Option<&R>) -> Vec<BucketItem<T>>
+    where
+        R: RangeBounds<Pubkey>,
+    {
+        self.bucket
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|bucket| bucket.items_in_range(range))
+            .unwrap_or_default()
+    }
+
+    /// Get the Pubkeys
+    pub fn keys(&self) -> Vec<Pubkey> {
+        self.bucket
+            .read()
+            .unwrap()
+            .as_ref()
+            .map_or_else(Vec::default, |bucket| bucket.keys())
+    }
+
+    /// Get the values for Pubkey `key`
+    pub fn read_value(&self, key: &Pubkey) -> Option<(Vec<T>, RefCount)> {
+        self.bucket
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(|bucket| bucket.read_value(key).map(|value| (vec![*value], 1)))
+    }
+
+    pub fn bucket_len(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    pub fn delete_key(&self, key: &Pubkey) {
+        let mut bucket = self.get_write_bucket();
+        if let Some(bucket) = bucket.as_mut() {
+            bucket.delete_key(key)
+        }
+    }
+
+    fn get_write_bucket(&self) -> RwLockWriteGuard<Option<BucketSingle<T>>> {
+        let mut bucket = self.bucket.write().unwrap();
+        if bucket.is_none() {
+            *bucket = Some(BucketSingle::new(
+                Arc::clone(&self.drives),
+                self.max_search,
+                Arc::clone(&self.stats),
+                Arc::clone(&self.count),
+            ));
+        } else {
+            let write = bucket.as_mut().unwrap();
+            write.handle_delayed_grows();
+        }
+        bucket
+    }
+
+    pub fn addref(&self, key: &Pubkey) -> Option<RefCount> {
+        self.get_write_bucket()
+            .as_mut()
+            .and_then(|bucket| bucket.addref(key))
+    }
+
+    pub fn unref(&self, key: &Pubkey) -> Option<RefCount> {
+        self.get_write_bucket()
+            .as_mut()
+            .and_then(|bucket| bucket.unref(key))
+    }
+
+    pub fn insert(&self, pubkey: &Pubkey, value: (&[T], RefCount)) {
+        let mut bucket = self.get_write_bucket();
+        bucket.as_mut().unwrap().insert(pubkey, value.0[0])
+    }
+
+    pub fn grow(&self, err: BucketMapError) {
+        // grows are special - they get a read lock and modify 'reallocated'
+        // the grown changes are applied the next time there is a write lock taken
+        if let Some(bucket) = self.bucket.read().unwrap().as_ref() {
+            bucket.grow(err)
+        }
+    }
+
+    pub fn update<F>(&self, key: &Pubkey, updatefn: F)
+    where
+        F: FnMut(Option<&T>) -> Option<T>,
+    {
+        let mut bucket = self.get_write_bucket();
+        bucket.as_mut().unwrap().update(key, updatefn)
+    }
+
+    pub fn try_write(
+        &self,
+        pubkey: &Pubkey,
+        value: (&[T], RefCount),
+    ) -> Result<(), BucketMapError> {
+        let mut bucket = self.get_write_bucket();
+        bucket.as_mut().unwrap().try_write(pubkey, value.0[0])
     }
 }

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -1,7 +1,11 @@
 //! BucketMap is a mostly contention free concurrent map backed by MmapMut
 
 use {
-    crate::{bucket_api::BucketApi, bucket_stats::BucketMapStats, MaxSearch, RefCount},
+    crate::{
+        bucket_api::{BucketApi, BucketApiSingle},
+        bucket_stats::BucketMapStats,
+        MaxSearch, RefCount,
+    },
     solana_sdk::pubkey::Pubkey,
     std::{convert::TryInto, fmt::Debug, fs, path::PathBuf, sync::Arc},
     tempfile::TempDir,
@@ -33,6 +37,14 @@ pub struct BucketMap<T: Clone + Copy + Debug> {
     pub temp_dir: Option<TempDir>,
 }
 
+pub struct BucketMapSingle<T: Clone + Copy + Debug> {
+    buckets: Vec<Arc<BucketApiSingle<T>>>,
+    drives: Arc<Vec<PathBuf>>,
+    max_buckets_pow2: u8,
+    pub stats: Arc<BucketMapStats>,
+    pub temp_dir: Option<TempDir>,
+}
+
 impl<T: Clone + Copy + Debug> Drop for BucketMap<T> {
     fn drop(&mut self) {
         if self.temp_dir.is_none() {
@@ -42,6 +54,20 @@ impl<T: Clone + Copy + Debug> Drop for BucketMap<T> {
 }
 
 impl<T: Clone + Copy + Debug> std::fmt::Debug for BucketMap<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+impl<T: Clone + Copy + Debug> Drop for BucketMapSingle<T> {
+    fn drop(&mut self) {
+        if self.temp_dir.is_none() {
+            BucketMapSingle::<T>::erase_previous_drives(&self.drives);
+        }
+    }
+}
+
+impl<T: Clone + Copy + Debug> std::fmt::Debug for BucketMapSingle<T> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
@@ -146,6 +172,125 @@ impl<T: Clone + Copy + Debug> BucketMap<T> {
     }
 
     pub fn get_bucket_from_index(&self, ix: usize) -> &Arc<BucketApi<T>> {
+        &self.buckets[ix]
+    }
+
+    /// Get the bucket index for Pubkey `key`
+    pub fn bucket_ix(&self, key: &Pubkey) -> usize {
+        if self.max_buckets_pow2 > 0 {
+            let location = read_be_u64(key.as_ref());
+            (location >> (u64::BITS - self.max_buckets_pow2 as u32)) as usize
+        } else {
+            0
+        }
+    }
+
+    /// Increment the refcount for Pubkey `key`
+    pub fn addref(&self, key: &Pubkey) -> Option<RefCount> {
+        let ix = self.bucket_ix(key);
+        let bucket = &self.buckets[ix];
+        bucket.addref(key)
+    }
+
+    /// Decrement the refcount for Pubkey `key`
+    pub fn unref(&self, key: &Pubkey) -> Option<RefCount> {
+        let ix = self.bucket_ix(key);
+        let bucket = &self.buckets[ix];
+        bucket.unref(key)
+    }
+}
+
+impl<T: Clone + Copy + Debug> BucketMapSingle<T> {
+    pub fn new(config: BucketMapConfig) -> Self {
+        assert_ne!(
+            config.max_buckets, 0,
+            "Max number of buckets must be non-zero"
+        );
+        assert!(
+            config.max_buckets.is_power_of_two(),
+            "Max number of buckets must be a power of two"
+        );
+        // this should be <= 1 << DEFAULT_CAPACITY or we end up searching the same items over and over - probably not a big deal since it is so small anyway
+        const MAX_SEARCH: MaxSearch = 32;
+        let max_search = config.max_search.unwrap_or(MAX_SEARCH);
+
+        if let Some(drives) = config.drives.as_ref() {
+            Self::erase_previous_drives(drives);
+        }
+        let mut temp_dir = None;
+        let drives = config.drives.unwrap_or_else(|| {
+            temp_dir = Some(TempDir::new().unwrap());
+            vec![temp_dir.as_ref().unwrap().path().to_path_buf()]
+        });
+        let drives = Arc::new(drives);
+
+        let stats = Arc::default();
+        let buckets = (0..config.max_buckets)
+            .map(|_| {
+                Arc::new(BucketApiSingle::new(
+                    Arc::clone(&drives),
+                    max_search,
+                    Arc::clone(&stats),
+                ))
+            })
+            .collect();
+
+        // A simple log2 function that is correct if x is a power of two
+        let log2 = |x: usize| usize::BITS - x.leading_zeros() - 1;
+
+        Self {
+            buckets,
+            drives,
+            max_buckets_pow2: log2(config.max_buckets) as u8,
+            stats,
+            temp_dir,
+        }
+    }
+
+    fn erase_previous_drives(drives: &[PathBuf]) {
+        drives.iter().for_each(|folder| {
+            let _ = fs::remove_dir_all(folder);
+            let _ = fs::create_dir_all(folder);
+        })
+    }
+
+    pub fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Get the values for Pubkey `key`
+    pub fn read_value(&self, key: &Pubkey) -> Option<(Vec<T>, RefCount)> {
+        self.get_bucket(key).read_value(key)
+    }
+
+    /// Delete the Pubkey `key`
+    pub fn delete_key(&self, key: &Pubkey) {
+        self.get_bucket(key).delete_key(key);
+    }
+
+    /// Update Pubkey `key`'s value with 'value'
+    pub fn insert(&self, key: &Pubkey, value: (&[T], RefCount)) {
+        self.get_bucket(key).insert(key, value)
+    }
+
+    /// Update Pubkey `key`'s value with 'value'
+    pub fn try_insert(&self, key: &Pubkey, value: (&[T], RefCount)) -> Result<(), BucketMapError> {
+        self.get_bucket(key).try_write(key, value)
+    }
+
+    /// Update Pubkey `key`'s value with function `updatefn`
+    pub fn update<F>(&self, key: &Pubkey, updatefn: F)
+    where
+        F: FnMut(Option<&T>) -> Option<T>,
+    {
+        self.get_bucket(key).update(key, updatefn)
+    }
+
+    pub fn get_bucket(&self, key: &Pubkey) -> &Arc<BucketApiSingle<T>> {
+        self.get_bucket_from_index(self.bucket_ix(key))
+    }
+
+    pub fn get_bucket_from_index(&self, ix: usize) -> &Arc<BucketApiSingle<T>> {
         &self.buckets[ix]
     }
 

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -19,6 +19,15 @@ use {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 // one instance of this per item in the index
 // stored in the index bucket
+pub struct IndexEntrySingle<T> {
+    pub key: Pubkey, // can this be smaller if we have reduced the keys into buckets already?
+    pub info: T,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+// one instance of this per item in the index
+// stored in the index bucket
 pub struct IndexEntry {
     pub key: Pubkey, // can this be smaller if we have reduced the keys into buckets already?
     pub ref_count: RefCount, // can this be smaller? Do we ever need more than 4B refcounts?
@@ -34,6 +43,13 @@ pub struct IndexEntry {
 struct PackedStorage {
     capacity_when_created_pow2: B8,
     offset: B56,
+}
+
+impl<T> IndexEntrySingle<T> {
+    pub fn init(&mut self, pubkey: &Pubkey, info: T) {
+        self.key = *pubkey;
+        self.info = info;
+    }
 }
 
 impl IndexEntry {


### PR DESCRIPTION
#### Problem
It is more efficient to store a single account info per slot than having the ability to store multiple (0-n) per slot.

#### Summary of Changes
Introduce 'Single' instances of necessary BucketMap structs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
