### PR TITLE
Remove unused error variant

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -47,9 +47,6 @@ pub const MAX_GRACE_SLOTS: u64 = 2;
 
 #[derive(Error, Debug, Clone)]
 pub enum PohRecorderError {
-    #[error("invalid calling object")]
-    InvalidCallingObject,
-
     #[error("max height reached")]
     MaxHeightReached,
 


### PR DESCRIPTION
#### Problem
This error variant, `PohRecorderError::InvalidCallingObject`, is unused.

#### Summary of Changes
Remove `PohRecorderError::InvalidCallingObject`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
