### PR TITLE
Scheduler Messages

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -48,6 +48,8 @@ pub mod consumer;
 mod decision_maker;
 mod forwarder;
 mod packet_receiver;
+#[allow(dead_code)]
+mod scheduler_messages;
 
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 6;

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,0 +1,76 @@
+use {
+    crate::immutable_deserialized_packet::ImmutableDeserializedPacket,
+    solana_sdk::transaction::SanitizedTransaction, std::sync::Arc,
+};
+
+/// A unique identifier for a transaction batch.
+/// The lower 64 bits are based on the order the transaction batch was scheduled.
+/// The upper 64 bits are an optional priority field - currently unused.
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransactionBatchId(u128);
+
+impl TransactionBatchId {
+    pub fn new(index: u64) -> Self {
+        Self(index as u128)
+    }
+}
+
+/// A unique identifier for a transaction.
+/// The lower 64 bits are based on the order the transaction entered banking stage.
+/// The upper 64 bits are the priority of the transaction.
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransactionId(u128);
+
+impl TransactionId {
+    pub fn new(priority: u64, index: u64) -> Self {
+        Self(((priority as u128) << 64) | (index as u128))
+    }
+}
+
+/// Message: [Scheduler -> Worker]
+/// Transactions to be consumed (executed, recorded, committed)
+pub struct ConsumeWork {
+    pub batch_id: TransactionBatchId,
+    pub transaction_ids: Vec<TransactionId>,
+    pub transactions: Vec<SanitizedTransaction>,
+}
+
+/// Message: [Worker -> Scheduler]
+/// Transactions to be forwarded to the next leader(s)
+pub struct ForwardWork {
+    pub ids: Vec<TransactionId>,
+    pub packets: Vec<Arc<ImmutableDeserializedPacket>>,
+}
+
+/// Message: [Worker -> Scheduler]
+/// Processed transactions.
+pub struct FinishedConsumeWork {
+    pub work: ConsumeWork,
+    pub retryable_indexes: Vec<usize>,
+}
+
+/// Message: [Worker -> Scheduler]
+/// Forwarded transactions.
+pub struct FinishedForwardWork {
+    pub work: ForwardWork,
+    pub successful: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transaction_id_ordering() {
+        let id1 = TransactionId::new(0, 0);
+        let id2 = TransactionId::new(0, 1);
+        let id3 = TransactionId::new(1, 0);
+        let id4 = TransactionId::new(1, 1);
+        assert!(id1 < id2);
+        assert!(id1 < id3);
+        assert!(id1 < id4);
+        assert!(id2 < id3);
+        assert!(id2 < id4);
+        assert!(id3 < id4);
+    }
+}

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -27,7 +27,7 @@ impl TransactionId {
 /// Transactions to be consumed (i.e. executed, recorded, committed)
 pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
-    pub transaction_ids: Vec<TransactionId>,
+    pub ids: Vec<TransactionId>,
     pub transactions: Vec<SanitizedTransaction>,
     pub max_age_slots: Vec<Slot>,
 }

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -24,7 +24,7 @@ impl TransactionId {
 }
 
 /// Message: [Scheduler -> Worker]
-/// Transactions to be consumed (executed, recorded, committed)
+/// Transactions to be consumed (i.e. executed, recorded, committed)
 pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
     pub transaction_ids: Vec<TransactionId>,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,6 +1,6 @@
 use {
     crate::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_sdk::transaction::SanitizedTransaction, std::sync::Arc,
+    solana_poh::poh_recorder::Slot, solana_sdk::transaction::SanitizedTransaction, std::sync::Arc,
 };
 
 /// A unique identifier for a transaction batch.
@@ -29,6 +29,7 @@ pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
     pub transaction_ids: Vec<TransactionId>,
     pub transactions: Vec<SanitizedTransaction>,
+    pub max_age_slots: Vec<Slot>,
 }
 
 /// Message: [Scheduler -> Worker]

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -31,7 +31,7 @@ pub struct ConsumeWork {
     pub transactions: Vec<SanitizedTransaction>,
 }
 
-/// Message: [Worker -> Scheduler]
+/// Message: [Scheduler -> Worker]
 /// Transactions to be forwarded to the next leader(s)
 pub struct ForwardWork {
     pub ids: Vec<TransactionId>,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -14,14 +14,12 @@ impl TransactionBatchId {
 }
 
 /// A unique identifier for a transaction.
-/// The lower 64 bits are based on the order the transaction entered banking stage.
-/// The upper 64 bits are the priority of the transaction.
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TransactionId(u128);
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct TransactionId(u64);
 
 impl TransactionId {
-    pub fn new(priority: u64, index: u64) -> Self {
-        Self(((priority as u128) << 64) | (index as u128))
+    pub fn new(index: u64) -> Self {
+        Self(index)
     }
 }
 
@@ -52,23 +50,4 @@ pub struct FinishedConsumeWork {
 pub struct FinishedForwardWork {
     pub work: ForwardWork,
     pub successful: bool,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_transaction_id_ordering() {
-        let id1 = TransactionId::new(0, 0);
-        let id2 = TransactionId::new(0, 1);
-        let id3 = TransactionId::new(1, 0);
-        let id4 = TransactionId::new(1, 1);
-        assert!(id1 < id2);
-        assert!(id1 < id3);
-        assert!(id1 < id4);
-        assert!(id2 < id3);
-        assert!(id2 < id4);
-        assert!(id3 < id4);
-    }
 }

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -4,14 +4,12 @@ use {
 };
 
 /// A unique identifier for a transaction batch.
-/// The lower 64 bits are based on the order the transaction batch was scheduled.
-/// The upper 64 bits are an optional priority field - currently unused.
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TransactionBatchId(u128);
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct TransactionBatchId(u64);
 
 impl TransactionBatchId {
     pub fn new(index: u64) -> Self {
-        Self(index as u128)
+        Self(index)
     }
 }
 

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,6 +1,7 @@
 use {
     crate::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_poh::poh_recorder::Slot, solana_sdk::transaction::SanitizedTransaction, std::sync::Arc,
+    solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
+    std::sync::Arc,
 };
 
 /// A unique identifier for a transaction batch.

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -25,7 +25,7 @@ impl TransactionId {
 }
 
 /// Message: [Scheduler -> Worker]
-/// Transactions to be consumed (i.e. executed, recorded, committed)
+/// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,


### PR DESCRIPTION
#### Problem
Banking Scheduler and Worker threads need to communicate via message passing.
Scheduler PR and Worker PR will both use these messages, so it makes sense to separate them into a separate PR to be merged before either scheduler/worker.

#### Summary of Changes
Messages that are passed from [scheduler to worker] and [worker to scheduler].


The message flow between Scheduler and Worker(s) is as follows:
```mermaid
flowchart LR

    subgraph Forwarding
        direction LR
        C[Scheduler];
        D[Worker];
        C -->|ForwardWork|D -->|FinishedForwardWork|C;
    end
    
    subgraph Consuming
        direction LR
        A[Scheduler];
        B[Worker];
        A -->|ConsumeWork|B -->|FinishedConsumeWork|A;
    end
```




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
