### PR TITLE
Add new_from_file() API to AccountsFile

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -7,7 +7,7 @@ use {
         storable_accounts::StorableAccounts,
     },
     solana_sdk::{account::ReadableAccount, clock::Slot, hash::Hash, pubkey::Pubkey},
-    std::{borrow::Borrow, io, path::PathBuf},
+    std::{borrow::Borrow, io, path::{Path, PathBuf}},
 };
 
 #[derive(Debug)]
@@ -22,11 +22,11 @@ impl AccountsFile {
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
-    pub fn new_from_file<P: AsRef<std::path::Path>>(
-        path: P,
+    pub fn new_from_file(
+        path: impl AsRef<Path>,
         current_len: usize,
     ) -> io::Result<(Self, usize)> {
-        let (av, num_accounts) = AppendVec::new_from_file(path, current_len).unwrap();
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }
 

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -7,7 +7,11 @@ use {
         storable_accounts::StorableAccounts,
     },
     solana_sdk::{account::ReadableAccount, clock::Slot, hash::Hash, pubkey::Pubkey},
-    std::{borrow::Borrow, io, path::{Path, PathBuf}},
+    std::{
+        borrow::Borrow,
+        io,
+        path::{Path, PathBuf},
+    },
 };
 
 #[derive(Debug)]
@@ -22,10 +26,7 @@ impl AccountsFile {
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
-    pub fn new_from_file(
-        path: impl AsRef<Path>,
-        current_len: usize,
-    ) -> io::Result<(Self, usize)> {
+    pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> io::Result<(Self, usize)> {
         let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -18,6 +18,18 @@ pub enum AccountsFile {
 }
 
 impl AccountsFile {
+    /// Create an AccountsFile instance from the specified path.
+    ///
+    /// The second element of the returned tuple is the number of accounts in the
+    /// accounts file.
+    pub fn new_from_file<P: AsRef<std::path::Path>>(
+        path: P,
+        current_len: usize,
+    ) -> io::Result<(Self, usize)> {
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len).unwrap();
+        Ok((Self::AppendVec(av), num_accounts))
+    }
+
     /// By default, all AccountsFile will remove its underlying file on
     /// drop.  Calling this function to disable such behavior for this
     /// instance.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -10,7 +10,6 @@ use {
         accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
-        append_vec::AppendVec,
         bank::{Bank, BankFieldsToDeserialize, BankIncrementalSnapshotPersistence, BankRc},
         blockhash_queue::BlockhashQueue,
         builtins::Builtins,
@@ -607,8 +606,7 @@ fn reconstruct_single_storage(
     current_len: usize,
     append_vec_id: AppendVecId,
 ) -> io::Result<Arc<AccountStorageEntry>> {
-    let (append_vec, num_accounts) = AppendVec::new_from_file(append_vec_path, current_len)?;
-    let accounts_file = AccountsFile::AppendVec(append_vec);
+    let (accounts_file, num_accounts) = AccountsFile::new_from_file(append_vec_path, current_len)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
@@ -628,7 +626,7 @@ fn remap_append_vec_file(
     // due to full snapshots and incremental snapshots generated from different nodes
     let (remapped_append_vec_id, remapped_append_vec_path) = loop {
         let remapped_append_vec_id = next_append_vec_id.fetch_add(1, Ordering::AcqRel);
-        let remapped_file_name = AppendVec::file_name(slot, remapped_append_vec_id);
+        let remapped_file_name = AccountsFile::file_name(slot, remapped_append_vec_id);
         let remapped_append_vec_path = append_vec_path.parent().unwrap().join(remapped_file_name);
 
         // Break out of the loop in the following situations:

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -10,7 +10,6 @@ use {
         },
         accounts_file::AccountsFile,
         accounts_hash::{AccountsDeltaHash, AccountsHash},
-        append_vec::AppendVec,
         bank::{Bank, BankTestConfig},
         epoch_accounts_hash,
         genesis_utils::{self, activate_all_features, activate_feature},
@@ -50,14 +49,14 @@ fn copy_append_vecs<P: AsRef<Path>>(
     for storage_entry in storage_entries.into_iter() {
         // Copy file to new directory
         let storage_path = storage_entry.get_path();
-        let file_name = AppendVec::file_name(storage_entry.slot(), storage_entry.append_vec_id());
+        let file_name =
+            AccountsFile::file_name(storage_entry.slot(), storage_entry.append_vec_id());
         let output_path = output_dir.as_ref().join(file_name);
         std::fs::copy(storage_path, &output_path)?;
 
         // Read new file into append-vec and build new entry
-        let (append_vec, num_accounts) =
-            AppendVec::new_from_file(output_path, storage_entry.accounts.len())?;
-        let accounts_file = AccountsFile::AppendVec(append_vec);
+        let (accounts_file, num_accounts) =
+            AccountsFile::new_from_file(output_path, storage_entry.accounts.len())?;
         let new_storage_entry = AccountStorageEntry::new_existing(
             storage_entry.slot(),
             storage_entry.append_vec_id(),


### PR DESCRIPTION
#### Problem
Accounts db currently use AppendVec::new_from_file() directly
to create a new AcountsFile instance from an existing file.
However, this method should be abstracted out to AccountsFile
so that an existing file can be opened correctly using the right format.

#### Summary of Changes
Add new_from_file() API to AccountsFile which will open an existing
file based on its accounts file format.

Currently, it only supports AppendVec.

