### PR TITLE
disk index: store ref_count in data file

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -264,6 +264,18 @@ impl<O: BucketOccupied> BucketStorage<O> {
             }
     }
 
+    pub(crate) fn get_header<T>(&self, ix: u64) -> &T {
+        let slice = self.get_cell_slice::<T>(ix, 1, IncludeHeader::Header);
+        // SAFETY: `get_cell_slice` ensures there's at least one element in the slice
+        unsafe { slice.get_unchecked(0) }
+    }
+
+    pub(crate) fn get_header_mut<T>(&mut self, ix: u64) -> &mut T {
+        let slice = self.get_mut_cell_slice::<T>(ix, 1, IncludeHeader::Header);
+        // SAFETY: `get_mut_cell_slice` ensures there's at least one element in the slice
+        unsafe { slice.get_unchecked_mut(0) }
+    }
+
     pub(crate) fn get<T>(&self, ix: u64) -> &T {
         let slice = self.get_cell_slice::<T>(ix, 1, IncludeHeader::NoHeader);
         // SAFETY: `get_cell_slice` ensures there's at least one element in the slice
@@ -276,14 +288,12 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { slice.get_unchecked_mut(0) }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn get_mut_from_parts<T>(item_slice: &mut [u8]) -> &mut T {
         debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
         let item = item_slice.as_mut_ptr() as *mut T;
         unsafe { &mut *item }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn get_from_parts<T>(item_slice: &[u8]) -> &T {
         debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
         let item = item_slice.as_ptr() as *const T;


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

![image](https://user-images.githubusercontent.com/75863576/228668530-75b3dadb-763a-4032-aa4b-d64eef00640f.png)

Top line is master now.
On the right graph, the drop in the blue line is the index file shrinking thanks to index entry no longer containing u64 refcount.
The left graph is total data file size. The very bottom line is the change that stores slotlist=1 elements in the index file (4MB). The line just above it is THIS change, which adds a u64 per element so we can store ref_count. Not sure why we have a handful of data files. 6MB total allocated now when it used to be 4MB.
Note that both scales are log.
The very bottom line on the right graph is a test validator that increases the search length, thus, reducing the # of over-allocations we attempt.
These compound, so with that change, we’d be in the mid 20GB for the entire index basically.
Beats 74GB or whatever the previous impl was at.

#### Summary of Changes
When ref_count != 1, store ref_count per element in the data file. This means the 99.9% case of ref_count=1 does not have to be stored per allocated element.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
