### PR TITLE
Increment usage count for loaded programs and call eviction

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -68,7 +68,7 @@ use {
         fmt::Debug,
         mem,
         rc::Rc,
-        sync::Arc,
+        sync::{atomic::Ordering, Arc},
     },
     thiserror::Error,
 };
@@ -588,6 +588,8 @@ fn process_instruction_common(
     if let Some(load_program_metrics) = load_program_metrics {
         load_program_metrics.submit_datapoint(&mut invoke_context.timings);
     }
+
+    executor.usage_counter.fetch_add(1, Ordering::Relaxed);
     match &executor.program {
         LoadedProgramType::Invalid => Err(InstructionError::InvalidAccountData),
         LoadedProgramType::LegacyV0(executable) => execute(executable, invoke_context),

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -30,7 +30,11 @@ use {
         saturating_add_assign,
         transaction_context::{BorrowedAccount, InstructionContext},
     },
-    std::{cell::RefCell, rc::Rc, sync::Arc},
+    std::{
+        cell::RefCell,
+        rc::Rc,
+        sync::{atomic::Ordering, Arc},
+    },
 };
 
 fn get_state(data: &[u8]) -> Result<&LoaderV3State, InstructionError> {
@@ -584,6 +588,7 @@ pub fn process_instruction(invoke_context: &mut InvokeContext) -> Result<(), Ins
             get_or_create_executor_time.as_us()
         );
         drop(program);
+        loaded_program.usage_counter.fetch_add(1, Ordering::Relaxed);
         match &loaded_program.program {
             LoadedProgramType::Invalid => Err(InstructionError::InvalidAccountData),
             LoadedProgramType::Typed(executable) => execute(invoke_context, executable),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4650,6 +4650,11 @@ impl Bank {
 
         execution_time.stop();
 
+        self.loaded_programs_cache
+            .write()
+            .unwrap()
+            .sort_and_evict(None);
+
         debug!(
             "check: {}us load: {}us execute: {}us txs_len={}",
             check_time.as_us(),


### PR DESCRIPTION
#### Problem
The new `LoadedPrograms` cache eviction logic is not being exercised.

#### Summary of Changes

- Increment usage count of a `LoadedProgram` when it is executed.
- Call cache eviction code after a batch of transaction has been executed. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
