### PR TITLE
Renames types to be consistent with verify_accounts_hash

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -24,7 +24,7 @@ use {
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank::{
             Bank, RentDebits, TransactionBalancesSet, TransactionExecutionDetails,
-            TransactionExecutionResult, TransactionResults, VerifyBankHash,
+            TransactionExecutionResult, TransactionResults, VerifyAccountsHashConfig,
         },
         bank_forks::BankForks,
         bank_utils,
@@ -1533,7 +1533,7 @@ fn load_frozen_forks(
 fn run_final_hash_calc(bank: &Bank, on_halt_store_hash_raw_data_for_debug: bool) {
     bank.force_flush_accounts_cache();
     // note that this slot may not be a root
-    let _ = bank.verify_accounts_hash(VerifyBankHash {
+    let _ = bank.verify_accounts_hash(VerifyAccountsHashConfig {
         test_hash_calculation: false,
         ignore_mismatch: true,
         require_rooted_bank: false,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -10,7 +10,8 @@ use {
     solana_runtime::{
         accounts::{AccountAddressFilter, Accounts},
         accounts_db::{
-            test_utils::create_test_accounts, AccountShrinkThreshold, BankHashLamportsVerifyConfig,
+            test_utils::create_test_accounts, AccountShrinkThreshold,
+            VerifyAccountsHashAndLamportsConfig,
         },
         accounts_index::{AccountSecondaryIndexes, ScanConfig},
         ancestors::Ancestors,
@@ -103,7 +104,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         assert!(accounts.verify_accounts_hash_and_lamports(
             0,
             total_lamports,
-            BankHashLamportsVerifyConfig {
+            VerifyAccountsHashAndLamportsConfig {
                 ancestors: &ancestors,
                 test_hash_calculation,
                 epoch_schedule: &EpochSchedule::default(),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,8 +4,9 @@ use {
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
             AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashLamportsVerifyConfig, IncludeSlotInHash, LoadHint, LoadedAccount,
-            ScanStorageResult, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            IncludeSlotInHash, LoadHint, LoadedAccount, ScanStorageResult,
+            VerifyAccountsHashAndLamportsConfig, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
             AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError, ScanResult, ZeroLamport,
@@ -866,7 +867,7 @@ impl Accounts {
         &self,
         slot: Slot,
         total_lamports: u64,
-        config: BankHashLamportsVerifyConfig,
+        config: VerifyAccountsHashAndLamportsConfig,
     ) -> bool {
         if let Err(err) =
             self.accounts_db

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -46,7 +46,7 @@ use {
         },
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDbConfig,
-            BankHashLamportsVerifyConfig, CalcAccountsHashDataSource, IncludeSlotInHash,
+            CalcAccountsHashDataSource, IncludeSlotInHash, VerifyAccountsHashAndLamportsConfig,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_hash::AccountsHash,
@@ -181,8 +181,8 @@ use {
     },
 };
 
-/// params to `verify_bank_hash`
-pub struct VerifyBankHash {
+/// params to `verify_accounts_hash`
+pub struct VerifyAccountsHashConfig {
     pub test_hash_calculation: bool,
     pub ignore_mismatch: bool,
     pub require_rooted_bank: bool,
@@ -6944,7 +6944,7 @@ impl Bank {
     /// return true if all is good
     /// Only called from startup or test code.
     #[must_use]
-    pub fn verify_accounts_hash(&self, config: VerifyBankHash) -> bool {
+    pub fn verify_accounts_hash(&self, config: VerifyAccountsHashConfig) -> bool {
         let accounts = &self.rc.accounts;
         // Wait until initial hash calc is complete before starting a new hash calc.
         // This should only occur when we halt at a slot in ledger-tool.
@@ -6989,7 +6989,7 @@ impl Bank {
                         let result = accounts_.verify_accounts_hash_and_lamports(
                             slot,
                             cap,
-                            BankHashLamportsVerifyConfig {
+                            VerifyAccountsHashAndLamportsConfig {
                                 ancestors: &ancestors,
                                 test_hash_calculation: config.test_hash_calculation,
                                 epoch_schedule: &epoch_schedule,
@@ -7012,7 +7012,7 @@ impl Bank {
             let result = accounts.verify_accounts_hash_and_lamports(
                 slot,
                 cap,
-                BankHashLamportsVerifyConfig {
+                VerifyAccountsHashAndLamportsConfig {
                     ancestors,
                     test_hash_calculation: config.test_hash_calculation,
                     epoch_schedule,
@@ -7307,7 +7307,7 @@ impl Bank {
             let should_verify_accounts = !self.rc.accounts.accounts_db.skip_initial_hash_calc;
             if should_verify_accounts {
                 info!("Verifying accounts...");
-                let verified = self.verify_accounts_hash(VerifyBankHash {
+                let verified = self.verify_accounts_hash(VerifyAccountsHashConfig {
                     test_hash_calculation,
                     ignore_mismatch: false,
                     require_rooted_bank: false,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2661,7 +2661,7 @@ fn test_bank_update_rewards_determinism() {
     }
 }
 
-impl VerifyBankHash {
+impl VerifyAccountsHashConfig {
     fn default_for_test() -> Self {
         Self {
             test_hash_calculation: true,
@@ -2744,7 +2744,7 @@ fn test_purge_empty_accounts() {
 
         if pass == 0 {
             add_root_and_flush_write_cache(&bank0);
-            assert!(bank0.verify_accounts_hash(VerifyBankHash::default_for_test()));
+            assert!(bank0.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
             continue;
         }
 
@@ -2753,7 +2753,7 @@ fn test_purge_empty_accounts() {
         bank0.squash();
         add_root_and_flush_write_cache(&bank0);
         if pass == 1 {
-            assert!(bank0.verify_accounts_hash(VerifyBankHash::default_for_test()));
+            assert!(bank0.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
             continue;
         }
 
@@ -2761,7 +2761,7 @@ fn test_purge_empty_accounts() {
         bank1.squash();
         add_root_and_flush_write_cache(&bank1);
         bank1.update_accounts_hash_for_tests();
-        assert!(bank1.verify_accounts_hash(VerifyBankHash::default_for_test()));
+        assert!(bank1.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
 
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
@@ -2769,7 +2769,7 @@ fn test_purge_empty_accounts() {
 
         bank1.clean_accounts_for_tests();
 
-        assert!(bank1.verify_accounts_hash(VerifyBankHash::default_for_test()));
+        assert!(bank1.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
     }
 }
 
@@ -3923,7 +3923,7 @@ fn test_bank_hash_internal_state() {
     add_root_and_flush_write_cache(&bank1);
     add_root_and_flush_write_cache(&bank2);
     bank2.update_accounts_hash_for_tests();
-    assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
+    assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
 }
 
 #[test]
@@ -3953,13 +3953,13 @@ fn test_bank_hash_internal_state_verify() {
             // we later modify bank 2, so this flush is destructive to the test
             add_root_and_flush_write_cache(&bank2);
             bank2.update_accounts_hash_for_tests();
-            assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
+            assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
         }
         let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set the bank hash in the pass==0 if above
-            assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
+            assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
             continue;
         }
         if pass == 1 {
@@ -3968,7 +3968,7 @@ fn test_bank_hash_internal_state_verify() {
             // Doing so throws an assert. So, we can't flush 3 until 2 is flushed.
             add_root_and_flush_write_cache(&bank3);
             bank3.update_accounts_hash_for_tests();
-            assert!(bank3.verify_accounts_hash(VerifyBankHash::default_for_test()));
+            assert!(bank3.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
             continue;
         }
 
@@ -3977,10 +3977,10 @@ fn test_bank_hash_internal_state_verify() {
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
         add_root_and_flush_write_cache(&bank2);
         bank2.update_accounts_hash_for_tests();
-        assert!(bank2.verify_accounts_hash(VerifyBankHash::default_for_test()));
+        assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
         add_root_and_flush_write_cache(&bank3);
         bank3.update_accounts_hash_for_tests();
-        assert!(bank3.verify_accounts_hash(VerifyBankHash::default_for_test()));
+        assert!(bank3.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test()));
     }
 }
 


### PR DESCRIPTION
#### Problem

The name of the types that call the family of "verify accounts hash" functions are incorrect. They often say "bank hash" when they should say "accounts hash".


#### Summary of Changes

Rename 'em.
