### PR TITLE
[docs][ci] skip usage doc build for non-deploys

### DIFF
--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -16,8 +16,8 @@ out=${1:-src/cli/usage.md}
 cat src/cli/.usage.md.header > "$out"
 
 # Skip generating the usage doc for non deployment commits of the docs
-if [[ ! -z $CI ]]; then
-  if [[ $CI_BRANCH != $EDGE_CHANNEL ]] && [[ $CI_BRANCH != $BETA_CHANNEL ]] && [[ $CI_BRANCH != $STABLE_CHANNEL ]]; then
+if [[ -n $CI ]]; then
+  if [[ $CI_BRANCH != $EDGE_CHANNEL* ]] && [[ $CI_BRANCH != $BETA_CHANNEL* ]] && [[ $CI_BRANCH != $STABLE_CHANNEL* ]]; then
     echo "**NOTE:** The usage doc is only auto-generated during full production deployments of the docs"
     echo "**NOTE:** This usage doc is auto-generated during deployments" >> "$out"
     exit

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -3,6 +3,29 @@ set -e
 
 cd "$(dirname "$0")"
 
+# shellcheck source=ci/env.sh
+source ../ci/env.sh
+
+# Get current channel
+eval "$(../ci/channel-info.sh)"
+
+# set the output file' location
+out=${1:-src/cli/usage.md}
+
+# load the usage file's header
+cat src/cli/.usage.md.header > "$out"
+
+# Only build the usage doc for doc deployment commits (e.g. to a select branch)
+if [[ ! -z $CI_BRANCH ]]; then
+  if [[ $CI_BRANCH != $EDGE_CHANNEL ]] && [[ $CI_BRANCH != $BETA_CHANNEL ]] && [[ $CI_BRANCH != $STABLE_CHANNEL ]]; then
+    echo "**NOTE:** This usage doc is auto-generated during deployments"
+    echo "**NOTE:** This usage doc is auto-generated during deployments" >> "$out"
+    exit
+  fi
+fi
+
+echo 'Building the solana cli from source...'
+
 # shellcheck source=ci/rust-version.sh
 source ../ci/rust-version.sh stable
 
@@ -12,10 +35,6 @@ source ../ci/rust-version.sh stable
 cargo build -p solana-cli
 
 usage=$(cargo -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
-
-out=${1:-src/cli/usage.md}
-
-cat src/cli/.usage.md.header > "$out"
 
 section() {
   declare mark=${2:-"###"}

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -15,10 +15,10 @@ out=${1:-src/cli/usage.md}
 # load the usage file's header
 cat src/cli/.usage.md.header > "$out"
 
-# Only build the usage doc for doc deployment commits (e.g. to a select branch)
-if [[ ! -z $CI_BRANCH ]]; then
+# Skip generating the usage doc for non deployment commits of the docs 
+if [[ ! -z $CI ]]; then
   if [[ $CI_BRANCH != $EDGE_CHANNEL ]] && [[ $CI_BRANCH != $BETA_CHANNEL ]] && [[ $CI_BRANCH != $STABLE_CHANNEL ]]; then
-    echo "**NOTE:** This usage doc is auto-generated during deployments"
+    echo "**NOTE:** The usage doc is only auto-generated during full production deployments of the docs"
     echo "**NOTE:** This usage doc is auto-generated during deployments" >> "$out"
     exit
   fi

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -15,7 +15,7 @@ out=${1:-src/cli/usage.md}
 # load the usage file's header
 cat src/cli/.usage.md.header > "$out"
 
-# Skip generating the usage doc for non deployment commits of the docs 
+# Skip generating the usage doc for non deployment commits of the docs
 if [[ ! -z $CI ]]; then
   if [[ $CI_BRANCH != $EDGE_CHANNEL ]] && [[ $CI_BRANCH != $BETA_CHANNEL ]] && [[ $CI_BRANCH != $STABLE_CHANNEL ]]; then
     echo "**NOTE:** The usage doc is only auto-generated during full production deployments of the docs"


### PR DESCRIPTION
#### Problem

CI build times for any commits within the docs directory take a long time to complete due to compiling the solana cli from source on each push.

Specifically, the `build.sh` script runs `build-cli-usage.sh`, which uses docker to compile the solana cli from source. Which is then used to output each cli command into the `cli/usage.md` doc for viewing on the actual docs site frontend (currently: Docusaurus)

Having the complete output of the solana cli is only needed for deployments of the docs, not within the rest of the CI pipeline

#### Summary of Changes

For non deployment-grade commits within the docs directory, tweaked the `build-cli-usage.sh` script to skip generating the entire `usage.md` by compiling the solana cli from source.

NOTE: The `build-cli-usage.sh` script will still always output contents to the `cli/usage.md` file to ensure that Docusaurus will still build successfully.

With this update, non-deployment CI builds of the docs take ~5-7 minutes, instead of ~15-17 minutes previously.