### PR TITLE
Add Geyser entry interfaces

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -353,4 +353,11 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     fn transaction_notifications_enabled(&self) -> bool {
         false
     }
+
+    /// Check if the plugin is interested in entry data
+    /// Default is false -- if the plugin is interested in
+    /// entry data, return true.
+    fn entry_notifications_enabled(&self) -> bool {
+        false
+    }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -348,8 +348,8 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     }
 
     /// Check if the plugin is interested in transaction data
-    /// Default is false -- if the plugin is not interested in
-    /// transaction data, please return false.
+    /// Default is false -- if the plugin is interested in
+    /// transaction data, please return true.
     fn transaction_notifications_enabled(&self) -> bool {
         false
     }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -163,6 +163,28 @@ pub enum ReplicaTransactionInfoVersions<'a> {
 }
 
 #[derive(Clone, Debug)]
+pub struct ReplicaEntryInfo<'a> {
+    /// The slot number of the block containing this Entry
+    pub slot: Slot,
+    /// The Entry's index in the block
+    pub index: usize,
+    /// The number of hashes since the previous Entry
+    pub num_hashes: u64,
+    /// The Entry's SHA-256 hash, generated from the previous Entry's hash with
+    /// `solana_entry::entry::next_hash()`
+    pub hash: &'a [u8],
+    /// The number of executed transactions in the Entry
+    pub executed_transaction_count: u64,
+}
+
+/// A wrapper to future-proof ReplicaEntryInfo handling. To make a change to the structure of
+/// ReplicaEntryInfo, add an new enum variant wrapping a newer version, which will force plugin
+/// implementations to handle the change.
+pub enum ReplicaEntryInfoVersions<'a> {
+    V0_0_1(&'a ReplicaEntryInfo<'a>),
+}
+
+#[derive(Clone, Debug)]
 pub struct ReplicaBlockInfo<'a> {
     pub slot: Slot,
     pub blockhash: &'a str,
@@ -303,6 +325,12 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         transaction: ReplicaTransactionInfoVersions,
         slot: Slot,
     ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when an entry is executed.
+    #[allow(unused_variables)]
+    fn notify_entry(&self, entry: ReplicaEntryInfoVersions) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,7 +3,11 @@
 /// In addition, the dynamic library must export a "C" function _create_plugin which
 /// creates the implementation of the plugin.
 use {
-    solana_sdk::{clock::UnixTimestamp, signature::Signature, transaction::SanitizedTransaction},
+    solana_sdk::{
+        clock::{Slot, UnixTimestamp},
+        signature::Signature,
+        transaction::SanitizedTransaction,
+    },
     solana_transaction_status::{Reward, TransactionStatusMeta},
     std::{any::Any, error, io},
     thiserror::Error,
@@ -160,7 +164,7 @@ pub enum ReplicaTransactionInfoVersions<'a> {
 
 #[derive(Clone, Debug)]
 pub struct ReplicaBlockInfo<'a> {
-    pub slot: u64,
+    pub slot: Slot,
     pub blockhash: &'a str,
     pub rewards: &'a [Reward],
     pub block_time: Option<UnixTimestamp>,
@@ -170,9 +174,9 @@ pub struct ReplicaBlockInfo<'a> {
 /// Extending ReplicaBlockInfo by sending the transaction_entries_count.
 #[derive(Clone, Debug)]
 pub struct ReplicaBlockInfoV2<'a> {
-    pub parent_slot: u64,
+    pub parent_slot: Slot,
     pub parent_blockhash: &'a str,
-    pub slot: u64,
+    pub slot: Slot,
     pub blockhash: &'a str,
     pub rewards: &'a [Reward],
     pub block_time: Option<UnixTimestamp>,
@@ -270,7 +274,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     fn update_account(
         &self,
         account: ReplicaAccountInfoVersions,
-        slot: u64,
+        slot: Slot,
         is_startup: bool,
     ) -> Result<()> {
         Ok(())
@@ -283,7 +287,12 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
 
     /// Called when a slot status is updated
     #[allow(unused_variables)]
-    fn update_slot_status(&self, slot: u64, parent: Option<u64>, status: SlotStatus) -> Result<()> {
+    fn update_slot_status(
+        &self,
+        slot: Slot,
+        parent: Option<u64>,
+        status: SlotStatus,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -292,7 +301,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     fn notify_transaction(
         &self,
         transaction: ReplicaTransactionInfoVersions,
-        slot: u64,
+        slot: Slot,
     ) -> Result<()> {
         Ok(())
     }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -287,7 +287,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
-    /// Called when a transaction is updated at a slot.
+    /// Called when a transaction is processed in a slot.
     #[allow(unused_variables)]
     fn notify_transaction(
         &self,


### PR DESCRIPTION
#### Problem
Various users, including RPC providers, would like to be able to cryptographically verify that a block stored in long-term storage (either via Bigtable upload or streamed via Geyser) contains complete and correct transaction data. There is currently no way to do this, because the transactions get flattened and the Entry data is not included in the stored copy.
This PR is the first toward [this project](https://github.com/orgs/solana-labs/projects/29) to address the Geyser side of the issue.

#### Summary of Changes
Add basic Entry interface elements to solana-geyser-plugin-interface
The entry notification is not actually sent anywhere yet.
