### PR TITLE
Uses strong types for snapshot hashes in SnapshotPackagerService

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -230,7 +230,7 @@ fn bank_forks_from_snapshot(
     let full_snapshot_hash = FullSnapshotHash {
         hash: (
             full_snapshot_archive_info.slot(),
-            full_snapshot_archive_info.hash().0,
+            *full_snapshot_archive_info.hash(),
         ),
     };
     let starting_incremental_snapshot_hash =
@@ -239,7 +239,7 @@ fn bank_forks_from_snapshot(
                 base: full_snapshot_hash.hash,
                 hash: (
                     incremental_snapshot_archive_info.slot(),
-                    incremental_snapshot_archive_info.hash().0,
+                    *incremental_snapshot_archive_info.hash(),
                 ),
             }
         });

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -11,7 +11,7 @@ use {
 /// SnapshotPackagerService, which is in charge of pushing the hashes to CRDS.  This struct wraps
 /// up those values make it easier to pass from bank_forks_utils, through validator, to
 /// SnapshotPackagerService.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StartingSnapshotHashes {
     pub full: FullSnapshotHash,
     pub incremental: Option<IncrementalSnapshotHash>,
@@ -19,34 +19,34 @@ pub struct StartingSnapshotHashes {
 
 /// Used by SnapshotPackagerService and SnapshotGossipManager, this struct adds type safety to
 /// ensure a full snapshot hash is pushed to the right CRDS.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FullSnapshotHash {
-    pub hash: (Slot, Hash),
+    pub hash: (Slot, SnapshotHash),
 }
 
 /// Used by SnapshotPackagerService and SnapshotGossipManager, this struct adds type safety to
 /// ensure an incremental snapshot hash is pushed to the right CRDS.  `base` is the (full) snapshot
 /// this incremental snapshot (`hash`) is based on.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IncrementalSnapshotHash {
-    pub base: (Slot, Hash),
-    pub hash: (Slot, Hash),
+    pub base: (Slot, SnapshotHash),
+    pub hash: (Slot, SnapshotHash),
 }
 
 /// FullSnapshotHashes is used by SnapshotPackagerService to collect the snapshot hashes from full
 /// snapshots and then push those hashes to CRDS.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FullSnapshotHashes {
-    pub hashes: Vec<(Slot, Hash)>,
+    pub hashes: Vec<(Slot, SnapshotHash)>,
 }
 
 /// IncrementalSnapshotHashes is used by SnapshotPackagerService to collect the snapshot hashes
 /// from incremental snapshots and then push those hashes to CRDS.  `base` is the (full) snapshot
 /// all the incremental snapshots (`hashes`) are based on.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncrementalSnapshotHashes {
-    pub base: (Slot, Hash),
-    pub hashes: Vec<(Slot, Hash)>,
+    pub base: (Slot, SnapshotHash),
+    pub hashes: Vec<(Slot, SnapshotHash)>,
 }
 
 /// The hash used for snapshot archives


### PR DESCRIPTION
#### Problem

As part of work for [Incremental Accounts Hash](https://github.com/orgs/solana-labs/projects/13), I was looking into how to pass the snapshots used at startup into AccountsHashVerifier. Since we already do something similar for AccountsBackgroundService and SnapshotPackagerService (SPS), I started looking there and noticed in SPS that the snapshot hashes are plain `Hash`es instead of `SnapshotHash`es. We can use the strong `SnapshotHash` type to make the code also stronger 🦾 


#### Summary of Changes

Use `SnapshotHash` instead of `Hash` in SPS