### PR TITLE
ledger: Extract `BatchExecutionTiming`

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -65,7 +65,7 @@ impl ReplaySlotStats {
                     i64
                 ),
                 ("replay_time", self.replay_elapsed as i64, i64),
-                ("execute_batches_us", self.execute_batches_us as i64, i64),
+                ("execute_batches_us", self.batch_execute.wall_clock_us as i64, i64),
                 (
                     "replay_total_elapsed",
                     self.started.elapsed().as_micros() as i64,
@@ -77,14 +77,15 @@ impl ReplaySlotStats {
                 ("total_shreds", num_shreds as i64, i64),
                 // Everything inside the `eager!` block will be eagerly expanded before
                 // evaluation of the rest of the surrounding macro.
-                eager!{report_execute_timings!(self.execute_timings)}
+                eager!{report_execute_timings!(self.batch_execute.totals)}
             );
         };
 
-        self.end_to_end_execute_timings.report_stats(slot);
+        self.batch_execute.slowest_thread.report_stats(slot);
 
         let mut per_pubkey_timings: Vec<_> = self
-            .execute_timings
+            .batch_execute
+            .totals
             .details
             .per_program_timings
             .iter()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2585,10 +2585,12 @@ impl ReplayStage {
                 let r_replay_stats = replay_stats.read().unwrap();
                 let replay_progress = bank_progress.replay_progress.clone();
                 let r_replay_progress = replay_progress.read().unwrap();
-                debug!("bank {} is completed replay from blockstore, contribute to update cost with {:?}",
+                debug!(
+                    "bank {} has completed replay from blockstore, \
+                     contribute to update cost with {:?}",
                     bank.slot(),
-                    r_replay_stats.execute_timings
-                    );
+                    r_replay_stats.batch_execute.totals
+                );
                 did_complete_bank = true;
                 let _ = cluster_slots_update_sender.send(vec![bank_slot]);
                 if let Some(transaction_status_sender) = transaction_status_sender {
@@ -2682,7 +2684,7 @@ impl ReplayStage {
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
                 );
-                execute_timings.accumulate(&r_replay_stats.execute_timings);
+                execute_timings.accumulate(&r_replay_stats.batch_execute.totals);
             } else {
                 trace!(
                     "bank {} not completed tick_height: {}, max_tick_height: {}",


### PR DESCRIPTION
#### Problem
`ConfirmationTiming` has 3 fields that measure `execute_batch()` performance over time and across threads.  They are interconnected and have dedicated logic.

#### Summary of Changes
Extracted time metrics related to transaction execution into a separate structure.  This allows me to call `process_entries_with_callback()` without locking the whole instance of `ConfirmationTiming`, passing just the `BatchExecutionTiming` part.

I want to add a new metric that starts at the beginning of the `confirm_slot_entries()` call and ends until the very end.  In order to use a `scopeguard::defer`, I need to be able to have an excursive reference to it for the whole body of `confirm_slot_entries()`.

Plus a few minor renamings to clarify which verifications and results variables actually store.  And corrected a few messages, that incorrectly stated PoH verification, while they were actually issued for transaction verification failures.