### PR TITLE
Include stake % in failed switch threshold

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -2013,10 +2013,12 @@ pub mod test {
             if slot == 48 {
                 assert!(results.get(&slot).unwrap().is_empty());
             } else {
-                assert_eq!(
-                    *results.get(&slot).unwrap(),
-                    vec![HeaviestForkFailures::FailedSwitchThreshold(slot)]
-                );
+                match results.get(&slot).unwrap().first() {
+                    Some(HeaviestForkFailures::FailedSwitchThreshold(result_slot, _)) => {
+                        assert_eq!(*result_slot, slot);
+                    }
+                    _ => panic!(),
+                }
             }
         }
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -107,10 +107,10 @@ lazy_static! {
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum HeaviestForkFailures {
-    LockedOut(u64),
-    FailedThreshold(u64),
-    FailedSwitchThreshold(u64),
-    NoPropagatedConfirmation(u64),
+    LockedOut(Slot),
+    FailedThreshold(Slot),
+    FailedSwitchThreshold(Slot, u64 /* stake % */),
+    NoPropagatedConfirmation(Slot),
 }
 
 // Implement a destructor for the ReplayStage thread to signal it exited
@@ -3150,6 +3150,9 @@ impl ReplayStage {
                     );
                     failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
                         heaviest_bank.slot(),
+                        switch_proof_stake
+                            .saturating_mul(100)
+                            .saturating_div(total_stake),
                     ));
                     reset_bank.map(|b| (b, switch_fork_decision))
                 }
@@ -3198,6 +3201,7 @@ impl ReplayStage {
                     );
                     failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
                         heaviest_bank.slot(),
+                        0,
                     ));
                     reset_bank.map(|b| (b, switch_fork_decision))
                 }


### PR DESCRIPTION
#### Problem
It would be useful to understand what stake % is being observed on the majority fork when we fail the switching threshold.

#### Summary of Changes

1. Include stake percentage as part of `HeaviestForkFailure::FailedSwitchThreshold`
2. Fix up unit test
3. Use `Slot` instead of `u64` for `HeaviestForkFailure` enums to make it clear what these are.