### PR TITLE
AHV logs when stopped

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -103,6 +103,7 @@ impl AccountsHashVerifier {
                         std::thread::sleep(LOOP_LIMITER);
                     }
                 }
+                info!("Accounts Hash Verifier has stopped");
             })
             .unwrap();
         Self {


### PR DESCRIPTION
#### Problem

It is not possible to tell if/when AHV has stopped solely by inspecting logs, which can be useful for debugging.

SPS *does* log when stopped, so AHV could do the same thing.
https://github.com/solana-labs/solana/blob/db94e4564fefdf37d35362d42bfd9e3ade36261b/core/src/snapshot_packager_service.rs#L129


#### Summary of Changes

Log when AHV stops