### PR TITLE
removes false_positive_rate field from Deduper

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -44,8 +44,7 @@ impl ShredFetchStage {
     ) {
         const STATS_SUBMIT_CADENCE: Duration = Duration::from_secs(1);
         let mut rng = rand::thread_rng();
-        let mut deduper =
-            Deduper::<2>::new(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_NUM_BITS);
+        let mut deduper = Deduper::<2>::new(&mut rng, DEDUPER_NUM_BITS);
         let mut last_updated = Instant::now();
         let mut keypair = repair_context
             .as_ref()
@@ -60,7 +59,7 @@ impl ShredFetchStage {
         let mut stats = ShredFetchStats::default();
 
         for mut packet_batch in recvr {
-            deduper.maybe_reset(&mut rng, &DEDUPER_RESET_CYCLE);
+            deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE);
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
                 {
@@ -286,7 +285,7 @@ mod tests {
     fn test_data_code_same_index() {
         solana_logger::setup();
         let mut rng = rand::thread_rng();
-        let deduper = Deduper::<2>::new(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, 640_007);
+        let deduper = Deduper::<2>::new(&mut rng, /*num_bits:*/ 640_007);
         let mut packet = Packet::default();
         let mut stats = ShredFetchStats::default();
 
@@ -338,7 +337,7 @@ mod tests {
     fn test_shred_filter() {
         solana_logger::setup();
         let mut rng = rand::thread_rng();
-        let deduper = Deduper::<2>::new(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, 640_007);
+        let deduper = Deduper::<2>::new(&mut rng, /*num_bits:*/ 640_007);
         let mut packet = Packet::default();
         let mut stats = ShredFetchStats::default();
         let last_root = 0;

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -416,10 +416,9 @@ impl SigVerifyStage {
             .name("solSigVerifier".to_string())
             .spawn(move || {
                 let mut rng = rand::thread_rng();
-                let mut deduper =
-                    Deduper::<2>::new(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_NUM_BITS);
+                let mut deduper = Deduper::<2>::new(&mut rng, DEDUPER_NUM_BITS);
                 loop {
-                    deduper.maybe_reset(&mut rng, &MAX_DEDUPER_AGE);
+                    deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, MAX_DEDUPER_AGE);
                     if let Err(e) =
                         Self::verifier(&deduper, &packet_receiver, &mut verifier, &mut stats)
                     {

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -25,12 +25,14 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
 fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) {
     // verify packets
     let mut rng = rand::thread_rng();
-    let mut deduper = Deduper::<2>::new(
-        &mut rng, /*false_positive_rate:*/ 0.001, /*num_bits:*/ 63_999_979,
-    );
+    let mut deduper = Deduper::<2>::new(&mut rng, /*num_bits:*/ 63_999_979);
     bencher.iter(|| {
         let _ans = deduper.dedup_packets_and_count_discards(&mut batches, |_, _, _| ());
-        deduper.maybe_reset(&mut rng, /*reset_cycle:*/ &Duration::from_secs(2));
+        deduper.maybe_reset(
+            &mut rng,
+            0.001,                  // false_positive_rate
+            Duration::from_secs(2), // reset_cycle
+        );
         batches
             .iter_mut()
             .for_each(|b| b.iter_mut().for_each(|p| p.meta_mut().set_discard(false)));
@@ -116,10 +118,12 @@ fn bench_dedup_baseline(bencher: &mut Bencher) {
 #[ignore]
 fn bench_dedup_reset(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
-    let mut deduper = Deduper::<2>::new(
-        &mut rng, /*false_positive_rate:*/ 0.001, /*num_bits:*/ 63_999_979,
-    );
+    let mut deduper = Deduper::<2>::new(&mut rng, /*num_bits:*/ 63_999_979);
     bencher.iter(|| {
-        deduper.maybe_reset(&mut rng, /*reset_cycle:*/ &Duration::from_millis(0));
+        deduper.maybe_reset(
+            &mut rng,
+            0.001,                    // false_positive_rate
+            Duration::from_millis(0), // reset_cycle
+        );
     });
 }


### PR DESCRIPTION

#### Problem
`Deduper.false_positive_rate` field is misleading because it is not enforced until `maybe_reset` is called. But then `maybe_reset` can be invoked with an explicit argument.


#### Summary of Changes
* removed the `false_positive_rate` field from `Deduper`.
* `maybe_reset` now takes a `false_positive_rate` argument.