### PR TITLE
ledger/blockstore: Use `u32` for shred indices.

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -465,7 +465,7 @@ pub mod test {
     #[allow(clippy::type_complexity)]
     fn make_transmit_shreds(
         slot: Slot,
-        num: u64,
+        num: u32,
     ) -> (
         Vec<Shred>,
         Vec<Shred>,
@@ -504,21 +504,21 @@ pub mod test {
 
     fn check_all_shreds_received(
         transmit_receiver: &TransmitReceiver,
-        mut data_index: u64,
-        mut coding_index: u64,
-        num_expected_data_shreds: u64,
-        num_expected_coding_shreds: u64,
+        mut data_index: u32,
+        mut coding_index: u32,
+        num_expected_data_shreds: u32,
+        num_expected_coding_shreds: u32,
     ) {
         while let Ok((shreds, _)) = transmit_receiver.try_recv() {
             if shreds[0].is_data() {
                 for data_shred in shreds.iter() {
-                    assert_eq!(data_shred.index() as u64, data_index);
+                    assert_eq!(data_shred.index(), data_index);
                     data_index += 1;
                 }
             } else {
-                assert_eq!(shreds[0].index() as u64, coding_index);
+                assert_eq!(shreds[0].index(), coding_index);
                 for coding_shred in shreds.iter() {
-                    assert_eq!(coding_shred.index() as u64, coding_index);
+                    assert_eq!(coding_shred.index(), coding_index);
                     coding_index += 1;
                 }
             }
@@ -540,8 +540,8 @@ pub mod test {
         let updated_slot = 0;
         let (all_data_shreds, all_coding_shreds, _, _all_coding_transmit_shreds) =
             make_transmit_shreds(updated_slot, 10);
-        let num_data_shreds = all_data_shreds.len();
-        let num_coding_shreds = all_coding_shreds.len();
+        let num_data_shreds = u32::try_from(all_data_shreds.len()).unwrap();
+        let num_coding_shreds = u32::try_from(all_coding_shreds.len()).unwrap();
         assert!(num_data_shreds >= 10);
 
         // Insert all the shreds
@@ -563,13 +563,7 @@ pub mod test {
         )
         .unwrap();
         // Check all the data shreds were received only once
-        check_all_shreds_received(
-            &transmit_receiver,
-            0,
-            0,
-            num_data_shreds as u64,
-            num_coding_shreds as u64,
-        );
+        check_all_shreds_received(&transmit_receiver, 0, 0, num_data_shreds, num_coding_shreds);
     }
 
     struct MockBroadcastStage {

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -263,8 +263,8 @@ impl StandardBroadcastRun {
                 is_last_in_slot,
                 cluster_type,
                 &mut process_stats,
-                blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
-                shred_code::MAX_CODE_SHREDS_PER_SLOT as u32,
+                blockstore::MAX_DATA_SHREDS_PER_SLOT,
+                shred_code::MAX_CODE_SHREDS_PER_SLOT,
             )
             .unwrap();
         // Insert the first data shred synchronously so that blockstore stores
@@ -523,7 +523,7 @@ mod test {
 
     #[allow(clippy::type_complexity)]
     fn setup(
-        num_shreds_per_slot: Slot,
+        num_shreds_per_slot: u32,
     ) -> (
         Arc<Blockstore>,
         GenesisConfig,
@@ -633,7 +633,7 @@ mod test {
             )
             .unwrap();
         let unfinished_slot = standard_broadcast_run.unfinished_slot.as_ref().unwrap();
-        assert_eq!(unfinished_slot.next_shred_index as u64, num_shreds_per_slot);
+        assert_eq!(unfinished_slot.next_shred_index, num_shreds_per_slot);
         assert_eq!(unfinished_slot.slot, 0);
         assert_eq!(unfinished_slot.parent, 0);
         // Make sure the slot is not complete
@@ -702,7 +702,7 @@ mod test {
 
         // The shred index should have reset to 0, which makes it possible for the
         // index < the previous shred index for slot 0
-        assert_eq!(unfinished_slot.next_shred_index as u64, num_shreds);
+        assert_eq!(unfinished_slot.next_shred_index, num_shreds);
         assert_eq!(unfinished_slot.slot, 2);
         assert_eq!(unfinished_slot.parent, 0);
 

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -41,7 +41,7 @@ impl ReplaySlotStats {
         slot: Slot,
         num_txs: usize,
         num_entries: usize,
-        num_shreds: u64,
+        num_shreds: u32,
         bank_complete_time_us: u64,
     ) {
         lazy! {

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -10,7 +10,7 @@ use {
 pub fn repair_response_packet(
     blockstore: &Blockstore,
     slot: Slot,
-    shred_index: u64,
+    shred_index: u32,
     dest: &SocketAddr,
     nonce: Nonce,
 ) -> Option<Packet> {

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -596,7 +596,11 @@ impl RepairService {
             if let Some(reference_tick) = slot_meta
                 .received
                 .checked_sub(1)
-                .and_then(|index| blockstore.get_data_shred(slot, index).ok()?)
+                .and_then(|index| {
+                    blockstore
+                        .get_data_shred(slot, u32::try_from(index).ok()?)
+                        .ok()?
+                })
                 .and_then(|shred| shred::layout::get_reference_tick(&shred).ok())
                 .map(u64::from)
             {

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -108,8 +108,12 @@ pub enum ShredRepairType {
     /// Requesting `MAX_ORPHAN_REPAIR_RESPONSES ` parent shreds
     Orphan(Slot),
     /// Requesting any shred with index greater than or equal to the particular index
+    // TODO As the value is a shred index, it should use `u32`.  But as changing the type would
+    // affect the serialized representation, we would need to introduce a conversion.
     HighestShred(Slot, u64),
     /// Requesting the missing shred at a particular index
+    // TODO As the value is a shred index, it should use `u32`.  But as changing the type would
+    // affect the serialized representation, we would need to introduce a conversion.
     Shred(Slot, u64),
 }
 
@@ -228,6 +232,7 @@ impl RepairRequestHeader {
 pub(crate) type Ping = ping_pong::Ping<[u8; REPAIR_PING_TOKEN_SIZE]>;
 
 /// Window protocol messages
+// TODO All `u64`s in the branches of this enum are shred indices, and they should be used `u32`.
 #[derive(Debug, AbiEnumVisitor, AbiExample, Deserialize, Serialize)]
 #[frozen_abi(digest = "6VyBwHjkAMXAN97fdhQgFv6VdPEnfJo9LdUAd2SFtwF3")]
 pub enum RepairProtocol {
@@ -433,7 +438,7 @@ impl ServeRepair {
                         from_addr,
                         blockstore,
                         *slot,
-                        *shred_index,
+                        u32::try_from(*shred_index).expect("All shred indices fit into u32"),
                         *nonce,
                     );
                     if batch.is_none() {
@@ -459,7 +464,7 @@ impl ServeRepair {
                             from_addr,
                             blockstore,
                             *slot,
-                            *highest_index,
+                            u32::try_from(*highest_index).expect("All shred indices fit into u32"),
                             *nonce,
                         ),
                         "HighestWindowIndexWithNonce",
@@ -1266,7 +1271,7 @@ impl ServeRepair {
         from_addr: &SocketAddr,
         blockstore: &Blockstore,
         slot: Slot,
-        shred_index: u64,
+        shred_index: u32,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
         // Try to find the requested index in one of the slots
@@ -1289,17 +1294,17 @@ impl ServeRepair {
         from_addr: &SocketAddr,
         blockstore: &Blockstore,
         slot: Slot,
-        highest_index: u64,
+        highest_index: u32,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
         // Try to find the requested index in one of the slots
         let meta = blockstore.meta(slot).ok()??;
-        if meta.received > highest_index {
+        if meta.received > highest_index.into() {
             // meta.received must be at least 1 by this point
             let packet = repair_response::repair_response_packet(
                 blockstore,
                 slot,
-                meta.received - 1,
+                u32::try_from(meta.received - 1).expect("All shred indices fit into u32"),
                 from_addr,
                 nonce,
             )?;
@@ -1330,7 +1335,8 @@ impl ServeRepair {
             repair_response::repair_response_packet(
                 blockstore,
                 meta.slot,
-                meta.received.checked_sub(1u64)?,
+                u32::try_from(meta.received.checked_sub(1u64)?)
+                    .expect("All shred indices fit into u32"),
                 from_addr,
                 nonce,
             )
@@ -1820,7 +1826,7 @@ mod tests {
                 nonce,
             )
             .expect("packets");
-            let request = ShredRepairType::HighestShred(slot, index);
+            let request = ShredRepairType::HighestShred(slot, index.into());
             verify_responses(&request, rv.iter());
 
             let rv: Vec<Shred> = rv
@@ -1831,8 +1837,10 @@ mod tests {
                 })
                 .collect();
             assert!(!rv.is_empty());
-            let index = blockstore.meta(slot).unwrap().unwrap().received - 1;
-            assert_eq!(rv[0].index(), index as u32);
+            let index: u32 = (blockstore.meta(slot).unwrap().unwrap().received - 1)
+                .try_into()
+                .unwrap();
+            assert_eq!(rv[0].index(), index);
             assert_eq!(rv[0].slot(), slot);
 
             let rv = ServeRepair::run_highest_window_request(
@@ -1886,7 +1894,7 @@ mod tests {
                 nonce,
             )
             .expect("packets");
-            let request = ShredRepairType::Shred(slot, index);
+            let request = ShredRepairType::Shred(slot, index.into());
             verify_responses(&request, rv.iter());
             let rv: Vec<Shred> = rv
                 .into_iter()
@@ -2065,7 +2073,7 @@ mod tests {
                     repair_response::repair_response_packet(
                         &blockstore,
                         slot,
-                        index,
+                        index.try_into().unwrap(),
                         &socketaddr_any!(),
                         nonce,
                     )

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -390,7 +390,7 @@ mod tests {
             &mut stats,
         ));
 
-        let index = MAX_DATA_SHREDS_PER_SLOT as u32;
+        let index = MAX_DATA_SHREDS_PER_SLOT;
         let shred = Shred::new_from_data(5, index, 0, &[], ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 0);
         shred.copy_to_packet(&mut packet);
         assert!(should_discard_shred(

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -32,7 +32,7 @@ mod tests {
     const DEFAULT_BENCHMARK_SLOTS: u64 = 50;
     const DEFAULT_BATCH_SIZE_SLOTS: u64 = 1;
     const DEFAULT_MAX_LEDGER_SHREDS: u64 = 50;
-    const DEFAULT_SHREDS_PER_SLOT: u64 = 25;
+    const DEFAULT_SHREDS_PER_SLOT: u32 = 25;
     const DEFAULT_STOP_SIZE_BYTES: u64 = 0;
     const DEFAULT_STOP_SIZE_ITERATIONS: u64 = 0;
     const DEFAULT_STOP_SIZE_CF_DATA_BYTES: u64 = 0;
@@ -43,7 +43,7 @@ mod tests {
         benchmark_slots: u64,
         batch_size_slots: u64,
         max_ledger_shreds: u64,
-        shreds_per_slot: u64,
+        shreds_per_slot: u32,
         stop_size_bytes: u64,
         stop_size_iterations: u64,
         stop_size_cf_data_bytes: u64,
@@ -244,8 +244,8 @@ mod tests {
         data_shred_storage_previous: &mut u64,
         start_slot: u64,
         batch_size: u64,
-        num_shreds: u64,
-        max_shreds: i64,
+        num_shreds: u32,
+        max_shreds: u64,
         blockstore: &Blockstore,
         cpu: &CpuStatsInner,
     ) {
@@ -261,7 +261,7 @@ mod tests {
             start_slot,
             batch_size,
             num_shreds,
-            max_shreds,
+            max_shreds as i64,
             storage_now,
             storage_now as i64 - *storage_previous as i64,
             data_shred_storage_now,
@@ -360,7 +360,7 @@ mod tests {
         let cleanup_service = config.cleanup_service;
 
         let num_batches = benchmark_slots / batch_size_slots;
-        let num_shreds_total = benchmark_slots * shreds_per_slot;
+        let num_shreds_total = benchmark_slots * u64::from(shreds_per_slot);
 
         let (sender, receiver) = unbounded();
         let exit = Arc::new(AtomicBool::new(false));
@@ -553,7 +553,7 @@ mod tests {
                 finished_slot,
                 batch_size_slots,
                 shreds_per_slot,
-                max_ledger_shreds as i64,
+                max_ledger_shreds,
                 &blockstore,
                 &sys.get_stats(),
             );

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -30,13 +30,13 @@ fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Pa
 // Insert some shreds into the ledger in preparation for read benchmarks
 fn setup_read_bench(
     blockstore: &mut Blockstore,
-    num_small_shreds: u64,
-    num_large_shreds: u64,
+    num_small_shreds: u32,
+    num_large_shreds: u32,
     slot: Slot,
 ) {
     // Make some big and small entries
     let entries = create_ticks(
-        num_large_shreds * 4 + num_small_shreds * 2,
+        (num_large_shreds * 4 + num_small_shreds * 2).into(),
         0,
         Hash::default(),
     );
@@ -121,12 +121,12 @@ fn bench_read_random(bench: &mut Bencher) {
     // Generate a num_reads sized random sample of indexes in range [0, total_shreds - 1],
     // simulating random reads
     let mut rng = rand::thread_rng();
-    let indexes: Vec<usize> = (0..num_reads)
-        .map(|_| rng.gen_range(0, total_shreds) as usize)
+    let indexes: Vec<u32> = (0..num_reads)
+        .map(|_| rng.gen_range(0, total_shreds))
         .collect();
     bench.iter(move || {
         for i in indexes.iter() {
-            let _ = blockstore.get_data_shred(slot, *i as u64);
+            let _ = blockstore.get_data_shred(slot, *i);
         }
     });
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -233,14 +233,16 @@ pub mod columns {
     #[derive(Debug)]
     /// The shred data column
     ///
-    /// * index type: `(u64, u64)`
+    /// * index type: `(Slot, u64)`
+    ///   Second element is the shred index and should be `u32`.
     /// * value type: [`Vec<u8>`]
     pub struct ShredData;
 
     #[derive(Debug)]
     /// The shred erasure code column
     ///
-    /// * index type: `(u64, u64)`
+    /// * index type: `(Slot, u64)`
+    ///   Second element is the shred index and should be `u32`.
     /// * value type: [`Vec<u8>`]
     pub struct ShredCode;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1041,7 +1041,7 @@ impl BatchExecutionTiming {
 pub struct ConfirmationProgress {
     pub last_entry: Hash,
     pub tick_hash_count: u64,
-    pub num_shreds: u64,
+    pub num_shreds: u32,
     pub num_entries: usize,
     pub num_txs: usize,
 }
@@ -1104,7 +1104,7 @@ pub fn confirm_slot(
 #[allow(clippy::too_many_arguments)]
 fn confirm_slot_entries(
     bank: &Arc<Bank>,
-    slot_entries_load_result: (Vec<Entry>, u64, bool),
+    slot_entries_load_result: (Vec<Entry>, u32, bool),
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
     skip_verification: bool,

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -80,7 +80,7 @@ impl<'a> Shred<'a> for ShredData {
         shred.sanitize().map(|_| shred)
     }
 
-    fn erasure_shard_index(&self) -> Result<usize, Error> {
+    fn erasure_shard_index(&self) -> Result<u32, Error> {
         shred_data::erasure_shard_index(self).ok_or_else(|| {
             let headers = Box::new((self.common_header, self.data_header));
             Error::InvalidErasureShardIndex(headers)
@@ -142,7 +142,7 @@ impl<'a> Shred<'a> for ShredCode {
         shred.sanitize().map(|_| shred)
     }
 
-    fn erasure_shard_index(&self) -> Result<usize, Error> {
+    fn erasure_shard_index(&self) -> Result<u32, Error> {
         shred_code::erasure_shard_index(self).ok_or_else(|| {
             let headers = Box::new((self.common_header, self.coding_header));
             Error::InvalidErasureShardIndex(headers)
@@ -379,7 +379,7 @@ mod test {
         }
         {
             let mut shred = shred.clone();
-            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32;
+            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT;
             assert_matches!(
                 shred.sanitize(),
                 Err(Error::InvalidShredIndex(ShredType::Data, 32768))
@@ -439,7 +439,7 @@ mod test {
         }
         {
             let mut shred = shred.clone();
-            shred.common_header.index = MAX_CODE_SHREDS_PER_SLOT as u32;
+            shred.common_header.index = MAX_CODE_SHREDS_PER_SLOT;
             assert_matches!(
                 shred.sanitize(),
                 Err(Error::InvalidShredIndex(ShredType::Code, 32_768))
@@ -459,11 +459,11 @@ mod test {
         // shred has index > u32::MAX should fail.
         {
             let mut shred = shred.clone();
-            shred.common_header.fec_set_index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
+            shred.common_header.fec_set_index = MAX_DATA_SHREDS_PER_SLOT - 2;
             shred.coding_header.num_data_shreds = 3;
             shred.coding_header.num_coding_shreds = 4;
             shred.coding_header.position = 1;
-            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
+            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT - 2;
             assert_matches!(
                 shred.sanitize(),
                 Err(Error::InvalidErasureShardIndex { .. })

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -22,7 +22,7 @@ pub(super) trait Shred<'a>: Sized {
     fn into_payload(self) -> Vec<u8>;
 
     // Returns the shard index within the erasure coding set.
-    fn erasure_shard_index(&self) -> Result<usize, Error>;
+    fn erasure_shard_index(&self) -> Result<u32, Error>;
     // Returns the portion of the shred's payload which is erasure coded.
     fn erasure_shard(self) -> Result<Vec<u8>, Error>;
     // Like Shred::erasure_shard but returning a slice.


### PR DESCRIPTION
#### Problem

Shred indices, within a slot, can not exceed a `u32` value. Unfortunately, there is no common type that is used when a shred index needs to be stored.  Part of the code use `u32`, another considerable part uses `u64` and a few places use `usize`.

Ideally, it would be better to have a dedicated type, wrapping a primitive `u32` value.

#### Summary of Changes

This change is trying to unify the types used, moving most of the code that works with shred indices to `u32`.  `u64` is used in a few locations that are serialized into the blockstore or are part of the wire protocol.  Those are left as is for now.

As the conversion is not 100%, there are still a few conversions left, that could be avoided should both the serialization and the wire protocol code use `u32`.  I also was not completely sure about the `usize` types used by the Merkel tree code - those might be convertible to `u32` as well.

Stats (roughly):

  * Removed `as u{32,64}`:
    ```
    $ git diff --cached | grep '^-.*as u\(32\|64\)' | wc -l
    54
    ```
  * Removed `unwrap()`/`expect()`:
    ```
    $ git diff --cached | grep '^-.*\(unwrap()\|expect()\)' | wc -l
    18
    ```
  * Added `as u{32,64}`:
    ```
    $ git diff --cached | grep '^+.*as u\(32\|64\)' | wc -l
    8
    ```
  * Added `unwrap()`/`expect()`:
    ```
    $ git diff --cached | grep '^+.*\(unwrap()\|expect()\)' | wc -l
    31
    ```

Total is 37 + 14 - 8 - 28 = 15 conversions removed.  And a lot of the removed conversion are unchecked, while a lot of the added ones are checked.  Current version would still panic, if a value outside the `u32` scope is used - it will just panic further away from the bug location, complicating the debugging efforts.

This change also prepares the grounds for removal of most of the conversion that are still present.  We would need to convert the serialization and the wire code to `u32` as well.

There are a number of `as usize` conversions added in the new code. Those should be safe, as they convert from `u32`.  Most of them are used when indexing into `Vec`s.