### PR TITLE
Update accounts-cluster-bench to work against public clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4813,6 +4813,7 @@ dependencies = [
  "rayon",
  "solana-account-decoder",
  "solana-clap-utils",
+ "solana-cli-config",
  "solana-client",
  "solana-core",
  "solana-faucet",

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -15,6 +15,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-clap-utils = { workspace = true }
+solana-cli-config = { workspace = true }
 solana-client = { workspace = true }
 solana-faucet = { workspace = true }
 solana-gossip = { workspace = true }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -83,7 +83,7 @@ pub fn poll_get_fee_for_message(client: &RpcClient, message: &mut Message) -> (O
     }
 }
 
-pub fn airdrop_lamports(
+fn airdrop_lamports(
     client: &RpcClient,
     faucet_addr: &SocketAddr,
     id: &Keypair,

--- a/client/src/transaction_executor.rs
+++ b/client/src/transaction_executor.rs
@@ -32,13 +32,25 @@ pub struct TransactionExecutor {
 
 impl TransactionExecutor {
     pub fn new(entrypoint_addr: SocketAddr) -> Self {
-        let sigs = Arc::new(RwLock::new(Vec::new()));
-        let cleared = Arc::new(RwLock::new(Vec::new()));
-        let exit = Arc::new(AtomicBool::new(false));
         let client = Arc::new(RpcClient::new_socket_with_commitment(
             entrypoint_addr,
             CommitmentConfig::confirmed(),
         ));
+        Self::new_with_rpc_client(client)
+    }
+
+    pub fn new_with_url<U: ToString>(url: U) -> Self {
+        let client = Arc::new(RpcClient::new_with_commitment(
+            url,
+            CommitmentConfig::confirmed(),
+        ));
+        Self::new_with_rpc_client(client)
+    }
+
+    pub fn new_with_rpc_client(client: Arc<RpcClient>) -> Self {
+        let sigs = Arc::new(RwLock::new(Vec::new()));
+        let cleared = Arc::new(RwLock::new(Vec::new()));
+        let exit = Arc::new(AtomicBool::new(false));
         let sig_clear_t = Self::start_sig_clear_thread(&exit, &sigs, &cleared, &client);
         Self {
             sigs,


### PR DESCRIPTION
#### Problem
Similar [to bench-tps](https://github.com/solana-labs/solana/pull/24227), accounts-cluster-bench was written for custom clusters, so it assumes rpc access is available at the entrypoint and every node in the cluster. This means the tool can't be easy pointed at public clusters, like testnet.

Broader context: we are using this tool to increase the size of testnet snapshots, and an expanded version of this tool may be useful in the future to make testnet topography better reflect that on mainnet-beta

#### Summary of Changes
Add support for the `--url` parameter and monikers in accounts-cluster-bench, and use to create RpcClient.
Also update airdrops to use rpc instead of trying to target the faucet directly (avoiding the need for the machine where accounts-cluster-bench to be whitelisted on a public faucet).

This PR changes the default behavior when no `--entrypoint` (or `--url`) parameter is passed from connecting to 127.0.0.1:8001 via gossip to using the url set in the rpc config file. But since this default seems better, and afaik Haoran and I are the only people using this tool, and we always pass `--entrypoint` explicitly, I think this breakage is okay.
