### PR TITLE
[keygen] refactor argument parsing logic into separate `app(...)` function and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5749,6 +5749,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk 1.16.0",
  "solana-version",
+ "tempfile",
  "tiny-bip39",
 ]
 

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -21,6 +21,9 @@ solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 tiny-bip39 = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3.4.0"
+
 [[bin]]
 name = "solana-keygen"
 path = "src/keygen.rs"

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -564,7 +564,9 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let default_num_threads = num_cpus::get().to_string();
-    let matches = app(&default_num_threads, solana_version::version!()).try_get_matches()?;
+    let matches = app(&default_num_threads, solana_version::version!())
+        .try_get_matches()
+        .unwrap_or_else(|e| e.exit());
     do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -887,7 +887,7 @@ mod tests {
 
     fn tmp_outfile_path(name: &str) -> String {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
-        format!("{}/tmp/{}", out_dir, name)
+        format!("{out_dir}/tmp/{name}")
     }
 
     fn remove_tmp_outfile(outfile_path: &str) {
@@ -937,7 +937,7 @@ mod tests {
         .unwrap_err()
         .to_string();
 
-        let expected = format!("Verification for public key: {}: Failed", incorrect_pubkey,);
+        let expected = format!("Verification for public key: {incorrect_pubkey}: Failed");
         assert_eq!(result, expected);
 
         // fail case using a config file
@@ -951,7 +951,7 @@ mod tests {
         .unwrap_err()
         .to_string();
 
-        let expected = format!("Verification for public key: {}: Failed", incorrect_pubkey,);
+        let expected = format!("Verification for public key: {incorrect_pubkey}: Failed");
         assert_eq!(result, expected);
 
         // keypair file takes precedence over config file
@@ -978,7 +978,7 @@ mod tests {
         .unwrap_err()
         .to_string();
 
-        let expected = format!("Verification for public key: {}: Failed", incorrect_pubkey,);
+        let expected = format!("Verification for public key: {incorrect_pubkey}: Failed");
         assert_eq!(result, expected);
 
         remove_tmp_keypair_and_config_file(&keypair_path, &config_path);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -872,7 +872,7 @@ mod tests {
 
         let config = Config {
             keypair_path: keypair_outfile.clone(),
-            ..Default::default()
+            ..Config::default()
         };
         let config_outfile = format!("{}/tmp/{}-config", out_dir, keypair.pubkey());
         config.save(&config_outfile).unwrap();

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -892,7 +892,7 @@ mod tests {
     }
 
     fn tmp_outfile_path(out_dir: &TempDir, name: &str) -> String {
-        let path = out_dir.path().join(format!("{name}"));
+        let path = out_dir.path().join(name);
         path.into_os_string().into_string().unwrap()
     }
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1065,8 +1065,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--outfile",
             &outfile_path,
             "--no-bip39-passphrase",
@@ -1077,8 +1075,6 @@ mod tests {
         let result = process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--outfile",
             &outfile_path,
             "--no-bip39-passphrase",
@@ -1093,8 +1089,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--no-bip39-passphrase",
             "--no-outfile",
         ])
@@ -1118,8 +1112,6 @@ mod tests {
                 process_test_command(&[
                     "solana-keygen",
                     "new",
-                    "--config",
-                    &config_path,
                     "--no-outfile",
                     "--no-bip39-passphrase",
                     "--language",
@@ -1135,8 +1127,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--no-bip39-passphrase",
             "--no-outfile",
             "--derivation-path",
@@ -1147,8 +1137,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--no-bip39-passphrase",
             "--no-outfile",
             "--derivation-path",
@@ -1159,8 +1147,6 @@ mod tests {
         let result = process_test_command(&[
             "solana-keygen",
             "new",
-            "--config",
-            &config_path,
             "--no-bip39-passphrase",
             "--no-outfile",
             "--derivation-path",
@@ -1177,12 +1163,28 @@ mod tests {
     }
 
     #[test]
-    fn test_recover() {
-        unimplemented!()
-    }
-
-    #[test]
     fn test_grind() {
-        unimplemented!()
+        // simple sanity checks
+        process_test_command(&[
+            "solana-keygen",
+            "grind",
+            "--no-outfile",
+            "--no-bip39-passphrase",
+            "--use-mnemonic",
+            "--starts-with",
+            "a:1",
+        ])
+        .unwrap();
+
+        process_test_command(&[
+            "solana-keygen",
+            "grind",
+            "--no-outfile",
+            "--no-bip39-passphrase",
+            "--use-mnemonic",
+            "--ends-with",
+            "b:1",
+        ])
+        .unwrap();
     }
 }


### PR DESCRIPTION
#### Problem
There are no tests for solana-keygen (https://github.com/solana-labs/solana/issues/24691). For PRs like this https://github.com/solana-labs/solana/pull/30977, it would be great to have some sanity tests that we can run to verify that it is not breaking anything.

#### Summary of Changes
Since the cli behavior is via stdout, it is not possible to exhaustively test all behavior of its behavior without significant refactor of the code or additional testing tools. This PR adds just the simple sanity tests to check that the cli does not panic when it is not expected to do so (e.g. https://github.com/solana-labs/solana/pull/24686).

Some notable changes to the code:
- Reorganized argument parsing into a separate `app(...)` function to be able to run clap's internal `debug_asserts`
- For a couple places in `do_main` where we print error `eprint!("..")` and exit `exit(1)`, I modified it so that `do_main` returns an error type back to `main`. I believe this does not change the main behavior (exit code, print statements) and it allows us to test for some additinal errors. This change should also allow destructors/clean-ups to be run after the logic exits `do_main` in contrast to exiting by calling `exit(1)` (unless this is intentional, in which case I can change it back).

Some notable omissions:
- Omitted using `--force` in any of the tests since this could be dangerous
- Did not write tests for `recover` since it requires a user to provide input via a prompt
- Only added minimal tests for `grind` because adding `--use-mnemonics` (required for `--no-outfile`) makes the tests run for a very long time

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
