### PR TITLE
make_slot_entries(): Use unique hashes

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4237,7 +4237,7 @@ pub fn make_slot_entries(
     num_entries: u64,
     merkle_variant: bool,
 ) -> (Vec<Shred>, Vec<Entry>) {
-    let entries = create_ticks(num_entries, 0, Hash::default());
+    let entries = create_ticks(num_entries, 1, Hash::new_unique());
     let shreds = entries_to_test_shreds(&entries, slot, parent_slot, true, 0, merkle_variant);
     (shreds, entries)
 }


### PR DESCRIPTION
#### Problem
When `create_ticks()` is called with `0` for `hashes_per_tick` it does not update the hash value at all for empty ticks.  And as we start with a `default()` hash every time, which is actually all zero, we end up with identical PoH hashes in all the generated `entries`.

This could hide bugs in tests.

#### Summary of Changes
Start with a unique hash every time and call the hashing function once per tick.