### PR TITLE
Use feature gate to set effective slot of loaded programs

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -132,6 +132,7 @@ impl LoadedProgram {
         loader_key: &Pubkey,
         loader: Arc<BuiltInProgram<InvokeContext<'static>>>,
         deployment_slot: Slot,
+        effective_slot: Slot,
         elf_bytes: &[u8],
         account_size: usize,
         use_jit: bool,
@@ -176,7 +177,7 @@ impl LoadedProgram {
         Ok(Self {
             deployment_slot,
             account_size,
-            effective_slot: deployment_slot.saturating_add(1),
+            effective_slot,
             usage_counter: AtomicU64::new(0),
             program,
         })

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -119,10 +119,17 @@ pub fn load_program_from_bytes(
     register_syscalls_time.stop();
     load_program_metrics.register_syscalls_us = register_syscalls_time.as_us();
 
+    let effective_slot = if feature_set.is_active(&delay_visibility_of_program_deployment::id()) {
+        deployment_slot.saturating_add(1)
+    } else {
+        deployment_slot
+    };
+
     let loaded_program = LoadedProgram::new(
         loader_key,
         loader,
         deployment_slot,
+        effective_slot,
         programdata,
         account_size,
         use_jit,

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -114,6 +114,7 @@ pub fn load_program_from_account(
         &loader_v3::id(),
         Arc::new(loader),
         state.slot,
+        state.slot.saturating_add(1),
         programdata,
         program.get_data().len(),
         use_jit,


### PR DESCRIPTION
#### Problem
The new cache sets effective slot of a program at the next slot to the deployment slot. If the program gets upgraded or deployed, it won't be active for another slot. This behavior should be covered under the existing feature gate `delay_visibility_of_program_deployment`.

#### Summary of Changes
If `delay_visibility_of_program_deployment` is not active, set the effective slot to the deployment slot. If the feature is active, set it to the next slot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
