### PR TITLE
Do not log detailed epoch stakes

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2294,7 +2294,7 @@ impl Bank {
                     .delegated_stakes()
                     .map(|(pubkey, stake)| (*pubkey, stake))
                     .collect();
-                trace!("new epoch stakes, stakes: {:#?}", vote_stakes,);
+                trace!("new epoch stakes, stakes: {vote_stakes:#?}");
             }
             self.epoch_stakes
                 .insert(leader_schedule_epoch, new_epoch_stakes);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2283,6 +2283,19 @@ impl Bank {
                 leader_schedule_epoch,
                 new_epoch_stakes.total_stake(),
             );
+
+            // It is expensive to log the details of epoch stakes. Only log them at "trace"
+            // level for debugging purpose.
+            if log::log_enabled!(log::Level::Trace) {
+                let vote_stakes: HashMap<_, _> = self
+                    .stakes_cache
+                    .stakes()
+                    .vote_accounts()
+                    .delegated_stakes()
+                    .map(|(pubkey, stake)| (*pubkey, stake))
+                    .collect();
+                trace!("new epoch stakes, stakes: {:#?}", vote_stakes,);
+            }
             self.epoch_stakes
                 .insert(leader_schedule_epoch, new_epoch_stakes);
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2278,21 +2278,11 @@ impl Bank {
             let stakes = self.stakes_cache.stakes().clone();
             let stakes = Arc::new(StakesEnum::from(stakes));
             let new_epoch_stakes = EpochStakes::new(stakes, leader_schedule_epoch);
-            {
-                let vote_stakes: HashMap<_, _> = self
-                    .stakes_cache
-                    .stakes()
-                    .vote_accounts()
-                    .delegated_stakes()
-                    .map(|(pubkey, stake)| (*pubkey, stake))
-                    .collect();
-                info!(
-                    "new epoch stakes, epoch: {}, stakes: {:#?}, total_stake: {}",
-                    leader_schedule_epoch,
-                    vote_stakes,
-                    new_epoch_stakes.total_stake(),
-                );
-            }
+            info!(
+                "new epoch stakes, epoch: {}, total_stake: {}",
+                leader_schedule_epoch,
+                new_epoch_stakes.total_stake(),
+            );
             self.epoch_stakes
                 .insert(leader_schedule_epoch, new_epoch_stakes);
         }

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -125,6 +125,7 @@ impl VoteAccounts {
             .map(|(vote_pubkey, (_stake, vote_account))| (vote_pubkey, vote_account))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn delegated_stakes(&self) -> impl Iterator<Item = (&Pubkey, u64)> {
         self.vote_accounts
             .iter()

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -125,7 +125,6 @@ impl VoteAccounts {
             .map(|(vote_pubkey, (_stake, vote_account))| (vote_pubkey, vote_account))
     }
 
-    #[allow(dead_code)]
     pub(crate) fn delegated_stakes(&self) -> impl Iterator<Item = (&Pubkey, u64)> {
         self.vote_accounts
             .iter()


### PR DESCRIPTION
#### Problem

On mainnet, it shows that it takes 100ms - 400ms to update epoch stakes at the
epoch boundary. 

Most of the time is spent on logging the details of epoch stakes. 


#### Summary of Changes

Do not log the details of epoch stakes.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
