### PR TITLE
Feature - Stop truncating strings in syscalls

### DIFF
--- a/programs/bpf_loader/src/syscalls/logging.rs
+++ b/programs/bpf_loader/src/syscalls/logging.rs
@@ -24,6 +24,9 @@ declare_syscall!(
             len,
             invoke_context.get_check_aligned(),
             invoke_context.get_check_size(),
+            invoke_context
+                .feature_set
+                .is_active(&stop_truncating_strings_in_syscalls::id()),
             &mut |string: &str| {
                 stable_log::program_log(&invoke_context.get_log_collector(), string);
                 Ok(0)

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -641,8 +641,13 @@ pub mod include_loaded_accounts_data_size_in_fee_calculation {
 pub mod native_programs_consume_cu {
     solana_sdk::declare_id!("8pgXCMNXC8qyEFypuwpXyRxLXZdpM4Qo72gJ6k87A6wL");
 }
+
 pub mod simplify_writable_program_account_check {
     solana_sdk::declare_id!("5ZCcFAzJ1zsFKe1KSZa9K92jhx7gkcKj97ci2DBo1vwj");
+}
+
+pub mod stop_truncating_strings_in_syscalls {
+    solana_sdk::declare_id!("16FMCmgLzCNNz6eTwGanbyN2ZxvTBSLuQ6DZhgeMshg");
 }
 
 lazy_static! {
@@ -801,6 +806,7 @@ lazy_static! {
         (include_loaded_accounts_data_size_in_fee_calculation::id(), "include transaction loaded accounts data size in base fee calculation #30657"),
         (native_programs_consume_cu::id(), "Native program should consume compute units #30620"),
         (simplify_writable_program_account_check::id(), "Simplify checks performed for writable upgradeable program accounts #30559"),
+        (stop_truncating_strings_in_syscalls::id(), "Stop truncating strings in syscalls #31029"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
All call sites of `translate_string_and_do()` supply the length, a linear search for it is simply superfluous and wastes performance.

#### Summary of Changes
Adds a feature gate to remove the search for the end and truncation of the tail.

Feature Gate Issue: #31029