### PR TITLE
validator: `--tpu-host-addr` -> `--public-tpu-address`

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3002,7 +3002,7 @@ impl Node {
         gossip_addr: &SocketAddr,
         port_range: PortRange,
         bind_ip_addr: IpAddr,
-        overwrite_tpu_addr: Option<SocketAddr>,
+        public_tpu_addr: Option<SocketAddr>,
     ) -> Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
@@ -3056,7 +3056,7 @@ impl Node {
         let _ = info.set_tvu((addr, tvu_port));
         let _ = info.set_tvu_forwards((addr, tvu_forwards_port));
         let _ = info.set_repair((addr, repair_port));
-        let _ = info.set_tpu(overwrite_tpu_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)));
+        let _ = info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)));
         let _ = info.set_tpu_forwards((addr, tpu_forwards_port));
         let _ = info.set_tpu_vote((addr, tpu_vote_port));
         let _ = info.set_serve_repair((addr, serve_repair_port));

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -372,8 +372,9 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]"),
         )
         .arg(
-            Arg::with_name("tpu_host_addr")
-                .long("tpu-host-addr")
+            Arg::with_name("public_tpu_addr")
+                .long("public-tpu-address")
+                .alias("tpu-host-addr")
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host_port)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1676,9 +1676,9 @@ pub fn main() {
         }),
     );
 
-    let overwrite_tpu_addr = matches.value_of("tpu_host_addr").map(|tpu_addr| {
-        solana_net_utils::parse_host_port(tpu_addr).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --overwrite-tpu-addr: {err}");
+    let public_tpu_addr = matches.value_of("public_tpu_addr").map(|public_tpu_addr| {
+        solana_net_utils::parse_host_port(public_tpu_addr).unwrap_or_else(|err| {
+            eprintln!("Failed to parse --public-tpu-address: {err}");
             exit(1);
         })
     });
@@ -1693,7 +1693,7 @@ pub fn main() {
         &gossip_addr,
         dynamic_port_range,
         bind_address,
-        overwrite_tpu_addr,
+        public_tpu_addr,
     );
 
     if restricted_repair_only_mode {


### PR DESCRIPTION
#### Problem

`--tpu-host-addr` is not very clear and does not match other similar arguments

See https://github.com/solana-labs/solana/pull/30452#issuecomment-1475316593 and below

#### Summary of Changes

`--tpu-host-addr` arg has been renamed to `--public-tpu-address` (with an added alias)

