### PR TITLE
reverse duplicate instance check to shutdown newer instance

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2413,7 +2413,7 @@ impl ClusterInfo {
         };
 
         // Check if there is a duplicate instance of
-        // this node with more recent timestamp.
+        // this node with an older timestamp.
         let instance = self.instance.read().unwrap();
         let check_duplicate_instance = |values: &[CrdsValue]| {
             if should_check_duplicate_instance {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2412,8 +2412,6 @@ impl ClusterInfo {
             })
         };
 
-        // Check if there is a duplicate instance of
-        // this node with an older timestamp.
         let instance = self.instance.read().unwrap();
         let check_duplicate_instance = |values: &[CrdsValue]| {
             if should_check_duplicate_instance {

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -440,12 +440,12 @@ impl NodeInstance {
     }
 
     // Returns true if the crds-value is a duplicate instance
-    // of this node, with a more recent timestamp.
+    // of this node, with an older timestamp.
     pub(crate) fn check_duplicate(&self, other: &CrdsValue) -> bool {
         match &other.data {
             CrdsData::NodeInstance(other) => {
                 self.token != other.token
-                    && self.timestamp <= other.timestamp
+                    && self.timestamp > other.timestamp
                     && self.from == other.from
             }
             _ => false,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -983,8 +983,8 @@ mod test {
             token: rng.gen(),
         };
         let other_crds = make_crds_value(other.clone());
-        assert!(!node.check_duplicate(&other_crds));
-        assert!(other.check_duplicate(&node_crds));
+        assert!(node.check_duplicate(&other_crds));
+        assert!(!other.check_duplicate(&node_crds));
         assert_eq!(node.overrides(&other_crds), Some(true));
         assert_eq!(other.overrides(&node_crds), Some(false));
         // Updated wallclock is not a duplicate.
@@ -1012,8 +1012,8 @@ mod test {
                 token: rng.gen(),
             };
             let other_crds = make_crds_value(other.clone());
-            assert!(node.check_duplicate(&other_crds));
-            assert!(other.check_duplicate(&node_crds));
+            assert!(!node.check_duplicate(&other_crds));
+            assert!(!other.check_duplicate(&node_crds));
             assert_eq!(node.overrides(&other_crds), Some(other.token < node.token));
             assert_eq!(other.overrides(&node_crds), Some(node.token < other.token));
         }
@@ -1026,8 +1026,8 @@ mod test {
                 token: rng.gen(),
             };
             let other_crds = make_crds_value(other.clone());
-            assert!(node.check_duplicate(&other_crds));
-            assert!(!other.check_duplicate(&node_crds));
+            assert!(!node.check_duplicate(&other_crds));
+            assert!(other.check_duplicate(&node_crds));
             assert_eq!(node.overrides(&other_crds), Some(false));
             assert_eq!(other.overrides(&node_crds), Some(true));
         }


### PR DESCRIPTION
#### Problem
Duplicate instance check will terminate the older node. The _newer_ node should be terminated as it is more likely to have operator engagement and terminating the older node could lead to a restart cycle between duplicate nodes if they are using auto-restart with systemd.

#### Summary of Changes
Shutdown newer node when duplicate instance is detected.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
