### PR TITLE
rpc_service: Rename variable for consistency with the rest of the code base

### DIFF
--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -357,7 +357,7 @@ impl JsonRpcService {
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         connection_cache: Arc<ConnectionCache>,
-        current_transaction_status_slot: Arc<AtomicU64>,
+        max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
     ) -> Result<Self, String> {
         info!("rpc bound to {:?}", rpc_addr);
@@ -428,7 +428,7 @@ impl JsonRpcService {
                                 bigtable_ledger_storage.clone(),
                                 blockstore.clone(),
                                 block_commitment_cache.clone(),
-                                current_transaction_status_slot.clone(),
+                                max_complete_transaction_status_slot.clone(),
                                 ConfirmedBlockUploadConfig::default(),
                                 exit_bigtable_ledger_upload_service.clone(),
                             )))
@@ -469,7 +469,7 @@ impl JsonRpcService {
             largest_accounts_cache,
             max_slots,
             leader_schedule_cache,
-            current_transaction_status_slot,
+            max_complete_transaction_status_slot,
             prioritization_fee_cache,
         );
 


### PR DESCRIPTION
rpc_service.rs uses `current_transaction_status_slot` where the rest of the code base calls this variable `max_complete_transaction_status_slot`. Rename within rpc_service.rs for easier searching across files