### PR TITLE
Revert Rust 1.68.0 upgrade

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.68.0
+FROM solanalabs/rust:1.67.1
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/rust-version.sh to pick up the new image tag
-FROM rust:1.68.0
+FROM rust:1.67.1
 
 RUN set -x \
  && apt update \

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2023-02-08
+  nightly_version=2023-01-22
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.67.1"


### PR DESCRIPTION
#### Problem
The nightly upgrade is breaking the `geyser_plugin_manager`.  We will probably need more investigation before we can move forward with it.

Examples of failed CI runs:
https://buildkite.com/solana-labs/solana/builds/92624#0187160f-ec5e-40ae-84b8-a1859f44986a
https://buildkite.com/solana-labs/solana/builds/92627#0187161c-4431-4f62-945a-5e07869b3163
https://buildkite.com/solana-labs/solana/builds/92619#018715aa-c516-4f5f-886c-dd2f9628ec73

The CI log says
```
ci/intercept.sh: command failed; please see ./intercepted-console-2023y03m24d22h15m46s071144271ns.log in artifacts
```
In this log file I see:
```
+ exec cargo +nightly-2023-02-08 test --jobs 48 --target-dir target/cov --lib --all --exclude solana-local-cluster -- --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.62s
warning: the following packages contain code that will be rejected by a future version of Rust: fs_extra v1.2.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running unittests src/lib.rs (target/cov/debug/deps/solana_account_decoder-85cdc6863184cf35)
[...]
error: test failed, to rerun pass `-p solana-geyser-plugin-manager --lib`

Caused by:
  process didn't exit successfully: `/solana/target/cov/debug/deps/solana_geyser_plugin_manager-9fbd116de18ee1f8 --nocapture` (signal: 11, SIGSEGV: invalid memory reference)
```

Unfortunately, I can not reproduce it locally.  The same command as the one CI is running:
```
./cargo +nightly --target-dir target/cov --lib --all --exclude solana-local-cluster -- --nocapture
```
succeeds on my machine.

#### Summary of Changes
Just revert [the upgrade](https://github.com/solana-labs/solana/pull/30664) for now.