### PR TITLE
Renames to StakeState::Staked

### DIFF
--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -19,7 +19,7 @@ pub fn parse_stake(data: &[u8]) -> Result<StakeAccountType, ParseAccountError> {
             meta: meta.into(),
             stake: None,
         }),
-        StakeState::Stake(meta, stake) => StakeAccountType::Delegated(UiStakeAccount {
+        StakeState::Staked(meta, stake) => StakeAccountType::Delegated(UiStakeAccount {
             meta: meta.into(),
             stake: Some(stake.into()),
         }),
@@ -194,7 +194,7 @@ mod test {
             credits_observed: 10,
         };
 
-        let stake_state = StakeState::Stake(meta, stake);
+        let stake_state = StakeState::Staked(meta, stake);
         let stake_data = serialize(&stake_state).unwrap();
         assert_eq!(
             parse_stake(&stake_data).unwrap(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1819,7 +1819,7 @@ pub fn process_show_stakes(
                         });
                     }
                 }
-                StakeState::Stake(_, stake) => {
+                StakeState::Staked(_, stake) => {
                     if vote_account_pubkeys.is_none()
                         || vote_account_pubkeys
                             .unwrap()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1498,7 +1498,7 @@ pub fn process_stake_authorize(
         let authority = config.signers[*authority];
         if let Some(current_stake_account) = current_stake_account {
             let authorized = match current_stake_account {
-                StakeState::Stake(Meta { authorized, .. }, ..) => Some(authorized),
+                StakeState::Staked(Meta { authorized, .. }, ..) => Some(authorized),
                 StakeState::Initialized(Meta { authorized, .. }) => Some(authorized),
                 _ => None,
             };
@@ -1628,7 +1628,7 @@ pub fn process_deactivate_stake_account(
 
         let vote_account_address = match stake_account.state() {
             Ok(stake_state) => match stake_state {
-                StakeState::Stake(_, stake) => stake.delegation.voter_pubkey,
+                StakeState::Staked(_, stake) => stake.delegation.voter_pubkey,
                 _ => {
                     return Err(CliError::BadParameter(format!(
                         "{stake_account_address} is not a delegated stake account",
@@ -2114,7 +2114,7 @@ pub fn process_stake_set_lockup(
     if !sign_only {
         let state = get_stake_account_state(rpc_client, stake_account_pubkey, config.commitment)?;
         let lockup = match state {
-            StakeState::Stake(Meta { lockup, .. }, ..) => Some(lockup),
+            StakeState::Staked(Meta { lockup, .. }, ..) => Some(lockup),
             StakeState::Initialized(Meta { lockup, .. }) => Some(lockup),
             _ => None,
         };
@@ -2188,7 +2188,7 @@ pub fn build_stake_state(
     clock: &Clock,
 ) -> CliStakeState {
     match stake_state {
-        StakeState::Stake(
+        StakeState::Staked(
             Meta {
                 rent_exempt_reserve,
                 authorized,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -165,7 +165,7 @@ fn test_stake_redelegation() {
     let stake_state: StakeState = stake_account.state().unwrap();
 
     let rent_exempt_reserve = match stake_state {
-        StakeState::Stake(meta, stake) => {
+        StakeState::Staked(meta, stake) => {
             assert_eq!(stake.delegation.voter_pubkey, vote_keypair.pubkey());
             meta.rent_exempt_reserve
         }
@@ -270,7 +270,7 @@ fn test_stake_redelegation() {
     let stake2_state: StakeState = stake2_account.state().unwrap();
 
     match stake2_state {
-        StakeState::Stake(_meta, stake) => {
+        StakeState::Staked(_meta, stake) => {
             assert_eq!(stake.delegation.voter_pubkey, vote2_keypair.pubkey());
         }
         _ => panic!("Unexpected stake2 state!"),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3236,7 +3236,7 @@ fn main() {
                                 .unwrap()
                                 .into_iter()
                             {
-                                if let Ok(StakeState::Stake(meta, stake)) = account.state() {
+                                if let Ok(StakeState::Staked(meta, stake)) = account.state() {
                                     if vote_accounts_to_destake
                                         .contains(&stake.delegation.voter_pubkey)
                                     {

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -60,7 +60,7 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCircu
                     non_circulating_accounts_set.insert(*pubkey);
                 }
             }
-            StakeState::Stake(meta, _stake) => {
+            StakeState::Staked(meta, _stake) => {
                 if meta.lockup.is_in_force(&clock, None)
                     || withdraw_authority_list.contains(&meta.authorized.withdrawer)
                 {

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -127,7 +127,7 @@ impl AbiExample for StakeAccount<Delegation> {
             account::Account,
             stake::state::{Meta, Stake},
         };
-        let stake_state = StakeState::Stake(Meta::example(), Stake::example());
+        let stake_state = StakeState::Staked(Meta::example(), Stake::example());
         let mut account = Account::example();
         account.data.resize(196, 0u8);
         account.owner = solana_stake_program::id();

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -346,7 +346,7 @@ fn test_stake_account_lifetime() {
     // Test that correct lamports are staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeState::Stake(_meta, stake) = stake_state {
+    if let StakeState::Staked(_meta, stake) = stake_state {
         assert_eq!(stake.delegation.stake, stake_starting_delegation,);
     } else {
         panic!("wrong account type found")
@@ -370,7 +370,7 @@ fn test_stake_account_lifetime() {
     // Test that lamports are still staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeState::Stake(_meta, stake) = stake_state {
+    if let StakeState::Staked(_meta, stake) = stake_state {
         assert_eq!(stake.delegation.stake, stake_starting_delegation,);
     } else {
         panic!("wrong account type found")
@@ -615,7 +615,7 @@ fn test_create_stake_account_from_seed() {
     // Test that correct lamports are staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeState::Stake(_meta, stake) = stake_state {
+    if let StakeState::Staked(_meta, stake) = stake_state {
         assert_eq!(stake.delegation.stake, delegation);
     } else {
         panic!("wrong account type found")

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -22,7 +22,7 @@ pub enum StakeState {
     #[default]
     Uninitialized,
     Initialized(Meta),
-    Stake(Meta, Stake),
+    Staked(Meta, Stake),
     RewardsPool,
 }
 
@@ -38,7 +38,7 @@ impl BorshDeserialize for StakeState {
             2 => {
                 let meta: Meta = BorshDeserialize::deserialize(buf)?;
                 let stake: Stake = BorshDeserialize::deserialize(buf)?;
-                Ok(StakeState::Stake(meta, stake))
+                Ok(StakeState::Staked(meta, stake))
             }
             3 => Ok(StakeState::RewardsPool),
             _ => Err(io::Error::new(
@@ -57,7 +57,7 @@ impl BorshSerialize for StakeState {
                 writer.write_all(&1u32.to_le_bytes())?;
                 meta.serialize(writer)
             }
-            StakeState::Stake(meta, stake) => {
+            StakeState::Staked(meta, stake) => {
                 writer.write_all(&2u32.to_le_bytes())?;
                 meta.serialize(writer)?;
                 stake.serialize(writer)
@@ -75,21 +75,21 @@ impl StakeState {
 
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeState::Stake(_meta, stake) => Some(*stake),
+            StakeState::Staked(_meta, stake) => Some(*stake),
             _ => None,
         }
     }
 
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
-            StakeState::Stake(_meta, stake) => Some(stake.delegation),
+            StakeState::Staked(_meta, stake) => Some(stake.delegation),
             _ => None,
         }
     }
 
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
-            StakeState::Stake(meta, _stake) => Some(meta.authorized),
+            StakeState::Staked(meta, _stake) => Some(meta.authorized),
             StakeState::Initialized(meta) => Some(meta.authorized),
             _ => None,
         }
@@ -101,7 +101,7 @@ impl StakeState {
 
     pub fn meta(&self) -> Option<Meta> {
         match self {
-            StakeState::Stake(meta, _stake) => Some(*meta),
+            StakeState::Staked(meta, _stake) => Some(*meta),
             StakeState::Initialized(meta) => Some(*meta),
             _ => None,
         }
@@ -610,7 +610,7 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
-        check_borsh_deserialization(StakeState::Stake(
+        check_borsh_deserialization(StakeState::Staked(
             Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {
@@ -644,7 +644,7 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
-        check_borsh_serialization(StakeState::Stake(
+        check_borsh_serialization(StakeState::Staked(
             Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {


### PR DESCRIPTION
#### Problem

One of these is not like the other:

* Uninitialized
* Initialized
* Stake

The enum variant for the Stake State should be Stake**D** for consistency (and my sanity, heh).

Also, there's already other things called `Stake` (like `stake::state::Stake`, which is different that `stake::state::StakeState::Stake`), which was confusing for me when initially reading the code. 


#### Summary of Changes

Rename the variant.