### PR TITLE
Enforce minimum of 1 for --maximum-full-snapshots-to-retain

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -83,6 +83,7 @@ pub(crate) const TMP_BANK_SNAPSHOT_PREFIX: &str = "tmp-bank-snapshot-";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
 pub const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8; // Save some bank snapshots but not too many
+pub const MIN_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 1;
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 2;
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 4;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -41,6 +41,7 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
             self, create_all_accounts_run_and_snapshot_dirs, ArchiveFormat, SnapshotVersion,
+            MIN_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
     },
     solana_sdk::{
@@ -1391,6 +1392,13 @@ pub fn main() {
     let maximum_local_snapshot_age = value_t_or_exit!(matches, "maximum_local_snapshot_age", u64);
     let maximum_full_snapshot_archives_to_retain =
         value_t_or_exit!(matches, "maximum_full_snapshots_to_retain", usize);
+    if maximum_full_snapshot_archives_to_retain < MIN_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN {
+        eprintln!(
+            "The provided --maximum-full-snapshots-to-retain value is too small, \
+            the minimum value is {MIN_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN}"
+        );
+        exit(1);
+    }
     let maximum_incremental_snapshot_archives_to_retain =
         value_t_or_exit!(matches, "maximum_incremental_snapshots_to_retain", usize);
     let snapshot_packager_niceness_adj =


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30794

#### Summary of Changes
Some existing logic already assumes a minimum of 1, so enforce this restriction at the command line arg to avoid a user to specify a value of 0 and break invariants.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
