### PR TITLE
validators always skip clean/shrink on startup

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1186,12 +1186,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(true)
         )
         .arg(
-            Arg::with_name("accounts_db_skip_shrink")
-                .long("accounts-db-skip-shrink")
-                .help("This is obsolete since it is now enabled by default. Enables faster starting of validators by skipping startup clean and shrink.")
-                .hidden(true),
-        )
-        .arg(
             Arg::with_name("accounts_db_create_ancient_storage_packed")
                 .long("accounts-db-create-ancient-storage-packed")
                 .help("Create ancient storages in one shot instead of appending.")
@@ -1560,6 +1554,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
 // avoid breaking validator startup commands
 fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
     vec![
+        Arg::with_name("accounts_db_skip_shrink")
+            .long("accounts-db-skip-shrink")
+            .help("This is obsolete since it is now enabled by default. Enables faster starting of validators by skipping startup clean and shrink.")
+            .hidden(true),
         Arg::with_name("accounts_db_caching_enabled")
             .long("accounts-db-caching-enabled")
             .hidden(true),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1188,8 +1188,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("accounts_db_skip_shrink")
                 .long("accounts-db-skip-shrink")
-                .help("Enables faster starting of validators by skipping shrink. \
-                      This option is for use during testing."),
+                .help("This is obsolete since it is now enabled by default. Enables faster starting of validators by skipping startup clean and shrink.")
+                .hidden(true),
         )
         .arg(
             Arg::with_name("accounts_db_create_ancient_storage_packed")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1234,7 +1234,7 @@ pub fn main() {
         account_indexes,
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         accounts_db_config,
-        accounts_db_skip_shrink: matches.is_present("accounts_db_skip_shrink"),
+        accounts_db_skip_shrink: true,
         tpu_coalesce_ms,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         accounts_shrink_ratio,


### PR DESCRIPTION
#### Problem
See
[discord discussion](https://discord.com/channels/428295358100013066/1075087536361320548/1084962412744147057)

When starting a validator, we currently skip startup clean and shrink if the snapshot was generated locally. As of 1.13 or 1.14?, we now start accounts background service much earlier in the startup process. Accounts background service does a clean and shrink concurrently with tx processing.

Note that clean is probably slower with a disk index than without. This synchronous clean thus has a bigger penalty on startup when disk index is enabled.

#### Summary of Changes
Always skip the synchronous initial clean/shrink on validator startup. Make the cli arg obsolete.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
