### PR TITLE
disk index find_entry -> find_index_entry

### DIFF
--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -11,7 +11,7 @@ pub struct BucketStats {
     pub new_file_us: AtomicU64,
     pub flush_file_us: AtomicU64,
     pub mmap_us: AtomicU64,
-    pub find_entry_mut_us: AtomicU64,
+    pub find_index_entry_mut_us: AtomicU64,
     pub file_count: AtomicU64,
     pub total_file_size: AtomicU64,
 }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -447,11 +447,11 @@ impl BucketMapHolderStats {
                     i64
                 ),
                 (
-                    "disk_index_find_entry_mut_us",
+                    "disk_index_find_index_entry_mut_us",
                     disk.map(|disk| disk
                         .stats
                         .index
-                        .find_entry_mut_us
+                        .find_index_entry_mut_us
                         .swap(0, Ordering::Relaxed))
                         .unwrap_or_default(),
                     i64


### PR DESCRIPTION
#### Problem
see https://github.com/solana-labs/solana/issues/30711

disk buckets for data and index are quite different.

#### Summary of Changes
Add more clarity to important `find` method by clarifying that it finds the index entry.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
