### PR TITLE
Panic when shred index exceeds the max per slot

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -82,7 +82,7 @@ pub use {
 mod common;
 mod legacy;
 mod merkle;
-mod shred_code;
+pub mod shred_code;
 mod shred_data;
 mod stats;
 mod traits;

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -14,8 +14,7 @@ use {
 };
 
 const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768 * 17);
-pub(crate) const MAX_CODE_SHREDS_PER_SLOT: usize =
-    MAX_DATA_SHREDS_PER_SLOT * (ERASURE_BATCH_SIZE[1] - 1);
+pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT * (ERASURE_BATCH_SIZE[1] - 1);
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 


### PR DESCRIPTION
#### Problem

Nodes keep making new shreds and broadcasting them after hitting the shred limit

#### Summary of Changes

Panic the node when this case happens

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
