### PR TITLE
ci: test-checks.sh all sbf code & use nightly only

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -66,6 +66,10 @@ edition = { workspace = true }
 [features]
 sbf_c = []
 sbf_rust = []
+dummy-for-ci-check = [
+    "sbf_c",
+    "sbf_rust",
+]
 
 [build-dependencies]
 walkdir = "2"

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -1,5 +1,7 @@
 #![feature(test)]
 #![cfg(feature = "sbf_c")]
+#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::integer_arithmetic)]
 
 use {solana_rbpf::memory_region::MemoryState, std::slice};
 

--- a/programs/sbf/build.rs
+++ b/programs/sbf/build.rs
@@ -37,6 +37,11 @@ fn rerun_if_changed(files: &[&str], directories: &[&str], excludes: &[&str]) {
 }
 
 fn main() {
+    if env::var("CARGO_FEATURE_DUMMY_FOR_CI_CHECK").is_ok() {
+        println!("cargo:warning=(not a warning) Compiling with host toolchain for CI...");
+        return;
+    }
+
     let sbf_c = env::var("CARGO_FEATURE_SBF_C").is_ok();
     if sbf_c {
         let install_dir = "OUT_DIR=../target/".to_string() + &env::var("PROFILE").unwrap() + "/sbf";

--- a/programs/sbf/rust/128bit/src/lib.rs
+++ b/programs/sbf/rust/128bit/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program tests loop iteration
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::{custom_heap_default, custom_panic_default, entrypoint::SUCCESS};
 

--- a/programs/sbf/rust/128bit_dep/src/lib.rs
+++ b/programs/sbf/rust/128bit_dep/src/lib.rs
@@ -1,5 +1,7 @@
 //! Solana Rust-based SBF program utility functions and types
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 
 pub fn uadd(x: u128, y: u128) -> u128 {

--- a/programs/sbf/rust/alloc/src/lib.rs
+++ b/programs/sbf/rust/alloc/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program that test dynamic memory allocation
 
+#![allow(clippy::integer_arithmetic)]
+
 #[macro_use]
 extern crate alloc;
 use {
@@ -37,7 +39,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
             *ptr.add(i) = i as u8;
         }
         for i in 0..ITERS {
-            assert_eq!(*ptr.add(i as usize), i as u8);
+            assert_eq!(*ptr.add(i), i as u8);
         }
         sol_log_64(0x3, 0, 0, 0, u64::from(*ptr.add(42)));
         assert_eq!(*ptr.add(42), 42);

--- a/programs/sbf/rust/custom_heap/src/lib.rs
+++ b/programs/sbf/rust/custom_heap/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF that tests out using a custom heap
 
+#![allow(clippy::integer_arithmetic)]
+
 use {
     solana_program::{
         account_info::AccountInfo,

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -1,6 +1,7 @@
 //! Example Rust-based SBF program that supports the deprecated loader
 
 #![allow(unreachable_code)]
+#![allow(clippy::integer_arithmetic)]
 
 extern crate solana_program;
 use solana_program::{
@@ -23,7 +24,7 @@ fn return_sstruct() -> SStruct {
 #[no_mangle]
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Full panic reporting
-    msg!(&format!("{}", info));
+    msg!(&format!("{info}"));
 }
 
 solana_program::entrypoint_deprecated!(process_instruction);

--- a/programs/sbf/rust/dup_accounts/src/lib.rs
+++ b/programs/sbf/rust/dup_accounts/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program that tests duplicate accounts passed via accounts
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo,

--- a/programs/sbf/rust/external_spend/src/lib.rs
+++ b/programs/sbf/rust/external_spend/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program that moves a lamport from one account to another
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 

--- a/programs/sbf/rust/inner_instruction_alignment_check/src/lib.rs
+++ b/programs/sbf/rust/inner_instruction_alignment_check/src/lib.rs
@@ -40,5 +40,5 @@ custom_heap_default!();
 #[no_mangle]
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Full panic reporting
-    msg!(&format!("{}", info));
+    msg!(&format!("{info}"));
 }

--- a/programs/sbf/rust/instruction_introspection/src/lib.rs
+++ b/programs/sbf/rust/instruction_introspection/src/lib.rs
@@ -42,7 +42,7 @@ fn process_instruction(
     msg!(&format!("id: {}", instruction.program_id));
 
     msg!(&format!("data[0]: {}", instruction.data[0]));
-    msg!(&format!("index: {}", current_instruction));
+    msg!(&format!("index: {current_instruction}"));
 
     if instruction_data.len() == 2 {
         // CPI ourself with the same arguments to confirm the instructions sysvar reports the same

--- a/programs/sbf/rust/invoked/src/processor.rs
+++ b/programs/sbf/rust/invoked/src/processor.rs
@@ -1,6 +1,7 @@
 //! Example Rust-based SBF program that issues a cross-program-invocation
 
 #![cfg(feature = "program")]
+#![allow(clippy::integer_arithmetic)]
 
 use {
     crate::instructions::*,

--- a/programs/sbf/rust/iter/src/lib.rs
+++ b/programs/sbf/rust/iter/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program tests loop iteration
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::{
     custom_heap_default, custom_panic_default, entrypoint::SUCCESS, log::sol_log_64,

--- a/programs/sbf/rust/many_args/src/helper.rs
+++ b/programs/sbf/rust/many_args/src/helper.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program tests loop iteration
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::log::*;
 

--- a/programs/sbf/rust/many_args_dep/src/lib.rs
+++ b/programs/sbf/rust/many_args_dep/src/lib.rs
@@ -1,5 +1,7 @@
 //! Solana Rust-based SBF program utility functions and types
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 use solana_program::{log::sol_log_64, msg};
 

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [features]
 no-entrypoint = []
+test-bpf = []
+dummy-for-ci-check = ["test-bpf"]
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/mem/src/lib.rs
+++ b/programs/sbf/rust/mem/src/lib.rs
@@ -1,6 +1,6 @@
 //! Test mem functions
 
-#[cfg(not(feature = "no-entrypoint"))]
+#[cfg(any(not(feature = "no-entrypoint"), feature = "test-bpf"))]
 pub mod entrypoint;
 
 pub trait MemOps {

--- a/programs/sbf/rust/mem/tests/lib.rs
+++ b/programs/sbf/rust/mem/tests/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-bpf")]
+
 use {
     solana_program_test::*,
     solana_sbf_rust_mem::entrypoint::process_instruction,

--- a/programs/sbf/rust/panic/src/lib.rs
+++ b/programs/sbf/rust/panic/src/lib.rs
@@ -5,7 +5,7 @@
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Note: Full panic reporting is included here for testing purposes
     solana_program::msg!("program custom panic enabled");
-    solana_program::msg!(&format!("{}", info));
+    solana_program::msg!(&format!("{info}"));
 }
 
 extern crate solana_program;

--- a/programs/sbf/rust/param_passing_dep/src/lib.rs
+++ b/programs/sbf/rust/param_passing_dep/src/lib.rs
@@ -1,5 +1,7 @@
 //! Example Rust-based SBF program tests loop iteration
 
+#![allow(clippy::integer_arithmetic)]
+
 extern crate solana_program;
 
 #[derive(Debug)]

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [features]
 test-bpf = []
+dummy-for-ci-check = ["test-bpf"]
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/sanity/src/lib.rs
+++ b/programs/sbf/rust/sanity/src/lib.rs
@@ -1,6 +1,7 @@
 //! Example Rust-based SBF sanity program that prints out the parameters passed to it
 
 #![allow(unreachable_code)]
+#![allow(clippy::integer_arithmetic)]
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/sbf/rust/sanity/tests/lib.rs
+++ b/programs/sbf/rust/sanity/tests/lib.rs
@@ -12,7 +12,7 @@ use {
 };
 
 #[tokio::test]
-async fn test_sysvars() {
+async fn test_sanity() {
     let program_id = Pubkey::new_unique();
     let program_test = ProgramTest::new(
         "solana_sbf_rust_sanity",

--- a/programs/sbf/rust/secp256k1_recover/src/lib.rs
+++ b/programs/sbf/rust/secp256k1_recover/src/lib.rs
@@ -60,7 +60,7 @@ fn test_secp256k1_recover_malleability() {
     let signature = libsecp256k1::Signature::parse_standard_slice(&signature_bytes).unwrap();
 
     // Flip the S value in the signature to make a different but valid signature.
-    let mut alt_signature = signature.clone();
+    let mut alt_signature = signature;
     alt_signature.s = -alt_signature.s;
     let alt_recovery_id = libsecp256k1::RecoveryId::parse(recovery_id ^ 1).unwrap();
 

--- a/programs/sbf/rust/sibling_inner_instruction/src/lib.rs
+++ b/programs/sbf/rust/sibling_inner_instruction/src/lib.rs
@@ -1,6 +1,7 @@
 //! Example Rust-based SBF program that queries sibling instructions
 
 #![cfg(feature = "program")]
+#![allow(clippy::integer_arithmetic)]
 
 use solana_program::{
     account_info::AccountInfo,

--- a/programs/sbf/rust/simulation/src/lib.rs
+++ b/programs/sbf/rust/simulation/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::integer_arithmetic)]
+
 use {
     solana_program::{
         account_info::{next_account_info, AccountInfo},
@@ -29,7 +31,7 @@ pub fn process_instruction(
     let slot: u64 = u64::from_le_bytes(data[data.len() - 8..].try_into().unwrap());
 
     let clock_from_cache = Clock::get().unwrap();
-    let clock_from_account = Clock::from_account_info(&clock_account_info).unwrap();
+    let clock_from_account = Clock::from_account_info(clock_account_info).unwrap();
 
     msg!("next_slot from slot history is {:?} ", slot);
     msg!("clock from cache is in slot {:?} ", clock_from_cache.slot);

--- a/programs/sbf/rust/simulation/tests/lib.rs
+++ b/programs/sbf/rust/simulation/tests/lib.rs
@@ -13,7 +13,7 @@ use {
 };
 
 #[tokio::test]
-async fn no_panic() {
+async fn no_panic_banks_client() {
     let program_id = Pubkey::new_unique();
     let program_test = ProgramTest::new(
         "solana_sbf_rust_simulation",

--- a/programs/sbf/rust/simulation/tests/validator.rs
+++ b/programs/sbf/rust/simulation/tests/validator.rs
@@ -11,7 +11,7 @@ use {
 };
 
 #[test]
-fn no_panic() {
+fn no_panic_rpc_client() {
     solana_logger::setup_with_default("solana_program_runtime=debug");
     let program_id = Pubkey::new_unique();
 

--- a/programs/sbf/rust/spoof1_system/src/lib.rs
+++ b/programs/sbf/rust/spoof1_system/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::integer_arithmetic)]
+
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
 solana_program::entrypoint!(process_instruction);

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -12,6 +12,10 @@ edition = { workspace = true }
 [dependencies]
 solana-program = { workspace = true }
 
+[features]
+test-bpf = []
+dummy-for-ci-check = ["test-bpf"]
+
 [dev-dependencies]
 solana-program-runtime = { workspace = true }
 solana-program-test = { workspace = true }

--- a/programs/sbf/rust/sysvar/tests/lib.rs
+++ b/programs/sbf/rust/sysvar/tests/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-bpf")]
+
 use {
     solana_program_test::*,
     solana_sbf_rust_sysvar::process_instruction,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1,4 +1,13 @@
 #![cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
+#![allow(clippy::clone_on_copy)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::redundant_clone)]
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::cmp_owned)]
+#![allow(clippy::needless_collect)]
+#![allow(clippy::match_like_matches_macro)]
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::uninlined_format_args)]
 
 #[macro_use]
 extern crate solana_bpf_loader_program;

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -18,6 +18,9 @@ solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-sdk = { workspace = true }
 
+[features]
+dummy-for-ci-check = []
+
 [lib]
 name = "solana_version"
 


### PR DESCRIPTION
#### Problem

~When overloaded with rather hard rustc bump (https://github.com/solana-labs/solana/pull/10585), I've sneaked some piggybacked changes to ci. specifically at https://github.com/solana-labs/solana/pull/10585/commits/78dc87dea1883d63efc822d5fd5179c8b3681b43~

~EDIT: scope changed to: make some ci jobs faster~

EDIT2: sbf code isn't `cargo {check/clippy}`-ed.

#### Summary of Changes

~Document the intention properly.~

EDIT2: use host toolchain for `cargo {check/clippy}`-ing sbf code.