### PR TITLE
cli: require one or more authority params in `stake-authorized-checked`

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -950,6 +950,11 @@ pub fn parse_stake_authorize(
         default_signer.generate_unique_signers(bulk_signers, matches, wallet_manager)?;
     let compute_unit_price = value_of(matches, COMPUTE_UNIT_PRICE_ARG.name);
 
+    if new_authorizations.is_empty() {
+        return Err(CliError::BadParameter(
+            "New authorization list must include at least one authority".to_string(),
+        ));
+    }
     let new_authorizations = new_authorizations
         .into_iter()
         .map(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -392,6 +392,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
+                        .required_unless("new_withdraw_authority")
                         .help("New authorized staker")
                 )
                 .arg(
@@ -400,6 +401,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
+                        .required_unless("new_stake_authority")
                         .help("New authorized withdrawer")
                 )
                 .arg(stake_authority_arg())


### PR DESCRIPTION
#### Problem
The cli doesn't require that `stake-authorize-checked` include an authority to change, and ultimately submits an empty transaction if you don't provide one.
In contrast, the unchecked `stake-authorize` uses `.required_unless("new_withdraw_authority")` on `new_stake_authority` and `.required_unless("new_stake_authority")` on `new_withdraw_authority`.

```
$ solana stake-authorize
error: The following required arguments were not provided:
    <STAKE_ACCOUNT_ADDRESS>
    --new-stake-authority <PUBKEY>
    --new-withdraw-authority <PUBKEY>

USAGE:
    solana stake-authorize <STAKE_ACCOUNT_ADDRESS> --config <FILEPATH> --new-stake-authority <PUBKEY> --new-withdraw-authority <PUBKEY>
```
```
$ solana stake-authorize-checked
error: The following required arguments were not provided:
    <STAKE_ACCOUNT_ADDRESS>

USAGE:
    solana stake-authorize-checked <STAKE_ACCOUNT_ADDRESS> --config <FILEPATH>
```

#### Summary of Changes
Add `required_unless` settings to stake-authorize-checked authority parameters
Also add a check for new_authorization len when parsing args to prevent a similar issue if more authorities are added in the future.