### PR TITLE
Plumb Entry notification into plugin manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,6 +5642,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
+ "solana-entry",
  "solana-geyser-plugin-interface",
  "solana-measure",
  "solana-metrics",

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -19,6 +19,7 @@ jsonrpc-server-utils = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
+solana-entry = { workspace = true }
 solana-geyser-plugin-interface = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -1,0 +1,76 @@
+/// Module responsible for notifying plugins about entries
+use {
+    crate::geyser_plugin_manager::GeyserPluginManager,
+    log::*,
+    solana_entry::entry::Entry,
+    solana_geyser_plugin_interface::geyser_plugin_interface::{
+        ReplicaEntryInfo, ReplicaEntryInfoVersions,
+    },
+    solana_measure::measure::Measure,
+    solana_metrics::*,
+    solana_rpc::entry_notifier_interface::EntryNotifier,
+    solana_sdk::clock::Slot,
+    std::sync::{Arc, RwLock},
+};
+
+pub(crate) struct EntryNotifierImpl {
+    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+}
+
+impl EntryNotifier for EntryNotifierImpl {
+    fn notify_entry<'a>(&'a self, slot: Slot, index: usize, entry: &'a Entry) {
+        let mut measure = Measure::start("geyser-plugin-notify_plugins_of_entry_info");
+
+        let plugin_manager = self.plugin_manager.read().unwrap();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let entry_info = Self::build_replica_entry_info(slot, index, entry);
+
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.entry_notifications_enabled() {
+                continue;
+            }
+            match plugin.notify_entry(ReplicaEntryInfoVersions::V0_0_1(&entry_info)) {
+                Err(err) => {
+                    error!(
+                        "Failed to notify entry, error: ({}) to plugin {}",
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!("Successfully notified entry to plugin {}", plugin.name());
+                }
+            }
+        }
+        measure.stop();
+        inc_new_counter_debug!(
+            "geyser-plugin-notify_plugins_of_entry_info-us",
+            measure.as_us() as usize,
+            10000,
+            10000
+        );
+    }
+}
+
+impl EntryNotifierImpl {
+    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+        Self { plugin_manager }
+    }
+
+    fn build_replica_entry_info(
+        slot: Slot,
+        index: usize,
+        entry: &'_ Entry,
+    ) -> ReplicaEntryInfo<'_> {
+        ReplicaEntryInfo {
+            slot,
+            index,
+            num_hashes: entry.num_hashes,
+            hash: entry.hash.as_ref(),
+            executed_transaction_count: entry.transactions.len() as u64,
+        }
+    }
+}

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -54,6 +54,16 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if there is any plugin interested in entry data
+    pub fn entry_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.entry_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())

--- a/geyser-plugin-manager/src/lib.rs
+++ b/geyser-plugin-manager/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod accounts_update_notifier;
 pub mod block_metadata_notifier;
 pub mod block_metadata_notifier_interface;
+pub mod entry_notifier;
 pub mod geyser_plugin_manager;
 pub mod geyser_plugin_service;
 pub mod slot_status_notifier;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4841,6 +4841,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
+ "solana-entry",
  "solana-geyser-plugin-interface",
  "solana-measure",
  "solana-metrics",

--- a/rpc/src/entry_notifier_interface.rs
+++ b/rpc/src/entry_notifier_interface.rs
@@ -1,0 +1,11 @@
+use {
+    solana_entry::entry::Entry,
+    solana_sdk::clock::Slot,
+    std::sync::{Arc, RwLock},
+};
+
+pub trait EntryNotifier {
+    fn notify_entry(&self, slot: Slot, index: usize, entry: &Entry);
+}
+
+pub type EntryNotifierLock = Arc<RwLock<dyn EntryNotifier + Sync + Send>>;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 mod cluster_tpu_info;
+pub mod entry_notifier_interface;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;
 pub mod parsed_token_accounts;


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/30872 added geyser interfaces for receiving/handling Entry notifications, but the validator plugin manager isn't yet able to actually send these notifications.

#### Summary of Changes
Add plumbing toward Entry notifications. This adds the geyser-plugin-manager pieces needed to construct and send the notifications, but still does not actually send them.
