### PR TITLE
solana-program: Deduplicate code in hash modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6335,6 +6335,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
+ "digest 0.10.6",
  "getrandom 0.2.8",
  "itertools",
  "js-sys",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
+ "digest 0.10.6",
  "getrandom 0.2.8",
  "itertools",
  "js-sys",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -18,6 +18,7 @@ borsh-derive = { workspace = true }
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true, features = ["derive"] }
+digest = { workspace = true }
 itertools =  { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/sdk/program/src/blake3.rs
+++ b/sdk/program/src/blake3.rs
@@ -2,38 +2,10 @@
 //!
 //! [blake3]: https://github.com/BLAKE3-team/BLAKE3
 
-use {
-    crate::sanitize::Sanitize,
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    std::{convert::TryFrom, fmt, mem, str::FromStr},
-    thiserror::Error,
-};
+use crate::hash::Hash;
+pub use crate::hash::{ParseHashError, HASH_BYTES};
 
-/// Size of a hash in bytes.
-pub const HASH_BYTES: usize = 32;
-/// Maximum string length of a base58 encoded hash.
-const MAX_BASE58_LEN: usize = 44;
-
-/// A blake3 hash.
-#[derive(
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    Clone,
-    Copy,
-    Default,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    AbiExample,
-)]
-#[repr(transparent)]
-pub struct Hash(pub [u8; HASH_BYTES]);
-
+/// A Blake3 hasher.
 #[derive(Clone, Default)]
 pub struct Hasher {
     hasher: blake3::Hasher,
@@ -50,77 +22,6 @@ impl Hasher {
     }
     pub fn result(self) -> Hash {
         Hash(*self.hasher.finalize().as_bytes())
-    }
-}
-
-impl Sanitize for Hash {}
-
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
-}
-
-impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
-    }
-}
-
-impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ParseHashError {
-    #[error("string decoded to wrong size for hash")]
-    WrongSize,
-    #[error("failed to decoded string to hash")]
-    Invalid,
-}
-
-impl FromStr for Hash {
-    type Err = ParseHashError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > MAX_BASE58_LEN {
-            return Err(ParseHashError::WrongSize);
-        }
-        let bytes = bs58::decode(s)
-            .into_vec()
-            .map_err(|_| ParseHashError::Invalid)?;
-        if bytes.len() != mem::size_of::<Hash>() {
-            Err(ParseHashError::WrongSize)
-        } else {
-            Ok(Hash::new(&bytes))
-        }
-    }
-}
-
-impl Hash {
-    pub fn new(hash_slice: &[u8]) -> Self {
-        Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
-    }
-
-    pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
-        Self(hash_array)
-    }
-
-    /// unique Hash for tests and benchmarks.
-    pub fn new_unique() -> Self {
-        use crate::atomic_u64::AtomicU64;
-        static I: AtomicU64 = AtomicU64::new(1);
-
-        let mut b = [0u8; HASH_BYTES];
-        let i = I.fetch_add(1);
-        b[0..8].copy_from_slice(&i.to_le_bytes());
-        Self::new(&b)
-    }
-
-    pub fn to_bytes(self) -> [u8; HASH_BYTES] {
-        self.0
     }
 }
 
