### PR TITLE
Add test for transaction has too high prioritization fee

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10820,10 +10820,13 @@ fn test_calculate_prioritization_fee() {
         ..FeeStructure::default()
     };
 
-    let request_units = 1_000_000;
-    let request_unit_price = 2_000_000_000; // 2B micro-lamports/CU
-                                            // prioritization_fee = 2B micro-lamports/CU * 1M CUs = (2B / 1M) * 1M = 2B lamports
-    let prioritization_fee = 2_000_000_000;
+    let request_units = 1_000_000_u32;
+    let request_unit_price = 2_000_000_000_u64;
+    let prioritization_fee_details = PrioritizationFeeDetails::new(
+        PrioritizationFeeType::ComputeUnitPrice(request_unit_price),
+        request_units as u64,
+    );
+    let prioritization_fee = prioritization_fee_details.get_fee();
 
     let message = SanitizedMessage::try_from(Message::new(
         &[

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10833,23 +10833,22 @@ fn test_calculate_prioritization_fee() {
         Some(&Pubkey::new_unique()),
     ))
     .unwrap();
-    for support_set_accounts_data_size_limit_ix in [true, false] {
-        let fee = Bank::calculate_fee(
-            &message,
-            fee_structure.lamports_per_signature,
-            &fee_structure,
-            true,  // use_default_units_per_instruction
-            false, // not support_request_units_deprecated
-            true,  // remove_congestion_multiplier
-            true,  // enable_request_heap_frame_ix
-            support_set_accounts_data_size_limit_ix,
-            false, // include_loaded_account_data_size_in_fee
-        );
-        assert_eq!(
-            fee,
-            fee_structure.lamports_per_signature + prioritization_fee
-        );
-    }
+
+    let fee = Bank::calculate_fee(
+        &message,
+        fee_structure.lamports_per_signature,
+        &fee_structure,
+        true,  // use_default_units_per_instruction
+        false, // not support_request_units_deprecated
+        true,  // remove_congestion_multiplier
+        true,  // enable_request_heap_frame_ix
+        true,  // support_set_accounts_data_size_limit_ix,
+        false, // include_loaded_account_data_size_in_fee
+    );
+    assert_eq!(
+        fee,
+        fee_structure.lamports_per_signature + prioritization_fee
+    );
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
Web3.js has a test started to fail against tip of validator master. The test sends a transaction requesting 2sol as prioritization fee, with payer account has 2sol balance. Test correctly expects the transaction to failed due to `Err(TransactionError::InsufficientFundsForFee)` therefore not landed.

#### Summary of Changes
- Add tests to confirm the transaction base fee calculation and payer account validation behave correctly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
