### PR TITLE
doc: typo in geyser plugin doc

### DIFF
--- a/docs/src/developing/plugins/geyser-plugins.md
+++ b/docs/src/developing/plugins/geyser-plugins.md
@@ -141,7 +141,7 @@ The following method is used for notifying transactions:
     ) -> Result<()>
 ```
 
-The `ReplicaTransactionInfoVersionsoVersions` struct
+The `ReplicaTransactionInfoVersions` struct
 contains the information about a streamed transaction. It wraps `ReplicaTransactionInfo`
 
 ```


### PR DESCRIPTION
#### Problem

Typo `ReplicaTransactionInfoVersionsoVersions`

#### Summary of Changes

`ReplicaTransactionInfoVersionsoVersions` - > `ReplicaTransactionInfoVersions`
