### PR TITLE
v1.14: Admin RPC Service: move post-init activation to before wait-for-supermajority (backport of #30544)

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -1,0 +1,13 @@
+use {
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_runtime::bank_forks::BankForks,
+    solana_sdk::pubkey::Pubkey,
+    std::sync::{Arc, RwLock},
+};
+
+#[derive(Clone)]
+pub struct AdminRpcRequestMetadataPostInit {
+    pub cluster_info: Arc<ClusterInfo>,
+    pub bank_forks: Arc<RwLock<BankForks>>,
+    pub vote_account: Pubkey,
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 
 pub mod accounts_hash_verifier;
+pub mod admin_rpc_post_init;
 pub mod ancestor_hashes_service;
 pub mod banking_stage;
 pub mod broadcast_stage;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,6 +4,7 @@ pub use solana_perf::report_target_features;
 use {
     crate::{
         accounts_hash_verifier::AccountsHashVerifier,
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         broadcast_stage::BroadcastStageType,
         cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
         cluster_info_vote_listener::VoteTracker,
@@ -395,6 +396,7 @@ impl Validator {
         use_quic: bool,
         tpu_connection_pool_size: usize,
         tpu_enable_udp: bool,
+        admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     ) -> Self {
         let id = identity_keypair.pubkey();
         assert_eq!(id, node.info.id);
@@ -925,6 +927,12 @@ impl Validator {
             stats_reporter_sender,
             exit.clone(),
         );
+
+        *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
+            bank_forks: bank_forks.clone(),
+            cluster_info: cluster_info.clone(),
+            vote_account: *vote_account,
+        });
 
         let waited_for_supermajority = if let Ok(waited) = wait_for_supermajority(
             config,
@@ -2158,6 +2166,7 @@ mod tests {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         );
 
         assert_eq!(
@@ -2252,6 +2261,7 @@ mod tests {
                     DEFAULT_TPU_USE_QUIC,
                     DEFAULT_TPU_CONNECTION_POOL_SIZE,
                     DEFAULT_TPU_ENABLE_UDP,
+                    Arc::new(RwLock::new(None)),
                 )
             })
             .collect();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -285,6 +285,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         );
 
         let mut validators = HashMap::new();
@@ -484,6 +485,7 @@ impl LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         );
 
         let validator_pubkey = validator_keypair.pubkey();
@@ -846,6 +848,7 @@ impl Cluster for LocalCluster {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
+            Arc::new(RwLock::new(None)),
         );
         cluster_validator_info.validator = Some(restarted_node);
         cluster_validator_info

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -11,6 +11,7 @@ use {
         rpc_request::MAX_MULTIPLE_ACCOUNTS,
     },
     solana_core::{
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         tower_storage::TowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     },
@@ -126,6 +127,7 @@ pub struct TestValidatorGenesis {
     compute_unit_limit: Option<u64>,
     pub log_messages_bytes_limit: Option<usize>,
     pub tpu_enable_udp: bool,
+    admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
 }
 
 impl Default for TestValidatorGenesis {
@@ -156,6 +158,8 @@ impl Default for TestValidatorGenesis {
             compute_unit_limit: Option::<u64>::default(),
             log_messages_bytes_limit: Option::<usize>::default(),
             tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+            admin_rpc_service_post_init:
+                Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
         }
     }
 }
@@ -844,6 +848,7 @@ impl TestValidator {
             DEFAULT_TPU_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
+            config.admin_rpc_service_post_init.clone(),
         ));
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -7,15 +7,12 @@ use {
     log::*,
     serde::{Deserialize, Serialize},
     solana_core::{
-        consensus::Tower, tower_storage::TowerStorage, validator::ValidatorStartProgress,
+        admin_rpc_post_init::AdminRpcRequestMetadataPostInit, consensus::Tower,
+        tower_storage::TowerStorage, validator::ValidatorStartProgress,
     },
-    solana_gossip::{
-        cluster_info::ClusterInfo, legacy_contact_info::LegacyContactInfo as ContactInfo,
-    },
-    solana_runtime::bank_forks::BankForks,
+    solana_gossip::legacy_contact_info::LegacyContactInfo as ContactInfo,
     solana_sdk::{
         exit::Exit,
-        pubkey::Pubkey,
         signature::{read_keypair_file, Keypair, Signer},
     },
     std::{
@@ -27,13 +24,6 @@ use {
         time::{Duration, SystemTime},
     },
 };
-
-#[derive(Clone)]
-pub struct AdminRpcRequestMetadataPostInit {
-    pub cluster_info: Arc<ClusterInfo>,
-    pub bank_forks: Arc<RwLock<BankForks>>,
-    pub vote_account: Pubkey,
-}
 
 #[derive(Clone)]
 pub struct AdminRpcRequestMetadata {

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -697,7 +697,7 @@ fn main() {
             start_time: std::time::SystemTime::now(),
             validator_exit: genesis.validator_exit.clone(),
             authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
-            post_init: admin_service_post_init.clone(),
+            post_init: admin_service_post_init,
             tower_storage: tower_storage.clone(),
         },
     );
@@ -823,12 +823,6 @@ fn main() {
 
     match genesis.start_with_mint_address(mint_address, socket_addr_space) {
         Ok(test_validator) => {
-            *admin_service_post_init.write().unwrap() =
-                Some(admin_rpc_service::AdminRpcRequestMetadataPostInit {
-                    bank_forks: test_validator.bank_forks(),
-                    cluster_info: test_validator.cluster_info(),
-                    vote_account: test_validator.vote_account_address(),
-                });
             if let Some(dashboard) = dashboard {
                 dashboard.run(Duration::from_millis(250));
             }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -3145,13 +3145,8 @@ pub fn main() {
         tpu_use_quic,
         tpu_connection_pool_size,
         tpu_enable_udp,
+        admin_service_post_init,
     );
-    *admin_service_post_init.write().unwrap() =
-        Some(admin_rpc_service::AdminRpcRequestMetadataPostInit {
-            bank_forks: validator.bank_forks.clone(),
-            cluster_info: validator.cluster_info.clone(),
-            vote_account,
-        });
 
     if let Some(filename) = init_complete_file {
         File::create(filename).unwrap_or_else(|_| {


### PR DESCRIPTION
Backport of https://github.com/solana-labs/solana/pull/30544 to v1.14