### PR TITLE
chore: Variable rename `height` ==> `slot` in blockstore function

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3043,7 +3043,7 @@ impl Blockstore {
         let result: HashMap<u64, Vec<u64>> = slots
             .iter()
             .zip(slot_metas)
-            .filter_map(|(height, meta)| meta.map(|meta| (*height, meta.next_slots.to_vec())))
+            .filter_map(|(slot, meta)| meta.map(|meta| (*slot, meta.next_slots.to_vec())))
             .collect();
 
         Ok(result)


### PR DESCRIPTION
#### Problem
Slots refer to time windows where a block could be produced whereas height refers to how many blocks are actually in a fork. This function is operating on a list of slots, so the use of "height" is incorrect and misleading.

#### Summary of Changes
Rename variable