### PR TITLE
Make redelegate signer more optional

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -214,7 +214,7 @@ pub enum CliCommand {
         nonce_authority: SignerIndex,
         memo: Option<String>,
         fee_payer: SignerIndex,
-        redelegation_stake_account_pubkey: Option<Pubkey>,
+        redelegation_stake_account: Option<SignerIndex>,
         compute_unit_price: Option<u64>,
     },
     SplitStake {
@@ -1172,7 +1172,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             nonce_authority,
             memo,
             fee_payer,
-            redelegation_stake_account_pubkey,
+            redelegation_stake_account,
             compute_unit_price,
         } => process_delegate_stake(
             &rpc_client,
@@ -1188,7 +1188,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            redelegation_stake_account_pubkey.as_ref(),
+            *redelegation_stake_account,
             compute_unit_price.as_ref(),
         ),
         CliCommand::SplitStake {

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -152,7 +152,7 @@ fn test_stake_redelegation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config).unwrap();
@@ -216,7 +216,7 @@ fn test_stake_redelegation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: Some(stake2_keypair.pubkey()),
+        redelegation_stake_account: Some(1),
         compute_unit_price: None,
     };
     process_command(&config).unwrap();
@@ -371,7 +371,7 @@ fn test_stake_delegation_force() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config).unwrap_err();
@@ -389,7 +389,7 @@ fn test_stake_delegation_force() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config).unwrap();
@@ -468,7 +468,7 @@ fn test_seed_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config_validator).unwrap();
@@ -560,7 +560,7 @@ fn test_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config_validator).unwrap();
@@ -676,7 +676,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
@@ -699,7 +699,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config_payer).unwrap();
@@ -837,7 +837,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        redelegation_stake_account_pubkey: None,
+        redelegation_stake_account: None,
         compute_unit_price: None,
     };
     process_command(&config).unwrap();


### PR DESCRIPTION
#### Problem
We introduced a bug in https://github.com/solana-labs/solana/pull/26294, namely that the `redelegation_stake_account` is always included in `bulk_signers`, which pulls in the default keypair when not redelegating. This causes problems for a normal `solana delegate-stake` command that attempts to specify all signers to other than the default keypair -- `try_partial_sign` attempts to sign with the default keypair, even though that pubkey is not present in the transaction.

#### Summary of Changes
Rework `redelegation_stake_account` to match the pattern for optional signers in other commands

Incidentally, I [mentioned nonces](https://discord.com/channels/428295358100013066/910937142182682656/1085590351915520203) in my initial look at this bug. This is because it was the `nonce_authority` index that was pointing to the default signer. It's not really the fault of the nonce_authority, because that wasn't why it was added to the signers list. But it is a bit of a red herring that made debugging more difficult. I think I will fix to make nonce_authority an Option<SignerIndex> too, but in a separate PR... which is going to be annoyingly large, because we use the same pattern everywhere in solana-cli.
