### PR TITLE
Truncate discarded packets in last batch

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -520,7 +520,7 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) {
     // Truncate batches that only contain discarded packets.
     batches.truncate(last_valid_batch);
     // Truncate discarded packets from the last batch.
-    batches.last_mut().unwrap().truncate(valid_packet_ix + 1);
+    if let Some(batch) = batches.last_mut() {batch.truncate(valid_packet_ix.saturating_add(1))}
 }
 
 pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -517,7 +517,10 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) {
             }
         }
     }
+    // Truncate batches that only contain discarded packets.
     batches.truncate(last_valid_batch);
+    // Truncate discarded packets from the last batch.
+    batches.last_mut().unwrap().truncate(valid_packet_ix + 1);
 }
 
 pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -520,7 +520,9 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) {
     // Truncate batches that only contain discarded packets.
     batches.truncate(last_valid_batch);
     // Truncate discarded packets from the last batch.
-    if let Some(batch) = batches.last_mut() {batch.truncate(valid_packet_ix.saturating_add(1))}
+    if let Some(batch) = batches.last_mut() {
+        batch.truncate(valid_packet_ix.saturating_add(1))
+    }
 }
 
 pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {


### PR DESCRIPTION
#### Problem
When shrinking batches, we only truncate at batch granularity (i.e. only truncate batches where every packet is flagged as discard). It's possible (likely) the last valid batch contains some number of packets marked as discarded that could be purged.

#### Summary of Changes
Tightly pack valid (not marked for discard) packets into packet batches. Truncate all discarded packets in the last valid packet batch.

Performance benchmarking for the shrink process itself is showing very little difference between baseline and this code for the shrink process itself (bsv_* indicates the discard percentage of packets):
```
With change: 
test bsv_0                                 ... bench:   1,105,012 ns/iter (+/- 314,506)
test bsv_10                                ... bench:     992,936 ns/iter (+/- 137,961)
test bsv_90                                ... bench:   1,016,222 ns/iter (+/- 51,501)

Baseline:
test bsv_0                                 ... bench:     984,050 ns/iter (+/- 64,749)
test bsv_10                                ... bench:   1,033,788 ns/iter (+/- 116,391)
test bsv_90                                ... bench:   1,125,088 ns/iter (+/- 317,942)
```