### PR TITLE
ledger-tool: Add flag to find non-vote optimistic slots

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2331,6 +2331,12 @@ fn main() {
                         .required(false)
                         .help("Number of slots in the output"),
                 )
+                .arg(
+                    Arg::with_name("exclude_vote_only_slots")
+                        .long("exclude-vote-only-slots")
+                        .required(false)
+                        .help("Exclude slots that contain only votes from output"),
+                )
         )
         .subcommand(
             SubCommand::with_name("repair-roots")
@@ -4207,11 +4213,37 @@ fn main() {
                     force_update_to_open,
                 );
                 let num_slots = value_t_or_exit!(arg_matches, "num_slots", usize);
-                let slots = blockstore
-                    .get_latest_optimistic_slots(num_slots)
-                    .expect("Failed to get latest optimistic slots");
-                println!("{:>20} {:>44} {:>32}", "Slot", "Hash", "Timestamp");
-                for (slot, hash, timestamp) in slots.iter() {
+                let exclude_vote_only_slots = arg_matches.is_present("exclude_vote_only_slots");
+
+                let slots_iter = blockstore
+                    .reversed_optimistic_slots_iterator()
+                    .expect("Failed to get reversed optimistic slots iterator")
+                    .map(|(slot, hash, timestamp)| {
+                        let (entries, _, _) = blockstore
+                            .get_slot_entries_with_shred_info(slot, 0, false)
+                            .expect("Failed to get slot entries");
+                        let contains_nonvote = entries
+                            .iter()
+                            .flat_map(|entry| entry.transactions.iter())
+                            .flat_map(get_program_ids)
+                            .any(|program_id| *program_id != solana_vote_program::id());
+                        (slot, hash, timestamp, contains_nonvote)
+                    });
+
+                let slots: Vec<_> = if exclude_vote_only_slots {
+                    slots_iter
+                        .filter(|(_, _, _, contains_nonvote)| *contains_nonvote)
+                        .take(num_slots)
+                        .collect()
+                } else {
+                    slots_iter.take(num_slots).collect()
+                };
+
+                println!(
+                    "{:>20} {:>44} {:>32} {:>13}",
+                    "Slot", "Hash", "Timestamp", "Vote Only?"
+                );
+                for (slot, hash, timestamp, contains_nonvote) in slots.iter() {
                     let time_str = {
                         let secs: u64 = (timestamp / 1_000) as u64;
                         let nanos: u32 = ((timestamp % 1_000) * 1_000_000) as u32;
@@ -4220,7 +4252,10 @@ fn main() {
                         datetime.to_rfc3339()
                     };
                     let hash_str = format!("{hash}");
-                    println!("{:>20} {:>44} {:>32}", slot, &hash_str, &time_str);
+                    println!(
+                        "{:>20} {:>44} {:>32} {:>13}",
+                        slot, &hash_str, &time_str, !contains_nonvote
+                    );
                 }
             }
             ("repair-roots", Some(arg_matches)) => {


### PR DESCRIPTION
#### Problem
In cluster restart scenarios, it is desirable to know the latest
optimistic slot(s), which the subcommand latest-optimistic-slots will
return. However, it is also useful to know whether slots contain only
votes or if they contain votes and user transactions.

#### Summary of Changes
This change adds an extra column of output that tells whether a slot is
vote only (contains zero non-votes), and adds a flag that enables viewing
only slots that are NOT vote-only.

#### Testing
On a ledger from a node that has yet to be restarted after the outage, I see the following:
```
// Without flag
$ ./cargo run --release --bin solana-ledger-tool -- latest-optimistic-slots --ledger ~/ledger/ --num-slots 2

                Slot                                         Hash                        Timestamp    Vote Only?
           179528951 2eynRb7ZdEBE7coH37s78eyADyYr1qNZJBSrT35shkhe    2023-02-25T06:30:59.644+00:00          true
           179528950 5daw95oGvDPssHmVnsvjouQSGfQoUT9UusRLc6ctVhnQ    2023-02-25T06:30:57.366+00:00          true
           
// With flag
$ cargo run --release --bin solana-ledger-tool -- latest-optimistic-slots --ledger ~/ledger/ --num-slots 2 --exclude-vote-only-slots

                Slot                                         Hash                        Timestamp    Vote Only?
           179526402 3iLerbAEuZ4ceMa5gFqZwt8FZVqmnLGsDvUaFEDoaHoy    2023-02-25T05:52:20.307+00:00         false
           179526401 AnE3sHjCiPPqqjEnMefjNz5qARk9mKqr4oAjjc7TqvyG    2023-02-25T05:52:18.665+00:00         false
```

With the new flag, the command spit out 179526402, [which was also identified](https://discord.com/channels/428295358100013066/1078921440620986388/1079113705721176085) by hand as the last non-vote-only-bank that had been optimistically confirmed.

This PR is built on top of https://github.com/solana-labs/solana/pull/30575
