### PR TITLE
Adds test for programs which read from a program account

### DIFF
--- a/programs/sbf/c/src/read_program/read_program.c
+++ b/programs/sbf/c/src/read_program/read_program.c
@@ -1,0 +1,22 @@
+#include <solana_sdk.h>
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  SolAccountInfo ka[1];
+  SolParameters params = (SolParameters){.ka = ka};
+
+  sol_log(__FILE__);
+
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
+    return ERROR_INVALID_ARGUMENT;
+  }
+
+  char ka_data[] = {0x7F, 0x45, 0x4C, 0x46};
+
+  sol_assert(params.ka_num == 1);
+  sol_assert(!sol_memcmp(params.ka[0].data, ka_data, 4));
+  sol_assert(params.ka[0].is_signer == false);
+  sol_assert(params.ka[0].is_writable == false);
+  sol_assert(params.ka[0].executable == true);
+
+  return SUCCESS;
+}

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2203,6 +2203,34 @@ fn test_program_sbf_disguised_as_sbf_loader() {
 
 #[test]
 #[cfg(feature = "sbf_c")]
+fn test_program_reads_from_program_account() {
+    solana_logger::setup();
+
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(50);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (name, id, entrypoint) = solana_bpf_loader_program!();
+    bank.add_builtin(&name, &id, entrypoint);
+    let bank_client = BankClient::new(bank);
+
+    let program_id = load_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "read_program",
+    );
+    let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
+    let instruction = Instruction::new_with_bytes(program_id, &[], account_metas);
+    bank_client
+        .send_and_confirm_instruction(&mint_keypair, instruction)
+        .unwrap();
+}
+
+#[test]
+#[cfg(feature = "sbf_c")]
 fn test_program_sbf_c_dup() {
     solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
We are currently missing a test to check the following use case:
A program reads data from a program account.
E.g. to verify the version or some sort of signature.

#### Summary of Changes
Adds `test_program_reads_from_program_account()`.