### PR TITLE
increase retransmit shreds received cache size

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -42,7 +42,7 @@ use {
 };
 
 const MAX_DUPLICATE_COUNT: usize = 2;
-const DEFAULT_LRU_SIZE: usize = 10_000;
+const DEFAULT_LRU_SIZE: usize = 1 << 20;
 // Minimum number of shreds to use rayon parallel iterators.
 const PAR_ITER_MIN_NUM_SHREDS: usize = 2;
 


### PR DESCRIPTION
#### Problem
Retransmit shreds received cache can overflow with supported slot sizes.

#### Summary of Changes
- Increase packet cache size based on max number of shreds per slot.
- Add metric to count number of times an entry is evicted from the LRU shred cache to detect overflow.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
