### PR TITLE
ledger-tool: chore: Cleanup snapshot retention constants

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1418,6 +1418,11 @@ fn main() {
     const DEFAULT_ROOT_COUNT: &str = "1";
     const DEFAULT_LATEST_OPTIMISTIC_SLOTS_COUNT: &str = "1";
     const DEFAULT_MAX_SLOTS_ROOT_REPAIR: &str = "2000";
+    // Use std::usize::MAX for DEFAULT_MAX_*_SNAPSHOTS_TO_RETAIN such that
+    // ledger-tool commands won't accidentally remove any snapshots by default
+    const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = std::usize::MAX;
+    const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = std::usize::MAX;
+
     solana_logger::setup_with_default("solana=info");
 
     let starting_slot_arg = Arg::with_name("starting_slot")
@@ -1579,9 +1584,8 @@ fn main() {
         .takes_value(true)
         .help("Log when transactions are processed that reference the given key(s).");
 
-    // Use std::usize::MAX for maximum_*_snapshots_to_retain such that
-    // ledger-tool commands will not remove any snapshots by default
-    let default_max_full_snapshot_archives_to_retain = &std::usize::MAX.to_string();
+    let default_max_full_snapshot_archives_to_retain =
+        &DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
     let maximum_full_snapshot_archives_to_retain = Arg::with_name(
         "maximum_full_snapshots_to_retain",
     )
@@ -1594,7 +1598,8 @@ fn main() {
         "The maximum number of full snapshot archives to hold on to when purging older snapshots.",
     );
 
-    let default_max_incremental_snapshot_archives_to_retain = &std::usize::MAX.to_string();
+    let default_max_incremental_snapshot_archives_to_retain =
+        &DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
     let maximum_incremental_snapshot_archives_to_retain = Arg::with_name(
         "maximum_incremental_snapshots_to_retain",
     )


### PR DESCRIPTION
#### Summary of Changes
Declare constants at top of function with comment, and stringify the constants when needed to be in line with how other defaults are done in ledger-tool main function.

This stemmed from a comment in https://github.com/solana-labs/solana/pull/30704 - Upstreaming this in master and will BP to other branches for sake of consistency between them. 