### PR TITLE
Clean orphaned account snapshot dirs

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -497,10 +497,14 @@ impl Validator {
         info!("done. {}", start);
 
         info!("Cleaning orphaned account snapshot directories..");
-        clean_orphaned_account_snapshot_dirs(
+        if let Err(e) = clean_orphaned_account_snapshot_dirs(
             &config.snapshot_config.bank_snapshots_dir,
             &config.account_snapshot_paths,
-        );
+        ) {
+            return Err(format!(
+                "Failed to clean orphaned account snapshot directories: {e:?}"
+            ));
+        }
 
         let exit = Arc::new(AtomicBool::new(false));
         {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -89,7 +89,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_utils::{self, move_and_async_delete_path},
+        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path},
     },
     solana_sdk::{
         clock::Slot,
@@ -128,6 +128,7 @@ pub struct ValidatorConfig {
     pub expected_shred_version: Option<u16>,
     pub voting_disabled: bool,
     pub account_paths: Vec<PathBuf>,
+    pub account_snapshot_paths: Vec<PathBuf>,
     pub account_shrink_paths: Option<Vec<PathBuf>>,
     pub rpc_config: JsonRpcConfig,
     /// Specifies which plugins to start up with
@@ -193,6 +194,7 @@ impl Default for ValidatorConfig {
             voting_disabled: false,
             max_ledger_shreds: None,
             account_paths: Vec::new(),
+            account_snapshot_paths: Vec::new(),
             account_shrink_paths: None,
             rpc_config: JsonRpcConfig::default(),
             on_start_geyser_plugin_config_files: None,
@@ -494,6 +496,13 @@ impl Validator {
         start.stop();
         info!("done. {}", start);
 
+        info!("Cleaning orphaned account snapshot directories..");
+        clean_orphaned_account_snapshot_dirs(
+            &config.snapshot_config.bank_snapshots_dir,
+            &config.account_snapshot_paths,
+        );
+
+        let exit = Arc::new(AtomicBool::new(false));
         {
             let exit = exit.clone();
             config

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1181,13 +1181,10 @@ fn load_bank_forks(
     };
 
     let (account_run_paths, account_snapshot_paths) =
-        match create_all_accounts_run_and_snapshot_dirs(&account_paths) {
-            Ok((run_paths, snapshot_paths)) => (run_paths, snapshot_paths),
-            Err(err) => {
-                eprintln!("Error: {err:?}");
-                exit(1);
-            }
-        };
+        create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap_or_else(|err| {
+            eprintln!("Error: {err:?}");
+            exit(1);
+        });
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     let account_paths = account_run_paths;

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -68,8 +68,8 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_minimizer::SnapshotMinimizer,
         snapshot_utils::{
-            self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path,
-            set_up_account_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+            self, clean_orphaned_account_snapshot_dirs, create_all_accounts_run_and_snapshot_dirs,
+            move_and_async_delete_path, ArchiveFormat, SnapshotVersion,
             DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
@@ -1181,7 +1181,7 @@ fn load_bank_forks(
     };
 
     let (account_run_paths, account_snapshot_paths) =
-        match set_up_account_run_and_snapshot_paths(&account_paths) {
+        match create_all_accounts_run_and_snapshot_dirs(&account_paths) {
             Ok((run_paths, snapshot_paths)) => (run_paths, snapshot_paths),
             Err(err) => {
                 eprintln!("Error: {err:?}");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1184,7 +1184,7 @@ fn load_bank_forks(
         match set_up_account_run_and_snapshot_paths(&account_paths) {
             Ok((run_paths, snapshot_paths)) => (run_paths, snapshot_paths),
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err:?}");
                 exit(1);
             }
         };

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1206,7 +1206,12 @@ fn load_bank_forks(
         "Cleaning contents of account snapshot paths: {:?}",
         account_snapshot_paths
     );
-    clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &account_snapshot_paths);
+    if let Err(e) =
+        clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &account_snapshot_paths)
+    {
+        eprintln!("Failed to clean orphaned account snapshot dirs.  Error: {e:?}");
+        exit(1);
+    }
 
     let mut accounts_update_notifier = Option::<AccountsUpdateNotifier>::default();
     let mut transaction_notifier = Option::<TransactionNotifierLock>::default();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -68,8 +68,9 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_minimizer::SnapshotMinimizer,
         snapshot_utils::{
-            self, create_accounts_run_and_snapshot_dirs, move_and_async_delete_path, ArchiveFormat,
-            SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
+            self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path,
+            set_up_account_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+            DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
     solana_sdk::{
@@ -1112,7 +1113,7 @@ fn load_bank_forks(
         Some(SnapshotConfig {
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
-            bank_snapshots_dir,
+            bank_snapshots_dir: bank_snapshots_dir.clone(),
             ..SnapshotConfig::new_load_only()
         })
     };
@@ -1179,18 +1180,8 @@ fn load_bank_forks(
         vec![non_primary_accounts_path]
     };
 
-    // For all account_paths, set up the run/ and snapshot/ sub directories.
-    // If the sub directories do not exist, the account_path will be cleaned because older version put account files there
-    let account_run_paths: Vec<PathBuf> = account_paths.into_iter().map(
-        |account_path| {
-            match create_accounts_run_and_snapshot_dirs(&account_path) {
-                Ok((account_run_path, _account_snapshot_path)) => account_run_path,
-                Err(err) => {
-                    eprintln!("Unable to create account run and snapshot sub directories: {}, err: {err:?}", account_path.display());
-                    exit(1);
-                }
-            }
-        }).collect();
+    let (account_run_paths, account_snapshot_paths) =
+        set_up_account_run_and_snapshot_paths(&account_paths);
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     let account_paths = account_run_paths;
@@ -1204,6 +1195,12 @@ fn load_bank_forks(
     });
     measure.stop();
     info!("done. {}", measure);
+
+    info!(
+        "Cleaning contents of account snapshot paths: {:?}",
+        account_snapshot_paths
+    );
+    clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &account_snapshot_paths);
 
     let mut accounts_update_notifier = Option::<AccountsUpdateNotifier>::default();
     let mut transaction_notifier = Option::<TransactionNotifierLock>::default();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1181,7 +1181,13 @@ fn load_bank_forks(
     };
 
     let (account_run_paths, account_snapshot_paths) =
-        set_up_account_run_and_snapshot_paths(&account_paths);
+        match set_up_account_run_and_snapshot_paths(&account_paths) {
+            Ok((run_paths, snapshot_paths)) => (run_paths, snapshot_paths),
+            Err(err) => {
+                eprintln!("Error: {}", err);
+                exit(1);
+            }
+        };
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     let account_paths = account_run_paths;

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -12,6 +12,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         expected_shred_version: config.expected_shred_version,
         voting_disabled: config.voting_disabled,
         account_paths: config.account_paths.clone(),
+        account_snapshot_paths: config.account_snapshot_paths.clone(),
         account_shrink_paths: config.account_shrink_paths.clone(),
         rpc_config: config.rpc_config.clone(),
         on_start_geyser_plugin_config_files: config.on_start_geyser_plugin_config_files.clone(),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1015,16 +1015,6 @@ pub fn create_all_accounts_run_and_snapshot_dirs(
     let mut run_dirs = Vec::with_capacity(account_paths.len());
     let mut snapshot_dirs = Vec::with_capacity(account_paths.len());
     for account_path in account_paths {
-        fs::create_dir_all(account_path)
-            .and_then(|_| fs::canonicalize(account_path))
-            .map_err(|err| {
-                SnapshotError::IoWithSourceAndFile(
-                    err,
-                    "Unable to create account directory",
-                    account_path.to_path_buf(),
-                )
-            })?;
-
         // create the run/ and snapshot/ sub directories for each account_path
         let (run_dir, snapshot_dir) =
             create_accounts_run_and_snapshot_dirs(account_path).map_err(|err| {
@@ -1034,7 +1024,6 @@ pub fn create_all_accounts_run_and_snapshot_dirs(
                     account_path.to_path_buf(),
                 )
             })?;
-
         run_dirs.push(run_dir);
         snapshot_dirs.push(snapshot_dir);
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -479,7 +479,7 @@ pub fn clean_orphaned_account_snapshot_dirs(
     // This is used to clean up any hardlinks that are no longer referenced by the snapshot dirs.
 
     let mut account_snapshot_dirs_referenced = HashSet::new();
-    let snapshots = get_bank_snapshots(&bank_snapshots_dir);
+    let snapshots = get_bank_snapshots(bank_snapshots_dir);
     for snapshot in snapshots {
         let account_hardlinks_dir = snapshot.snapshot_dir.join("account_hardlinks");
         // loop through entries in the snapshot_hardlink_dir, read the symlinks, add the target to the HashSet
@@ -512,7 +512,7 @@ pub fn clean_orphaned_account_snapshot_dirs(
 
     // loop through the account snapshot hardlink directories, if the directory is not in the account_snapshot_dirs_referenced set, delete it
     for account_snapshot_path in account_snapshot_paths {
-        fs::read_dir(&account_snapshot_path)
+        fs::read_dir(account_snapshot_path)
             .unwrap_or_else(|_| {
                 panic!(
                     "Unable to read snapshot hardlink directory: {}",
@@ -541,14 +541,14 @@ pub fn clean_orphaned_account_snapshot_dirs(
 // For all account_paths, set up the run/ and snapshot/ sub directories.
 // If the sub directories do not exist, the account_path will be cleaned because older version put account files there
 pub fn set_up_account_run_and_snapshot_paths(
-    account_paths: &Vec<PathBuf>,
+    account_paths: &[PathBuf],
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     // create the run/ and snapshot/ sub directories for each account_path
 
     let account_run_and_snapshot_paths: Vec<(PathBuf, PathBuf)> = account_paths
-        .into_iter()
+        .iter()
         .map(|account_path| {
-            match fs::create_dir_all(&account_path).and_then(|_| fs::canonicalize(&account_path)) {
+            match fs::create_dir_all(account_path).and_then(|_| fs::canonicalize(account_path)) {
                 Ok(account_path) => account_path,
                 Err(err) => {
                     panic!("Unable to access account path: {account_path:?}, err: {err:?}");

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -548,10 +548,9 @@ pub fn clean_orphaned_account_snapshot_dirs(
 /// If the sub directories do not exist, the account_path will be cleaned because older version put account files there
 pub fn set_up_account_run_and_snapshot_paths(
     account_paths: &[PathBuf],
-) -> (Vec<PathBuf>, Vec<PathBuf>) {
-    // create the run/ and snapshot/ sub directories for each account_path
-
-    let account_run_and_snapshot_paths: Vec<(PathBuf, PathBuf)> = account_paths
+) -> (Vec<PathBuf>, Vec<PathBuf>) // (run_paths, snapshot_paths)
+{
+    account_paths
         .iter()
         .map(|account_path| {
             match fs::create_dir_all(account_path).and_then(|_| fs::canonicalize(account_path)) {
@@ -562,6 +561,7 @@ pub fn set_up_account_run_and_snapshot_paths(
             }
         })
         .map(|account_path| {
+            // create the run/ and snapshot/ sub directories for each account_path
             create_accounts_run_and_snapshot_dirs(&account_path).unwrap_or_else(|err| {
                 panic!(
                     "Unable to create account run and snapshot sub directories: {}, err: {err:?}",
@@ -569,9 +569,7 @@ pub fn set_up_account_run_and_snapshot_paths(
                 );
             })
         })
-        .collect();
-
-    account_run_and_snapshot_paths.into_iter().unzip()
+        .unzip()
 }
 
 /// If the validator halts in the middle of `archive_snapshot_package()`, the temporary staging

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1014,7 +1014,7 @@ pub fn create_all_accounts_run_and_snapshot_dirs(
 ) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
     Ok(account_paths
         .iter()
-        .map(|account_path| -> Result<(PathBuf, PathBuf)> {
+        .map(|account_path| {
             fs::create_dir_all(account_path)
                 .and_then(|_| fs::canonicalize(account_path))
                 .map_err(|err| {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -52,7 +52,7 @@ use {
         fs::{self, File},
         io::{BufReader, BufWriter, Error as IoError, ErrorKind, Read, Seek, Write},
         path::{Path, PathBuf},
-        process::ExitStatus,
+        process::{exit, ExitStatus},
         str::FromStr,
         sync::{
             atomic::{AtomicBool, AtomicU32},
@@ -550,7 +550,8 @@ pub fn set_up_account_run_and_snapshot_paths(
             match fs::create_dir_all(account_path).and_then(|_| fs::canonicalize(account_path)) {
                 Ok(account_path) => account_path,
                 Err(err) => {
-                    panic!("Unable to access account path: {account_path:?}, err: {err:?}");
+                    eprintln!("Unable to access account path: {account_path:?}, err: {err:?}");
+                    exit(1);
                 }
             }
         })

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4796,16 +4796,8 @@ mod tests {
         assert!(result.is_ok());
 
         let (account_run_paths, account_snapshot_paths) = result.unwrap();
-
-        account_run_paths.iter().for_each(|path| {
-            assert!(path.exists());
-            assert!(path.is_dir());
-        });
-
-        account_snapshot_paths.iter().for_each(|path| {
-            assert!(path.exists());
-            assert!(path.is_dir());
-        });
+        account_run_paths.iter().all(|path| path.is_dir());
+        account_snapshot_paths.iter().all(|path| path.is_dir());
 
         delete_contents_of_path(account_path_first);
         assert!(account_path_first.exists());

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -72,6 +72,7 @@ pub use archive_format::*;
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
 pub const SNAPSHOT_STATE_COMPLETE_FILENAME: &str = "state_complete";
+pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 25_000;
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
@@ -481,7 +482,7 @@ pub fn clean_orphaned_account_snapshot_dirs(
     let mut account_snapshot_dirs_referenced = HashSet::new();
     let snapshots = get_bank_snapshots(bank_snapshots_dir);
     for snapshot in snapshots {
-        let account_hardlinks_dir = snapshot.snapshot_dir.join("account_hardlinks");
+        let account_hardlinks_dir = snapshot.snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
         // loop through entries in the snapshot_hardlink_dir, read the symlinks, add the target to the HashSet
         fs::read_dir(&account_hardlinks_dir)
             .unwrap_or_else(|_| {
@@ -498,15 +499,13 @@ pub fn clean_orphaned_account_snapshot_dirs(
                     )
                 });
                 let path = entry.path();
-                if path.is_dir() {
-                    let target = fs::read_link(&path).unwrap_or_else(|_| {
-                        panic!(
-                            "Unable to read snapshot hardlink directory entry: {}",
-                            path.display()
-                        )
-                    });
-                    account_snapshot_dirs_referenced.insert(target);
-                }
+                let target = fs::read_link(&path).unwrap_or_else(|_| {
+                    panic!(
+                        "Unable to read snapshot hardlink directory entry: {}",
+                        path.display()
+                    )
+                });
+                account_snapshot_dirs_referenced.insert(target);
             });
     }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -471,6 +471,103 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path> + Copy) {
         .unwrap();
 }
 
+pub fn clean_orphaned_account_snapshot_dirs(
+    bank_snapshots_dir: &Path,
+    account_snapshot_paths: &Vec<PathBuf>,
+) {
+    // Create the HashSet of the account snapshot hardlink directories referenced by the snapshot dirs.
+    // This is used to clean up any hardlinks that are no longer referenced by the snapshot dirs.
+
+    let mut account_snapshot_dirs_referenced = HashSet::new();
+    let snapshots = get_bank_snapshots(&bank_snapshots_dir);
+    for snapshot in snapshots {
+        let account_hardlinks_dir = snapshot.snapshot_dir.join("account_hardlinks");
+        // loop through entries in the snapshot_hardlink_dir, read the symlinks, add the target to the HashSet
+        fs::read_dir(&account_hardlinks_dir)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Unable to read snapshot hardlink directory: {}",
+                    account_hardlinks_dir.display()
+                )
+            })
+            .for_each(|entry| {
+                let entry = entry.unwrap_or_else(|_| {
+                    panic!(
+                        "Unable to read snapshot hardlink directory entry: {}",
+                        account_hardlinks_dir.display()
+                    )
+                });
+                let path = entry.path();
+                if path.is_dir() {
+                    let target = fs::read_link(&path).unwrap_or_else(|_| {
+                        panic!(
+                            "Unable to read snapshot hardlink directory entry: {}",
+                            path.display()
+                        )
+                    });
+                    account_snapshot_dirs_referenced.insert(target);
+                }
+            });
+    }
+
+    // loop through the account snapshot hardlink directories, if the directory is not in the account_snapshot_dirs_referenced set, delete it
+    for account_snapshot_path in account_snapshot_paths {
+        fs::read_dir(&account_snapshot_path)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Unable to read snapshot hardlink directory: {}",
+                    account_snapshot_path.display()
+                )
+            })
+            .for_each(|entry| {
+                let entry = entry.unwrap_or_else(|_| {
+                    panic!(
+                        "Unable to read snapshot hardlink directory entry: {}",
+                        account_snapshot_path.display()
+                    )
+                });
+                let path = entry.path();
+                if !account_snapshot_dirs_referenced.contains(&path) {
+                    info!(
+                        "Removing unreferenced account snapshot hardlink directory: {}",
+                        path.display()
+                    );
+                    move_and_async_delete_path(&path);
+                }
+            });
+    }
+}
+
+// For all account_paths, set up the run/ and snapshot/ sub directories.
+// If the sub directories do not exist, the account_path will be cleaned because older version put account files there
+pub fn set_up_account_run_and_snapshot_paths(
+    account_paths: &Vec<PathBuf>,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    // create the run/ and snapshot/ sub directories for each account_path
+
+    let account_run_and_snapshot_paths: Vec<(PathBuf, PathBuf)> = account_paths
+        .into_iter()
+        .map(|account_path| {
+            match fs::create_dir_all(&account_path).and_then(|_| fs::canonicalize(&account_path)) {
+                Ok(account_path) => account_path,
+                Err(err) => {
+                    panic!("Unable to access account path: {account_path:?}, err: {err:?}");
+                }
+            }
+        })
+        .map(|account_path| {
+            create_accounts_run_and_snapshot_dirs(&account_path).unwrap_or_else(|err| {
+                panic!(
+                    "Unable to create account run and snapshot sub directories: {}, err: {err:?}",
+                    account_path.display()
+                );
+            })
+        })
+        .collect();
+
+    account_run_and_snapshot_paths.into_iter().unzip()
+}
+
 /// If the validator halts in the middle of `archive_snapshot_package()`, the temporary staging
 /// directory won't be cleaned up.  Call this function to clean them up.
 pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -52,7 +52,7 @@ use {
         fs::{self, File},
         io::{BufReader, BufWriter, Error as IoError, ErrorKind, Read, Seek, Write},
         path::{Path, PathBuf},
-        process::{exit, ExitStatus},
+        process::ExitStatus,
         str::FromStr,
         sync::{
             atomic::{AtomicBool, AtomicU32},
@@ -550,8 +550,7 @@ pub fn set_up_account_run_and_snapshot_paths(
             match fs::create_dir_all(account_path).and_then(|_| fs::canonicalize(account_path)) {
                 Ok(account_path) => account_path,
                 Err(err) => {
-                    eprintln!("Unable to access account path: {account_path:?}, err: {err:?}");
-                    exit(1);
+                    panic!("Unable to access account path: {account_path:?}, err: {err:?}");
                 }
             }
         })

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -478,7 +478,7 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path> + Copy) {
 /// could be deleted but the account snapshot directories were left behind, possibly by some manual operations
 /// or some legacy code not using the symlinks to clean up the acccount snapshot hardlink directories.
 /// This function cleans up any account snapshot directories that are no longer referenced by the bank
-/// snapshot dirs, to ensure propper snapshot operations.
+/// snapshot dirs, to ensure proper snapshot operations.
 pub fn clean_orphaned_account_snapshot_dirs(
     bank_snapshots_dir: impl AsRef<Path>,
     account_snapshot_paths: &[PathBuf],
@@ -545,10 +545,11 @@ pub fn clean_orphaned_account_snapshot_dirs(
 }
 
 /// For all account_paths, set up the run/ and snapshot/ sub directories.
-/// If the sub directories do not exist, the account_path will be cleaned because older version put account files there
+/// If the sub directories do not exist, the account_path will be cleaned because older version put account files there.
+/// It returns (run_paths, snapshot_paths) or error
 pub fn set_up_account_run_and_snapshot_paths(
     account_paths: &[PathBuf],
-) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> // (run_paths, snapshot_paths) or error
+) -> Result<(Vec<PathBuf>, Vec<PathBuf>)>
 {
     Ok(account_paths
         .iter()

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1006,8 +1006,8 @@ pub fn create_accounts_run_and_snapshot_dirs(
     Ok((run_path, snapshot_path))
 }
 
-/// For all account_paths, set up the run/ and snapshot/ sub directories.
-/// If the sub directories do not exist, the account_path will be cleaned because older version put account files there.
+/// For all account_paths, create the run/ and snapshot/ sub directories.
+/// If an account_path directory does not exist, create it.
 /// It returns (account_run_paths, account_snapshot_paths) or error
 pub fn create_all_accounts_run_and_snapshot_dirs(
     account_paths: &[PathBuf],

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1351,15 +1351,10 @@ pub fn main() {
             .ok();
 
     let (account_run_paths, account_snapshot_paths) =
-        match create_all_accounts_run_and_snapshot_dirs(&account_paths) {
-            Ok((account_run_paths, account_snapshot_paths)) => {
-                (account_run_paths, account_snapshot_paths)
-            }
-            Err(err) => {
-                eprintln!("Error: {err:?}");
-                exit(1);
-            }
-        };
+        create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap_or_else(|err| {
+            eprintln!("Error: {err:?}");
+            exit(1);
+        });
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     validator_config.account_paths = account_run_paths;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1351,7 +1351,15 @@ pub fn main() {
             .ok();
 
     let (account_run_paths, account_snapshot_paths) =
-        set_up_account_run_and_snapshot_paths(&account_paths);
+        match set_up_account_run_and_snapshot_paths(&account_paths) {
+            Ok((account_run_paths, account_snapshot_paths)) => {
+                (account_run_paths, account_snapshot_paths)
+            }
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                exit(1);
+            }
+        };
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     validator_config.account_paths = account_run_paths;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1350,6 +1350,16 @@ pub fn main() {
             .map(|shrink_paths| shrink_paths.into_iter().map(PathBuf::from).collect())
             .ok();
 
+    // Create and canonicalize account paths to avoid issues with symlink creation
+    account_paths.iter().for_each(|account_path| {
+        fs::create_dir_all(account_path)
+            .and_then(|_| fs::canonicalize(account_path))
+            .unwrap_or_else(|err| {
+                eprintln!("Unable to access account path: {account_path:?}, err: {err:?}");
+                exit(1);
+            });
+    });
+
     let (account_run_paths, account_snapshot_paths) =
         create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap_or_else(|err| {
             eprintln!("Error: {err:?}");

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -40,7 +40,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
-            self, set_up_account_run_and_snapshot_paths, ArchiveFormat, SnapshotVersion,
+            self, create_all_accounts_run_and_snapshot_dirs, ArchiveFormat, SnapshotVersion,
         },
     },
     solana_sdk::{
@@ -1351,7 +1351,7 @@ pub fn main() {
             .ok();
 
     let (account_run_paths, account_snapshot_paths) =
-        match set_up_account_run_and_snapshot_paths(&account_paths) {
+        match create_all_accounts_run_and_snapshot_dirs(&account_paths) {
             Ok((account_run_paths, account_snapshot_paths)) => {
                 (account_run_paths, account_snapshot_paths)
             }


### PR DESCRIPTION
#### Problem
In the bank snapshot dir snpashot/\<slot\>/, there is account_hardlinks/ which contains a list of symlinks to <account_path>/snapshot/\<slot\>/.  When purging an old bank snapshot, the code follows the these symlinks to go to <account_path>/ to clear the old snapshot slots there.

We observed a case that there are extra <account_path>/snapshot/\<slot\>/ not referenced by the symlinks in snpashot/\<slot\>/account_hardlinks/, therefore they are left unpurged.

#### Summary of Changes

Add the function clean_orphaned_account_snapshot_dirs to clean up all <account_path>/snapshot/\<slot\>/ directories not referenced by the symlinks in  snpashot/\<slot\>/account_hardlinks/

clean_orphaned_account_snapshot_dirs requires account_snapshot_paths, which were returned by create_accounts_run_and_snapshot_dirs but dropped.  I have to change the loop to get it in the vector of tuples, and unzip to get them in its own vector.
I have to do the same for both validator and ledger.  It is better to factor the common logic into one utility function and put it into a util file than duplicating the logic in the validator and ledger main

This is part of the effort to boot the validator from the snapshot directory. https://github.com/solana-labs/solana/pull/28745.  It fix the issues resulted from https://github.com/solana-labs/solana/pull/29496

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
