### PR TITLE
disk index handles empty slot list more correctly

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -76,7 +76,7 @@ pub struct Bucket<T> {
     pub reallocated: Reallocated,
 }
 
-impl<'b, T: Clone + Copy + 'b> Bucket<T> {
+impl<'b, T: Clone + Copy + 'static> Bucket<T> {
     pub fn new(
         drives: Arc<Vec<PathBuf>>,
         max_search: MaxSearch,

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -16,7 +16,7 @@ use {
 
 type LockedBucket<T> = RwLock<Option<Bucket<T>>>;
 
-pub struct BucketApi<T: Clone + Copy> {
+pub struct BucketApi<T: Clone + Copy + 'static> {
     drives: Arc<Vec<PathBuf>>,
     max_search: MaxSearch,
     pub stats: Arc<BucketMapStats>,

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -25,7 +25,7 @@ impl BucketMapConfig {
     }
 }
 
-pub struct BucketMap<T: Clone + Copy + Debug> {
+pub struct BucketMap<T: Clone + Copy + Debug + 'static> {
     buckets: Vec<Arc<BucketApi<T>>>,
     drives: Arc<Vec<PathBuf>>,
     max_buckets_pow2: u8,

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -214,13 +214,8 @@ impl BucketStorage {
         }
     }
 
-    pub fn get_empty_cell_slice<T: Sized>(&self) -> &[T] {
-        let len = 0;
-        let item_slice: &[u8] = &self.mmap[0..0];
-        unsafe {
-            let item = item_slice.as_ptr() as *const T;
-            std::slice::from_raw_parts(item, len as usize)
-        }
+    pub fn get_empty_cell_slice<T: Sized + 'static>() -> &'static [T] {
+        &[]
     }
 
     pub fn get_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &[T] {


### PR DESCRIPTION
#### Problem
Working towards improving disk index performance:
#30711

#### Summary of Changes
avoid difficulties by returning `&[]` instead of something more complicated from disk index when an empty slice is required

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
