### PR TITLE
Docs: state that getRecentPrioritizationFees RPC method makes a minimization

### DIFF
--- a/docs/src/api/methods/_getRecentPrioritizationFees.mdx
+++ b/docs/src/api/methods/_getRecentPrioritizationFees.mdx
@@ -38,8 +38,7 @@ If this parameter is provided, the response will reflect a fee to land a transac
 An array of `RpcPrioritizationFee<object>` with the following fields:
 
 - `slot: <u64>` - slot in which the fee was observed
-- `prioritizationFee: <u64>` - the per-compute-unit fee paid by at least
-  one successfully landed transaction, specified in increments of 0.000001 lamports
+- `prioritizationFee: <u64>` - the minimum per-compute-unit fee paid considering all successfully landed transactions in this slot, specified in increments of 0.000001 lamports
 
 </CodeParams>
 


### PR DESCRIPTION
#### Problem
The [docs' description for the getRecentPrioritizationFees RPC method's response](https://docs.solana.com/api/http#getrecentprioritizationfees) says the following about the `prioritizationFee` response field:
> prioritizationFee: <u64> - the per-compute-unit fee paid by at least one successfully landed transaction, specified in increments of 0.000001 lamports

After trying it out a couple of times, I didn't understand why I always got 0 as values for every slot (when the account filter parameter array was empty).

Then, it was clear to me after @CriesofCarrots' kind answers to my questions here: https://github.com/solana-labs/solana/pull/29562#pullrequestreview-1333864848.

The reason why I get 0s as fee values for this RPC method is because this method, when no filter is applied, gets the minimum prioritization fee value obtained that was used to land any transactions in the referred slot.
Because of that, it feels to me that the docs could mention that the values returned are minimizations, because this is not mentioned at all, and can only be found out by browsing through the method's implementation code.

#### Summary of Changes
This PR proposes a simple phrasing change in the explanation of the `prioritizationFee` response field, such that it is mentioned that this value is the minimum per-compute-unit fee paid considering all successfully landed transactions in this slot, specified in increments of 0.000001 lamports.