### PR TITLE
Remove locks from geyser plugin

### DIFF
--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -17,11 +17,11 @@ use {
         pubkey::Pubkey,
         transaction::SanitizedTransaction,
     },
-    std::sync::{Arc, RwLock},
+    std::sync::Arc,
 };
 #[derive(Debug)]
 pub(crate) struct AccountsUpdateNotifierImpl {
-    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    plugin_manager: Arc<GeyserPluginManager>,
 }
 
 impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
@@ -68,12 +68,7 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
     }
 
     fn notify_end_of_restore_from_snapshot(&self) {
-        let plugin_manager = self.plugin_manager.read().unwrap();
-        if plugin_manager.plugins.is_empty() {
-            return;
-        }
-
-        for plugin in plugin_manager.plugins.iter() {
+        for plugin in self.plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-end-of-restore-from-snapshot");
             match plugin.notify_end_of_startup() {
                 Err(err) => {
@@ -100,7 +95,7 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
 }
 
 impl AccountsUpdateNotifierImpl {
-    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+    pub fn new(plugin_manager: Arc<GeyserPluginManager>) -> Self {
         AccountsUpdateNotifierImpl { plugin_manager }
     }
 
@@ -145,13 +140,12 @@ impl AccountsUpdateNotifierImpl {
         slot: Slot,
         is_startup: bool,
     ) {
-        let mut measure2 = Measure::start("geyser-plugin-notify_plugins_of_account_update");
-        let plugin_manager = self.plugin_manager.read().unwrap();
-
-        if plugin_manager.plugins.is_empty() {
+        if self.plugin_manager.plugins.is_empty() {
             return;
         }
-        for plugin in plugin_manager.plugins.iter() {
+
+        let mut measure2 = Measure::start("geyser-plugin-notify_plugins_of_account_update");
+        for plugin in self.plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-account");
             match plugin.update_account(
                 ReplicaAccountInfoVersions::V0_0_3(&account),

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -16,7 +16,7 @@ use {
 };
 
 pub(crate) struct BlockMetadataNotifierImpl {
-    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    plugin_manager: Arc<GeyserPluginManager>,
 }
 
 impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
@@ -32,13 +32,12 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
     ) {
-        let plugin_manager = self.plugin_manager.read().unwrap();
-        if plugin_manager.plugins.is_empty() {
+        if self.plugin_manager.plugins.is_empty() {
             return;
         }
         let rewards = Self::build_rewards(rewards);
 
-        for plugin in plugin_manager.plugins.iter() {
+        for plugin in self.plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             let block_info = Self::build_replica_block_info(
                 parent_slot,
@@ -116,7 +115,7 @@ impl BlockMetadataNotifierImpl {
         }
     }
 
-    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+    pub fn new(plugin_manager: Arc<GeyserPluginManager>) -> Self {
         Self { plugin_manager }
     }
 }

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -18,6 +18,8 @@ pub trait BlockMetadataNotifier {
         block_height: Option<u64>,
         executed_transaction_count: u64,
     );
+
+    fn join(&mut self);
 }
 
 pub type BlockMetadataNotifierLock = Arc<RwLock<dyn BlockMetadataNotifier + Sync + Send>>;

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -42,34 +42,28 @@ impl GeyserPluginManager {
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire
     /// their `on_plugin_unload()` methods so they can do any necessary cleanup.
-    pub fn unload(&mut self) {
-        for mut plugin in self.plugins.drain(..) {
+    pub fn unload(self) {
+        for mut plugin in self.plugins {
             info!("Unloading plugin for {:?}", plugin.name());
             plugin.on_unload();
         }
 
-        for lib in self.libs.drain(..) {
+        for lib in self.libs {
             drop(lib);
         }
     }
 
     /// Check if there is any plugin interested in account data
     pub fn account_data_notifications_enabled(&self) -> bool {
-        for plugin in &self.plugins {
-            if plugin.account_data_notifications_enabled() {
-                return true;
-            }
-        }
-        false
+        self.plugins
+            .iter()
+            .any(|plugin| plugin.account_data_notifications_enabled())
     }
 
     /// Check if there is any plugin interested in transaction data
     pub fn transaction_notifications_enabled(&self) -> bool {
-        for plugin in &self.plugins {
-            if plugin.transaction_notifications_enabled() {
-                return true;
-            }
-        }
-        false
+        self.plugins
+            .iter()
+            .any(|plugin| plugin.transaction_notifications_enabled())
     }
 }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -42,13 +42,13 @@ impl GeyserPluginManager {
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire
     /// their `on_plugin_unload()` methods so they can do any necessary cleanup.
-    pub fn unload(self) {
-        for mut plugin in self.plugins {
+    pub fn unload(&mut self) {
+        for mut plugin in self.plugins.drain(..) {
             info!("Unloading plugin for {:?}", plugin.name());
             plugin.on_unload();
         }
 
-        for lib in self.libs {
+        for lib in self.libs.drain(..) {
             drop(lib);
         }
     }

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -201,11 +201,20 @@ impl GeyserPluginService {
         self.block_metadata_notifier.clone()
     }
 
-    pub fn join(self) -> thread::Result<()> {
+    pub fn join(mut self) -> thread::Result<()> {
         if let Some(mut slot_status_observer) = self.slot_status_observer {
             slot_status_observer.join()?;
         }
-        self.plugin_manager.unload();
+        if let Some(accounts_update_notifier) = self.accounts_update_notifier {
+            accounts_update_notifier.write().unwrap().join();
+        }
+        if let Some(transaction_notifier) = self.transaction_notifier {
+            transaction_notifier.write().unwrap().join();
+        }
+        if let Some(block_metadata_notifier) = self.block_metadata_notifier {
+            block_metadata_notifier.write().unwrap().join();
+        }
+        Arc::get_mut(&mut self.plugin_manager).unwrap().unload();
         Ok(())
     }
 }

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -47,7 +47,7 @@ pub enum GeyserPluginServiceError {
 /// The service managing the Geyser plugin workflow.
 pub struct GeyserPluginService {
     slot_status_observer: Option<SlotStatusObserver>,
-    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    plugin_manager: Arc<GeyserPluginManager>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     transaction_notifier: Option<TransactionNotifierLock>,
     block_metadata_notifier: Option<BlockMetadataNotifierLock>,
@@ -84,7 +84,7 @@ impl GeyserPluginService {
             plugin_manager.account_data_notifications_enabled();
         let transaction_notifications_enabled = plugin_manager.transaction_notifications_enabled();
 
-        let plugin_manager = Arc::new(RwLock::new(plugin_manager));
+        let plugin_manager = Arc::new(plugin_manager);
 
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
             if account_data_notifications_enabled {
@@ -205,7 +205,7 @@ impl GeyserPluginService {
         if let Some(mut slot_status_observer) = self.slot_status_observer {
             slot_status_observer.join()?;
         }
-        self.plugin_manager.write().unwrap().unload();
+        self.plugin_manager.unload();
         Ok(())
     }
 }

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -22,7 +22,7 @@ pub trait SlotStatusNotifierInterface {
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;
 
 pub struct SlotStatusNotifierImpl {
-    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    plugin_manager: Arc<GeyserPluginManager>,
 }
 
 impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
@@ -40,17 +40,12 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
 }
 
 impl SlotStatusNotifierImpl {
-    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+    pub fn new(plugin_manager: Arc<GeyserPluginManager>) -> Self {
         Self { plugin_manager }
     }
 
     pub fn notify_slot_status(&self, slot: Slot, parent: Option<Slot>, slot_status: SlotStatus) {
-        let plugin_manager = self.plugin_manager.read().unwrap();
-        if plugin_manager.plugins.is_empty() {
-            return;
-        }
-
-        for plugin in plugin_manager.plugins.iter() {
+        for plugin in self.plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             match plugin.update_slot_status(slot, parent, slot_status) {
                 Err(err) => {

--- a/geyser-plugin-manager/src/slot_status_observer.rs
+++ b/geyser-plugin-manager/src/slot_status_observer.rs
@@ -74,6 +74,7 @@ impl SlotStatusObserver {
                         }
                     }
                 }
+                slot_status_notifier.write().unwrap().join();
             })
             .unwrap()
     }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -10,7 +10,7 @@ use {
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
     solana_sdk::{clock::Slot, signature::Signature, transaction::SanitizedTransaction},
     solana_transaction_status::TransactionStatusMeta,
-    std::sync::{Arc, RwLock},
+    std::sync::Arc,
 };
 
 /// This implementation of TransactionNotifier is passed to the rpc's TransactionStatusService
@@ -18,7 +18,7 @@ use {
 /// for new transactions. The implementation in turn invokes the notify_transaction of each
 /// plugin enabled with transaction notification managed by the GeyserPluginManager.
 pub(crate) struct TransactionNotifierImpl {
-    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    plugin_manager: Arc<GeyserPluginManager>,
 }
 
 impl TransactionNotifier for TransactionNotifierImpl {
@@ -30,6 +30,10 @@ impl TransactionNotifier for TransactionNotifierImpl {
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
     ) {
+        if self.plugin_manager.plugins.is_empty() {
+            return;
+        }
+
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
         let transaction_log_info = Self::build_replica_transaction_info(
             index,
@@ -38,13 +42,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
             transaction,
         );
 
-        let plugin_manager = self.plugin_manager.read().unwrap();
-
-        if plugin_manager.plugins.is_empty() {
-            return;
-        }
-
-        for plugin in plugin_manager.plugins.iter() {
+        for plugin in self.plugin_manager.plugins.iter() {
             if !plugin.transaction_notifications_enabled() {
                 continue;
             }
@@ -78,7 +76,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
 }
 
 impl TransactionNotifierImpl {
-    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+    pub fn new(plugin_manager: Arc<GeyserPluginManager>) -> Self {
         Self { plugin_manager }
     }
 

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -13,6 +13,8 @@ pub trait TransactionNotifier {
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
     );
+
+    fn join(&mut self);
 }
 
 pub type TransactionNotifierLock = Arc<RwLock<dyn TransactionNotifier + Sync + Send>>;

--- a/runtime/src/accounts_update_notifier_interface.rs
+++ b/runtime/src/accounts_update_notifier_interface.rs
@@ -23,6 +23,8 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);
+
+    fn join(&mut self);
 }
 
 pub type AccountsUpdateNotifier = Arc<RwLock<dyn AccountsUpdateNotifierInterface + Sync + Send>>;


### PR DESCRIPTION
#### Problem

Locks in geyser plugin. Initial PR with removing `&mut`  in notifications methods: https://github.com/solana-labs/solana/pull/30380

#### Summary of Changes

I added `fn join(&mut self)` to notification interface which should stop `GeyserPluginManager` usage on shutdown, this allows us to be sure that we have only 1 reference and we can use `Arc::get_mut` to get plugin manager and unload plugins without locks.

cc @nickgarfield @lijunwangs