### PR TITLE
store data and index occupy in bitvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5031,6 +5031,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "fs_extra",
  "log",
  "memmap2",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bv = { workspace = true, features = ["serde"] }
 log = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -205,12 +205,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { &mut *item }
     }
 
-    pub(crate) fn get_from_parts<T: Sized>(item_slice: &[u8]) -> &T {
-        assert!(std::mem::size_of::<T>() <= item_slice.len());
-        let item = item_slice.as_ptr() as *const T;
-        unsafe { &*item }
-    }
-
     pub fn get_mut<T: Sized>(&mut self, ix: u64) -> &mut T {
         let start = self.get_start_offset_no_header(ix);
         let item_slice = &mut self.mmap[start..];

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4466,6 +4466,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "log",
  "memmap2",
  "modular-bitfield",


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
Remove header from both index and data files. Store occupy bit in bitvec.
So, a u64 per allocated entry on disk (and mmapped) is replaced with a single bit in an in-mem BitVec.
See comment below for effects.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
