### PR TITLE
remove pub from to_packet_batches_for_tests

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -224,7 +224,7 @@ pub fn to_packet_batches<T: Serialize>(items: &[T], chunk_size: usize) -> Vec<Pa
 }
 
 #[cfg(test)]
-pub fn to_packet_batches_for_tests<T: Serialize>(items: &[T]) -> Vec<PacketBatch> {
+fn to_packet_batches_for_tests<T: Serialize>(items: &[T]) -> Vec<PacketBatch> {
     to_packet_batches(items, NUM_PACKETS)
 }
 


### PR DESCRIPTION
#### Problem
This shouldn't be `pub` because it is marked as `cfg(test)` and is generic.
If you try to use this outside of the crate, it leads to confusing messaging about the fn not existing.

#### Summary of Changes
Remove pub

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
