### PR TITLE
AHV uses metrics names like SPS's

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -7,7 +7,7 @@
 use {
     crossbeam_channel::{Receiver, Sender},
     solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES},
-    solana_measure::{measure, measure::Measure},
+    solana_measure::{measure::Measure, measure_us},
     solana_runtime::{
         accounts_hash::{AccountsHashEnum, CalcAccountsHashConfig, HashStats},
         snapshot_config::SnapshotConfig,
@@ -72,7 +72,7 @@ impl AccountsHashVerifier {
                         info!("handling accounts package: {accounts_package:?}");
                         let enqueued_time = accounts_package.enqueued.elapsed();
 
-                        let (_, measure) = measure!(Self::process_accounts_package(
+                        let (_, handling_time_us) = measure_us!(Self::process_accounts_package(
                             accounts_package,
                             &cluster_info,
                             known_validators.as_ref(),
@@ -88,16 +88,16 @@ impl AccountsHashVerifier {
                             "accounts_hash_verifier",
                             (
                                 "num-outstanding-accounts-packages",
-                                num_outstanding_accounts_packages as i64,
+                                num_outstanding_accounts_packages,
                                 i64
                             ),
                             (
                                 "num-re-enqueued-accounts-packages",
-                                num_re_enqueued_accounts_packages as i64,
+                                num_re_enqueued_accounts_packages,
                                 i64
                             ),
-                            ("enqueued-time-us", enqueued_time.as_micros() as i64, i64),
-                            ("total-processing-time-us", measure.as_us() as i64, i64),
+                            ("enqueued-time-us", enqueued_time.as_micros(), i64),
+                            ("handling-time-us", handling_time_us, i64),
                         );
                     } else {
                         std::thread::sleep(LOOP_LIMITER);


### PR DESCRIPTION
#### Problem

AHV's datapoint names are not consistent with SPS's. This inconsistency makes it slightly harder to quickly understand that the datapoints in AHV and SPS are the same.

https://github.com/solana-labs/solana/blob/db94e4564fefdf37d35362d42bfd9e3ade36261b/core/src/snapshot_packager_service.rs#L113-L127


#### Summary of Changes

Rename AHV datapoints to match SPS