### PR TITLE
Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7201,7 +7201,6 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
- "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.16",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,6 @@ cargo_metadata = "0.15.0"
 cc = "1.0.79"
 chrono = { version = "0.4.23", default-features = false }
 chrono-humanize = "0.2.1"
-cipher = "0.4"
 clap = "2.33.1"
 console = "0.15.0"
 console_error_panic_hook = "0.1.7"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6355,7 +6355,6 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder 1.4.3",
- "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.14",
  "itertools",

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -19,7 +19,6 @@ aes-gcm-siv = { workspace = true }
 arrayref = { workspace = true }
 bincode = { workspace = true }
 byteorder = { workspace = true }
-cipher = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 getrandom = { workspace = true, features = ["dummy"] }
 itertools = { workspace = true }


### PR DESCRIPTION
#### Problem
`zk-token-sdk` lists `cipher` as a dependency, but nothing is being directly imported from it.

#### Summary of Changes
Remove unused declaration.
`cipher v0.4` is still being pulled because of spl-token-2022 v0.6 -> solana-zk-token-sdk v1.15, but will be removed from Cargo.lock entirely when we update to a version of spl-token on solana v1.16

Closes #30866
