### PR TITLE
validator: Rename arg: skip-{=>startup-ledger-}verification

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -612,8 +612,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        Reads/writes perf samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate."),
         )
         .arg(
-            Arg::with_name("skip_verification")
-                .long("skip-verification")
+            Arg::with_name("skip_startup_ledger_verification")
+                .long("skip-startup-ledger-verification")
                 .takes_value(false)
                 .help("Skip ledger verification at validator bootup."),
         )
@@ -1751,7 +1751,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("skip-poh-verify")
             .takes_value(false)
             .help("Skip ledger verification at validator bootup."),
-        replaced_by: "skip-verification",
+        replaced_by: "skip-startup-ledger-verification",
     );
 
     res

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1276,7 +1276,7 @@ pub fn main() {
         gossip_validators,
         wal_recovery_mode,
         run_verification: !(matches.is_present("skip_poh_verify")
-            || matches.is_present("skip_verification")),
+            || matches.is_present("skip_startup_ledger_verification")),
         debug_keys,
         contact_debug_interval,
         send_transaction_service_config: send_transaction_service::Config {


### PR DESCRIPTION
`--skip-verification` was introduced as a replacement for `--skip-poh-verify`, but the name does not reflect the important detail, that this argument only disables verification during the validator startup.

As the argument was introduced just a few days ago, it seems fine to rename it "in-place".
