### PR TITLE
fix: remove unnecessary --allow-private-addr setup

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -69,7 +69,6 @@ loadConfigFile() {
     entrypointIp=${validatorIpList[0]}
   else
     entrypointIp=${validatorIpListPrivate[0]}
-    maybeAllowPrivateAddr='--allow-private-addr'
   fi
 
   buildSshOptions

--- a/net/net.sh
+++ b/net/net.sh
@@ -323,7 +323,7 @@ startBootstrapLeader() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$maybeFullRpc\" \
@@ -397,7 +397,7 @@ startNode() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$maybeFullRpc\" \
@@ -797,7 +797,6 @@ maybeLimitLedgerSize=""
 maybeSkipLedgerVerify=""
 maybeDisableAirdrops=""
 maybeWaitForSupermajority=""
-maybeAllowPrivateAddr=""
 maybeAccountsDbSkipShrink=""
 maybeSkipRequireTower=""
 debugBuild=false
@@ -942,9 +941,7 @@ while [[ -n $1 ]]; do
       extraPrimordialStakes=$2
       shift 2
     elif [[ $1 = --allow-private-addr ]]; then
-      # May also be added by loadConfigFile if 'gce.sh create' was invoked
-      # without -P.
-      maybeAllowPrivateAddr="$1"
+      echo "--allow-private-addr is a default value"
       shift 1
     elif [[ $1 = --accounts-db-skip-shrink ]]; then
       maybeAccountsDbSkipShrink="$1"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -136,11 +136,6 @@ function launch_testnet() {
     maybeAsyncNodeInit="--async-node-init"
   fi
 
-  declare maybeAllowPrivateAddr
-  if [[ "$ALLOW_PRIVATE_ADDR" = "true" ]]; then
-    maybeAllowPrivateAddr="--allow-private-addr"
-  fi
-
   declare maybeExtraPrimordialStakes
   if [[ -n "$EXTRA_PRIMORDIAL_STAKES" ]]; then
     maybeExtraPrimordialStakes="--extra-primordial-stakes $EXTRA_PRIMORDIAL_STAKES"
@@ -151,7 +146,7 @@ function launch_testnet() {
   "${REPO_ROOT}"/net/net.sh start $version_args \
     -c idle=$NUMBER_OF_CLIENT_NODES $maybeStartAllowBootFailures \
     --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit \
-    $maybeExtraPrimordialStakes $maybeAllowPrivateAddr
+    $maybeExtraPrimordialStakes
 
   if [[ -n "$WAIT_FOR_EQUAL_STAKE" ]]; then
     wait_for_equal_stake


### PR DESCRIPTION
#### Problem

It seems that we make `--allow-private-addr` as a default arg. (https://github.com/solana-labs/solana/pull/30163)

However, we still may pass `--allow-private-addr` to `boostrap-validator.sh`
https://github.com/solana-labs/solana/blob/master/net/common.sh#L72
https://github.com/solana-labs/solana/blob/master/net/net.sh#L947
https://github.com/solana-labs/solana/blob/master/system-test/testnet-automation.sh#L141

and then we will get an error `echo "Unknown argument: --allow-private-addr"`

#### Summary of Changes

remove those possibilities and keep `--allow-private-addr` as a default setting

