### PR TITLE
Rename SnapshotHashes to LegacySnapshotHashes

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,7 @@
 use {
     crossbeam_channel::{Receiver, Sender},
     solana_gossip::cluster_info::{
-        ClusterInfo, MAX_INCREMENTAL_SNAPSHOT_HASHES, MAX_SNAPSHOT_HASHES,
+        ClusterInfo, MAX_INCREMENTAL_SNAPSHOT_HASHES, MAX_LEGACY_SNAPSHOT_HASHES,
     },
     solana_measure::measure_us,
     solana_perf::thread::renice_this_thread,
@@ -46,7 +46,7 @@ impl SnapshotPackagerService {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
         let max_full_snapshot_hashes = std::cmp::min(
-            MAX_SNAPSHOT_HASHES,
+            MAX_LEGACY_SNAPSHOT_HASHES,
             snapshot_config
                 .maximum_full_snapshot_archives_to_retain
                 .get(),
@@ -279,7 +279,7 @@ impl SnapshotGossipManager {
         );
 
         self.cluster_info
-            .push_snapshot_hashes(Self::clone_hashes_for_crds(
+            .push_legacy_snapshot_hashes(Self::clone_hashes_for_crds(
                 &self.full_snapshot_hashes.hashes,
             ));
     }

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -681,7 +681,7 @@ impl CrdsDataStats {
             CrdsData::LegacyContactInfo(_) => 0,
             CrdsData::Vote(_, _) => 1,
             CrdsData::LowestSlot(_, _) => 2,
-            CrdsData::SnapshotHashes(_) => 3,
+            CrdsData::LegacySnapshotHashes(_) => 3,
             CrdsData::AccountsHashes(_) => 4,
             CrdsData::EpochSlots(_, _) => 5,
             CrdsData::LegacyVersion(_) => 6,
@@ -720,7 +720,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            crds_value::{new_rand_timestamp, NodeInstance, SnapshotHashes},
+            crds_value::{new_rand_timestamp, LegacySnapshotHashes, NodeInstance},
             socketaddr,
         },
         rand::{thread_rng, Rng, SeedableRng},
@@ -1319,8 +1319,8 @@ mod tests {
         );
         assert_eq!(crds.get_shred_version(&pubkey), Some(8));
         // Add other crds values with the same pubkey.
-        let val = SnapshotHashes::new_rand(&mut rng, Some(pubkey));
-        let val = CrdsData::SnapshotHashes(val);
+        let val = LegacySnapshotHashes::new_rand(&mut rng, Some(pubkey));
+        let val = CrdsData::LegacySnapshotHashes(val);
         let val = CrdsValue::new_unsigned(val);
         assert_eq!(
             crds.insert(val, timestamp(), GossipRoute::LocalMessage),
@@ -1333,7 +1333,7 @@ mod tests {
         assert_eq!(crds.get::<&ContactInfo>(pubkey), None);
         assert_eq!(crds.get_shred_version(&pubkey), Some(8));
         // Remove the remaining entry with the same pubkey.
-        crds.remove(&CrdsValueLabel::SnapshotHashes(pubkey), timestamp());
+        crds.remove(&CrdsValueLabel::LegacySnapshotHashes(pubkey), timestamp());
         assert_eq!(crds.get_records(&pubkey).count(), 0);
         assert_eq!(crds.get_shred_version(&pubkey), None);
     }

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -2,8 +2,8 @@ use {
     crate::{
         crds::VersionedCrdsValue,
         crds_value::{
-            CrdsData, CrdsValue, CrdsValueLabel, IncrementalSnapshotHashes, LegacyVersion,
-            LowestSlot, SnapshotHashes, Version,
+            CrdsData, CrdsValue, CrdsValueLabel, IncrementalSnapshotHashes, LegacySnapshotHashes,
+            LegacyVersion, LowestSlot, Version,
         },
         legacy_contact_info::LegacyContactInfo,
     },
@@ -58,8 +58,8 @@ impl_crds_entry!(LegacyVersion, CrdsData::LegacyVersion(version), version);
 impl_crds_entry!(LowestSlot, CrdsData::LowestSlot(_, slot), slot);
 impl_crds_entry!(Version, CrdsData::Version(version), version);
 impl_crds_entry!(
-    SnapshotHashes,
-    CrdsData::SnapshotHashes(snapshot_hashes),
+    LegacySnapshotHashes,
+    CrdsData::LegacySnapshotHashes(snapshot_hashes),
     snapshot_hashes
 );
 impl_crds_entry!(
@@ -118,8 +118,8 @@ mod tests {
                 CrdsData::LegacyVersion(version) => {
                     assert_eq!(crds.get::<&LegacyVersion>(key), Some(version))
                 }
-                CrdsData::SnapshotHashes(hash) => {
-                    assert_eq!(crds.get::<&SnapshotHashes>(key), Some(hash))
+                CrdsData::LegacySnapshotHashes(hash) => {
+                    assert_eq!(crds.get::<&LegacySnapshotHashes>(key), Some(hash))
                 }
                 CrdsData::IncrementalSnapshotHashes(hash) => {
                     assert_eq!(crds.get::<&IncrementalSnapshotHashes>(key), Some(hash))

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -876,7 +876,7 @@ fn get_snapshot_hashes_from_known_validators(
     // Get the full snapshot hashes for a node from CRDS
     let get_full_snapshot_hashes_for_node = |node| {
         let mut full_snapshot_hashes = Vec::new();
-        cluster_info.get_snapshot_hash_for_node(node, |snapshot_hashes| {
+        cluster_info.get_legacy_snapshot_hash_for_node(node, |snapshot_hashes| {
             full_snapshot_hashes = snapshot_hashes.clone();
         });
         full_snapshot_hashes
@@ -1450,7 +1450,7 @@ fn get_highest_full_snapshot_hash_for_peer(
     peer: &Pubkey,
 ) -> Option<SnapshotHash> {
     let mut full_snapshot_hashes = Vec::new();
-    cluster_info.get_snapshot_hash_for_node(peer, |snapshot_hashes| {
+    cluster_info.get_legacy_snapshot_hash_for_node(peer, |snapshot_hashes| {
         full_snapshot_hashes = snapshot_hashes.clone()
     });
     full_snapshot_hashes


### PR DESCRIPTION
#### Problem

To handle bootstrap better, we'll be changing how `IncrementalSnapshotHashes` will be used. It will contain hashes for both full and incremental snapshots. Then, the current `SnapshotHashes` will no longer be used, and should be indicated as such.


#### Summary of Changes

Rename `SnapshotHashes` to `LegacySnapshotHashes`.

Also rename the push/pull functions to include "legacy" in the name.

(The next PR will rename `IncrementalSnapshotHashes` to `SnapshotHashes`)