### PR TITLE
snapshot dir to and from archive

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1624,7 +1624,7 @@ fn unarchive_to_snapshot_dir(
     );
     measure_streaming_unarchive.stop();
     info!(
-        "xxx measure_streaming_unarchive {}",
+        "measure_streaming_unarchive {}",
         measure_streaming_unarchive.as_ms()
     );
 }
@@ -2799,10 +2799,6 @@ pub fn bank_snapshot_dir_to_archive(
         .as_ref()
         .to_path_buf()
         .join(slot.to_string());
-    println!(
-        "xxx bank_snapshot_slot_dir {}",
-        bank_snapshot_slot_dir.as_display()
-    );
 
     let archive_filename = format!("new_{:?}.{}", slot, archive_format.extension());
     let archive_path = bank_snapshots_dir
@@ -4871,6 +4867,8 @@ mod tests {
         info!("Created archive {}", archive_path.display());
 
         // archive -> unpack dir
+        // To be debugged.  /tmp/unpack works.  but any directory generated from TempDir
+        // is unstable, causing flacky crashes.
         //let unpack_dir = bank_snapshots_dir.join("unpack");
         //let unpack_dir_tmp = tempfile::TempDir::new().unwrap();
         //let unpack_dir = unpack_dir_tmp.path().to_path_buf();


### PR DESCRIPTION
#### Problem

The current path of bank in memory <-> archive is complicated.  To build an archive, some info is from file system (snapshot file, account files in operation path), some is from memory (status cache).  For fast boot, we now have the complete snapshot info in the snapshot directory (PR https://github.com/solana-labs/solana/pull/28745's split PRs).  In the -> bank direction, we can construct a bank from only the files.  In the -> archive direction, we can now build the archive with only the files, without the need of any data structures in memory.

So it is now possible to break the bank in memory <-> archive path into two independent paths as 
memory <-> snapshot dir <-> archive with clean logic separation.
In memory <-> snapshot dir, the information goes between memory data structures and files, and there is no archiving logic involved;
In snapshot dir <-> archive, the information goes between archive and files, there is no data structure in memory involved.

With this, the code can be much simpler.  No more need for those intermediate data structures such SnapshotPackage, AccountsPackage.

#### Summary of Changes

Added the following functions and test.

fn bank_snapshot_dir_to_archive
This creates an archive with full info from the snapshot directory, so it has a different content format.  A new snapshot archive version should be defined.

fn unarchive_to_snapshot_dir

test test_roundtrip_snapshot_dir_to_and_from_archive

Open issues:
This new archive has a different content structure, with meta files included.  Should we define a new snapshot version?  It is actually more about the archive version, not the snapshot itself.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
