### PR TITLE
filters out merkle shreds until feature activation

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -262,11 +262,11 @@ fn should_discard_packet<const K: usize>(
 #[must_use]
 fn should_drop_merkle_shreds(shred_slot: Slot, root_bank: &Bank) -> bool {
     check_feature_activation(
-        &feature_set::drop_merkle_shreds::id(),
+        &feature_set::keep_merkle_shreds::id(),
         shred_slot,
         root_bank,
     ) && !check_feature_activation(
-        &feature_set::keep_merkle_shreds::id(),
+        &feature_set::drop_merkle_shreds::id(),
         shred_slot,
         root_bank,
     )


### PR DESCRIPTION

#### Problem
Current merkle shreds feature-gates are "on" by default which is not backward compatible.

#### Summary of Changes
In order to maintain backward compatibility, the commit reworks merkle shreds feature gate to off by default until the feature activation.
