### PR TITLE
Add .codecov.yml with checks disabled

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+comment:
+  behavior: default
+  layout: diff
+  require_changes: false
+coverage:
+  precision: 1
+  range:
+  - 50.0
+  - 100.0
+  round: down
+  status:
+    patch: false
+    project: false
+github_checks: false

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13,7 +13,7 @@
 //!
 //! The bank then stores the results to the accounts store.
 //!
-//! It then has apis for retrieving if a transaction has been processed and it's status.
+//! It then has APIs for retrieving if a transaction has been processed and it's status.
 //! See `get_signature_status` et al.
 //!
 //! Bank lifecycle:


### PR DESCRIPTION
#### Problem

restored codecov caused some issues: https://discord.com/channels/428295358100013066/560503042458517505/1083472186305675435

this is original yml (no text; took only screenshot when reviewing codecov's settings before enabling; never expected this would cause troubles and yml is nuked now... lol):

![image](https://user-images.githubusercontent.com/117807/224240117-6a5d32af-284b-4489-9b55-755f5a85b4ae.png)


#### Summary of Changes

- Removed `fixes: ... web3` thing (no longer needed thanks to #30062)
- Added `github_checks: false`. (this is crucial not to block merge, i think)

#### Sanity checks

```
$ curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "comment": {
    "behavior": "default",
    "layout": "diff",
    "require_changes": false
  },
  "coverage": {
    "precision": 1,
    "range": [
      50.0,
      100.0
    ],
    "round": "down",
    "status": {
      "patch": false,
      "project": false
    }
  },
  "github_checks": false
}

```