### PR TITLE
ci: use preinstalled openssl

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -47,8 +47,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          choco install openssl
-          export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
+          export OPENSSL_DIR="C:\Program Files\OpenSSL"
           choco install protoc
           export PROTOC="C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe"
           source /tmp/env.sh


### PR DESCRIPTION
#### Problem

our windows build got broken cuz openssl path.

conv: https://discord.com/channels/428295358100013066/560503042458517505/1093768739306094682

#### Summary of Changes

I found the Windows container already have it. I exported the path for openssl package.