### PR TITLE
Add --block-{verification,production}-method flags (noop atm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,6 +5387,8 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "static_assertions",
+ "strum",
+ "strum_macros",
  "sys-info",
  "sysctl",
  "systemstat",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,6 +63,8 @@ solana-tpu-client = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
+strum_macros = { workspace = true }
 sys-info = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -132,7 +132,7 @@ pub enum ReplayingBackend {
 }
 
 impl ReplayingBackend {
-    pub fn cli_names() -> &'static [&'static str] {
+    pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
 }
@@ -145,7 +145,7 @@ pub enum BankingBackend {
 }
 
 impl BankingBackend {
-    pub fn cli_names() -> &'static [&'static str] {
+    pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -116,53 +116,37 @@ use {
         thread::{sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
+    strum::VariantNames,
+    strum_macros::{Display, EnumString, EnumVariantNames, IntoStaticStr},
 };
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 
-pub const DEFAULT_REPLAYING_BACKEND: &str = "blockstore-processor";
-pub const DEFAULT_BANKING_BACKEND: &str = "multi-iterator";
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum ReplayingBackend {
+    #[default]
     BlockstoreProcessor,
     UnifiedScheduler,
 }
 
-impl Default for ReplayingBackend {
-    fn default() -> Self {
-        Self::from(DEFAULT_REPLAYING_BACKEND)
+impl ReplayingBackend {
+    pub fn cli_names() -> &'static [&'static str] {
+        Self::VARIANTS
     }
 }
 
-impl From<&str> for ReplayingBackend {
-    fn from(string: &str) -> Self {
-        match string {
-            "blockstore-processor" => Self::BlockstoreProcessor,
-            "unified-scheduler" => Self::UnifiedScheduler,
-            bad_backend => panic!("Invalid replaying backend: {bad_backend}"),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum BankingBackend {
+    #[default]
     MultiIterator,
 }
 
-impl Default for BankingBackend {
-    fn default() -> Self {
-        Self::from(DEFAULT_BANKING_BACKEND)
-    }
-}
-
-impl From<&str> for BankingBackend {
-    fn from(string: &str) -> Self {
-        match string {
-            "multi-iterator" => Self::MultiIterator,
-            bad_backend => panic!("Invalid banking backend: {bad_backend}"),
-        }
+impl BankingBackend {
+    pub fn cli_names() -> &'static [&'static str] {
+        Self::VARIANTS
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -128,7 +128,6 @@ const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 pub enum BlockVerificationMethod {
     #[default]
     BlockstoreProcessor,
-    UnifiedScheduler,
 }
 
 impl BlockVerificationMethod {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -28,6 +28,7 @@ use {
         tvu::{Tvu, TvuConfig, TvuSockets},
     },
     crossbeam_channel::{bounded, unbounded, Receiver},
+    lazy_static::lazy_static,
     rand::{thread_rng, Rng},
     solana_client::connection_cache::ConnectionCache,
     solana_entry::poh::compute_hash_time_ns,
@@ -135,11 +136,15 @@ impl BlockVerificationMethod {
         Self::VARIANTS
     }
 
-    pub fn cli_message() -> String {
-        format!(
-            "Switch transaction scheduling method for verifying ledger entries [default: {}]",
-            Self::default()
-        )
+    pub fn cli_message() -> &'static str {
+        lazy_static! {
+            static ref MESSAGE: String = format!(
+                "Switch transaction scheduling method for verifying ledger entries [default: {}]",
+                BlockVerificationMethod::default()
+            );
+        };
+
+        &MESSAGE
     }
 }
 
@@ -155,11 +160,15 @@ impl BlockProductionMethod {
         Self::VARIANTS
     }
 
-    pub fn cli_message() -> String {
-        format!(
-            "Switch transaction scheduling method for producing ledger entries [default: {}]",
-            Self::default()
-        )
+    pub fn cli_message() -> &'static str {
+        lazy_static! {
+            static ref MESSAGE: String = format!(
+                "Switch transaction scheduling method for producing ledger entries [default: {}]",
+                BlockProductionMethod::default()
+            );
+        };
+
+        &MESSAGE
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -148,7 +148,7 @@ impl BlockVerificationMethod {
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockProductionMethod {
     #[default]
-    MultiIterator,
+    ThreadLocalMultiIterator,
 }
 
 impl BlockProductionMethod {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -125,20 +125,20 @@ const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
-pub enum ReplayingBackend {
+pub enum BlockVerificationMethod {
     #[default]
     BlockstoreProcessor,
     UnifiedScheduler,
 }
 
-impl ReplayingBackend {
+impl BlockVerificationMethod {
     pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
 
     pub fn cli_message() -> String {
         format!(
-            "Switch transaction scheduling backend for validating ledger entries [default: {}]",
+            "Switch transaction scheduling method for verifying ledger entries [default: {}]",
             Self::default()
         )
     }
@@ -146,19 +146,19 @@ impl ReplayingBackend {
 
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
-pub enum BankingBackend {
+pub enum BlockProductionMethod {
     #[default]
     MultiIterator,
 }
 
-impl BankingBackend {
+impl BlockProductionMethod {
     pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
 
     pub fn cli_message() -> String {
         format!(
-            "Switch transaction scheduling backend for generating ledger entries [default: {}]",
+            "Switch transaction scheduling method for producing ledger entries [default: {}]",
             Self::default()
         )
     }
@@ -225,8 +225,8 @@ pub struct ValidatorConfig {
     pub runtime_config: RuntimeConfig,
     pub replay_slots_concurrently: bool,
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
-    pub replaying_backend: ReplayingBackend,
-    pub banking_backend: BankingBackend,
+    pub block_verification_method: BlockVerificationMethod,
+    pub block_production_method: BlockProductionMethod,
 }
 
 impl Default for ValidatorConfig {
@@ -291,8 +291,8 @@ impl Default for ValidatorConfig {
             runtime_config: RuntimeConfig::default(),
             replay_slots_concurrently: false,
             banking_trace_dir_byte_limit: 0,
-            replaying_backend: ReplayingBackend::default(),
-            banking_backend: BankingBackend::default(),
+            block_verification_method: BlockVerificationMethod::default(),
+            block_production_method: BlockProductionMethod::default(),
         }
     }
 }
@@ -733,8 +733,8 @@ impl Validator {
             last_full_snapshot_slot,
         );
         info!(
-            "Chosen backends: replaying: {}, banking: {}",
-            config.replaying_backend, config.banking_backend
+            "Using: block-verification-method: {}, block-production-method: {}",
+            config.block_verification_method, config.block_production_method
         );
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -135,6 +135,13 @@ impl ReplayingBackend {
     pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
+
+    pub fn cli_message() -> String {
+        format!(
+            "Switch transaction scheduling backend for validating ledger entries [default: {}]",
+            Self::default()
+        )
+    }
 }
 
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
@@ -147,6 +154,13 @@ pub enum BankingBackend {
 impl BankingBackend {
     pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
+    }
+
+    pub fn cli_message() -> String {
+        format!(
+            "Switch transaction scheduling backend for generating ledger entries [default: {}]",
+            Self::default()
+        )
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -123,7 +123,7 @@ use {
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 
-#[derive(Clone, Debug, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum ReplayingBackend {
     #[default]
@@ -137,7 +137,7 @@ impl ReplayingBackend {
     }
 }
 
-#[derive(Clone, Debug, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BankingBackend {
     #[default]
@@ -719,7 +719,7 @@ impl Validator {
             last_full_snapshot_slot,
         );
         info!(
-            "Chosen backends: replaying: {:?}, banking: {:?}",
+            "Chosen backends: replaying: {}, banking: {}",
             config.replaying_backend, config.banking_backend
         );
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,7 +27,7 @@ use {
     solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
     solana_core::{
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
-        validator::{BlockProductionMethod, BlockVerificationMethod},
+        validator::BlockVerificationMethod,
     },
     solana_entry::entry::Entry,
     solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
@@ -1253,15 +1253,9 @@ fn load_bank_forks(
         BlockVerificationMethod
     )
     .unwrap_or_default();
-    let block_production_method = value_t!(
-        arg_matches,
-        "block_production_method",
-        BlockProductionMethod
-    )
-    .unwrap_or_default();
     info!(
-        "Using: block-verification-method: {}, block-production-method: {}",
-        block_verification_method, block_production_method
+        "Using: block-verification-method: {}",
+        block_verification_method,
     );
 
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
@@ -1657,10 +1651,7 @@ fn main() {
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
-    let (block_verification_method_help, block_production_method_help) = (
-        &BlockVerificationMethod::cli_message(),
-        &BlockProductionMethod::cli_message(),
-    );
+    let block_verification_method_help = &BlockVerificationMethod::cli_message();
 
     let mut measure_total_execution_time = Measure::start("ledger tool");
 
@@ -1728,16 +1719,6 @@ fn main() {
                 .global(true)
                 .hidden(hidden_unless_forced())
                 .help(block_verification_method_help),
-        )
-        .arg(
-            Arg::with_name("block_production_method")
-                .long("block-production-method")
-                .value_name("METHOD")
-                .takes_value(true)
-                .possible_values(BlockProductionMethod::cli_names())
-                .global(true)
-                .hidden(hidden_unless_forced())
-                .help(block_production_method_help),
         )
         .arg(
             Arg::with_name("output_format")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,9 +27,7 @@ use {
     solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
     solana_core::{
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
-        validator::{
-            BankingBackend, ReplayingBackend, DEFAULT_BANKING_BACKEND, DEFAULT_REPLAYING_BACKEND,
-        },
+        validator::{BankingBackend, ReplayingBackend},
     },
     solana_entry::entry::Entry,
     solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
@@ -1249,14 +1247,8 @@ fn load_bank_forks(
             accounts_update_notifier,
             &Arc::default(),
         );
-    let replaying_backend = arg_matches
-        .value_of("replaying_backend")
-        .map(ReplayingBackend::from)
-        .unwrap();
-    let banking_backend = arg_matches
-        .value_of("banking_backend")
-        .map(BankingBackend::from)
-        .unwrap();
+    let replaying_backend = value_t_or_exit!(arg_matches, "replaying_backend", ReplayingBackend);
+    let banking_backend = value_t_or_exit!(arg_matches, "banking_backend", BankingBackend);
     info!(
         "Chosen backends: replaying: {:?}, banking: {:?}",
         replaying_backend, banking_backend
@@ -1717,13 +1709,10 @@ fn main() {
                 .long("replaying-backend")
                 .value_name("BACKEND")
                 .takes_value(true)
-                .possible_values(&[
-                    "blockstore-processor",
-                    "unified-scheduler",
-                    ])
-                .default_value(DEFAULT_REPLAYING_BACKEND)
+                .possible_values(ReplayingBackend::cli_names())
+                .default_value(ReplayingBackend::default().into())
                 .global(true)
-                .hidden(true)
+                .hidden(hidden_unless_forced())
                 .help(
                     "Switch transaction scheduling backend for validating ledger entries"
                 ),
@@ -1733,12 +1722,10 @@ fn main() {
                 .long("banking-backend")
                 .value_name("BACKEND")
                 .takes_value(true)
-                .possible_values(&[
-                    "multi-iterator",
-                    ])
-                .default_value(DEFAULT_BANKING_BACKEND)
+                .possible_values(BankingBackend::cli_names())
+                .default_value(BankingBackend::default().into())
                 .global(true)
-                .hidden(true)
+                .hidden(hidden_unless_forced())
                 .help(
                     "Switch transaction scheduling backend for generating ledger entries"
                 ),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1250,7 +1250,7 @@ fn load_bank_forks(
     let replaying_backend = value_t_or_exit!(arg_matches, "replaying_backend", ReplayingBackend);
     let banking_backend = value_t_or_exit!(arg_matches, "banking_backend", BankingBackend);
     info!(
-        "Chosen backends: replaying: {:?}, banking: {:?}",
+        "Chosen backends: replaying: {}, banking: {}",
         replaying_backend, banking_backend
     );
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1247,16 +1247,18 @@ fn load_bank_forks(
             accounts_update_notifier,
             &Arc::default(),
         );
-    let block_verification_method = value_t_or_exit!(
+    let block_verification_method = value_t!(
         arg_matches,
         "block_verification_method",
         BlockVerificationMethod
-    );
-    let block_production_method = value_t_or_exit!(
+    )
+    .unwrap_or_default();
+    let block_production_method = value_t!(
         arg_matches,
         "block_production_method",
         BlockProductionMethod
-    );
+    )
+    .unwrap_or_default();
     info!(
         "Using: block-verification-method: {}, block-production-method: {}",
         block_verification_method, block_production_method

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1651,8 +1651,6 @@ fn main() {
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
-    let block_verification_method_help = &BlockVerificationMethod::cli_message();
-
     let mut measure_total_execution_time = Measure::start("ledger tool");
 
     let matches = App::new(crate_name!())
@@ -1718,7 +1716,7 @@ fn main() {
                 .possible_values(BlockVerificationMethod::cli_names())
                 .global(true)
                 .hidden(hidden_unless_forced())
-                .help(block_verification_method_help),
+                .help(BlockVerificationMethod::cli_message()),
         )
         .arg(
             Arg::with_name("output_format")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,7 +27,7 @@ use {
     solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
     solana_core::{
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
-        validator::{BankingBackend, ReplayingBackend},
+        validator::{BlockProductionMethod, BlockVerificationMethod},
     },
     solana_entry::entry::Entry,
     solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
@@ -1247,11 +1247,19 @@ fn load_bank_forks(
             accounts_update_notifier,
             &Arc::default(),
         );
-    let replaying_backend = value_t_or_exit!(arg_matches, "replaying_backend", ReplayingBackend);
-    let banking_backend = value_t_or_exit!(arg_matches, "banking_backend", BankingBackend);
+    let block_verification_method = value_t_or_exit!(
+        arg_matches,
+        "block_verification_method",
+        BlockVerificationMethod
+    );
+    let block_production_method = value_t_or_exit!(
+        arg_matches,
+        "block_production_method",
+        BlockProductionMethod
+    );
     info!(
-        "Chosen backends: replaying: {}, banking: {}",
-        replaying_backend, banking_backend
+        "Using: block-verification-method: {}, block-production-method: {}",
+        block_verification_method, block_production_method
     );
 
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
@@ -1647,9 +1655,9 @@ fn main() {
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
-    let (replaying_backend_help, banking_backend_help) = (
-        &ReplayingBackend::cli_message(),
-        &BankingBackend::cli_message(),
+    let (block_verification_method_help, block_production_method_help) = (
+        &BlockVerificationMethod::cli_message(),
+        &BlockProductionMethod::cli_message(),
     );
 
     let mut measure_total_execution_time = Measure::start("ledger tool");
@@ -1710,24 +1718,24 @@ fn main() {
                 .help("Use DIR for separate incremental snapshot location"),
         )
         .arg(
-            Arg::with_name("replaying_backend")
-                .long("replaying-backend")
-                .value_name("BACKEND")
+            Arg::with_name("block_verification_method")
+                .long("block-verification-method")
+                .value_name("METHOD")
                 .takes_value(true)
-                .possible_values(ReplayingBackend::cli_names())
+                .possible_values(BlockVerificationMethod::cli_names())
                 .global(true)
                 .hidden(hidden_unless_forced())
-                .help(replaying_backend_help),
+                .help(block_verification_method_help),
         )
         .arg(
-            Arg::with_name("banking_backend")
-                .long("banking-backend")
-                .value_name("BACKEND")
+            Arg::with_name("block_production_method")
+                .long("block-production-method")
+                .value_name("METHOD")
                 .takes_value(true)
-                .possible_values(BankingBackend::cli_names())
+                .possible_values(BlockProductionMethod::cli_names())
                 .global(true)
                 .hidden(hidden_unless_forced())
-                .help(banking_backend_help),
+                .help(block_production_method_help),
         )
         .arg(
             Arg::with_name("output_format")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1647,6 +1647,11 @@ fn main() {
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
+    let (replaying_backend_help, banking_backend_help) = (
+        &ReplayingBackend::cli_message(),
+        &BankingBackend::cli_message(),
+    );
+
     let mut measure_total_execution_time = Measure::start("ledger tool");
 
     let matches = App::new(crate_name!())
@@ -1710,12 +1715,9 @@ fn main() {
                 .value_name("BACKEND")
                 .takes_value(true)
                 .possible_values(ReplayingBackend::cli_names())
-                .default_value(ReplayingBackend::default().into())
                 .global(true)
                 .hidden(hidden_unless_forced())
-                .help(
-                    "Switch transaction scheduling backend for validating ledger entries"
-                ),
+                .help(replaying_backend_help),
         )
         .arg(
             Arg::with_name("banking_backend")
@@ -1723,12 +1725,9 @@ fn main() {
                 .value_name("BACKEND")
                 .takes_value(true)
                 .possible_values(BankingBackend::cli_names())
-                .default_value(BankingBackend::default().into())
                 .global(true)
                 .hidden(hidden_unless_forced())
-                .help(
-                    "Switch transaction scheduling backend for generating ledger entries"
-                ),
+                .help(banking_backend_help),
         )
         .arg(
             Arg::with_name("output_format")

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -66,6 +66,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
+        replaying_backend: config.replaying_backend.clone(),
+        banking_backend: config.banking_backend.clone(),
     }
 }
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -66,8 +66,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
-        replaying_backend: config.replaying_backend.clone(),
-        banking_backend: config.banking_backend.clone(),
+        block_verification_method: config.block_verification_method.clone(),
+        block_production_method: config.block_production_method.clone(),
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4657,6 +4657,8 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
+ "strum",
+ "strum_macros",
  "sys-info",
  "sysctl",
  "tempfile",

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1341,7 +1341,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockVerificationMethod::cli_names())
-                .help(&default_args.block_verification_method_help),
+                .help(BlockVerificationMethod::cli_message())
         )
         .arg(
             Arg::with_name("block_production_method")
@@ -1350,7 +1350,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockProductionMethod::cli_names())
-                .help(&default_args.block_production_method_help),
+                .help(BlockProductionMethod::cli_message())
         )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
@@ -1781,8 +1781,6 @@ pub struct DefaultArgs {
     pub wait_for_restart_window_max_delinquent_stake: String,
 
     pub banking_trace_dir_byte_limit: String,
-    pub block_verification_method_help: String,
-    pub block_production_method_help: String,
 }
 
 impl DefaultArgs {
@@ -1862,8 +1860,6 @@ impl DefaultArgs {
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
-            block_verification_method_help: BlockVerificationMethod::cli_message(),
-            block_production_method_help: BlockProductionMethod::cli_message(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -11,7 +11,10 @@ use {
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
-    solana_core::banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
+    solana_core::{
+        banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
+        validator::{DEFAULT_BANKING_BACKEND, DEFAULT_REPLAYING_BACKEND},
+    },
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
@@ -1331,6 +1334,35 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        up to the default or specified total bytes in the \
                        ledger")
         )
+        .arg(
+            Arg::with_name("replaying_backend")
+                .long("replaying-backend")
+                .hidden(true)
+                .value_name("BACKEND")
+                .takes_value(true)
+                .possible_values(&[
+                    "blockstore-processor",
+                    "unified-scheduler",
+                    ])
+                .default_value(&default_args.replaying_backend)
+                .help(
+                    "Switch transaction scheduling backend for validating ledger entries"
+                ),
+        )
+        .arg(
+            Arg::with_name("banking_backend")
+                .long("banking-backend")
+                .hidden(true)
+                .value_name("BACKEND")
+                .takes_value(true)
+                .possible_values(&[
+                    "multi-iterator",
+                    ])
+                .default_value(&default_args.banking_backend)
+                .help(
+                    "Switch transaction scheduling backend for generating ledger entries"
+                ),
+        )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
         .subcommand(
@@ -1760,6 +1792,8 @@ pub struct DefaultArgs {
     pub wait_for_restart_window_max_delinquent_stake: String,
 
     pub banking_trace_dir_byte_limit: String,
+    pub replaying_backend: String,
+    pub banking_backend: String,
 }
 
 impl DefaultArgs {
@@ -1839,6 +1873,8 @@ impl DefaultArgs {
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
+            replaying_backend: DEFAULT_REPLAYING_BACKEND.to_string(),
+            banking_backend: DEFAULT_BANKING_BACKEND.to_string(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_core::{
         banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
-        validator::{DEFAULT_BANKING_BACKEND, DEFAULT_REPLAYING_BACKEND},
+        validator::{BankingBackend, ReplayingBackend},
     },
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
@@ -1337,13 +1337,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("replaying_backend")
                 .long("replaying-backend")
-                .hidden(true)
+                .hidden(hidden_unless_forced())
                 .value_name("BACKEND")
                 .takes_value(true)
-                .possible_values(&[
-                    "blockstore-processor",
-                    "unified-scheduler",
-                    ])
+                .possible_values(ReplayingBackend::cli_names())
                 .default_value(&default_args.replaying_backend)
                 .help(
                     "Switch transaction scheduling backend for validating ledger entries"
@@ -1352,12 +1349,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("banking_backend")
                 .long("banking-backend")
-                .hidden(true)
+                .hidden(hidden_unless_forced())
                 .value_name("BACKEND")
                 .takes_value(true)
-                .possible_values(&[
-                    "multi-iterator",
-                    ])
+                .possible_values(BankingBackend::cli_names())
                 .default_value(&default_args.banking_backend)
                 .help(
                     "Switch transaction scheduling backend for generating ledger entries"
@@ -1873,8 +1868,8 @@ impl DefaultArgs {
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
-            replaying_backend: DEFAULT_REPLAYING_BACKEND.to_string(),
-            banking_backend: DEFAULT_BANKING_BACKEND.to_string(),
+            replaying_backend: ReplayingBackend::default().to_string(),
+            banking_backend: BankingBackend::default().to_string(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_core::{
         banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
-        validator::{BankingBackend, ReplayingBackend},
+        validator::{BlockProductionMethod, BlockVerificationMethod},
     },
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
@@ -1335,22 +1335,22 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        ledger")
         )
         .arg(
-            Arg::with_name("replaying_backend")
-                .long("replaying-backend")
+            Arg::with_name("block_verification_method")
+                .long("block-verification-method")
                 .hidden(hidden_unless_forced())
-                .value_name("BACKEND")
+                .value_name("METHOD")
                 .takes_value(true)
-                .possible_values(ReplayingBackend::cli_names())
-                .help(&default_args.replaying_backend_help),
+                .possible_values(BlockVerificationMethod::cli_names())
+                .help(&default_args.block_verification_method_help),
         )
         .arg(
-            Arg::with_name("banking_backend")
-                .long("banking-backend")
+            Arg::with_name("block_production_method")
+                .long("block-production-method")
                 .hidden(hidden_unless_forced())
-                .value_name("BACKEND")
+                .value_name("METHOD")
                 .takes_value(true)
-                .possible_values(BankingBackend::cli_names())
-                .help(&default_args.banking_backend_help),
+                .possible_values(BlockProductionMethod::cli_names())
+                .help(&default_args.block_production_method_help),
         )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
@@ -1781,8 +1781,8 @@ pub struct DefaultArgs {
     pub wait_for_restart_window_max_delinquent_stake: String,
 
     pub banking_trace_dir_byte_limit: String,
-    pub replaying_backend_help: String,
-    pub banking_backend_help: String,
+    pub block_verification_method_help: String,
+    pub block_production_method_help: String,
 }
 
 impl DefaultArgs {
@@ -1862,8 +1862,8 @@ impl DefaultArgs {
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
-            replaying_backend_help: ReplayingBackend::cli_message(),
-            banking_backend_help: BankingBackend::cli_message(),
+            block_verification_method_help: BlockVerificationMethod::cli_message(),
+            block_production_method_help: BlockProductionMethod::cli_message(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1341,10 +1341,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("BACKEND")
                 .takes_value(true)
                 .possible_values(ReplayingBackend::cli_names())
-                .default_value(&default_args.replaying_backend)
-                .help(
-                    "Switch transaction scheduling backend for validating ledger entries"
-                ),
+                .help(&default_args.replaying_backend_help),
         )
         .arg(
             Arg::with_name("banking_backend")
@@ -1353,10 +1350,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("BACKEND")
                 .takes_value(true)
                 .possible_values(BankingBackend::cli_names())
-                .default_value(&default_args.banking_backend)
-                .help(
-                    "Switch transaction scheduling backend for generating ledger entries"
-                ),
+                .help(&default_args.banking_backend_help),
         )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
@@ -1787,8 +1781,8 @@ pub struct DefaultArgs {
     pub wait_for_restart_window_max_delinquent_stake: String,
 
     pub banking_trace_dir_byte_limit: String,
-    pub replaying_backend: String,
-    pub banking_backend: String,
+    pub replaying_backend_help: String,
+    pub banking_backend_help: String,
 }
 
 impl DefaultArgs {
@@ -1868,8 +1862,8 @@ impl DefaultArgs {
             wait_for_restart_window_min_idle_time: "10".to_string(),
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
-            replaying_backend: ReplayingBackend::default().to_string(),
-            banking_backend: BankingBackend::default().to_string(),
+            replaying_backend_help: ReplayingBackend::cli_message(),
+            banking_backend_help: BankingBackend::cli_message(),
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -14,7 +14,10 @@ use {
         system_monitor_service::SystemMonitorService,
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
-        validator::{is_snapshot_config_valid, Validator, ValidatorConfig, ValidatorStartProgress},
+        validator::{
+            is_snapshot_config_valid, BankingBackend, ReplayingBackend, Validator, ValidatorConfig,
+            ValidatorStartProgress,
+        },
     },
     solana_gossip::{cluster_info::Node, legacy_contact_info::LegacyContactInfo as ContactInfo},
     solana_ledger::blockstore_options::{
@@ -1521,6 +1524,14 @@ pub fn main() {
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
+    validator_config.replaying_backend = matches
+        .value_of("replaying_backend")
+        .map(ReplayingBackend::from)
+        .unwrap();
+    validator_config.banking_backend = matches
+        .value_of("banking_backend")
+        .map(BankingBackend::from)
+        .unwrap();
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -15,8 +15,8 @@ use {
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
         validator::{
-            is_snapshot_config_valid, BankingBackend, ReplayingBackend, Validator, ValidatorConfig,
-            ValidatorStartProgress,
+            is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod, Validator,
+            ValidatorConfig, ValidatorStartProgress,
         },
     },
     solana_gossip::{cluster_info::Node, legacy_contact_info::LegacyContactInfo as ContactInfo},
@@ -1524,9 +1524,16 @@ pub fn main() {
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
-    validator_config.replaying_backend =
-        value_t_or_exit!(matches, "replaying_backend", ReplayingBackend);
-    validator_config.banking_backend = value_t_or_exit!(matches, "banking_backend", BankingBackend);
+    validator_config.block_verification_method = value_t_or_exit!(
+        matches,
+        "block_verification_method",
+        BlockVerificationMethod
+    );
+    validator_config.block_production_method = value_t_or_exit!(
+        matches, // comment to align formatting...
+        "block_production_method",
+        BlockProductionMethod
+    );
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1524,14 +1524,9 @@ pub fn main() {
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
-    validator_config.replaying_backend = matches
-        .value_of("replaying_backend")
-        .map(ReplayingBackend::from)
-        .unwrap();
-    validator_config.banking_backend = matches
-        .value_of("banking_backend")
-        .map(BankingBackend::from)
-        .unwrap();
+    validator_config.replaying_backend =
+        value_t_or_exit!(matches, "replaying_backend", ReplayingBackend);
+    validator_config.banking_backend = value_t_or_exit!(matches, "banking_backend", BankingBackend);
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1524,16 +1524,18 @@ pub fn main() {
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
-    validator_config.block_verification_method = value_t_or_exit!(
+    validator_config.block_verification_method = value_t!(
         matches,
         "block_verification_method",
         BlockVerificationMethod
-    );
-    validator_config.block_production_method = value_t_or_exit!(
+    )
+    .unwrap_or_default();
+    validator_config.block_production_method = value_t!(
         matches, // comment to align formatting...
         "block_production_method",
         BlockProductionMethod
-    );
+    )
+    .unwrap_or_default();
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {


### PR DESCRIPTION
#### Problem

There's no way to switch block verification/production implementations from cli in the replay/banking stages.

#### Summary of Changes

Add minimal cli-side plumbing so that we can add actual impls. 

Hope, my unified scheduler for replaying can come soon....

Anyway, let's focus to battle for naming of cli args and descriptions here. :)

#### Conclusion

bike shed battle ended:

```
$ SOLANA_NO_HIDDEN_CLI_ARGS_= ./target/release/solana-ledger-tool verify --help
...
        --block-production-method <METHOD>
            Switch transaction scheduling method for producing ledger entries [default: thread-local-multi-iterator]
            [possible values: thread-local-multi-iterator]
        --block-verification-method <METHOD>
            Switch transaction scheduling method for verifying ledger entries [default: blockstore-processor] [possible
            values: blockstore-processor, unified-scheduler]
...

```
