### PR TITLE
Removes unused `ancestors` param from `get_snapshot_storages`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7070,7 +7070,7 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .get_snapshot_storages(requested_slots, None)
+            .get_snapshot_storages(requested_slots)
             .0
     }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -43,7 +43,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
     accounts_db: &AccountsDb,
     output_dir: P,
 ) -> std::io::Result<StorageAndNextAppendVecId> {
-    let storage_entries = accounts_db.get_snapshot_storages(RangeFull, None).0;
+    let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
     let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
     let mut next_append_vec_id = 0;
     for storage_entry in storage_entries.into_iter() {
@@ -196,7 +196,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &mut writer,
         &accounts.accounts_db,
         slot,
-        &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=slot, None).0),
+        &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=slot).0),
     )
     .unwrap();
 
@@ -434,7 +434,7 @@ pub(crate) fn reconstruct_accounts_db_via_serialization(
     slot: Slot,
 ) -> AccountsDb {
     let mut writer = Cursor::new(vec![]);
-    let snapshot_storages = accounts.get_snapshot_storages(..=slot, None).0;
+    let snapshot_storages = accounts.get_snapshot_storages(..=slot).0;
     accountsdb_to_stream(
         SerdeStyle::Newer,
         &mut writer,
@@ -738,12 +738,7 @@ mod test_bank_serialize {
             .accounts
             .accounts_db
             .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
-        let snapshot_storages = bank
-            .rc
-            .accounts
-            .accounts_db
-            .get_snapshot_storages(..=0, None)
-            .0;
+        let snapshot_storages = bank.rc.accounts.accounts_db.get_snapshot_storages(..=0).0;
         // ensure there is a single snapshot storage example for ABI digesting
         assert_eq!(snapshot_storages.len(), 1);
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -276,7 +276,7 @@ impl<'a> SnapshotMinimizer<'a> {
     ) -> (Vec<Slot>, Vec<Arc<AccountStorageEntry>>) {
         let snapshot_storages = self
             .accounts_db()
-            .get_snapshot_storages(..=self.starting_slot, None)
+            .get_snapshot_storages(..=self.starting_slot)
             .0;
 
         let dead_slots = Mutex::new(Vec::new());
@@ -677,7 +677,7 @@ mod tests {
         };
         minimizer.minimize_accounts_db();
 
-        let snapshot_storages = accounts.get_snapshot_storages(..=current_slot, None).0;
+        let snapshot_storages = accounts.get_snapshot_storages(..=current_slot).0;
         assert_eq!(snapshot_storages.len(), 3);
 
         let mut account_count = 0;


### PR DESCRIPTION
#### Problem

The `ancestors` param on `get_snapshot_storages()` is unused and can be removed from callers.


#### Summary of Changes

Remove it.