### PR TITLE
Reconfigure genesis hash download and check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,7 +5746,6 @@ name = "solana-genesis-utils"
 version = "1.16.0"
 dependencies = [
  "log",
- "solana-core",
  "solana-download-utils",
  "solana-rpc-client",
  "solana-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,7 +5745,10 @@ dependencies = [
 name = "solana-genesis-utils"
 version = "1.16.0"
 dependencies = [
+ "log",
+ "solana-core",
  "solana-download-utils",
+ "solana-rpc-client",
  "solana-runtime",
  "solana-sdk 1.16.0",
 ]

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -13,9 +13,9 @@ edition = { workspace = true }
 log = { workspace = true }
 solana-core = { workspace = true }
 solana-download-utils = { workspace = true }
+solana-rpc-client = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
-solana-rpc-client = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -10,9 +10,12 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+log = { workspace = true }
+solana-core = { workspace = true }
 solana-download-utils = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
+solana-rpc-client = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
-solana-core = { workspace = true }
 solana-download-utils = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-runtime = { workspace = true }

--- a/genesis-utils/src/lib.rs
+++ b/genesis-utils/src/lib.rs
@@ -1,5 +1,8 @@
 use {
+    log::*,
+    solana_core::validator::ValidatorConfig,
     solana_download_utils::download_genesis_if_missing,
+    solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::hardened_unpack::unpack_genesis_archive,
     solana_sdk::{
         genesis_config::{GenesisConfig, DEFAULT_GENESIS_ARCHIVE},
@@ -36,6 +39,51 @@ fn load_local_genesis(
     Ok(existing_genesis)
 }
 
+fn download_then_set_expected_genesis_hash(
+    rpc_addr: &SocketAddr,
+    ledger_path: &std::path::Path,
+    expected_genesis_hash: Option<Hash>,
+    max_genesis_archive_unpacked_size: u64,
+    no_genesis_fetch: bool,
+    use_progress_bar: bool,
+    validator_config: &mut ValidatorConfig,
+) -> Result<(), String> {
+    let genesis_config = if no_genesis_fetch {
+        load_local_genesis(ledger_path, expected_genesis_hash)?
+    } else {
+        let genesis_package = ledger_path.join(DEFAULT_GENESIS_ARCHIVE);
+        if let Ok(tmp_genesis_package) =
+            download_genesis_if_missing(rpc_addr, &genesis_package, use_progress_bar)
+        {
+            unpack_genesis_archive(
+                &tmp_genesis_package,
+                ledger_path,
+                max_genesis_archive_unpacked_size,
+            )
+            .map_err(|err| format!("Failed to unpack downloaded genesis config: {err}"))?;
+
+            let downloaded_genesis = GenesisConfig::load(ledger_path)
+                .map_err(|err| format!("Failed to load downloaded genesis config: {err}"))?;
+
+            check_genesis_hash(&downloaded_genesis, expected_genesis_hash)?;
+            std::fs::rename(tmp_genesis_package, genesis_package)
+                .map_err(|err| format!("Unable to rename: {err:?}"))?;
+
+            downloaded_genesis
+        } else {
+            load_local_genesis(ledger_path, expected_genesis_hash)?
+        }
+    };
+
+    let genesis_hash = genesis_config.hash();
+    if validator_config.expected_genesis_hash.is_none() {
+        info!("Expected genesis hash set to {}", genesis_hash);
+        validator_config.expected_genesis_hash = Some(genesis_hash);
+    }
+
+    Ok(())
+}
+
 pub fn download_then_check_genesis_hash(
     rpc_addr: &SocketAddr,
     ledger_path: &std::path::Path,
@@ -43,34 +91,34 @@ pub fn download_then_check_genesis_hash(
     max_genesis_archive_unpacked_size: u64,
     no_genesis_fetch: bool,
     use_progress_bar: bool,
-) -> Result<GenesisConfig, String> {
-    if no_genesis_fetch {
-        let genesis_config = load_local_genesis(ledger_path, expected_genesis_hash)?;
-        return Ok(genesis_config);
+    validator_config: &mut ValidatorConfig,
+    rpc_client: &RpcClient,
+) -> Result<(), String> {
+    if let Err(e) = download_then_set_expected_genesis_hash(
+        rpc_addr,
+        ledger_path,
+        expected_genesis_hash,
+        max_genesis_archive_unpacked_size,
+        no_genesis_fetch,
+        use_progress_bar,
+        validator_config,
+    ) {
+        error!("Failed to get genesis config: {e}");
     }
 
-    let genesis_package = ledger_path.join(DEFAULT_GENESIS_ARCHIVE);
-    let genesis_config = if let Ok(tmp_genesis_package) =
-        download_genesis_if_missing(rpc_addr, &genesis_package, use_progress_bar)
-    {
-        unpack_genesis_archive(
-            &tmp_genesis_package,
-            ledger_path,
-            max_genesis_archive_unpacked_size,
-        )
-        .map_err(|err| format!("Failed to unpack downloaded genesis config: {err}"))?;
+    if let Some(expected_genesis_hash) = validator_config.expected_genesis_hash {
+        // Sanity check that the RPC node is using the expected genesis hash before
+        // downloading a snapshot from it
+        let rpc_genesis_hash = rpc_client
+            .get_genesis_hash()
+            .map_err(|err| format!("Failed to get genesis hash: {err}"))?;
 
-        let downloaded_genesis = GenesisConfig::load(ledger_path)
-            .map_err(|err| format!("Failed to load downloaded genesis config: {err}"))?;
+        if expected_genesis_hash != rpc_genesis_hash {
+            return Err(format!(
+                "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis hash is {rpc_genesis_hash}"
+            ));
+        }
+    }
 
-        check_genesis_hash(&downloaded_genesis, expected_genesis_hash)?;
-        std::fs::rename(tmp_genesis_package, genesis_package)
-            .map_err(|err| format!("Unable to rename: {err:?}"))?;
-
-        downloaded_genesis
-    } else {
-        load_local_genesis(ledger_path, expected_genesis_hash)?
-    };
-
-    Ok(genesis_config)
+    Ok(())
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4942,7 +4942,10 @@ dependencies = [
 name = "solana-genesis-utils"
 version = "1.16.0"
 dependencies = [
+ "log",
+ "solana-core",
  "solana-download-utils",
+ "solana-rpc-client",
  "solana-runtime",
  "solana-sdk 1.16.0",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4943,7 +4943,6 @@ name = "solana-genesis-utils"
 version = "1.16.0"
 dependencies = [
  "log",
- "solana-core",
  "solana-download-utils",
  "solana-rpc-client",
  "solana-runtime",

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -398,36 +398,16 @@ pub fn attempt_download_genesis_and_snapshot(
     vote_account: &Pubkey,
     authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
 ) -> Result<(), String> {
-    let genesis_config = download_then_check_genesis_hash(
+    download_then_check_genesis_hash(
         &rpc_contact_info.rpc,
         ledger_path,
         validator_config.expected_genesis_hash,
         bootstrap_config.max_genesis_archive_unpacked_size,
         bootstrap_config.no_genesis_fetch,
         use_progress_bar,
-    );
-
-    if let Ok(genesis_config) = genesis_config {
-        let genesis_hash = genesis_config.hash();
-        if validator_config.expected_genesis_hash.is_none() {
-            info!("Expected genesis hash set to {}", genesis_hash);
-            validator_config.expected_genesis_hash = Some(genesis_hash);
-        }
-    }
-
-    if let Some(expected_genesis_hash) = validator_config.expected_genesis_hash {
-        // Sanity check that the RPC node is using the expected genesis hash before
-        // downloading a snapshot from it
-        let rpc_genesis_hash = rpc_client
-            .get_genesis_hash()
-            .map_err(|err| format!("Failed to get genesis hash: {err}"))?;
-
-        if expected_genesis_hash != rpc_genesis_hash {
-            return Err(format!(
-                "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis hash is {rpc_genesis_hash}"
-            ));
-        }
-    }
+        validator_config,
+        rpc_client,
+    )?;
 
     if let Some(gossip) = gossip.take() {
         shutdown_gossip_service(gossip);

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -401,11 +401,10 @@ pub fn attempt_download_genesis_and_snapshot(
     download_then_check_genesis_hash(
         &rpc_contact_info.rpc,
         ledger_path,
-        validator_config.expected_genesis_hash,
+        &mut validator_config.expected_genesis_hash,
         bootstrap_config.max_genesis_archive_unpacked_size,
         bootstrap_config.no_genesis_fetch,
         use_progress_bar,
-        validator_config,
         rpc_client,
     )?;
 


### PR DESCRIPTION
#### Problem
Abstraction boundary for downloading and checking genesis hash during bootstrap process is a little messy.

#### Summary of Changes
Push more of the genesis hash checking inside of `download_then_check_genesis_hash` function. Add another support function for download and setting expected hash.