### PR TITLE
ci: improve uploading test results

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -38,9 +38,11 @@ else
     echo "~~~ Uploading test results to Buildkite Analytics"
     buildkite-test-collector < sanitized-results.json
 
-    # upload to datadog
-    cargo2junit > results.xml < sanitized-results.json
-    datadog-ci junit upload --service solana results.xml
+    echo "~~~ Uploading test results to Datadog"
+    cargo2junit > results.xml < sanitized-results.json || true
+    if [[ -f "results.xml" ]]; then
+      datadog-ci junit upload --service solana results.xml
+    fi
   fi
 
   point_tags="pipeline=$BUILDKITE_PIPELINE_SLUG,job=$CI_LABEL,pr=$PR,success=$SUCCESS"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -32,8 +32,8 @@ else
   fi
 
   if [[ -n $BUILDKITE && -f "results.json" ]]; then
-    # prepare result file
-    awk '/{ "type": .* }/' results.json > sanitized-results.json
+    # extract lines which start with '{'
+    awk '/{.*/' results.json > sanitized-results.json
 
     echo "~~~ Uploading test results to Buildkite Analytics"
     buildkite-test-collector < sanitized-results.json


### PR DESCRIPTION
#### Summary of Changes

- ignore cargo2junit's error. (cargo2junit will return error when test result including failed test cases)
- group messages for datadog uploading. it looks like
<img width="455" alt="Screenshot 2023-04-05 at 6 19 45 PM" src="https://user-images.githubusercontent.com/8209234/230053045-4790745b-78ee-4e92-a975-0ab357c552e5.png">
