### PR TITLE
Update discord invite links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -100,7 +100,7 @@ module.exports = {
           position: "right",
         },
         {
-          href: "https://discordapp.com/invite/pquxPsq",
+          href: "https://discordapp.com/invite/kBbATFA7PW",
           // label: "Discord",
           className: "header-link-icon header-discord-link",
           "aria-label": "Solana Discord",
@@ -163,7 +163,7 @@ module.exports = {
             },
             {
               label: "Discord »",
-              href: "https://discordapp.com/invite/pquxPsq",
+              href: "https://discordapp.com/invite/kBbATFA7PW",
             },
             {
               label: "Twitter »",

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -100,7 +100,7 @@ module.exports = {
           position: "right",
         },
         {
-          href: "https://discordapp.com/invite/kBbATFA7PW",
+          href: "https://solana.com/discord",
           // label: "Discord",
           className: "header-link-icon header-discord-link",
           "aria-label": "Solana Discord",
@@ -163,7 +163,7 @@ module.exports = {
             },
             {
               label: "Discord »",
-              href: "https://discordapp.com/invite/kBbATFA7PW",
+              href: "https://solana.com/discord",
             },
             {
               label: "Twitter »",

--- a/geyser-plugin-interface/README.md
+++ b/geyser-plugin-interface/README.md
@@ -22,4 +22,4 @@ an external PostgreSQL databases.
 
 More information about Solana is available in the [Solana documentation](https://docs.solana.com/).
 
-Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)
+Still have questions?  Ask us on [Stack Exchange](https://sola.na/sse)

--- a/geyser-plugin-interface/README.md
+++ b/geyser-plugin-interface/README.md
@@ -22,4 +22,4 @@ an external PostgreSQL databases.
 
 More information about Solana is available in the [Solana documentation](https://docs.solana.com/).
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/pquxPsq)
+Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)

--- a/geyser-plugin-interface/README.md
+++ b/geyser-plugin-interface/README.md
@@ -22,4 +22,4 @@ an external PostgreSQL databases.
 
 More information about Solana is available in the [Solana documentation](https://docs.solana.com/).
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)
+Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 The [Solana Program Library](https://github.com/solana-labs/solana-program-library) provides examples of how to use this crate.
 
-Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)
+Still have questions?  Ask us on [Stack Exchange](https://sola.na/sse)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 The [Solana Program Library](https://github.com/solana-labs/solana-program-library) provides examples of how to use this crate.
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)
+Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 The [Solana Program Library](https://github.com/solana-labs/solana-program-library) provides examples of how to use this crate.
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/pquxPsq)
+Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)

--- a/sdk/program/README.md
+++ b/sdk/program/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 [Helloworld](https://github.com/solana-labs/example-helloworld) and the [Solana Program Library](https://github.com/solana-labs/solana-program-library) provide examples of how to use this crate.
 
-Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)
+Still have questions?  Ask us on [Stack Exchange](https://sola.na/sse)

--- a/sdk/program/README.md
+++ b/sdk/program/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 [Helloworld](https://github.com/solana-labs/example-helloworld) and the [Solana Program Library](https://github.com/solana-labs/solana-program-library) provide examples of how to use this crate.
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/pquxPsq)
+Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)

--- a/sdk/program/README.md
+++ b/sdk/program/README.md
@@ -12,4 +12,4 @@ More information about Solana is available in the [Solana documentation](https:/
 
 [Helloworld](https://github.com/solana-labs/example-helloworld) and the [Solana Program Library](https://github.com/solana-labs/solana-program-library) provide examples of how to use this crate.
 
-Still have questions?  Ask us on [Discord](https://discordapp.com/invite/kBbATFA7PW)
+Still have questions?  Ask us on [Stack Exchange](https://solana.stackexchange.com/)


### PR DESCRIPTION
#### Problem
See #30791 Old discords link (https://discord.com/invite/pquxPsq) being used in some places appears to be broken
![image](https://user-images.githubusercontent.com/44715351/228013223-43e24e3e-4e01-49f6-b584-2d18cdc0edde.png)
We also have a few READMEs pointing to Discord that should probably point to SSE instead.

#### Summary of Changes
Update Discord link to https://solana.com/discord
Point README files at SSE (https://sola.na/sse) instead of Discord

