### PR TITLE
Improves logs in bank verification at startup

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7275,13 +7275,14 @@ impl Bank {
     ) -> bool {
         let (_, clean_time_us) = measure_us!({
             let should_clean = !accounts_db_skip_shrink && self.slot() > 0;
-            info!("Cleaning...");
-            self.rc
-                .accounts
-                .accounts_db
-                .clean_accounts(None, true, Some(last_full_snapshot_slot));
-            info!("Cleaning... Done.");
             if should_clean {
+                info!("Cleaning...");
+                self.rc.accounts.accounts_db.clean_accounts(
+                    None,
+                    true,
+                    Some(last_full_snapshot_slot),
+                );
+                info!("Cleaning... Done.");
             } else {
                 info!("Cleaning... Skipped.");
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7273,62 +7273,74 @@ impl Bank {
         accounts_db_skip_shrink: bool,
         last_full_snapshot_slot: Slot,
     ) -> bool {
-        let mut clean_time = Measure::start("clean");
-        if !accounts_db_skip_shrink && self.slot() > 0 {
-            info!("cleaning..");
+        let (_, clean_time_us) = measure_us!({
+            let should_clean = !accounts_db_skip_shrink && self.slot() > 0;
+            info!("Cleaning...");
             self.rc
                 .accounts
                 .accounts_db
                 .clean_accounts(None, true, Some(last_full_snapshot_slot));
-        }
-        clean_time.stop();
+            info!("Cleaning... Done.");
+            if should_clean {
+            } else {
+                info!("Cleaning... Skipped.");
+            }
+        });
 
-        let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
-        if !accounts_db_skip_shrink && self.slot() > 0 {
-            info!("shrinking..");
-            self.rc
-                .accounts
-                .accounts_db
-                .shrink_all_slots(true, Some(last_full_snapshot_slot));
-        }
-        shrink_all_slots_time.stop();
+        let (_, shrink_time_us) = measure_us!({
+            let should_shrink = !accounts_db_skip_shrink && self.slot() > 0;
+            if should_shrink {
+                info!("Shrinking...");
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .shrink_all_slots(true, Some(last_full_snapshot_slot));
+                info!("Shrinking... Done.");
+            } else {
+                info!("Shrinking... Skipped.");
+            }
+        });
 
-        let (mut verify, verify_time_us) = if !self.rc.accounts.accounts_db.skip_initial_hash_calc {
-            info!("verify_bank_hash..");
-            let mut verify_time = Measure::start("verify_bank_hash");
-            let verify = self.verify_bank_hash(VerifyBankHash {
-                test_hash_calculation,
-                ignore_mismatch: false,
-                require_rooted_bank: false,
-                run_in_background: true,
-                store_hash_raw_data_for_debug: false,
-            });
-            verify_time.stop();
-            (verify, verify_time.as_us())
-        } else {
-            self.rc
-                .accounts
-                .accounts_db
-                .verify_accounts_hash_in_bg
-                .verification_complete();
-            (true, 0)
-        };
+        let (verified_accounts, verify_accounts_time_us) = measure_us!({
+            let should_verify_accounts = !self.rc.accounts.accounts_db.skip_initial_hash_calc;
+            if should_verify_accounts {
+                info!("Verifying accounts...");
+                let verified = self.verify_bank_hash(VerifyBankHash {
+                    test_hash_calculation,
+                    ignore_mismatch: false,
+                    require_rooted_bank: false,
+                    run_in_background: true,
+                    store_hash_raw_data_for_debug: false,
+                });
+                info!("Verifying accounts... In background.");
+                verified
+            } else {
+                info!("Verifying accounts... Skipped.");
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .verify_accounts_hash_in_bg
+                    .verification_complete();
+                true
+            }
+        });
 
-        info!("verify_hash..");
-        let mut verify2_time = Measure::start("verify_hash");
-        // Order and short-circuiting is significant; verify_hash requires a valid bank hash
-        verify = verify && self.verify_hash();
-        verify2_time.stop();
+        let (verified_bank, verify_bank_time_us) = measure_us!({
+            info!("Verifying bank...");
+            let verified = self.verify_hash();
+            info!("Verifying bank... Done.");
+            verified
+        });
 
         datapoint_info!(
             "verify_snapshot_bank",
-            ("clean_us", clean_time.as_us(), i64),
-            ("shrink_all_slots_us", shrink_all_slots_time.as_us(), i64),
-            ("verify_bank_hash_us", verify_time_us, i64),
-            ("verify_hash_us", verify2_time.as_us(), i64),
+            ("clean_us", clean_time_us, i64),
+            ("shrink_us", shrink_time_us, i64),
+            ("verify_accounts_us", verify_accounts_time_us, i64),
+            ("verify_bank_us", verify_bank_time_us, i64),
         );
 
-        verify
+        verified_accounts && verified_bank
     }
 
     /// Return the number of hashes per tick


### PR DESCRIPTION
#### Problem

The logs at startup when verifying a snapshot bank leave more to be desired—at least from me.
- It would be nice to know when each step completes
- It would be nice to know if a step was skipped
- The accounts hash calculation and verification is called "bank hash"
- The bank hash verification is just called "hash", so it's a bit confusing to see this right after seeing "verify_bank_hash.."


#### Summary of Changes

* Add explicit logs for when each step is done or skipped
* Correct the naming for accounts hash vs bank hash verification

Note, the diff makes it look like a lot changed. There was no change to any *functionality* (or at least there should not be). I recommend ignoring whitespace in the diff to make this more obvious.