### PR TITLE
Ledger-tool: add param to deactivate features in snapshot creation

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3146,6 +3146,7 @@ fn main() {
 
                             account.set_lamports(0);
                             bank.store_account(&address, &account);
+                            debug!("Account removed: {address}");
                         }
 
                         for address in features_to_deactivate {
@@ -3170,6 +3171,7 @@ fn main() {
 
                             account.set_lamports(0);
                             bank.store_account(&address, &account);
+                            debug!("Feature deactivated: {address}");
                         }
 
                         if !vote_accounts_to_destake.is_empty() {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2083,6 +2083,16 @@ fn main() {
                     .help("List of accounts to remove while creating the snapshot"),
             )
             .arg(
+                Arg::with_name("features_to_deactivate")
+                    .required(false)
+                    .long("deactivate-feature")
+                    .takes_value(true)
+                    .value_name("PUBKEY")
+                    .validator(is_pubkey)
+                    .multiple(true)
+                    .help("List of features to deactivate while creating the snapshot")
+            )
+            .arg(
                 Arg::with_name("vote_accounts_to_destake")
                     .required(false)
                     .long("destake-vote-account")
@@ -2963,6 +2973,8 @@ fn main() {
                 let bootstrap_validator_pubkeys = pubkeys_of(arg_matches, "bootstrap_validator");
                 let accounts_to_remove =
                     pubkeys_of(arg_matches, "accounts_to_remove").unwrap_or_default();
+                let features_to_deactivate =
+                    pubkeys_of(arg_matches, "features_to_deactivate").unwrap_or_default();
                 let vote_accounts_to_destake: HashSet<_> =
                     pubkeys_of(arg_matches, "vote_accounts_to_destake")
                         .unwrap_or_default()
@@ -3081,6 +3093,7 @@ fn main() {
                             || hashes_per_tick.is_some()
                             || remove_stake_accounts
                             || !accounts_to_remove.is_empty()
+                            || !features_to_deactivate.is_empty()
                             || !vote_accounts_to_destake.is_empty()
                             || faucet_pubkey.is_some()
                             || bootstrap_validator_pubkeys.is_some();
@@ -3130,6 +3143,30 @@ fn main() {
                                 );
                                 exit(1);
                             });
+
+                            account.set_lamports(0);
+                            bank.store_account(&address, &account);
+                        }
+
+                        for address in features_to_deactivate {
+                            let mut account = bank.get_account(&address).unwrap_or_else(|| {
+                                eprintln!(
+                                    "Error: Feature account does not exist, unable to deactivate it: {address}"
+                                );
+                                exit(1);
+                            });
+
+                            match feature::from_account(&account) {
+                                Some(feature) => {
+                                    if feature.activated_at.is_none() {
+                                        warn!("Feature is not yet activated: {address}");
+                                    }
+                                }
+                                None => {
+                                    eprintln!("Error: Account is not a Feature: {address}");
+                                    exit(1);
+                                }
+                            }
 
                             account.set_lamports(0);
                             bank.store_account(&address, &account);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2083,14 +2083,14 @@ fn main() {
                     .help("List of accounts to remove while creating the snapshot"),
             )
             .arg(
-                Arg::with_name("features_to_deactivate")
+                Arg::with_name("feature_gates_to_deactivate")
                     .required(false)
-                    .long("deactivate-feature")
+                    .long("deactivate-feature-gate")
                     .takes_value(true)
                     .value_name("PUBKEY")
                     .validator(is_pubkey)
                     .multiple(true)
-                    .help("List of features to deactivate while creating the snapshot")
+                    .help("List of feature gates to deactivate while creating the snapshot")
             )
             .arg(
                 Arg::with_name("vote_accounts_to_destake")
@@ -2973,8 +2973,8 @@ fn main() {
                 let bootstrap_validator_pubkeys = pubkeys_of(arg_matches, "bootstrap_validator");
                 let accounts_to_remove =
                     pubkeys_of(arg_matches, "accounts_to_remove").unwrap_or_default();
-                let features_to_deactivate =
-                    pubkeys_of(arg_matches, "features_to_deactivate").unwrap_or_default();
+                let feature_gates_to_deactivate =
+                    pubkeys_of(arg_matches, "feature_gates_to_deactivate").unwrap_or_default();
                 let vote_accounts_to_destake: HashSet<_> =
                     pubkeys_of(arg_matches, "vote_accounts_to_destake")
                         .unwrap_or_default()
@@ -3093,7 +3093,7 @@ fn main() {
                             || hashes_per_tick.is_some()
                             || remove_stake_accounts
                             || !accounts_to_remove.is_empty()
-                            || !features_to_deactivate.is_empty()
+                            || !feature_gates_to_deactivate.is_empty()
                             || !vote_accounts_to_destake.is_empty()
                             || faucet_pubkey.is_some()
                             || bootstrap_validator_pubkeys.is_some();
@@ -3149,10 +3149,10 @@ fn main() {
                             debug!("Account removed: {address}");
                         }
 
-                        for address in features_to_deactivate {
+                        for address in feature_gates_to_deactivate {
                             let mut account = bank.get_account(&address).unwrap_or_else(|| {
                                 eprintln!(
-                                    "Error: Feature account does not exist, unable to deactivate it: {address}"
+                                    "Error: Feature-gate account does not exist, unable to deactivate it: {address}"
                                 );
                                 exit(1);
                             });
@@ -3160,18 +3160,18 @@ fn main() {
                             match feature::from_account(&account) {
                                 Some(feature) => {
                                     if feature.activated_at.is_none() {
-                                        warn!("Feature is not yet activated: {address}");
+                                        warn!("Feature gate is not yet activated: {address}");
                                     }
                                 }
                                 None => {
-                                    eprintln!("Error: Account is not a Feature: {address}");
+                                    eprintln!("Error: Account is not a `Feature`: {address}");
                                     exit(1);
                                 }
                             }
 
                             account.set_lamports(0);
                             bank.store_account(&address, &account);
-                            debug!("Feature deactivated: {address}");
+                            debug!("Feature gate deactivated: {address}");
                         }
 
                         if !vote_accounts_to_destake.is_empty() {


### PR DESCRIPTION
#### Problem
To test future branches for mainnet-beta, we anticipate testnet first rolling back to mainnet-beta software version and feature-gate state and then executing the update. This will almost always require deactivating some feature gates that are active on testnet, but not yet on mainnet-beta. There's currently no overt way to deactivate feature gates when running `solana-ledger-tool create-snapshot`.

#### Summary of Changes
Add `--deactivate-feature` parameter, which checks that an account is indeed a `solana_sdk::feature::Feature` before removing it. Logs a warning if account is a queued feature gate that is not yet active.
