### PR TITLE
adds metrics tracking deduper saturations

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -59,7 +59,9 @@ impl ShredFetchStage {
         let mut stats = ShredFetchStats::default();
 
         for mut packet_batch in recvr {
-            deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE);
+            if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE) {
+                stats.num_deduper_saturations += 1;
+            }
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
                 {

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -32,6 +32,7 @@ pub struct ProcessShredsStats {
 pub struct ShredFetchStats {
     pub index_overrun: usize,
     pub shred_count: usize,
+    pub num_deduper_saturations: usize,
     pub(crate) num_shreds_merkle_code: usize,
     pub(crate) num_shreds_merkle_data: usize,
     pub ping_count: usize,
@@ -117,6 +118,7 @@ impl ShredFetchStats {
             name,
             ("index_overrun", self.index_overrun, i64),
             ("shred_count", self.shred_count, i64),
+            ("num_deduper_saturations", self.num_deduper_saturations, i64),
             ("num_shreds_merkle_code", self.num_shreds_merkle_code, i64),
             ("num_shreds_merkle_data", self.num_shreds_merkle_data, i64),
             ("ping_count", self.ping_count, i64),


### PR DESCRIPTION

#### Problem
track how often the deduper gets saturated before reset-cycle.

#### Summary of Changes
added metrics.