### PR TITLE
Verifies incremental accounts hash in verify_accounts_hash_and_lamports

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -104,6 +104,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         assert!(accounts.verify_accounts_hash_and_lamports(
             0,
             total_lamports,
+            None,
             VerifyAccountsHashAndLamportsConfig {
                 ancestors: &ancestors,
                 test_hash_calculation,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -867,11 +867,12 @@ impl Accounts {
         &self,
         slot: Slot,
         total_lamports: u64,
+        base: Option<(Slot, /*capitalization*/ u64)>,
         config: VerifyAccountsHashAndLamportsConfig,
     ) -> bool {
         if let Err(err) =
             self.accounts_db
-                .verify_accounts_hash_and_lamports(slot, total_lamports, config)
+                .verify_accounts_hash_and_lamports(slot, total_lamports, base, config)
         {
             warn!("verify_accounts_hash failed: {err:?}, slot: {slot}");
             false

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6989,6 +6989,7 @@ impl Bank {
                         let result = accounts_.verify_accounts_hash_and_lamports(
                             slot,
                             cap,
+                            None,
                             VerifyAccountsHashAndLamportsConfig {
                                 ancestors: &ancestors,
                                 test_hash_calculation: config.test_hash_calculation,
@@ -7012,6 +7013,7 @@ impl Bank {
             let result = accounts.verify_accounts_hash_and_lamports(
                 slot,
                 cap,
+                None,
                 VerifyAccountsHashAndLamportsConfig {
                     ancestors,
                     test_hash_calculation: config.test_hash_calculation,


### PR DESCRIPTION
#### Problem

At startup we verify the accounts hash and capitalization against what was in the snapshot. The verification doesn't know about Incremental Accounts Hash, so verification fails if we have an IAH.


#### Summary of Changes

verify_accounts_hash_and_lamports() now verifies the IAH