### PR TITLE
builtin program consumes default cost if instruction not manually deduct units

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -15,7 +15,10 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-        feature_set::{enable_early_verification_of_account_modifications, FeatureSet},
+        feature_set::{
+            enable_early_verification_of_account_modifications, native_programs_consume_cu,
+            FeatureSet,
+        },
         hash::Hash,
         instruction::{AccountMeta, InstructionError},
         native_loader,
@@ -777,7 +780,12 @@ impl<'a> InvokeContext<'a> {
 
                 // if builtin program didn't manually consume units when processing instruction,
                 // then its default_compute_unit_cost is used to deduct from budget.
-                if is_builtin_program && *compute_units_consumed == 0 {
+                if is_builtin_program
+                    && *compute_units_consumed == 0
+                    && self
+                        .feature_set
+                        .is_active(&native_programs_consume_cu::id())
+                {
                     self.consume_checked(entry.default_compute_unit_cost)?;
                 }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -626,6 +626,10 @@ pub mod switch_to_new_elf_parser {
     solana_sdk::declare_id!("Cdkc8PPTeTNUPoZEfCY5AyetUrEdkZtNPMgz58nqyaHD");
 }
 
+pub mod native_programs_consume_cu {
+    solana_sdk::declare_id!("8pgXCMNXC8qyEFypuwpXyRxLXZdpM4Qo72gJ6k87A6wL");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -777,6 +781,7 @@ lazy_static! {
         (apply_cost_tracker_during_replay::id(), "apply cost tracker to blocks during replay #29595"),
         (add_set_tx_loaded_accounts_data_size_instruction::id(), "add compute budget instruction for setting account data size per transaction #30366"),
         (switch_to_new_elf_parser::id(), "switch to new ELF parser #30497"),
+        (native_programs_consume_cu::id(), "Native program should consume compute units #30620"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
builtin programs not consuming compute units. #30639 mandates builtins to have a default compute unit cost, it can be used to deduct from budget if its instruction(s) don't manually consume units.

#### Summary of Changes
- consumes builtin.default_compute_unit_cost if its instruction didn't deduct units.

Feature Gate Issue: #30620
<!-- Don't forget to add the "feature-gate" label -->
