### PR TITLE
Unifies logging of start/stop for background services

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -61,6 +61,7 @@ impl AccountsHashVerifier {
         let t_accounts_hash_verifier = Builder::new()
             .name("solAcctHashVer".to_string())
             .spawn(move || {
+                info!("AccountsHashVerifier has started");
                 let mut hashes = vec![];
                 loop {
                     if exit.load(Ordering::Relaxed) {
@@ -109,7 +110,7 @@ impl AccountsHashVerifier {
                         ("handling-time-us", handling_time_us, i64),
                     );
                 }
-                info!("Accounts Hash Verifier has stopped");
+                info!("AccountsHashVerifier has stopped");
             })
             .unwrap();
         Self {

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -57,6 +57,7 @@ impl SnapshotPackagerService {
         let t_snapshot_packager = Builder::new()
             .name("solSnapshotPkgr".to_string())
             .spawn(move || {
+                info!("SnapshotPackagerService has started");
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push.then(||
                     SnapshotGossipManager::new(
@@ -122,7 +123,7 @@ impl SnapshotPackagerService {
                         ("handling-time-us", handling_time_us, i64),
                     );
                 }
-                info!("Snapshot Packager Service has stopped");
+                info!("SnapshotPackagerService has stopped");
             })
             .unwrap();
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -533,7 +533,6 @@ impl AccountsBackgroundService {
         test_hash_calculation: bool,
         mut last_full_snapshot_slot: Option<Slot>,
     ) -> Self {
-        info!("AccountsBackgroundService active");
         let exit = exit.clone();
         let mut last_cleaned_block_height = 0;
         let mut removed_slots_count = 0;
@@ -542,6 +541,7 @@ impl AccountsBackgroundService {
         let t_background = Builder::new()
             .name("solBgAccounts".to_string())
             .spawn(move || {
+                info!("AccountsBackgroundService has started");
                 let mut stats = StatsManager::new();
                 let mut last_snapshot_end_time = None;
 
@@ -656,12 +656,14 @@ impl AccountsBackgroundService {
                     stats.record_and_maybe_submit(start_time.elapsed());
                     sleep(Duration::from_millis(INTERVAL_MS));
                 }
-                info!(
-                    "ABS loop done.  Number of snapshot storages kept alive for fastboot: {}",
+                debug!(
+                    "Storages kept alive for fastboot: {}",
                     last_snapshot_storages
+                        .as_ref()
                         .map(|storages| storages.len())
                         .unwrap_or(0)
                 );
+                info!("AccountsBackgroundService has stopped");
             })
             .unwrap();
 


### PR DESCRIPTION
#### Problem

AccountsBackgroundService, AccountsHashVerifier, and SnapshotPackagerService do different logging for when they start and stop. 

When developing/testing, having all of these be the same is beneficial for log inspection. The same is true for inspecting validator logs. 

#### Summary of Changes

Unify logging of when background services start and stop.
* Log at the same start and stop (when the new *thread* starts, and when the loop stops)
* Unify the logging verbage
* Unify the naming of the services to align with their types