### PR TITLE
poh_verify => run_verification: Rename to be more accurate

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -152,7 +152,9 @@ pub struct ValidatorConfig {
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,
-    pub poh_verify: bool, // Perform PoH verification during blockstore processing at boo
+    /// Run PoH, transaction signature and other transaction verifications during blockstore
+    /// processing.
+    pub run_verification: bool,
     pub require_tower: bool,
     pub tower_storage: Arc<dyn TowerStorage>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -216,7 +218,7 @@ impl Default for ValidatorConfig {
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             wal_recovery_mode: None,
-            poh_verify: true,
+            run_verification: true,
             require_tower: false,
             tower_storage: Arc::new(crate::tower_storage::NullTowerStorage::default()),
             debug_keys: None,
@@ -1483,7 +1485,7 @@ fn load_blockstore(
         .or_else(|| blockstore.highest_slot().unwrap_or(None));
 
     let process_options = blockstore_processor::ProcessOptions {
-        poh_verify: config.poh_verify,
+        run_verification: config.run_verification,
         halt_at_slot,
         new_hard_forks: config.new_hard_forks.clone(),
         debug_keys: config.debug_keys.clone(),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1930,7 +1930,16 @@ fn main() {
                 Arg::with_name("skip_poh_verify")
                     .long("skip-poh-verify")
                     .takes_value(false)
-                    .help("Skip ledger PoH verification"),
+                    .help(
+                        "Deprecated, please use --skip-verification.\n\
+                         Skip ledger PoH and transaction verification."
+                    ),
+            )
+            .arg(
+                Arg::with_name("skip_verification")
+                    .long("skip-verification")
+                    .takes_value(false)
+                    .help("Skip ledger PoH and transaction verification."),
             )
             .arg(
                 Arg::with_name("print_accounts_stats")
@@ -2528,7 +2537,7 @@ fn main() {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     halt_at_slot: Some(0),
-                    poh_verify: false,
+                    run_verification: false,
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
@@ -2619,7 +2628,7 @@ fn main() {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
-                    poh_verify: false,
+                    run_verification: false,
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
@@ -2827,9 +2836,16 @@ fn main() {
                 let debug_keys = pubkeys_of(arg_matches, "debug_key")
                     .map(|pubkeys| Arc::new(pubkeys.into_iter().collect::<HashSet<_>>()));
 
+                if arg_matches.is_present("skip_poh_verify") {
+                    eprintln!(
+                        "--skip-poh-verify is deprecated.  Replace with --skip-verification."
+                    );
+                }
+
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
-                    poh_verify: !arg_matches.is_present("skip_poh_verify"),
+                    run_verification: !(arg_matches.is_present("skip_poh_verify")
+                        || arg_matches.is_present("skip_verification")),
                     on_halt_store_hash_raw_data_for_debug: arg_matches
                         .is_present("halt_at_slot_store_hash_raw_data"),
                     // ledger tool verify always runs the accounts hash calc at the end of processing the blockstore
@@ -2897,7 +2913,7 @@ fn main() {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
-                    poh_verify: false,
+                    run_verification: false,
                     ..ProcessOptions::default()
                 };
 
@@ -3081,7 +3097,7 @@ fn main() {
                     ProcessOptions {
                         new_hard_forks,
                         halt_at_slot: Some(snapshot_slot),
-                        poh_verify: false,
+                        run_verification: false,
                         accounts_db_config: Some(get_accounts_db_config(&ledger_path, arg_matches)),
                         accounts_db_skip_shrink: arg_matches.is_present("accounts_db_skip_shrink"),
                         ..ProcessOptions::default()
@@ -3433,7 +3449,7 @@ fn main() {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     halt_at_slot,
-                    poh_verify: false,
+                    run_verification: false,
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
@@ -3522,7 +3538,7 @@ fn main() {
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     halt_at_slot,
-                    poh_verify: false,
+                    run_verification: false,
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -595,7 +595,8 @@ pub type ProcessCallback = Arc<dyn Fn(&Bank) + Sync + Send>;
 
 #[derive(Default, Clone)]
 pub struct ProcessOptions {
-    pub poh_verify: bool,
+    /// Run PoH, transaction signature and other transaction verifications on the entries.
+    pub run_verification: bool,
     pub full_leader_cache: bool,
     pub halt_at_slot: Option<Slot>,
     pub new_hard_forks: Option<Vec<Slot>>,
@@ -881,7 +882,7 @@ fn confirm_full_slot(
     timing: &mut ExecuteTimings,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let mut confirmation_timing = ConfirmationTiming::default();
-    let skip_verification = !opts.poh_verify;
+    let skip_verification = !opts.run_verification;
     let _ignored_prioritization_fee_cache = PrioritizationFeeCache::new(0u64);
 
     confirm_slot(
@@ -1892,7 +1893,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions {
-                poh_verify: true,
+                run_verification: true,
                 ..ProcessOptions::default()
             },
             blockstore_access_type.clone(),
@@ -1947,7 +1948,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions {
-                poh_verify: true,
+                run_verification: true,
                 ..ProcessOptions::default()
             },
             &Arc::default(),
@@ -1962,7 +1963,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions {
-                poh_verify: true,
+                run_verification: true,
                 ..ProcessOptions::default()
             },
             &Arc::default(),
@@ -2016,7 +2017,7 @@ pub mod tests {
         );
 
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2081,7 +2082,7 @@ pub mod tests {
         fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 2, 1, blockhash);
 
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2099,7 +2100,7 @@ pub mod tests {
                slot 2 (all ticks)
         */
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2168,7 +2169,7 @@ pub mod tests {
         blockstore.set_roots(vec![0, 1, 4].iter()).unwrap();
 
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2248,7 +2249,7 @@ pub mod tests {
         blockstore.set_roots(vec![0, 1].iter()).unwrap();
 
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2462,7 +2463,7 @@ pub mod tests {
 
         // Check that we can properly restart the ledger / leader scheduler doesn't fail
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2607,7 +2608,7 @@ pub mod tests {
             )
             .unwrap();
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -2638,7 +2639,7 @@ pub mod tests {
 
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -3312,7 +3313,7 @@ pub mod tests {
 
         // Specify halting at slot 0
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             halt_at_slot: Some(0),
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
@@ -3366,7 +3367,7 @@ pub mod tests {
         let mut bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.get(0).unwrap();
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
@@ -3830,7 +3831,7 @@ pub mod tests {
         }
 
         let opts = ProcessOptions {
-            poh_verify: true,
+            run_verification: true,
             accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -36,7 +36,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_hash_interval_slots: config.accounts_hash_interval_slots,
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         wal_recovery_mode: config.wal_recovery_mode.clone(),
-        poh_verify: config.poh_verify,
+        run_verification: config.run_verification,
         require_tower: config.require_tower,
         tower_storage: config.tower_storage.clone(),
         debug_keys: config.debug_keys.clone(),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -23,7 +23,7 @@ use {
     },
     solana_local_cluster::{
         cluster::{Cluster, ClusterValidatorInfo},
-        cluster_tests::{self},
+        cluster_tests,
         local_cluster::{ClusterConfig, LocalCluster},
         validator_configs::*,
     },
@@ -2154,7 +2154,7 @@ fn create_snapshot_to_hard_fork(
     let process_options = ProcessOptions {
         halt_at_slot: Some(snapshot_slot),
         new_hard_forks: Some(hard_forks),
-        poh_verify: false,
+        run_verification: false,
         ..ProcessOptions::default()
     };
     let ledger_path = blockstore.ledger_path();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -941,7 +941,7 @@ impl TestValidator {
                     .unwrap()
                     .0,
             ],
-            poh_verify: false, // Skip PoH verification of ledger on startup for speed
+            run_verification: false, // Skip PoH verification of ledger on startup for speed
             snapshot_config: SnapshotConfig {
                 full_snapshot_archive_interval_slots: 100,
                 incremental_snapshot_archive_interval_slots: Slot::MAX,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -612,7 +612,16 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("skip_poh_verify")
                 .long("skip-poh-verify")
                 .takes_value(false)
-                .help("Skip ledger verification at validator bootup"),
+                .help(
+                    "Deprecated, please use --skip-verification.\n\
+                     Skip ledger verification at validator bootup."
+                ),
+        )
+        .arg(
+            Arg::with_name("skip_verification")
+                .long("skip-verification")
+                .takes_value(false)
+                .help("Skip ledger verification at validator bootup."),
         )
         .arg(
             Arg::with_name("cuda")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1188,6 +1188,10 @@ pub fn main() {
     }
     let full_api = matches.is_present("full_rpc_api");
 
+    if matches.is_present("skip_poh_verify") {
+        eprintln!("--skip-poh-verify is deprecated.  Replace with --skip-verification.");
+    }
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,
@@ -1272,7 +1276,8 @@ pub fn main() {
         repair_whitelist,
         gossip_validators,
         wal_recovery_mode,
-        poh_verify: !matches.is_present("skip_poh_verify"),
+        run_verification: !(matches.is_present("skip_poh_verify")
+            || matches.is_present("skip_verification")),
         debug_keys,
         contact_debug_interval,
         send_transaction_service_config: send_transaction_service::Config {


### PR DESCRIPTION
#### Problem
`poh_verify` actually disables transaction signature, tick count and built in program argument verifications as well.  It is somewhat confusing to call it `poh_verify`.

#### Summary of Changes
Renamed it to `run_verification`, along with the CLI argument.
Old argument is still accepted, but produces a deprecation message, suggesting a new name.