### PR TITLE
add stat for disk buckets flushed

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -41,6 +41,7 @@ pub struct BucketMapHolderStats {
     pub failed_to_evict: AtomicU64,
     pub keys: AtomicU64,
     pub deletes: AtomicU64,
+    pub buckets_scanned: AtomicU64,
     pub inserts: AtomicU64,
     count: AtomicUsize,
     pub bg_waiting_us: AtomicU64,
@@ -372,6 +373,11 @@ impl BucketMapHolderStats {
                 ("items", self.items.swap(0, Ordering::Relaxed), i64),
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
                 ("ms_per_age", ms_per_age, i64),
+                (
+                    "buckets_scanned",
+                    self.buckets_scanned.swap(0, Ordering::Relaxed),
+                    i64
+                ),
                 (
                     "flush_scan_us",
                     self.flush_scan_us.swap(0, Ordering::Relaxed),

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1109,6 +1109,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             return;
         }
 
+        Self::update_stat(&self.stats().buckets_scanned, 1);
         // scan in-mem map for items that we may evict
         let FlushScanResult {
             mut evictions_age_possible,


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

Disk bucket flushing is a source of much i/o.

#### Summary of Changes
Add stat for how many disk buckets are flushed when we log accounts index info every 10s.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
