### PR TITLE
Buffer excess packets in sigverify

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -460,9 +460,13 @@ impl SigVerifyStage {
                     Deduper::<2>::new(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_NUM_BITS);
                 loop {
                     deduper.maybe_reset(&mut rng, &MAX_DEDUPER_AGE);
-                    if let Err(e) =
-                        Self::verifier(&deduper, &packet_receiver, &mut verifier, &mut stats)
-                    {
+                    if let Err(e) = Self::verifier(
+                        &deduper,
+                        &packet_receiver,
+                        &mut verifier,
+                        &mut buffered_batches,
+                        &mut stats,
+                    ) {
                         match e {
                             SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
                                 RecvTimeoutError::Disconnected,

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -355,6 +355,7 @@ impl SigVerifyStage {
         // Shrink batches if many packets were discarded randomly.
         let (pre_shrink_time_us, pre_shrink_total) = Self::maybe_shrink_batches(buffered_batches);
         if buffered_batches.is_empty() {
+            verifier.send_packets(batches)?;
             return Ok(());
         }
 
@@ -374,6 +375,7 @@ impl SigVerifyStage {
         let num_packets_to_verify_valid = count_packets_in_batches(&batches_to_verify);
 
         if num_packets_to_verify_valid == 0 {
+            verifier.send_packets(batches)?;
             return Ok(());
         }
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -362,7 +362,7 @@ impl SigVerifyStage {
         // Peel off limited number of batches to verify so as not to overwhelm the verifier.
         let mut num_packets_to_verify_total = buffered_batches[0].len();
         let mut num_batches_to_verify = 1;
-        for batch in buffered_batches.iter_mut() {
+        for batch in buffered_batches[1..].iter_mut() {
             if num_packets_to_verify_total + batch.len() > MAX_SIGVERIFY_BATCH {
                 break;
             } else {

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -236,6 +236,15 @@ impl<T: Clone + Default + Sized> PinnedVec<T> {
         self.check_ptr(old_ptr, old_capacity, "resize");
     }
 
+    pub fn split_off(&mut self, at: usize) -> Self {
+        let mut other = Self::from_vec(self.x.split_off(at));
+        if self.pinned {
+            other.pinned = true;
+            other.pinnable = true;
+        }
+        other
+    }
+
     pub fn append(&mut self, other: &mut Vec<T>) {
         let (old_ptr, old_capacity) =
             self.prepare_realloc(self.x.len().saturating_add(other.len()));

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -119,6 +119,10 @@ impl PacketBatch {
         self.packets.push(packet);
     }
 
+    pub fn split_off(&mut self, at: usize) -> Self {
+        Self::new(self.packets.split_off(at).into())
+    }
+
     pub fn set_addr(&mut self, addr: &SocketAddr) {
         for p in self.iter_mut() {
             p.meta_mut().set_socket_addr(addr);

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -315,11 +315,17 @@ fn recv_send(
 
 pub fn recv_vec_packet_batches(
     recvr: &Receiver<Vec<PacketBatch>>,
+    buffered_packet_batches: bool,
 ) -> Result<(Vec<PacketBatch>, usize, Duration)> {
-    let timer = Duration::new(1, 0);
-    let mut packet_batches = recvr.recv_timeout(timer)?;
+    let mut packet_batches = if !buffered_packet_batches {
+        let timer = Duration::new(1, 0);
+        let batches = recvr.recv_timeout(timer)?;
+        trace!("got packets");
+        batches
+    } else {
+        vec![]
+    };
     let recv_start = Instant::now();
-    trace!("got packets");
     let mut num_packets = packet_batches
         .iter()
         .map(|packets| packets.len())


### PR DESCRIPTION
#### Problem
We are seeing cases where bursts of packets hit Tx sigverify and get load shed because we limit how many packets we'll feed into verification (2k per loop).

See #29895

#### Summary of Changes
- Buffer excess packets beyond the verify limit to retry them in the next loop.
- Load shed buffered packets to constrain memory from growing infinitely during DoS or sustained high throughput