### PR TITLE
Cleans up tests for verify_accounts_hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9621,8 +9621,8 @@ pub mod tests {
             ancestors: &'a Ancestors,
             epoch_schedule: &'a EpochSchedule,
             rent_collector: &'a RentCollector,
-        ) -> VerifyAccountsHashAndLamportsConfig<'a> {
-            VerifyAccountsHashAndLamportsConfig {
+        ) -> Self {
+            Self {
                 ancestors,
                 test_hash_calculation: true,
                 epoch_schedule,
@@ -12595,7 +12595,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_verify_bank_hash() {
+    fn test_verify_accounts_hash() {
         use AccountsHashVerificationError::*;
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
@@ -12694,7 +12694,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_verify_bank_hash_no_account() {
+    fn test_verify_accounts_hash_no_account() {
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
@@ -12719,7 +12719,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_verify_bank_hash_bad_account_hash() {
+    fn test_verify_accounts_hash_bad_account_hash() {
         use AccountsHashVerificationError::*;
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);


### PR DESCRIPTION
#### Problem

There were leftover bits from https://github.com/solana-labs/solana/pull/30674 that were not cleaned up.


#### Summary of Changes

Rename test bits that were still using `verify_bank_hash` instead of `verify_accounts_hash`.