@@ -163,7 +64,10 @@ pub fn extend_and_hash(id: &Hash, val: &[u8]) -> Hash {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        crate::hash::{ParseHashError, MAX_BASE58_LEN},
+    };
 
     #[test]
     fn test_new_unique() {

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -2,127 +2,14 @@
 //!
 //! [keccak]: https://keccak.team/keccak.html
 
+pub use crate::hash::{ParseHashError, HASH_BYTES};
 use {
-    crate::sanitize::Sanitize,
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    sha3::{Digest, Keccak256},
-    std::{convert::TryFrom, fmt, mem, str::FromStr},
-    thiserror::Error,
+    crate::hash::{self, Hash},
+    sha3::Keccak256,
 };
 
-pub const HASH_BYTES: usize = 32;
-/// Maximum string length of a base58 encoded hash
-const MAX_BASE58_LEN: usize = 44;
-#[derive(
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    Clone,
-    Copy,
-    Default,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    AbiExample,
-)]
-#[repr(transparent)]
-pub struct Hash(pub [u8; HASH_BYTES]);
-
-#[derive(Clone, Default)]
-pub struct Hasher {
-    hasher: Keccak256,
-}
-
-impl Hasher {
-    pub fn hash(&mut self, val: &[u8]) {
-        self.hasher.update(val);
-    }
-    pub fn hashv(&mut self, vals: &[&[u8]]) {
-        for val in vals {
-            self.hash(val);
-        }
-    }
-    pub fn result(self) -> Hash {
-        // At the time of this writing, the sha3 library is stuck on an old version
-        // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
-    }
-}
-
-impl Sanitize for Hash {}
-
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
-}
-
-impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
-    }
-}
-
-impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ParseHashError {
-    #[error("string decoded to wrong size for hash")]
-    WrongSize,
-    #[error("failed to decoded string to hash")]
-    Invalid,
-}
-
-impl FromStr for Hash {
-    type Err = ParseHashError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > MAX_BASE58_LEN {
-            return Err(ParseHashError::WrongSize);
-        }
-        let bytes = bs58::decode(s)
-            .into_vec()
-            .map_err(|_| ParseHashError::Invalid)?;
-        if bytes.len() != mem::size_of::<Hash>() {
-            Err(ParseHashError::WrongSize)
-        } else {
-            Ok(Hash::new(&bytes))
-        }
-    }
-}
-
-impl Hash {
-    pub fn new(hash_slice: &[u8]) -> Self {
-        Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
-    }
-
-    pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
-        Self(hash_array)
-    }
-
-    /// unique Hash for tests and benchmarks.
-    pub fn new_unique() -> Self {
-        use crate::atomic_u64::AtomicU64;
-        static I: AtomicU64 = AtomicU64::new(1);
-
-        let mut b = [0u8; HASH_BYTES];
-        let i = I.fetch_add(1);
-        b[0..8].copy_from_slice(&i.to_le_bytes());
-        Self::new(&b)
-    }
-
-    pub fn to_bytes(self) -> [u8; HASH_BYTES] {
-        self.0
-    }
-}
+/// A Keccak256 hasher.
+pub type Hasher = hash::GenericHasher<Keccak256>;
 
 /// Return a Keccak256 hash for the given data.
 pub fn hashv(vals: &[&[u8]]) -> Hash {

--- a/sdk/program/src/secp256k1_recover.rs
+++ b/sdk/program/src/secp256k1_recover.rs
@@ -315,7 +315,7 @@ impl Secp256k1Pubkey {
 ///     }
 ///
 ///     let recovered_pubkey = secp256k1_recover(
-///         &message_hash.0,
+///         &message_hash.as_ref(),
 ///         instruction.recovery_id,
 ///         &instruction.signature,
 ///     )
@@ -367,7 +367,7 @@ impl Secp256k1Pubkey {
 ///         hasher.result()
 ///     };
 ///
-///     let secp_message = libsecp256k1::Message::parse(&message_hash.0);
+///     let secp_message = libsecp256k1::Message::parse(&message_hash.as_ref());
 ///     let (signature, recovery_id) = libsecp256k1::sign(&secp_message, &secp256k1_secret_key);
 ///
 ///     let signature = signature.serialize();

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -1298,7 +1298,7 @@ pub mod test {
             hasher.result()
         };
 
-        let secp_message = libsecp256k1::Message::parse(&message_hash.0);
+        let secp_message = libsecp256k1::Message::parse(&message_hash.to_bytes());
         let (signature, recovery_id) = libsecp256k1::sign(&secp_message, &secret_key);
 
         // Flip the S value in the signature to make a different but valid signature.


### PR DESCRIPTION
Instead of re-implementing `Hash` and `Hasher` in each module (where the implementations were identical):

* Use `Hash` from `hash` module everywhere.
* Unify and rename `Hasher` traits to `GenricHasher`, taking a generic implementing the `digest::Digest` trait.
* Define `Hasher` in each module as a `pub type` providing a concrete hash struct to `GenericHasher`.
