### PR TITLE
Remove unneeded `clippy::new_ret_no_self` allows

### DIFF
--- a/core/src/cache_block_meta_service.rs
+++ b/core/src/cache_block_meta_service.rs
@@ -23,7 +23,6 @@ pub struct CacheBlockMetaService {
 const CACHE_BLOCK_TIME_WARNING_MS: u64 = 150;
 
 impl CacheBlockMetaService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         cache_block_meta_receiver: CacheBlockMetaReceiver,
         blockstore: Arc<Blockstore>,

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -20,7 +20,6 @@ pub struct CostUpdateService {
 }
 
 impl CostUpdateService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(blockstore: Arc<Blockstore>, cost_update_receiver: CostUpdateReceiver) -> Self {
         let thread_hdl = Builder::new()
             .name("solCostUpdtSvc".to_string())

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -30,7 +30,6 @@ pub struct FetchStage {
 }
 
 impl FetchStage {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         sockets: Vec<UdpSocket>,
         tpu_forwards_sockets: Vec<UdpSocket>,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -378,7 +378,7 @@ pub struct ReplayStage {
 }
 
 impl ReplayStage {
-    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: ReplayStageConfig,
         blockstore: Arc<Blockstore>,

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -28,7 +28,6 @@ pub struct RewardsRecorderService {
 }
 
 impl RewardsRecorderService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         rewards_receiver: RewardsRecorderReceiver,
         max_complete_rewards_slot: Arc<AtomicU64>,

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -19,7 +19,6 @@ pub struct SamplePerformanceService {
 }
 
 impl SamplePerformanceService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         bank_forks: &Arc<RwLock<BankForks>>,
         blockstore: &Arc<Blockstore>,

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -235,7 +235,6 @@ impl SigVerifier for DisabledSigVerifier {
 }
 
 impl SigVerifyStage {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new<T: SigVerifier + 'static + Send>(
         packet_receiver: FindPacketSenderStakeReceiver,
         verifier: T,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -100,7 +100,7 @@ impl Tvu {
     /// * `cluster_info` - The cluster_info state.
     /// * `sockets` - fetch, repair, and retransmit sockets
     /// * `blockstore` - the ledger itself
-    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -25,7 +25,6 @@ pub struct TransactionStatusService {
 }
 
 impl TransactionStatusService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         write_transaction_status_receiver: Receiver<TransactionStatusMessage>,
         max_complete_transaction_status_slot: Arc<AtomicU64>,

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -26,7 +26,6 @@ use {
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {
     #[cfg(not(target_os = "solana"))]
-    #[allow(clippy::new_ret_no_self)]
     fn keygen<T: RngCore + CryptoRng>(rng: &mut T) -> AeKey {
         AeKey(rng.gen::<[u8; 16]>())
     }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -177,7 +177,6 @@ impl ElGamalKeypair {
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
     #[cfg(not(target_os = "solana"))]
-    #[allow(clippy::new_ret_no_self)]
     pub fn new_rand() -> Self {
         ElGamal::keygen()
     }


### PR DESCRIPTION
#### Problem
While looking at some adjacent code, I thought it was weird that `TransactionStatusService::new()` is tagged with `#[allow(clippy::new_ret_no_self)]`, even though it returns Self.

Turns out, there are a bunch of unnecessary `#[allow(clippy::new_ret_no_self)]` tags. I think a lot of these are just copy-pasta from a thing that used to need it. Others return Result<Self> or a tuple including Self, which is okay since https://github.com/rust-lang/rust-clippy/pull/3338

#### Summary of Changes
Remove unnecessary allow tags
