### PR TITLE
Moves shrink after flush and clean

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -640,7 +640,6 @@ impl AccountsBackgroundService {
                             return;
                         }
                     } else {
-                        bank.shrink_candidate_slots();
                         if bank.block_height() - last_cleaned_block_height
                             > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0, 10))
                         {
@@ -652,6 +651,7 @@ impl AccountsBackgroundService {
                             bank.clean_accounts(last_full_snapshot_slot);
                             last_cleaned_block_height = bank.block_height();
                         }
+                        bank.shrink_candidate_slots();
                     }
                     stats.record_and_maybe_submit(start_time.elapsed());
                     sleep(Duration::from_millis(INTERVAL_MS));


### PR DESCRIPTION
#### Problem

Shrink is called before clean in AccountsBackgroundService when *not* handling a snapshot request. Shrink will have potentially more shrinkable storages after clean runs, vs before.


#### Summary of Changes

Move shrink *after* clean.