### PR TITLE
AccountsHashVerifier purges old accounts hashes

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -314,11 +314,16 @@ impl AccountsHashVerifier {
         if accounts_package.package_type
             == AccountsPackageType::Snapshot(SnapshotType::FullSnapshot)
         {
+            let last_full_snapshot_slot = accounts_package.slot;
             *last_full_snapshot = Some(FullSnapshotAccountsHashInfo {
-                slot: accounts_package.slot,
+                slot: last_full_snapshot_slot,
                 accounts_hash,
                 capitalization: lamports,
             });
+            accounts_package
+                .accounts
+                .accounts_db
+                .purge_old_accounts_hashes(last_full_snapshot_slot);
         }
 
         datapoint_info!(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7375,6 +7375,17 @@ impl AccountsDb {
         self.accounts_hashes.lock().unwrap().get(&slot).cloned()
     }
 
+    /// Purge accounts hashes that are older than `last_full_snapshot_slot`
+    ///
+    /// Should only be called by AccountsHashVerifier, since it consumes `account_hashes` and knows
+    /// which ones are still needed.
+    pub fn purge_old_accounts_hashes(&self, last_full_snapshot_slot: Slot) {
+        self.accounts_hashes
+            .lock()
+            .unwrap()
+            .retain(|&slot, _| slot >= last_full_snapshot_slot);
+    }
+
     /// scan 'storages', return a vec of 'CacheHashDataFile', one per pass
     fn scan_snapshot_stores_with_cache(
         &self,
@@ -7823,16 +7834,14 @@ impl AccountsDb {
 
     /// Remove "bank hash info" for `slots`
     ///
-    /// This fn removes the accounts delta hash, accounts hash, and bank hash stats for `slots` from
+    /// This fn removes the accounts delta hash and bank hash stats for `slots` from
     /// their respective maps.
     fn remove_bank_hash_infos<'s>(&self, slots: impl IntoIterator<Item = &'s Slot>) {
         let mut accounts_delta_hashes = self.accounts_delta_hashes.lock().unwrap();
-        let mut accounts_hashes = self.accounts_hashes.lock().unwrap();
         let mut bank_hash_stats = self.bank_hash_stats.lock().unwrap();
 
-        for slot in slots.into_iter() {
+        for slot in slots {
             accounts_delta_hashes.remove(slot);
-            accounts_hashes.remove(slot);
             bank_hash_stats.remove(slot);
         }
     }
@@ -12624,7 +12633,7 @@ pub mod tests {
             Ok(_)
         );
 
-        db.remove_bank_hash_info(&some_slot);
+        db.accounts_hashes.lock().unwrap().remove(&some_slot);
 
         assert_matches!(
             db.verify_bank_hash_and_lamports(some_slot, 1, config.clone()),


### PR DESCRIPTION
#### Problem

When processing an incremental snapshot package in AccountsHashVerifier, we will soon be calculating an Incremental Accounts Hash. We will then need the accounts hash information from the *full snapshot* that was the base of this incremental snapshot. That information is the slot, the accounts hash, and the capitalization. 

We can get the slot easily (from the AccountsPackage), and we can get the accounts hash & capitalization from the `accounts hashes` map in AccountsDb.

However, the accounts hashes map could be purged early, meaning that AHV would *not* be able to query the accounts hash for the last full snapshot slot. This could happen because `clean_accounts()` currently purges old accounts hashes if that slot was purged.

Soon we'll be querying `AccountsDb::accounts_hashes` instead of relying on AHV's own `last_full_snapshot` information when calculating an IAH (this is to support knowing the full snapshot used at startup). So we must guarantee that the accounts hash for the last full snapshot is present.

#### Summary of Changes

No longer remove entries of `AccountsDb::accounts_hashes` inside `clean_accounts()`. Instead, move the purging logic and responsibility to AHV.