### PR TITLE
AHV processes the snapshot dirs in place

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -297,7 +297,7 @@ impl AccountsHashVerifier {
 
         if let Some(snapshot_info) = &accounts_package.snapshot_info {
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                snapshot_info.snapshot_links.path(),
+                snapshot_info.snapshot_links.as_path(),
                 accounts_package.slot,
                 &accounts_hash_for_reserialize,
                 bank_incremental_snapshot_persistence.as_ref(),

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -297,15 +297,10 @@ impl AccountsHashVerifier {
 
         if let Some(snapshot_info) = &accounts_package.snapshot_info {
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                snapshot_info.snapshot_links.as_path(),
+                snapshot_info.snapshot_links.path(),
                 accounts_package.slot,
                 &accounts_hash_for_reserialize,
                 bank_incremental_snapshot_persistence.as_ref(),
-            );
-            info!(
-                "xxx AHV: reserialized bank for slot: {}, path {}",
-                accounts_package.slot,
-                snapshot_info.snapshot_links.display()
             );
         }
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -297,7 +297,7 @@ impl AccountsHashVerifier {
 
         if let Some(snapshot_info) = &accounts_package.snapshot_info {
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                snapshot_info.snapshot_links.as_path(),
+                &snapshot_info.snapshot_links,
                 accounts_package.slot,
                 &accounts_hash_for_reserialize,
                 bank_incremental_snapshot_persistence.as_ref(),

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -297,10 +297,15 @@ impl AccountsHashVerifier {
 
         if let Some(snapshot_info) = &accounts_package.snapshot_info {
             solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                snapshot_info.snapshot_links.path(),
+                snapshot_info.snapshot_links.as_path(),
                 accounts_package.slot,
                 &accounts_hash_for_reserialize,
                 bank_incremental_snapshot_persistence.as_ref(),
+            );
+            info!(
+                "xxx AHV: reserialized bank for slot: {}, path {}",
+                accounts_package.slot,
+                snapshot_info.snapshot_links.display()
             );
         }
 

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -285,7 +285,7 @@ mod tests {
                     archive_format: ArchiveFormat::Tar,
                 },
                 block_height: slot,
-                snapshot_links: TempDir::new().unwrap(),
+                snapshot_links: PathBuf::default(),
                 snapshot_storages: Vec::default(),
                 snapshot_version: SnapshotVersion::default(),
                 snapshot_type,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -299,7 +299,7 @@ mod tests {
                     archive_format: ArchiveFormat::Tar,
                 },
                 block_height: slot,
-                snapshot_links: TempDir::new().unwrap(),
+                snapshot_links: PathBuf::default(),
                 snapshot_storages: Vec::default(),
                 snapshot_version: SnapshotVersion::default(),
                 snapshot_type,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -182,7 +182,6 @@ impl SnapshotPackagerService {
 mod tests {
     use {
         super::*,
-        bincode::serialize_into,
         rand::seq::SliceRandom,
         solana_runtime::{
             snapshot_archive_info::SnapshotArchiveInfo,
@@ -257,19 +256,6 @@ mod tests {
             SnapshotVersion::default(),
             snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        )
-        .unwrap();
-
-        // before we compare, stick an empty status_cache in this dir so that the package comparison works
-        // This is needed since the status_cache is added by the packager and is not collected from
-        // the source dir for snapshots
-        let dummy_slot_deltas: Vec<BankSlotDelta> = vec![];
-        snapshot_utils::serialize_snapshot_data_file(
-            &snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME),
-            |stream| {
-                serialize_into(stream, &dummy_slot_deltas)?;
-                Ok(())
-            },
         )
         .unwrap();
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -31,6 +31,7 @@ use {
         snapshot_utils::{
             self, ArchiveFormat,
             SnapshotVersion::{self, V1_2_0},
+            MAX_BANK_SNAPSHOTS_TO_RETAIN,
         },
         status_cache::MAX_CACHE_ENTRIES,
     },

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -6,7 +6,6 @@ use {
     fs_extra::dir::CopyOptions,
     itertools::Itertools,
     log::{info, trace},
-    snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN,
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier,
         snapshot_packager_service::SnapshotPackagerService,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -76,13 +76,13 @@ impl AccountsPackage {
         }
 
         let bank_snapshot_dir = &bank_snapshot_info.snapshot_dir;
-        let snapshot_links = bank_snapshot_dir
+        let bank_snapshots_dir = bank_snapshot_dir
             .parent()
             .ok_or_else(|| SnapshotError::InvalidSnapshotDirPath(bank_snapshot_dir.to_path_buf()))?
             .to_path_buf();
 
         let snapshot_info = SupplementalSnapshotInfo {
-            snapshot_links,
+            snapshot_links: bank_snapshots_dir,
             archive_format,
             snapshot_version,
             full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -8,7 +8,9 @@ use {
         rent_collector::RentCollector,
         snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
         snapshot_hash::SnapshotHash,
-        snapshot_utils::{self, ArchiveFormat, BankSnapshotInfo, Result, SnapshotVersion},
+        snapshot_utils::{
+            self, ArchiveFormat, BankSnapshotInfo, Result, SnapshotError, SnapshotVersion,
+        },
     },
     log::*,
     solana_sdk::{clock::Slot, feature_set, sysvar::epoch_schedule::EpochSchedule},
@@ -73,10 +75,10 @@ impl AccountsPackage {
             }
         }
 
-        let snapshot_links = bank_snapshot_info
-            .snapshot_dir
+        let bank_snapshot_dir = &bank_snapshot_info.snapshot_dir;
+        let snapshot_links = bank_snapshot_dir
             .parent()
-            .unwrap()
+            .ok_or_else(|| SnapshotError::InvalidSnapshotDirPath(bank_snapshot_dir.to_path_buf()))?
             .to_path_buf();
 
         let snapshot_info = SupplementalSnapshotInfo {

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -170,9 +170,7 @@ impl AccountsPackage {
 
     /// Returns the path to the snapshot links directory
     ///
-    /// NOTE 1: This path is within the TempDir created for the AccountsPackage, *not* the bank
-    ///         snapshots dir passed into `new_for_snapshot()` when creating the AccountsPackage.
-    /// NOTE 2: This fn will panic if the AccountsPackage is of type EpochAccountsHash.
+    /// NOTE: This fn will panic if the AccountsPackage is of type EpochAccountsHash.
     pub fn snapshot_links_dir(&self) -> &Path {
         match self.package_type {
             AccountsPackageType::AccountsHashVerifier | AccountsPackageType::Snapshot(..) => self

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -73,7 +73,11 @@ impl AccountsPackage {
             }
         }
 
-        let snapshot_links = bank_snapshot_info.snapshot_dir.clone();
+        let snapshot_links = bank_snapshot_info
+            .snapshot_dir
+            .parent()
+            .unwrap()
+            .to_path_buf();
 
         let snapshot_info = SupplementalSnapshotInfo {
             snapshot_links,

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -80,7 +80,6 @@ mod tests {
         },
         solana_sdk::{clock::Slot, hash::Hash},
         std::{path::PathBuf, time::Instant},
-        tempfile::TempDir,
     };
 
     #[test]
@@ -94,7 +93,7 @@ mod tests {
                     archive_format: ArchiveFormat::Tar,
                 },
                 block_height: slot,
-                snapshot_links: TempDir::new().unwrap(),
+                snapshot_links: PathBuf::default(),
                 snapshot_storages: Vec::default(),
                 snapshot_version: SnapshotVersion::default(),
                 snapshot_type,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -644,6 +644,10 @@ pub fn archive_snapshot_package(
     })?;
 
     let src_snapshot_dir = snapshot_package.snapshot_links.join(&slot_str);
+    // To be a source for symlinking and archiving, the path need to be an aboslute path
+    let src_snapshot_dir = src_snapshot_dir
+        .canonicalize()
+        .map_err(|_e| SnapshotError::InvalidSnapshotDirPath(src_snapshot_dir.clone()))?;
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     symlink::symlink_file(src_snapshot_file, staging_snapshot_file)

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -83,7 +83,6 @@ pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
 const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 const VERSION_STRING_V1_2_0: &str = "1.2.0";
-pub(crate) const TMP_BANK_SNAPSHOT_PREFIX: &str = "tmp-bank-snapshot-";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
 // Save some bank snapshots but not too many
@@ -629,7 +628,7 @@ pub fn archive_snapshot_package(
 
     // Add the snapshots to the staging directory
     symlink::symlink_dir(
-        snapshot_package.snapshot_links.path(),
+        snapshot_package.snapshot_links.as_path(),
         staging_snapshots_dir,
     )
     .map_err(|e| SnapshotError::IoWithSource(e, "create staging symlinks"))?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -646,15 +646,15 @@ pub fn archive_snapshot_package(
     let src_snapshot_dir = snapshot_package.snapshot_links.join(&slot_str);
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
-    fs::hard_link(src_snapshot_file, staging_snapshot_file)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create snapshot hardlink"))?;
+    symlink::symlink_file(src_snapshot_file, staging_snapshot_file)
+        .map_err(|e| SnapshotError::IoWithSource(e, "create snapshot symlink"))?;
 
     // Following the existing archive format, the status cache is under snapshots/, not under <slot>/
     // like in the snapshot dir.
     let staging_status_cache = staging_snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
     let src_status_cache = src_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
-    fs::hard_link(src_status_cache, staging_status_cache)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create status cache hardlink"))?;
+    symlink::symlink_file(src_status_cache, staging_status_cache)
+        .map_err(|e| SnapshotError::IoWithSource(e, "create status cache symlink"))?;
 
     // Add the AppendVecs into the compressible list
     for storage in snapshot_package.snapshot_storages.iter() {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -647,14 +647,14 @@ pub fn archive_snapshot_package(
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     fs::hard_link(src_snapshot_file, staging_snapshot_file)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create snapshot symlink"))?;
+        .map_err(|e| SnapshotError::IoWithSource(e, "create snapshot hardlink"))?;
 
     // Following the existing archive format, the status cache is under snapshots/, not under <slot>/
     // like in the snapshot dir.
     let staging_status_cache = staging_snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
     let src_status_cache = src_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
     fs::hard_link(src_status_cache, staging_status_cache)
-        .map_err(|e| SnapshotError::IoWithSource(e, "create status cache symlink"))?;
+        .map_err(|e| SnapshotError::IoWithSource(e, "create status cache hardlink"))?;
 
     // Add the AppendVecs into the compressible list
     for storage in snapshot_package.snapshot_storages.iter() {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -622,16 +622,39 @@ pub fn archive_snapshot_package(
     let staging_accounts_dir = staging_dir.path().join("accounts");
     let staging_snapshots_dir = staging_dir.path().join("snapshots");
     let staging_version_file = staging_dir.path().join(SNAPSHOT_VERSION_FILENAME);
+
+    // Create staging/accounts/
     fs::create_dir_all(&staging_accounts_dir).map_err(|e| {
-        SnapshotError::IoWithSourceAndFile(e, "create staging path", staging_accounts_dir.clone())
+        SnapshotError::IoWithSourceAndFile(
+            e,
+            "create staging accounts path",
+            staging_accounts_dir.clone(),
+        )
     })?;
 
-    // Add the snapshots to the staging directory
-    symlink::symlink_dir(
-        snapshot_package.snapshot_links.as_path(),
-        staging_snapshots_dir,
-    )
-    .map_err(|e| SnapshotError::IoWithSource(e, "create staging symlinks"))?;
+    let slot_str = snapshot_package.slot().to_string();
+    let staging_snapshot_dir = staging_snapshots_dir.join(&slot_str);
+    // Creates staging snapshots/<slot>/
+    fs::create_dir_all(&staging_snapshot_dir).map_err(|e| {
+        SnapshotError::IoWithSourceAndFile(
+            e,
+            "create staging snapshots path",
+            staging_snapshots_dir.clone(),
+        )
+    })?;
+
+    let src_snapshot_dir = snapshot_package.snapshot_links.join(&slot_str);
+    let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
+    let src_snapshot_file = src_snapshot_dir.join(slot_str);
+    fs::hard_link(src_snapshot_file, staging_snapshot_file)
+        .map_err(|e| SnapshotError::IoWithSource(e, "create snapshot symlink"))?;
+
+    // Following the existing archive format, the status cache is under snapshots/, not under <slot>/
+    // like in the snapshot dir.
+    let staging_status_cache = staging_snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
+    let src_status_cache = src_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
+    fs::hard_link(src_status_cache, staging_status_cache)
+        .map_err(|e| SnapshotError::IoWithSource(e, "create status cache symlink"))?;
 
     // Add the AppendVecs into the compressible list
     for storage in snapshot_package.snapshot_storages.iter() {


### PR DESCRIPTION
#### Problem

For booting a bank from a snapshot dir, we need a post snapshot with hash calculated.  Previously, the account package is generated with a tmp dir, and the hash was calculated for the tmp dir and packaged into the archive.  The snapshot dir under snapshot/ stays at the PRE stage without the account hash.

#### Summary of Changes
Let account package use the snapshot dir in-place, so AHV computes the accounts hash and turns the pre snapshot dir into a post snapshot dir.

Change SnapshotPackage::snapshot_links from TempDir to PathBuf, let it point to the snapshot dir.  Remove the tempdir setup.
Build archive staging directory using the snashot dir info from the updated SnapshotPackage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
