### PR TITLE
disk index: add stat: disk_index_failed_resizes

### DIFF
--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -6,6 +6,7 @@ use std::sync::{
 #[derive(Debug, Default)]
 pub struct BucketStats {
     pub resizes: AtomicU64,
+    pub failed_resizes: AtomicU64,
     pub max_size: AtomicU64,
     pub resize_us: AtomicU64,
     pub new_file_us: AtomicU64,

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -405,6 +405,12 @@ impl BucketMapHolderStats {
                     i64
                 ),
                 (
+                    "disk_index_failed_resizes",
+                    disk.map(|disk| disk.stats.index.failed_resizes.swap(0, Ordering::Relaxed))
+                        .unwrap_or_default(),
+                    i64
+                ),
+                (
                     "disk_index_max_size",
                     disk.map(|disk| { disk.stats.index.max_size.swap(0, Ordering::Relaxed) })
                         .unwrap_or_default(),


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/30711

#### Summary of Changes
add stat counting # of failed resizes during disk index, index file grow

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
