### PR TITLE
ci: remove bench step

### DIFF
--- a/ci/buildkite-pipeline-in-disk.sh
+++ b/ci/buildkite-pipeline-in-disk.sh
@@ -260,21 +260,6 @@ EOF
       "wasm skipped as no relevant files were modified"
   fi
 
-  # Benches...
-  if affects \
-             .rs$ \
-             Cargo.lock$ \
-             Cargo.toml$ \
-             ^ci/rust-version.sh \
-             ^ci/test-coverage.sh \
-             ^ci/test-bench.sh \
-      ; then
-    command_step bench "ci/test-bench.sh" 40
-  else
-    annotate --style info --context test-bench \
-      "Bench skipped as no .rs files were modified"
-  fi
-
   command_step "local-cluster" \
     ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster.sh" \
     40


### PR DESCRIPTION
Uploading bench artifacts has been disabled for 3 years, there's little point in running benchmarks if nothing consumes the output. Also for the output to make sense, benchmarks need to run with a fixed hw/load configuration.

ci/test-bench.sh is left unchanged as it can still be used locally, and ideally at some point it should run as a nightly scheduled step or something.

All benches are still checked by the ci/test-checks.sh step.