### PR TITLE
Do not use ancestors in get_snapshot_storages

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -99,7 +99,8 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let (_, total_lamports) = accounts
         .accounts_db
         .update_accounts_hash_for_tests(0, &ancestors, false, false);
-    let test_hash_calculation = false;
+    accounts.add_root(slot);
+    accounts.accounts_db.flush_accounts_cache(true, Some(slot));
     bencher.iter(|| {
         assert!(accounts.verify_accounts_hash_and_lamports(
             0,
@@ -107,7 +108,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
             None,
             VerifyAccountsHashAndLamportsConfig {
                 ancestors: &ancestors,
-                test_hash_calculation,
+                test_hash_calculation: false,
                 epoch_schedule: &EpochSchedule::default(),
                 rent_collector: &RentCollector::default(),
                 ignore_mismatch: false,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8664,7 +8664,8 @@ impl AccountsDb {
     pub fn get_snapshot_storages(
         &self,
         requested_slots: impl RangeBounds<Slot> + Sync,
-        ancestors: Option<&Ancestors>,
+        // ancestors is unused and will be removed from callers next
+        _ancestors: Option<&Ancestors>,
     ) -> (Vec<Arc<AccountStorageEntry>>, Vec<Slot>) {
         let mut m = Measure::start("get slots");
         let mut slots_and_storages = self
@@ -8686,12 +8687,7 @@ impl AccountsDb {
                 .map(|slots_and_storages| {
                     slots_and_storages
                         .iter_mut()
-                        .filter(|(slot, _)| {
-                            self.accounts_index.is_alive_root(*slot)
-                                || ancestors
-                                    .map(|ancestors| ancestors.contains_key(slot))
-                                    .unwrap_or_default()
-                        })
+                        .filter(|(slot, _)| self.accounts_index.is_alive_root(*slot))
                         .filter_map(|(slot, store)| {
                             let store = std::mem::take(store).unwrap();
                             store.has_accounts().then_some((store, *slot))


### PR DESCRIPTION
#### Problem

`AccountsDb::get_snapshot_storages()` has a parameter for ancestors. Also, all storages returned must be for rooted slots. Since ancestors are only useful for disambiguating unrooted slots on forks, the param is effectively useless. Additionally, I was confused why it existed and had to investigate that it was left over from previous cleanup.


#### Summary of Changes

Remove `ancestors` param from `AccountsDb::get_snapshot_storages()`.

For small, incremental PRs and diffs, future PRs will clean up the *callers* of this function.