### PR TITLE
Forwarder: separate forward from metrics

### DIFF
--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -9,7 +9,7 @@ use {
     },
     solana_client::{connection_cache::ConnectionCache, tpu_connection::TpuConnection},
     solana_gossip::cluster_info::ClusterInfo,
-    solana_measure::measure::Measure,
+    solana_measure::measure_us,
     solana_perf::{data_budget::DataBudget, packet::Packet},
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::bank_forks::BankForks,
@@ -167,32 +167,18 @@ impl Forwarder {
         if !packet_vec.is_empty() {
             inc_new_counter_info!("banking_stage-forwarded_packets", packet_vec_len);
 
-            let mut measure = Measure::start("banking_stage-forward-us");
-
-            let res = if let ForwardOption::ForwardTpuVote = forward_option {
-                // The vote must be forwarded using only UDP.
+            let (res, forward_us) = measure_us!(self.forward(forward_option, packet_vec, &addr));
+            if let ForwardOption::ForwardTpuVote = forward_option {
                 banking_stage_stats
                     .forwarded_vote_count
                     .fetch_add(packet_vec_len, Ordering::Relaxed);
-                let pkts: Vec<_> = packet_vec.into_iter().zip(repeat(addr)).collect();
-                batch_send(&self.socket, &pkts).map_err(|err| err.into())
             } else {
-                // All other transactions can be forwarded using QUIC, get_connection() will use
-                // system wide setting to pick the correct connection object.
                 banking_stage_stats
                     .forwarded_transaction_count
                     .fetch_add(packet_vec_len, Ordering::Relaxed);
-                let conn = self.connection_cache.get_connection(&addr);
-                conn.send_data_batch_async(packet_vec)
             };
 
-            measure.stop();
-            inc_new_counter_info!(
-                "banking_stage-forward-us",
-                measure.as_us() as usize,
-                1000,
-                1000
-            );
+            inc_new_counter_info!("banking_stage-forward-us", forward_us as usize, 1000, 1000);
 
             if let Err(err) = res {
                 inc_new_counter_info!("banking_stage-forward_packets-failed-batches", 1);
@@ -230,6 +216,28 @@ impl Forwarder {
                 MAX_BYTES_BUDGET,
             )
         });
+    }
+
+    fn forward(
+        &self,
+        forward_option: &ForwardOption,
+        packet_vec: Vec<Vec<u8>>,
+        addr: &SocketAddr,
+    ) -> Result<(), TransportError> {
+        match forward_option {
+            ForwardOption::ForwardTpuVote => {
+                // The vote must be forwarded using only UDP.
+                let pkts: Vec<_> = packet_vec.into_iter().zip(repeat(*addr)).collect();
+                batch_send(&self.socket, &pkts).map_err(|err| err.into())
+            }
+            ForwardOption::ForwardTransaction => {
+                // All other transactions can be forwarded using QUIC, get_connection() will use
+                // system wide setting to pick the correct connection object.
+                let conn = self.connection_cache.get_connection(addr);
+                conn.send_data_batch_async(packet_vec)
+            }
+            ForwardOption::NotForward => panic!("should not forward"),
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Last clean up before #30925. Want to separate the actual forwarding from metric & counter updates. Banking workers under scheduler will not collect metrics in the same structure(s).

#### Summary of Changes
Separate `forward` function from the counter increments and `BankingStageStats` updates.
Unfortunately, this leads to checking the variant of `ForwardOption` twice.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
