### PR TITLE
Sets IncrementalAccountsHash in serde_snapshot when reconstructing AccountsDb

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -124,6 +124,7 @@ where
         &Arc::default(),
         None,
         (u64::default(), None),
+        None,
     )
     .map(|(accounts_db, _)| accounts_db)
 }


### PR DESCRIPTION
#### Problem

`serde_snapshot` does not know about Incremental Accounts Hash.


#### Summary of Changes

If there is a `BankIncrementalSnapshotPersistence` field in the snapshot, use it to extract the Incremental Accounts Hash information.

Feature Gate Issue: #30819