### PR TITLE
Refactor - Remove `first_instruction_account` in `bpf_loader`

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -86,40 +86,6 @@ pub enum BpfError {
 }
 impl UserDefinedError for BpfError {}
 
-// The BPF loader is special in that it is the only place in the runtime and its built-in programs,
-// where data comes not only from instruction account but also program accounts.
-// Thus, these two helper methods have to distinguish the mixed sources via index_in_instruction.
-
-fn get_index_in_transaction(
-    instruction_context: &InstructionContext,
-    index_in_instruction: IndexOfAccount,
-) -> Result<IndexOfAccount, InstructionError> {
-    if index_in_instruction < instruction_context.get_number_of_program_accounts() {
-        instruction_context.get_index_of_program_account_in_transaction(index_in_instruction)
-    } else {
-        instruction_context.get_index_of_instruction_account_in_transaction(
-            index_in_instruction
-                .saturating_sub(instruction_context.get_number_of_program_accounts()),
-        )
-    }
-}
-
-fn try_borrow_account<'a>(
-    transaction_context: &'a TransactionContext,
-    instruction_context: &'a InstructionContext,
-    index_in_instruction: IndexOfAccount,
-) -> Result<BorrowedAccount<'a>, InstructionError> {
-    if index_in_instruction < instruction_context.get_number_of_program_accounts() {
-        instruction_context.try_borrow_program_account(transaction_context, index_in_instruction)
-    } else {
-        instruction_context.try_borrow_instruction_account(
-            transaction_context,
-            index_in_instruction
-                .saturating_sub(instruction_context.get_number_of_program_accounts()),
-        )
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn load_program_from_bytes(
     feature_set: &FeatureSet,


### PR DESCRIPTION
#### Problem
The logic in `process_instruction_common()` is quite complex and hard to understand. Additionally, we want to get rid of `program_indices` and `try_borrow_program_account`, so their usage in the BPF loader needs to be minimized.

There are five cases of what `program_account` inputs `process_instruction_common()` needs to handle:
- Program Management Instruction: [Loader]
- Transaction Level Instruction: [Loader, Program]
- Transaction Level Instruction: [Loader, Programdata, Program]
- Cross Program Invocation: [Program]
- Cross Program Invocation: [Programdata, Program]

From that we can tell, that we only need to look at the last program in the chain, and only in case of the upgradeable loader also need the second last (the programdata account).

#### Summary of Changes
- Removes `first_instruction_account` from `process_instruction_common()`, `process_loader_upgradeable_instruction()`, `process_loader_instruction()` and `write_program_data()`.
- Removes `get_index_in_transaction()` and `try_borrow_account()`.