### PR TITLE
Add connection error metrics - v1.14 (bp #31049)

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -198,145 +198,191 @@ async fn setup_connection(
     max_unstaked_connections: usize,
     stats: Arc<StreamStats>,
 ) {
+    let from = connecting.remote_address();
     if let Ok(connecting_result) = timeout(
         Duration::from_millis(QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS),
         connecting,
     )
     .await
     {
-        if let Ok(new_connection) = connecting_result {
-            stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
-            let NewConnection {
-                connection,
-                uni_streams,
-                ..
-            } = new_connection;
+        match connecting_result {
+            Ok(new_connection) => {
+                stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
+                let NewConnection {
+                    connection,
+                    uni_streams,
+                    ..
+                } = new_connection;
 
-            let remote_addr = connection.remote_address();
-            let mut remote_pubkey = None;
+                let remote_addr = connection.remote_address();
+                let mut remote_pubkey = None;
 
-            let table_and_stake = {
-                let (some_pubkey, stake) = get_connection_stake(&connection, staked_nodes.clone())
-                    .map_or((None, 0), |(pubkey, stake)| (Some(pubkey), stake));
-                if stake > 0 {
-                    remote_pubkey = some_pubkey;
-                    let mut connection_table_l = staked_connection_table.lock().unwrap();
-                    if connection_table_l.total_size >= max_staked_connections {
-                        let num_pruned = connection_table_l.prune_random(stake);
-                        if num_pruned == 0 {
-                            if max_unstaked_connections > 0 {
-                                // If we couldn't prune a connection in the staked connection table, let's
-                                // put this connection in the unstaked connection table. If needed, prune a
-                                // connection from the unstaked connection table.
-                                connection_table_l = unstaked_connection_table.lock().unwrap();
-                                prune_unstaked_connection_table(
-                                    &mut connection_table_l,
-                                    max_unstaked_connections,
-                                    stats.clone(),
-                                );
-                                Some((connection_table_l, stake))
+                let table_and_stake = {
+                    let (some_pubkey, stake) =
+                        get_connection_stake(&connection, staked_nodes.clone())
+                            .map_or((None, 0), |(pubkey, stake)| (Some(pubkey), stake));
+                    if stake > 0 {
+                        remote_pubkey = some_pubkey;
+                        let mut connection_table_l = staked_connection_table.lock().unwrap();
+                        if connection_table_l.total_size >= max_staked_connections {
+                            let num_pruned = connection_table_l.prune_random(stake);
+                            if num_pruned == 0 {
+                                if max_unstaked_connections > 0 {
+                                    // If we couldn't prune a connection in the staked connection table, let's
+                                    // put this connection in the unstaked connection table. If needed, prune a
+                                    // connection from the unstaked connection table.
+                                    connection_table_l = unstaked_connection_table.lock().unwrap();
+                                    prune_unstaked_connection_table(
+                                        &mut connection_table_l,
+                                        max_unstaked_connections,
+                                        stats.clone(),
+                                    );
+                                    Some((connection_table_l, stake))
+                                } else {
+                                    stats
+                                        .connection_add_failed_on_pruning
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    None
+                                }
                             } else {
-                                stats
-                                    .connection_add_failed_on_pruning
-                                    .fetch_add(1, Ordering::Relaxed);
-                                None
+                                stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+                                Some((connection_table_l, stake))
                             }
                         } else {
-                            stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
                             Some((connection_table_l, stake))
                         }
+                    } else if max_unstaked_connections > 0 {
+                        let mut connection_table_l = unstaked_connection_table.lock().unwrap();
+                        prune_unstaked_connection_table(
+                            &mut connection_table_l,
+                            max_unstaked_connections,
+                            stats.clone(),
+                        );
+                        Some((connection_table_l, 0))
                     } else {
-                        Some((connection_table_l, stake))
+                        None
                     }
-                } else if max_unstaked_connections > 0 {
-                    let mut connection_table_l = unstaked_connection_table.lock().unwrap();
-                    prune_unstaked_connection_table(
-                        &mut connection_table_l,
-                        max_unstaked_connections,
-                        stats.clone(),
-                    );
-                    Some((connection_table_l, 0))
-                } else {
-                    None
-                }
-            };
+                };
 
-            if let Some((mut connection_table_l, stake)) = table_and_stake {
-                let table_type = connection_table_l.peer_type;
-                let total_stake = staked_nodes.read().map_or(0, |stakes| stakes.total_stake);
-                drop(staked_nodes);
+                if let Some((mut connection_table_l, stake)) = table_and_stake {
+                    let table_type = connection_table_l.peer_type;
+                    let total_stake = staked_nodes.read().map_or(0, |stakes| stakes.total_stake);
+                    drop(staked_nodes);
 
-                let max_uni_streams =
-                    VarInt::from_u64(
-                        compute_max_allowed_uni_streams(table_type, stake, total_stake) as u64,
-                    );
-
-                debug!(
-                    "Peer type: {:?}, stake {}, total stake {}, max streams {}",
-                    table_type,
-                    stake,
-                    total_stake,
-                    max_uni_streams.unwrap().into_inner()
-                );
-
-                if let Ok(max_uni_streams) = max_uni_streams {
-                    connection.set_max_concurrent_uni_streams(max_uni_streams);
-                    if let Some((last_update, stream_exit)) = connection_table_l.try_add_connection(
-                        ConnectionTableKey::new(remote_addr.ip(), remote_pubkey),
-                        remote_addr.port(),
-                        Some(connection),
+                    let max_uni_streams = VarInt::from_u64(compute_max_allowed_uni_streams(
+                        table_type,
                         stake,
-                        timing::timestamp(),
-                        max_connections_per_peer,
-                    ) {
-                        drop(connection_table_l);
-                        let stats = stats.clone();
-                        let connection_table = match table_type {
-                            ConnectionPeerType::Unstaked => {
-                                stats
-                                    .connection_added_from_unstaked_peer
-                                    .fetch_add(1, Ordering::Relaxed);
-                                unstaked_connection_table.clone()
-                            }
-                            ConnectionPeerType::Staked => {
-                                stats
-                                    .connection_added_from_staked_peer
-                                    .fetch_add(1, Ordering::Relaxed);
-                                staked_connection_table.clone()
-                            }
-                        };
-                        tokio::spawn(handle_connection(
-                            uni_streams,
-                            packet_sender,
-                            remote_addr,
-                            remote_pubkey,
-                            last_update,
-                            connection_table,
-                            stream_exit,
-                            stats,
-                            stake,
-                        ));
+                        total_stake,
+                    ) as u64);
+
+                    debug!(
+                        "Peer type: {:?}, stake {}, total stake {}, max streams {}",
+                        table_type,
+                        stake,
+                        total_stake,
+                        max_uni_streams.unwrap().into_inner()
+                    );
+
+                    if let Ok(max_uni_streams) = max_uni_streams {
+                        connection.set_max_concurrent_uni_streams(max_uni_streams);
+                        if let Some((last_update, stream_exit)) = connection_table_l
+                            .try_add_connection(
+                                ConnectionTableKey::new(remote_addr.ip(), remote_pubkey),
+                                remote_addr.port(),
+                                Some(connection),
+                                stake,
+                                timing::timestamp(),
+                                max_connections_per_peer,
+                            )
+                        {
+                            drop(connection_table_l);
+                            let stats = stats.clone();
+                            let connection_table = match table_type {
+                                ConnectionPeerType::Unstaked => {
+                                    stats
+                                        .connection_added_from_unstaked_peer
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    unstaked_connection_table.clone()
+                                }
+                                ConnectionPeerType::Staked => {
+                                    stats
+                                        .connection_added_from_staked_peer
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    staked_connection_table.clone()
+                                }
+                            };
+                            tokio::spawn(handle_connection(
+                                uni_streams,
+                                packet_sender,
+                                remote_addr,
+                                remote_pubkey,
+                                last_update,
+                                connection_table,
+                                stream_exit,
+                                stats,
+                                stake,
+                            ));
+                        } else {
+                            stats.connection_add_failed.fetch_add(1, Ordering::Relaxed);
+                        }
                     } else {
-                        stats.connection_add_failed.fetch_add(1, Ordering::Relaxed);
+                        stats
+                            .connection_add_failed_invalid_stream_count
+                            .fetch_add(1, Ordering::Relaxed);
                     }
                 } else {
+                    connection.close(0u32.into(), &[0u8]);
                     stats
-                        .connection_add_failed_invalid_stream_count
+                        .connection_add_failed_unstaked_node
                         .fetch_add(1, Ordering::Relaxed);
                 }
-            } else {
-                connection.close(0u32.into(), &[0u8]);
-                stats
-                    .connection_add_failed_unstaked_node
-                    .fetch_add(1, Ordering::Relaxed);
             }
-        } else {
-            stats.connection_setup_error.fetch_add(1, Ordering::Relaxed);
+            Err(e) => {
+                handle_connection_error(e, &stats, from);
+            }
         }
     } else {
         stats
             .connection_setup_timeout
             .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn handle_connection_error(e: quinn::ConnectionError, stats: &StreamStats, from: SocketAddr) {
+    debug!("error: {:?} from: {:?}", e, from);
+    stats.connection_setup_error.fetch_add(1, Ordering::Relaxed);
+    match e {
+        quinn::ConnectionError::TimedOut => {
+            stats
+                .connection_setup_error_timed_out
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        quinn::ConnectionError::ConnectionClosed(_) => {
+            stats
+                .connection_setup_error_closed
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        quinn::ConnectionError::TransportError(_) => {
+            stats
+                .connection_setup_error_transport
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        quinn::ConnectionError::ApplicationClosed(_) => {
+            stats
+                .connection_setup_error_app_closed
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        quinn::ConnectionError::Reset => {
+            stats
+                .connection_setup_error_reset
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        quinn::ConnectionError::LocallyClosed => {
+            stats
+                .connection_setup_error_locally_closed
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
     }
 }
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -137,6 +137,12 @@ pub struct StreamStats {
     pub(crate) connection_add_failed_on_pruning: AtomicUsize,
     pub(crate) connection_setup_timeout: AtomicUsize,
     pub(crate) connection_setup_error: AtomicUsize,
+    pub(crate) connection_setup_error_closed: AtomicUsize,
+    pub(crate) connection_setup_error_timed_out: AtomicUsize,
+    pub(crate) connection_setup_error_transport: AtomicUsize,
+    pub(crate) connection_setup_error_app_closed: AtomicUsize,
+    pub(crate) connection_setup_error_reset: AtomicUsize,
+    pub(crate) connection_setup_error_locally_closed: AtomicUsize,
     pub(crate) connection_removed: AtomicUsize,
     pub(crate) connection_remove_failed: AtomicUsize,
 }
@@ -223,6 +229,41 @@ impl StreamStats {
             (
                 "connection_setup_error",
                 self.connection_setup_error.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_timed_out",
+                self.connection_setup_error_timed_out
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_closed",
+                self.connection_setup_error_closed
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_transport",
+                self.connection_setup_error_transport
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_app_closed",
+                self.connection_setup_error_app_closed
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_reset",
+                self.connection_setup_error_reset.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_setup_error_locally_closed",
+                self.connection_setup_error_locally_closed
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
manual backport of #31049 to v1.14 (should pick clean onto v1.13 as well)