### PR TITLE
mergify: Remove v1.15 backport rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -121,30 +121,6 @@ ubscribers')) }}"
         ignore_conflicts: true
         branches:
           - v1.14
-  - name: v1.15 feature-gate backport
-    conditions:
-      - label=v1.15
-      - label=feature-gate
-    actions:
-      backport:
-        assignees: *BackportAssignee
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        labels:
-          - feature-gate
-        branches:
-          - v1.15
-  - name: v1.15 non-feature-gate backport
-    conditions:
-      - label=v1.15
-      - label!=feature-gate
-    actions:
-      backport:
-        assignees: *BackportAssignee
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        branches:
-          - v1.15
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.


### PR DESCRIPTION
v1.15 is dead. Once v1.14 hits mainnet, we'll create a v1.16 branch off master at that time and work towards stabilizing it.