### PR TITLE
disk index: remove Option on read_value

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -151,11 +151,11 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
             let ix = IndexEntryPlaceInBucket::new(ii);
             let key = ix.key(&self.index);
             if range.map(|r| r.contains(key)).unwrap_or(true) {
-                let val = ix.read_value(&self.index, &self.data);
+                let (v, ref_count) = ix.read_value(&self.index, &self.data);
                 result.push(BucketItem {
                     pubkey: *key,
-                    ref_count: ix.ref_count(&self.index),
-                    slot_list: val.map(|(v, _ref_count)| v.to_vec()).unwrap_or_default(),
+                    ref_count,
+                    slot_list: v.to_vec(),
                 });
             }
         }
@@ -264,7 +264,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
     pub fn read_value(&self, key: &Pubkey) -> Option<(&[T], RefCount)> {
         //debug!("READ_VALUE: {:?}", key);
         let (elem, _) = self.find_index_entry(key)?;
-        elem.read_value(&self.index, &self.data)
+        Some(elem.read_value(&self.index, &self.data))
     }
 
     pub fn try_write(

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -281,17 +281,17 @@ impl<T: Copy> IndexEntryPlaceInBucket<T> {
         index_entry.set_slot_count_enum_value(value);
     }
 
-    pub fn ref_count(&self, index_bucket: &BucketStorage<IndexBucket<T>>) -> RefCount {
+    fn ref_count(&self, index_bucket: &BucketStorage<IndexBucket<T>>) -> RefCount {
         let index_entry = index_bucket.get::<IndexEntry<T>>(self.ix);
         index_entry.packed_ref_count.ref_count()
     }
 
-    pub fn read_value<'a>(
+    pub(crate) fn read_value<'a>(
         &self,
         index_bucket: &'a BucketStorage<IndexBucket<T>>,
         data_buckets: &'a [BucketStorage<DataBucket>],
-    ) -> Option<(&'a [T], RefCount)> {
-        Some((
+    ) -> (&'a [T], RefCount) {
+        (
             match self.get_slot_count_enum(index_bucket) {
                 OccupiedEnum::ZeroSlots => {
                     // num_slots is 0. This means we don't have an actual allocation.
@@ -315,7 +315,7 @@ impl<T: Copy> IndexEntryPlaceInBucket<T> {
                 }
             },
             self.ref_count(index_bucket),
-        ))
+        )
     }
 
     pub fn new(ix: u64) -> Self {


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
`read_value` always returns Some(...). Simplify everyone by making it return the value directly without wrapping in an `Option`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
