### PR TITLE
Refactor - Remove `process_instruction` parameter `first_instruction_account`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -37,8 +37,7 @@ use {
     },
 };
 
-pub type ProcessInstructionWithContext =
-    fn(IndexOfAccount, &mut InvokeContext) -> Result<(), InstructionError>;
+pub type ProcessInstructionWithContext = fn(&mut InvokeContext) -> Result<(), InstructionError>;
 
 #[derive(Clone)]
 pub struct BuiltinProgram {
@@ -50,7 +49,7 @@ impl std::fmt::Debug for BuiltinProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // These are just type aliases for work around of Debug-ing above pointers
         type ErasedProcessInstructionWithContext =
-            fn(IndexOfAccount, &'static mut InvokeContext<'static>) -> Result<(), InstructionError>;
+            fn(&'static mut InvokeContext<'static>) -> Result<(), InstructionError>;
 
         // rustc doesn't compile due to bug without this work around
         // https://github.com/rust-lang/rust/issues/50280
@@ -733,15 +732,15 @@ impl<'a> InvokeContext<'a> {
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
         let mut process_executable_chain_time = Measure::start("process_executable_chain_time");
 
-        let (first_instruction_account, builtin_id) = {
+        let builtin_id = {
             let borrowed_root_account = instruction_context
                 .try_borrow_program_account(self.transaction_context, 0)
                 .map_err(|_| InstructionError::UnsupportedProgramId)?;
             let owner_id = borrowed_root_account.get_owner();
             if native_loader::check_id(owner_id) {
-                (1, *borrowed_root_account.get_key())
+                *borrowed_root_account.get_key()
             } else {
-                (0, *owner_id)
+                *owner_id
             }
         };
 
@@ -756,7 +755,7 @@ impl<'a> InvokeContext<'a> {
                 let result = if builtin_id == program_id {
                     let logger = self.get_log_collector();
                     stable_log::program_invoke(&logger, &program_id, self.get_stack_height());
-                    (entry.process_instruction)(first_instruction_account, self)
+                    (entry.process_instruction)(self)
                         .map(|()| {
                             stable_log::program_success(&logger, &program_id);
                         })
@@ -765,7 +764,7 @@ impl<'a> InvokeContext<'a> {
                             err
                         })
                 } else {
-                    (entry.process_instruction)(first_instruction_account, self)
+                    (entry.process_instruction)(self)
                 };
                 let post_remaining_units = self.get_remaining();
                 *compute_units_consumed = pre_remaining_units.saturating_sub(post_remaining_units);
@@ -1023,7 +1022,7 @@ pub fn mock_process_instruction(
         );
     let result = invoke_context
         .push()
-        .and_then(|_| process_instruction(1, &mut invoke_context));
+        .and_then(|_| process_instruction(&mut invoke_context));
     let pop_result = invoke_context.pop();
     assert_eq!(result.and(pop_result), expected_result);
     let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();
@@ -1062,16 +1061,12 @@ mod tests {
     fn test_program_entry_debug() {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
-            _first_instruction_account: IndexOfAccount,
             _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Ok(())
         }
         #[allow(clippy::unnecessary_wraps)]
-        fn mock_ix_processor(
-            _first_instruction_account: IndexOfAccount,
-            _invoke_context: &mut InvokeContext,
-        ) -> Result<(), InstructionError> {
+        fn mock_ix_processor(_invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
             Ok(())
         }
         let builtin_programs = &[
@@ -1089,7 +1084,6 @@ mod tests {
 
     #[allow(clippy::integer_arithmetic)]
     fn mock_process_instruction(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -99,7 +99,6 @@ fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
 
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
-    _first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
@@ -181,16 +180,9 @@ pub fn builtin_process_instruction(
 #[macro_export]
 macro_rules! processor {
     ($process_instruction:expr) => {
-        Some(
-            |first_instruction_account: $crate::IndexOfAccount,
-             invoke_context: &mut solana_program_test::InvokeContext| {
-                $crate::builtin_process_instruction(
-                    $process_instruction,
-                    first_instruction_account,
-                    invoke_context,
-                )
-            },
-        )
+        Some(|invoke_context: &mut solana_program_test::InvokeContext| {
+            $crate::builtin_process_instruction($process_instruction, invoke_context)
+        })
     };
 }
 

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -14,15 +14,11 @@ use {
         program_utils::limited_deserialize,
         pubkey::{Pubkey, PUBKEY_BYTES},
         system_instruction,
-        transaction_context::IndexOfAccount,
     },
     std::convert::TryFrom,
 };
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -49,6 +49,7 @@ use {
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
+        native_loader,
         program_error::{
             MAX_ACCOUNTS_DATA_ALLOCATIONS_EXCEEDED, MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED,
         },
@@ -381,21 +382,20 @@ pub fn create_vm<'a, 'b>(
 }
 
 pub fn process_instruction(
-    first_instruction_account: IndexOfAccount,
+    _first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    process_instruction_common(first_instruction_account, invoke_context, false)
+    process_instruction_common(invoke_context, false)
 }
 
 pub fn process_instruction_jit(
-    first_instruction_account: IndexOfAccount,
+    _first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    process_instruction_common(first_instruction_account, invoke_context, true)
+    process_instruction_common(invoke_context, true)
 }
 
 fn process_instruction_common(
-    first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -403,6 +403,17 @@ fn process_instruction_common(
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let program_id = instruction_context.get_last_program_key(transaction_context)?;
+
+    let first_instruction_account = {
+        let borrowed_root_account =
+            instruction_context.try_borrow_program_account(transaction_context, 0)?;
+        let owner_id = borrowed_root_account.get_owner();
+        if native_loader::check_id(owner_id) {
+            1
+        } else {
+            0
+        }
+    };
     let first_account_key = transaction_context.get_key_of_account_at_index(
         get_index_in_transaction(instruction_context, first_instruction_account)?,
     )?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -381,17 +381,11 @@ pub fn create_vm<'a, 'b>(
     result
 }
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     process_instruction_common(invoke_context, false)
 }
 
-pub fn process_instruction_jit(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction_jit(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     process_instruction_common(invoke_context, true)
 }
 
@@ -1904,9 +1898,9 @@ mod tests {
             None,
             None,
             Err(InstructionError::ProgramFailedToComplete),
-            |first_instruction_account: IndexOfAccount, invoke_context: &mut InvokeContext| {
+            |invoke_context: &mut InvokeContext| {
                 invoke_context.mock_set_remaining(0);
-                super::process_instruction(first_instruction_account, invoke_context)
+                super::process_instruction(invoke_context)
             },
         );
 

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,12 +1,9 @@
 use {
     solana_program_runtime::invoke_context::InvokeContext,
-    solana_sdk::{instruction::InstructionError, transaction_context::IndexOfAccount},
+    solana_sdk::instruction::InstructionError,
 };
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    _invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(_invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     // Do nothing, compute budget instructions handled by the runtime
     Ok(())
 }

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -11,10 +11,7 @@ use {
     std::collections::BTreeSet,
 };
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -51,10 +51,7 @@ fn get_optional_pubkey<'a>(
     )
 }
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
@@ -6475,8 +6472,8 @@ mod tests {
             None,
             Some(Arc::new(feature_set)),
             Ok(()),
-            |first_instruction_account, invoke_context| {
-                super::process_instruction(first_instruction_account, invoke_context)?;
+            |invoke_context| {
+                super::process_instruction(invoke_context)?;
                 let expected_minimum_delegation =
                     crate::get_minimum_delegation(&invoke_context.feature_set).to_le_bytes();
                 let actual_minimum_delegation =

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -123,8 +123,7 @@ fn bench_process_vote_instruction(
             .configure(&[0], &instruction_accounts, &instruction_data);
         invoke_context.push().unwrap();
         assert!(
-            solana_vote_program::vote_processor::process_instruction(1, &mut invoke_context)
-                .is_ok()
+            solana_vote_program::vote_processor::process_instruction(&mut invoke_context).is_ok()
         );
         invoke_context.pop().unwrap();
     });

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -12,9 +12,7 @@ use {
         instruction::InstructionError,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
-        transaction_context::{
-            BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
-        },
+        transaction_context::{BorrowedAccount, InstructionContext, TransactionContext},
     },
     std::collections::HashSet,
 };
@@ -57,10 +55,7 @@ fn process_authorize_with_seed_instruction(
     )
 }
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -3,10 +3,7 @@
 use {
     bytemuck::Pod,
     solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
-    solana_sdk::{
-        instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
-        transaction_context::IndexOfAccount,
-    },
+    solana_sdk::instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
     solana_zk_token_sdk::zk_token_proof_instruction::*,
     std::result::Result,
 };
@@ -28,10 +25,7 @@ fn verify<T: Pod + Verifiable>(invoke_context: &mut InvokeContext) -> Result<(),
     })
 }
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
         // Not supported as an inner instruction
         return Err(InstructionError::UnsupportedProgramId);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -20,7 +20,6 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         transaction::Transaction,
-        transaction_context::IndexOfAccount,
     },
     std::{sync::Arc, thread::sleep, time::Duration},
     test::Bencher,
@@ -37,10 +36,7 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 ];
 
 #[allow(clippy::unnecessary_wraps)]
-fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    _invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+fn process_instruction(_invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     Ok(())
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -91,7 +91,7 @@ use {
             Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode,
         },
-        transaction_context::{IndexOfAccount, TransactionAccount, TransactionContext},
+        transaction_context::{TransactionAccount, TransactionContext},
     },
     solana_stake_program::stake_state::{self, StakeState},
     solana_vote_program::{
@@ -1341,7 +1341,6 @@ fn test_rent_complex() {
     }
 
     fn mock_process_instruction(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -5068,7 +5067,6 @@ fn test_add_builtin() {
         Pubkey::from([42u8; 32])
     }
     fn mock_vote_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -5127,7 +5125,6 @@ fn test_add_duplicate_static_program() {
     let mut bank = Bank::new_for_tests(&genesis_config);
 
     fn mock_vote_processor(
-        _first_instruction_account: IndexOfAccount,
         _invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         Err(InstructionError::Custom(42))
@@ -5176,7 +5173,6 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         let mut bank = create_simple_test_bank(500);
 
         fn mock_ix_processor(
-            _first_instruction_account: IndexOfAccount,
             _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Err(InstructionError::Custom(42))
@@ -6467,7 +6463,6 @@ fn test_transaction_with_duplicate_accounts_in_instruction() {
     let mut bank = Bank::new_for_tests(&genesis_config);
 
     fn mock_process_instruction(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -6527,7 +6522,6 @@ fn test_transaction_with_program_ids_passed_to_programs() {
 
     #[allow(clippy::unnecessary_wraps)]
     fn mock_process_instruction(
-        _first_instruction_account: IndexOfAccount,
         _invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         Ok(())
@@ -6746,7 +6740,6 @@ fn test_program_id_as_payer() {
 
 #[allow(clippy::unnecessary_wraps)]
 fn mock_ok_vote_processor(
-    _first_instruction_account: IndexOfAccount,
     _invoke_context: &mut InvokeContext,
 ) -> std::result::Result<(), InstructionError> {
     Ok(())
@@ -6993,7 +6986,6 @@ fn test_bank_hash_consistency() {
 #[test]
 fn test_same_program_id_uses_unqiue_executable_accounts() {
     fn nested_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -7216,7 +7208,6 @@ fn test_shrink_candidate_slots_cached() {
 fn test_add_builtin_no_overwrite() {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         _invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         Ok(())
@@ -7248,7 +7239,6 @@ fn test_add_builtin_no_overwrite() {
 fn test_add_builtin_loader_no_overwrite() {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         _context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         Ok(())
@@ -9998,7 +9988,6 @@ fn test_tx_return_data() {
 
     let mock_program_id = Pubkey::from([2u8; 32]);
     fn mock_process_instruction(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let mock_program_id = Pubkey::from([2u8; 32]);
@@ -10196,7 +10185,6 @@ fn test_transfer_sysvar() {
     let mut bank = Bank::new_for_tests(&genesis_config);
 
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -10408,7 +10396,6 @@ fn test_compute_budget_program_noop() {
     let mut bank = Bank::new_for_tests(&genesis_config);
 
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         let compute_budget = invoke_context.get_compute_budget();
@@ -10452,7 +10439,6 @@ fn test_compute_request_instruction() {
     let mut bank = Bank::new_for_tests(&genesis_config);
 
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         let compute_budget = invoke_context.get_compute_budget();
@@ -10503,7 +10489,6 @@ fn test_failed_compute_request_instruction() {
         .unwrap();
 
     fn mock_ix_processor(
-        _first_instruction_account: IndexOfAccount,
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         let compute_budget = invoke_context.get_compute_budget();
@@ -11061,7 +11046,6 @@ enum MockTransferInstruction {
 }
 
 fn mock_transfer_process_instruction(
-    _first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
 ) -> result::Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
@@ -11870,7 +11854,6 @@ enum MockReallocInstruction {
 }
 
 fn mock_realloc_process_instruction(
-    _first_instruction_account: IndexOfAccount,
     invoke_context: &mut InvokeContext,
 ) -> result::Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -40,7 +40,7 @@ impl AbiExample for Builtin {
         Self {
             name: String::default(),
             id: Pubkey::default(),
-            process_instruction_with_context: |_, _| Ok(()),
+            process_instruction_with_context: |_invoke_context| Ok(()),
         }
     }
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -218,7 +218,6 @@ mod tests {
         }
 
         fn mock_system_process_instruction(
-            _first_instruction_account: IndexOfAccount,
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -430,7 +429,6 @@ mod tests {
         }
 
         fn mock_system_process_instruction(
-            _first_instruction_account: IndexOfAccount,
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -644,7 +642,6 @@ mod tests {
     fn test_precompile() {
         let mock_program_id = Pubkey::new_unique();
         fn mock_process_instruction(
-            _first_instruction_account: IndexOfAccount,
             _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Err(InstructionError::Custom(0xbabb1e))

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -315,10 +315,7 @@ fn transfer_with_seed(
     )
 }
 
-pub fn process_instruction(
-    _first_instruction_account: IndexOfAccount,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
@@ -1867,9 +1864,9 @@ mod tests {
                 },
             ],
             Ok(()),
-            |first_instruction_account: IndexOfAccount, invoke_context: &mut InvokeContext| {
+            |invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                super::process_instruction(first_instruction_account, invoke_context)
+                super::process_instruction(invoke_context)
             },
         );
     }
@@ -2225,9 +2222,9 @@ mod tests {
                 },
             ],
             Err(NonceError::NoRecentBlockhashes.into()),
-            |first_instruction_account: IndexOfAccount, invoke_context: &mut InvokeContext| {
+            |invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                super::process_instruction(first_instruction_account, invoke_context)
+                super::process_instruction(invoke_context)
             },
         );
     }


### PR DESCRIPTION
#### Problem
`first_instruction_account` is being passed around to all built-in programs even though it is only used in `bpf_loader`.

#### Summary of Changes
Moves the calculation of `first_instruction_account` from `InvokeContext::process_executable_chain()` into `bpf_loader::process_instruction_common()`.