### PR TITLE
Fix wrongly swapped parent slot and block height

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1728,8 +1728,8 @@ impl Bank {
 
         report_new_bank_metrics(
             slot,
-            new.block_height,
             parent.slot(),
+            new.block_height,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/29628 swapped args in wrong way

this is breaking my consensus rainbow charting tool....

#### Summary of Changes

Fix it.