### PR TITLE
disk index: set_anticipated_count to optimally grow disk buckets at startup

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -96,6 +96,10 @@ pub struct Bucket<T: Copy + 'static> {
     pub data: Vec<BucketStorage<DataBucket>>,
     stats: Arc<BucketMapStats>,
 
+    /// # entries caller expects the map to need to contain.
+    /// Used as a hint for the next time we need to grow.
+    anticipated_size: AtomicU64,
+
     pub reallocated: Reallocated<IndexBucket<T>, DataBucket>,
 }
 
@@ -123,6 +127,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
             data: vec![],
             stats,
             reallocated: Reallocated::default(),
+            anticipated_size: AtomicU64::default(),
         }
     }
 
@@ -420,21 +425,29 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
         }
     }
 
+    pub(crate) fn set_anticipated_count(&self, count: u64) {
+        self.anticipated_size.store(count, Ordering::Release);
+    }
+
     pub fn grow_index(&self, current_capacity_pow2: u8) {
         if self.index.capacity_pow2 == current_capacity_pow2 {
+            let mut starting_size_pow2 = self.index.capacity_pow2;
+            let anticipated_size = self.anticipated_size.load(Ordering::Acquire);
+            if anticipated_size > 0 {
+                // start the growth at the next pow2 larger than what would be required to hold `anticipated_size`.
+                // This will prevent unnecessary repeated grows at startup.
+                starting_size_pow2 = starting_size_pow2.max(anticipated_size.ilog2() as u8);
+            }
             let mut m = Measure::start("grow_index");
             //debug!("GROW_INDEX: {}", current_capacity_pow2);
             let increment = 1;
             for i in increment.. {
-                //increasing the capacity by ^4 reduces the
-                //likelihood of a re-index collision of 2^(max_search)^2
-                //1 in 2^32
                 let mut index = BucketStorage::new_with_capacity(
                     Arc::clone(&self.drives),
                     1,
                     std::mem::size_of::<IndexEntry<T>>() as u64,
-                    // *2 causes rapid growth of index buckets
-                    self.index.capacity_pow2 + i, // * 2,
+                    // the subtle `+ i` here causes us to grow from the starting size by a power of 2 on each iteration of the for loop
+                    starting_size_pow2 + i,
                     self.index.max_search,
                     Arc::clone(&self.stats.index),
                     Arc::clone(&self.index.count),

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -114,12 +114,6 @@ impl<T: Clone + Copy> BucketApi<T> {
     /// caller can specify that the index needs to hold approximately `count` entries soon.
     /// This gives a hint to the resizing algorithm and prevents repeated incremental resizes.
     pub fn set_anticipated_count(&self, count: u64) {
-        if let Some(bucket) = self.bucket.read().unwrap().as_ref() {
-            bucket.set_anticipated_count(count);
-            return;
-        }
-        // caller is about to write a lot of elements to this bucket, so we need to allocate it first
-        // so we have somewhere to store the anticipated count
         let mut bucket = self.get_write_bucket();
         bucket.as_mut().unwrap().set_anticipated_count(count);
     }

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -111,6 +111,19 @@ impl<T: Clone + Copy> BucketApi<T> {
         }
     }
 
+    /// caller can specify that the index needs to hold approximately `count` entries soon.
+    /// This gives a hint to the resizing algorithm and prevents repeated incremental resizes.
+    pub fn set_anticipated_count(&self, count: u64) {
+        if let Some(bucket) = self.bucket.read().unwrap().as_ref() {
+            bucket.set_anticipated_count(count);
+            return;
+        }
+        // caller is about to write a lot of elements to this bucket, so we need to allocate it first
+        // so we have somewhere to store the anticipated count
+        let mut bucket = self.get_write_bucket();
+        bucket.as_mut().unwrap().set_anticipated_count(count);
+    }
+
     pub fn update<F>(&self, key: &Pubkey, updatefn: F)
     where
         F: FnMut(Option<(&[T], RefCount)>) -> Option<(Vec<T>, RefCount)>,


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711
At startup, we know how many inserts are soon coming.

This appears to cut ~15s off startup time and should greatly reduce disk i/o during startup.
This is a candidate for 1.14 if we want to enable disk index.

#### Summary of Changes
Tell the disk index code how many inserts are coming so that the resizing algorithm doesn't go through unnecessary incremental regrows.
This becomes very important when we stop doubling the index size each time we grow the index bucket.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
