### PR TITLE
Fix cargo-build-bpf removing a wrong command line option

### DIFF
--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -30,9 +30,6 @@ fn main() {
             args.remove(0);
         }
     }
-    let index = args.iter().position(|x| x == "--").unwrap_or(args.len());
-    args.insert(index, "bpf".to_string());
-    args.insert(index, "--arch".to_string());
     info!("cargo-build-bpf child: {}", program.display());
     for a in &args {
         info!(" {}", a);


### PR DESCRIPTION
#### Problem

The tool adds a removed command line option when it invokes cargo-build-sbf.

#### Summary of Changes

Remove the wrong option.