### PR TITLE
disk index: correctly keep track of count during batch add

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -329,6 +329,10 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
                 Ok(_result) => {
                     // everything added
                     self.set_anticipated_count(0);
+                    self.index.count.fetch_add(
+                        count.saturating_sub(duplicates.len()) as u64,
+                        Ordering::Relaxed,
+                    );
                     return duplicates;
                 }
                 Err(error) => {

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -400,9 +400,14 @@ mod tests {
             };
 
             let verify = || {
+                let expected_count = hash_map.read().unwrap().len();
                 let mut maps = maps
                     .iter()
                     .map(|map| {
+                        let total_entries = (0..map.num_buckets())
+                            .map(|bucket| map.get_bucket_from_index(bucket).bucket_len() as usize)
+                            .sum::<usize>();
+                        assert_eq!(total_entries, expected_count);
                         let mut r = vec![];
                         for bin in 0..map.num_buckets() {
                             r.append(


### PR DESCRIPTION
#### Problem
#31094 failed to update the count in the disk index after batch insertion.

Symptom of failure was `panic!` from `Vec::with_capacity`, trying to allocate too large of a vec based on an incorrect negative count.

#### Summary of Changes
Update the count correctly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
