### PR TITLE
wip: rework uid to use bits better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5032,6 +5032,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "fs_extra",
  "log",
  "memmap2",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bv = { workspace = true, features = ["serde"] }
 log = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -192,6 +192,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         let ix = Self::bucket_index_ix(index, key, random);
         for i in ix..ix + index.max_search() {
             let ii = i % index.capacity();
+            assert!(ii < index.capacity(), "{}, {}", ii, index.capacity());
             if index.is_free(ii) {
                 continue;
             }

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -1,5 +1,6 @@
 use {
     crate::{bucket_stats::BucketStats, MaxSearch},
+    bv::BitVec,
     memmap2::MmapMut,
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
@@ -33,6 +34,9 @@ use {
 24  16,777,216
 */
 pub const DEFAULT_CAPACITY_POW2: u8 = 5;
+
+/// true if the 'allocated' flag per entry should be represented in a memory bitvec instead of a u64 header per entry
+pub const IN_MEM_BITFIELD_FOR_ALLOCATED: bool = true;
 
 /// A Header UID of 0 indicates that the header is unlocked
 const UID_UNLOCKED: Uid = 0;
@@ -80,6 +84,7 @@ pub struct BucketStorage {
     pub count: Arc<AtomicU64>,
     pub stats: Arc<BucketStats>,
     pub max_search: MaxSearch,
+    pub bit_field: Option<BitVec>,
 }
 
 #[derive(Debug)]
@@ -103,7 +108,13 @@ impl BucketStorage {
         stats: Arc<BucketStats>,
         count: Arc<AtomicU64>,
     ) -> Self {
-        let cell_size = elem_size * num_elems + std::mem::size_of::<Header>() as u64;
+        let use_bit_field = IN_MEM_BITFIELD_FOR_ALLOCATED;
+        let cell_size = elem_size * num_elems
+            + if use_bit_field {
+                0
+            } else {
+                std::mem::size_of::<Header>() as u64
+            };
         let (mmap, path) = Self::new_map(&drives, cell_size as usize, capacity_pow2, &stats);
         Self {
             path,
@@ -113,6 +124,7 @@ impl BucketStorage {
             capacity_pow2,
             stats,
             max_search,
+            bit_field: use_bit_field.then(|| BitVec::new_fill(false, 1u64 << capacity_pow2)),
         }
     }
 
@@ -137,10 +149,27 @@ impl BucketStorage {
             stats,
             count,
         )
-    }
+    } /*
+      fn calculate_header_offset(&self, ix: u64) -> HeaderOffsets {
+          // the header bits are always before the entries they correspond to
+          let size_header = std::mem::size_of::<Header>();
+          let items_per_header = u64::BITS as u64;
+          let earlier_headers = ix / items_per_header;
+          let offset_in_header = ix % items_per_header;
+          let all_entries_with_earlier_header = earlier_headers * items_per_header;
+          let size_of_previous_headers = earlier_headers * size_header;
+          let size_of_previous_entries = all_entries_with_earlier_header * self.cell_size; // cell size should be a constant todo
+          let offset_of_this_header = size_of_previous_headers.saturating_add(size_of_previous_entries);
+          let offset_of_this_cell = offset_of_this_header + size_header + offset_in_header  * self.cell_size;
+          HeaderOffsets {
+              offset_of_this_header,
+              offset_of_this_cell,
+          }
+      }*/
 
     /// return ref to header of item 'ix' in mmapped file
     fn header_ptr(&self, ix: u64) -> &Header {
+        assert!(self.bit_field.is_none());
         let ix = (ix * self.cell_size) as usize;
         let hdr_slice: &[u8] = &self.mmap[ix..ix + std::mem::size_of::<Header>()];
         unsafe {
@@ -152,6 +181,7 @@ impl BucketStorage {
     /// return ref to header of item 'ix' in mmapped file
     #[allow(clippy::mut_from_ref)]
     fn header_mut_ptr(&self, ix: u64) -> &mut Header {
+        assert!(self.bit_field.is_none());
         let ix = (ix * self.cell_size) as usize;
         let hdr_slice: &[u8] = &self.mmap[ix..ix + std::mem::size_of::<Header>()];
         unsafe {
@@ -164,16 +194,32 @@ impl BucketStorage {
     pub fn is_free(&self, ix: u64) -> bool {
         // note that the terminology in the implementation is locked or unlocked.
         // but our api is allocate/free
-        self.header_ptr(ix).is_unlocked()
+        self.bit_field
+            .as_ref()
+            .map(|bit_field| !bit_field.get(ix))
+            .or_else(|| Some(self.header_ptr(ix).is_unlocked()))
+            .unwrap()
+    }
+
+    fn try_lock(&mut self, ix: u64) -> bool {
+        if let Some(bit_field) = self.bit_field.as_mut() {
+            let in_use = bit_field.get(ix);
+            if !in_use {
+                bit_field.set(ix, true);
+            }
+            !in_use
+        } else {
+            self.header_mut_ptr(ix).try_lock()
+        }
     }
 
     /// 'is_resizing' true if caller is resizing the index (so don't increment count)
     /// 'is_resizing' false if caller is adding an item to the index (so increment count)
-    pub fn allocate(&self, ix: u64, is_resizing: bool) -> Result<(), BucketStorageError> {
+    pub fn allocate(&mut self, ix: u64, is_resizing: bool) -> Result<(), BucketStorageError> {
         assert!(ix < self.capacity(), "allocate: bad index size");
         let mut e = Err(BucketStorageError::AlreadyAllocated);
         //debug!("ALLOC {} {}", ix, uid);
-        if self.header_mut_ptr(ix).try_lock() {
+        if self.try_lock(ix) {
             e = Ok(());
             if !is_resizing {
                 self.count.fetch_add(1, Ordering::Relaxed);
@@ -182,15 +228,29 @@ impl BucketStorage {
         e
     }
 
+    fn unlock(&mut self, ix: u64) {
+        if let Some(bit_field) = self.bit_field.as_mut() {
+            assert!(bit_field.get(ix));
+            bit_field.set(ix, false);
+        } else {
+            self.header_mut_ptr(ix).unlock();
+        }
+    }
+
     pub fn free(&mut self, ix: u64) {
         assert!(ix < self.capacity(), "bad index size");
-        self.header_mut_ptr(ix).unlock();
+        self.unlock(ix);
         self.count.fetch_sub(1, Ordering::Relaxed);
     }
 
     pub fn get<T: Sized>(&self, ix: u64) -> &T {
         assert!(ix < self.capacity(), "bad index size");
-        let start = (ix * self.cell_size) as usize + std::mem::size_of::<Header>();
+        let start = (ix * self.cell_size) as usize
+            + if self.bit_field.is_none() {
+                std::mem::size_of::<Header>()
+            } else {
+                0
+            };
         let end = start + std::mem::size_of::<T>();
         let item_slice: &[u8] = &self.mmap[start..end];
         unsafe {
@@ -206,7 +266,12 @@ impl BucketStorage {
     pub fn get_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &[T] {
         assert!(ix < self.capacity(), "bad index size");
         let ix = self.cell_size * ix;
-        let start = ix as usize + std::mem::size_of::<Header>();
+        let start = ix as usize
+            + if self.bit_field.is_none() {
+                std::mem::size_of::<Header>()
+            } else {
+                0
+            };
         let end = start + std::mem::size_of::<T>() * len as usize;
         //debug!("GET slice {} {}", start, end);
         let item_slice: &[u8] = &self.mmap[start..end];
@@ -219,7 +284,12 @@ impl BucketStorage {
     #[allow(clippy::mut_from_ref)]
     pub fn get_mut<T: Sized>(&self, ix: u64) -> &mut T {
         assert!(ix < self.capacity(), "bad index size");
-        let start = (ix * self.cell_size) as usize + std::mem::size_of::<Header>();
+        let start = (ix * self.cell_size) as usize
+            + if self.bit_field.is_none() {
+                std::mem::size_of::<Header>()
+            } else {
+                0
+            };
         let end = start + std::mem::size_of::<T>();
         let item_slice: &[u8] = &self.mmap[start..end];
         unsafe {
@@ -232,7 +302,12 @@ impl BucketStorage {
     pub fn get_mut_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &mut [T] {
         assert!(ix < self.capacity(), "bad index size");
         let ix = self.cell_size * ix;
-        let start = ix as usize + std::mem::size_of::<Header>();
+        let start = ix as usize
+            + if self.bit_field.is_none() {
+                std::mem::size_of::<Header>()
+            } else {
+                0
+            };
         let end = start + std::mem::size_of::<T>() * len as usize;
         //debug!("GET mut slice {} {}", start, end);
         let item_slice: &[u8] = &self.mmap[start..end];
@@ -306,16 +381,23 @@ impl BucketStorage {
         let increment = self.capacity_pow2 - old_bucket.capacity_pow2;
         let index_grow = 1 << increment;
         (0..old_cap as usize).for_each(|i| {
-            let old_ix = i * old_bucket.cell_size as usize;
-            let new_ix = old_ix * index_grow;
-            let dst_slice: &[u8] = &self.mmap[new_ix..new_ix + old_bucket.cell_size as usize];
-            let src_slice: &[u8] = &old_map[old_ix..old_ix + old_bucket.cell_size as usize];
+            if !old_bucket.is_free(i as u64) {
+                if self.bit_field.is_some() {
+                    self.try_lock((i * index_grow) as u64);
+                } else {
+                    assert!(old_bucket.bit_field.is_none());
+                }
+                let old_ix = i * old_bucket.cell_size as usize;
+                let new_ix = old_ix * index_grow;
+                let dst_slice: &[u8] = &self.mmap[new_ix..new_ix + old_bucket.cell_size as usize];
+                let src_slice: &[u8] = &old_map[old_ix..old_ix + old_bucket.cell_size as usize];
 
-            unsafe {
-                let dst = dst_slice.as_ptr() as *mut u8;
-                let src = src_slice.as_ptr() as *const u8;
-                std::ptr::copy_nonoverlapping(src, dst, old_bucket.cell_size as usize);
-            };
+                unsafe {
+                    let dst = dst_slice.as_ptr() as *mut u8;
+                    let src = src_slice.as_ptr() as *const u8;
+                    std::ptr::copy_nonoverlapping(src, dst, old_bucket.cell_size as usize);
+                };
+            }
         });
         m.stop();
         // resized so update total file size

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "log",
  "memmap2",
  "modular-bitfield",


### PR DESCRIPTION
#### Problem
currently the accounts index uses a u64 per entry to hold a single bit of 'occupied'

#### Summary of Changes
64 entries share a single bitfield.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
