### PR TITLE
decision maker perf

### DIFF
--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -42,50 +42,44 @@ impl DecisionMaker {
     }
 
     pub(crate) fn make_consume_or_forward_decision(&self) -> BufferedPacketsDecision {
-        let (leader_at_slot_offset, bank_start, would_be_leader, would_be_leader_shortly) = {
-            let poh = self.poh_recorder.read().unwrap();
-            let bank_start = poh
-                .bank_start()
-                .filter(|bank_start| bank_start.should_working_bank_still_be_processing_txs());
-            (
-                poh.leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET),
-                bank_start,
-                poh.would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET * DEFAULT_TICKS_PER_SLOT),
-                poh.would_be_leader(
-                    (FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET - 1) * DEFAULT_TICKS_PER_SLOT,
-                ),
-            )
-        };
-
+        let poh_recorder = self.poh_recorder.read().unwrap();
         Self::consume_or_forward_packets(
             &self.my_pubkey,
-            leader_at_slot_offset,
-            bank_start,
-            would_be_leader,
-            would_be_leader_shortly,
+            #[inline]
+            || {
+                poh_recorder
+                    .bank_start()
+                    .filter(|bank_start| bank_start.should_working_bank_still_be_processing_txs())
+            },
+            #[inline]
+            || poh_recorder.would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET * DEFAULT_TICKS_PER_SLOT),
+            #[inline]
+            || poh_recorder.would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET * DEFAULT_TICKS_PER_SLOT),
+            #[inline]
+            || poh_recorder.leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET),
         )
     }
 
     fn consume_or_forward_packets(
         my_pubkey: &Pubkey,
-        leader_pubkey: Option<Pubkey>,
-        bank_start: Option<BankStart>,
-        would_be_leader: bool,
-        would_be_leader_shortly: bool,
+        bank_start_fn: impl FnOnce() -> Option<BankStart>,
+        would_be_leader_shortly_fn: impl FnOnce() -> bool,
+        would_be_leader_fn: impl FnOnce() -> bool,
+        leader_pubkey_fn: impl FnOnce() -> Option<Pubkey>,
     ) -> BufferedPacketsDecision {
         // If has active bank, then immediately process buffered packets
         // otherwise, based on leader schedule to either forward or hold packets
-        if let Some(bank_start) = bank_start {
+        if let Some(bank_start) = bank_start_fn() {
             // If the bank is available, this node is the leader
             BufferedPacketsDecision::Consume(bank_start)
-        } else if would_be_leader_shortly {
+        } else if would_be_leader_shortly_fn() {
             // If the node will be the leader soon, hold the packets for now
             BufferedPacketsDecision::Hold
-        } else if would_be_leader {
+        } else if would_be_leader_fn() {
             // Node will be leader within ~20 slots, hold the transactions in
             // case it is the only node which produces an accepted slot.
             BufferedPacketsDecision::ForwardAndHold
-        } else if let Some(x) = leader_pubkey {
+        } else if let Some(x) = leader_pubkey_fn() {
             if x != *my_pubkey {
                 // If the current node is not the leader, forward the buffered packets
                 BufferedPacketsDecision::Forward
@@ -104,6 +98,7 @@ impl DecisionMaker {
 mod tests {
     use {
         super::*,
+        core::panic,
         solana_runtime::bank::Bank,
         std::{sync::Arc, time::Instant},
     };
@@ -138,82 +133,67 @@ mod tests {
         assert_matches!(
             DecisionMaker::consume_or_forward_packets(
                 &my_pubkey,
-                None,
-                bank_start.clone(),
-                false,
-                false
+                || bank_start.clone(),
+                || panic!("should not be called"),
+                || panic!("should not be called"),
+                || panic!("should not be called")
             ),
             BufferedPacketsDecision::Consume(_)
         );
-        assert_matches!(
-            DecisionMaker::consume_or_forward_packets(&my_pubkey, None, None, false, false),
-            BufferedPacketsDecision::Hold
-        );
-        assert_matches!(
-            DecisionMaker::consume_or_forward_packets(&my_pubkey1, None, None, false, false),
-            BufferedPacketsDecision::Hold
-        );
-
+        // Unknown leader, hold the packets
         assert_matches!(
             DecisionMaker::consume_or_forward_packets(
                 &my_pubkey,
-                Some(my_pubkey1),
-                None,
-                false,
-                false
+                || None,
+                || false,
+                || false,
+                || None
+            ),
+            BufferedPacketsDecision::Hold
+        );
+        // Leader other than me, forward the packets
+        assert_matches!(
+            DecisionMaker::consume_or_forward_packets(
+                &my_pubkey,
+                || None,
+                || false,
+                || false,
+                || Some(my_pubkey1),
             ),
             BufferedPacketsDecision::Forward
         );
-
+        // Will be leader shortly, hold the packets
         assert_matches!(
             DecisionMaker::consume_or_forward_packets(
                 &my_pubkey,
-                Some(my_pubkey1),
-                None,
-                true,
-                true
+                || None,
+                || true,
+                || panic!("should not be called"),
+                || panic!("should not be called"),
             ),
             BufferedPacketsDecision::Hold
         );
+        // Will be leader (not shortly), forward and hold
         assert_matches!(
             DecisionMaker::consume_or_forward_packets(
                 &my_pubkey,
-                Some(my_pubkey1),
-                None,
-                true,
-                false
+                || None,
+                || false,
+                || true,
+                || panic!("should not be called"),
             ),
             BufferedPacketsDecision::ForwardAndHold
         );
-        assert_matches!(
-            DecisionMaker::consume_or_forward_packets(
-                &my_pubkey,
-                Some(my_pubkey1),
-                bank_start.clone(),
-                false,
-                false
-            ),
-            BufferedPacketsDecision::Consume(_)
-        );
+        // Current leader matches my pubkey, hold
         assert_matches!(
             DecisionMaker::consume_or_forward_packets(
                 &my_pubkey1,
-                Some(my_pubkey1),
-                None,
-                false,
-                false
+                || None,
+                || false,
+                || false,
+                || Some(my_pubkey1),
             ),
             BufferedPacketsDecision::Hold
-        );
-        assert_matches!(
-            DecisionMaker::consume_or_forward_packets(
-                &my_pubkey1,
-                Some(my_pubkey1),
-                bank_start,
-                false,
-                false
-            ),
-            BufferedPacketsDecision::Consume(_)
         );
     }
 }

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -45,17 +45,13 @@ impl DecisionMaker {
         let poh_recorder = self.poh_recorder.read().unwrap();
         Self::consume_or_forward_packets(
             &self.my_pubkey,
-            #[inline]
             || {
                 poh_recorder
                     .bank_start()
                     .filter(|bank_start| bank_start.should_working_bank_still_be_processing_txs())
             },
-            #[inline]
             || poh_recorder.would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET * DEFAULT_TICKS_PER_SLOT),
-            #[inline]
             || poh_recorder.would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET * DEFAULT_TICKS_PER_SLOT),
-            #[inline]
             || poh_recorder.leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET),
         )
     }


### PR DESCRIPTION
#### Problem
If we have a working bank, we don't need to find the next leader or check if we are the leader in the next 20 slots.

Without considering testability, the solution we'd have likely gone with originally is checking each condition in the if statements of `consume_or_forward_packets`, because if we have a working bank we can return immediately.

We can achieve the same using closures so that we don't need to rangle the `poh_recorder` in our tests.


#### Summary of Changes
Take in functions (generic) for checking bank_start, would_be_leader_shortly, etc.
This is a nice balance between leaving the function in an easily testable format, while also making it exit (drop the lock) earlier.

Blocked by #30481

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
