### PR TITLE
Cannot get snapshot storages if base slot is Slot::MAX

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7063,7 +7063,8 @@ impl Bank {
     /// If a base slot is provided, return only the storages that are *higher* than this slot.
     pub fn get_snapshot_storages(&self, base_slot: Option<Slot>) -> Vec<Arc<AccountStorageEntry>> {
         // if a base slot is provided, request storages starting at the slot *after*
-        let start_slot = base_slot.map_or(0, |slot| slot.saturating_add(1));
+        let start_slot =
+            base_slot.map_or(0, |slot| slot.checked_add(1).expect("slot less than max"));
         // we want to *include* the storage at our slot
         let requested_slots = start_slot..=self.slot();
 


### PR DESCRIPTION
#### Problem

When getting snapshot storages *with a base slot*, the starting slot *must* be greater than the base slot.

Right now if base slot is Slot::MAX, the saturating add will cause the starting slot to be the same value, which is illegal. Instead of only relying on other parts of the code to ensure slots get numbered correctly, we can also state the requirements of this function in the code as well.


#### Summary of Changes

Replace saturating add with checked add.