### PR TITLE
ci: add SCCACHE_S3_KEY_PREFIX

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-eval "$(ejson2env .buildkite/env/secrets.ejson)"
+# eval "$(ejson2env .buildkite/env/secrets.ejson)"
 
 # Ensure the pattern "+++ ..." never occurs when |set -x| is set, as buildkite
 # interprets this as the start of a log group.
@@ -19,3 +19,8 @@ pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
 if [[ ${HOST_RUST_VERSION} =~ ${pattern} ]]; then
     HOST_RUST_VERSION="${rust_stable%.*}"
 fi
+
+export SBF_TOOLS_VERSION
+
+SCCACHE_S3_KEY_PREFIX="${rust_stable}_${rust_nightly}_${SBF_TOOLS_VERSION}"
+export SCCACHE_S3_KEY_PREFIX

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -62,6 +62,7 @@ if [[ -n $CI ]]; then
         --env AWS_SECRET_ACCESS_KEY
         --env SCCACHE_BUCKET
         --env SCCACHE_REGION
+        --env SCCACHE_S3_KEY_PREFIX
       )
     fi
   fi


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1083170016163274812

#### Summary of Changes

add `SCCACHE_S3_KEY_PREFIX` to share cache in a more stable way. It will create a folder for us. for now I use 
`SCCACHE_S3_KEY_PREFIX="${rust_stable}_${rust_nightly}_${SBF_TOOLS_VERSION}"`

it looks like this on s3
<img width="1112" alt="Screenshot 2023-03-09 at 7 01 48 PM" src="https://user-images.githubusercontent.com/8209234/224006572-98095324-3991-4a68-8922-a7a43553044a.png">


Close #29366