### PR TITLE
Quic server log data rate

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -269,9 +269,8 @@ enum ConnectionHandlerError {
 }
 
 struct NewConnectionHandlerParams {
-    // In principle, the code should work as-is if we replaced this with a crossbeam channel
-    // as the server code never does a blocking send (as the channel's unbounded)
-    // or a blocking recv (as we always use try_recv)
+    // In principle, the code can be made to work with a crossbeam channel
+    // as long as we're careful never to use a blocking recv or send call
     // but I've found that it's simply too easy to accidentally block
     // in async code when using the crossbeam channel, so for the sake of maintainability,
     // we're sticking with an async channel
@@ -621,6 +620,8 @@ async fn packet_batch_sender(
                     packet_batch.set_len(packet_batch.len() + 1);
                 }
 
+                // Start the timeout from when we first put a packet in the batch,
+                // making it non-empty
                 if packet_batch.len() == 1 {
                     batch_start_time = Instant::now();
                 }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -616,14 +616,13 @@ async fn packet_batch_sender(
             let timeout_res = timeout(Duration::from_micros(250), packet_receiver.recv()).await;
 
             if let Ok(Ok(packet_accumulator)) = timeout_res {
-                unsafe {
-                    packet_batch.set_len(packet_batch.len() + 1);
+                // Start the timeout from when the packet batch first becomes non-empty
+                if packet_batch.is_empty() {
+                    batch_start_time = Instant::now();
                 }
 
-                // Start the timeout from when we first put a packet in the batch,
-                // making it non-empty
-                if packet_batch.len() == 1 {
-                    batch_start_time = Instant::now();
+                unsafe {
+                    packet_batch.set_len(packet_batch.len() + 1);
                 }
 
                 let i = packet_batch.len() - 1;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -130,7 +130,9 @@ pub struct StreamStats {
     pub(crate) total_packet_batches_sent: AtomicUsize,
     pub(crate) total_packet_batches_none: AtomicUsize,
     pub(crate) total_packets_sent_for_batching: AtomicUsize,
+    pub(crate) total_bytes_sent_for_batching: AtomicUsize,
     pub(crate) total_packets_sent_to_consumer: AtomicUsize,
+    pub(crate) total_bytes_sent_to_consumer: AtomicUsize,
     pub(crate) total_stream_read_errors: AtomicUsize,
     pub(crate) total_stream_read_timeouts: AtomicUsize,
     pub(crate) num_evictions: AtomicUsize,
@@ -259,9 +261,20 @@ impl StreamStats {
                 i64
             ),
             (
+                "bytes_sent_for_batching",
+                self.total_bytes_sent_for_batching
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "packets_sent_to_consumer",
                 self.total_packets_sent_to_consumer
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "bytes_sent_to_consumer",
+                self.total_bytes_sent_to_consumer.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
We recently had a surge in possible Quic traffic associated with some nodes going down, and were unable to directly estimate the amount of actual Quic traffic incoming to the Quic server due to lack of appropriate statistics.

#### Summary of Changes
Add appropriate statistics

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
