### PR TITLE
Add units to incremental accounts hash datapoint

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -417,7 +417,11 @@ impl AccountsHashVerifier {
 
         datapoint_info!(
             "accounts_hash_verifier",
-            ("calculate_incremental_accounts_hash", measure_hash_us, i64),
+            (
+                "calculate_incremental_accounts_hash_us",
+                measure_hash_us,
+                i64
+            ),
         );
 
         incremental_accounts_hash


### PR DESCRIPTION
#### Problem

The kin sim cluster was upgraded and had Incremental Accounts Hash enabled. I was eager to evaluate the performance of IAH, so I went looking at the metrics. I first pulled up the datapoint, but wasn't sure what the units were. I had to double check by looking at the code. It would be helpful to not need to check the code for the units.

#### Summary of Changes

Append `_us` to the datapoint's name.