### PR TITLE
[clap-v3-utils] Define `EncodableKey` and make `keypair_from_path` and `keypair_from_seed` generic functions

### DIFF
--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -29,9 +29,8 @@ use {
         message::Message,
         pubkey::Pubkey,
         signature::{
-            generate_seed_from_seed_phrase_and_passphrase, keypair_from_seed,
-            keypair_from_seed_and_derivation_path, keypair_from_seed_phrase_and_passphrase,
-            read_keypair, read_keypair_file, Keypair, NullSigner, Presigner, Signature, Signer,
+            generate_seed_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
+            EncodableKey, Keypair, NullSigner, Presigner, Signature, Signer,
         },
     },
     std::{
@@ -1000,6 +999,15 @@ pub fn keypair_from_path(
     keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
+    encodable_key_from_path(matches, path, keypair_name, confirm_pubkey)
+}
+
+fn encodable_key_from_path<K: EncodableKey>(
+    matches: &ArgMatches,
+    path: &str,
+    keypair_name: &str,
+    confirm_pubkey: bool,
+) -> Result<K, Box<dyn error::Error>> {
     let SignerSource {
         kind,
         derivation_path,
@@ -1008,7 +1016,7 @@ pub fn keypair_from_path(
     match kind {
         SignerSourceKind::Prompt => {
             let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(keypair_from_seed_phrase(
+            Ok(encodable_key_from_seed_phrase(
                 keypair_name,
                 skip_validation,
                 confirm_pubkey,
@@ -1016,7 +1024,7 @@ pub fn keypair_from_path(
                 legacy,
             )?)
         }
-        SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
+        SignerSourceKind::Filepath(path) => match K::read_key_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
@@ -1029,7 +1037,7 @@ pub fn keypair_from_path(
         },
         SignerSourceKind::Stdin => {
             let mut stdin = std::io::stdin();
-            Ok(read_keypair(&mut stdin)?)
+            Ok(K::read_key(&mut stdin)?)
         }
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -1050,6 +1058,22 @@ pub fn keypair_from_seed_phrase(
     derivation_path: Option<DerivationPath>,
     legacy: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
+    encodable_key_from_seed_phrase(
+        keypair_name,
+        skip_validation,
+        confirm_pubkey,
+        derivation_path,
+        legacy,
+    )
+}
+
+fn encodable_key_from_seed_phrase<K: EncodableKey>(
+    keypair_name: &str,
+    skip_validation: bool,
+    confirm_pubkey: bool,
+    derivation_path: Option<DerivationPath>,
+    legacy: bool,
+) -> Result<K, Box<dyn error::Error>> {
     let seed_phrase = prompt_password(format!("[{keypair_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
@@ -1059,10 +1083,10 @@ pub fn keypair_from_seed_phrase(
     let keypair = if skip_validation {
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         if legacy {
-            keypair_from_seed_phrase_and_passphrase(seed_phrase, &passphrase)?
+            K::key_from_seed_phrase_and_passphrase(seed_phrase, &passphrase)?
         } else {
             let seed = generate_seed_from_seed_phrase_and_passphrase(seed_phrase, &passphrase);
-            keypair_from_seed_and_derivation_path(&seed, derivation_path)?
+            K::key_from_seed_and_derivation_path(&seed, derivation_path)?
         }
     } else {
         let sanitized = sanitize_seed_phrase(seed_phrase);
@@ -1087,14 +1111,14 @@ pub fn keypair_from_seed_phrase(
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         let seed = Seed::new(&mnemonic, &passphrase);
         if legacy {
-            keypair_from_seed(seed.as_bytes())?
+            K::key_from_seed(seed.as_bytes())?
         } else {
-            keypair_from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
+            K::key_from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
         }
     };
 
     if confirm_pubkey {
-        let pubkey = keypair.pubkey();
+        let pubkey = keypair.pubkey_string()?;
         print!("Recovered pubkey `{pubkey:?}`. Continue? (y/n): ");
         let _ignored = stdout().flush();
         let mut input = String::new();

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1024,7 +1024,7 @@ fn encodable_key_from_path<K: EncodableKey>(
                 legacy,
             )?)
         }
-        SignerSourceKind::Filepath(path) => match K::read_key_file(&path) {
+        SignerSourceKind::Filepath(path) => match K::read_from_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
@@ -1037,7 +1037,7 @@ fn encodable_key_from_path<K: EncodableKey>(
         },
         SignerSourceKind::Stdin => {
             let mut stdin = std::io::stdin();
-            Ok(K::read_key(&mut stdin)?)
+            Ok(K::read(&mut stdin)?)
         }
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -1083,10 +1083,10 @@ fn encodable_key_from_seed_phrase<K: EncodableKey>(
     let key = if skip_validation {
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         if legacy {
-            K::key_from_seed_phrase_and_passphrase(seed_phrase, &passphrase)?
+            K::from_seed_phrase_and_passphrase(seed_phrase, &passphrase)?
         } else {
             let seed = generate_seed_from_seed_phrase_and_passphrase(seed_phrase, &passphrase);
-            K::key_from_seed_and_derivation_path(&seed, derivation_path)?
+            K::from_seed_and_derivation_path(&seed, derivation_path)?
         }
     } else {
         let sanitized = sanitize_seed_phrase(seed_phrase);
@@ -1111,9 +1111,9 @@ fn encodable_key_from_seed_phrase<K: EncodableKey>(
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         let seed = Seed::new(&mnemonic, &passphrase);
         if legacy {
-            K::key_from_seed(seed.as_bytes())?
+            K::from_seed(seed.as_bytes())?
         } else {
-            K::key_from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
+            K::from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
         }
     };
 

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1068,19 +1068,19 @@ pub fn keypair_from_seed_phrase(
 }
 
 fn encodable_key_from_seed_phrase<K: EncodableKey>(
-    keypair_name: &str,
+    key_name: &str,
     skip_validation: bool,
     confirm_pubkey: bool,
     derivation_path: Option<DerivationPath>,
     legacy: bool,
 ) -> Result<K, Box<dyn error::Error>> {
-    let seed_phrase = prompt_password(format!("[{keypair_name}] seed phrase: "))?;
+    let seed_phrase = prompt_password(format!("[{key_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
-        "[{keypair_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
+        "[{key_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
     );
 
-    let keypair = if skip_validation {
+    let key = if skip_validation {
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         if legacy {
             K::key_from_seed_phrase_and_passphrase(seed_phrase, &passphrase)?
@@ -1118,7 +1118,7 @@ fn encodable_key_from_seed_phrase<K: EncodableKey>(
     };
 
     if confirm_pubkey {
-        let pubkey = keypair.pubkey_string()?;
+        let pubkey = key.get_pubkey()?.to_string();
         print!("Recovered pubkey `{pubkey:?}`. Continue? (y/n): ");
         let _ignored = stdout().flush();
         let mut input = String::new();
@@ -1129,7 +1129,7 @@ fn encodable_key_from_seed_phrase<K: EncodableKey>(
         }
     }
 
-    Ok(keypair)
+    Ok(key)
 }
 
 fn sanitize_seed_phrase(seed_phrase: &str) -> String {

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1118,7 +1118,7 @@ fn encodable_key_from_seed_phrase<K: EncodableKey>(
     };
 
     if confirm_pubkey {
-        let pubkey = key.get_pubkey()?.to_string();
+        let pubkey = key.pubkey_string()?;
         print!("Recovered pubkey `{pubkey:?}`. Continue? (y/n): ");
         let _ignored = stdout().flush();
         let mut input = String::new();

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -246,7 +246,10 @@ mod tests {
     use {
         super::*,
         bip39::{Language, Mnemonic, MnemonicType, Seed},
-        std::mem,
+        std::{
+            fs::{self, File},
+            mem,
+        },
     };
 
     fn tmp_file_path(name: &str) -> String {

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -113,10 +113,6 @@ where
 }
 
 impl EncodableKey for Keypair {
-    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>> {
-        Ok(self.pubkey().to_string())
-    }
-
     fn read<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
         read_keypair(reader)
     }

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -114,10 +114,8 @@ where
 }
 
 impl EncodableKey for Keypair {
-    type Pubkey = Pubkey;
-
-    fn get_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
-        Ok(self.pubkey())
+    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>> {
+        Ok(self.pubkey().to_string())
     }
 
     fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -5,7 +5,7 @@ use {
         derivation_path::DerivationPath,
         pubkey::Pubkey,
         signature::Signature,
-        signer::{Signer, SignerError},
+        signer::{EncodableKey, Signer, SignerError},
     },
     ed25519_dalek::Signer as DalekSigner,
     ed25519_dalek_bip32::Error as Bip32Error,
@@ -110,6 +110,46 @@ where
 {
     fn eq(&self, other: &T) -> bool {
         self.pubkey() == other.pubkey()
+    }
+}
+
+impl EncodableKey for Keypair {
+    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>> {
+        Ok(self.pubkey().to_string())
+    }
+
+    fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
+        read_keypair(reader)
+    }
+
+    fn read_key_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
+        read_keypair_file(path)
+    }
+
+    fn write_key<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
+        write_keypair(self, writer)
+    }
+
+    fn write_key_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>> {
+        write_keypair_file(self, outfile)
+    }
+
+    fn key_from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed(seed)
+    }
+
+    fn key_from_seed_and_derivation_path(
+        seed: &[u8],
+        derivation_path: Option<DerivationPath>,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_and_derivation_path(seed, derivation_path)
+    }
+
+    fn key_from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_phrase_and_passphrase(seed_phrase, passphrase)
     }
 }
 

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -118,34 +118,34 @@ impl EncodableKey for Keypair {
         Ok(self.pubkey().to_string())
     }
 
-    fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
+    fn read<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
         read_keypair(reader)
     }
 
-    fn read_key_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
+    fn read_from_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
         read_keypair_file(path)
     }
 
-    fn write_key<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
+    fn write<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
         write_keypair(self, writer)
     }
 
-    fn write_key_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>> {
+    fn write_to_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>> {
         write_keypair_file(self, outfile)
     }
 
-    fn key_from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
         keypair_from_seed(seed)
     }
 
-    fn key_from_seed_and_derivation_path(
+    fn from_seed_and_derivation_path(
         seed: &[u8],
         derivation_path: Option<DerivationPath>,
     ) -> Result<Self, Box<dyn error::Error>> {
         keypair_from_seed_and_derivation_path(seed, derivation_path)
     }
 
-    fn key_from_seed_phrase_and_passphrase(
+    fn from_seed_phrase_and_passphrase(
         seed_phrase: &str,
         passphrase: &str,
     ) -> Result<Self, Box<dyn error::Error>> {

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -114,8 +114,10 @@ where
 }
 
 impl EncodableKey for Keypair {
-    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>> {
-        Ok(self.pubkey().to_string())
+    type Pubkey = Pubkey;
+
+    fn get_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
+        Ok(self.pubkey())
     }
 
     fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -113,8 +113,7 @@ pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
 /// The `EncodableKey` trait defines the interface by which cryptographic keys/keypairs are read,
 /// written, and derived from sources.
 pub trait EncodableKey: Sized {
-    type Pubkey: ToString;
-    fn get_pubkey(&self) -> Result<Self::Pubkey, Box<dyn error::Error>>;
+    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>>;
     fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
     fn read_key_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
         let mut file = File::open(path.as_ref())?;

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -114,13 +114,13 @@ pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
 /// written, and derived from sources.
 pub trait EncodableKey: Sized {
     fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>>;
-    fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
-    fn read_key_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
+    fn read<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
+    fn read_from_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
         let mut file = File::open(path.as_ref())?;
-        Self::read_key(&mut file)
+        Self::read(&mut file)
     }
-    fn write_key<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>>;
-    fn write_key_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>> {
+    fn write<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>>;
+    fn write_to_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>> {
         let outfile = outfile.as_ref();
 
         if let Some(outdir) = outfile.parent() {
@@ -143,14 +143,14 @@ pub trait EncodableKey: Sized {
         .create(true)
         .open(outfile)?;
 
-        self.write_key(&mut f)
+        self.write(&mut f)
     }
-    fn key_from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>>;
-    fn key_from_seed_and_derivation_path(
+    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>>;
+    fn from_seed_and_derivation_path(
         seed: &[u8],
         derivation_path: Option<DerivationPath>,
     ) -> Result<Self, Box<dyn error::Error>>;
-    fn key_from_seed_phrase_and_passphrase(
+    fn from_seed_phrase_and_passphrase(
         seed_phrase: &str,
         passphrase: &str,
     ) -> Result<Self, Box<dyn error::Error>>;

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -4,11 +4,17 @@
 
 use {
     crate::{
+        derivation_path::DerivationPath,
         pubkey::Pubkey,
         signature::{PresignerError, Signature},
         transaction::TransactionError,
     },
     itertools::Itertools,
+    std::{
+        error,
+        io::{Read, Write},
+        path::Path,
+    },
     thiserror::Error,
 };
 
@@ -101,6 +107,25 @@ impl std::fmt::Debug for dyn Signer {
 /// Removes duplicate signers while preserving order. O(n²)
 pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
     signers.into_iter().unique_by(|s| s.pubkey()).collect()
+}
+
+/// The `EncodableKey` trait defines the interface by which cryptographic keys/keypairs are read,
+/// written, and derived from sources.
+pub trait EncodableKey: Sized {
+    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>>;
+    fn read_key<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
+    fn read_key_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>>;
+    fn write_key<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>>;
+    fn write_key_file<F: AsRef<Path>>(&self, outfile: F) -> Result<String, Box<dyn error::Error>>;
+    fn key_from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>>;
+    fn key_from_seed_and_derivation_path(
+        seed: &[u8],
+        derivation_path: Option<DerivationPath>,
+    ) -> Result<Self, Box<dyn error::Error>>;
+    fn key_from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>>;
 }
 
 #[cfg(test)]

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -113,7 +113,6 @@ pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
 /// The `EncodableKey` trait defines the interface by which cryptographic keys/keypairs are read,
 /// written, and derived from sources.
 pub trait EncodableKey: Sized {
-    fn pubkey_string(&self) -> Result<String, Box<dyn error::Error>>;
     fn read<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
     fn read_from_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
         let mut file = File::open(path.as_ref())?;


### PR DESCRIPTION
#### Problem
The clap utils do not yet support ElGamal keypairs and authenticated encryption key that are needed in cli tools such as the token-cli. Adding support for these types would require creating analogous functions to `keypair_from_path` and `keypair_from_seed` in the clap-v3-utils.

Instead of writing these separate functions, it would be nice to write `keypair_from_path` and `keypair_from_seed` as generic functions that can support any type of cryptographic keys/keypairs that implement a certain interface.

#### Summary of Changes
- Create a trait `EncodableKey` that defines the interface for cryptographic keys/keypairs are read, written, and derived from sources.
- Implement `EncodableKey` for the standard `Keypair` in the sdk.
- Write `keypair_from_path` and `keypair_from_seed` as generic functions using `EncodableKey`.

This is a split PR from https://github.com/solana-labs/solana/pull/30901

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
