### PR TITLE
v1.13: increases shred-fetch-stage deduper capacity and reset-cycle (backport of #30690)

### DIFF
--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -5,7 +5,6 @@ use {
     ahash::AHasher,
     rand::{thread_rng, Rng},
     solana_ledger::shred::Shred,
-    solana_perf::packet::Packet,
     std::hash::Hasher,
 };
 
@@ -25,10 +24,6 @@ impl Default for PacketHasher {
 }
 
 impl PacketHasher {
-    pub(crate) fn hash_packet(&self, packet: &Packet) -> u64 {
-        self.hash_data(packet.data(..).unwrap_or_default())
-    }
-
     pub(crate) fn hash_shred(&self, shred: &Shred) -> u64 {
         self.hash_data(&shred.payload)
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2007,8 +2007,7 @@ mod tests {
             sender.send(()).unwrap();
         });
 
-        // timeout of 30s for shutting down the validators
-        let timeout = Duration::from_secs(30);
+        let timeout = Duration::from_secs(60);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             panic!("timeout for shutting down validators",);
         }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -526,9 +526,7 @@ impl<const K: usize> Deduper<K> {
     // Returns true if the packet is duplicate.
     #[must_use]
     #[allow(clippy::integer_arithmetic)]
-    fn dedup_packet(&self, packet: &Packet) -> bool {
-        // Should not dedup packet if already discarded.
-        debug_assert!(!packet.meta.discard());
+    pub fn dedup_packet(&self, packet: &Packet) -> bool {
         let mut out = true;
         for seed in self.seeds {
             let mut hasher = AHasher::new_with_keys(seed.0, seed.1);


### PR DESCRIPTION
```diff
- This is manual v1.13 backport of:
- https://github.com/solana-labs/solana/pull/30690
```

increases shred-fetch-stage deduper capacity and reset-cycle (#30690)

(cherry picked from commit 93f696dac720ec6beac70ea01508872e6851bd36)