### PR TITLE
Generalize the return value of append_accounts()

### DIFF
--- a/runtime/src/account_storage/meta.rs
+++ b/runtime/src/account_storage/meta.rs
@@ -10,6 +10,12 @@ use {
 };
 
 pub type StoredMetaWriteVersion = u64;
+// A tuple that stores offset and size respectively
+#[derive(Debug, Clone)]
+pub struct StoredAccountInfo {
+    pub offset: usize,
+    pub size: usize,
+}
 
 /// Goal is to eliminate copies and data reshaping given various code paths that store accounts.
 /// This struct contains what is needed to store accounts to a storage

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6167,12 +6167,11 @@ impl AccountsDb {
             }
 
             let store_id = storage.append_vec_id();
-            for (i, offsets) in rvs.unwrap().windows(2).enumerate() {
-                let stored_size = offsets[1] - offsets[0];
-                storage.add_account(stored_size);
+            for (i, stored_account_info) in rvs.unwrap().into_iter().enumerate() {
+                storage.add_account(stored_account_info.size);
 
                 infos.push(AccountInfo::new(
-                    StorageLocation::AppendVec(store_id, offsets[0]),
+                    StorageLocation::AppendVec(store_id, stored_account_info.offset),
                     accounts_and_meta_to_store
                         .account(i)
                         .map(|account| account.lamports())
@@ -10412,19 +10411,18 @@ pub mod tests {
                 vec![&hash],
                 vec![write_version],
             );
-        let old_written = storage.written_bytes();
-        let offsets = storage
+        let stored_accounts_info = storage
             .accounts
             .append_accounts(&storable_accounts, 0)
             .unwrap();
         if mark_alive {
             // updates 'alive_bytes' on the storage
-            storage.add_account((storage.written_bytes() - old_written) as usize);
+            storage.add_account(stored_accounts_info[0].size);
         }
 
         if let Some(index) = add_to_index {
             let account_info = AccountInfo::new(
-                StorageLocation::AppendVec(storage.append_vec_id(), offsets[0]),
+                StorageLocation::AppendVec(storage.append_vec_id(), stored_accounts_info[0].offset),
                 account.lamports(),
             );
             index.upsert(

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        account_storage::meta::{StorableAccountsWithHashesAndWriteVersions, StoredAccountMeta},
+        account_storage::meta::{
+            StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredAccountMeta,
+        },
         append_vec::{AppendVec, MatchAccountOwnerError},
         storable_accounts::StorableAccounts,
     },
@@ -120,7 +122,7 @@ impl AccountsFile {
         &self,
         accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
         skip: usize,
-    ) -> Option<Vec<usize>> {
+    ) -> Option<Vec<StoredAccountInfo>> {
         match self {
             Self::AppendVec(av) => av.append_accounts(accounts, skip),
         }


### PR DESCRIPTION
#### Problem
The existing append_accounts returns a vector of offsets, which accounts-db
later uses it to infer the storage size of each account.  However, such inference
does not apply to the new hot/cold storage format.

#### Summary of Changes
This PR changes the return value of append_accounts() to `Vec<StoredAccountInfo>`,
which includes both offset and storage size information of an account.

