### PR TITLE
Fix unused import error in LoadedPrograms

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1,10 +1,11 @@
+#[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+use solana_rbpf::error::EbpfError;
 use {
     crate::{invoke_context::InvokeContext, timings::ExecuteDetailsTimings},
     itertools::Itertools,
     solana_measure::measure::Measure,
     solana_rbpf::{
         elf::Executable,
-        error::EbpfError,
         verifier::RequisiteVerifier,
         vm::{BuiltInProgram, VerifiedExecutable},
     },


### PR DESCRIPTION
#### Problem
Seeing this warning while building on MacOS.
```
 --> program-runtime/src/loaded_programs.rs:8:9
  |
8 |         error::EbpfError,
  |         ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

#### Summary of Changes
Move import under the requied config flag.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
