### PR TITLE
[ledger-tool] Enable `accounts top` to list accounts by exec/non-exec data size.

### DIFF
--- a/ledger-tool/src/accounts.rs
+++ b/ledger-tool/src/accounts.rs
@@ -1,7 +1,7 @@
 //! The `accounts_tool` subcommand
 use {
     crate::utils::*,
-    clap::{value_t, App, AppSettings, Arg, ArgMatches, SubCommand},
+    clap::{value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     serde::ser::{SerializeSeq, Serializer},
     solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
@@ -10,19 +10,59 @@ use {
         blockstore_processor::ProcessOptions,
     },
     solana_measure::measure::Measure,
-    solana_runtime::{accounts::Accounts, bank::TotalAccountsStats},
+    solana_runtime::{accounts::Accounts, accounts_file::AccountsFile, bank::TotalAccountsStats},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
         pubkey::Pubkey,
     },
     std::{
+        cmp::Reverse,
+        collections::BinaryHeap,
         io::stdout,
         path::{Path, PathBuf},
         process::exit,
         sync::Arc,
     },
 };
+
+#[derive(Debug, Eq)]
+struct TopAccountsStatsEntry<V: std::cmp::Ord> {
+    key: Pubkey,
+    value: V,
+}
+
+impl<V: std::cmp::Ord> Ord for TopAccountsStatsEntry<V> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<V: std::cmp::Ord> PartialOrd for TopAccountsStatsEntry<V> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<V: std::cmp::Ord> PartialEq for TopAccountsStatsEntry<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+#[derive(PartialEq)]
+enum TopAccountsRankingField {
+    AccountDataSize,
+}
+
+impl TopAccountsRankingField {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "data_size" => Some(Self::AccountDataSize),
+            _ => None,
+        }
+    }
+}
 
 pub trait AccountsSubCommand<'a> {
     #[allow(clippy::too_many_arguments)]
@@ -40,6 +80,7 @@ pub trait AccountsSubCommand<'a> {
         hard_forks_arg: &'a Arg,
         max_genesis_archive_unpacked_size_arg: &'a Arg,
         no_snapshot_arg: &'a Arg,
+        default_top_accounts_file_count_limit: &'a str,
     ) -> Self;
 }
 
@@ -59,6 +100,7 @@ impl<'a> AccountsSubCommand<'a> for App<'a, '_> {
         hard_forks_arg: &'a Arg,
         max_genesis_archive_unpacked_size_arg: &'a Arg,
         no_snapshot_arg: &'a Arg,
+        default_top_accounts_file_count_limit: &'a str,
     ) -> Self {
         self.subcommand(
             SubCommand::with_name("accounts")
@@ -93,6 +135,43 @@ impl<'a> AccountsSubCommand<'a> for App<'a, '_> {
                 .help("Do not print account data when printing account contents."),
             )
             .arg(max_genesis_archive_unpacked_size_arg)
+            .subcommand(
+                SubCommand::with_name("top")
+                .about("Print the top N accounts of the specified field.")
+                .arg(
+                    Arg::with_name("n")
+                        .takes_value(true)
+                        .value_name("N")
+                        .default_value("30")
+                        .help("Collect the top N entries of the specified --field")
+                )
+                .arg(
+                    Arg::with_name("path")
+                        .long("path")
+                        .takes_value(true)
+                        .value_name("ACCOUNTS_DB_PATH")
+                        .help("Path to the accounts_db.")
+                )
+                .arg(
+                    Arg::with_name("field")
+                        .long("field")
+                        .takes_value(true)
+                        .value_name("FIELD")
+                        .possible_values(&["data_size"])
+                        .default_value("data_size")
+                        .help("Determine which stats to print. \
+                               Possible values are: \
+                               'data_size': print the top N accounts with the largest account data size.")
+                )
+                .arg(
+                    Arg::with_name("limit")
+                        .long("limit")
+                        .takes_value(true)
+                        .value_name("LIMIT")
+                        .default_value(default_top_accounts_file_count_limit)
+                        .help("Collect stats from up to LIMIT accounts db files.")
+                )
+            )
         )
     }
 }
