### PR TITLE
disk index: index files grow by bytes instead of doubling

### DIFF
--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -51,12 +51,12 @@ impl<T: Clone + Copy + Debug> std::fmt::Debug for BucketMap<T> {
 #[derive(Debug)]
 pub enum BucketMapError {
     /// (bucket_index, current_capacity_pow2)
-    /// Note that this is specific to data buckets
+    /// Note that this is specific to data buckets, which grow in powers of 2
     DataNoSpace((u64, u8)),
 
-    /// current_capacity_pow2
-    /// Note that this is specific to index buckets
-    IndexNoSpace(u8),
+    /// current_capacity_entries
+    /// Note that this is specific to index buckets, which can be 'Actual' sizes
+    IndexNoSpace(u64),
 }
 
 impl<T: Clone + Copy + Debug> BucketMap<T> {

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -77,7 +77,8 @@ impl BucketOccupied for BucketWithHeader {
 pub struct IndexBucketUsingBitVecBits<T: 'static> {
     /// 2 bits per entry that represent a 4 state enum tag
     pub enum_tag: BitVec,
-    capacity_pow2: Capacity,
+    /// number of elements allocated
+    capacity: u64,
     _phantom: PhantomData<&'static T>,
 }
 
@@ -124,7 +125,7 @@ impl<T: Copy + 'static> BucketOccupied for IndexBucketUsingBitVecBits<T> {
         Self {
             // note: twice as many bits allocated as `num_elements` because we store 2 bits per element
             enum_tag: BitVec::new_fill(false, capacity.capacity() * 2),
-            capacity_pow2: capacity,
+            capacity: capacity.capacity(),
             _phantom: PhantomData,
         }
     }
@@ -144,10 +145,7 @@ impl<T: Copy + 'static> BucketOccupied for IndexBucketUsingBitVecBits<T> {
 
 impl<T> BucketCapacity for IndexBucketUsingBitVecBits<T> {
     fn capacity(&self) -> u64 {
-        self.capacity_pow2.capacity()
-    }
-    fn capacity_pow2(&self) -> u8 {
-        self.capacity_pow2.capacity_pow2()
+        self.capacity
     }
 }
 


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
Instead of index files doubling in size, grow them more incrementally.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
