### PR TITLE
Move alignment related consts from append_vec.rs to accounts_file.rs

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -5,8 +5,8 @@
 use {
     crate::{
         accounts_db::AppendVecId,
+        accounts_file::ALIGN_BOUNDARY_OFFSET,
         accounts_index::{IsCached, ZeroLamport},
-        append_vec::ALIGN_BOUNDARY_OFFSET,
     },
     modular_bitfield::prelude::*,
 };

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -17,6 +17,7 @@ use {
 // Data placement should be aligned at the next boundary. Without alignment accessing the memory may
 // crash on some architectures.
 pub const ALIGN_BOUNDARY_OFFSET: usize = mem::size_of::<u64>();
+#[macro_export]
 macro_rules! u64_align {
     ($addr: expr) => {
         ($addr + (ALIGN_BOUNDARY_OFFSET - 1)) & !(ALIGN_BOUNDARY_OFFSET - 1)

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -9,10 +9,19 @@ use {
     solana_sdk::{account::ReadableAccount, clock::Slot, hash::Hash, pubkey::Pubkey},
     std::{
         borrow::Borrow,
-        io,
+        io, mem,
         path::{Path, PathBuf},
     },
 };
+
+// Data placement should be aligned at the next boundary. Without alignment accessing the memory may
+// crash on some architectures.
+pub const ALIGN_BOUNDARY_OFFSET: usize = mem::size_of::<u64>();
+macro_rules! u64_align {
+    ($addr: expr) => {
+        ($addr + (ALIGN_BOUNDARY_OFFSET - 1)) & !(ALIGN_BOUNDARY_OFFSET - 1)
+    };
+}
 
 #[derive(Debug)]
 /// An enum for accessing an accounts file which can be implemented

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -12,6 +12,7 @@ use {
         },
         accounts_file::ALIGN_BOUNDARY_OFFSET,
         storable_accounts::StorableAccounts,
+        u64_align,
     },
     log::*,
     memmap2::MmapMut,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -10,6 +10,7 @@ use {
             AccountMeta, StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo,
             StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
         },
+        accounts_file::ALIGN_BOUNDARY_OFFSET,
         storable_accounts::StorableAccounts,
     },
     log::*,
@@ -37,15 +38,6 @@ use {
 };
 
 pub mod test_utils;
-
-// Data placement should be aligned at the next boundary. Without alignment accessing the memory may
-// crash on some architectures.
-pub const ALIGN_BOUNDARY_OFFSET: usize = mem::size_of::<u64>();
-macro_rules! u64_align {
-    ($addr: expr) => {
-        ($addr + (ALIGN_BOUNDARY_OFFSET - 1)) & !(ALIGN_BOUNDARY_OFFSET - 1)
-    };
-}
 
 /// size of the fixed sized fields in an append vec
 /// we need to add data len and align it to get the actual stored size

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,7 +12,6 @@ pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;
 pub mod accounts_db;
-#[macro_use]
 pub mod accounts_file;
 pub mod accounts_hash;
 pub mod accounts_index;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;
 pub mod accounts_db;
+#[macro_use]
 pub mod accounts_file;
 pub mod accounts_hash;
 pub mod accounts_index;


### PR DESCRIPTION
#### Problem
As we start supporting new storage formats, alignment-related constants and macros
defined in append_vec.rs aren't only specific to AppendVec.

#### Summary of Changes
Move alignment-related constants/macros from append_vec.rs to accounts_file.rs

