### PR TITLE
validator: Move `skip_poh_verify` into the deprecated list

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -613,15 +613,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        Reads/writes perf samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate."),
         )
         .arg(
-            Arg::with_name("skip_poh_verify")
-                .long("skip-poh-verify")
-                .takes_value(false)
-                .help(
-                    "Deprecated, please use --skip-verification.\n\
-                     Skip ledger verification at validator bootup."
-                ),
-        )
-        .arg(
             Arg::with_name("skip_verification")
                 .long("skip-verification")
                 .takes_value(false)
@@ -1700,6 +1691,14 @@ fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
             .hidden(hidden_unless_forced())
             .takes_value(false)
             .help("Disable manual compaction of the ledger database (this is ignored)."),
+        Arg::with_name("skip_poh_verify")
+            .long("skip-poh-verify")
+            .hidden(hidden_unless_forced())
+            .takes_value(false)
+            .help(
+                "Please use --skip-verification.\n\
+                 Skip ledger verification at validator bootup."
+            ),
         Arg::with_name("rocksdb_compaction_interval")
             .long("rocksdb-compaction-interval-slots")
             .hidden(hidden_unless_forced())
@@ -1940,6 +1939,7 @@ lazy_static! {
             "Vote account sanity checks are no longer performed by default.",
         ),
         ("no_rocksdb_compaction", ""),
+        ("skip_poh_verify", "Please use --skip-verification"),
         ("rocksdb_compaction_interval", ""),
         ("rocksdb_max_compaction_jitter", ""),
     ];

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1191,10 +1191,6 @@ pub fn main() {
     }
     let full_api = matches.is_present("full_rpc_api");
 
-    if matches.is_present("skip_poh_verify") {
-        eprintln!("--skip-poh-verify is deprecated.  Replace with --skip-verification.");
-    }
-
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,


### PR DESCRIPTION
Follow-up for
```
  commit 809041b1519ebaa54d6ffe4ce194f04feb8eda0f
  Author: Illia Bobyr <illia.bobyr@solana.com>
  Date:   Wed Mar 22 11:03:30 2023 -0700

      poh_verify => run_verification: Rename to be more accurate (#30811)

      `poh_verify` actually disables transaction signature, tick count and
      built in program argument verifications as well.  It is somewhat
      confusing to call it `poh_verify`.
```