### PR TITLE
AccountsHashVerifier writes BankIncrementalSnapshotPersistence

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -10,6 +10,8 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_runtime::{
         accounts_hash::{AccountsHashEnum, CalcAccountsHashConfig, HashStats},
+        bank::BankIncrementalSnapshotPersistence,
+        serde_snapshot::SerdeIncrementalAccountsHash,
         snapshot_config::SnapshotConfig,
         snapshot_package::{
             self, retain_max_n_elements, AccountsPackage, AccountsPackageType, SnapshotPackage,
@@ -306,12 +308,36 @@ impl AccountsHashVerifier {
             );
 
         measure_hash.stop();
+
+        let bank_incremental_snapshot_persistence = if let AccountsPackageType::Snapshot(
+            SnapshotType::IncrementalSnapshot(base_slot),
+        ) = accounts_package.package_type
+        {
+            let (full_accounts_hash, full_capitalization) = accounts_package
+                .accounts
+                .accounts_db
+                .get_accounts_hash(base_slot)
+                .expect("incremental snapshot requires accounts hash and capitalization from its full snapshot");
+            Some(BankIncrementalSnapshotPersistence {
+                full_slot: base_slot,
+                full_hash: full_accounts_hash.into(),
+                full_capitalization,
+                // NOTE: The value for the incremental accounts hash is actually a *full* accounts
+                // hash here.  Once an incremental accounts hash is calculated for incremental
+                // snapshots, this value will be corrected.
+                incremental_hash: SerdeIncrementalAccountsHash(accounts_hash.0),
+                incremental_capitalization: lamports,
+            })
+        } else {
+            None
+        };
+
         if let Some(snapshot_info) = &accounts_package.snapshot_info {
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
                 snapshot_info.snapshot_links.path(),
                 accounts_package.slot,
                 &accounts_hash,
-                None,
+                bank_incremental_snapshot_persistence.as_ref(),
             );
         }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -60,9 +60,12 @@ mod utils;
 // a number of test cases in accounts_db use this
 #[cfg(test)]
 pub(crate) use tests::reconstruct_accounts_db_via_serialization;
+// NOTE: AHV currently needs `SerdeIncrmentalAccountsHash`, which is why this `use` is not
+// `pub(crate)`.  Once AHV calculates incremental accounts hashes, this can be reverted.
+pub use types::SerdeIncrementalAccountsHash;
 pub(crate) use {
     storage::SerializedAppendVecId,
-    types::{SerdeAccountsDeltaHash, SerdeAccountsHash, SerdeIncrementalAccountsHash},
+    types::{SerdeAccountsDeltaHash, SerdeAccountsHash},
 };
 
 #[derive(Copy, Clone, Eq, PartialEq)]


### PR DESCRIPTION
#### Problem

For Incremental Accounts Hash, AccountsHashVerifier needs to write the BankIncrementalSnapshotPersistence field when processing an incremental snapshot package and reserializing the bank snapshot.


#### Summary of Changes

Write BankIncrementalSnapshotPersistence when processing an incremental snapshot package