### PR TITLE
Cleans *up to* the last full snapshot slot in verify_snapshot_bank()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7328,8 +7328,12 @@ impl Bank {
             let should_clean = !accounts_db_skip_shrink && self.slot() > 0;
             if should_clean {
                 info!("Cleaning...");
+                // We cannot clean past the last full snapshot's slot because we are about to
+                // perform an accounts hash calculation *up to that slot*.  If we cleaned *past*
+                // that slot, then accounts could be removed from older storages, which would
+                // change the accounts hash.
                 self.rc.accounts.accounts_db.clean_accounts(
-                    None,
+                    Some(last_full_snapshot_slot),
                     true,
                     Some(last_full_snapshot_slot),
                 );


### PR DESCRIPTION
#### Problem

At startup verification, we calculate the accounts hash and compare it with what was in the snapshot. This accounts hash calculation is over the whole slot range, so `clean` and `shrink` here don't affect the calculation.

However, with Incremental Accounts Hash, we're going to calculate the accounts hash over a *subset* of slots/storages—not all. This means if we `clean` *past* the slot we're about to use for the accounts hash calculation, then accounts can be removed from older storages, which will affect the calculation and produce a different value, and then cause startup snapshot verification to fail.


#### Summary of Changes

At startup in snapshot verification, do not clean past the last full snapshot slot.

(I remember we've also talked about removing this serial `clean` and `shrink` entirely; I didn't want to do that for this PR, and instead only do what's required for IAH. The rest can be handled in another PR.)