### PR TITLE
Includes error in panic in initial accounts hash verification

### DIFF
--- a/runtime/src/verify_accounts_hash_in_background.rs
+++ b/runtime/src/verify_accounts_hash_in_background.rs
@@ -67,7 +67,7 @@ impl VerifyAccountsHashInBackground {
         }
         let result = lock.take().unwrap().join().unwrap();
         if !result {
-            panic!("initial hash verification failed");
+            panic!("initial hash verification failed: {result:?}");
         }
         // we never have to check again
         self.verification_complete();


### PR DESCRIPTION
#### Problem

If the initial accounts hash verification fails, and you're *not* logging, then the panic message doesn't tell you *why* the verification failed.

The work-around is to rerun the test/ledger-tool/etc and turn on logging, but it would be nice (and easy) to include the error reason in the panic message.



#### Summary of Changes

Include the error in the panic message.