### PR TITLE
ledger: confirm_slot_entries(): confirmation_elapsed metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5779,6 +5779,7 @@ dependencies = [
  "reed-solomon-erasure",
  "rocksdb",
  "rustc_version 0.4.0",
+ "scopeguard",
  "serde",
  "serde_bytes",
  "sha2 0.10.6",

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -64,6 +64,7 @@ impl ReplaySlotStats {
                     self.transaction_verify_elapsed as i64,
                     i64
                 ),
+                ("confirmation_time_us", self.confirmation_elapsed as i64, i64),
                 ("replay_time", self.replay_elapsed as i64, i64),
                 ("execute_batches_us", self.batch_execute.wall_clock_us as i64, i64),
                 (

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -32,6 +32,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 reed-solomon-erasure = { workspace = true, features = ["simd-accel"] }
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 sha2 = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
  "reed-solomon-erasure",
  "rocksdb",
  "rustc_version 0.4.0",
+ "scopeguard",
  "serde",
  "serde_bytes",
  "sha2 0.10.6",


### PR DESCRIPTION
#### Problem
We do not have a metric that covers wall clock time that would include both PoH/transaction verification, and the subsequent replay stage.

#### Summary of Changes
Measure total time spent inside `confirm_slot_entries()`.  Useful metric
in addition to `replay_elapsed` and
`poh_verify_elapsed`/`transaction_verify_elapsed`, as it shows how PoH
and transaction verification interact with the replay process.