### PR TITLE
Remove unused ProcessOptions::entry_callback

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1836,7 +1836,6 @@ impl ReplayStage {
             false,
             transaction_status_sender,
             Some(replay_vote_sender),
-            None,
             verify_recyclers,
             false,
             log_messages_bytes_limit,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -226,15 +226,14 @@ fn execute_batches_internal(
                 let mut timings = ExecuteTimings::default();
                 let (result, execute_batches_time): (Result<()>, Measure) = measure!(
                     {
-                        let result = execute_batch(
+                        execute_batch(
                             transaction_batch,
                             bank,
                             transaction_status_sender,
                             replay_vote_sender,
                             &mut timings,
                             log_messages_bytes_limit,
-                        );
-                        result
+                        )
                     },
                     "execute_batch",
                 );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -227,6 +227,9 @@ fn execute_batches_internal(
                 let mut timings = ExecuteTimings::default();
                 let (result, execute_batches_time): (Result<()>, Measure) = measure!(
                     {
+                        // suppress clippy, which is confused by the following
+                        // #[cfg(test)]-ed entry_callback code
+                        #[cfg_attr(not(test), allow(clippy::let_and_return))]
                         let result = execute_batch(
                             transaction_batch,
                             bank,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -207,7 +207,7 @@ struct ExecuteBatchesInternalMetrics {
 fn execute_batches_internal(
     bank: &Arc<Bank>,
     batches: &[TransactionBatchWithIndexes],
-    entry_callback: Option<&ProcessCallback>,
+    #[cfg(test)] entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     log_messages_bytes_limit: Option<usize>,
@@ -235,6 +235,7 @@ fn execute_batches_internal(
                             &mut timings,
                             log_messages_bytes_limit,
                         );
+                        #[cfg(test)]
                         if let Some(entry_callback) = entry_callback {
                             entry_callback(bank);
                         }
@@ -303,7 +304,7 @@ fn rebatch_transactions<'a>(
 fn execute_batches(
     bank: &Arc<Bank>,
     batches: &[TransactionBatchWithIndexes],
-    entry_callback: Option<&ProcessCallback>,
+    #[cfg(test)] entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     confirmation_timing: &mut ConfirmationTiming,
@@ -386,6 +387,7 @@ fn execute_batches(
     let execute_batches_internal_metrics = execute_batches_internal(
         bank,
         rebatched_txs,
+        #[cfg(test)]
         entry_callback,
         transaction_status_sender,
         replay_vote_sender,
@@ -440,6 +442,7 @@ pub fn process_entries_for_tests(
         bank,
         &mut replay_entries,
         randomize,
+        #[cfg(test)]
         None,
         transaction_status_sender,
         replay_vote_sender,
@@ -458,7 +461,7 @@ fn process_entries_with_callback(
     bank: &Arc<Bank>,
     entries: &mut [ReplayEntry],
     randomize: bool,
-    entry_callback: Option<&ProcessCallback>,
+    #[cfg(test)] entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     confirmation_timing: &mut ConfirmationTiming,
@@ -485,6 +488,7 @@ fn process_entries_with_callback(
                     execute_batches(
                         bank,
                         &batches,
+                        #[cfg(test)]
                         entry_callback,
                         transaction_status_sender,
                         replay_vote_sender,
@@ -551,6 +555,7 @@ fn process_entries_with_callback(
                         execute_batches(
                             bank,
                             &batches,
+                            #[cfg(test)]
                             entry_callback,
                             transaction_status_sender,
                             replay_vote_sender,
@@ -566,6 +571,7 @@ fn process_entries_with_callback(
     execute_batches(
         bank,
         &batches,
+        #[cfg(test)]
         entry_callback,
         transaction_status_sender,
         replay_vote_sender,
@@ -610,6 +616,7 @@ pub struct ProcessOptions {
     pub poh_verify: bool,
     pub full_leader_cache: bool,
     pub halt_at_slot: Option<Slot>,
+    #[cfg(test)]
     pub entry_callback: Option<ProcessCallback>,
     pub new_hard_forks: Option<Vec<Slot>>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -905,6 +912,7 @@ fn confirm_full_slot(
         skip_verification,
         transaction_status_sender,
         replay_vote_sender,
+        #[cfg(test)]
         opts.entry_callback.as_ref(),
         recyclers,
         opts.allow_dead_slots,
@@ -1032,7 +1040,7 @@ pub fn confirm_slot(
     skip_verification: bool,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
-    entry_callback: Option<&ProcessCallback>,
+    #[cfg(test)] entry_callback: Option<&ProcessCallback>,
     recyclers: &VerifyRecyclers,
     allow_dead_slots: bool,
     log_messages_bytes_limit: Option<usize>,
@@ -1062,6 +1070,7 @@ pub fn confirm_slot(
         skip_verification,
         transaction_status_sender,
         replay_vote_sender,
+        #[cfg(test)]
         entry_callback,
         recyclers,
         log_messages_bytes_limit,
@@ -1078,7 +1087,7 @@ fn confirm_slot_entries(
     skip_verification: bool,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
-    entry_callback: Option<&ProcessCallback>,
+    #[cfg(test)] entry_callback: Option<&ProcessCallback>,
     recyclers: &VerifyRecyclers,
     log_messages_bytes_limit: Option<usize>,
     prioritization_fee_cache: &PrioritizationFeeCache,
@@ -1176,6 +1185,7 @@ fn confirm_slot_entries(
                 bank,
                 &mut replay_entries,
                 true, // shuffle transactions.
+                #[cfg(test)]
                 entry_callback,
                 transaction_status_sender,
                 replay_vote_sender,


### PR DESCRIPTION
#### Problem

it's bothersome to understand how `entry_callback` is used. ~Actually, it can be `#cfg(test)`-ed trivially.~

#### Summary of Changes


~do it for easier reasoning.~

~just by coincidence, this is very similar to this: https://github.com/solana-labs/solana/pull/30288#discussion_r1121013327 (so, I'm requesting @apfitzge for review, how you'd like these along line of changes, in general)~

~context here is that, I'm finally creating preparatory prs to merge the unified scheduler. for it to make compatible with current impl, I need to be very careful to the extent i need to examine the actual use of each and every args of blockstore_processor.~

EDIT: turned out it can be removed.