### PR TITLE
disk index: break ref_count u64 into reserved bits

### DIFF
--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -365,7 +365,7 @@ mod tests {
             let v = (0..count)
                 .map(|x| (x as usize, x as usize /*thread_rng().gen::<usize>()*/))
                 .collect::<Vec<_>>();
-            let rc = thread_rng().gen::<RefCount>();
+            let rc = thread_rng().gen_range(0, RefCount::MAX >> 2);
             (v, rc)
         };
 

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -372,7 +372,7 @@ mod test {
         let mut storage = BucketStorage::<IndexBucket<u64>>::new(
             Arc::new(paths),
             1,
-            1,
+            std::mem::size_of::<crate::index_entry::IndexEntry<u64>>() as u64,
             1,
             Arc::default(),
             Arc::default(),


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
We can use extra bits inside of `RefCount` to store bits like `Occupied` inside a disk index or data bucket. We can also use them as an enum tag for more complicated implementations such as storing a single slot list entry inside `IndexEntry` and not using the data file at all.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
