### PR TITLE
when writing to disk bucket index, tune towards packing tighter

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -308,7 +308,15 @@ impl<'b, T: Clone + Copy + 'b> Bucket<T> {
             let cap_power = best_bucket.capacity_pow2;
             let cap = best_bucket.capacity();
             let pos = thread_rng().gen_range(0, cap);
-            for i in pos..pos + self.index.max_search() {
+            // max search is increased here by a lot for this search. The idea is that we just have to find an empty bucket somewhere.
+            // We don't mind waiting on a new write (by searching longer). Writing is done in the background only.
+            // Wasting space by doubling the bucket size is worse behavior. We expect more
+            // updates and fewer inserts, so we optimize for more compact data.
+            // We can accomplish this by increasing how many locations we're willing to search for an empty data cell.
+            // For the index bucket, it is more like a hash table and we have to exhaustively search 'max_search' to prove an item does not exist.
+            // And we do have to support the 'does not exist' case with good performance. So, it makes sense to grow the index bucket when it is too large.
+            // For data buckets, the offset is stored in the index, so it is directly looked up. So, the only search is on INSERT or update to a new sized value.
+            for i in pos..pos + (self.index.max_search() * 10).max(cap) {
                 let ix = i % cap;
                 if best_bucket.is_free(ix) {
                     let elem_loc = elem.data_loc(current_bucket);

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -316,7 +316,7 @@ impl<'b, T: Clone + Copy + 'b> Bucket<T> {
             // For the index bucket, it is more like a hash table and we have to exhaustively search 'max_search' to prove an item does not exist.
             // And we do have to support the 'does not exist' case with good performance. So, it makes sense to grow the index bucket when it is too large.
             // For data buckets, the offset is stored in the index, so it is directly looked up. So, the only search is on INSERT or update to a new sized value.
-            for i in pos..pos + (self.index.max_search() * 10).max(cap) {
+            for i in pos..pos + (self.index.max_search() * 10).min(cap) {
                 let ix = i % cap;
                 if best_bucket.is_free(ix) {
                     let elem_loc = elem.data_loc(current_bucket);


### PR DESCRIPTION
#### Problem
see #30711
The current implementation of disk buckets (as used by accounts index on disk) was optimized for use as a hashmap with good speed in all cases.
The implementation in the validator synchronizes the in-mem hash map with the disk based one in the background.
Currently, we resize data buckets when we don't find an empty spot when starting a search at a random offset and searching for `max_search`, which is defaulted to approximately 32.
This max search makes sense for the index buckets where we have to exhaustively search on read and write to prove something does not exist. For data buckets, we just need to find any vacant bucket to store data. The offset will then be stored in the index bucket.

#### Summary of Changes
Search 10x locations before resizing disk buckets. This will result in more compact data buckets, improving performance for reads and writes. Insertions or updates with grown/shrunk slot lists can be slower, but these only happen in the background.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
