### PR TITLE
Fix deployment slot for upgraded programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -934,7 +934,7 @@ fn process_loader_upgradeable_instruction(
                 );
                 return Err(InstructionError::InsufficientFunds);
             }
-            let deployment_slot = if let UpgradeableLoaderState::ProgramData {
+            if let UpgradeableLoaderState::ProgramData {
                 slot,
                 upgrade_authority_address,
             } = programdata.get_state()?
@@ -959,7 +959,6 @@ fn process_loader_upgradeable_instruction(
                     ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                     return Err(InstructionError::MissingRequiredSignature);
                 }
-                slot
             } else {
                 ic_logger_msg!(log_collector, "Invalid ProgramData account");
                 return Err(InstructionError::InvalidAccountData);
@@ -976,7 +975,7 @@ fn process_loader_upgradeable_instruction(
                 new_program_id,
                 program_id,
                 UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
-                deployment_slot,
+                clock.slot,
                 {
                     drop(buffer);
                 },


### PR DESCRIPTION
#### Problem
The deployment slot for the upgraded program is incorrect. It's being set to the deployment slot of the old program.

#### Summary of Changes
Use the `clock.slot` to set the deployment slot of the upgraded program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
