### PR TITLE
Add note on how cargo build-bpf works

### DIFF
--- a/docs/src/getstarted/rust.md
+++ b/docs/src/getstarted/rust.md
@@ -125,6 +125,7 @@ cargo build-bpf
 
 > **NOTE:**
 > After each time you build your Solana program, the above command will output the build path of your compiled program's `.so` file and the default keyfile that will be used for the program's address.
+> `cargo build-bpf` installs the toolchain from the currently installed solana CLI tools. You may need to upgrade those tools if you encounter any version incompatibilities.
 
 ## Deploy your Solana program
 


### PR DESCRIPTION
#### Problem

cargo build-bpf is a bit of a black box and it's not obvious where the rust smart contract toolchain comes from.

#### Summary of Changes

Add a note in the docs about how it's installed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
