### PR TITLE
PohRecorderError::MinHeightNotReached

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1623,7 +1623,7 @@ mod tests {
             let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
+            error!("bank tick height: {}", bank.tick_height());
             poh_recorder.write().unwrap().set_bank(&bank, false);
 
             let shreds = entries_to_test_shreds(


### PR DESCRIPTION
#### Problem
`PohRecorderError::MaxHeightReached` is overloaded in **many** ways.
Currently returned if there is no working bank or working bank slot mismatches in `record`. This even happens if the provided slot is in the future, which has clearly not hit max height!

#### Summary of Changes
Return `PohRecorderError::MinHeightNotReached` if the provided slot is higher than the working slot, or if there is no working slot, the previous working slot.

##### IMPORTANT
This will introduce potential new panics if recording for a future slot

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
