### PR TITLE
Clean up/forwarder

### DIFF
--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -162,17 +162,7 @@ impl Forwarder {
             None => return (Ok(()), 0, None),
         };
 
-        const INTERVAL_MS: u64 = 100;
-        // 12 MB outbound limit per second
-        const MAX_BYTES_PER_SECOND: usize = 12_000_000;
-        const MAX_BYTES_PER_INTERVAL: usize = MAX_BYTES_PER_SECOND * INTERVAL_MS as usize / 1000;
-        const MAX_BYTES_BUDGET: usize = MAX_BYTES_PER_INTERVAL * 5;
-        self.data_budget.update(INTERVAL_MS, |bytes| {
-            std::cmp::min(
-                bytes.saturating_add(MAX_BYTES_PER_INTERVAL),
-                MAX_BYTES_BUDGET,
-            )
-        });
+        self.update_data_budget();
 
         let packet_vec: Vec<_> = forwardable_packets
             .filter_map(|p| {
@@ -226,6 +216,21 @@ impl Forwarder {
         }
 
         (Ok(()), packet_vec_len, Some(leader_pubkey))
+    }
+
+    // Updates the data budget for forwarding packets if enough time has passed
+    fn update_data_budget(&self) {
+        const INTERVAL_MS: u64 = 100;
+        // 12 MB outbound limit per second
+        const MAX_BYTES_PER_SECOND: usize = 12_000_000;
+        const MAX_BYTES_PER_INTERVAL: usize = MAX_BYTES_PER_SECOND * INTERVAL_MS as usize / 1000;
+        const MAX_BYTES_BUDGET: usize = MAX_BYTES_PER_INTERVAL * 5;
+        self.data_budget.update(INTERVAL_MS, |bytes| {
+            std::cmp::min(
+                bytes.saturating_add(MAX_BYTES_PER_INTERVAL),
+                MAX_BYTES_BUDGET,
+            )
+        });
     }
 }
 

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -165,13 +165,9 @@ impl Forwarder {
         self.update_data_budget();
 
         let packet_vec: Vec<_> = forwardable_packets
-            .filter_map(|p| {
-                if !p.meta().forwarded() && self.data_budget.take(p.meta().size) {
-                    Some(p.data(..)?.to_vec())
-                } else {
-                    None
-                }
-            })
+            .filter(|p| !p.meta().forwarded())
+            .filter(|p| self.data_budget.take(p.meta().size))
+            .filter_map(|p| p.data(..).map(|d| d.to_vec()))
             .collect();
 
         let packet_vec_len = packet_vec.len();


### PR DESCRIPTION
#### Problem
Worker threads with transaction scheduler will not use same BankingStageStats structs or buffers. Want to separate the buffer and stats from core logic of forwarding so we aren't forced to use them.

#### Summary of Changes
Create `forward` method (and additional separation within) which does the forwarding and collects stats, but does not record to banking stage stats.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
