### PR TITLE
Make BanksClient timeout after 10 seconds instead of 60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6239,6 +6239,7 @@ dependencies = [
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
+ "futures 0.3.24",
  "log",
  "serde",
  "solana-banks-client",
@@ -6251,6 +6252,7 @@ dependencies = [
  "solana-sdk 1.16.0",
  "solana-stake-program",
  "solana-vote-program",
+ "tarpc",
  "thiserror",
  "tokio",
 ]

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -537,7 +537,7 @@ mod tests {
         solana_sdk::{message::Message, signature::Signer, system_instruction},
         std::sync::{Arc, RwLock},
         tarpc::transport,
-        tokio::{runtime::Runtime, time::sleep},
+        tokio::{runtime::Runtime, time::{sleep, Duration}},
     };
 
     #[test]

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -33,7 +33,7 @@ use {
         serde_transport::tcp,
         ClientMessage, Response, Transport,
     },
-    tokio::{net::ToSocketAddrs, time::Duration},
+    tokio::net::ToSocketAddrs,
     tokio_serde::formats::Bincode,
 };
 
@@ -234,8 +234,7 @@ impl BanksClient {
         transaction: Transaction,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
-        let mut ctx = context::current();
-        ctx.deadline += Duration::from_secs(50);
+        let ctx = context::current();
         self.process_transaction_with_commitment_and_context(ctx, transaction, commitment)
             .map(|result| match result? {
                 None => Err(BanksClientError::ClientError(
@@ -251,8 +250,7 @@ impl BanksClient {
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<BanksTransactionResultWithMetadata, BanksClientError>> + '_
     {
-        let mut ctx = context::current();
-        ctx.deadline += Duration::from_secs(50);
+        let ctx = context::current();
         self.process_transaction_with_metadata_and_context(ctx, transaction.into())
     }
 
@@ -263,8 +261,7 @@ impl BanksClient {
         transaction: Transaction,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
-        let mut ctx = context::current();
-        ctx.deadline += Duration::from_secs(50);
+        let ctx = context::current();
         self.process_transaction_with_preflight_and_commitment_and_context(
             ctx,
             transaction,

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -537,7 +537,10 @@ mod tests {
         solana_sdk::{message::Message, signature::Signer, system_instruction},
         std::sync::{Arc, RwLock},
         tarpc::transport,
-        tokio::{runtime::Runtime, time::{sleep, Duration}},
+        tokio::{
+            runtime::Runtime,
+            time::{sleep, Duration},
+        },
     };
 
     #[test]

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -29,6 +29,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 solana-stake-program = { workspace = true }
 tarpc = { workspace = true }
-futures = { workspace = true }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -30,3 +30,5 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-stake-program = { workspace = true }
+tarpc = { workspace = true }
+futures = { workspace = true }

--- a/program-test/tests/timeout.rs
+++ b/program-test/tests/timeout.rs
@@ -15,7 +15,7 @@ async fn timeout() {
     let mut client = context.banks_client;
     let payer = context.payer;
     let receiver = Pubkey::new_unique();
-    // If you set num_txs to 1 it never hangs.
+    // If you set num_txs to 1, the process_transactions call never hangs.
     // If you set it to 2 it sometimes hangs.
     // If you set it to 10 it seems to always hang.
     // Based on the logs this test usually hangs after processing 3 or 4 transactions

--- a/program-test/tests/timeout.rs
+++ b/program-test/tests/timeout.rs
@@ -6,6 +6,9 @@ use {
 #[should_panic(expected = "RpcError(DeadlineExceeded")]
 #[tokio::test]
 async fn timeout() {
+    // example of a test that hangs. The reasons for this hanging are a separate issue:
+    // https://github.com/solana-labs/solana/issues/30527).
+    // We just want to observe the timeout behaviour here.
     let mut pt = ProgramTest::default();
     pt.prefer_bpf(true);
     let context = pt.start_with_context().await;
@@ -15,7 +18,7 @@ async fn timeout() {
     // If you set num_txs to 1 it never hangs.
     // If you set it to 2 it sometimes hangs.
     // If you set it to 10 it seems to always hang.
-    // Based on the logs it usually hangs after processing 3 or 4 transactions
+    // Based on the logs this test usually hangs after processing 3 or 4 transactions
     let num_txs = 10;
     let num_txs_u64 = num_txs as u64;
     let transfer_lamports_base = 1_000_000u64;

--- a/program-test/tests/timeout.rs
+++ b/program-test/tests/timeout.rs
@@ -1,0 +1,42 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, transaction::Transaction,
+    },
+};
+
+
+#[should_panic(expected = "RpcError(DeadlineExceeded")]
+#[tokio::test]
+async fn timeout() {
+    let mut pt = ProgramTest::default();
+    pt.prefer_bpf(true);
+    let context = pt.start_with_context().await;
+    let mut client = context.banks_client;
+    let payer = context.payer;
+    let receiver = Pubkey::new_unique();
+    // If you set num_txs to 1 it never hangs.
+    // If you set it to 2 it sometimes hangs.
+    // If you set it to 10 it seems to always hang.
+    // Based on the logs it usually hangs after processing 3 or 4 transactions
+    let num_txs = 10;
+    let num_txs_u64 = num_txs as u64;
+    let transfer_lamports_base = 1_000_000u64;
+    let mut txs: Vec<Transaction> = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let ixs = [solana_sdk::system_instruction::transfer(
+            &payer.pubkey(),
+            &receiver,
+            transfer_lamports_base + i as u64, // deduping the tx
+        )];
+        let msg = solana_sdk::message::Message::new_with_blockhash(&ixs, Some(&payer.pubkey()), &context.last_blockhash);
+        let tx = Transaction::new(&[&payer], msg, context.last_blockhash);
+        txs.push(tx);
+    }
+    client.process_transactions(txs).await.unwrap();
+    let balance_after = client.get_balance(receiver).await.unwrap();
+    assert_eq!(
+        balance_after,
+        num_txs_u64 * transfer_lamports_base + ((num_txs_u64 - 1) * num_txs_u64) / 2
+    );
+}

--- a/program-test/tests/timeout.rs
+++ b/program-test/tests/timeout.rs
@@ -1,10 +1,7 @@
 use {
     solana_program_test::ProgramTest,
-    solana_sdk::{
-        pubkey::Pubkey, signature::Signer, transaction::Transaction,
-    },
+    solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction},
 };
-
 
 #[should_panic(expected = "RpcError(DeadlineExceeded")]
 #[tokio::test]
@@ -29,7 +26,11 @@ async fn timeout() {
             &receiver,
             transfer_lamports_base + i as u64, // deduping the tx
         )];
-        let msg = solana_sdk::message::Message::new_with_blockhash(&ixs, Some(&payer.pubkey()), &context.last_blockhash);
+        let msg = solana_sdk::message::Message::new_with_blockhash(
+            &ixs,
+            Some(&payer.pubkey()),
+            &context.last_blockhash,
+        );
         let tx = Transaction::new(&[&payer], msg, context.last_blockhash);
         txs.push(tx);
     }


### PR DESCRIPTION
#### Problem

BanksClient times out in certain situations, such as when you try to send a transaction but it doesn't get committed (https://github.com/solana-labs/solana/issues/30527). This should be fixed but in the meantime it would be better not to wait a whole minute before timing out.


#### Summary of Changes

Removed lines that increment the deadline by 50 seconds, with the result that the deadline is now 10 seconds instead of 60. Those lines were written by @garious in #10728. Unfortunately I can't tell why they are there, maybe @garious remembers why.

Also added a test to demonstrate a panic on timeout.

