### PR TITLE
v1.13: removes lazy-static thread-pool from sigverify-shreds (backport of #30787)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,7 +5432,6 @@ dependencies = [
  "fs_extra",
  "futures 0.3.21",
  "itertools",
- "lazy_static",
  "libc",
  "log",
  "lru",

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -234,7 +234,7 @@ impl SigVerifier for DisabledSigVerifier {
 
 impl SigVerifyStage {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<T: SigVerifier + 'static + Send + Clone>(
+    pub fn new<T: SigVerifier + 'static + Send>(
         packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
         verifier: T,
         name: &'static str,
@@ -405,7 +405,7 @@ impl SigVerifyStage {
         Ok(())
     }
 
-    fn verifier_service<T: SigVerifier + 'static + Send + Clone>(
+    fn verifier_service<T: SigVerifier + 'static + Send>(
         packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
         mut verifier: T,
         name: &'static str,
@@ -449,7 +449,7 @@ impl SigVerifyStage {
             .unwrap()
     }
 
-    fn verifier_services<T: SigVerifier + 'static + Send + Clone>(
+    fn verifier_services<T: SigVerifier + 'static + Send>(
         packet_receiver: find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
         verifier: T,
         name: &'static str,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -19,7 +19,6 @@ crossbeam-channel = "0.5"
 fs_extra = "1.2.0"
 futures = "0.3.21"
 itertools = "0.10.3"
-lazy_static = "1.4.0"
 libc = "0.2.120"
 log = { version = "0.4.14" }
 lru = "0.7.5"

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -2,6 +2,7 @@
 
 extern crate test;
 use {
+    rayon::ThreadPoolBuilder,
     solana_ledger::{
         shred::{Shred, SIZE_OF_DATA_SHRED_PAYLOAD},
         sigverify_shreds::{sign_shreds_cpu, sign_shreds_gpu, sign_shreds_gpu_pinned_keypair},
@@ -10,6 +11,7 @@ use {
         packet::{Packet, PacketBatch},
         recycler_cache::RecyclerCache,
     },
+    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::signature::Keypair,
     std::sync::Arc,
     test::Bencher,
@@ -19,6 +21,10 @@ const NUM_PACKETS: usize = 256;
 const NUM_BATCHES: usize = 1;
 #[bench]
 fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
+    let thread_pool = ThreadPoolBuilder::new()
+        .num_threads(get_thread_count())
+        .build()
+        .unwrap();
     let recycler_cache = RecyclerCache::default();
 
     let mut packet_batch = PacketBatch::new_pinned_with_capacity(NUM_PACKETS);
@@ -44,15 +50,31 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let pinned_keypair = Some(Arc::new(pinned_keypair));
     //warmup
     for _ in 0..100 {
-        sign_shreds_gpu(&keypair, &pinned_keypair, &mut batches, &recycler_cache);
+        sign_shreds_gpu(
+            &thread_pool,
+            &keypair,
+            &pinned_keypair,
+            &mut batches,
+            &recycler_cache,
+        );
     }
     bencher.iter(|| {
-        sign_shreds_gpu(&keypair, &pinned_keypair, &mut batches, &recycler_cache);
+        sign_shreds_gpu(
+            &thread_pool,
+            &keypair,
+            &pinned_keypair,
+            &mut batches,
+            &recycler_cache,
+        );
     })
 }
 
 #[bench]
 fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
+    let thread_pool = ThreadPoolBuilder::new()
+        .num_threads(get_thread_count())
+        .build()
+        .unwrap();
     let mut packet_batch = PacketBatch::default();
     let slot = 0xdead_c0de;
     packet_batch.resize(NUM_PACKETS, Packet::default());
@@ -73,6 +95,6 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
     let mut batches = vec![packet_batch; NUM_BATCHES];
     let keypair = Keypair::new();
     bencher.iter(|| {
-        sign_shreds_cpu(&keypair, &mut batches);
+        sign_shreds_cpu(&thread_pool, &keypair, &mut batches);
     })
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -36,7 +36,4 @@ extern crate solana_metrics;
 extern crate log;
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate solana_frozen_abi_macro;

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4949,7 +4949,6 @@ dependencies = [
  "fs_extra",
  "futures 0.3.21",
  "itertools",
- "lazy_static",
  "libc",
  "log",
  "lru",


### PR DESCRIPTION
```diff
- This is manual v1.13 backport of
- https://github.com/solana-labs/solana/pull/30787
```

removes lazy-static thread-pool from sigverify-shreds #30787

Instead the thread-pool is passed explicitly from higher in the call stack so that
https://github.com/solana-labs/solana/pull/30786
can use the same thread-pool for shred deduplication.

(cherry picked from commit c6e7aaf96ce2a524fe0a0b65e1de66a4a80bcd1e)