@@ -105,89 +184,143 @@ pub fn accounts_process_command(
     incremental_snapshot_archive_path: Option<PathBuf>,
     arg_matches: &ArgMatches<'_>,
 ) {
-    let halt_at_slot = value_t!(arg_matches, "halt_at_slot", Slot).ok();
-    let process_options = ProcessOptions {
-        new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
-        halt_at_slot,
-        run_verification: false,
-        accounts_db_config: Some(get_accounts_db_config(ledger_path, arg_matches)),
-        ..ProcessOptions::default()
-    };
-    let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
-    let include_sysvars = arg_matches.is_present("include_sysvars");
-    let blockstore = open_blockstore(
-        ledger_path,
-        AccessType::Secondary,
-        wal_recovery_mode,
-        force_update_to_open,
-    );
-    let (bank_forks, ..) = load_bank_forks(
-        arg_matches,
-        &genesis_config,
-        Arc::new(blockstore),
-        process_options,
-        snapshot_archive_path,
-        incremental_snapshot_archive_path,
-    )
-    .unwrap_or_else(|err| {
-        eprintln!("Failed to load ledger: {err:?}");
-        exit(1);
-    });
+    let (subcommand, sub_matches) = arg_matches.subcommand();
+    match (subcommand, sub_matches) {
+        ("top", Some(arg_matches)) => {
+            let accounts_db_path = value_t_or_exit!(arg_matches, "path", String);
+            let acc_file_paths = std::fs::read_dir(accounts_db_path).unwrap();
+            let heap_size = value_t_or_exit!(arg_matches, "n", usize);
+            let limit = value_t_or_exit!(arg_matches, "limit", usize);
+            let field_str = value_t_or_exit!(arg_matches, "field", String);
+            let field = TopAccountsRankingField::from_str(&field_str).unwrap();
 
-    let bank = bank_forks.read().unwrap().working_bank();
-    let mut serializer = serde_json::Serializer::new(stdout());
-    let (summarize, mut json_serializer) =
-        match OutputFormat::from_matches(arg_matches, "output_format", false) {
-            OutputFormat::Json | OutputFormat::JsonCompact => {
-                (false, Some(serializer.serialize_seq(None).unwrap()))
+            let mut min_heap = BinaryHeap::new();
+            let mut file_count = 0;
+            debug!("paths = {:?}", acc_file_paths);
+            for path in acc_file_paths {
+                debug!("Collecting stats from {:?}", path);
+                let av_path = path.expect("success").path();
+                let av_len = std::fs::metadata(&av_path).unwrap().len() as usize;
+                if let Ok((mut acc_file, _)) = AccountsFile::new_from_file(av_path, av_len) {
+                    acc_file.set_no_remove_on_drop();
+
+                    // read append-vec
+                    let mut offset = 0;
+                    while let Some((account, next_offset)) = acc_file.get_account(offset) {
+                        offset = next_offset;
+                        // data_size
+                        min_heap.push(Reverse(TopAccountsStatsEntry {
+                            key: *account.pubkey(),
+                            value: match field {
+                                TopAccountsRankingField::AccountDataSize => account.data_len(),
+                            },
+                        }));
+                        if min_heap.len() > heap_size {
+                            min_heap.pop();
+                        }
+                    }
+                    file_count += 1;
+                    if file_count >= limit {
+                        break;
+                    }
+                }
             }
-            _ => (true, None),
-        };
-    let mut total_accounts_stats = TotalAccountsStats::default();
-    let rent_collector = bank.rent_collector();
-    let print_account_contents = !arg_matches.is_present("no_account_contents");
-    let print_account_data = !arg_matches.is_present("no_account_data");
-    let data_encoding = parse_encoding_format(arg_matches);
-    let cli_account_new_config = CliAccountNewConfig {
-        data_encoding,
-        ..CliAccountNewConfig::default()
-    };
-    let scan_func = |some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
-        if let Some((pubkey, account, slot)) =
-            some_account_tuple.filter(|(_, account, _)| Accounts::is_loadable(account.lamports()))
-        {
-            if !include_sysvars && solana_sdk::sysvar::is_sysvar_id(pubkey) {
-                return;
-            }
-
-            total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
-
-            if print_account_contents {
-                if let Some(json_serializer) = json_serializer.as_mut() {
-                    let cli_account =
-                        CliAccount::new_with_config(pubkey, &account, &cli_account_new_config);
-                    json_serializer.serialize_element(&cli_account).unwrap();
-                } else {
-                    output_account(
-                        pubkey,
-                        &account,
-                        Some(slot),
-                        print_account_data,
-                        data_encoding,
-                    );
+            println!("Collected top {:?} samples", min_heap.len());
+            while !min_heap.is_empty() {
+                if let Some(Reverse(entry)) = min_heap.pop() {
+                    println!("account: {:?}, {}: {:?}", entry.key, field_str, entry.value);
                 }
             }
         }
-    };
-    let mut measure = Measure::start("scanning accounts");
-    bank.scan_all_accounts_with_modified_slots(scan_func)
-        .unwrap();
-    measure.stop();
-    info!("{}", measure);
-    if let Some(json_serializer) = json_serializer {
-        json_serializer.end().unwrap();
-    }
-    if summarize {
-        println!("\n{total_accounts_stats:#?}");
+        _ => {
+            let halt_at_slot = value_t!(arg_matches, "halt_at_slot", Slot).ok();
+            let process_options = ProcessOptions {
+                new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
+                halt_at_slot,
+                run_verification: false,
+                accounts_db_config: Some(get_accounts_db_config(ledger_path, arg_matches)),
+                ..ProcessOptions::default()
+            };
+            let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
+            let include_sysvars = arg_matches.is_present("include_sysvars");
+            let blockstore = open_blockstore(
+                ledger_path,
+                AccessType::Secondary,
+                wal_recovery_mode,
+                force_update_to_open,
+            );
+            let (bank_forks, ..) = load_bank_forks(
+                arg_matches,
+                &genesis_config,
+                Arc::new(blockstore),
+                process_options,
+                snapshot_archive_path,
+                incremental_snapshot_archive_path,
+            )
+            .unwrap_or_else(|err| {
+                eprintln!("Failed to load ledger: {err:?}");
+                exit(1);
+            });
+
+            let bank = bank_forks.read().unwrap().working_bank();
+            let mut serializer = serde_json::Serializer::new(stdout());
+            let (summarize, mut json_serializer) =
+                match OutputFormat::from_matches(arg_matches, "output_format", false) {
+                    OutputFormat::Json | OutputFormat::JsonCompact => {
+                        (false, Some(serializer.serialize_seq(None).unwrap()))
+                    }
+                    _ => (true, None),
+                };
+            let mut total_accounts_stats = TotalAccountsStats::default();
+            let rent_collector = bank.rent_collector();
+            let print_account_contents = !arg_matches.is_present("no_account_contents");
+            let print_account_data = !arg_matches.is_present("no_account_data");
+            let data_encoding = parse_encoding_format(arg_matches);
+            let cli_account_new_config = CliAccountNewConfig {
+                data_encoding,
+                ..CliAccountNewConfig::default()
+            };
+            let scan_func = |some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
+                if let Some((pubkey, account, slot)) = some_account_tuple
+                    .filter(|(_, account, _)| Accounts::is_loadable(account.lamports()))
+                {
+                    if !include_sysvars && solana_sdk::sysvar::is_sysvar_id(pubkey) {
+                        return;
+                    }
+
+                    total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
+
+                    if print_account_contents {
+                        if let Some(json_serializer) = json_serializer.as_mut() {
+                            let cli_account = CliAccount::new_with_config(
+                                pubkey,
+                                &account,
+                                &cli_account_new_config,
+                            );
+                            json_serializer.serialize_element(&cli_account).unwrap();
+                        } else {
+                            output_account(
+                                pubkey,
+                                &account,
+                                Some(slot),
+                                print_account_data,
+                                data_encoding,
+                            );
+                        }
+                    }
+                }
+            };
+            let mut measure = Measure::start("scanning accounts");
+            bank.scan_all_accounts_with_modified_slots(scan_func)
+                .unwrap();
+            measure.stop();
+            info!("{}", measure);
+            if let Some(json_serializer) = json_serializer {
+                json_serializer.end().unwrap();
+            }
+            if summarize {
+                println!("\n{total_accounts_stats:#?}");
+            }
+        }
     }
 }

--- a/ledger-tool/src/accounts.rs
+++ b/ledger-tool/src/accounts.rs
@@ -51,14 +51,19 @@ impl<V: std::cmp::Ord> PartialEq for TopAccountsStatsEntry<V> {
 }
 
 #[derive(PartialEq)]
+#[allow(clippy::enum_variant_names)]
 enum TopAccountsRankingField {
-    AccountDataSize,
+    DataSize,
+    ExecutableDataSize,
+    NonExecutableDataSize,
 }
 
 impl TopAccountsRankingField {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
-            "data_size" => Some(Self::AccountDataSize),
+            "data_size" => Some(Self::DataSize),
+            "exec_data_size" => Some(Self::ExecutableDataSize),
+            "non_exec_data_size" => Some(Self::NonExecutableDataSize),
             _ => None,
         }
     }
@@ -157,11 +162,13 @@ impl<'a> AccountsSubCommand<'a> for App<'a, '_> {
                         .long("field")
                         .takes_value(true)
                         .value_name("FIELD")
-                        .possible_values(&["data_size"])
+                        .possible_values(&["data_size", "exec_data_size", "non_exec_data_size"])
                         .default_value("data_size")
                         .help("Determine which stats to print. \
                                Possible values are: \
-                               'data_size': print the top N accounts with the largest account data size.")
+                               'data_size': print the top N accounts ranked by the account data size. \
+                               'exec_data_size': print the top N accounts ranked by the executable account data size. \
+                               'non_exec_data_size': print the top N accounts ranked by the non-executable account data size.")
                 )
                 .arg(
                     Arg::with_name("limit")
@@ -212,7 +219,21 @@ pub fn accounts_process_command(
                         min_heap.push(Reverse(TopAccountsStatsEntry {
                             key: *account.pubkey(),
                             value: match field {
-                                TopAccountsRankingField::AccountDataSize => account.data_len(),
+                                TopAccountsRankingField::DataSize => account.data_len(),
+                                TopAccountsRankingField::ExecutableDataSize => {
+                                    if account.executable() {
+                                        account.data_len()
+                                    } else {
+                                        0
+                                    }
+                                }
+                                TopAccountsRankingField::NonExecutableDataSize => {
+                                    if account.executable() {
+                                        0
+                                    } else {
+                                        account.data_len()
+                                    }
+                                }
                             },
                         }));
                         if min_heap.len() > heap_size {

--- a/ledger-tool/src/accounts.rs
+++ b/ledger-tool/src/accounts.rs
@@ -1,0 +1,193 @@
+//! The `accounts_tool` subcommand
+use {
+    crate::utils::*,
+    clap::{value_t, App, AppSettings, Arg, ArgMatches, SubCommand},
+    log::*,
+    serde::ser::{SerializeSeq, Serializer},
+    solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
+    solana_ledger::{
+        blockstore_options::{AccessType, BlockstoreRecoveryMode},
+        blockstore_processor::ProcessOptions,
+    },
+    solana_measure::measure::Measure,
+    solana_runtime::{accounts::Accounts, bank::TotalAccountsStats},
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
+        pubkey::Pubkey,
+    },
+    std::{
+        io::stdout,
+        path::{Path, PathBuf},
+        process::exit,
+        sync::Arc,
+    },
+};
+
+pub trait AccountsSubCommand<'a> {
+    #[allow(clippy::too_many_arguments)]
+    fn accounts_subcommand(
+        self,
+        account_paths_arg: &'a Arg,
+        accounts_data_encoding_arg: &'a Arg,
+        accounts_db_skip_initial_hash_calc_arg: &'a Arg,
+        accounts_index_bins: &'a Arg,
+        accounts_index_limit: &'a Arg,
+        accountsdb_verify_refcounts: &'a Arg,
+        disable_disk_index: &'a Arg,
+        geyser_plugin_args: &'a Arg,
+        halt_at_slot_arg: &'a Arg,
+        hard_forks_arg: &'a Arg,
+        max_genesis_archive_unpacked_size_arg: &'a Arg,
+        no_snapshot_arg: &'a Arg,
+    ) -> Self;
+}
+
+impl<'a> AccountsSubCommand<'a> for App<'a, '_> {
+    #[allow(clippy::too_many_arguments)]
+    fn accounts_subcommand(
+        self,
+        account_paths_arg: &'a Arg,
+        accounts_data_encoding_arg: &'a Arg,
+        accounts_db_skip_initial_hash_calc_arg: &'a Arg,
+        accounts_index_bins: &'a Arg,
+        accounts_index_limit: &'a Arg,
+        accountsdb_verify_refcounts: &'a Arg,
+        disable_disk_index: &'a Arg,
+        geyser_plugin_args: &'a Arg,
+        halt_at_slot_arg: &'a Arg,
+        hard_forks_arg: &'a Arg,
+        max_genesis_archive_unpacked_size_arg: &'a Arg,
+        no_snapshot_arg: &'a Arg,
+    ) -> Self {
+        self.subcommand(
+            SubCommand::with_name("accounts")
+            .about("Print account stats and contents after processing the ledger")
+            .setting(AppSettings::InferSubcommands)
+            .arg(no_snapshot_arg)
+            .arg(account_paths_arg)
+            .arg(accounts_index_bins)
+            .arg(accounts_index_limit)
+            .arg(disable_disk_index)
+            .arg(accountsdb_verify_refcounts)
+            .arg(accounts_db_skip_initial_hash_calc_arg)
+            .arg(halt_at_slot_arg)
+            .arg(hard_forks_arg)
+            .arg(geyser_plugin_args)
+            .arg(accounts_data_encoding_arg)
+            .arg(
+                Arg::with_name("include_sysvars")
+                    .long("include-sysvars")
+                    .takes_value(false)
+                    .help("Include sysvars too"),
+            )
+            .arg(
+                Arg::with_name("no_account_contents")
+                    .long("no-account-contents")
+                    .takes_value(false)
+                    .help("Do not print contents of each account, which is very slow with lots of accounts."),
+            )
+            .arg(Arg::with_name("no_account_data")
+                .long("no-account-data")
+                .takes_value(false)
+                .help("Do not print account data when printing account contents."),
+            )
+            .arg(max_genesis_archive_unpacked_size_arg)
+        )
+    }
+}
+
+pub fn accounts_process_command(
+    ledger_path: &Path,
+    force_update_to_open: bool,
+    wal_recovery_mode: Option<BlockstoreRecoveryMode>,
+    snapshot_archive_path: Option<PathBuf>,
+    incremental_snapshot_archive_path: Option<PathBuf>,
+    arg_matches: &ArgMatches<'_>,
+) {
+    let halt_at_slot = value_t!(arg_matches, "halt_at_slot", Slot).ok();
+    let process_options = ProcessOptions {
+        new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
+        halt_at_slot,
+        run_verification: false,
+        accounts_db_config: Some(get_accounts_db_config(ledger_path, arg_matches)),
+        ..ProcessOptions::default()
+    };
+    let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
+    let include_sysvars = arg_matches.is_present("include_sysvars");
+    let blockstore = open_blockstore(
+        ledger_path,
+        AccessType::Secondary,
+        wal_recovery_mode,
+        force_update_to_open,
+    );
+    let (bank_forks, ..) = load_bank_forks(
+        arg_matches,
+        &genesis_config,
+        Arc::new(blockstore),
+        process_options,
+        snapshot_archive_path,
+        incremental_snapshot_archive_path,
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to load ledger: {err:?}");
+        exit(1);
+    });
+
+    let bank = bank_forks.read().unwrap().working_bank();
+    let mut serializer = serde_json::Serializer::new(stdout());
+    let (summarize, mut json_serializer) =
+        match OutputFormat::from_matches(arg_matches, "output_format", false) {
+            OutputFormat::Json | OutputFormat::JsonCompact => {
+                (false, Some(serializer.serialize_seq(None).unwrap()))
+            }
+            _ => (true, None),
+        };
+    let mut total_accounts_stats = TotalAccountsStats::default();
+    let rent_collector = bank.rent_collector();
+    let print_account_contents = !arg_matches.is_present("no_account_contents");
+    let print_account_data = !arg_matches.is_present("no_account_data");
+    let data_encoding = parse_encoding_format(arg_matches);
+    let cli_account_new_config = CliAccountNewConfig {
+        data_encoding,
+        ..CliAccountNewConfig::default()
+    };
+    let scan_func = |some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
+        if let Some((pubkey, account, slot)) =
+            some_account_tuple.filter(|(_, account, _)| Accounts::is_loadable(account.lamports()))
+        {
+            if !include_sysvars && solana_sdk::sysvar::is_sysvar_id(pubkey) {
+                return;
+            }
+
+            total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
+
+            if print_account_contents {
+                if let Some(json_serializer) = json_serializer.as_mut() {
+                    let cli_account =
+                        CliAccount::new_with_config(pubkey, &account, &cli_account_new_config);
+                    json_serializer.serialize_element(&cli_account).unwrap();
+                } else {
+                    output_account(
+                        pubkey,
+                        &account,
+                        Some(slot),
+                        print_account_data,
+                        data_encoding,
+                    );
+                }
+            }
+        }
+    };
+    let mut measure = Measure::start("scanning accounts");
+    bank.scan_all_accounts_with_modified_slots(scan_func)
+        .unwrap();
+    measure.stop();
+    info!("{}", measure);
+    if let Some(json_serializer) = json_serializer {
+        json_serializer.end().unwrap();
+    }
+    if summarize {
+        println!("\n{total_accounts_stats:#?}");
+    }
+}

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1441,6 +1441,7 @@ fn main() {
         .max(rent.minimum_balance(StakeState::size_of()))
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
+    let default_top_accounts_file_count_limit = &std::usize::MAX.to_string();
 
     let mut measure_total_execution_time = Measure::start("ledger tool");
 
@@ -1540,7 +1541,8 @@ fn main() {
             &halt_at_slot_arg,
             &hard_forks_arg,
             &max_genesis_archive_unpacked_size_arg,
-            &no_snapshot_arg)
+            &no_snapshot_arg,
+            default_top_accounts_file_count_limit)
         .bigtable_subcommand()
         .subcommand(
             SubCommand::with_name("print")

--- a/ledger-tool/src/utils.rs
+++ b/ledger-tool/src/utils.rs
@@ -1,0 +1,517 @@
+#![allow(clippy::integer_arithmetic)]
+use {
+    clap::{value_t, value_t_or_exit, values_t_or_exit, ArgMatches},
+    crossbeam_channel::unbounded,
+    log::*,
+    solana_account_decoder::{UiAccount, UiAccountData, UiAccountEncoding},
+    solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
+    solana_ledger::{
+        bank_forks_utils,
+        blockstore::{Blockstore, BlockstoreError},
+        blockstore_options::{
+            AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
+            ShredStorageType,
+        },
+        blockstore_processor::{
+            self, BlockstoreProcessorError, ProcessOptions, TransactionStatusSender,
+        },
+    },
+    solana_measure::measure::Measure,
+    solana_rpc::{
+        transaction_notifier_interface::TransactionNotifierLock,
+        transaction_status_service::TransactionStatusService,
+    },
+    solana_runtime::{
+        accounts_background_service::{
+            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
+            PrunedBanksRequestHandler, SnapshotRequestHandler,
+        },
+        accounts_db::{AccountsDb, AccountsDbConfig, FillerAccountsConfig},
+        accounts_index::{AccountsIndexConfig, IndexLimitMb},
+        accounts_update_notifier_interface::AccountsUpdateNotifier,
+        bank_forks::BankForks,
+        hardened_unpack::open_genesis_config,
+        snapshot_config::SnapshotConfig,
+        snapshot_hash::StartingSnapshotHashes,
+        snapshot_utils::{self, create_accounts_run_and_snapshot_dirs, move_and_async_delete_path},
+    },
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
+        genesis_config::GenesisConfig,
+        native_token::lamports_to_sol,
+        pubkey::Pubkey,
+    },
+    std::{
+        path::{Path, PathBuf},
+        process::exit,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+    },
+};
+
+pub(crate) fn open_genesis_config_by(
+    ledger_path: &Path,
+    matches: &ArgMatches<'_>,
+) -> GenesisConfig {
+    let max_genesis_archive_unpacked_size =
+        value_t_or_exit!(matches, "max_genesis_archive_unpacked_size", u64);
+    open_genesis_config(ledger_path, max_genesis_archive_unpacked_size)
+}
+
+// This function is duplicated in validator/src/main.rs...
+pub(crate) fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
+    if matches.is_present(name) {
+        Some(values_t_or_exit!(matches, name, Slot))
+    } else {
+        None
+    }
+}
+
+/// Open blockstore with temporary primary access to allow necessary,
+/// persistent changes to be made to the blockstore (such as creation of new
+/// column family(s)). Then, continue opening with `original_access_type`
+fn open_blockstore_with_temporary_primary_access(
+    ledger_path: &Path,
+    original_access_type: AccessType,
+    wal_recovery_mode: Option<BlockstoreRecoveryMode>,
+) -> Result<Blockstore, BlockstoreError> {
+    // Open with Primary will allow any configuration that automatically
+    // updates to take effect
+    info!("Attempting to temporarily open blockstore with Primary access in order to update");
+    {
+        let _ = Blockstore::open_with_options(
+            ledger_path,
+            BlockstoreOptions {
+                access_type: AccessType::PrimaryForMaintenance,
+                recovery_mode: wal_recovery_mode.clone(),
+                enforce_ulimit_nofile: true,
+                ..BlockstoreOptions::default()
+            },
+        )?;
+    }
+    // Now, attempt to open the blockstore with original AccessType
+    info!(
+        "Blockstore forced open succeeded, retrying with original access: {:?}",
+        original_access_type
+    );
+    Blockstore::open_with_options(
+        ledger_path,
+        BlockstoreOptions {
+            access_type: original_access_type,
+            recovery_mode: wal_recovery_mode,
+            enforce_ulimit_nofile: true,
+            ..BlockstoreOptions::default()
+        },
+    )
+}
+
+pub(crate) fn open_blockstore(
+    ledger_path: &Path,
+    access_type: AccessType,
+    wal_recovery_mode: Option<BlockstoreRecoveryMode>,
+    force_update_to_open: bool,
+) -> Blockstore {
+    let shred_storage_type = get_shred_storage_type(
+        ledger_path,
+        &format!(
+            "Shred stroage type cannot be inferred for ledger at {ledger_path:?}, \
+         using default RocksLevel",
+        ),
+    );
+
+    match Blockstore::open_with_options(
+        ledger_path,
+        BlockstoreOptions {
+            access_type: access_type.clone(),
+            recovery_mode: wal_recovery_mode.clone(),
+            enforce_ulimit_nofile: true,
+            column_options: LedgerColumnOptions {
+                shred_storage_type,
+                ..LedgerColumnOptions::default()
+            },
+        },
+    ) {
+        Ok(blockstore) => blockstore,
+        Err(BlockstoreError::RocksDb(err))
+            if (err
+                .to_string()
+                // Missing column family
+                .starts_with("Invalid argument: Column family not found:")
+                || err
+                    .to_string()
+                    // Missing essential file, indicative of blockstore not existing
+                    .starts_with("IO error: No such file or directory:"))
+                && access_type == AccessType::Secondary =>
+        {
+            error!("Blockstore is incompatible with current software and requires updates");
+            if !force_update_to_open {
+                error!("Use --force-update-to-open to allow blockstore to update");
+                exit(1);
+            }
+            open_blockstore_with_temporary_primary_access(
+                ledger_path,
+                access_type,
+                wal_recovery_mode,
+            )
+            .unwrap_or_else(|err| {
+                error!(
+                    "Failed to open blockstore (with --force-update-to-open) at {:?}: {:?}",
+                    ledger_path, err
+                );
+                exit(1);
+            })
+        }
+        Err(err) => {
+            eprintln!("Failed to open blockstore at {ledger_path:?}: {err:?}");
+            exit(1);
+        }
+    }
+}
+
+pub(crate) fn load_bank_forks(
+    arg_matches: &ArgMatches,
+    genesis_config: &GenesisConfig,
+    blockstore: Arc<Blockstore>,
+    process_options: ProcessOptions,
+    snapshot_archive_path: Option<PathBuf>,
+    incremental_snapshot_archive_path: Option<PathBuf>,
+) -> Result<(Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>), BlockstoreProcessorError> {
+    let bank_snapshots_dir = blockstore
+        .ledger_path()
+        .join(if blockstore.is_primary_access() {
+            "snapshot"
+        } else {
+            "snapshot.ledger-tool"
+        });
+
+    let mut starting_slot = 0; // default start check with genesis
+    let snapshot_config = if arg_matches.is_present("no_snapshot") {
+        None
+    } else {
+        let full_snapshot_archives_dir =
+            snapshot_archive_path.unwrap_or_else(|| blockstore.ledger_path().to_path_buf());
+        let incremental_snapshot_archives_dir =
+            incremental_snapshot_archive_path.unwrap_or_else(|| full_snapshot_archives_dir.clone());
+        if let Some(full_snapshot_slot) =
+            snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
+        {
+            let incremental_snapshot_slot =
+                snapshot_utils::get_highest_incremental_snapshot_archive_slot(
+                    &incremental_snapshot_archives_dir,
+                    full_snapshot_slot,
+                )
+                .unwrap_or_default();
+            starting_slot = std::cmp::max(full_snapshot_slot, incremental_snapshot_slot);
+        }
+
+        Some(SnapshotConfig {
+            full_snapshot_archives_dir,
+            incremental_snapshot_archives_dir,
+            bank_snapshots_dir,
+            ..SnapshotConfig::new_load_only()
+        })
+    };
+
+    match process_options.halt_at_slot {
+        // Skip the following checks for sentinel values of Some(0) and None.
+        // For Some(0), no slots will be be replayed after starting_slot.
+        // For None, all available children of starting_slot will be replayed.
+        None | Some(0) => {}
+        Some(halt_slot) => {
+            if halt_slot < starting_slot {
+                eprintln!(
+                "Unable to load bank forks at slot {halt_slot} because it is less than the starting slot {starting_slot}. \
+                The starting slot will be the latest snapshot slot, or genesis if --no-snapshot flag specified or no snapshots found."
+            );
+                exit(1);
+            }
+            // Check if we have the slot data necessary to replay from starting_slot to >= halt_slot.
+            if !blockstore.slot_range_connected(starting_slot, halt_slot) {
+                eprintln!(
+                    "Unable to load bank forks at slot {halt_slot} due to disconnected blocks.",
+                );
+                exit(1);
+            }
+        }
+    }
+
+    let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {
+        // If this blockstore access is Primary, no other process (solana-validator) can hold
+        // Primary access. So, allow a custom accounts path without worry of wiping the accounts
+        // of solana-validator.
+        if !blockstore.is_primary_access() {
+            // Attempt to open the Blockstore in Primary access; if successful, no other process
+            // was holding Primary so allow things to proceed with custom accounts path. Release
+            // the Primary access instead of holding it to give priority to solana-validator over
+            // solana-ledger-tool should solana-validator start before we've finished.
+            info!(
+                "Checking if another process currently holding Primary access to {:?}",
+                blockstore.ledger_path()
+            );
+            if Blockstore::open_with_options(
+                blockstore.ledger_path(),
+                BlockstoreOptions {
+                    access_type: AccessType::PrimaryForMaintenance,
+                    ..BlockstoreOptions::default()
+                },
+            )
+            .is_err()
+            {
+                // Couldn't get Primary access, error out to be defensive.
+                eprintln!("Error: custom accounts path is not supported under secondary access");
+                exit(1);
+            }
+        }
+        account_paths.split(',').map(PathBuf::from).collect()
+    } else if blockstore.is_primary_access() {
+        vec![blockstore.ledger_path().join("accounts")]
+    } else {
+        let non_primary_accounts_path = blockstore.ledger_path().join("accounts.ledger-tool");
+        info!(
+            "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
+            non_primary_accounts_path
+        );
+        vec![non_primary_accounts_path]
+    };
+
+    // For all account_paths, set up the run/ and snapshot/ sub directories.
+    // If the sub directories do not exist, the account_path will be cleaned because older version put account files there
+    let account_run_paths: Vec<PathBuf> = account_paths.into_iter().map(
+        |account_path| {
+            match create_accounts_run_and_snapshot_dirs(&account_path) {
+                Ok((account_run_path, _account_snapshot_path)) => account_run_path,
+                Err(err) => {
+                    eprintln!("Unable to create account run and snapshot sub directories: {}, err: {err:?}", account_path.display());
+                    exit(1);
+                }
+            }
+        }).collect();
+
+    // From now on, use run/ paths in the same way as the previous account_paths.
+    let account_paths = account_run_paths;
+
+    info!("Cleaning contents of account paths: {:?}", account_paths);
+    let mut measure = Measure::start("clean_accounts_paths");
+    account_paths.iter().for_each(|path| {
+        if path.exists() {
+            move_and_async_delete_path(path);
+        }
+    });
+    measure.stop();
+    info!("done. {}", measure);
+
+    let mut accounts_update_notifier = Option::<AccountsUpdateNotifier>::default();
+    let mut transaction_notifier = Option::<TransactionNotifierLock>::default();
+    if arg_matches.is_present("geyser_plugin_config") {
+        let geyser_config_files = values_t_or_exit!(arg_matches, "geyser_plugin_config", String)
+            .into_iter()
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+
+        let (confirmed_bank_sender, confirmed_bank_receiver) = unbounded();
+        drop(confirmed_bank_sender);
+        let geyser_service =
+            GeyserPluginService::new(confirmed_bank_receiver, &geyser_config_files).unwrap_or_else(
+                |err| {
+                    eprintln!("Failed to setup Geyser service: {err:?}");
+                    exit(1);
+                },
+            );
+        accounts_update_notifier = geyser_service.get_accounts_update_notifier();
+        transaction_notifier = geyser_service.get_transaction_notifier();
+    }
+
+    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) =
+        bank_forks_utils::load_bank_forks(
+            genesis_config,
+            blockstore.as_ref(),
+            account_paths,
+            None,
+            snapshot_config.as_ref(),
+            &process_options,
+            None,
+            accounts_update_notifier,
+            &Arc::default(),
+        );
+
+    let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
+    let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
+    let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
+    let snapshot_request_handler = SnapshotRequestHandler {
+        snapshot_config: SnapshotConfig::new_load_only(),
+        snapshot_request_sender,
+        snapshot_request_receiver,
+        accounts_package_sender,
+    };
+    let pruned_banks_receiver =
+        AccountsBackgroundService::setup_bank_drop_callback(bank_forks.clone());
+    let pruned_banks_request_handler = PrunedBanksRequestHandler {
+        pruned_banks_receiver,
+    };
+    let abs_request_handler = AbsRequestHandlers {
+        snapshot_request_handler,
+        pruned_banks_request_handler,
+    };
+    let exit = Arc::new(AtomicBool::new(false));
+    let accounts_background_service = AccountsBackgroundService::new(
+        bank_forks.clone(),
+        &exit,
+        abs_request_handler,
+        process_options.accounts_db_test_hash_calculation,
+        None,
+    );
+
+    let (transaction_status_sender, transaction_status_service) = if transaction_notifier.is_some()
+    {
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            Arc::default(),
+            false,
+            transaction_notifier,
+            blockstore.clone(),
+            false,
+            &exit,
+        );
+        (
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+            }),
+            Some(transaction_status_service),
+        )
+    } else {
+        (None, None)
+    };
+
+    let result = blockstore_processor::process_blockstore_from_root(
+        blockstore.as_ref(),
+        &bank_forks,
+        &leader_schedule_cache,
+        &process_options,
+        transaction_status_sender.as_ref(),
+        None,
+        &accounts_background_request_sender,
+    )
+    .map(|_| (bank_forks, starting_snapshot_hashes));
+
+    exit.store(true, Ordering::Relaxed);
+    accounts_background_service.join().unwrap();
+    if let Some(service) = transaction_status_service {
+        service.join().unwrap();
+    }
+
+    result
+}
+
+pub(crate) fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncoding {
+    match matches.value_of("encoding") {
+        Some("jsonParsed") => UiAccountEncoding::JsonParsed,
+        Some("base64") => UiAccountEncoding::Base64,
+        Some("base64+zstd") => UiAccountEncoding::Base64Zstd,
+        _ => UiAccountEncoding::Base64,
+    }
+}
+
+pub(crate) fn output_account(
+    pubkey: &Pubkey,
+    account: &AccountSharedData,
+    modified_slot: Option<Slot>,
+    print_account_data: bool,
+    encoding: UiAccountEncoding,
+) {
+    println!("{pubkey}:");
+    println!("  balance: {} SOL", lamports_to_sol(account.lamports()));
+    println!("  owner: '{}'", account.owner());
+    println!("  executable: {}", account.executable());
+    if let Some(slot) = modified_slot {
+        println!("  slot: {slot}");
+    }
+    println!("  rent_epoch: {}", account.rent_epoch());
+    println!("  data_len: {}", account.data().len());
+    if print_account_data {
+        let account_data = UiAccount::encode(pubkey, account, encoding, None, None).data;
+        match account_data {
+            UiAccountData::Binary(data, data_encoding) => {
+                println!("  data: '{data}'");
+                println!(
+                    "  encoding: {}",
+                    serde_json::to_string(&data_encoding).unwrap()
+                );
+            }
+            UiAccountData::Json(account_data) => {
+                println!(
+                    "  data: '{}'",
+                    serde_json::to_string(&account_data).unwrap()
+                );
+                println!("  encoding: \"jsonParsed\"");
+            }
+            UiAccountData::LegacyBinary(_) => {}
+        };
+    }
+}
+
+pub(crate) fn get_shred_storage_type(ledger_path: &Path, message: &str) -> ShredStorageType {
+    // TODO: the following shred_storage_type inference must be updated once
+    // the rocksdb options can be constructed via load_options_file() as the
+    // value picked by passing None for `max_shred_storage_size` could affect
+    // the persisted rocksdb options file.
+    match ShredStorageType::from_ledger_path(ledger_path, None) {
+        Some(s) => s,
+        None => {
+            info!("{}", message);
+            ShredStorageType::RocksLevel
+        }
+    }
+}
+
+// Build an `AccountsDbConfig` from subcommand arguments. All of the arguments
+// matched by this functional are either optional or have a default value.
+// Thus, a subcommand need not support all of the arguments that are matched
+// by this function.
+pub(crate) fn get_accounts_db_config(
+    ledger_path: &Path,
+    arg_matches: &ArgMatches<'_>,
+) -> AccountsDbConfig {
+    let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
+    let accounts_index_index_limit_mb =
+        if let Some(limit) = value_t!(arg_matches, "accounts_index_memory_limit_mb", usize).ok() {
+            IndexLimitMb::Limit(limit)
+        } else if arg_matches.is_present("disable_accounts_disk_index") {
+            IndexLimitMb::InMemOnly
+        } else {
+            IndexLimitMb::Unspecified
+        };
+    let accounts_index_drives: Vec<PathBuf> = if arg_matches.is_present("accounts_index_path") {
+        values_t_or_exit!(arg_matches, "accounts_index_path", String)
+            .into_iter()
+            .map(PathBuf::from)
+            .collect()
+    } else {
+        vec![ledger_path.join("accounts_index.ledger-tool")]
+    };
+    let accounts_index_config = AccountsIndexConfig {
+        bins: accounts_index_bins,
+        index_limit_mb: accounts_index_index_limit_mb,
+        drives: Some(accounts_index_drives),
+        ..AccountsIndexConfig::default()
+    };
+
+    let filler_accounts_config = FillerAccountsConfig {
+        count: value_t!(arg_matches, "accounts_filler_count", usize).unwrap_or(0),
+        size: value_t!(arg_matches, "accounts_filler_size", usize).unwrap_or(0),
+    };
+
+    AccountsDbConfig {
+        index: Some(accounts_index_config),
+        accounts_hash_cache_path: Some(ledger_path.join(AccountsDb::ACCOUNTS_HASH_CACHE_DIR)),
+        filler_accounts_config,
+        ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
+            .ok(),
+        exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
+        skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
+        ..AccountsDbConfig::default()
+    }
+}


### PR DESCRIPTION
#### Summary of Changes
Enable ledger-tool `accounts top` subcommand to list accounts
by exec/non-exec data size.

This PR depends on #30812.