### PR TITLE
ci: export channel info in buildkite pre-command

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -10,6 +10,14 @@ export PS4="++"
 # Restore target/ from the previous CI build on this machine
 #
 eval "$(ci/channel-info.sh)"
+export EDGE_CHANNEL
+export BETA_CHANNEL
+export BETA_CHANNEL_LATEST_TAG
+export STABLE_CHANNEL
+export STABLE_CHANNEL_LATEST_TAG
+export CHANNEL
+export CHANNEL_LATEST_TAG
+
 eval "$(ci/platform-tools-info.sh)"
 source "ci/rust-version.sh"
 HOST_RUST_VERSION="$rust_stable"


### PR DESCRIPTION
#### Problem

We need to do `eval "$(ci/channel-info.sh)"` everywhere to get the channel info. I think we can get rid of this in Buildkite by exporting them in the pre-command

#### Summary of Changes

export channel info in Buildkite's pre-command
