### PR TITLE
Refactor - Cleanup error handling in program runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7343,9 +7343,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.40"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5735b8c9defc3723162321a61ef738d34168401eeef213f62a32809739b0f5"
+checksum = "edb31627f86190e2d97f86988f1de1a757b530caa50694244d9d28812611b063"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ signal-hook = "0.3.14"
 smpl_jwt = "0.7.1"
 socket2 = "0.4.7"
 soketto = "0.7"
-solana_rbpf = "=0.2.40"
+solana_rbpf = "=0.3.0"
 solana-account-decoder = { path = "account-decoder", version = "=1.16.0" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.16.0" }
 solana-banks-client = { path = "banks-client", version = "=1.16.0" }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2975,7 +2975,7 @@ pub mod tests {
 
         fn mock_processor_ok(
             invoke_context: &mut InvokeContext,
-        ) -> std::result::Result<(), InstructionError> {
+        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
             invoke_context.consume_checked(1)?;
             Ok(())
         }
@@ -3006,7 +3006,7 @@ pub mod tests {
 
         fn mock_processor_err(
             invoke_context: &mut InvokeContext,
-        ) -> std::result::Result<(), InstructionError> {
+        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
             let instruction_errors = get_instruction_errors();
 
             invoke_context.consume_checked(1)?;
@@ -3017,10 +3017,12 @@ pub mod tests {
                 .get_instruction_data()
                 .first()
                 .expect("Failed to get instruction data");
-            Err(instruction_errors
-                .get(*err as usize)
-                .expect("Invalid error index")
-                .clone())
+            Err(Box::new(
+                instruction_errors
+                    .get(*err as usize)
+                    .expect("Invalid error index")
+                    .clone(),
+            ))
         }
 
         let mut bankhash_err = None;

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -38,7 +38,27 @@ use {
     },
 };
 
-pub type ProcessInstructionWithContext = fn(&mut InvokeContext) -> Result<(), InstructionError>;
+/// Adapter so we can unify the interfaces of built-in programs and syscalls
+#[macro_export]
+macro_rules! declare_process_instruction {
+    ($cu_to_consume:expr) => {
+        pub fn process_instruction(
+            invoke_context: &mut InvokeContext,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            if invoke_context
+                .feature_set
+                .is_active(&feature_set::native_programs_consume_cu::id())
+            {
+                invoke_context.consume_checked($cu_to_consume)?;
+            }
+            process_instruction_inner(invoke_context)
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+        }
+    };
+}
+
+pub type ProcessInstructionWithContext =
+    fn(&mut InvokeContext) -> Result<(), Box<dyn std::error::Error>>;
 
 #[derive(Clone)]
 pub struct BuiltinProgram {
@@ -50,7 +70,7 @@ impl std::fmt::Debug for BuiltinProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // These are just type aliases for work around of Debug-ing above pointers
         type ErasedProcessInstructionWithContext =
-            fn(&'static mut InvokeContext<'static>) -> Result<(), InstructionError>;
+            fn(&'static mut InvokeContext<'static>) -> Result<(), Box<dyn std::error::Error>>;
 
         // rustc doesn't compile due to bug without this work around
         // https://github.com/rust-lang/rust/issues/50280
@@ -697,8 +717,12 @@ impl<'a> InvokeContext<'a> {
                         stable_log::program_success(&logger, &program_id);
                     })
                     .map_err(|err| {
-                        stable_log::program_failure(&logger, &program_id, &err);
-                        err
+                        stable_log::program_failure(&logger, &program_id, err.as_ref());
+                        if let Some(err) = err.downcast_ref::<InstructionError>() {
+                            err.clone()
+                        } else {
+                            InstructionError::ProgramFailedToComplete
+                        }
                     });
                 let post_remaining_units = self.get_remaining();
                 *compute_units_consumed = pre_remaining_units.saturating_sub(post_remaining_units);
@@ -981,14 +1005,14 @@ mod tests {
 
     #[test]
     fn test_program_entry_debug() {
-        #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _invoke_context: &mut InvokeContext,
-        ) -> Result<(), InstructionError> {
+        ) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
-        #[allow(clippy::unnecessary_wraps)]
-        fn mock_ix_processor(_invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+        fn mock_ix_processor(
+            _invoke_context: &mut InvokeContext,
+        ) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         let builtin_programs = &[
@@ -1009,7 +1033,7 @@ mod tests {
     #[allow(clippy::integer_arithmetic)]
     fn mock_process_instruction(
         invoke_context: &mut InvokeContext,
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let instruction_data = instruction_context.get_instruction_data();
@@ -1043,7 +1067,7 @@ mod tests {
         if let Ok(instruction) = bincode::deserialize(instruction_data) {
             match instruction {
                 MockInstruction::NoopSuccess => (),
-                MockInstruction::NoopFail => return Err(InstructionError::GenericError),
+                MockInstruction::NoopFail => return Err(Box::new(InstructionError::GenericError)),
                 MockInstruction::ModifyOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
                     .set_data_from_slice(&[1])?,
@@ -1093,14 +1117,15 @@ mod tests {
                     desired_result,
                 } => {
                     invoke_context.consume_checked(compute_units_to_consume)?;
-                    return desired_result;
+                    return desired_result
+                        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>);
                 }
                 MockInstruction::Resize { new_len } => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
                     .set_data(vec![0; new_len as usize])?,
             }
         } else {
-            return Err(InstructionError::InvalidInstructionData);
+            return Err(Box::new(InstructionError::InvalidInstructionData));
         }
         Ok(())
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -758,13 +758,13 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Consume compute units
-    pub fn consume_checked(&self, amount: u64) -> Result<(), InstructionError> {
+    pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
         self.log_consumed_bpf_units(amount);
         let mut compute_meter = self.compute_meter.borrow_mut();
         let exceeded = *compute_meter < amount;
         *compute_meter = compute_meter.saturating_sub(amount);
         if exceeded {
-            return Err(InstructionError::ComputationalBudgetExceeded);
+            return Err(Box::new(InstructionError::ComputationalBudgetExceeded));
         }
         Ok(())
     }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -137,7 +137,7 @@ impl LoadedProgram {
         account_size: usize,
         use_jit: bool,
         metrics: &mut LoadProgramMetrics,
-    ) -> Result<Self, EbpfError> {
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut load_elf_time = Measure::start("load_elf_time");
         let executable = Executable::load(elf_bytes, loader.clone())?;
         load_elf_time.stop();

--- a/program-runtime/src/stable_log.rs
+++ b/program-runtime/src/stable_log.rs
@@ -5,7 +5,7 @@
 use {
     crate::{ic_logger_msg, log_collector::LogCollector},
     itertools::Itertools,
-    solana_sdk::{instruction::InstructionError, pubkey::Pubkey},
+    solana_sdk::pubkey::Pubkey,
     std::{cell::RefCell, rc::Rc},
 };
 
@@ -103,7 +103,7 @@ pub fn program_success(log_collector: &Option<Rc<RefCell<LogCollector>>>, progra
 pub fn program_failure(
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
     program_id: &Pubkey,
-    err: &InstructionError,
+    err: &dyn std::error::Error,
 ) {
     ic_logger_msg!(log_collector, "Program {} failed: {}", program_id, err);
 }

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -6,7 +6,7 @@ use {
             LOOKUP_TABLE_MAX_ADDRESSES, LOOKUP_TABLE_META_SIZE,
         },
     },
-    solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
+    solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         clock::Slot,
         feature_set,
@@ -18,14 +18,10 @@ use {
     std::convert::TryFrom,
 };
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
-    // Consume compute units if feature `native_programs_consume_cu` is activated,
-    if invoke_context
-        .feature_set
-        .is_active(&feature_set::native_programs_consume_cu::id())
-    {
-        invoke_context.consume_checked(750)?;
-    }
+declare_process_instruction!(750);
+pub fn process_instruction_inner(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -432,15 +432,21 @@ fn create_memory_mapping<'a, 'b, C: ContextObject>(
     })
 }
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
-    process_instruction_common(invoke_context, false)
+pub fn process_instruction(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    process_instruction_inner(invoke_context, false)
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
 }
 
-pub fn process_instruction_jit(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
-    process_instruction_common(invoke_context, true)
+pub fn process_instruction_jit(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    process_instruction_inner(invoke_context, true)
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
 }
 
-fn process_instruction_common(
+fn process_instruction_inner(
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -1627,9 +1633,7 @@ fn execute<'a, 'b: 'a>(
                             _ => unreachable!(),
                         }
                     }
-                    err => {
-                        InstructionError::ProgramFailedToComplete
-                    }
+                    err => InstructionError::ProgramFailedToComplete,
                 };
                 Err(error)
             }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1751,7 +1751,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "ExceededMaxInstructions(31, 10)")]
+    #[should_panic(expected = "ExceededMaxInstructions(31)")]
     fn test_bpf_loader_non_terminating_program() {
         #[rustfmt::skip]
         let program = &[

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -26,9 +26,8 @@ use {
         aligned_memory::AlignedMemory,
         ebpf::{self, HOST_ALIGN, MM_HEAP_START},
         elf::Executable,
-        error::UserDefinedError,
         memory_region::{MemoryCowCallback, MemoryMapping, MemoryRegion},
-        verifier::{RequisiteVerifier, VerifierError},
+        verifier::RequisiteVerifier,
         vm::{ContextObject, EbpfVm, ProgramResult, VerifiedExecutable},
     },
     solana_sdk::{
@@ -61,12 +60,10 @@ use {
     },
     std::{
         cell::{RefCell, RefMut},
-        fmt::Debug,
         mem,
         rc::Rc,
         sync::{atomic::Ordering, Arc},
     },
-    thiserror::Error,
 };
 
 solana_sdk::declare_builtin!(
@@ -74,16 +71,6 @@ solana_sdk::declare_builtin!(
     solana_bpf_loader_program,
     solana_bpf_loader_program::process_instruction
 );
-
-/// Errors returned by functions the BPF Loader registers with the VM
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum BpfError {
-    #[error("{0}")]
-    VerifierError(#[from] VerifierError),
-    #[error("{0}")]
-    SyscallError(#[from] SyscallError),
-}
-impl UserDefinedError for BpfError {}
 
 #[allow(clippy::too_many_arguments)]
 pub fn load_program_from_bytes(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -369,7 +369,12 @@ pub fn create_ebpf_vm<'a, 'b>(
         None,
     )?;
 
-    EbpfVm::new(program, invoke_context, memory_mapping, stack_len)
+    Ok(EbpfVm::new(
+        program,
+        invoke_context,
+        memory_mapping,
+        stack_len,
+    ))
 }
 
 #[macro_export]

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -39,7 +39,7 @@ impl<'a> CallerAccount<'a> {
         _vm_addr: u64,
         account_info: &AccountInfo,
         original_data_len: usize,
-    ) -> Result<CallerAccount<'a>, Box<dyn std::error::Error>> {
+    ) -> Result<CallerAccount<'a>, Error> {
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
 
@@ -129,7 +129,7 @@ impl<'a> CallerAccount<'a> {
         vm_addr: u64,
         account_info: &SolAccountInfo,
         original_data_len: usize,
-    ) -> Result<CallerAccount<'a>, Box<dyn std::error::Error>> {
+    ) -> Result<CallerAccount<'a>, Error> {
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
 
@@ -212,7 +212,7 @@ trait SyscallInvokeSigned {
         addr: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Box<dyn std::error::Error>>;
+    ) -> Result<StableInstruction, Error>;
     fn translate_accounts<'a>(
         instruction_accounts: &[InstructionAccount],
         program_indices: &[IndexOfAccount],
@@ -220,14 +220,14 @@ trait SyscallInvokeSigned {
         account_infos_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, Box<dyn std::error::Error>>;
+    ) -> Result<TranslatedAccounts<'a>, Error>;
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Box<dyn std::error::Error>>;
+    ) -> Result<Vec<Pubkey>, Error>;
 }
 
 declare_syscall!(
@@ -241,7 +241,7 @@ declare_syscall!(
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         cpi_common::<Self>(
             invoke_context,
             instruction_addr,
@@ -259,7 +259,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         addr: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Box<dyn std::error::Error>> {
+    ) -> Result<StableInstruction, Error> {
         let ix = translate_type::<StableInstruction>(
             memory_mapping,
             addr,
@@ -312,7 +312,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         account_infos_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, Box<dyn std::error::Error>> {
+    ) -> Result<TranslatedAccounts<'a>, Error> {
         let (account_infos, account_info_keys) = translate_account_infos(
             account_infos_addr,
             account_infos_len,
@@ -339,7 +339,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         signers_seeds_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<Pubkey>, Error> {
         let mut signers = Vec::new();
         if signers_seeds_len > 0 {
             let signers_seeds = translate_slice::<&[&[u8]]>(
@@ -374,7 +374,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                             invoke_context.get_check_size(),
                         )
                     })
-                    .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
+                    .collect::<Result<Vec<_>, Error>>()?;
                 let signer = Pubkey::create_program_address(&seeds, program_id)
                     .map_err(SyscallError::BadSeeds)?;
                 signers.push(signer);
@@ -450,7 +450,7 @@ declare_syscall!(
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         cpi_common::<Self>(
             invoke_context,
             instruction_addr,
@@ -468,7 +468,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         addr: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Box<dyn std::error::Error>> {
+    ) -> Result<StableInstruction, Error> {
         let ix_c = translate_type::<SolInstruction>(
             memory_mapping,
             addr,
@@ -527,7 +527,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
                     is_writable: meta_c.is_writable,
                 })
             })
-            .collect::<Result<Vec<AccountMeta>, Box<dyn std::error::Error>>>()?;
+            .collect::<Result<Vec<AccountMeta>, Error>>()?;
 
         Ok(StableInstruction {
             accounts: accounts.into(),
@@ -543,7 +543,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         account_infos_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, Box<dyn std::error::Error>> {
+    ) -> Result<TranslatedAccounts<'a>, Error> {
         let (account_infos, account_info_keys) = translate_account_infos(
             account_infos_addr,
             account_infos_len,
@@ -570,7 +570,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         signers_seeds_len: u64,
         memory_mapping: &mut MemoryMapping,
         invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<Pubkey>, Error> {
         if signers_seeds_len > 0 {
             let signers_seeds = translate_slice::<SolSignerSeedsC>(
                 memory_mapping,
@@ -593,8 +593,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
                         invoke_context.get_check_size(),
                     )?;
                     if seeds.len() > MAX_SEEDS {
-                        return Err(Box::new(InstructionError::MaxSeedLengthExceeded)
-                            as Box<dyn std::error::Error>);
+                        return Err(Box::new(InstructionError::MaxSeedLengthExceeded) as Error);
                     }
                     let seeds_bytes = seeds
                         .iter()
@@ -607,12 +606,11 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
                                 invoke_context.get_check_size(),
                             )
                         })
-                        .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
-                    Pubkey::create_program_address(&seeds_bytes, program_id).map_err(|err| {
-                        Box::new(SyscallError::BadSeeds(err)) as Box<dyn std::error::Error>
-                    })
+                        .collect::<Result<Vec<_>, Error>>()?;
+                    Pubkey::create_program_address(&seeds_bytes, program_id)
+                        .map_err(|err| Box::new(SyscallError::BadSeeds(err)) as Error)
                 })
-                .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?)
+                .collect::<Result<Vec<_>, Error>>()?)
         } else {
             Ok(vec![])
         }
@@ -625,7 +623,7 @@ fn translate_account_infos<'a, T, F>(
     key_addr: F,
     memory_mapping: &mut MemoryMapping,
     invoke_context: &mut InvokeContext,
-) -> Result<(&'a [T], Vec<&'a Pubkey>), Box<dyn std::error::Error>>
+) -> Result<(&'a [T], Vec<&'a Pubkey>), Error>
 where
     F: Fn(&T) -> u64,
 {
@@ -646,7 +644,7 @@ where
                 invoke_context.get_check_aligned(),
             )
         })
-        .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
+        .collect::<Result<Vec<_>, Error>>()?;
 
     Ok((account_infos, account_info_keys))
 }
@@ -662,15 +660,9 @@ fn translate_and_update_accounts<'a, T, F>(
     invoke_context: &mut InvokeContext,
     memory_mapping: &MemoryMapping,
     do_translate: F,
-) -> Result<TranslatedAccounts<'a>, Box<dyn std::error::Error>>
+) -> Result<TranslatedAccounts<'a>, Error>
 where
-    F: Fn(
-        &InvokeContext,
-        &MemoryMapping,
-        u64,
-        &T,
-        usize,
-    ) -> Result<CallerAccount<'a>, Box<dyn std::error::Error>>,
+    F: Fn(&InvokeContext, &MemoryMapping, u64, &T, usize) -> Result<CallerAccount<'a>, Error>,
 {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -765,7 +757,7 @@ fn check_instruction_size(
     num_accounts: usize,
     data_len: usize,
     invoke_context: &mut InvokeContext,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     if invoke_context
         .feature_set
         .is_active(&feature_set::loosen_cpi_size_restriction::id())
@@ -802,7 +794,7 @@ fn check_instruction_size(
 fn check_account_infos(
     num_account_infos: usize,
     invoke_context: &mut InvokeContext,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     if invoke_context
         .feature_set
         .is_active(&feature_set::loosen_cpi_size_restriction::id())
@@ -839,7 +831,7 @@ fn check_authorized_program(
     program_id: &Pubkey,
     instruction_data: &[u8],
     invoke_context: &InvokeContext,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     if native_loader::check_id(program_id)
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
@@ -871,7 +863,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
     memory_mapping: &mut MemoryMapping,
-) -> Result<u64, Box<dyn std::error::Error>> {
+) -> Result<u64, Error> {
     // CPI entry.
     //
     // Translate the inputs to the syscall and synchronize the caller's account
@@ -949,7 +941,7 @@ fn update_callee_account(
     invoke_context: &InvokeContext,
     caller_account: &CallerAccount,
     mut callee_account: BorrowedAccount<'_>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     let is_disable_cpi_setting_executable_and_rent_epoch_active = invoke_context
         .feature_set
         .is_active(&disable_cpi_setting_executable_and_rent_epoch::id());
@@ -1019,7 +1011,7 @@ fn update_caller_account(
     memory_mapping: &MemoryMapping,
     caller_account: &mut CallerAccount,
     callee_account: &BorrowedAccount<'_>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     *caller_account.lamports = callee_account.get_lamports();
     *caller_account.owner = *callee_account.get_owner();
     let new_len = callee_account.get_data().len();

--- a/programs/bpf_loader/src/syscalls/logging.rs
+++ b/programs/bpf_loader/src/syscalls/logging.rs
@@ -11,7 +11,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         let cost = invoke_context
             .get_compute_budget()
             .syscall_base_cost
@@ -47,7 +47,7 @@ declare_syscall!(
         arg4: u64,
         arg5: u64,
         _memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         let cost = invoke_context.get_compute_budget().log_64_units;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -70,7 +70,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         _memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         let cost = invoke_context.get_compute_budget().syscall_base_cost;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -94,7 +94,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         let cost = invoke_context.get_compute_budget().log_pubkey_units;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -119,7 +119,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         let budget = invoke_context.get_compute_budget();
 
         consume_compute_meter(invoke_context, budget.syscall_base_cost)?;

--- a/programs/bpf_loader/src/syscalls/logging.rs
+++ b/programs/bpf_loader/src/syscalls/logging.rs
@@ -11,7 +11,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         let cost = invoke_context
             .get_compute_budget()
             .syscall_base_cost
@@ -47,7 +47,7 @@ declare_syscall!(
         arg4: u64,
         arg5: u64,
         _memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         let cost = invoke_context.get_compute_budget().log_64_units;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -70,7 +70,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         _memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         let cost = invoke_context.get_compute_budget().syscall_base_cost;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -94,7 +94,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         let cost = invoke_context.get_compute_budget().log_pubkey_units;
         consume_compute_meter(invoke_context, cost)?;
 
@@ -119,7 +119,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         let budget = invoke_context.get_compute_budget();
 
         consume_compute_meter(invoke_context, budget.syscall_base_cost)?;

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -1,6 +1,9 @@
 use {super::*, crate::declare_syscall};
 
-fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), EbpfError> {
+fn mem_op_consume(
+    invoke_context: &mut InvokeContext,
+    n: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let compute_budget = invoke_context.get_compute_budget();
     let cost = compute_budget
         .mem_op_base_cost
@@ -19,7 +22,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         mem_op_consume(invoke_context, n)?;
 
         if !is_nonoverlapping(src_addr, n, dst_addr, n) {
@@ -66,7 +69,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         mem_op_consume(invoke_context, n)?;
 
         let dst = translate_slice_mut::<u8>(
@@ -101,7 +104,7 @@ declare_syscall!(
         cmp_result_addr: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         mem_op_consume(invoke_context, n)?;
 
         let s1 = translate_slice::<u8>(
@@ -149,7 +152,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         mem_op_consume(invoke_context, n)?;
 
         let s = translate_slice_mut::<u8>(

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -1,9 +1,6 @@
 use {super::*, crate::declare_syscall};
 
-fn mem_op_consume(
-    invoke_context: &mut InvokeContext,
-    n: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), Error> {
     let compute_budget = invoke_context.get_compute_budget();
     let cost = compute_budget
         .mem_op_base_cost
@@ -22,7 +19,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
         if !is_nonoverlapping(src_addr, n, dst_addr, n) {
@@ -69,7 +66,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
         let dst = translate_slice_mut::<u8>(
@@ -104,7 +101,7 @@ declare_syscall!(
         cmp_result_addr: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
         let s1 = translate_slice::<u8>(
@@ -152,7 +149,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
         let s = translate_slice_mut::<u8>(

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -11,13 +11,11 @@ pub use self::{
 };
 #[allow(deprecated)]
 use {
-    crate::BpfError,
     solana_program_runtime::{
         compute_budget::ComputeBudget, ic_logger_msg, ic_msg, invoke_context::InvokeContext,
         stable_log, timings::ExecuteTimings,
     },
     solana_rbpf::{
-        error::EbpfError,
         memory_region::{AccessType, MemoryMapping},
         vm::{BuiltInProgram, Config, ProgramResult, PROGRAM_ENVIRONMENT_KEY_SHIFT},
     },
@@ -126,11 +124,6 @@ pub enum SyscallError {
     },
     #[error("InvalidAttribute")]
     InvalidAttribute,
-}
-impl From<SyscallError> for EbpfError {
-    fn from(error: SyscallError) -> Self {
-        EbpfError::UserError(Box::<BpfError>::new(error.into()))
-    }
 }
 
 fn consume_compute_meter(

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -16,7 +16,7 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     )?;
     let var = translate_type_mut::<T>(memory_mapping, var_addr, check_aligned)?;
 
-    let sysvar: Arc<T> = sysvar.map_err(SyscallError::InstructionError)?;
+    let sysvar: Arc<T> = sysvar?;
     *var = T::clone(sysvar.as_ref());
 
     Ok(SUCCESS)

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -6,7 +6,7 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     check_aligned: bool,
     memory_mapping: &mut MemoryMapping,
     invoke_context: &mut InvokeContext,
-) -> Result<u64, EbpfError> {
+) -> Result<u64, Box<dyn std::error::Error>> {
     consume_compute_meter(
         invoke_context,
         invoke_context
@@ -33,7 +33,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_clock(),
             var_addr,
@@ -55,7 +55,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_epoch_schedule(),
             var_addr,
@@ -77,7 +77,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         #[allow(deprecated)]
         {
             get_sysvar(
@@ -102,7 +102,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, EbpfError> {
+    ) -> Result<u64, Box<dyn std::error::Error>> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_rent(),
             var_addr,

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -6,7 +6,7 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     check_aligned: bool,
     memory_mapping: &mut MemoryMapping,
     invoke_context: &mut InvokeContext,
-) -> Result<u64, Box<dyn std::error::Error>> {
+) -> Result<u64, Error> {
     consume_compute_meter(
         invoke_context,
         invoke_context
@@ -33,7 +33,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_clock(),
             var_addr,
@@ -55,7 +55,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_epoch_schedule(),
             var_addr,
@@ -77,7 +77,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         #[allow(deprecated)]
         {
             get_sysvar(
@@ -102,7 +102,7 @@ declare_syscall!(
         _arg4: u64,
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
-    ) -> Result<u64, Box<dyn std::error::Error>> {
+    ) -> Result<u64, Error> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_rent(),
             var_addr,

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,9 +1,8 @@
-use {
-    solana_program_runtime::invoke_context::InvokeContext,
-    solana_sdk::{feature_set, instruction::InstructionError},
-};
+use {solana_program_runtime::invoke_context::InvokeContext, solana_sdk::feature_set};
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+pub fn process_instruction(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Consume compute units if feature `native_programs_consume_cu` is activated,
     if invoke_context
         .feature_set

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -3,7 +3,7 @@
 use {
     crate::ConfigKeys,
     bincode::deserialize,
-    solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
+    solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         feature_set, instruction::InstructionError, program_utils::limited_deserialize,
         pubkey::Pubkey, transaction_context::IndexOfAccount,
@@ -11,18 +11,13 @@ use {
     std::collections::BTreeSet,
 };
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+declare_process_instruction!(450);
+pub fn process_instruction_inner(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
-
-    // Consume compute units if feature `native_programs_consume_cu` is activated,
-    if invoke_context
-        .feature_set
-        .is_active(&feature_set::native_programs_consume_cu::id())
-    {
-        invoke_context.consume_checked(450)?;
-    }
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let config_account_key = transaction_context.get_key_of_account_at_index(

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -141,7 +141,7 @@ fn calculate_heap_cost(heap_size: u64, heap_cost: u64) -> u64 {
 pub fn create_vm<'a, 'b>(
     invoke_context: &'a mut InvokeContext<'b>,
     program: &'a VerifiedExecutable<RequisiteVerifier, InvokeContext<'b>>,
-) -> Result<EbpfVm<'a, RequisiteVerifier, InvokeContext<'b>>, InstructionError> {
+) -> Result<EbpfVm<'a, RequisiteVerifier, InvokeContext<'b>>, Box<dyn std::error::Error>> {
     let config = program.get_executable().get_config();
     let compute_budget = invoke_context.get_compute_budget();
     let heap_size = compute_budget.heap_size.unwrap_or(HEAP_LENGTH);
@@ -164,14 +164,14 @@ pub fn create_vm<'a, 'b>(
         .and_then(|memory_mapping| EbpfVm::new(program, invoke_context, memory_mapping, stack_len))
         .map_err(|err| {
             ic_logger_msg!(log_collector, "Failed to create SBF VM: {}", err);
-            InstructionError::ProgramEnvironmentSetupFailure
+            Box::new(InstructionError::ProgramEnvironmentSetupFailure)
         })
 }
 
 fn execute(
     invoke_context: &mut InvokeContext,
     program: &VerifiedExecutable<RequisiteVerifier, InvokeContext<'static>>,
-) -> Result<(), InstructionError> {
+) -> Result<(), Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();
     let stack_height = invoke_context.get_stack_height();
     let transaction_context = &invoke_context.transaction_context;
@@ -214,7 +214,7 @@ fn execute(
             let error = status.into();
             Err(error)
         }
-        ProgramResult::Err(_) => Err(InstructionError::ProgramFailedToComplete),
+        ProgramResult::Err(_) => Err(Box::new(InstructionError::ProgramFailedToComplete)),
         _ => Ok(()),
     }
 }
@@ -531,7 +531,9 @@ pub fn process_instruction_transfer_authority(
     Ok(())
 }
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+pub fn process_instruction(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     let use_jit = true;
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
@@ -558,20 +560,21 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
                 process_instruction_transfer_authority(invoke_context)
             }
         }
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     } else {
         let program = instruction_context.try_borrow_last_program_account(transaction_context)?;
         if !loader_v3::check_id(program.get_owner()) {
             ic_logger_msg!(log_collector, "Program not owned by loader");
-            return Err(InstructionError::InvalidAccountOwner);
+            return Err(Box::new(InstructionError::InvalidAccountOwner));
         }
         if program.get_data().is_empty() {
             ic_logger_msg!(log_collector, "Program is uninitialized");
-            return Err(InstructionError::InvalidAccountData);
+            return Err(Box::new(InstructionError::InvalidAccountData));
         }
         let state = get_state(program.get_data())?;
         if !state.is_deployed {
             ic_logger_msg!(log_collector, "Program is not deployed");
-            return Err(InstructionError::InvalidArgument);
+            return Err(Box::new(InstructionError::InvalidArgument));
         }
         let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
         let (loaded_program, load_program_metrics) = load_program_from_account(
@@ -593,9 +596,11 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
         match &loaded_program.program {
             LoadedProgramType::FailedVerification
             | LoadedProgramType::Closed
-            | LoadedProgramType::DelayVisibility => Err(InstructionError::InvalidAccountData),
+            | LoadedProgramType::DelayVisibility => {
+                Err(Box::new(InstructionError::InvalidAccountData))
+            }
             LoadedProgramType::Typed(executable) => execute(invoke_context, executable),
-            _ => Err(InstructionError::IncorrectProgramId),
+            _ => Err(Box::new(InstructionError::IncorrectProgramId)),
         }
     }
 }

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -215,10 +215,10 @@ fn execute(
 
     match result {
         ProgramResult::Ok(status) if status != SUCCESS => {
-            let error = status.into();
-            Err(error)
+            let error: InstructionError = status.into();
+            Err(Box::new(error) as Box<dyn std::error::Error>)
         }
-        ProgramResult::Err(_) => Err(Box::new(InstructionError::ProgramFailedToComplete)),
+        ProgramResult::Err(error) => Err(error),
         _ => Ok(()),
     }
 }

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -160,12 +160,16 @@ pub fn create_vm<'a, 'b>(
         MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
     ];
     let log_collector = invoke_context.get_log_collector();
-    MemoryMapping::new(regions, config)
-        .and_then(|memory_mapping| EbpfVm::new(program, invoke_context, memory_mapping, stack_len))
-        .map_err(|err| {
-            ic_logger_msg!(log_collector, "Failed to create SBF VM: {}", err);
-            Box::new(InstructionError::ProgramEnvironmentSetupFailure)
-        })
+    let memory_mapping = MemoryMapping::new(regions, config).map_err(|err| {
+        ic_logger_msg!(log_collector, "Failed to create SBF VM: {}", err);
+        Box::new(InstructionError::ProgramEnvironmentSetupFailure)
+    })?;
+    Ok(EbpfVm::new(
+        program,
+        invoke_context,
+        memory_mapping,
+        stack_len,
+    ))
 }
 
 fn execute(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6497,9 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.40"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5735b8c9defc3723162321a61ef738d34168401eeef213f62a32809739b0f5"
+checksum = "edb31627f86190e2d97f86988f1de1a757b530caa50694244d9d28812611b063"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 rand = "0.7"
 serde = "1.0.112"
 serde_json = "1.0.56"
-solana_rbpf = "=0.2.40"
+solana_rbpf = "=0.3.0"
 solana-account-decoder = { path = "../../account-decoder", version = "=1.16.0" }
 solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.16.0" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.16.0" }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -918,6 +918,7 @@ fn test_program_sbf_invoke_sanity() {
                 assert_eq!(result, Err(expected_error));
                 assert_eq!(invoked_programs, expected_invoked_programs);
                 if let Some(expected_log_messages) = expected_log_messages {
+                    assert_eq!(log_messages.len(), expected_log_messages.len());
                     expected_log_messages
                         .into_iter()
                         .zip(log_messages)
@@ -985,8 +986,7 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction data len exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                "Program failed to complete: Invoked an instruction with data that is too large (10241 > 10240)".into(),
-                format!("Program {invoke_program_id} failed: Program failed to complete"),
+                format!("Program {invoke_program_id} failed: Invoked an instruction with data that is too large (10241 > 10240)"),
             ]),
         );
 
@@ -999,8 +999,7 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction accounts exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                "Program failed to complete: Invoked an instruction with too many accounts (256 > 255)".into(),
-                format!("Program {invoke_program_id} failed: Program failed to complete"),
+                format!("Program {invoke_program_id} failed: Invoked an instruction with too many accounts (256 > 255)"),
             ]),
         );
 
@@ -1013,8 +1012,7 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max account infos exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                "Program failed to complete: Invoked an instruction with too many account info's (129 > 128)".into(),
-                format!("Program {invoke_program_id} failed: Program failed to complete"),
+                format!("Program {invoke_program_id} failed: Invoked an instruction with too many account info's (129 > 128)"),
             ]),
         );
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -8,7 +8,8 @@ use {
     },
     log::*,
     solana_program_runtime::{
-        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
+        declare_process_instruction, invoke_context::InvokeContext,
+        sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         clock::Clock,
@@ -51,20 +52,15 @@ fn get_optional_pubkey<'a>(
     )
 }
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+declare_process_instruction!(750);
+pub fn process_instruction_inner(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
 
     trace!("process_instruction: {:?}", data);
-
-    // Consume compute units if feature `native_programs_consume_cu` is activated,
-    if invoke_context
-        .feature_set
-        .is_active(&feature_set::native_programs_consume_cu::id())
-    {
-        invoke_context.consume_checked(750)?;
-    }
 
     let get_stake_account = || {
         let me = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -2,7 +2,7 @@
 
 use {
     bytemuck::Pod,
-    solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
+    solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         feature_set,
         instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
@@ -114,7 +114,10 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
     Ok(())
 }
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+declare_process_instruction!(0);
+pub fn process_instruction_inner(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
     if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
         // Not supported as an inner instruction
         return Err(InstructionError::UnsupportedProgramId);
@@ -137,21 +140,27 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
         }
         ProofInstruction::VerifyCloseAccount => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(6_012)?;
+                invoke_context
+                    .consume_checked(6_012)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyCloseAccount");
             process_verify_proof::<CloseAccountData, CloseAccountProofContext>(invoke_context)
         }
         ProofInstruction::VerifyWithdraw => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(112_454)?;
+                invoke_context
+                    .consume_checked(112_454)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyWithdraw");
             process_verify_proof::<WithdrawData, WithdrawProofContext>(invoke_context)
         }
         ProofInstruction::VerifyWithdrawWithheldTokens => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(7_943)?;
+                invoke_context
+                    .consume_checked(7_943)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyWithdrawWithheldTokens");
             process_verify_proof::<WithdrawWithheldTokensData, WithdrawWithheldTokensProofContext>(
@@ -160,21 +169,27 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
         }
         ProofInstruction::VerifyTransfer => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(219_290)?;
+                invoke_context
+                    .consume_checked(219_290)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyTransfer");
             process_verify_proof::<TransferData, TransferProofContext>(invoke_context)
         }
         ProofInstruction::VerifyTransferWithFee => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(407_121)?;
+                invoke_context
+                    .consume_checked(407_121)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyTransferWithFee");
             process_verify_proof::<TransferWithFeeData, TransferWithFeeProofContext>(invoke_context)
         }
         ProofInstruction::VerifyPubkeyValidity => {
             if native_programs_consume_cu {
-                invoke_context.consume_checked(2_619)?;
+                invoke_context
+                    .consume_checked(2_619)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyPubkeyValidity");
             process_verify_proof::<PubkeyValidityData, PubkeyValidityProofContext>(invoke_context)

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -15,7 +15,6 @@ use {
         client::{AsyncClient, SyncClient},
         clock::MAX_RECENT_BLOCKHASHES,
         genesis_config::create_genesis_config,
-        instruction::InstructionError,
         message::Message,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -35,8 +34,9 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ];
 
-#[allow(clippy::unnecessary_wraps)]
-fn process_instruction(_invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+fn process_instruction(
+    _invoke_context: &mut InvokeContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1342,7 +1342,7 @@ fn test_rent_complex() {
 
     fn mock_process_instruction(
         invoke_context: &mut InvokeContext,
-    ) -> result::Result<(), InstructionError> {
+    ) -> result::Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let instruction_data = instruction_context.get_instruction_data();
@@ -1359,7 +1359,7 @@ fn test_rent_complex() {
                 }
             }
         } else {
-            Err(InstructionError::InvalidInstructionData)
+            Err(Box::new(InstructionError::InvalidInstructionData))
         }
     }
 
@@ -5072,14 +5072,14 @@ fn test_add_builtin() {
     }
     fn mock_vote_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let program_id = instruction_context.get_last_program_key(transaction_context)?;
         if mock_vote_program_id() != *program_id {
-            return Err(InstructionError::IncorrectProgramId);
+            return Err(Box::new(InstructionError::IncorrectProgramId));
         }
-        Err(InstructionError::Custom(42))
+        Err(Box::new(InstructionError::Custom(42)))
     }
 
     assert!(bank.get_account(&mock_vote_program_id()).is_none());
@@ -5130,10 +5130,10 @@ fn test_add_duplicate_static_program() {
 
     fn mock_vote_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         // mock builtin must consume units
         invoke_context.consume_checked(1)?;
-        Err(InstructionError::Custom(42))
+        Err(Box::new(InstructionError::Custom(42)))
     }
 
     let mock_account = Keypair::new();
@@ -5180,10 +5180,10 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
 
         fn mock_ix_processor(
             invoke_context: &mut InvokeContext,
-        ) -> std::result::Result<(), InstructionError> {
+        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
             // mock builtin must consume units
             invoke_context.consume_checked(1)?;
-            Err(InstructionError::Custom(42))
+            Err(Box::new(InstructionError::Custom(42)))
         }
 
         // Non-builtin loader accounts can not be used for instruction processing
@@ -6472,7 +6472,7 @@ fn test_transaction_with_duplicate_accounts_in_instruction() {
 
     fn mock_process_instruction(
         invoke_context: &mut InvokeContext,
-    ) -> result::Result<(), InstructionError> {
+    ) -> result::Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let instruction_data = instruction_context.get_instruction_data();
@@ -6533,7 +6533,7 @@ fn test_transaction_with_program_ids_passed_to_programs() {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_process_instruction(
         invoke_context: &mut InvokeContext,
-    ) -> result::Result<(), InstructionError> {
+    ) -> result::Result<(), Box<dyn std::error::Error>> {
         // mock builtin must consume units
         invoke_context.consume_checked(1)?;
         Ok(())
@@ -6753,7 +6753,7 @@ fn test_program_id_as_payer() {
 #[allow(clippy::unnecessary_wraps)]
 fn mock_ok_vote_processor(
     invoke_context: &mut InvokeContext,
-) -> std::result::Result<(), InstructionError> {
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
     // mock builtin must consume units
     invoke_context.consume_checked(1)?;
     Ok(())
@@ -7001,7 +7001,7 @@ fn test_bank_hash_consistency() {
 fn test_same_program_id_uses_unqiue_executable_accounts() {
     fn nested_processor(
         invoke_context: &mut InvokeContext,
-    ) -> result::Result<(), InstructionError> {
+    ) -> result::Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let _ = instruction_context
@@ -7223,7 +7223,7 @@ fn test_add_builtin_no_overwrite() {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ix_processor(
         _invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -7254,7 +7254,7 @@ fn test_add_builtin_loader_no_overwrite() {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ix_processor(
         _context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -10002,7 +10002,7 @@ fn test_tx_return_data() {
     let mock_program_id = Pubkey::from([2u8; 32]);
     fn mock_process_instruction(
         invoke_context: &mut InvokeContext,
-    ) -> result::Result<(), InstructionError> {
+    ) -> result::Result<(), Box<dyn std::error::Error>> {
         let mock_program_id = Pubkey::from([2u8; 32]);
         let transaction_context = &mut invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -10199,7 +10199,7 @@ fn test_transfer_sysvar() {
 
     fn mock_ix_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         // mock builtin should consume units
@@ -10412,7 +10412,7 @@ fn test_compute_budget_program_noop() {
 
     fn mock_ix_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let compute_budget = invoke_context.get_compute_budget();
         assert_eq!(
             *compute_budget,
@@ -10459,7 +10459,7 @@ fn test_compute_request_instruction() {
 
     fn mock_ix_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let compute_budget = invoke_context.get_compute_budget();
         assert_eq!(
             *compute_budget,
@@ -10513,7 +10513,7 @@ fn test_failed_compute_request_instruction() {
 
     fn mock_ix_processor(
         invoke_context: &mut InvokeContext,
-    ) -> std::result::Result<(), InstructionError> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let compute_budget = invoke_context.get_compute_budget();
         assert_eq!(
             *compute_budget,
@@ -11078,7 +11078,7 @@ enum MockTransferInstruction {
 
 fn mock_transfer_process_instruction(
     invoke_context: &mut InvokeContext,
-) -> result::Result<(), InstructionError> {
+) -> result::Result<(), Box<dyn std::error::Error>> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
@@ -11097,7 +11097,7 @@ fn mock_transfer_process_instruction(
             }
         }
     } else {
-        Err(InstructionError::InvalidInstructionData)
+        Err(Box::new(InstructionError::InvalidInstructionData))
     }
 }
 
@@ -11890,7 +11890,7 @@ enum MockReallocInstruction {
 
 fn mock_realloc_process_instruction(
     invoke_context: &mut InvokeContext,
-) -> result::Result<(), InstructionError> {
+) -> result::Result<(), Box<dyn std::error::Error>> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
@@ -11929,7 +11929,7 @@ fn mock_realloc_process_instruction(
             }
         }
     } else {
-        Err(InstructionError::InvalidInstructionData)
+        Err(Box::new(InstructionError::InvalidInstructionData))
     }
 }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -219,7 +219,7 @@ mod tests {
 
         fn mock_system_process_instruction(
             invoke_context: &mut InvokeContext,
-        ) -> Result<(), InstructionError> {
+        ) -> Result<(), Box<dyn std::error::Error>> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
             let instruction_data = instruction_context.get_instruction_data();
@@ -245,7 +245,7 @@ mod tests {
                     }
                 }
             } else {
-                Err(InstructionError::InvalidInstructionData)
+                Err(Box::new(InstructionError::InvalidInstructionData))
             }
         }
 
@@ -432,7 +432,7 @@ mod tests {
 
         fn mock_system_process_instruction(
             invoke_context: &mut InvokeContext,
-        ) -> Result<(), InstructionError> {
+        ) -> Result<(), Box<dyn std::error::Error>> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
             let instruction_data = instruction_context.get_instruction_data();
@@ -448,7 +448,7 @@ mod tests {
                         let dup_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 2)?;
                         if from_account.get_lamports() != dup_account.get_lamports() {
-                            return Err(InstructionError::InvalidArgument);
+                            return Err(Box::new(InstructionError::InvalidArgument));
                         }
                         Ok(())
                     }
@@ -460,7 +460,7 @@ mod tests {
                             .try_borrow_instruction_account(transaction_context, 2)?
                             .get_lamports();
                         if lamports_a != lamports_b {
-                            return Err(InstructionError::InvalidArgument);
+                            return Err(Box::new(InstructionError::InvalidArgument));
                         }
                         Ok(())
                     }
@@ -479,7 +479,7 @@ mod tests {
                     }
                 }
             } else {
-                Err(InstructionError::InvalidInstructionData)
+                Err(Box::new(InstructionError::InvalidInstructionData))
             }
         }
 
@@ -647,10 +647,10 @@ mod tests {
         let mock_program_id = Pubkey::new_unique();
         fn mock_process_instruction(
             invoke_context: &mut InvokeContext,
-        ) -> Result<(), InstructionError> {
+        ) -> Result<(), Box<dyn std::error::Error>> {
             // mock builtin should consume units
             let _ = invoke_context.consume_checked(1);
-            Err(InstructionError::Custom(0xbabb1e))
+            Err(Box::new(InstructionError::Custom(0xbabb1e)))
         }
         let builtin_programs = &[BuiltinProgram {
             program_id: mock_program_id,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -5,7 +5,8 @@ use {
     },
     log::*,
     solana_program_runtime::{
-        ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
+        declare_process_instruction, ic_msg, invoke_context::InvokeContext,
+        sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         account::AccountSharedData,
@@ -315,21 +316,16 @@ fn transfer_with_seed(
     )
 }
 
-pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+declare_process_instruction!(150);
+pub fn process_instruction_inner(
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
     let instruction = limited_deserialize(instruction_data)?;
 
     trace!("process_instruction: {:?}", instruction);
-
-    // Consume compute units if feature `native_programs_consume_cu` is activated,
-    if invoke_context
-        .feature_set
-        .is_active(&feature_set::native_programs_consume_cu::id())
-    {
-        invoke_context.consume_checked(150)?;
-    }
 
     let signers = instruction_context.get_signers(transaction_context)?;
     match instruction {


### PR DESCRIPTION
#### Problem
We pack error types into deeply nested structures such as `EbpfError::UserError(BpfError::SyscallError(SyscallError::InstructionError(err)))` and
unpack and repack them multiple times when switching between the control flow of the program-runtime, the RBPF-VM and (CPI) syscalls. This is not only annoying to deal with, but also hinders the unification of built-in programs and syscalls, as that would require a common return type, which requires a common result type, which in turn requires a common error type.

#### Summary of Changes
- Removes these wrapped error types: `BpfError::VerifierError`, `BpfError::SyscallError`, `rbpf::EbpfError::UserError`, `SyscallError::InstructionError`
and turns them into `Box<dyn std::error::Error>` instead.
- Turns result of `ProcessInstructionWithContext` from `InstructionError` into `Box<dyn std::error::Error>`.
- Changes stable log: Unifies the redundant error message "Program failed to complete: {error_message}" "Program {invoke_program_id} failed: Program failed to complete" into "Program {invoke_program_id} failed: {error_message}".