### PR TITLE
Verifies accounts hash in snapshot tests

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -463,6 +463,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
             )
             .unwrap()
             .0;
+            deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
 
             assert_eq!(&deserialized_bank, bank.as_ref());
             assert_eq!(

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -181,6 +181,7 @@ fn restore_from_snapshot(
         &Arc::default(),
     )
     .unwrap();
+    deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
 
     let bank = old_bank_forks.get(deserialized_bank.slot()).unwrap();
     assert_eq!(bank.as_ref(), &deserialized_bank);
@@ -927,6 +928,7 @@ fn restore_from_snapshots_and_check_banks_are_equal(
         None,
         &Arc::default(),
     )?;
+    deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
 
     assert_eq!(bank, &deserialized_bank);
 
@@ -1143,6 +1145,7 @@ fn test_snapshots_with_background_services(
         &exit,
     )
     .unwrap();
+    deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
 
     assert_eq!(
         deserialized_bank.slot(),


### PR DESCRIPTION
#### Problem

While working on Incremental Accounts Hash where I was changing which accounts hashes were stored in snapshots, I was surprised that tests were *not* failing. Turns out that our snapshot tests were not waiting for the initial accounts hash verification to complete, which runs in the background. Tests need to explicitly do this.

#### Summary of Changes

In snapshot tests, wait for the initial accounts hash verification to complete, which verifies the accounts hash from the snapshot.