### PR TITLE
AccountsHashVerifier updates AccountsDb after calculating accounts hash

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -244,7 +244,18 @@ impl AccountsHashVerifier {
                 &sorted_storages,
                 timings,
             )
-            .unwrap();
+            .unwrap(); // unwrap here will never fail since check_hash = false
+
+        let old_accounts_hash = accounts_package
+            .accounts
+            .accounts_db
+            .set_accounts_hash(accounts_package.slot, (accounts_hash, lamports));
+        if let Some(old_accounts_hash) = old_accounts_hash {
+            warn!(
+                "Accounts hash was already set for slot {}! old: {}, new: {}",
+                accounts_package.slot, &old_accounts_hash.0 .0, &accounts_hash.0
+            );
+        }
 
         if accounts_package.expected_capitalization != lamports {
             // before we assert, run the hash calc again. This helps track down whether it could have been a failure in a race condition possibly with shrink.

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7353,7 +7353,7 @@ impl AccountsDb {
     /// Set the accounts hash for `slot` in the `accounts_hashes` map
     ///
     /// returns the previous accounts hash for `slot`
-    fn set_accounts_hash(
+    pub fn set_accounts_hash(
         &self,
         slot: Slot,
         accounts_hash: (AccountsHash, /*capitalization*/ u64),


### PR DESCRIPTION
#### Problem

For Incremental Accounts Hash, when processing an incremental snapshot package in AccountsHashVerifier (AHV), we will need to get the full snapshot's accounts hash and capitalization. That information will come from `AccountsDb::accounts_hashes`. But right now *no one*[^1] updates `AccountsDb::accounts_hashes`. Thus, the full snapshot's accounts hash and capitalization are *not* available in AHV when needed.


#### Summary of Changes

In AHV, update `AccountsDb::accounts_hashes` with the calculated accounts hash and capitalization


[^1]: When creating a snapshot with ledger-tool, `AccountsDb::accounts_hashes` is updated. But that's not useful/usable for a normal validator.