### PR TITLE
accounts_db::get_all_accounts: Select slots with an iterator

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -17278,7 +17278,7 @@ pub mod tests {
 
     pub(crate) fn get_all_accounts(
         db: &AccountsDb,
-        slots: Range<Slot>,
+        slots: impl Iterator<Item = Slot>,
     ) -> Vec<(Pubkey, AccountSharedData)> {
         slots
             .filter_map(|slot| {


### PR DESCRIPTION
#### Problem
`get_all_accounts()` does not accept closed ranges.

#### Summary of Changes
As `Range` is a special case of an `Iterator`, this is a generalization that makes `get_all_accounts()` accept other kinds of ranges.  Such as `RangeInclusive`.