### PR TITLE
[docs] Fix typos

### DIFF
--- a/docs/src/index.mdx
+++ b/docs/src/index.mdx
@@ -9,7 +9,7 @@ description:
 # displayed_sidebar: introductionSidebar
 ---
 
-# Solana Documentaion
+# Solana Documentation
 
 Solana is a blockchain built for mass adoption. It's a high performance network that is utilized for
 a range of use cases, including finance, NFTs, payments, and gaming. Solana operates as a single


### PR DESCRIPTION
#### Problem
I discovered a typo in the index of Solana documentation

#### Summary of Changes
Fix the typo: `Documentaion` -> `Documentation` 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
