### PR TITLE
disk bucket: get mut right on get_mut_cell_slice

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -289,13 +289,13 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
 
         elem.set_ref_count(&mut self.index, ref_count);
         let bucket_ix = elem.data_bucket_ix(&self.index);
-        let current_bucket = &self.data[bucket_ix as usize];
         let num_slots = data_len as u64;
         if best_fit_bucket == bucket_ix && elem.num_slots(&self.index) > 0 {
+            let current_bucket = &mut self.data[bucket_ix as usize];
             // in place update
             let elem_loc = elem.data_loc(&self.index, current_bucket);
-            let slice: &mut [T] = current_bucket.get_mut_cell_slice(elem_loc, data_len as u64);
             assert!(!current_bucket.is_free(elem_loc));
+            let slice: &mut [T] = current_bucket.get_mut_cell_slice(elem_loc, data_len as u64);
             elem.set_num_slots(&mut self.index, num_slots);
 
             slice.iter_mut().zip(data).for_each(|(dest, src)| {
@@ -305,6 +305,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         } else {
             // need to move the allocation to a best fit spot
             let best_bucket = &self.data[best_fit_bucket as usize];
+            let current_bucket = &self.data[bucket_ix as usize];
             let cap_power = best_bucket.capacity_pow2;
             let cap = best_bucket.capacity();
             let pos = thread_rng().gen_range(0, cap);

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -212,8 +212,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
         Self::get_mut_from_parts(item_slice)
     }
 
-    #[allow(clippy::mut_from_ref)]
-    pub fn get_mut_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &mut [T] {
+    pub fn get_mut_cell_slice<T: Sized>(&mut self, ix: u64, len: u64) -> &mut [T] {
         let start = self.get_start_offset_no_header(ix);
         let end = start + std::mem::size_of::<T>() * len as usize;
         //debug!("GET mut slice {} {}", start, end);


### PR DESCRIPTION
#### Problem
see https://github.com/solana-labs/solana/issues/30711

`get_mut_cell_slice()` should have taken `&mut self` but took `&self` due to borrow checker difficulties.

#### Summary of Changes
correctly use `&mut self`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
