### PR TITLE
Renames fns to verify_accounts_hash

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1533,7 +1533,7 @@ fn load_frozen_forks(
 fn run_final_hash_calc(bank: &Bank, on_halt_store_hash_raw_data_for_debug: bool) {
     bank.force_flush_accounts_cache();
     // note that this slot may not be a root
-    let _ = bank.verify_bank_hash(VerifyBankHash {
+    let _ = bank.verify_accounts_hash(VerifyBankHash {
         test_hash_calculation: false,
         ignore_mismatch: true,
         require_rooted_bank: false,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -100,7 +100,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         .update_accounts_hash_for_tests(0, &ancestors, false, false);
     let test_hash_calculation = false;
     bencher.iter(|| {
-        assert!(accounts.verify_bank_hash_and_lamports(
+        assert!(accounts.verify_accounts_hash_and_lamports(
             0,
             total_lamports,
             BankHashLamportsVerifyConfig {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -862,7 +862,7 @@ impl Accounts {
 
     /// Only called from startup or test code.
     #[must_use]
-    pub fn verify_bank_hash_and_lamports(
+    pub fn verify_accounts_hash_and_lamports(
         &self,
         slot: Slot,
         total_lamports: u64,
@@ -870,9 +870,9 @@ impl Accounts {
     ) -> bool {
         if let Err(err) =
             self.accounts_db
-                .verify_bank_hash_and_lamports(slot, total_lamports, config)
+                .verify_accounts_hash_and_lamports(slot, total_lamports, config)
         {
-            warn!("verify_bank_hash failed: {:?}, slot: {}", err, slot);
+            warn!("verify_accounts_hash failed: {err:?}, slot: {slot}");
             false
         } else {
             true

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7640,7 +7640,7 @@ impl AccountsDb {
     }
 
     /// Only called from startup or test code.
-    pub fn verify_bank_hash_and_lamports(
+    pub fn verify_accounts_hash_and_lamports(
         &self,
         slot: Slot,
         total_lamports: u64,
@@ -7680,8 +7680,8 @@ impl AccountsDb {
                 Ok(())
             } else {
                 warn!(
-                    "mismatched bank hash for slot {}: {:?} (calculated) != {:?} (expected)",
-                    slot, calculated_accounts_hash, found_accounts_hash,
+                    "mismatched accounts hash for slot {slot}: \
+                    {calculated_accounts_hash:?} (calculated) != {found_accounts_hash:?} (expected)"
                 );
                 Err(MismatchedBankHash)
             }
@@ -12196,7 +12196,7 @@ pub mod tests {
         );
 
         accounts
-            .verify_bank_hash_and_lamports(4, 1222, config)
+            .verify_accounts_hash_and_lamports(4, 1222, config)
             .unwrap();
     }
 
@@ -12620,21 +12620,21 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, 1, config.clone()),
+            db.verify_accounts_hash_and_lamports(some_slot, 1, config.clone()),
             Ok(_)
         );
 
         db.remove_bank_hash_info(&some_slot);
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, 1, config.clone()),
+            db.verify_accounts_hash_and_lamports(some_slot, 1, config.clone()),
             Err(MissingBankHash)
         );
 
         db.set_accounts_hash(some_slot, AccountsHash(Hash::new(&[0xca; HASH_BYTES])));
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, 1, config),
+            db.verify_accounts_hash_and_lamports(some_slot, 1, config),
             Err(MismatchedBankHash)
         );
     }
@@ -12665,7 +12665,7 @@ pub mod tests {
                 db.update_accounts_hash_for_tests(some_slot, &ancestors, true, true);
 
                 assert_matches!(
-                    db.verify_bank_hash_and_lamports(some_slot, 1, config.clone()),
+                    db.verify_accounts_hash_and_lamports(some_slot, 1, config.clone()),
                     Ok(_)
                 );
                 continue;
@@ -12683,12 +12683,12 @@ pub mod tests {
             db.update_accounts_hash_for_tests(some_slot, &ancestors, true, true);
 
             assert_matches!(
-                db.verify_bank_hash_and_lamports(some_slot, 2, config.clone()),
+                db.verify_accounts_hash_and_lamports(some_slot, 2, config.clone()),
                 Ok(_)
             );
 
             assert_matches!(
-                db.verify_bank_hash_and_lamports(some_slot, 10, config),
+                db.verify_accounts_hash_and_lamports(some_slot, 10, config),
                 Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
             );
         }
@@ -12714,7 +12714,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, 0, config),
+            db.verify_accounts_hash_and_lamports(some_slot, 0, config),
             Ok(_)
         );
     }
@@ -12754,7 +12754,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, 1, config),
+            db.verify_accounts_hash_and_lamports(some_slot, 1, config),
             Err(MismatchedBankHash)
         );
     }
@@ -13294,12 +13294,12 @@ pub mod tests {
 
             accounts.update_accounts_hash_for_tests(current_slot, &no_ancestors, false, false);
             accounts
-                .verify_bank_hash_and_lamports(current_slot, 22300, config.clone())
+                .verify_accounts_hash_and_lamports(current_slot, 22300, config.clone())
                 .unwrap();
 
             let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
             accounts
-                .verify_bank_hash_and_lamports(current_slot, 22300, config)
+                .verify_accounts_hash_and_lamports(current_slot, 22300, config)
                 .unwrap();
 
             // repeating should be no-op

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6944,7 +6944,7 @@ impl Bank {
     /// return true if all is good
     /// Only called from startup or test code.
     #[must_use]
-    pub fn verify_bank_hash(&self, config: VerifyBankHash) -> bool {
+    pub fn verify_accounts_hash(&self, config: VerifyBankHash) -> bool {
         let accounts = &self.rc.accounts;
         // Wait until initial hash calc is complete before starting a new hash calc.
         // This should only occur when we halt at a slot in ledger-tool.
@@ -6961,7 +6961,7 @@ impl Bank {
         {
             if let Some(parent) = self.parent() {
                 info!("{} is not a root, so attempting to verify bank hash on parent bank at slot: {}", self.slot(), parent.slot());
-                return parent.verify_bank_hash(config);
+                return parent.verify_accounts_hash(config);
             } else {
                 // this will result in mismatch errors
                 // accounts hash calc doesn't include unrooted slots
@@ -6986,7 +6986,7 @@ impl Bank {
                         info!(
                             "running initial verification accounts hash calculation in background"
                         );
-                        let result = accounts_.verify_bank_hash_and_lamports(
+                        let result = accounts_.verify_accounts_hash_and_lamports(
                             slot,
                             cap,
                             BankHashLamportsVerifyConfig {
@@ -7009,7 +7009,7 @@ impl Bank {
             });
             true // initial result is true. We haven't failed yet. If verification fails, we'll panic from bg thread.
         } else {
-            let result = accounts.verify_bank_hash_and_lamports(
+            let result = accounts.verify_accounts_hash_and_lamports(
                 slot,
                 cap,
                 BankHashLamportsVerifyConfig {
@@ -7307,7 +7307,7 @@ impl Bank {
             let should_verify_accounts = !self.rc.accounts.accounts_db.skip_initial_hash_calc;
             if should_verify_accounts {
                 info!("Verifying accounts...");
-                let verified = self.verify_bank_hash(VerifyBankHash {
+                let verified = self.verify_accounts_hash(VerifyBankHash {
                     test_hash_calculation,
                     ignore_mismatch: false,
                     require_rooted_bank: false,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2744,7 +2744,7 @@ fn test_purge_empty_accounts() {
 
         if pass == 0 {
             add_root_and_flush_write_cache(&bank0);
-            assert!(bank0.verify_bank_hash(VerifyBankHash::default_for_test()));
+            assert!(bank0.verify_accounts_hash(VerifyBankHash::default_for_test()));
             continue;
         }
 
@@ -2753,7 +2753,7 @@ fn test_purge_empty_accounts() {
         bank0.squash();
         add_root_and_flush_write_cache(&bank0);
         if pass == 1 {
-            assert!(bank0.verify_bank_hash(VerifyBankHash::default_for_test()));
+            assert!(bank0.verify_accounts_hash(VerifyBankHash::default_for_test()));
             continue;
         }
 
@@ -2761,7 +2761,7 @@ fn test_purge_empty_accounts() {
         bank1.squash();
         add_root_and_flush_write_cache(&bank1);
         bank1.update_accounts_hash_for_tests();
-        assert!(bank1.verify_bank_hash(VerifyBankHash::default_for_test()));
+        assert!(bank1.verify_accounts_hash(VerifyBankHash::default_for_test()));
 
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
@@ -2769,7 +2769,7 @@ fn test_purge_empty_accounts() {
 
         bank1.clean_accounts_for_tests();
 
-        assert!(bank1.verify_bank_hash(VerifyBankHash::default_for_test()));
+        assert!(bank1.verify_accounts_hash(VerifyBankHash::default_for_test()));
     }
 }
 
@@ -3923,7 +3923,7 @@ fn test_bank_hash_internal_state() {
     add_root_and_flush_write_cache(&bank1);
     add_root_and_flush_write_cache(&bank2);
     bank2.update_accounts_hash_for_tests();
-    assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
+    assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
 }
 
 #[test]
@@ -3953,13 +3953,13 @@ fn test_bank_hash_internal_state_verify() {
             // we later modify bank 2, so this flush is destructive to the test
             add_root_and_flush_write_cache(&bank2);
             bank2.update_accounts_hash_for_tests();
-            assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
+            assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
         }
         let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set the bank hash in the pass==0 if above
-            assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
+            assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
             continue;
         }
         if pass == 1 {
@@ -3968,7 +3968,7 @@ fn test_bank_hash_internal_state_verify() {
             // Doing so throws an assert. So, we can't flush 3 until 2 is flushed.
             add_root_and_flush_write_cache(&bank3);
             bank3.update_accounts_hash_for_tests();
-            assert!(bank3.verify_bank_hash(VerifyBankHash::default_for_test()));
+            assert!(bank3.verify_accounts_hash(VerifyBankHash::default_for_test()));
             continue;
         }
 
@@ -3977,10 +3977,10 @@ fn test_bank_hash_internal_state_verify() {
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
         add_root_and_flush_write_cache(&bank2);
         bank2.update_accounts_hash_for_tests();
-        assert!(bank2.verify_bank_hash(VerifyBankHash::default_for_test()));
+        assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
         add_root_and_flush_write_cache(&bank3);
         bank3.update_accounts_hash_for_tests();
-        assert!(bank3.verify_bank_hash(VerifyBankHash::default_for_test()));
+        assert!(bank3.verify_accounts_hash(VerifyBankHash::default_for_test()));
     }
 }
 


### PR DESCRIPTION
#### Problem

There are verification functions that run at startup for verifying the accounts hash and the bank hash. Many of the functions that verify the accounts hash are actually named a variant of `verify_bank_hash`, which I find confusing/annoying.


#### Summary of Changes

* Rename the functions that verify the accounts hash to `verify_accounts_hash` from `verify_bank_hash`
* Update appropriate logs

Note, I purposely did not rename any types that also exhibit this same issue. That'll be a subsequent PR.
