### PR TITLE
reduce header level

### DIFF
--- a/docs/src/getstarted/local.md
+++ b/docs/src/getstarted/local.md
@@ -68,7 +68,7 @@ By default, the `solana-keygen` command will create a new file system wallet loc
 > **NOTE:**
 > If you already have a file system wallet saved at the default location, this command will **NOT** override it (unless you explicitly force override using the `--force` flag).
 
-#### Set your new wallet as default
+### Set your new wallet as default
 
 With your new file system wallet created, you must tell the Solana CLI to use this wallet to deploy and take ownership of your on chain program:
 


### PR DESCRIPTION
#### Problem
Went from a `##`(2) header to `####`(4), markdown linter was complaining at me:
```
MD001/heading-increment/header-increment: Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
```

#### Summary of Changes
Reduce the header level to `###`(3).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
