### PR TITLE
Refactors common accounts hash calculation config in AccountsHashVerifier

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -267,15 +267,16 @@ impl AccountsHashVerifier {
                 "hash calc with index: {}, {result_with_index:?}",
                 accounts_package.slot
             );
+            let calculate_accounts_hash_config = CalcAccountsHashConfig {
+                // now that we've failed, store off the failing contents that produced a bad capitalization
+                store_detailed_debug_info_on_failure: true,
+                ..calculate_accounts_hash_config
+            };
             _ = accounts_package
                 .accounts
                 .accounts_db
                 .calculate_accounts_hash_from_storages(
-                    &CalcAccountsHashConfig {
-                        // now that we've failed, store off the failing contents that produced a bad capitalization
-                        store_detailed_debug_info_on_failure: true,
-                        ..calculate_accounts_hash_config
-                    },
+                    &calculate_accounts_hash_config,
                     &sorted_storages,
                     HashStats::default(),
                 );


### PR DESCRIPTION
#### Problem

In AccountsHashVerifier the accounts hash calculation fn is called (can be called) multiple times. All have basically the same config passed in. We spell it out fully each time, but since most is shared, I think it'd be clearer not to.


#### Summary of Changes

Refactor common accounts hash calculation configs.

Note, no behavior should've changed.