### PR TITLE
v1.13: stops nodes from broadcasting slots twice (backport of #30681)

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -337,26 +337,22 @@ impl ValidatorStakeInfo {
 pub const RETRANSMIT_BASE_DELAY_MS: u64 = 5_000;
 pub const RETRANSMIT_BACKOFF_CAP: u32 = 6;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RetransmitInfo {
-    pub retry_time: Option<Instant>,
-    pub retry_iteration: u32,
+    pub(crate) retry_time: Instant,
+    pub(crate) retry_iteration: u32,
 }
 
 impl RetransmitInfo {
     pub fn reached_retransmit_threshold(&self) -> bool {
         let backoff = std::cmp::min(self.retry_iteration, RETRANSMIT_BACKOFF_CAP);
         let backoff_duration_ms = (1_u64 << backoff) * RETRANSMIT_BASE_DELAY_MS;
-        self.retry_time
-            .map(|time| time.elapsed().as_millis() > backoff_duration_ms.into())
-            .unwrap_or(true)
+        self.retry_time.elapsed().as_millis() > u128::from(backoff_duration_ms)
     }
 
     pub fn increment_retry_iteration(&mut self) {
-        if self.retry_time.is_some() {
-            self.retry_iteration += 1;
-        }
-        self.retry_time = Some(Instant::now());
+        self.retry_iteration = self.retry_iteration.saturating_add(1);
+        self.retry_time = Instant::now();
     }
 }
 
@@ -424,7 +420,10 @@ impl ForkProgress {
                 total_epoch_stake,
                 ..PropagatedStats::default()
             },
-            retransmit_info: RetransmitInfo::default(),
+            retransmit_info: RetransmitInfo {
+                retry_time: Instant::now(),
+                retry_iteration: 0u32,
+            },
         }
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4600,12 +4600,12 @@ pub fn make_chaining_slot_entries(
     slots_shreds_and_entries
 }
 
-#[cfg(not(unix))]
+#[cfg(not(unixx))]
 fn adjust_ulimit_nofile(_enforce_ulimit_nofile: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(unixx)]
 fn adjust_ulimit_nofile(enforce_ulimit_nofile: bool) -> Result<()> {
     // Rocks DB likes to have many open files.  The default open file descriptor limit is
     // usually not enough


### PR DESCRIPTION
```diff
- This is manual v1.13 backport of:
- https://github.com/solana-labs/solana/pull/30681
```

#### Problem

https://github.com/solana-labs/solana/blob/94ef881de/core/src/progress_map.rs#L178 always returns true the first time around because retry_time is None. So every slot is broadcasted twice.

#### Summary of Changes
removed `unwrap_or(true)`.

