### PR TITLE
Stop loading program accounts if program exists in cache

### DIFF
--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -1,5 +1,5 @@
 use {
-    crate::loaded_programs::{InvalidProgramReason, LoadedProgram},
+    crate::loaded_programs::LoadedProgram,
     log::*,
     rand::Rng,
     solana_sdk::{pubkey::Pubkey, saturating_add_assign, slot_history::Slot, stake_history::Epoch},
@@ -44,10 +44,7 @@ impl TransactionExecutorCache {
     pub fn set_tombstone(&mut self, key: Pubkey, slot: Slot) {
         self.visible.insert(
             key,
-            Arc::new(LoadedProgram::new_tombstone(
-                slot,
-                InvalidProgramReason::Closed,
-            )),
+            Arc::new(LoadedProgram::new_tombstone_program_closed(slot)),
         );
     }
 
@@ -65,10 +62,7 @@ impl TransactionExecutorCache {
                 // we don't load the new version from the database as it should remain invisible
                 self.visible.insert(
                     key,
-                    Arc::new(LoadedProgram::new_tombstone(
-                        current_slot,
-                        InvalidProgramReason::DelayVisibility,
-                    )),
+                    Arc::new(LoadedProgram::new_tombstone_delay_visibility(current_slot)),
                 );
             } else {
                 self.visible.insert(key, executor.clone());

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -1,5 +1,5 @@
 use {
-    crate::loaded_programs::LoadedProgram,
+    crate::loaded_programs::{LoadedProgram, LoadedProgramType},
     log::*,
     rand::Rng,
     solana_sdk::{pubkey::Pubkey, saturating_add_assign, slot_history::Slot, stake_history::Epoch},
@@ -44,7 +44,10 @@ impl TransactionExecutorCache {
     pub fn set_tombstone(&mut self, key: Pubkey, slot: Slot) {
         self.visible.insert(
             key,
-            Arc::new(LoadedProgram::new_tombstone_program_closed(slot)),
+            Arc::new(LoadedProgram::new_tombstone(
+                slot,
+                LoadedProgramType::Closed,
+            )),
         );
     }
 
@@ -62,7 +65,10 @@ impl TransactionExecutorCache {
                 // we don't load the new version from the database as it should remain invisible
                 self.visible.insert(
                     key,
-                    Arc::new(LoadedProgram::new_tombstone_delay_visibility(current_slot)),
+                    Arc::new(LoadedProgram::new_tombstone(
+                        current_slot,
+                        LoadedProgramType::DelayVisibility,
+                    )),
                 );
             } else {
                 self.visible.insert(key, executor.clone());

--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -1,5 +1,5 @@
 use {
-    crate::loaded_programs::LoadedProgram,
+    crate::loaded_programs::{InvalidProgramReason, LoadedProgram},
     log::*,
     rand::Rng,
     solana_sdk::{pubkey::Pubkey, saturating_add_assign, slot_history::Slot, stake_history::Epoch},
@@ -42,8 +42,13 @@ impl TransactionExecutorCache {
     }
 
     pub fn set_tombstone(&mut self, key: Pubkey, slot: Slot) {
-        self.visible
-            .insert(key, Arc::new(LoadedProgram::new_tombstone(slot)));
+        self.visible.insert(
+            key,
+            Arc::new(LoadedProgram::new_tombstone(
+                slot,
+                InvalidProgramReason::Closed,
+            )),
+        );
     }
 
     pub fn set(
@@ -58,7 +63,13 @@ impl TransactionExecutorCache {
             if delay_visibility_of_program_deployment {
                 // Place a tombstone in the cache so that
                 // we don't load the new version from the database as it should remain invisible
-                self.set_tombstone(key, current_slot);
+                self.visible.insert(
+                    key,
+                    Arc::new(LoadedProgram::new_tombstone(
+                        current_slot,
+                        InvalidProgramReason::DelayVisibility,
+                    )),
+                );
             } else {
                 self.visible.insert(key, executor.clone());
             }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -227,12 +227,12 @@ impl LoadedProgram {
     }
 
     pub fn is_tombstone(&self) -> bool {
-        match self.program {
+        matches!(
+            self.program,
             LoadedProgramType::FailedVerification
-            | LoadedProgramType::Closed
-            | LoadedProgramType::DelayVisibility => true,
-            _ => false,
-        }
+                | LoadedProgramType::Closed
+                | LoadedProgramType::DelayVisibility
+        )
     }
 }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -379,11 +379,10 @@ impl LoadedPrograms {
 
 #[cfg(test)]
 mod tests {
-    use crate::loaded_programs::InvalidProgramReason;
     use {
         crate::loaded_programs::{
-            BlockRelation, ForkGraph, LoadedProgram, LoadedProgramEntry, LoadedProgramType,
-            LoadedPrograms, WorkingSlot,
+            BlockRelation, ForkGraph, InvalidProgramReason, LoadedProgram, LoadedProgramEntry,
+            LoadedProgramType, LoadedPrograms, WorkingSlot,
         },
         solana_rbpf::vm::BuiltInProgram,
         solana_sdk::{clock::Slot, pubkey::Pubkey},

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -408,7 +408,13 @@ mod tests {
     }
 
     fn set_tombstone(cache: &mut LoadedPrograms, key: Pubkey, slot: Slot) -> Arc<LoadedProgram> {
-        cache.assign_program(key, Arc::new(LoadedProgram::new_tombstone(slot)))
+        cache.assign_program(
+            key,
+            Arc::new(LoadedProgram::new_tombstone(
+                slot,
+                InvalidProgramReason::FailedToCompile,
+            )),
+        )
     }
 
     #[test]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -279,7 +279,15 @@ impl LoadedPrograms {
             let existing = second_level
                 .get(index)
                 .expect("Missing entry, even though position was found");
-            assert!(
+            if existing.is_tombstone()
+                && entry.is_tombstone()
+                && existing.deployment_slot == entry.deployment_slot
+            {
+                // If there's already a tombstone for the program at the given slot, let's return
+                // the existing entry instead of adding another.
+                return existing.clone();
+            }
+            debug_assert!(
                 existing.deployment_slot != entry.deployment_slot
                     || existing.effective_slot != entry.effective_slot
             );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -556,31 +556,21 @@ fn process_instruction_common(
         ic_logger_msg!(log_collector, "Program is not executable");
         return Err(InstructionError::IncorrectProgramId);
     }
-    let programdata_account = if bpf_loader_upgradeable::check_id(program_account.get_owner()) {
-        instruction_context
-            .try_borrow_program_account(
-                transaction_context,
-                instruction_context
-                    .get_number_of_program_accounts()
-                    .saturating_sub(2),
-            )
-            .ok()
-    } else {
-        None
-    };
 
     let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
-    let (executor, load_program_metrics) = load_program_from_account(
-        &invoke_context.feature_set,
-        invoke_context.get_compute_budget(),
-        log_collector,
-        Some(invoke_context.tx_executor_cache.borrow_mut()),
-        &program_account,
-        programdata_account.as_ref().unwrap_or(&program_account),
-        use_jit,
-    )?;
+    let executor = invoke_context
+        .tx_executor_cache
+        .borrow()
+        .get(program_account.get_key())
+        .expect("Failed to find the program in the cache");
+
+    if executor.is_tombstone() {
+        // We cached that the Executor does not exist, abort
+        // This case can only happen once delay_visibility_of_program_deployment is active.
+        return Err(InstructionError::InvalidAccountData);
+    }
+
     drop(program_account);
-    drop(programdata_account);
     get_or_create_executor_time.stop();
     saturating_add_assign!(
         invoke_context.timings.get_or_create_executor_us,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -185,7 +185,6 @@ pub fn load_program_from_account(
         if let Some(loaded_program) = tx_executor_cache.get(program.get_key()) {
             if loaded_program.is_tombstone() {
                 // We cached that the Executor does not exist, abort
-                // This case can only happen once delay_visibility_of_program_deployment is active.
                 return Err(InstructionError::InvalidAccountData);
             }
             // Executor exists and is cached, use it
@@ -593,7 +592,9 @@ fn process_instruction_common(
 
     executor.usage_counter.fetch_add(1, Ordering::Relaxed);
     match &executor.program {
-        LoadedProgramType::Invalid(_) => Err(InstructionError::InvalidAccountData),
+        LoadedProgramType::FailedVerification
+        | LoadedProgramType::Closed
+        | LoadedProgramType::DelayVisibility => Err(InstructionError::InvalidAccountData),
         LoadedProgramType::LegacyV0(executable) => execute(executable, invoke_context),
         LoadedProgramType::LegacyV1(executable) => execute(executable, invoke_context),
         _ => Err(InstructionError::IncorrectProgramId),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -593,7 +593,7 @@ fn process_instruction_common(
 
     executor.usage_counter.fetch_add(1, Ordering::Relaxed);
     match &executor.program {
-        LoadedProgramType::Invalid => Err(InstructionError::InvalidAccountData),
+        LoadedProgramType::Invalid(_) => Err(InstructionError::InvalidAccountData),
         LoadedProgramType::LegacyV0(executable) => execute(executable, invoke_context),
         LoadedProgramType::LegacyV1(executable) => execute(executable, invoke_context),
         _ => Err(InstructionError::IncorrectProgramId),

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -590,7 +590,9 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
         drop(program);
         loaded_program.usage_counter.fetch_add(1, Ordering::Relaxed);
         match &loaded_program.program {
-            LoadedProgramType::Invalid(_) => Err(InstructionError::InvalidAccountData),
+            LoadedProgramType::FailedVerification
+            | LoadedProgramType::Closed
+            | LoadedProgramType::DelayVisibility => Err(InstructionError::InvalidAccountData),
             LoadedProgramType::Typed(executable) => execute(invoke_context, executable),
             _ => Err(InstructionError::IncorrectProgramId),
         }

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -590,7 +590,7 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
         drop(program);
         loaded_program.usage_counter.fetch_add(1, Ordering::Relaxed);
         match &loaded_program.program {
-            LoadedProgramType::Invalid => Err(InstructionError::InvalidAccountData),
+            LoadedProgramType::Invalid(_) => Err(InstructionError::InvalidAccountData),
             LoadedProgramType::Typed(executable) => execute(invoke_context, executable),
             _ => Err(InstructionError::IncorrectProgramId),
         }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -309,6 +309,7 @@ impl Accounts {
         Ok(program_account)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn load_transaction_accounts(
         &self,
         ancestors: &Ancestors,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1425,6 +1425,7 @@ mod tests {
         solana_program_runtime::executor_cache::TransactionExecutorCache,
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
+            bpf_loader_upgradeable::UpgradeableLoaderState,
             epoch_schedule::EpochSchedule,
             genesis_config::ClusterType,
             hash::Hash,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -45,7 +45,6 @@ use {
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
-        instruction::InstructionError::InvalidAccountData,
         message::{
             v0::{LoadedAddresses, MessageAddressTableLookup},
             SanitizedMessage,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -26,8 +26,10 @@ use {
     dashmap::DashMap,
     log::*,
     solana_address_lookup_table_program::{error::AddressLookupError, state::AddressLookupTable},
-    solana_program_runtime::compute_budget::{self, ComputeBudget},
-    solana_program_runtime::loaded_programs::LoadedProgram,
+    solana_program_runtime::{
+        compute_budget::{self, ComputeBudget},
+        loaded_programs::LoadedProgram,
+    },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2557,10 +2557,6 @@ mod tests {
         );
         assert_eq!(
             result.accounts[result.program_indices[0][1] as usize],
-            accounts[4]
-        );
-        assert_eq!(
-            result.accounts[result.program_indices[0][2] as usize],
             accounts[3]
         );
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4451,11 +4451,14 @@ impl Bank {
         (program_accounts_map, loaded_programs_for_txs)
     }
 
-    fn replenish_executor_cache(
+    fn replenish_executor_cache<'a>(
         &self,
-        program_owners: &[&Pubkey],
+        program_owners: &[&'a Pubkey],
         sanitized_txs: &[SanitizedTransaction],
         check_results: &mut [TransactionCheckResult],
+    ) -> (
+        HashMap<Pubkey, &'a Pubkey>,
+        HashMap<Pubkey, Arc<LoadedProgram>>,
     ) {
         let mut filter_programs_time = Measure::start("filter_programs_accounts");
         let program_accounts_map = self.rc.accounts.filter_executable_program_accounts(
@@ -4467,6 +4470,7 @@ impl Bank {
         );
         filter_programs_time.stop();
 
+        let mut loaded_programs_for_txs = HashMap::new();
         let mut filter_missing_programs_time = Measure::start("filter_missing_programs_accounts");
         let missing_executors = program_accounts_map
             .keys()
@@ -4475,6 +4479,10 @@ impl Bank {
                     .read()
                     .unwrap()
                     .get(key)
+                    .map(|program| {
+                        loaded_programs_for_txs.insert(*key, program.clone());
+                        program
+                    })
                     .is_none()
                     .then_some(key)
             })
@@ -4484,15 +4492,24 @@ impl Bank {
         let executors = missing_executors
             .iter()
             .map(|pubkey| match self.load_program(pubkey) {
-                Ok(program) => (**pubkey, program),
+                Ok(program) => {
+                    loaded_programs_for_txs.insert(**pubkey, program.clone());
+                    (**pubkey, program)
+                }
                 // Create a tombstone for the programs that failed to load
-                Err(_) => (**pubkey, Arc::new(LoadedProgram::new_tombstone(self.slot))),
+                Err(_) => {
+                    let tombstone = Arc::new(LoadedProgram::new_tombstone(self.slot));
+                    loaded_programs_for_txs.insert(**pubkey, tombstone.clone());
+                    (**pubkey, tombstone)
+                }
             });
 
         // avoid locking the cache if there are no new executors
         if executors.len() > 0 {
             self.executor_cache.write().unwrap().put(executors);
         }
+
+        (program_accounts_map, loaded_programs_for_txs)
     }
 
     #[allow(clippy::type_complexity)]
@@ -4561,7 +4578,6 @@ impl Bank {
             bpf_loader_upgradeable::id(),
             bpf_loader::id(),
             bpf_loader_deprecated::id(),
-            native_loader::id(),
         ];
 
         let program_owners_refs: Vec<&Pubkey> = program_owners.iter().collect();
@@ -4574,7 +4590,8 @@ impl Bank {
             &check_results,
         );
         */
-        self.replenish_executor_cache(&program_owners_refs, sanitized_txs, &mut check_results);
+        let (executable_programs_in_tx_batch, loaded_programs_map) =
+            self.replenish_executor_cache(&program_owners_refs, sanitized_txs, &mut check_results);
 
         let mut load_time = Measure::start("accounts_load");
         let mut loaded_transactions = self.rc.accounts.load_accounts(
@@ -4587,6 +4604,8 @@ impl Bank {
             &self.feature_set,
             &self.fee_structure,
             account_overrides,
+            &executable_programs_in_tx_batch,
+            &loaded_programs_map,
         );
         load_time.stop();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -95,7 +95,9 @@ use {
         compute_budget::{self, ComputeBudget},
         executor_cache::{BankExecutorCache, TransactionExecutorCache, MAX_CACHED_EXECUTORS},
         invoke_context::{BuiltinProgram, ProcessInstructionWithContext},
-        loaded_programs::{LoadedProgram, LoadedProgramEntry, LoadedPrograms, WorkingSlot},
+        loaded_programs::{
+            LoadedProgram, LoadedProgramEntry, LoadedProgramType, LoadedPrograms, WorkingSlot,
+        },
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
@@ -4435,7 +4437,10 @@ impl Bank {
                     debug!("Failed to load program {}, error {:?}", pubkey, e);
                     let tombstone = self.loaded_programs_cache.write().unwrap().assign_program(
                         *pubkey,
-                        Arc::new(LoadedProgram::new_tombstone_verification_failed(self.slot)),
+                        Arc::new(LoadedProgram::new_tombstone(
+                            self.slot,
+                            LoadedProgramType::FailedVerification,
+                        )),
                     );
                     loaded_programs_for_txs.insert(*pubkey, tombstone);
                 }
@@ -4491,8 +4496,10 @@ impl Bank {
                 }
                 // Create a tombstone for the programs that failed to load
                 Err(_) => {
-                    let tombstone =
-                        Arc::new(LoadedProgram::new_tombstone_verification_failed(self.slot));
+                    let tombstone = Arc::new(LoadedProgram::new_tombstone(
+                        self.slot,
+                        LoadedProgramType::FailedVerification,
+                    ));
                     loaded_programs_for_txs.insert(**pubkey, tombstone.clone());
                     (**pubkey, tombstone)
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -95,9 +95,7 @@ use {
         compute_budget::{self, ComputeBudget},
         executor_cache::{BankExecutorCache, TransactionExecutorCache, MAX_CACHED_EXECUTORS},
         invoke_context::{BuiltinProgram, ProcessInstructionWithContext},
-        loaded_programs::{
-            InvalidProgramReason, LoadedProgram, LoadedProgramEntry, LoadedPrograms, WorkingSlot,
-        },
+        loaded_programs::{LoadedProgram, LoadedProgramEntry, LoadedPrograms, WorkingSlot},
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
@@ -4437,10 +4435,7 @@ impl Bank {
                     debug!("Failed to load program {}, error {:?}", pubkey, e);
                     let tombstone = self.loaded_programs_cache.write().unwrap().assign_program(
                         *pubkey,
-                        Arc::new(LoadedProgram::new_tombstone(
-                            self.slot,
-                            InvalidProgramReason::FailedToCompile,
-                        )),
+                        Arc::new(LoadedProgram::new_tombstone_verification_failed(self.slot)),
                     );
                     loaded_programs_for_txs.insert(*pubkey, tombstone);
                 }
@@ -4496,10 +4491,8 @@ impl Bank {
                 }
                 // Create a tombstone for the programs that failed to load
                 Err(_) => {
-                    let tombstone = Arc::new(LoadedProgram::new_tombstone(
-                        self.slot,
-                        InvalidProgramReason::FailedToCompile,
-                    ));
+                    let tombstone =
+                        Arc::new(LoadedProgram::new_tombstone_verification_failed(self.slot));
                     loaded_programs_for_txs.insert(**pubkey, tombstone.clone());
                     (**pubkey, tombstone)
                 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11740,6 +11740,8 @@ fn test_rent_state_list_len() {
         &bank.feature_set,
         &FeeStructure::default(),
         None,
+        &HashMap::new(),
+        &HashMap::new(),
     );
 
     let compute_budget = bank.runtime_config.compute_budget.unwrap_or_else(|| {


### PR DESCRIPTION
#### Problem
Program/ProgramData accounts get loaded even though the compiled program exists in the cache.

#### Summary of Changes
Check if the compiled program is already cached. If it is, do not load its program and program data accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
