### PR TITLE
Only pass num_transactions to EntryNotifier

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -146,6 +146,22 @@ pub struct Entry {
     pub transactions: Vec<VersionedTransaction>,
 }
 
+pub struct EntrySummary {
+    pub num_hashes: u64,
+    pub hash: Hash,
+    pub num_transactions: u64,
+}
+
+impl From<Entry> for EntrySummary {
+    fn from(entry: Entry) -> Self {
+        Self {
+            num_hashes: entry.num_hashes,
+            hash: entry.hash,
+            num_transactions: entry.transactions.len() as u64,
+        }
+    }
+}
+
 /// Typed entry to distinguish between transaction and tick entries
 pub enum EntryType {
     Transactions(Vec<SanitizedTransaction>),

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     log::*,
-    solana_entry::entry::Entry,
+    solana_entry::entry::EntrySummary,
     solana_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaEntryInfo, ReplicaEntryInfoVersions,
     },
@@ -18,7 +18,7 @@ pub(crate) struct EntryNotifierImpl {
 }
 
 impl EntryNotifier for EntryNotifierImpl {
-    fn notify_entry<'a>(&'a self, slot: Slot, index: usize, entry: &'a Entry) {
+    fn notify_entry<'a>(&'a self, slot: Slot, index: usize, entry: &'a EntrySummary) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_entry_info");
 
         let plugin_manager = self.plugin_manager.read().unwrap();
@@ -63,14 +63,14 @@ impl EntryNotifierImpl {
     fn build_replica_entry_info(
         slot: Slot,
         index: usize,
-        entry: &'_ Entry,
+        entry: &'_ EntrySummary,
     ) -> ReplicaEntryInfo<'_> {
         ReplicaEntryInfo {
             slot,
             index,
             num_hashes: entry.num_hashes,
             hash: entry.hash.as_ref(),
-            executed_transaction_count: entry.transactions.len() as u64,
+            executed_transaction_count: entry.num_transactions,
         }
     }
 }

--- a/rpc/src/entry_notifier_interface.rs
+++ b/rpc/src/entry_notifier_interface.rs
@@ -1,11 +1,11 @@
 use {
-    solana_entry::entry::Entry,
+    solana_entry::entry::EntrySummary,
     solana_sdk::clock::Slot,
     std::sync::{Arc, RwLock},
 };
 
 pub trait EntryNotifier {
-    fn notify_entry(&self, slot: Slot, index: usize, entry: &Entry);
+    fn notify_entry(&self, slot: Slot, index: usize, entry: &EntrySummary);
 }
 
 pub type EntryNotifierLock = Arc<RwLock<dyn EntryNotifier + Sync + Send>>;


### PR DESCRIPTION
#### Problem
The EntryNotifier expects a complete entry to build the geyser notification from. We decided to implement a separate service to call `EntryNotifier::notify_enrtry()`, which means that as currently implemented, the complete entry with all the transactions would need to be cloned to the service. Since we only actually need `transactions.len()`, this is a waste.

#### Summary of Changes
Add a new EntrySummary struct to minimize the data that needs to be sent to the EntryNOtifier
