### PR TITLE
Tweak net.sh docs for primordial stakes

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -72,7 +72,8 @@ Operate a configured testnet
    --faucet-lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 500000000000000000 lamports minted in genesis
    --extra-primordial-stakes NUM_EXTRA_PRIMORDIAL_STAKES
-                                      - Number of extra nodes to be initially staked in genesis.
+                                      - Number of nodes to be initially staked in genesis.
+                                        Gives extra stake in genesis to NUM_EXTRA_PRIMORDIAL_STAKES many nodes.
                                         Implies --wait-for-supermajority 1 --async-node-init and the supermajority
                                         wait slot may be overridden with the corresponding flag
    --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE


### PR DESCRIPTION
#### Problem

Primordial stakes argument documentation is a bit confusing

#### Summary of Changes

Tweak the docs to not say "extra nodes" which implied that maybe it was adding stake for nodes outside of the validators which are started.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
