### PR TITLE
dependabot: Increase PR limit to 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
     timezone: America/Los_Angeles
   #labels:
   #  - "automerge"
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 6


### PR DESCRIPTION
#### Problem

The current limit of 3 is too low, as the updates are happening faster than they are processed via our review process.

As this limit applies to the total number of outstanding PRs, any PR that requires additional investigation is further reducing the update speed.

#### Summary of Changes

Bumping 2x to see if this would get us back on track to catching up with the current state of the world.