### PR TITLE
removes ip_stake_map field from streamer::StakedNodes

### DIFF
--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -30,7 +30,6 @@ pub struct StakedNodes {
     pub total_stake: u64,
     pub max_stake: u64,
     pub min_stake: u64,
-    pub ip_stake_map: HashMap<IpAddr, u64>,
     pub pubkey_stake_map: HashMap<Pubkey, u64>,
 }
 


### PR DESCRIPTION


#### Problem
Since https://github.com/solana-labs/solana/pull/31077 `ip_stake_map` is no longer used.

#### Summary of Changes
Removed it.