### PR TITLE
StoredAccountMeta: Relax returned refs lifetimes.

### DIFF
--- a/runtime/src/account_storage/meta.rs
+++ b/runtime/src/account_storage/meta.rs
@@ -119,11 +119,11 @@ impl<'a> StoredAccountMeta<'a> {
         })
     }
 
-    pub fn pubkey(&self) -> &Pubkey {
+    pub fn pubkey(&self) -> &'a Pubkey {
         &self.meta.pubkey
     }
 
-    pub fn hash(&self) -> &Hash {
+    pub fn hash(&self) -> &'a Hash {
         self.hash
     }
 
@@ -135,7 +135,7 @@ impl<'a> StoredAccountMeta<'a> {
         self.offset
     }
 
-    pub fn data(&self) -> &[u8] {
+    pub fn data(&self) -> &'a [u8] {
         self.data
     }
 
@@ -161,7 +161,7 @@ impl<'a> StoredAccountMeta<'a> {
         self.account_meta.lamports != 0 || self.clone_account() == AccountSharedData::default()
     }
 
-    pub(crate) fn ref_executable_byte(&self) -> &u8 {
+    pub(crate) fn ref_executable_byte(&self) -> &'a u8 {
         // Use extra references to avoid value silently clamped to 1 (=true) and 0 (=false)
         // Yes, this really happens; see test_new_from_file_crafted_executable
         let executable_bool: &bool = &self.account_meta.executable;


### PR DESCRIPTION
#### Problem

All the references returned from a `StoredAccountMeta` instance actually come from the underlying account.  As written, the lifetimes of the returned references is constrained by the lifetime of the `StoredAccountMeta` instance.

#### Summary of Changes

While technically correct, it is overly strict.  It is totally fine to use the returned reference as long as the underlying account is alive. Which could be longer than the lifetime of the `StoredAccountMeta` wrapper.