### PR TITLE
Add missing versioned tx support to BanksClient

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -25,7 +25,7 @@ use {
         commitment_config::CommitmentLevel,
         message::Message,
         signature::Signature,
-        transaction::{self, Transaction, VersionedTransaction},
+        transaction::{self, VersionedTransaction},
     },
     tarpc::{
         client::{self, NewClient, RequestDispatch},
@@ -310,9 +310,9 @@ impl BanksClient {
         self.process_transaction_with_commitment(transaction, CommitmentLevel::default())
     }
 
-    pub async fn process_transactions_with_commitment(
+    pub async fn process_transactions_with_commitment<T: Into<VersionedTransaction>>(
         &mut self,
-        transactions: Vec<Transaction>,
+        transactions: Vec<T>,
         commitment: CommitmentLevel,
     ) -> Result<(), BanksClientError> {
         let mut clients: Vec<_> = transactions.iter().map(|_| self.clone()).collect();
@@ -327,9 +327,9 @@ impl BanksClient {
     }
 
     /// Send transactions and return until the transaction has been finalized or rejected.
-    pub fn process_transactions(
-        &mut self,
-        transactions: Vec<Transaction>,
+    pub fn process_transactions<'a, T: Into<VersionedTransaction> + 'a>(
+        &'a mut self,
+        transactions: Vec<T>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transactions_with_commitment(transactions, CommitmentLevel::default())
     }
@@ -534,7 +534,7 @@ mod tests {
             bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
             genesis_utils::create_genesis_config,
         },
-        solana_sdk::{message::Message, signature::Signer, system_instruction},
+        solana_sdk::{message::Message, signature::Signer, system_instruction, transaction::Transaction},
         std::sync::{Arc, RwLock},
         tarpc::transport,
         tokio::{

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -534,7 +534,9 @@ mod tests {
             bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
             genesis_utils::create_genesis_config,
         },
-        solana_sdk::{message::Message, signature::Signer, system_instruction, transaction::Transaction},
+        solana_sdk::{
+            message::Message, signature::Signer, system_instruction, transaction::Transaction,
+        },
         std::sync::{Arc, RwLock},
         tarpc::transport,
         tokio::{

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -231,7 +231,7 @@ impl BanksClient {
     /// reached the given level of commitment.
     pub fn process_transaction_with_commitment(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         let ctx = context::current();
@@ -258,7 +258,7 @@ impl BanksClient {
     /// after the transaction has been rejected or reached the given level of commitment.
     pub fn process_transaction_with_preflight_and_commitment(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         let ctx = context::current();
@@ -294,7 +294,7 @@ impl BanksClient {
     /// after the transaction has been finalized or rejected.
     pub fn process_transaction_with_preflight(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transaction_with_preflight_and_commitment(
             transaction,
@@ -305,7 +305,7 @@ impl BanksClient {
     /// Send a transaction and return until the transaction has been finalized or rejected.
     pub fn process_transaction(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transaction_with_commitment(transaction, CommitmentLevel::default())
     }
@@ -337,7 +337,7 @@ impl BanksClient {
     /// Simulate a transaction at the given commitment level
     pub fn simulate_transaction_with_commitment(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
     {
@@ -351,7 +351,7 @@ impl BanksClient {
     /// Simulate a transaction at the default commitment level
     pub fn simulate_transaction(
         &mut self,
-        transaction: Transaction,
+        transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
     {
         self.simulate_transaction_with_commitment(transaction, CommitmentLevel::default())


### PR DESCRIPTION
This takes care of everything but the `VersionedMessage` part of #30434. It replaces `Transaction` with `impl Into<VersionedTransaction>` in the relevant BanksClient methods, as had been started by #28739