### PR TITLE
Adds plumbing to get starting full snapshot information for AHV

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -38,6 +38,7 @@ pub struct AccountsHashVerifier {
 }
 
 impl AccountsHashVerifier {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         accounts_package_sender: Sender<AccountsPackage>,
         accounts_package_receiver: Receiver<AccountsPackage>,
@@ -48,6 +49,7 @@ impl AccountsHashVerifier {
         halt_on_known_validators_accounts_hash_mismatch: bool,
         fault_injection_rate_slots: u64,
         snapshot_config: SnapshotConfig,
+        starting_full_snapshot: Option<FullSnapshotAccountsHashInfo>,
     ) -> Self {
         // If there are no accounts packages to process, limit how often we re-check
         const LOOP_LIMITER: Duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
@@ -56,7 +58,7 @@ impl AccountsHashVerifier {
         let t_accounts_hash_verifier = Builder::new()
             .name("solAcctHashVer".to_string())
             .spawn(move || {
-                let mut last_full_snapshot = None;
+                let mut last_full_snapshot = starting_full_snapshot;
                 let mut hashes = vec![];
                 loop {
                     if exit.load(Ordering::Relaxed) {
@@ -473,7 +475,7 @@ impl AccountsHashVerifier {
 /// snapshot verification at load time, the incremental snapshot will need to include *this*
 /// information about the full snapshot it was based on.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct FullSnapshotAccountsHashInfo {
+pub struct FullSnapshotAccountsHashInfo {
     slot: Slot,
     accounts_hash: AccountsHash,
     capitalization: u64,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -635,6 +635,8 @@ impl Validator {
             config.halt_on_known_validators_accounts_hash_mismatch,
             config.accounts_hash_fault_injection_slots,
             config.snapshot_config.clone(),
+            // soon; will populate the starting full snapshot information
+            None,
         );
 
         let (snapshot_request_sender, snapshot_request_receiver) = unbounded();

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -201,6 +201,7 @@ impl BackgroundServices {
             false,
             0,
             snapshot_config.clone(),
+            None,
         );
 
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -230,6 +230,7 @@ fn run_bank_forks_snapshot_n<F>(
         false,
         0,
         snapshot_test_config.snapshot_config.clone(),
+        None,
     );
 
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
@@ -746,6 +747,7 @@ fn test_bank_forks_incremental_snapshot(
         false,
         0,
         snapshot_test_config.snapshot_config.clone(),
+        None,
     );
 
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
@@ -1040,6 +1042,7 @@ fn test_snapshots_with_background_services(
         false,
         0,
         snapshot_test_config.snapshot_config.clone(),
+        None,
     );
 
     let accounts_background_service =


### PR DESCRIPTION
#### Problem

AHV will need to write `BankIncrementalSnapshotPersistence` when handling incremental snapshot packages. If the first accounts package to be processed is an incremental snapshot package,`last_full_snapshot` will not have been populated yet. However, we know that a full snapshot must've been used to boot from, so that starting full snapshot information needs to be plumbed into AHV.

Please see https://github.com/solana-labs/solana/pull/30582 for more/initial context.


#### Summary of Changes

Plumb "starting full snapshot information" into AHV.

Note: This PR does not *populate* that information yet; a future PR will handle that.