### PR TITLE
disk index: add stats for max search

### DIFF
--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+use {
+    crate::bucket_storage::COUNT_MAX_SEARCHES,
+    std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 #[derive(Debug, Default)]
@@ -15,6 +18,8 @@ pub struct BucketStats {
     pub find_index_entry_mut_us: AtomicU64,
     pub file_count: AtomicU64,
     pub total_file_size: AtomicU64,
+    pub count_max_searches: [AtomicU64; COUNT_MAX_SEARCHES],
+    pub max_search_distance: AtomicU64,
 }
 
 impl BucketStats {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -14,6 +14,8 @@ use {
     },
 };
 
+pub const COUNT_MAX_SEARCHES: usize = 3;
+
 /*
 1	2
 2	4
@@ -78,6 +80,8 @@ pub struct BucketStorage<O: BucketOccupied> {
     pub count: Arc<AtomicU64>,
     pub stats: Arc<BucketStats>,
     pub max_search: MaxSearch,
+    pub longest_current_search: MaxSearch,
+    pub count_max_searches: Vec<u64>,
     pub contents: O,
 }
 
@@ -155,6 +159,8 @@ impl<O: BucketOccupied> BucketStorage<O> {
             count,
             stats,
             max_search,
+            longest_current_search: 0,
+            count_max_searches: vec![0; COUNT_MAX_SEARCHES],
             contents: O::new(capacity),
         }
     }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -399,6 +399,24 @@ impl BucketMapHolderStats {
                     i64
                 ),
                 (
+                    "disk_index_max_search_0",
+                    disk.map(|disk| disk.stats.index.count_max_searches[0].load(Ordering::Relaxed))
+                        .unwrap_or_default(),
+                    i64
+                ),
+                (
+                    "disk_index_max_search_1",
+                    disk.map(|disk| disk.stats.index.count_max_searches[1].load(Ordering::Relaxed))
+                        .unwrap_or_default(),
+                    i64
+                ),
+                (
+                    "disk_index_max_search_2",
+                    disk.map(|disk| disk.stats.index.count_max_searches[2].load(Ordering::Relaxed))
+                        .unwrap_or_default(),
+                    i64
+                ),
+                (
                     "disk_index_resizes",
                     disk.map(|disk| disk.stats.index.resizes.swap(0, Ordering::Relaxed))
                         .unwrap_or_default(),


### PR DESCRIPTION
#### Problem
Add stats giving us indications of the max search length required for the disk index.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
