### PR TITLE
Retain usage counter on program upgrade

### DIFF
--- a/program-runtime/src/executor_cache.rs
+++ b/program-runtime/src/executor_cache.rs
@@ -63,13 +63,12 @@ impl TransactionExecutorCache {
             if delay_visibility_of_program_deployment {
                 // Place a tombstone in the cache so that
                 // we don't load the new version from the database as it should remain invisible
-                self.visible.insert(
-                    key,
-                    Arc::new(LoadedProgram::new_tombstone(
-                        current_slot,
-                        LoadedProgramType::DelayVisibility,
-                    )),
-                );
+                let tombstone =
+                    LoadedProgram::new_tombstone(current_slot, LoadedProgramType::DelayVisibility);
+                tombstone
+                    .usage_counter
+                    .store(executor.usage_counter.load(Relaxed), Relaxed);
+                self.visible.insert(key, Arc::new(tombstone));
             } else {
                 self.visible.insert(key, executor.clone());
             }


### PR DESCRIPTION
#### Problem
The usage count for the program resets when the program is upgraded. This could lead to unnecessary eviction of frequently used program on their upgrade.

#### Summary of Changes
Copy over the usage count to the upgraded program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
