### PR TITLE
Adds accounts hashes from full & incremental snapshots at startup

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -124,7 +124,7 @@ where
         None,
         &Arc::default(),
         None,
-        u64::default(),
+        (u64::default(), None),
     )
     .map(|(accounts_db, _)| accounts_db)
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2187,7 +2187,7 @@ fn bank_fields_from_snapshots(
         Ok(
             match incremental_snapshot_version.unwrap_or(full_snapshot_version) {
                 SnapshotVersion::V1_2_0 => fields_from_streams(SerdeStyle::Newer, snapshot_streams)
-                    .map(|(bank_fields, _accountsdb_fields)| bank_fields),
+                    .map(|(bank_fields, _accountsdb_fields)| bank_fields.collapse_into()),
             }?,
         )
     })


### PR DESCRIPTION
#### Problem

For Incremental Accounts Hash, we'll need the associated full snapshot's accounts hash and capitalization. In AccountsHashVerifier (AHV) we currently remember the last full snapshot we processed, however this won't work if the first snapshot package to process is an incremental snapshot. IOW, if AHV hasn't processed a full snapshot yet, it won't have information about one, in the case where its first package to process is an incremental snapshot.

When reconstructing the bank and accounts db during load/deserialization, we *do* update the accounts db with the accounts hash and capitalization, but *only from the latest snapshot*. Thus, if we've started up from a full and incremental snapshot, we would've only written the accounts hash & capitalization information *from the incremental snapshot* into the accounts db.

Obviously this is a problem for AHV.

Luckily, we have the accounts hashes & capitalizations from both/all snapshots at startup, which means we have the information from the full snapshot that AHV needs!


#### Summary of Changes

When reconstructing AccountsDb from snapshots, add the accounts hash & capitalization from both/all snapshots into the new AccountsDb (instead of just the latest).