### PR TITLE
Forwarder: separate get_leader_and_addr

### DIFF
--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -17,7 +17,7 @@ use {
     solana_streamer::sendmmsg::batch_send,
     std::{
         iter::repeat,
-        net::UdpSocket,
+        net::{SocketAddr, UdpSocket},
         sync::{atomic::Ordering, Arc, RwLock},
     },
 };
@@ -147,19 +147,8 @@ impl Forwarder {
         usize,
         Option<Pubkey>,
     ) {
-        let leader_and_addr = match forward_option {
-            ForwardOption::NotForward => return (Ok(()), 0, None),
-            ForwardOption::ForwardTransaction => {
-                next_leader_tpu_forwards(&self.cluster_info, &self.poh_recorder)
-            }
-
-            ForwardOption::ForwardTpuVote => {
-                next_leader_tpu_vote(&self.cluster_info, &self.poh_recorder)
-            }
-        };
-        let (leader_pubkey, addr) = match leader_and_addr {
-            Some(leader_and_addr) => leader_and_addr,
-            None => return (Ok(()), 0, None),
+        let Some((leader_pubkey, addr)) = self.get_leader_and_addr(forward_option) else {
+            return (Ok(()), 0, None);
         };
 
         self.update_data_budget();
@@ -216,6 +205,20 @@ impl Forwarder {
         }
 
         (Ok(()), packet_vec_len, Some(leader_pubkey))
+    }
+
+    /// Get the pubkey and socket address for the leader to forward to
+    fn get_leader_and_addr(&self, forward_option: &ForwardOption) -> Option<(Pubkey, SocketAddr)> {
+        match forward_option {
+            ForwardOption::NotForward => None,
+            ForwardOption::ForwardTransaction => {
+                next_leader_tpu_forwards(&self.cluster_info, &self.poh_recorder)
+            }
+
+            ForwardOption::ForwardTpuVote => {
+                next_leader_tpu_vote(&self.cluster_info, &self.poh_recorder)
+            }
+        }
     }
 
     /// Re-fill the data budget if enough time has passed


### PR DESCRIPTION
#### Problem
Just cleaning up some of this in preparation for #30925.

#### Summary of Changes
Move `get_leader_and_addr` into a separate function so our forwarding function is less cluttered.
Use ["new" let-else rust syntax](https://github.com/rust-lang/rfcs/pull/3137) to return early 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
