### PR TITLE
Adds plumbing and tests for verify_snapshot_bank() with Incremental Accounts Hash

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1515,13 +1515,16 @@ fn load_frozen_forks(
 fn run_final_hash_calc(bank: &Bank, on_halt_store_hash_raw_data_for_debug: bool) {
     bank.force_flush_accounts_cache();
     // note that this slot may not be a root
-    let _ = bank.verify_accounts_hash(VerifyAccountsHashConfig {
-        test_hash_calculation: false,
-        ignore_mismatch: true,
-        require_rooted_bank: false,
-        run_in_background: false,
-        store_hash_raw_data_for_debug: on_halt_store_hash_raw_data_for_debug,
-    });
+    let _ = bank.verify_accounts_hash(
+        None,
+        VerifyAccountsHashConfig {
+            test_hash_calculation: false,
+            ignore_mismatch: true,
+            require_rooted_bank: false,
+            run_in_background: false,
+            store_hash_raw_data_for_debug: on_halt_store_hash_raw_data_for_debug,
+        },
+    );
 }
 
 // `roots` is sorted largest to smallest by root slot

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7353,6 +7353,25 @@ impl AccountsDb {
         (accounts_hash, total_lamports)
     }
 
+    /// Calculate the incremental accounts hash for `storages` and save the results at `slot`
+    pub fn update_incremental_accounts_hash(
+        &self,
+        config: &CalcAccountsHashConfig<'_>,
+        storages: &SortedStorages<'_>,
+        slot: Slot,
+        stats: HashStats,
+    ) -> Result<(IncrementalAccountsHash, /*capitalization*/ u64), AccountsHashVerificationError>
+    {
+        let incremental_accounts_hash =
+            self.calculate_incremental_accounts_hash(config, storages, stats)?;
+        let old_incremental_accounts_hash =
+            self.set_incremental_accounts_hash(slot, incremental_accounts_hash);
+        if let Some(old_incremental_accounts_hash) = old_incremental_accounts_hash {
+            warn!("Incremental accounts hash was already set for slot {slot}! old: {old_incremental_accounts_hash:?}, new: {incremental_accounts_hash:?}");
+        }
+        Ok(incremental_accounts_hash)
+    }
+
     /// Set the accounts hash for `slot`
     ///
     /// returns the previous accounts hash for `slot`

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1482,6 +1482,7 @@ pub fn bank_from_snapshot_archives(
         test_hash_calculation,
         accounts_db_skip_shrink || !full_snapshot_archive_info.is_remote(),
         full_snapshot_archive_info.slot(),
+        None,
     ) && limit_load_slot_count_from_snapshot.is_none()
     {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());


### PR DESCRIPTION
#### Problem

After deserializing and reconstructing a bank, it is verified. In that verification, it checks the accounts hash, but currently does not check for Incremental Accounts Hash.

#### Summary of Changes

* Plumb the base snapshot information (full snapshot slot and capitalization) to `verify_snapshot_bank()` and lower.
* Add `Bank::update_incremental_accounts_hash()` and `AccountsDb::incremental_accounts_hash()`
    * currently only used in the new test, but will be adopted by AccountsHashVerifier and `snapshot_utils::bank_to_incremental_snapshot_archive()`