### PR TITLE
Refactor fault hash injection into lambda 

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -191,7 +191,7 @@ impl AccountsHashVerifier {
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         snapshot_config: &SnapshotConfig,
-        fault_hash_generator: Option<AccountsFaultHashInjector>,
+        accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
     ) {
         let accounts_hash = Self::calculate_and_verify_accounts_hash(&accounts_package);
 
@@ -457,7 +457,7 @@ impl AccountsHashVerifier {
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         accounts_hash: AccountsHashEnum,
-        fault_hash_generator: Option<AccountsFaultHashInjector>,
+        accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
     ) {
         let hash = fault_hash_generator
             .and_then(|f| f(accounts_hash.as_hash(), accounts_package.slot))

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -38,7 +38,7 @@ use {
     },
 };
 
-pub type AccountsFaultHashInjector = fn(&Hash, Slot) -> Option<Hash>;
+pub type AccountsHashFaultInjector = fn(&Hash, Slot) -> Option<Hash>;
 
 pub struct AccountsHashVerifier {
     t_accounts_hash_verifier: JoinHandle<()>,
@@ -53,7 +53,7 @@ impl AccountsHashVerifier {
         cluster_info: &Arc<ClusterInfo>,
         known_validators: Option<HashSet<Pubkey>>,
         halt_on_known_validators_accounts_hash_mismatch: bool,
-        accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
+        accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
         snapshot_config: SnapshotConfig,
     ) -> Self {
         // If there are no accounts packages to process, limit how often we re-check
@@ -192,7 +192,7 @@ impl AccountsHashVerifier {
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         snapshot_config: &SnapshotConfig,
-        accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
+        accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
     ) {
         let accounts_hash = Self::calculate_and_verify_accounts_hash(&accounts_package);
 
@@ -458,7 +458,7 @@ impl AccountsHashVerifier {
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         accounts_hash: AccountsHashEnum,
-        accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
+        accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
     ) {
         let hash = accounts_hash_fault_injector
             .and_then(|f| f(accounts_hash.as_hash(), accounts_package.slot))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,7 +3,7 @@
 pub use solana_perf::report_target_features;
 use {
     crate::{
-        accounts_hash_verifier::AccountsHashVerifier,
+        accounts_hash_verifier::{AccountsFaultHashInjector, AccountsHashVerifier},
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_trace::{self, BankingTracer},
         broadcast_stage::BroadcastStageType,
@@ -171,8 +171,6 @@ impl BlockProductionMethod {
         &MESSAGE
     }
 }
-
-pub type AccountsFaultHashInjector = fn(&Hash, Slot) -> Option<Hash>;
 
 pub struct ValidatorConfig {
     pub halt_at_slot: Option<Slot>,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,7 +3,7 @@
 pub use solana_perf::report_target_features;
 use {
     crate::{
-        accounts_hash_verifier::{AccountsFaultHashInjector, AccountsHashVerifier},
+        accounts_hash_verifier::{AccountsHashFaultInjector, AccountsHashVerifier},
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_trace::{self, BankingTracer},
         broadcast_stage::BroadcastStageType,
@@ -199,7 +199,7 @@ pub struct ValidatorConfig {
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub halt_on_known_validators_accounts_hash_mismatch: bool,
-    pub accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
+    pub accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -172,6 +172,8 @@ impl BlockProductionMethod {
     }
 }
 
+pub type AccountsFaultHashInjector = fn(&Hash, Slot) -> Option<Hash>;
+
 pub struct ValidatorConfig {
     pub halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,
@@ -199,7 +201,7 @@ pub struct ValidatorConfig {
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub halt_on_known_validators_accounts_hash_mismatch: bool,
-    pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
+    pub accounts_hash_fault_injector: Option<AccountsFaultHashInjector>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,
@@ -267,7 +269,7 @@ impl Default for ValidatorConfig {
             repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
             gossip_validators: None,
             halt_on_known_validators_accounts_hash_mismatch: false,
-            accounts_hash_fault_injection_slots: 0,
+            accounts_hash_fault_injector: None,
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             wal_recovery_mode: None,
@@ -715,7 +717,7 @@ impl Validator {
             &cluster_info,
             config.known_validators.clone(),
             config.halt_on_known_validators_accounts_hash_mismatch,
-            config.accounts_hash_fault_injection_slots,
+            config.accounts_hash_fault_injector,
             config.snapshot_config.clone(),
         );
 

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -199,7 +199,7 @@ impl BackgroundServices {
             &cluster_info,
             None,
             false,
-            0,
+            None,
             snapshot_config.clone(),
         );
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1001,7 +1001,7 @@ fn test_snapshots_with_background_services(
         &cluster_info,
         None,
         false,
-        0,
+        None,
         snapshot_test_config.snapshot_config.clone(),
     );
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -32,8 +32,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         gossip_validators: config.gossip_validators.clone(),
         halt_on_known_validators_accounts_hash_mismatch: config
             .halt_on_known_validators_accounts_hash_mismatch,
-        accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
         accounts_hash_interval_slots: config.accounts_hash_interval_slots,
+        accounts_hash_fault_injector: config.accounts_hash_fault_injector,
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         wal_recovery_mode: config.wal_recovery_mode.clone(),
         run_verification: config.run_verification,

--- a/local-cluster/tests/local_cluster_slow_2.rs
+++ b/local-cluster/tests/local_cluster_slow_2.rs
@@ -4,6 +4,7 @@
 use {
     common::*,
     log::*,
+    rand::{thread_rng, Rng},
     serial_test::serial,
     solana_core::validator::ValidatorConfig,
     solana_gossip::gossip_service::discover_cluster,
@@ -17,6 +18,7 @@ use {
     solana_sdk::{
         client::SyncClient,
         clock::Slot,
+        hash::{extend_and_hash, Hash},
         poh_config::PohConfig,
         signature::{Keypair, Signer},
     },
@@ -74,9 +76,21 @@ fn test_consistency_halt() {
     // Create cluster with a leader producing bad snapshot hashes.
     let mut leader_snapshot_test_config =
         setup_snapshot_validator_config(snapshot_interval_slots, num_account_paths);
+
+    // Prepare fault hash injection for testing.
     leader_snapshot_test_config
         .validator_config
-        .accounts_hash_fault_injection_slots = 40;
+        .accounts_hash_fault_injector = Some(|hash: &Hash, slot: Slot| {
+        const FAULT_INJECTION_RATE_SLOTS: u64 = 40; // Inject a fault hash every 40 slots
+        if slot % FAULT_INJECTION_RATE_SLOTS == 0 {
+            let rand = thread_rng().gen_range(0, 10);
+            let fault_hash = extend_and_hash(hash, &[rand]);
+            warn!("inserting fault at slot: {}", slot);
+            Some(fault_hash)
+        } else {
+            None
+        }
+    });
 
     let validator_stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {

--- a/local-cluster/tests/local_cluster_slow_2.rs
+++ b/local-cluster/tests/local_cluster_slow_2.rs
@@ -82,14 +82,12 @@ fn test_consistency_halt() {
         .validator_config
         .accounts_hash_fault_injector = Some(|hash: &Hash, slot: Slot| {
         const FAULT_INJECTION_RATE_SLOTS: u64 = 40; // Inject a fault hash every 40 slots
-        if slot % FAULT_INJECTION_RATE_SLOTS == 0 {
+        (slot % FAULT_INJECTION_RATE_SLOTS == 0).then(|| {
             let rand = thread_rng().gen_range(0, 10);
             let fault_hash = extend_and_hash(hash, &[rand]);
             warn!("inserting fault at slot: {}", slot);
-            Some(fault_hash)
-        } else {
-            None
-        }
+            fault_hash
+        })
     });
 
     let validator_stake = DEFAULT_NODE_STAKE;


### PR DESCRIPTION
#### Problem

The current test code of fault hash injection for AccountsHashVerifier is
implemented with account package processing code, which is tightly coupled with
the normal account package processing code. And because of this,
`fault_injection_rate_slots` param has to be passed down into implementation of
account package processing code. 

This make the code less readable and more difficult to change.


#### Summary of Changes

- refactor out fault hash inject code into lambda fn out of AccountsHashVerifier

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
