### PR TITLE
Remove redundant check during loading upgradeable program for writing

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -394,11 +394,12 @@ impl Accounts {
                     }
 
                     if bpf_loader_upgradeable::check_id(account.owner()) {
-                        if !feature_set.is_active(&simplify_writable_program_account_check::id()) {
-                            if message.is_writable(i) && !message.is_upgradeable_loader_present() {
-                                error_counters.invalid_writable_account += 1;
-                                return Err(TransactionError::InvalidWritableAccount);
-                            }
+                        if !feature_set.is_active(&simplify_writable_program_account_check::id())
+                            && message.is_writable(i)
+                            && !message.is_upgradeable_loader_present()
+                        {
+                            error_counters.invalid_writable_account += 1;
+                            return Err(TransactionError::InvalidWritableAccount);
                         }
 
                         if account.executable() {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -641,6 +641,9 @@ pub mod include_loaded_accounts_data_size_in_fee_calculation {
 pub mod native_programs_consume_cu {
     solana_sdk::declare_id!("8pgXCMNXC8qyEFypuwpXyRxLXZdpM4Qo72gJ6k87A6wL");
 }
+pub mod simplify_writable_program_account_check {
+    solana_sdk::declare_id!("5ZCcFAzJ1zsFKe1KSZa9K92jhx7gkcKj97ci2DBo1vwj");
+}
 
 lazy_static! {
     /// Map of feature identifiers to user-visible description
@@ -797,6 +800,7 @@ lazy_static! {
         (remove_bpf_loader_incorrect_program_id::id(), "stop incorrectly throwing IncorrectProgramId in bpf_loader #30747"),
         (include_loaded_accounts_data_size_in_fee_calculation::id(), "include transaction loaded accounts data size in base fee calculation #30657"),
         (native_programs_consume_cu::id(), "Native program should consume compute units #30620"),
+        (simplify_writable_program_account_check::id(), "Simplify checks performed for writable upgradeable program accounts #30559"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The accounts.rs code currently checks if the message includes upgradeable loader key, if an upgradeable program is being loaded for writing. The check looks necessary and harmless at quick glance. But its unnecessary, as the transaction will fail due to other checks in the execution. The check is making it harder to refactor the code for the runtime V2/Cache replacement (https://github.com/solana-labs/solana/issues/29803).

#### Summary of Changes
- Remove the check under a feature gate.
- Update the unit tests.
- Add feature gate.

Feature Gate Issue #30559 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
