### PR TITLE
add top turbine addrs datapoint

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -117,9 +117,9 @@ impl WindowServiceMetrics {
                 i64
             ),
             ("num_addrs", self.addrs.len(), i64),
-            ("top_addr_1", packed_ips.next().unwrap_or(0), i64),
-            ("top_addr_2", packed_ips.next().unwrap_or(0), i64),
-            ("top_addr_3", packed_ips.next().unwrap_or(0), i64),
+            ("top_addr_as_int_1", packed_ips.next().unwrap_or(0), i64),
+            ("top_addr_as_int_2", packed_ips.next().unwrap_or(0), i64),
+            ("top_addr_as_int_3", packed_ips.next().unwrap_or(0), i64),
         );
 
         info!(


### PR DESCRIPTION
#### Problem
Top turbine sender addresses are only logged to info log.

#### Summary of Changes
Add `datapoint_info` metric to mirror data logged with `info!()`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
