### PR TITLE
rename process_entries_with_callback to process_entries

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -429,7 +429,7 @@ pub fn process_entries_for_tests(
             .collect();
 
     let _ignored_prioritization_fee_cache = PrioritizationFeeCache::new(0u64);
-    let result = process_entries_with_callback(
+    let result = process_entries(
         bank,
         &mut replay_entries,
         randomize,
@@ -445,8 +445,7 @@ pub fn process_entries_for_tests(
 }
 
 // Note: If randomize is true this will shuffle entries' transactions in-place.
-#[allow(clippy::too_many_arguments)]
-fn process_entries_with_callback(
+fn process_entries(
     bank: &Arc<Bank>,
     entries: &mut [ReplayEntry],
     randomize: bool,
@@ -1194,7 +1193,7 @@ fn confirm_slot_entries(
         })
         .collect();
     // Note: This will shuffle entries' transactions in-place.
-    let process_result = process_entries_with_callback(
+    let process_result = process_entries(
         bank,
         &mut replay_entries,
         true, // shuffle transactions.


### PR DESCRIPTION
#### Problem
#30600 removed the `entry_callback` parameter for `process_entries_with_callback`. Name is now misleading.

#### Summary of Changes
Rename it to simply `process_entries`. Also we no longer have too many parameters -> goodbye clippy allow

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
