### PR TITLE
use bits from ref count to store an enum tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5032,6 +5032,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "fs_extra",
  "log",
  "memmap2",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bv = { workspace = true, features = ["serde"] }
 log = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -3,8 +3,8 @@ use {
         bucket_item::BucketItem,
         bucket_map::BucketMapError,
         bucket_stats::BucketMapStats,
-        bucket_storage::{BucketStorage, DEFAULT_CAPACITY_POW2},
-        index_entry::IndexEntry,
+        bucket_storage::{BucketOccupied, BucketStorage, DEFAULT_CAPACITY_POW2},
+        index_entry::{DataBucket, IndexBucket, IndexEntry},
         MaxSearch, RefCount,
     },
     rand::{thread_rng, Rng},
@@ -24,26 +24,26 @@ use {
 };
 
 #[derive(Default)]
-pub struct ReallocatedItems {
+pub struct ReallocatedItems<I: BucketOccupied, D: BucketOccupied> {
     // Some if the index was reallocated
     // u64 is random associated with the new index
-    pub index: Option<(u64, BucketStorage)>,
+    pub index: Option<(u64, BucketStorage<I>)>,
     // Some for a data bucket reallocation
     // u64 is data bucket index
-    pub data: Option<(u64, BucketStorage)>,
+    pub data: Option<(u64, BucketStorage<D>)>,
 }
 
 #[derive(Default)]
-pub struct Reallocated {
+pub struct Reallocated<I: BucketOccupied, D: BucketOccupied> {
     /// > 0 if reallocations are encoded
     pub active_reallocations: AtomicUsize,
 
     /// actual reallocated bucket
     /// mutex because bucket grow code runs with a read lock
-    pub items: Mutex<ReallocatedItems>,
+    pub items: Mutex<ReallocatedItems<I, D>>,
 }
 
-impl Reallocated {
+impl<I: BucketOccupied, D: BucketOccupied> Reallocated<I, D> {
     /// specify that a reallocation has occurred
     pub fn add_reallocation(&self) {
         assert_eq!(
@@ -65,15 +65,15 @@ impl Reallocated {
 pub struct Bucket<T> {
     drives: Arc<Vec<PathBuf>>,
     //index
-    pub index: BucketStorage,
+    pub index: BucketStorage<IndexBucket>,
     //random offset for the index
     random: u64,
     //storage buckets to store SlotSlice up to a power of 2 in len
-    pub data: Vec<BucketStorage>,
+    pub data: Vec<BucketStorage<DataBucket>>,
     _phantom: PhantomData<T>,
     stats: Arc<BucketMapStats>,
 
-    pub reallocated: Reallocated,
+    pub reallocated: Reallocated<IndexBucket, DataBucket>,
 }
 
 impl<'b, T: Clone + Copy + 'static> Bucket<T> {
@@ -149,7 +149,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
     /// if entry does not exist, return just the index of an empty entry appropriate for this key
     /// returns (existing entry, index of the found or empty entry)
     fn find_entry_mut<'a>(
-        index: &'a mut BucketStorage,
+        index: &'a mut BucketStorage<IndexBucket>,
         key: &Pubkey,
         random: u64,
     ) -> Result<(Option<&'a mut IndexEntry>, u64), BucketMapError> {
@@ -188,7 +188,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
     }
 
     fn bucket_find_entry<'a>(
-        index: &'a BucketStorage,
+        index: &'a BucketStorage<IndexBucket>,
         key: &Pubkey,
         random: u64,
     ) -> Option<(&'a IndexEntry, u64)> {
@@ -207,7 +207,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
     }
 
     fn bucket_create_key(
-        index: &mut BucketStorage,
+        index: &mut BucketStorage<IndexBucket>,
         key: &Pubkey,
         random: u64,
         is_resizing: bool,
@@ -219,7 +219,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
             if !index.is_free(ii) {
                 continue;
             }
-            index.allocate(ii, is_resizing).unwrap();
+            index.occupy(ii, is_resizing).unwrap();
             let elem: &mut IndexEntry = index.get_mut(ii);
             // These fields will be overwritten after allocation by callers.
             // Since this part of the mmapped file could have previously been used by someone else, there can be garbage here.
@@ -280,7 +280,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
             elem
         } else {
             let is_resizing = false;
-            self.index.allocate(elem_ix, is_resizing).unwrap();
+            self.index.occupy(elem_ix, is_resizing).unwrap();
             // These fields will be overwritten after allocation by callers.
             // Since this part of the mmapped file could have previously been used by someone else, there can be garbage here.
             let elem_allocate: &mut IndexEntry = self.index.get_mut(elem_ix);
@@ -332,7 +332,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
                     //debug!(                        "DATA ALLOC {:?} {} {} {}",                        key, elem.data_location, best_bucket.capacity, elem_uid                    );
                     if num_slots > 0 {
                         let best_bucket = &mut self.data[best_fit_bucket as usize];
-                        best_bucket.allocate(ix, false).unwrap();
+                        best_bucket.occupy(ix, false).unwrap();
                         let slice = best_bucket.get_mut_cell_slice(ix, num_slots);
                         slice.iter_mut().zip(data).for_each(|(dest, src)| {
                             *dest = *src;
@@ -418,7 +418,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         }
     }
 
-    pub fn apply_grow_index(&mut self, random: u64, index: BucketStorage) {
+    pub fn apply_grow_index(&mut self, random: u64, index: BucketStorage<IndexBucket>) {
         self.stats
             .index
             .resize_grow(self.index.capacity_bytes(), index.capacity_bytes());
@@ -431,13 +431,13 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         std::mem::size_of::<T>() as u64
     }
 
-    fn add_data_bucket(&mut self, bucket: BucketStorage) {
+    fn add_data_bucket(&mut self, bucket: BucketStorage<DataBucket>) {
         self.stats.data.file_count.fetch_add(1, Ordering::Relaxed);
         self.stats.data.resize_grow(0, bucket.capacity_bytes());
         self.data.push(bucket);
     }
 
-    pub fn apply_grow_data(&mut self, ix: usize, bucket: BucketStorage) {
+    pub fn apply_grow_data(&mut self, ix: usize, bucket: BucketStorage<DataBucket>) {
         if self.data.get(ix).is_none() {
             for i in self.data.len()..ix {
                 // insert empty data buckets
@@ -477,7 +477,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         items.data = Some((data_index, new_bucket));
     }
 
-    fn bucket_index_ix(index: &BucketStorage, key: &Pubkey, random: u64) -> u64 {
+    fn bucket_index_ix(index: &BucketStorage<IndexBucket>, key: &Pubkey, random: u64) -> u64 {
         let mut s = DefaultHasher::new();
         key.hash(&mut s);
         //the locally generated random will make it hard for an attacker

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -371,7 +371,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let hash_map = RwLock::new(HashMap::<Pubkey, (Vec<(usize, usize)>, RefCount)>::new());
-        let max_slot_list_len = 3;
+        let max_slot_list_len = 5;
         let all_keys = Mutex::new(vec![]);
 
         let gen_rand_value = || {

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -204,6 +204,7 @@ mod tests {
             let config = BucketMapConfig::new(1 << 1);
             let index = BucketMap::new(config);
             let bucket = index.get_bucket(&key);
+            let value = [0];
             if pass == 0 {
                 index.insert(&key, (&[0], 0));
             } else {
@@ -220,7 +221,7 @@ mod tests {
                 let result = index.try_insert(&key, (&[0], 0));
                 assert!(result.is_ok());
             }
-            assert_eq!(index.read_value(&key), Some((vec![0], 0)));
+            assert_eq!(index.read_value(&key), Some((value.to_vec(), 0)));
         }
     }
 
@@ -379,7 +380,7 @@ mod tests {
             let v = (0..count)
                 .map(|x| (x as usize, x as usize /*thread_rng().gen::<usize>()*/))
                 .collect::<Vec<_>>();
-            let rc = thread_rng().gen::<RefCount>();
+            let rc = thread_rng().gen_range(0, RefCount::MAX >> 2);
             (v, rc)
         };
 

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -194,6 +194,13 @@ impl<O: BucketOccupied> BucketStorage<O> {
         }
     }
 
+    pub(crate) fn get_from_parts<T: Sized>(item_slice: &[u8]) -> &T {
+        unsafe {
+            let item = item_slice.as_ptr() as *const T;
+            &*item
+        }
+    }
+
     pub fn get_mut<T: Sized>(&mut self, ix: u64) -> &mut T {
         let start = self.get_start_offset_no_header(ix);
         let item_slice = &mut self.mmap[start..];
@@ -356,7 +363,7 @@ mod test {
         let paths: Vec<PathBuf> = vec![tmpdir.path().to_path_buf()];
         assert!(!paths.is_empty());
 
-        let mut storage = BucketStorage::<IndexBucket>::new(
+        let mut storage = BucketStorage::<IndexBucket<u64>>::new(
             Arc::new(paths),
             1,
             1,

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -34,53 +34,19 @@ use {
 */
 pub const DEFAULT_CAPACITY_POW2: u8 = 5;
 
-#[derive(Debug, PartialEq, Eq)]
-enum IsAllocatedFlagLocation {
-    /// 'allocated' flag per entry is stored in a u64 header per entry
-    InHeader,
+pub trait BucketOccupied {
+    /// set entry at `ix` as occupied (as opposed to free)
+    fn occupy(&mut self, cell: &mut [u8], ix: usize);
+    /// set entry at `ix` as free
+    fn free(&mut self, cell: &mut [u8], ix: usize);
+    /// return true if entry at `ix` is free
+    fn is_free(&self, cell: &[u8], ix: usize) -> bool;
+    /// # of bytes prior to first data held in the element.
+    /// This is the header size, if a header exists per element in the data.
+    fn offset_to_first_data() -> usize;
 }
 
-const IS_ALLOCATED_FLAG_LOCATION: IsAllocatedFlagLocation = IsAllocatedFlagLocation::InHeader;
-
-/// A Header UID of 0 indicates that the header is unlocked
-const UID_UNLOCKED: Uid = 0;
-/// uid in maps is 1 or 0, where 0 is empty, 1 is in-use
-const UID_LOCKED: Uid = 1;
-
-/// u64 for purposes of 8 byte alignment
-/// We only need 1 bit of this.
-type Uid = u64;
-
-#[repr(C)]
-struct Header {
-    lock: u64,
-}
-
-impl Header {
-    /// try to lock this entry with 'uid'
-    /// return true if it could be locked
-    fn try_lock(&mut self) -> bool {
-        if self.lock == UID_UNLOCKED {
-            self.lock = UID_LOCKED;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// mark this entry as unlocked
-    fn unlock(&mut self) {
-        assert_eq!(UID_LOCKED, self.lock);
-        self.lock = UID_UNLOCKED;
-    }
-
-    /// true if this entry is unlocked
-    fn is_unlocked(&self) -> bool {
-        self.lock == UID_UNLOCKED
-    }
-}
-
-pub struct BucketStorage {
+pub struct BucketStorage<T: BucketOccupied> {
     path: PathBuf,
     mmap: MmapMut,
     pub cell_size: u64,
@@ -88,20 +54,21 @@ pub struct BucketStorage {
     pub count: Arc<AtomicU64>,
     pub stats: Arc<BucketStats>,
     pub max_search: MaxSearch,
+    pub contents: T,
 }
 
 #[derive(Debug)]
 pub enum BucketStorageError {
-    AlreadyAllocated,
+    AlreadyOccupied,
 }
 
-impl Drop for BucketStorage {
+impl<O: BucketOccupied> Drop for BucketStorage<O> {
     fn drop(&mut self) {
-        let _ = remove_file(&self.path);
+        _ = remove_file(&self.path);
     }
 }
 
-impl BucketStorage {
+impl<O: BucketOccupied + Default> BucketStorage<O> {
     pub fn new_with_capacity(
         drives: Arc<Vec<PathBuf>>,
         num_elems: u64,
@@ -111,7 +78,7 @@ impl BucketStorage {
         stats: Arc<BucketStats>,
         count: Arc<AtomicU64>,
     ) -> Self {
-        let cell_size = elem_size * num_elems + Self::header_size() as u64;
+        let cell_size = elem_size * num_elems + O::offset_to_first_data() as u64;
         let (mmap, path) = Self::new_map(&drives, cell_size as usize, capacity_pow2, &stats);
         Self {
             path,
@@ -121,13 +88,7 @@ impl BucketStorage {
             capacity_pow2,
             stats,
             max_search,
-        }
-    }
-
-    /// non-zero if there is a header allocated prior to each element to store the 'allocated' bit
-    fn header_size() -> usize {
-        match IS_ALLOCATED_FLAG_LOCATION {
-            IsAllocatedFlagLocation::InHeader => std::mem::size_of::<Header>(),
+            contents: O::default(),
         }
     }
 
@@ -154,46 +115,29 @@ impl BucketStorage {
         )
     }
 
-    /// return ref to header of item 'ix' in mmapped file
-    fn header_ptr(&self, ix: u64) -> &Header {
-        self.header_mut_ptr(ix)
-    }
-
-    /// return ref to header of item 'ix' in mmapped file
-    #[allow(clippy::mut_from_ref)]
-    fn header_mut_ptr(&self, ix: u64) -> &mut Header {
-        assert_eq!(
-            IS_ALLOCATED_FLAG_LOCATION,
-            IsAllocatedFlagLocation::InHeader
-        );
-        let ix = (ix * self.cell_size) as usize;
-        let hdr_slice: &[u8] = &self.mmap[ix..ix + std::mem::size_of::<Header>()];
-        unsafe {
-            let hdr = hdr_slice.as_ptr() as *mut Header;
-            hdr.as_mut().unwrap()
-        }
-    }
-
-    /// true if the entry at index 'ix' is free (as opposed to being allocated)
+    /// true if the entry at index 'ix' is free (as opposed to being occupied)
     pub fn is_free(&self, ix: u64) -> bool {
-        // note that the terminology in the implementation is locked or unlocked.
-        // but our api is allocate/free
-        match IS_ALLOCATED_FLAG_LOCATION {
-            IsAllocatedFlagLocation::InHeader => self.header_ptr(ix).is_unlocked(),
-        }
+        let start = self.get_start_offset_with_header(ix);
+        let entry = &self.mmap[start..];
+        self.contents.is_free(entry, ix as usize)
     }
 
     fn try_lock(&mut self, ix: u64) -> bool {
-        match IS_ALLOCATED_FLAG_LOCATION {
-            IsAllocatedFlagLocation::InHeader => self.header_mut_ptr(ix).try_lock(),
+        let start = self.get_start_offset_with_header(ix);
+        let entry = &mut self.mmap[start..];
+        if self.contents.is_free(entry, ix as usize) {
+            self.contents.occupy(entry, ix as usize);
+            true
+        } else {
+            false
         }
     }
 
     /// 'is_resizing' true if caller is resizing the index (so don't increment count)
     /// 'is_resizing' false if caller is adding an item to the index (so increment count)
-    pub fn allocate(&mut self, ix: u64, is_resizing: bool) -> Result<(), BucketStorageError> {
-        assert!(ix < self.capacity(), "allocate: bad index size");
-        let mut e = Err(BucketStorageError::AlreadyAllocated);
+    pub fn occupy(&mut self, ix: u64, is_resizing: bool) -> Result<(), BucketStorageError> {
+        assert!(ix < self.capacity(), "occupy: bad index size");
+        let mut e = Err(BucketStorageError::AlreadyOccupied);
         //debug!("ALLOC {} {}", ix, uid);
         if self.try_lock(ix) {
             e = Ok(());
@@ -206,16 +150,13 @@ impl BucketStorage {
 
     pub fn free(&mut self, ix: u64) {
         assert!(ix < self.capacity(), "bad index size");
-        match IS_ALLOCATED_FLAG_LOCATION {
-            IsAllocatedFlagLocation::InHeader => {
-                self.header_mut_ptr(ix).unlock();
-            }
-        }
+        let start = self.get_start_offset_with_header(ix);
+        self.contents.free(&mut self.mmap[start..], ix as usize);
         self.count.fetch_sub(1, Ordering::Relaxed);
     }
 
     pub fn get<T: Sized>(&self, ix: u64) -> &T {
-        let start = self.get_start_offset(ix);
+        let start = self.get_start_offset_no_header(ix);
         let end = start + std::mem::size_of::<T>();
         let item_slice: &[u8] = &self.mmap[start..end];
         unsafe {
@@ -224,18 +165,17 @@ impl BucketStorage {
         }
     }
 
-    pub fn get_empty_cell_slice<T: Sized + 'static>() -> &'static [T] {
-        &[]
+    fn get_start_offset_with_header(&self, ix: u64) -> usize {
+        assert!(ix < self.capacity(), "bad index size");
+        (self.cell_size * ix) as usize
     }
 
-    fn get_start_offset(&self, ix: u64) -> usize {
-        assert!(ix < self.capacity(), "bad index size");
-        let ix = self.cell_size * ix;
-        ix as usize + Self::header_size()
+    fn get_start_offset_no_header(&self, ix: u64) -> usize {
+        self.get_start_offset_with_header(ix) + O::offset_to_first_data()
     }
 
     pub fn get_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &[T] {
-        let start = self.get_start_offset(ix);
+        let start = self.get_start_offset_no_header(ix);
         let end = start + std::mem::size_of::<T>() * len as usize;
         //debug!("GET slice {} {}", start, end);
         let item_slice: &[u8] = &self.mmap[start..end];
@@ -246,19 +186,30 @@ impl BucketStorage {
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub fn get_mut<T: Sized>(&self, ix: u64) -> &mut T {
-        let start = self.get_start_offset(ix);
-        let end = start + std::mem::size_of::<T>();
-        let item_slice: &[u8] = &self.mmap[start..end];
+    pub fn get_mut_from_parts<T: Sized>(item_slice: &mut [u8]) -> &mut T {
         unsafe {
             let item = item_slice.as_ptr() as *mut T;
             &mut *item
         }
     }
 
+    pub fn get_from_parts<T: Sized>(item_slice: &[u8]) -> &T {
+        unsafe {
+            let item = item_slice.as_ptr() as *const T;
+            &*item
+        }
+    }
+
+    pub fn get_mut<T: Sized>(&mut self, ix: u64) -> &mut T {
+        let start = self.get_start_offset_no_header(ix);
+        let item_slice = &mut self.mmap[start..];
+        let item_slice = &mut item_slice[..std::mem::size_of::<T>()];
+        Self::get_mut_from_parts(item_slice)
+    }
+
     #[allow(clippy::mut_from_ref)]
     pub fn get_mut_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &mut [T] {
-        let start = self.get_start_offset(ix);
+        let start = self.get_start_offset_no_header(ix);
         let end = start + std::mem::size_of::<T>() * len as usize;
         //debug!("GET mut slice {} {}", start, end);
         let item_slice: &[u8] = &self.mmap[start..end];
@@ -333,10 +284,12 @@ impl BucketStorage {
         let index_grow = 1 << increment;
         (0..old_cap as usize).for_each(|i| {
             if !old_bucket.is_free(i as u64) {
-                match IS_ALLOCATED_FLAG_LOCATION {
-                    IsAllocatedFlagLocation::InHeader => {
-                        // nothing to do when bit is in header
-                    }
+                {
+                    // copying from old to new. If 'occupied' bit is stored outside the data, then
+                    // occupied has to be set on the new entry in the new bucket.
+                    let start = self.get_start_offset_with_header((i * index_grow) as u64);
+                    self.contents
+                        .occupy(&mut self.mmap[start..], i * index_grow);
                 }
                 let old_ix = i * old_bucket.cell_size as usize;
                 let new_ix = old_ix * index_grow;
@@ -401,7 +354,7 @@ impl BucketStorage {
 
 #[cfg(test)]
 mod test {
-    use {super::*, tempfile::tempdir};
+    use {super::*, crate::index_entry::IndexBucket, tempfile::tempdir};
 
     #[test]
     fn test_bucket_storage() {
@@ -409,18 +362,24 @@ mod test {
         let paths: Vec<PathBuf> = vec![tmpdir.path().to_path_buf()];
         assert!(!paths.is_empty());
 
-        let mut storage =
-            BucketStorage::new(Arc::new(paths), 1, 1, 1, Arc::default(), Arc::default());
+        let mut storage = BucketStorage::<IndexBucket>::new(
+            Arc::new(paths),
+            1,
+            1,
+            1,
+            Arc::default(),
+            Arc::default(),
+        );
         let ix = 0;
         assert!(storage.is_free(ix));
-        assert!(storage.allocate(ix, false).is_ok());
-        assert!(storage.allocate(ix, false).is_err());
+        assert!(storage.occupy(ix, false).is_ok());
+        assert!(storage.occupy(ix, false).is_err());
         assert!(!storage.is_free(ix));
         storage.free(ix);
         assert!(storage.is_free(ix));
         assert!(storage.is_free(ix));
-        assert!(storage.allocate(ix, false).is_ok());
-        assert!(storage.allocate(ix, false).is_err());
+        assert!(storage.occupy(ix, false).is_ok());
+        assert!(storage.occupy(ix, false).is_err());
         assert!(!storage.is_free(ix));
         storage.free(ix);
         assert!(storage.is_free(ix));

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -44,6 +44,7 @@ pub trait BucketOccupied {
     /// # of bytes prior to first data held in the element.
     /// This is the header size, if a header exists per element in the data.
     fn offset_to_first_data() -> usize;
+    fn new(num_elements: usize) -> Self;
 }
 
 pub struct BucketStorage<T: BucketOccupied> {
@@ -68,7 +69,7 @@ impl<O: BucketOccupied> Drop for BucketStorage<O> {
     }
 }
 
-impl<O: BucketOccupied + Default> BucketStorage<O> {
+impl<O: BucketOccupied> BucketStorage<O> {
     pub fn new_with_capacity(
         drives: Arc<Vec<PathBuf>>,
         num_elems: u64,
@@ -88,7 +89,7 @@ impl<O: BucketOccupied + Default> BucketStorage<O> {
             capacity_pow2,
             stats,
             max_search,
-            contents: O::default(),
+            contents: O::new(1 << capacity_pow2),
         }
     }
 
@@ -190,13 +191,6 @@ impl<O: BucketOccupied + Default> BucketStorage<O> {
         unsafe {
             let item = item_slice.as_ptr() as *mut T;
             &mut *item
-        }
-    }
-
-    pub fn get_from_parts<T: Sized>(item_slice: &[u8]) -> &T {
-        unsafe {
-            let item = item_slice.as_ptr() as *const T;
-            &*item
         }
     }
 

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::marker::PhantomData;
+
 use {
     crate::{
         bucket::Bucket,
@@ -46,39 +48,76 @@ impl BucketOccupied for BucketWithBitVec {
     }
 }
 
-pub type DataBucket = BucketWithBitVec;
-pub type IndexBucket = BucketWithBitVec;
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-// one instance of this per item in the index
-// stored in the index bucket
-pub struct IndexEntry {
-    pub key: Pubkey, // can this be smaller if we have reduced the keys into buckets already?
-    pub ref_count: RefCount, // can this be smaller? Do we ever need more than 4B refcounts?
-    storage_cap_and_offset: PackedStorage,
-    // if the bucket doubled, the index can be recomputed using create_bucket_capacity_pow2
-    pub num_slots: Slot, // can this be smaller? epoch size should ~ be the max len. this is the num elements in the slot list
+/// allocated in `contents` in a BucketStorage
+#[derive(Debug, Default)]
+pub struct IndexBucketUsingRefCountBits<T> {
+    _phantom: PhantomData<T>,
 }
 
-/// Pack the storage offset and capacity-when-crated-pow2 fields into a single u64
+impl<T: Copy + 'static> BucketOccupied for IndexBucketUsingRefCountBits<T> {
+    fn occupy(&mut self, element: &mut [u8], _ix: usize) {
+        let entry: &mut IndexEntry<T> =
+            BucketStorage::<IndexBucketUsingRefCountBits<T>>::get_mut_from_parts(element);
+        assert!(matches!(entry.get_slot_count_enum(), SlotCountEnum::Free));
+        entry.set_slot_count_enum_value(SlotCountEnum::ZeroSlots);
+    }
+    fn free(&mut self, element: &mut [u8], _ix: usize) {
+        let entry: &mut IndexEntry<T> =
+            BucketStorage::<IndexBucketUsingRefCountBits<T>>::get_mut_from_parts(element);
+        assert!(!matches!(entry.get_slot_count_enum(), SlotCountEnum::Free));
+        entry.set_slot_count_enum_value(SlotCountEnum::Free);
+    }
+    fn is_free(&self, element: &[u8], _ix: usize) -> bool {
+        let entry: &IndexEntry<T> =
+            BucketStorage::<IndexBucketUsingRefCountBits<T>>::get_from_parts(element);
+        matches!(entry.get_slot_count_enum(), SlotCountEnum::Free)
+    }
+    fn offset_to_first_data() -> usize {
+        0
+    }
+    fn new(_num_elements: usize) -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub type DataBucket = BucketWithBitVec;
+pub type IndexBucket<T> = IndexBucketUsingRefCountBits<T>;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+// one instance of this per item in the index
+// stored in the index bucket
+pub struct IndexEntry<T: Clone + Copy> {
+    pub(crate) key: Pubkey, // can this be smaller if we have reduced the keys into buckets already?
+    packed_ref_count: PackedRefCount,
+    /// depends on the contents of ref_count.slot_count_enum
+    pub(crate) contents: SingleElementOrMultipleSlots<T>,
+}
+
 #[bitfield(bits = 64)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-struct PackedStorage {
-    capacity_when_created_pow2: B8,
-    offset: B56,
+pub(crate) struct PackedRefCount {
+    /// tag for `SlotCountEnum`
+    pub(crate) slot_count_enum: B2,
+    /// ref_count of this entry. We don't need any where near 62 bits for this value
+    pub(crate) ref_count: B62,
 }
 
-impl IndexEntry {
-    pub fn init(&mut self, pubkey: &Pubkey) {
-        self.key = *pubkey;
-        self.ref_count = 0;
-        self.storage_cap_and_offset = PackedStorage::default();
-        self.num_slots = 0;
-    }
+/// required fields when an index element references the data file
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub(crate) struct MultipleSlots {
+    // if the bucket doubled, the index can be recomputed using storage_cap_and_offset.create_bucket_capacity_pow2
+    pub(crate) storage_cap_and_offset: PackedStorage,
+    /// num elements in the slot list
+    pub num_slots: Slot,
+}
 
-    pub fn set_storage_capacity_when_created_pow2(
+impl MultipleSlots {
+    pub(crate) fn set_storage_capacity_when_created_pow2(
         &mut self,
         storage_capacity_when_created_pow2: u8,
     ) {
@@ -86,10 +125,101 @@ impl IndexEntry {
             .set_capacity_when_created_pow2(storage_capacity_when_created_pow2)
     }
 
-    pub fn set_storage_offset(&mut self, storage_offset: u64) {
+    pub(crate) fn set_storage_offset(&mut self, storage_offset: u64) {
         self.storage_cap_and_offset
             .set_offset_checked(storage_offset)
             .expect("New storage offset must fit into 7 bytes!")
+    }
+
+    pub(crate) fn storage_capacity_when_created_pow2(&self) -> u8 {
+        self.storage_cap_and_offset.capacity_when_created_pow2()
+    }
+
+    fn storage_offset(&self) -> u64 {
+        self.storage_cap_and_offset.offset()
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) union SingleElementOrMultipleSlots<T: Clone + Copy> {
+    /// the slot list contains a single element. No need for an entry in the data file.
+    pub(crate) single_element: T,
+    /// the slot list ocntains more than one element. This contains the reference to the data file.
+    pub(crate) multiple_slots: MultipleSlots,
+}
+
+#[repr(u8)]
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SlotCountEnum<'a, T> {
+    /// this spot is not allocated
+    Free = 0,
+    /// zero slots in the slot list
+    ZeroSlots = 1,
+    /// one slot in the slot list, it is stored in the index
+    OneSlotInIndex(&'a T) = 2,
+    /// > 1 slots, slots are stored in data file
+    MultipleSlots(&'a MultipleSlots) = 3,
+}
+
+/// Pack the storage offset and capacity-when-crated-pow2 fields into a single u64
+#[bitfield(bits = 64)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub(crate) struct PackedStorage {
+    capacity_when_created_pow2: B8,
+    offset: B56,
+}
+
+impl<T: Clone + Copy + 'static> IndexEntry<T> {
+    pub fn init(&mut self, pubkey: &Pubkey) {
+        self.key = *pubkey;
+        self.packed_ref_count.set_ref_count(0);
+        self.set_slot_count_enum_value(SlotCountEnum::ZeroSlots);
+    }
+
+    pub(crate) fn set_ref_count(&mut self, ref_count: RefCount) {
+        self.packed_ref_count
+            .set_ref_count_checked(ref_count)
+            .expect("ref count must fit into 62 bits!")
+    }
+
+    pub(crate) fn get_slot_count_enum(&self) -> SlotCountEnum<'_, T> {
+        unsafe {
+            match self.packed_ref_count.slot_count_enum() {
+                0 => SlotCountEnum::Free,
+                1 => SlotCountEnum::ZeroSlots,
+                2 => SlotCountEnum::OneSlotInIndex(&self.contents.single_element),
+                3 => SlotCountEnum::MultipleSlots(&self.contents.multiple_slots),
+                _ => {
+                    panic!("unexpected value");
+                }
+            }
+        }
+    }
+
+    pub(crate) fn get_multiple_slots_mut(&mut self) -> Option<&mut MultipleSlots> {
+        unsafe {
+            match self.packed_ref_count.slot_count_enum() {
+                3 => Some(&mut self.contents.multiple_slots),
+                _ => None,
+            }
+        }
+    }
+
+    pub(crate) fn set_slot_count_enum_value<'a>(&'a mut self, value: SlotCountEnum<'a, T>) {
+        self.packed_ref_count.set_slot_count_enum(match value {
+            SlotCountEnum::Free => 0,
+            SlotCountEnum::ZeroSlots => 1,
+            SlotCountEnum::OneSlotInIndex(single_element) => {
+                self.contents.single_element = *single_element;
+                2
+            }
+            SlotCountEnum::MultipleSlots(multiple_slots) => {
+                self.contents.multiple_slots = *multiple_slots;
+                3
+            }
+        });
     }
 
     /// return closest bucket index fit for the slot slice.
@@ -106,40 +236,44 @@ impl IndexEntry {
         }
     }
 
-    pub fn data_bucket_ix(&self) -> u64 {
-        Self::data_bucket_from_num_slots(self.num_slots)
-    }
-
     pub fn ref_count(&self) -> RefCount {
-        self.ref_count
-    }
-
-    fn storage_capacity_when_created_pow2(&self) -> u8 {
-        self.storage_cap_and_offset.capacity_when_created_pow2()
-    }
-
-    fn storage_offset(&self) -> u64 {
-        self.storage_cap_and_offset.offset()
+        self.packed_ref_count.ref_count()
     }
 
     // This function maps the original data location into an index in the current bucket storage.
     // This is coupled with how we resize bucket storages.
-    pub fn data_loc(&self, storage: &BucketStorage<DataBucket>) -> u64 {
-        self.storage_offset() << (storage.capacity_pow2 - self.storage_capacity_when_created_pow2())
+    pub(crate) fn data_loc(
+        storage: &BucketStorage<DataBucket>,
+        multiple_slots: &MultipleSlots,
+    ) -> u64 {
+        multiple_slots.storage_offset()
+            << (storage.capacity_pow2 - multiple_slots.storage_capacity_when_created_pow2())
     }
 
-    pub fn read_value<'a, T: 'static>(&self, bucket: &'a Bucket<T>) -> Option<(&'a [T], RefCount)> {
-        let slice = if self.num_slots > 0 {
-            let data_bucket_ix = self.data_bucket_ix();
-            let data_bucket = &bucket.data[data_bucket_ix as usize];
-            let loc = self.data_loc(data_bucket);
-            assert!(!data_bucket.is_free(loc));
-            data_bucket.get_cell_slice(loc, self.num_slots)
-        } else {
-            // num_slots is 0. This means we don't have an actual allocation.
-            &[]
-        };
-        Some((slice, self.ref_count))
+    pub fn read_value<'a>(&'a self, bucket: &'a Bucket<T>) -> Option<(&'a [T], RefCount)> {
+        Some((
+            match self.get_slot_count_enum() {
+                SlotCountEnum::ZeroSlots => {
+                    // num_slots is 0. This means we don't have an actual allocation.
+                    &[]
+                }
+                SlotCountEnum::OneSlotInIndex(single_element) => {
+                    // only element is stored in the index entry
+                    std::slice::from_ref(single_element)
+                }
+                SlotCountEnum::MultipleSlots(multiple_slots) => {
+                    let data_bucket_ix = Self::data_bucket_from_num_slots(multiple_slots.num_slots);
+                    let data_bucket = &bucket.data[data_bucket_ix as usize];
+                    let loc = Self::data_loc(data_bucket, multiple_slots);
+                    assert!(!data_bucket.is_free(loc));
+                    data_bucket.get_cell_slice::<T>(loc, multiple_slots.num_slots)
+                }
+                _ => {
+                    unimplemented!();
+                }
+            },
+            self.ref_count(),
+        ))
     }
 }
 
@@ -147,13 +281,17 @@ impl IndexEntry {
 mod tests {
     use super::*;
 
-    impl IndexEntry {
+    impl<T: Clone + Copy + Debug> IndexEntry<T> {
         pub fn new(key: Pubkey) -> Self {
             IndexEntry {
                 key,
-                ref_count: 0,
-                storage_cap_and_offset: PackedStorage::default(),
-                num_slots: 0,
+                packed_ref_count: PackedRefCount::default(),
+                contents: SingleElementOrMultipleSlots {
+                    multiple_slots: MultipleSlots {
+                        storage_cap_and_offset: PackedStorage::default(),
+                        num_slots: 0,
+                    },
+                },
             }
         }
     }
@@ -163,7 +301,7 @@ mod tests {
     #[test]
     fn test_api() {
         for offset in [0, 1, u32::MAX as u64] {
-            let mut index = IndexEntry::new(solana_sdk::pubkey::new_rand());
+            let mut index = MultipleSlots::default();
             if offset != 0 {
                 index.set_storage_offset(offset);
             }
@@ -180,32 +318,46 @@ mod tests {
     #[test]
     fn test_size() {
         assert_eq!(std::mem::size_of::<PackedStorage>(), 1 + 7);
-        assert_eq!(std::mem::size_of::<IndexEntry>(), 32 + 8 + 8 + 8);
+        assert_eq!(
+            std::mem::size_of::<IndexEntry::<u64>>(),
+            32 + 8 + (8 + 8).max(std::mem::size_of::<u64>())
+        );
     }
 
     #[test]
     #[should_panic(expected = "New storage offset must fit into 7 bytes!")]
     fn test_set_storage_offset_value_too_large() {
         let too_big = 1 << 56;
-        let mut index = IndexEntry::new(Pubkey::new_unique());
-        index.set_storage_offset(too_big);
+        let mut multiple_slots = MultipleSlots::default();
+        multiple_slots.set_storage_offset(too_big);
+    }
+
+    #[test]
+    #[should_panic(expected = "ref count must fit into 62 bits!")]
+    fn test_set_ref_count_too_large() {
+        let too_big = 1 << 62;
+        let mut index = IndexEntry::<u64>::new(Pubkey::default());
+        index.set_ref_count(too_big);
     }
 
     #[test]
     fn test_data_bucket_from_num_slots() {
         for n in 0..512 {
             assert_eq!(
-                IndexEntry::data_bucket_from_num_slots(n),
+                IndexEntry::<u64>::data_bucket_from_num_slots(n),
                 (n as f64).log2().ceil() as u64
             );
         }
-        assert_eq!(IndexEntry::data_bucket_from_num_slots(u32::MAX as u64), 32);
         assert_eq!(
-            IndexEntry::data_bucket_from_num_slots(u32::MAX as u64 + 1),
+            IndexEntry::<u64>::data_bucket_from_num_slots(u32::MAX as u64),
             32
         );
         assert_eq!(
-            IndexEntry::data_bucket_from_num_slots(u32::MAX as u64 + 2),
+            IndexEntry::<u64>::data_bucket_from_num_slots(u32::MAX as u64 + 1),
+            32
+        );
+        assert_eq!(
+            IndexEntry::<u64>::data_bucket_from_num_slots(u32::MAX as u64 + 2),
             33
         );
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.16.0"
 dependencies = [
+ "bv",
  "log",
  "memmap2",
  "modular-bitfield",


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
remove bits from bitvec and instead store the bits in extra bits in the refcount field.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
