### PR TITLE
[cargo-test-sbf] Rename sbf-tools to platform-tools and use sbfv1

### DIFF
--- a/sdk/cargo-test-sbf/src/main.rs
+++ b/sdk/cargo-test-sbf/src/main.rs
@@ -48,7 +48,7 @@ impl Default for Config<'_> {
             verbose: false,
             workspace: false,
             jobs: None,
-            arch: "sbf",
+            arch: "sbfv1",
         }
     }
 }
@@ -102,7 +102,11 @@ where
     }
 }
 
-fn test_sbf_package(config: &Config, target_directory: &Path, package: &cargo_metadata::Package) {
+fn test_solana_package(
+    config: &Config,
+    target_directory: &Path,
+    package: &cargo_metadata::Package,
+) {
     let sbf_out_dir = config
         .sbf_out_dir
         .as_ref()
@@ -191,7 +195,7 @@ fn test_sbf_package(config: &Config, target_directory: &Path, package: &cargo_me
     );
 }
 
-fn test_sbf(config: Config, manifest_path: Option<PathBuf>) {
+fn test_solana(config: Config, manifest_path: Option<PathBuf>) {
     let mut metadata_command = cargo_metadata::MetadataCommand::new();
     if let Some(manifest_path) = manifest_path.as_ref() {
         metadata_command.manifest_path(manifest_path);
@@ -214,7 +218,7 @@ fn test_sbf(config: Config, manifest_path: Option<PathBuf>) {
                     .any(|p| root_package.id.repr.contains(p)))
         {
             debug!("test root package {:?}", root_package.id);
-            test_sbf_package(&config, metadata.target_directory.as_ref(), root_package);
+            test_solana_package(&config, metadata.target_directory.as_ref(), root_package);
             return;
         }
     }
@@ -238,7 +242,7 @@ fn test_sbf(config: Config, manifest_path: Option<PathBuf>) {
         if config.packages.is_empty() || config.packages.iter().any(|p| package.id.repr.contains(p))
         {
             debug!("test package {:?}", package.id);
-            test_sbf_package(&config, metadata.target_directory.as_ref(), package);
+            test_solana_package(&config, metadata.target_directory.as_ref(), package);
         }
     }
 }
@@ -344,7 +348,7 @@ fn main() {
                 .long("workspace")
                 .takes_value(false)
                 .alias("all")
-                .help("Test all SBF packages in the workspace"),
+                .help("Test all Solana packages in the workspace"),
         )
         .arg(
             Arg::new("jobs")
@@ -358,9 +362,9 @@ fn main() {
         .arg(
             Arg::new("arch")
                 .long("arch")
-                .possible_values(["bpf", "sbf", "sbfv2"])
-                .default_value("sbf")
-                .help("Build for the given SBF version"),
+                .possible_values(["sbfv1", "sbfv2"])
+                .default_value("sbfv1")
+                .help("Build for the given target architecture"),
         )
         .arg(
             Arg::new("extra_cargo_test_args")
@@ -416,5 +420,5 @@ fn main() {
     }
 
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
-    test_sbf(config, manifest_path);
+    test_solana(config, manifest_path);
 }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/30764 renamed sbf-tools to platform-tools and made some nice clean-ups, but it seems like cargo-test-sbf is not yet updated accordingly.

In particular, you cannot currently run cargo-test-sbf due to the default `--arch` being `sbf` --> `sbfv1`. This makes the CI to fail in the spl repo.
```
     Running `token/twoxtx-solana/target/debug/cargo-build-sbf --manifest-path /home/runner/work/solana-program-library/solana-program-library/token/program-2022-test/Cargo.toml --sbf-sdk ./token/twoxtx-solana/sdk/sbf --sbf-out-dir /home/runner/work/solana-program-library/solana-program-library/target/deploy --arch sbf`
error: "sbf" isn't a valid value for '--arch <arch>'
	[possible values: sbfv1, sbfv2]

	Did you mean "sbfv2"?

USAGE:
    cargo-build-sbf --manifest-path <PATH> --sbf-sdk <PATH> --sbf-out-dir <DIRECTORY> --arch <arch>

For more information try --help
```

#### Summary of Changes
Made some rudimentary naming changes in cargo-test-sbf following https://github.com/solana-labs/solana/pull/30764 and updated the default `--arch` from `sbf` to `sbfv1`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
