### PR TITLE
Removes unnecessary AccountsHashVerifier from snapshot tests

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -213,26 +213,7 @@ fn run_bank_forks_snapshot_n<F>(
     let bank_forks = &mut snapshot_test_config.bank_forks;
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
-    let (accounts_package_sender, accounts_package_receiver) = crossbeam_channel::unbounded();
-    let exit = Arc::new(AtomicBool::new(false));
-    let node_id = Arc::new(Keypair::new());
-    let cluster_info = Arc::new(ClusterInfo::new(
-        ContactInfo::new_localhost(&node_id.pubkey(), timestamp()),
-        Arc::clone(&node_id),
-        SocketAddrSpace::Unspecified,
-    ));
-    let accounts_hash_verifier = AccountsHashVerifier::new(
-        accounts_package_sender.clone(),
-        accounts_package_receiver,
-        None,
-        &exit,
-        &cluster_info,
-        None,
-        false,
-        0,
-        snapshot_test_config.snapshot_config.clone(),
-    );
-
+    let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
     let request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_request_handler = SnapshotRequestHandler {
@@ -297,9 +278,6 @@ fn run_bank_forks_snapshot_n<F>(
     let account_paths = &[temporary_accounts_dir];
     let genesis_config = &snapshot_test_config.genesis_config_info.genesis_config;
     restore_from_snapshot(bank_forks, last_slot, genesis_config, account_paths);
-
-    exit.store(true, Ordering::Relaxed);
-    accounts_hash_verifier.join().unwrap();
 }
 
 #[test_case(V1_2_0, Development)]
@@ -729,26 +707,7 @@ fn test_bank_forks_incremental_snapshot(
     let bank_forks = &mut snapshot_test_config.bank_forks;
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
-    let (accounts_package_sender, accounts_package_receiver) = crossbeam_channel::unbounded();
-    let exit = Arc::new(AtomicBool::new(false));
-    let node_id = Arc::new(Keypair::new());
-    let cluster_info = Arc::new(ClusterInfo::new(
-        ContactInfo::new_localhost(&node_id.pubkey(), timestamp()),
-        Arc::clone(&node_id),
-        SocketAddrSpace::Unspecified,
-    ));
-    let accounts_hash_verifier = AccountsHashVerifier::new(
-        accounts_package_sender.clone(),
-        accounts_package_receiver,
-        None,
-        &exit,
-        &cluster_info,
-        None,
-        false,
-        0,
-        snapshot_test_config.snapshot_config.clone(),
-    );
-
+    let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
     let request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_request_handler = SnapshotRequestHandler {
@@ -829,8 +788,6 @@ fn test_bank_forks_incremental_snapshot(
             .unwrap();
         }
     }
-    exit.store(true, Ordering::Relaxed);
-    accounts_hash_verifier.join().unwrap();
 }
 
 fn make_full_snapshot_archive(


### PR DESCRIPTION
#### Problem

Some snapshot tests unnecessarily spin up AccountsHashVerifier. This was originally put in during development of EpochAccountsHash, but its impl changed and AHV is no longer needed here for EAH. Now, while working on Incremental Accounts Hash, I came across duplicate accounts hash calculations that were initially confusing; those should not happen for tests that do not spin up the background services fully.


#### Summary of Changes

Remove AHV from snapshot tests that do not need it.