### PR TITLE
Derives Serialize and Deserialize for SnapshotHash

### DIFF
--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -50,7 +50,7 @@ pub struct IncrementalSnapshotHashes {
 }
 
 /// The hash used for snapshot archives
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub struct SnapshotHash(pub Hash);
 
 impl SnapshotHash {


### PR DESCRIPTION
#### Problem

I'd like to use a strong type for snapshot hashes for gossip in a CRDS value. In order to use `SnapshotHash`, it needs to implement Serialize and Deserialize, which it currently does not.


#### Summary of Changes

Derive `Serialize` and `Deserialize` for `SnapshotHash`.