### PR TITLE
disk bucket: add trait fn copying_entry

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -447,6 +447,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
                         let new_ix = new_ix.unwrap();
                         let new_elem: &mut IndexEntry<T> = index.get_mut(new_ix);
                         *new_elem = *elem;
+                        index.copying_entry(new_ix, &self.index, ix);
                         /*
                         let dbg_elem: IndexEntry = *new_elem;
                         assert_eq!(


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

Working on moving refcount to data file and assuming 1 otherwise.

#### Summary of Changes
Add trait fn to get notified when an index entry is copied during resizing. This lets in-memory data be copied if necessary.
Note that there are no buckets that require this fn yet, but the index buckets will soon require this.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
