### PR TITLE
Return error early if program is a tombstone

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -300,9 +300,7 @@ impl Accounts {
         program_accounts: &HashMap<Pubkey, &Pubkey>,
     ) -> Result<AccountSharedData> {
         // Check for tombstone
-        // Ignoring the tombstone here for now. The loader will catch this condition and return
-        // error.
-        let _ignore = match &program.program {
+        match &program.program {
             LoadedProgramType::FailedVerification | LoadedProgramType::Closed => {
                 Err(TransactionError::InvalidProgramForExecution)
             }
@@ -311,7 +309,7 @@ impl Accounts {
                 Err(TransactionError::InvalidProgramForExecution)
             }
             _ => Ok(()),
-        };
+        }?;
         // It's an executable program account. The program is already loaded in the cache.
         // So the account data is not needed. Return a dummy AccountSharedData with meta
         // information.

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -300,7 +300,7 @@ impl Accounts {
         program_accounts: &HashMap<Pubkey, &Pubkey>,
     ) -> Result<AccountSharedData> {
         // Check for tombstone
-        match &program.program {
+        let result = match &program.program {
             LoadedProgramType::FailedVerification | LoadedProgramType::Closed => {
                 Err(TransactionError::InvalidProgramForExecution)
             }
@@ -309,7 +309,13 @@ impl Accounts {
                 Err(TransactionError::InvalidProgramForExecution)
             }
             _ => Ok(()),
-        }?;
+        };
+        if feature_set.is_active(&simplify_writable_program_account_check::id()) {
+            // Currently CPI only fails if an execution is actually attempted. With this check it
+            // would also fail if a transaction just references an invalid program. So the checking
+            // of the result is being feature gated.
+            result?;
+        }
         // It's an executable program account. The program is already loaded in the cache.
         // So the account data is not needed. Return a dummy AccountSharedData with meta
         // information.


### PR DESCRIPTION
#### Problem
The program cache could contain a tombstone for a program (e.g. if it failed verification, or was closed). It's already detected early in `accounts.rs`. But it currently returns error from BPF loader. The check could be made early and error could be returned earlier in the processing pipeline.

#### Summary of Changes
Return early if the program cache contains a tombstone for the program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
