### PR TITLE
MultiIteratorScanner::finalize returns (payload, already_processed)

### DIFF
--- a/core/src/multi_iterator_scanner.rs
+++ b/core/src/multi_iterator_scanner.rs
@@ -114,8 +114,8 @@ where
     }
 
     /// Consume the iterator and return the payload.
-    pub fn finalize(self) -> U {
-        self.payload
+    pub fn finalize(self) -> (U, Vec<bool>) {
+        (self.payload, self.already_handled)
     }
 
     /// Initialize the `current_positions` vector for the first batch.
@@ -282,7 +282,7 @@ mod tests {
         let expected_batches = vec![vec![&0, &1], vec![&0, &2], vec![&0, &3], vec![&1]];
         assert_eq!(actual_batches, expected_batches);
 
-        let TestScannerPayload { locks } = scanner.finalize();
+        let TestScannerPayload { locks } = scanner.finalize().0;
         assert_eq!(locks, vec![false; 4]);
     }
 
@@ -325,7 +325,7 @@ mod tests {
         ];
         assert_eq!(actual_batches, expected_batches);
 
-        let TestScannerPayload { locks } = scanner.finalize();
+        let TestScannerPayload { locks } = scanner.finalize().0;
         assert_eq!(locks, vec![false; 4]);
     }
 

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -489,7 +489,7 @@ impl VoteStorage {
             }
         }
 
-        scanner.finalize().0.reached_end_of_slot
+        scanner.finalize().payload.reached_end_of_slot
     }
 }
 
@@ -901,7 +901,7 @@ impl ThreadLocalUnprocessedPackets {
             new_retryable_packets.extend(retryable_packets);
         }
 
-        let reached_end_of_slot = scanner.finalize().0.reached_end_of_slot;
+        let reached_end_of_slot = scanner.finalize().payload.reached_end_of_slot;
 
         self.unprocessed_packet_batches.packet_priority_queue = new_retryable_packets;
         self.verify_priority_queue(original_capacity);

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -489,7 +489,7 @@ impl VoteStorage {
             }
         }
 
-        scanner.finalize().reached_end_of_slot
+        scanner.finalize().0.reached_end_of_slot
     }
 }
 
@@ -901,7 +901,7 @@ impl ThreadLocalUnprocessedPackets {
             new_retryable_packets.extend(retryable_packets);
         }
 
-        let reached_end_of_slot = scanner.finalize().reached_end_of_slot;
+        let reached_end_of_slot = scanner.finalize().0.reached_end_of_slot;
 
         self.unprocessed_packet_batches.packet_priority_queue = new_retryable_packets;
         self.verify_priority_queue(original_capacity);


### PR DESCRIPTION
#### Problem
The current use-cases of the `MultiIteratorScanner` will always handle all items in the given slice.
However, this is not guaranteed to be the case (and will not for the multi-iterator scheduler).
Currently, there is no way of determining which items were handled vs not after finalizing the `MultiIteratorScanner`.

#### Summary of Changes
`MultiIteratorScanner::finalize` returns `(self.payload, self.already_handled)`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
