### PR TITLE
Enable JIT in Bank::new_with_config_for_tests()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1265,7 +1265,10 @@ impl Bank {
     ) -> Self {
         Self::new_with_paths_for_tests(
             genesis_config,
-            Arc::<RuntimeConfig>::default(),
+            Arc::new(RuntimeConfig {
+                bpf_jit: true,
+                ..RuntimeConfig::default()
+            }),
             Vec::new(),
             account_indexes,
             shrink_ratio,


### PR DESCRIPTION
The most common validator configuration is JIT on, so test that. On platforms that don't support JIT we'll still fallback on the interpreter.