### PR TITLE
Plumb Entry notification into plugin manager using TransactionNotifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
+ "solana-entry",
  "solana-geyser-plugin-interface",
  "solana-measure",
  "solana-metrics",

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -19,6 +19,7 @@ jsonrpc-server-utils = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
+solana-entry = { workspace = true }
 solana-geyser-plugin-interface = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -54,6 +54,16 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if there is any plugin interested in entry data
+    pub fn entry_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.entry_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -74,6 +74,7 @@ impl GeyserPluginService {
         let account_data_notifications_enabled =
             plugin_manager.account_data_notifications_enabled();
         let transaction_notifications_enabled = plugin_manager.transaction_notifications_enabled();
+        let entry_notifications_enabled = plugin_manager.entry_notifications_enabled();
         let plugin_manager = Arc::new(RwLock::new(plugin_manager));
 
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
@@ -86,7 +87,7 @@ impl GeyserPluginService {
             };
 
         let transaction_notifier: Option<TransactionNotifierLock> =
-            if transaction_notifications_enabled {
+            if transaction_notifications_enabled || entry_notifications_enabled {
                 let transaction_notifier = TransactionNotifierImpl::new(plugin_manager.clone());
                 Some(Arc::new(RwLock::new(transaction_notifier)))
             } else {
@@ -96,7 +97,10 @@ impl GeyserPluginService {
         let (slot_status_observer, block_metadata_notifier): (
             Option<SlotStatusObserver>,
             Option<BlockMetadataNotifierLock>,
-        ) = if account_data_notifications_enabled || transaction_notifications_enabled {
+        ) = if account_data_notifications_enabled
+            || transaction_notifications_enabled
+            || entry_notifications_enabled
+        {
             let slot_status_notifier = SlotStatusNotifierImpl::new(plugin_manager.clone());
             let slot_status_notifier = Arc::new(RwLock::new(slot_status_notifier));
             (

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4840,6 +4840,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
+ "solana-entry",
  "solana-geyser-plugin-interface",
  "solana-measure",
  "solana-metrics",

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,4 +1,5 @@
 use {
+    solana_entry::entry::Entry,
     solana_sdk::{clock::Slot, signature::Signature, transaction::SanitizedTransaction},
     solana_transaction_status::TransactionStatusMeta,
     std::sync::{Arc, RwLock},
@@ -13,6 +14,8 @@ pub trait TransactionNotifier {
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
     );
+
+    fn notify_entry(&self, slot: Slot, index: usize, entry: &Entry);
 }
 
 pub type TransactionNotifierLock = Arc<RwLock<dyn TransactionNotifier + Sync + Send>>;

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -227,6 +227,7 @@ pub(crate) mod tests {
         crossbeam_channel::unbounded,
         dashmap::DashMap,
         solana_account_decoder::parse_token::token_amount_to_ui_amount,
+        solana_entry::entry::Entry,
         solana_ledger::{genesis_utils::create_genesis_config, get_tmp_ledger_path},
         solana_runtime::bank::{Bank, NonceFull, NoncePartial, RentDebits, TransactionBalancesSet},
         solana_sdk::{
@@ -304,6 +305,8 @@ pub(crate) mod tests {
                 },
             );
         }
+
+        fn notify_entry(&self, _slot: Slot, _index: usize, _entry: &Entry) {}
     }
 
     fn build_test_transaction_legacy() -> Transaction {


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/30872 added geyser interfaces for receiving/handling Entry notifications, but the validator plugin manager isn't yet able to actually send these notifications.

#### Summary of Changes
Add plumbing toward Entry notifications. This adds the geyser-plugin-manager pieces needed to construct and send the notifications by piggybacking on the TransactionNotifier, but still does not actually send them.
