### PR TITLE
Enforce a minimum of 1 on full and incremental snapshot retention

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -367,6 +367,34 @@ where
     }
 }
 
+pub fn validate_maximum_full_snapshot_archives_to_retain<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    let value = value.as_ref();
+    if value.eq("0") {
+        Err(String::from(
+            "--maximum-full-snapshot-archives-to-retain cannot be zero",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn validate_maximum_incremental_snapshot_archives_to_retain<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    let value = value.as_ref();
+    if value.eq("0") {
+        Err(String::from(
+            "--maximum-incremental-snapshot-archives-to-retain cannot be zero",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -47,11 +47,15 @@ impl SnapshotPackagerService {
         let cluster_info = cluster_info.clone();
         let max_full_snapshot_hashes = std::cmp::min(
             MAX_SNAPSHOT_HASHES,
-            snapshot_config.maximum_full_snapshot_archives_to_retain,
+            snapshot_config
+                .maximum_full_snapshot_archives_to_retain
+                .get(),
         );
         let max_incremental_snapshot_hashes = std::cmp::min(
             MAX_INCREMENTAL_SNAPSHOT_HASHES,
-            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
+            snapshot_config
+                .maximum_incremental_snapshot_archives_to_retain
+                .get(),
         );
 
         let t_snapshot_packager = Builder::new()

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -13,6 +13,7 @@ use {
         fs::{self, File},
         io::{self, Read},
         net::SocketAddr,
+        num::NonZeroUsize,
         path::{Path, PathBuf},
         time::{Duration, Instant},
     },
@@ -263,8 +264,8 @@ pub fn download_snapshot_archive(
     incremental_snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, SnapshotHash),
     snapshot_type: SnapshotType,
-    maximum_full_snapshot_archives_to_retain: usize,
-    maximum_incremental_snapshot_archives_to_retain: usize,
+    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
+    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
     use_progress_bar: bool,
     progress_notify_callback: &mut DownloadProgressCallbackOption<'_>,
 ) -> Result<(), String> {

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -36,6 +36,7 @@ use {
     std::{
         collections::HashSet,
         fs, iter,
+        num::NonZeroUsize,
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -498,8 +499,8 @@ impl SnapshotValidatorConfig {
                 .path()
                 .to_path_buf(),
             bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
-            maximum_full_snapshot_archives_to_retain: usize::MAX,
-            maximum_incremental_snapshot_archives_to_retain: usize::MAX,
+            maximum_full_snapshot_archives_to_retain: NonZeroUsize::new(usize::MAX).unwrap(),
+            maximum_incremental_snapshot_archives_to_retain: NonZeroUsize::new(usize::MAX).unwrap(),
             ..SnapshotConfig::default()
         };
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -67,6 +67,7 @@ use {
         fs,
         io::Read,
         iter,
+        num::NonZeroUsize,
         path::Path,
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -2185,8 +2186,8 @@ fn create_snapshot_to_hard_fork(
         ledger_path,
         ledger_path,
         ArchiveFormat::TarZstd,
-        1,
-        1,
+        NonZeroUsize::new(1).unwrap(),
+        NonZeroUsize::new(1).unwrap(),
     )
     .unwrap();
     info!(

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -31,6 +31,7 @@ use {
     },
     std::{
         io::{BufReader, Cursor},
+        num::NonZeroUsize,
         ops::RangeFull,
         path::Path,
         sync::{Arc, RwLock},
@@ -609,8 +610,8 @@ fn test_extra_fields_full_snapshot_archive() {
         full_snapshot_archives_dir.path(),
         incremental_snapshot_archives_dir.path(),
         ArchiveFormat::TarBzip2,
-        1,
-        0,
+        NonZeroUsize::new(1).unwrap(),
+        NonZeroUsize::new(1).unwrap(),
     )
     .unwrap();
 

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,7 +1,7 @@
 use {
     crate::snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
     solana_sdk::clock::Slot,
-    std::path::PathBuf,
+    std::{num::NonZeroUsize, path::PathBuf},
 };
 
 /// Snapshot configuration and runtime information
@@ -32,11 +32,11 @@ pub struct SnapshotConfig {
     pub snapshot_version: SnapshotVersion,
 
     /// Maximum number of full snapshot archives to retain
-    pub maximum_full_snapshot_archives_to_retain: usize,
+    pub maximum_full_snapshot_archives_to_retain: NonZeroUsize,
 
     /// Maximum number of incremental snapshot archives to retain
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
-    pub maximum_incremental_snapshot_archives_to_retain: usize,
+    pub maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 
     /// This is the `debug_verify` parameter to use when calling `update_accounts_hash()`
     pub accounts_hash_debug_verify: bool,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -7,6 +7,8 @@ use {
             is_keypair, is_keypair_or_ask_keyword, is_niceness_adjustment_valid, is_parsable,
             is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
             is_valid_percentage, is_within_range,
+            validate_maximum_full_snapshot_archives_to_retain,
+            validate_maximum_incremental_snapshot_archives_to_retain,
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
@@ -443,6 +445,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.maximum_full_snapshot_archives_to_retain)
+                .validator(validate_maximum_full_snapshot_archives_to_retain)
                 .help("The maximum number of full snapshot archives to hold on to when purging older snapshots.")
         )
         .arg(
@@ -451,6 +454,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.maximum_incremental_snapshot_archives_to_retain)
+                .validator(validate_maximum_incremental_snapshot_archives_to_retain)
                 .help("The maximum number of incremental snapshot archives to hold on to when purging older snapshots.")
         )
         .arg(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -70,6 +70,7 @@ use {
         env,
         fs::{self, File},
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroUsize,
         path::{Path, PathBuf},
         process::exit,
         str::FromStr,
@@ -1394,9 +1395,12 @@ pub fn main() {
 
     let maximum_local_snapshot_age = value_t_or_exit!(matches, "maximum_local_snapshot_age", u64);
     let maximum_full_snapshot_archives_to_retain =
-        value_t_or_exit!(matches, "maximum_full_snapshots_to_retain", usize);
-    let maximum_incremental_snapshot_archives_to_retain =
-        value_t_or_exit!(matches, "maximum_incremental_snapshots_to_retain", usize);
+        value_t_or_exit!(matches, "maximum_full_snapshots_to_retain", NonZeroUsize);
+    let maximum_incremental_snapshot_archives_to_retain = value_t_or_exit!(
+        matches,
+        "maximum_incremental_snapshots_to_retain",
+        NonZeroUsize
+    );
     let snapshot_packager_niceness_adj =
         value_t_or_exit!(matches, "snapshot_packager_niceness_adj", i8);
     let minimal_snapshot_download_speed =


### PR DESCRIPTION
#### Problem
Retaining 0 full or incremental snapshots doesn't make a lot of sense, since that would mean immediately purging any created snapshots. Moreso, we have some code in place that already assumed that these values would be > 0.

#### Summary of Changes
This changes the snapshots_to_retain config parameters from usize to NonZeroUsize to enforce that values must be nonzero.

Fixes #30794
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
