### PR TITLE
Add links to Stack Exchange and Discord on the ‘create an issue’ page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - about: "Have a question about using this software, or about Solana in general? Post it on the Solana Stack Exchange."
+    name: Ask a Question
+    url: "https://solana.stackexchange.com/questions/ask"
+  - about: "Start or join a discussion on the Solana Tech Discord."
+    name: Start a Discussion
+    url: "https://solana.com/discord"


### PR DESCRIPTION
#### Problem

Sometimes people create issues when all they want is to ask a usage question.

#### Summary of Changes

I learned you can do this from the Typescript GitHub: https://github.com/microsoft/TypeScript/issues/new/choose

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/13243/227270458-7e62b7ae-73f1-4849-977a-e020c3c0cdfc.png">
