### PR TITLE
disk index: use bits in ref count to store occupied

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -190,6 +190,18 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { slice.get_unchecked_mut(0) }
     }
 
+    pub(crate) fn get_mut_from_parts<T: Sized>(item_slice: &mut [u8]) -> &mut T {
+        debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
+        let item = item_slice.as_mut_ptr() as *mut T;
+        unsafe { &mut *item }
+    }
+
+    pub(crate) fn get_from_parts<T: Sized>(item_slice: &[u8]) -> &T {
+        debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
+        let item = item_slice.as_ptr() as *const T;
+        unsafe { &*item }
+    }
+
     pub fn get_cell_slice<T>(&self, ix: u64, len: u64) -> &[T] {
         let start = self.get_start_offset_no_header(ix);
         let slice = {


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

We'll be moving 0 or 1 slot entries into the index entry instead of the data file. This is a step in that direction.

#### Summary of Changes
Store the occupied/free bit in the refcount spare bits as an enum.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
