### PR TITLE
removes lazy-static thread-pool from sigverify-shreds

### DIFF
--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -1,10 +1,12 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
+    rayon::{ThreadPool, ThreadPoolBuilder},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache, shred, sigverify_shreds::verify_shreds_gpu,
     },
     solana_perf::{self, packet::PacketBatch, recycler_cache::RecyclerCache},
+    solana_rayon_threadlimit::get_thread_count,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{clock::Slot, pubkey::Pubkey},
     std::{
@@ -36,10 +38,15 @@ pub(crate) fn spawn_shred_sigverify(
 ) -> JoinHandle<()> {
     let recycler_cache = RecyclerCache::warmed();
     let mut stats = ShredSigVerifyStats::new(Instant::now());
-    Builder::new()
-        .name("solShredVerifr".to_string())
-        .spawn(move || loop {
+    let thread_pool = ThreadPoolBuilder::new()
+        .num_threads(get_thread_count())
+        .thread_name(|i| format!("solSvrfyShred{i:02}"))
+        .build()
+        .unwrap();
+    let run_shred_sigverify = move || {
+        loop {
             match run_shred_sigverify(
+                &thread_pool,
                 // We can't store the pubkey outside the loop
                 // because the identity might be hot swapped.
                 &cluster_info.id(),
@@ -58,11 +65,17 @@ pub(crate) fn spawn_shred_sigverify(
                 Err(Error::SendError) => break,
             }
             stats.maybe_submit();
-        })
+        }
+    };
+    Builder::new()
+        .name("solShredVerifr".to_string())
+        .spawn(run_shred_sigverify)
         .unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_shred_sigverify(
+    thread_pool: &ThreadPool,
     self_pubkey: &Pubkey,
     bank_forks: &RwLock<BankForks>,
     leader_schedule_cache: &LeaderScheduleCache,
@@ -83,6 +96,7 @@ fn run_shred_sigverify(
     stats.num_packets += packets.iter().map(PacketBatch::len).sum::<usize>();
     stats.num_discards_pre += count_discards(&packets);
     verify_packets(
+        thread_pool,
         self_pubkey,
         bank_forks,
         leader_schedule_cache,
@@ -108,6 +122,7 @@ fn run_shred_sigverify(
 }
 
 fn verify_packets(
+    thread_pool: &ThreadPool,
     self_pubkey: &Pubkey,
     bank_forks: &RwLock<BankForks>,
     leader_schedule_cache: &LeaderScheduleCache,
@@ -121,7 +136,7 @@ fn verify_packets(
             .filter_map(|(slot, pubkey)| Some((slot, pubkey?.to_bytes())))
             .chain(std::iter::once((Slot::MAX, [0u8; 32])))
             .collect();
-    let out = verify_shreds_gpu(packets, &leader_slots, recycler_cache);
+    let out = verify_shreds_gpu(thread_pool, packets, &leader_slots, recycler_cache);
     solana_perf::sigverify::mark_disabled(packets, &out);
 }
 
@@ -284,7 +299,9 @@ mod tests {
         batches[0][1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
         batches[0][1].meta_mut().size = shred.payload().len();
 
+        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         verify_packets(
+            &thread_pool,
             &Pubkey::new_unique(), // self_pubkey
             &bank_forks,
             &leader_schedule_cache,


### PR DESCRIPTION

#### Problem
The lazy-static thread-pool is not accessible from outside the `ledger/src/sigverfiy_shreds.rs` file.

#### Summary of Changes
The commit passes the thread-pool explicitly from higher in the call stack so that https://github.com/solana-labs/solana/pull/30786 can use the same thread-pool for shred deduplication.