### PR TITLE
programs/sbf: bench running programs with input accounts

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -61,7 +61,7 @@ _ $cargoNightly bench --manifest-path core/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run sbf benches
-_ $cargoNightly bench --manifest-path programs/sbf/Cargo.toml ${V:+--verbose} --features=sbf_c \
+_ $cargoNightly bench --manifest-path programs/sbf/Cargo.toml ${V:+--verbose} --features=sbf_c,sbf_rust \
   -- -Z unstable-options --format=json --nocapture | tee -a "$BENCH_FILE"
 
 # Run banking/accounts bench. Doesn't require nightly, but use since it is already built.

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5437,6 +5437,7 @@ dependencies = [
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime",
+ "solana-sbf-rust-bench",
  "solana-sbf-rust-invoke",
  "solana-sbf-rust-realloc",
  "solana-sbf-rust-realloc-invoke",
@@ -5463,6 +5464,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alloc"
+version = "1.16.0"
+dependencies = [
+ "solana-program 1.16.0",
+]
+
+[[package]]
+name = "solana-sbf-rust-bench"
 version = "1.16.0"
 dependencies = [
  "solana-program 1.16.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -37,6 +37,7 @@ solana-program-runtime = { path = "../../program-runtime", version = "=1.16.0" }
 solana-program-test = { path = "../../program-test", version = "=1.16.0" }
 solana-runtime = { path = "../../runtime", version = "=1.16.0" }
 solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=1.16.0" }
+solana-sbf-rust-bench = { path = "rust/bench", version = "=1.16.0" }
 solana-sbf-rust-invoke = { path = "rust/invoke", version = "=1.16.0" }
 solana-sbf-rust-invoked = { path = "rust/invoked", version = "=1.16.0", default-features = false }
 solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=1.16.0" }
@@ -85,6 +86,7 @@ solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true }
+solana-sbf-rust-bench = { workspace = true }
 solana-sbf-rust-invoke = { workspace = true }
 solana-sbf-rust-realloc = { workspace = true, features = ["default"] }
 solana-sbf-rust-realloc-invoke = { workspace = true }
@@ -104,6 +106,7 @@ members = [
     "rust/128bit_dep",
     "rust/alloc",
     "rust/alt_bn128",
+    "rust/bench",
     "rust/big_mod_exp",
     "rust/call_depth",
     "rust/caller_access",

--- a/programs/sbf/benches/bpf_loader_accounts.rs
+++ b/programs/sbf/benches/bpf_loader_accounts.rs
@@ -1,0 +1,176 @@
+#![feature(test)]
+#![cfg(feature = "sbf_rust")]
+
+use solana_sbf_rust_bench::instructions::Recurse;
+
+extern crate test;
+
+use {
+    solana_bpf_loader_program::solana_bpf_loader_program,
+    solana_runtime::{
+        bank::Bank,
+        bank_client::BankClient,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        loader_utils::load_program,
+    },
+    solana_sbf_rust_bench::instructions::{BenchInstruction, ReadAccounts, WriteAccounts},
+    solana_sdk::{
+        account::AccountSharedData,
+        bpf_loader,
+        client::SyncClient,
+        instruction::{AccountMeta, Instruction},
+        message::Message,
+        pubkey::Pubkey,
+        signature::Signer,
+    },
+    std::sync::Arc,
+    test::Bencher,
+};
+
+fn bench_accounts(
+    bencher: &mut Bencher,
+    num_accounts: usize,
+    account_size: usize,
+    instruction: BenchInstruction,
+) {
+    solana_logger::setup();
+
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(50);
+    let mut bank = Bank::new_for_benches(&genesis_config);
+    let (name, id, entrypoint) = solana_bpf_loader_program!();
+    bank.add_builtin(&name, &id, entrypoint);
+    let bank = Arc::new(bank);
+    let bank_client = BankClient::new_shared(&bank);
+
+    let program_id = load_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_sbf_rust_bench",
+    );
+
+    let accounts = (0..num_accounts)
+        .map(|_| {
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(10, account_size, &program_id),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for (pubkey, account) in &accounts {
+        bank.store_account(pubkey, account);
+    }
+
+    let mint_pubkey = mint_keypair.pubkey();
+    let mut account_metas = accounts
+        .iter()
+        .map(|(pubkey, _)| AccountMeta::new(*pubkey, false))
+        .collect::<Vec<_>>();
+    account_metas.push(AccountMeta::new(program_id, false));
+
+    let instruction = Instruction {
+        program_id,
+        accounts: account_metas,
+        data: instruction.to_bytes(),
+    };
+    let message = Message::new(&[instruction], Some(&mint_pubkey));
+
+    bank_client
+        .send_and_confirm_message(&[&mint_keypair], message.clone())
+        .unwrap();
+
+    bencher.iter(|| {
+        bank.clear_signatures();
+        bank_client
+            .send_and_confirm_message(&[&mint_keypair], message.clone())
+            .unwrap();
+    });
+}
+
+macro_rules! bench_program_execute_read_accounts {
+    ($($name:ident: $num_accounts:expr, $account_size:expr, $read_size:expr),+) => {
+        $(
+            #[bench]
+            fn $name(bencher: &mut Bencher) {
+                bench_accounts(bencher, $num_accounts, $account_size, BenchInstruction::ReadAccounts(ReadAccounts {
+                    num_accounts: $num_accounts,
+                    size: $read_size,
+                }))
+            }
+        )+
+    };
+}
+
+bench_program_execute_read_accounts!(
+    bench_program_execute_read_1_1k_account: 1, 1024, 1,
+    bench_program_execute_read_1_100k_account: 1, 100 * 1024, 1,
+    bench_program_execute_read_1_1mb_account: 1, 1024 * 1024, 1,
+    bench_program_execute_read_1_10mb_account: 1, 10 * 1024 * 1024, 1,
+
+    bench_program_execute_read_10_1k_account: 10, 1024, 1,
+    bench_program_execute_read_10_100k_account: 10, 100 * 1024, 1,
+    bench_program_execute_read_10_1mb_account: 10, 1024 * 1024, 1,
+
+    bench_program_execute_read_126_1k_account: 126, 1024, 1,
+    bench_program_execute_read_126_100k_account: 126, 100 * 1024, 1,
+    bench_program_execute_read_126_500k_account: 126, 500 * 1024, 1
+);
+
+macro_rules! bench_program_execute_write_accounts {
+    ($($name:ident: $num_accounts:expr, $account_size:expr, $write_size:expr),+) => {
+        $(
+            #[bench]
+            fn $name(bencher: &mut Bencher) {
+                bench_accounts(bencher, $num_accounts, $account_size, BenchInstruction::WriteAccounts(WriteAccounts {
+                    num_accounts: 1,
+                    size: $write_size,
+                }))
+            }
+        )+
+    };
+}
+
+bench_program_execute_write_accounts!(
+    bench_program_execute_write_1_1k_account: 1, 1024, 1,
+    bench_program_execute_write_1_100k_account: 1, 100 * 1024, 1,
+    bench_program_execute_write_1_1mb_account: 1, 1024 * 1024, 1,
+    bench_program_execute_write_1_10mb_account: 1, 10 * 1024 * 1024, 1,
+
+    bench_program_execute_write_10_1k_account: 10, 1024, 1,
+    bench_program_execute_write_10_100k_account: 10, 100 * 1024, 1,
+    bench_program_execute_write_10_1mb_account: 10, 1024 * 1024, 1,
+
+    bench_program_execute_write_126_1k_account: 126, 1024, 1,
+    bench_program_execute_write_126_100k_account: 126, 100 * 1024, 1,
+    bench_program_execute_write_126_500k_account: 126, 500 * 1024, 1
+);
+macro_rules! bench_program_execute_recurse {
+    ($($name:ident: $num_accounts:expr, $account_size:expr, $n:expr),+) => {
+        $(
+            #[bench]
+            fn $name(bencher: &mut Bencher) {
+                bench_accounts(bencher, $num_accounts, $account_size, BenchInstruction::Recurse(Recurse {
+					n: $n
+                }))
+            }
+        )+
+    };
+}
+
+bench_program_execute_recurse!(
+    bench_program_execute_recurse_1_1k_account: 1, 1024, 4,
+    bench_program_execute_recurse_1_100k_account: 1, 100 * 1024, 4,
+    bench_program_execute_recurse_1_1mb_account: 1, 1024 * 1024, 4,
+    bench_program_execute_recurse_1_10mb_account: 1, 10 * 1024 * 1024, 4,
+
+    bench_program_execute_recurse_10_1k_account: 10, 1024, 4,
+    bench_program_execute_recurse_10_100k_account: 10, 100 * 1024, 4,
+
+    bench_program_execute_recurse_50_1k_account: 50, 1024, 1,
+    bench_program_execute_recurse_50_100k_account: 50, 100 * 1024, 1
+);

--- a/programs/sbf/rust/bench/Cargo.toml
+++ b/programs/sbf/rust/bench/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-sbf-rust-bench"
+documentation = "https://docs.rs/solana-sbf-rust-bench"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[features]
+default = ["program"]
+program = []
+
+[dependencies]
+solana-program = { workspace = true }
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/bench/src/instructions.rs
+++ b/programs/sbf/rust/bench/src/instructions.rs
@@ -1,0 +1,90 @@
+//! Example Rust-based SBF program that issues a cross-program-invocation
+
+use {
+    core::slice,
+    std::{mem, ptr},
+};
+
+pub enum BenchInstruction {
+    Nop,
+    ReadAccounts(ReadAccounts),
+    WriteAccounts(WriteAccounts),
+    Recurse(Recurse),
+}
+
+impl BenchInstruction {
+    pub fn tag(&self) -> u8 {
+        match self {
+            BenchInstruction::Nop => 0,
+            BenchInstruction::ReadAccounts(_) => 1,
+            BenchInstruction::WriteAccounts(_) => 2,
+            BenchInstruction::Recurse(_) => 3,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![self.tag()];
+        match self {
+            BenchInstruction::Nop => {}
+            BenchInstruction::ReadAccounts(read_accounts) => bytes.extend_from_slice(unsafe {
+                slice::from_raw_parts(
+                    read_accounts as *const _ as *const u8,
+                    mem::size_of::<ReadAccounts>(),
+                )
+            }),
+            BenchInstruction::WriteAccounts(write_accounts) => bytes.extend_from_slice(unsafe {
+                slice::from_raw_parts(
+                    write_accounts as *const _ as *const u8,
+                    mem::size_of::<WriteAccounts>(),
+                )
+            }),
+            BenchInstruction::Recurse(recurse) => bytes.extend_from_slice(unsafe {
+                slice::from_raw_parts(recurse as *const _ as *const u8, mem::size_of::<Recurse>())
+            }),
+        }
+        bytes
+    }
+}
+
+impl TryFrom<&[u8]> for BenchInstruction {
+    type Error = ();
+
+    fn try_from(input: &[u8]) -> Result<Self, Self::Error> {
+        let (tag, rest) = input.split_first().ok_or(())?;
+        match tag {
+            0 => Ok(BenchInstruction::Nop),
+            1 => {
+                let read_accounts =
+                    unsafe { ptr::read_unaligned(rest.as_ptr() as *const ReadAccounts) };
+                Ok(BenchInstruction::ReadAccounts(read_accounts))
+            }
+            2 => {
+                let write_accounts =
+                    unsafe { ptr::read_unaligned(rest.as_ptr() as *const WriteAccounts) };
+                Ok(BenchInstruction::WriteAccounts(write_accounts))
+            }
+            3 => {
+                let recurse = unsafe { ptr::read_unaligned(rest.as_ptr() as *const Recurse) };
+                Ok(BenchInstruction::Recurse(recurse))
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct ReadAccounts {
+    pub num_accounts: usize,
+    pub size: usize,
+}
+
+#[repr(C)]
+pub struct WriteAccounts {
+    pub num_accounts: usize,
+    pub size: usize,
+}
+
+#[repr(C)]
+pub struct Recurse {
+    pub n: usize,
+}

--- a/programs/sbf/rust/bench/src/lib.rs
+++ b/programs/sbf/rust/bench/src/lib.rs
@@ -1,0 +1,4 @@
+//! Example Rust-based SBF program that issues a cross-program-invocation
+
+pub mod instructions;
+pub mod processor;

--- a/programs/sbf/rust/bench/src/processor.rs
+++ b/programs/sbf/rust/bench/src/processor.rs
@@ -1,0 +1,82 @@
+//#![cfg(feature = "program")]
+
+use {
+    crate::instructions::*,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program::invoke,
+        pubkey::Pubkey,
+    },
+};
+
+solana_program::entrypoint!(process_instruction);
+
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("Bench processor");
+
+    match BenchInstruction::try_from(instruction_data).unwrap() {
+        BenchInstruction::Nop => msg!("nop"),
+        BenchInstruction::ReadAccounts(r) => read_accounts(accounts, r),
+        BenchInstruction::WriteAccounts(w) => write_accounts(accounts, w),
+        BenchInstruction::Recurse(r) => recurse(program_id, accounts, r.n),
+    };
+
+    Ok(())
+}
+
+fn read_accounts(accounts: &[AccountInfo], r: ReadAccounts) {
+    msg!("read_accounts");
+
+    let mut read = 0u64;
+    for account in accounts.iter().take(r.num_accounts) {
+        let data = account.data.borrow();
+        msg!("account len {}", data.len());
+        for x in 0..r.size {
+            read = read.saturating_add(data[x] as u64);
+        }
+    }
+
+    // this is so the whole thing doesn't get optimized away
+    msg!("read {}", read);
+}
+
+fn write_accounts(accounts: &[AccountInfo], w: WriteAccounts) {
+    msg!("write_accounts");
+
+    for account in accounts.iter().take(w.num_accounts) {
+        let mut data = account.data.borrow_mut();
+        for x in 0..w.size {
+            data[x] = x as u8;
+        }
+    }
+}
+
+fn recurse(program_id: &Pubkey, accounts: &[AccountInfo], n: usize) {
+    msg!("recurse {}", n);
+
+    if n > 0 {
+        let instruction = Instruction {
+            program_id: *program_id,
+            accounts: accounts
+                .iter()
+                .map(|a| AccountMeta {
+                    pubkey: *a.key,
+                    is_writable: a.is_writable,
+                    is_signer: a.is_signer,
+                })
+                .collect(),
+            data: BenchInstruction::Recurse(Recurse {
+                n: n.saturating_sub(1),
+            })
+            .to_bytes(),
+        };
+        invoke(&instruction, accounts).unwrap();
+    }
+}


### PR DESCRIPTION
The existing bpf_loader benches execute transactions with only one input account. This PR adds benches with different account configurations (number and size).