### PR TITLE
bank_from_snapshot_dir returns BankFromDirTimings

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1334,6 +1334,12 @@ pub struct BankFromArchiveTimings {
     pub verify_snapshot_bank_us: u64,
 }
 
+#[derive(Debug, Default)]
+pub struct BankFromDirTimings {
+    pub rebuild_bank_from_snapshot_us: u64,
+    pub build_storage_us: u64,
+}
+
 // From testing, 4 seems to be a sweet spot for ranges of 60M-360M accounts and 16-64 cores. This may need to be tuned later.
 const PARALLEL_UNTAR_READERS_DEFAULT: usize = 4;
 
@@ -1659,7 +1665,7 @@ pub fn bank_from_snapshot_dir(
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: &Arc<AtomicBool>,
-) -> Result<(Bank, BankFromArchiveTimings)> {
+) -> Result<(Bank, BankFromDirTimings)> {
     let next_append_vec_id = Arc::new(AtomicAppendVecId::new(0));
 
     let (storage, measure_build_storage) = measure!(
@@ -1698,11 +1704,9 @@ pub fn bank_from_snapshot_dir(
     // will calculate and check the accounts hash, so we will still have safety/correctness there.
     bank.set_initial_accounts_hash_verification_completed();
 
-    let timings = BankFromArchiveTimings {
-        rebuild_bank_from_snapshots_us: measure_rebuild.as_us(),
-        full_snapshot_untar_us: measure_build_storage.as_us(),
-        incremental_snapshot_untar_us: 0,
-        verify_snapshot_bank_us: 0,
+    let timings = BankFromDirTimings {
+        rebuild_bank_from_snapshot_us: measure_rebuild.as_us(),
+        build_storage_us: measure_build_storage.as_us(),
     };
     Ok((bank, timings))
 }


### PR DESCRIPTION
#### Problem
bank_from_snapshot_dir returns BankFromArchiveTimings.  This is not clean, because the the from_dir route has not archive involved.  It was copied over from the from_archive route.

#### Summary of Changes
Generate a new structure BankFromDirTimings and use that for the return.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
