### PR TITLE
flush entire bucket of writes at once

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -51,7 +51,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     // used by bg processing to know when any bucket has become dirty
     pub wait_dirty_or_aged: Arc<WaitableCondvar>,
     next_bucket_to_flush: AtomicUsize,
-    bins: usize,
+    pub(crate) bins: usize,
 
     pub threads: usize,
 

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -68,6 +68,8 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// Note startup is an optimization and is not required for correctness.
     startup: AtomicBool,
     _phantom: PhantomData<T>,
+
+    pub(crate) write_active: AtomicBool,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -258,6 +260,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             startup: AtomicBool::default(),
             mem_budget_mb,
             threads,
+            write_active: AtomicBool::default(),
             _phantom: PhantomData,
         }
     }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -62,6 +62,8 @@ pub struct BucketMapHolderStats {
     bins: u64,
     pub estimate_mem: AtomicU64,
     pub flush_should_evict_us: AtomicU64,
+    pub buckets_written_to_disk: AtomicU64,
+    pub buckets_skipped_writing_to_disk: AtomicU64,
 }
 
 impl BucketMapHolderStats {
@@ -240,6 +242,17 @@ impl BucketMapHolderStats {
                 (
                     "flush_should_evict_us",
                     self.flush_should_evict_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "buckets_written_to_disk",
+                    self.buckets_written_to_disk.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "buckets_skipped_writing_to_disk",
+                    self.buckets_skipped_writing_to_disk
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -49,6 +49,8 @@ pub struct BucketMapHolderStats {
     pub per_bucket_count: Vec<AtomicUsize>,
     pub flush_entries_updated_on_disk: AtomicU64,
     pub flush_entries_evicted_from_mem: AtomicU64,
+    pub flush_entries_remaining_age: AtomicU64,
+    pub flush_entries_scanned: AtomicU64,
     pub active_threads: AtomicU64,
     pub get_range_us: AtomicU64,
     last_age: AtomicU8,
@@ -496,6 +498,18 @@ impl BucketMapHolderStats {
                 (
                     "flush_entries_evicted_from_mem",
                     self.flush_entries_evicted_from_mem
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_entries_remaining_age",
+                    self.flush_entries_remaining_age
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_entries_scanned",
+                    self.flush_entries_scanned
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -946,10 +946,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         startup: bool,
         update_stats: bool,
         exceeds_budget: bool,
+        ignore_age: bool,
     ) -> (bool, Option<std::sync::RwLockReadGuard<'a, SlotList<T>>>) {
         // this could be tunable dynamically based on memory pressure
         // we could look at more ages or we could throw out more items we are choosing to keep in the cache
-        if Self::should_evict_based_on_age(current_age, entry, startup) {
+        if ignore_age || Self::should_evict_based_on_age(current_age, entry, startup) {
             if exceeds_budget {
                 // if we are already holding too many items in-mem, then we need to be more aggressive at kicking things out
                 (true, None)
@@ -1201,6 +1202,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                 startup,
                                 true,
                                 exceeds_budget,
+                                write_to_disk,
                             );
                             slot_list = slot_list_temp;
                             mse.stop();

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1022,11 +1022,20 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         // flush all dirty entries now, regardless of age
                         0
                     } else {
-                        if ages_in_future >= ages_to_scan {
+                        if !can_write && ages_in_future >= ages_to_scan {
                             // not planning to evict this item from memory within the next few ages
                             continue;
                         }
-                        ages_in_future
+                        else if can_write {
+                            if ages_in_future >= Age::MAX.saturating_sub(self.storage.ages_to_stay_in_cache) {
+                                continue;
+                            }
+                            // clear all read entries that are not within 5 of current
+                            0
+                        }
+                        else {
+                            ages_in_future
+                        }
                     }
                 };
 

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1019,7 +1019,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     0
                 } else {
                     let ages_in_future = v.age().wrapping_sub(current_age);
-                    if can_write && v.dirty() {
+                    if false { //can_write && v.dirty() {
                         // flush all dirty entries now, regardless of age
                         0
                     } else {
@@ -1028,7 +1028,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                             continue;
                         }
                         else if can_write {
-                            if ages_in_future >= Age::MAX.saturating_sub(self.storage.ages_to_stay_in_cache) {
+                            // ages_in_future >= Age::MAX.saturating_sub(self.storage.ages_to_stay_in_cache) {
+                            if ages_in_future > 0 && ages_in_future < self.storage.ages_to_stay_in_cache {
                                 continue;
                             }
                             // clear all read entries that are not within 5 of current

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1117,7 +1117,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .mem_budget_mb
             .map(|budget_mb| {
                 // at half the overall bytes allowed
-                let threshold_flush_bytes = budget_mb * 1024 * 1024 / 2;
+                let threshold_flush_bytes = budget_mb * 1024 * 1024 / 10;
                 // assume each entry is this many bytes
                 let average_size = 400;
                 let threshold_flush_entries = threshold_flush_bytes / average_size;

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -957,7 +957,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             if exceeds_budget {
                 // if we are already holding too many items in-mem, then we need to be more aggressive at kicking things out
                 (true, None)
-            } else if entry.ref_count() != 1 {
+            } else if false && entry.ref_count() != 1 {
                 Self::update_stat(&self.stats().held_in_mem.ref_count, 1);
                 (false, None)
             } else {
@@ -1245,7 +1245,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                 continue;
                             }
                         } else if v.ref_count() != 1 {
-                            continue;
+                            //continue;
                         }
 
                         // try to evict this entry. If it is dirty and we don't write it (or if it becomes dirty in the interim), then we will fail to evict it this time.

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1371,9 +1371,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         continue;
                     }
 
-                    if v.dirty()
+                    if v.dirty()/*
                         || (!randomly_evicted
-                            && !Self::should_evict_based_on_age(current_age, v, startup))
+                            && !Self::should_evict_based_on_age(current_age, v, startup))*/
                     {
                         // marked dirty or bumped in age after we looked above
                         // these evictions will be handled in later passes (at later ages)

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1150,7 +1150,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             },
             1,
         );
-        if write_to_disk {
+        if !write_to_disk {
             if iterate_for_age {
                 // completed iteration of the buckets at the current age
                 assert_eq!(current_age, self.storage.current_age());


### PR DESCRIPTION
#### Problem
#30711

When disk index is enabled, validators are having a hard time catching up initially.
Disk i/o, possibly write specifically, increases a lot.
Machines with older or only a single ssd are experiencing issues.

Here are some mitigation strategies to reduce disk i/o

#### Summary of Changes
Perform writes for entire bucket to reduce # page writes during index updates
Only flush buckets when contents exceed some limit

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
