### PR TITLE
Removes extraneous accounts hash calculations in snapshot tests

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -251,7 +251,6 @@ fn run_bank_forks_snapshot_n<F>(
         if slot % set_root_interval == 0 || slot == last_slot {
             // set_root should send a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
-            bank.update_accounts_hash_for_tests();
             snapshot_request_handler.handle_snapshot_requests(false, 0, &mut None);
         }
     }
@@ -275,7 +274,7 @@ fn run_bank_forks_snapshot_n<F>(
         None,
     )
     .unwrap();
-    let accounts_hash = last_bank.get_accounts_hash().unwrap();
+    let accounts_hash = last_bank.update_accounts_hash_for_tests();
     solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         accounts_package.snapshot_links_dir(),
         accounts_package.slot,
@@ -785,7 +784,6 @@ fn test_bank_forks_incremental_snapshot(
         if slot % SET_ROOT_INTERVAL == 0 {
             // set_root sends a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
-            bank.update_accounts_hash_for_tests();
             snapshot_request_handler.handle_snapshot_requests(
                 false,
                 0,
@@ -796,6 +794,7 @@ fn test_bank_forks_incremental_snapshot(
         // Since AccountsBackgroundService isn't running, manually make a full snapshot archive
         // at the right interval
         if snapshot_utils::should_take_full_snapshot(slot, FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS) {
+            bank.update_accounts_hash_for_tests();
             make_full_snapshot_archive(&bank, &snapshot_test_config.snapshot_config).unwrap();
         }
         // Similarly, make an incremental snapshot archive at the right interval, but only if
@@ -809,6 +808,7 @@ fn test_bank_forks_incremental_snapshot(
             last_full_snapshot_slot,
         ) && slot != last_full_snapshot_slot.unwrap()
         {
+            bank.update_accounts_hash_for_tests();
             make_incremental_snapshot_archive(
                 &bank,
                 last_full_snapshot_slot.unwrap(),


### PR DESCRIPTION
#### Problem

Some snapshot tests calculate accounts hashes extraneously. This just wastes time. And when Incremental Accounts Hash support is to be added, accounts hash calculation in these tests will need to change too. Doing some of the work now will make the future PR diffs easier.


#### Summary of Changes

Removes extraneous accounts hash calculations in snapshot tests.