### PR TITLE
bpf_loader: move heap cost calculation inside create_vm! macro

### DIFF
--- a/programs/bpf_loader/src/allocator_bump.rs
+++ b/programs/bpf_loader/src/allocator_bump.rs
@@ -2,32 +2,24 @@
 
 use {
     solana_program_runtime::invoke_context::{Alloc, AllocErr},
-    solana_rbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     std::alloc::Layout,
 };
 
 #[derive(Debug)]
 pub struct BpfAllocator {
     #[allow(dead_code)]
-    heap: AlignedMemory<HOST_ALIGN>,
     start: u64,
     len: u64,
     pos: u64,
 }
 
 impl BpfAllocator {
-    pub fn new(heap: AlignedMemory<HOST_ALIGN>, virtual_address: u64) -> Self {
-        let len = heap.len() as u64;
+    pub fn new(len: u64, virtual_address: u64) -> Self {
         Self {
-            heap,
             start: virtual_address,
             len,
             pos: 0,
         }
-    }
-
-    pub fn heap_mut(&mut self) -> &mut AlignedMemory<HOST_ALIGN> {
-        &mut self.heap
     }
 }
 

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1502,15 +1502,13 @@ mod tests {
             &[0],
             &[1, 1]
         );
+        let heap = AlignedMemory::<{ solana_rbpf::ebpf::HOST_ALIGN }>::with_capacity(0);
         invoke_context
             .set_syscall_context(
                 true,
                 true,
                 vec![original_data_len],
-                Rc::new(RefCell::new(BpfAllocator::new(
-                    AlignedMemory::with_capacity(0),
-                    0,
-                ))),
+                Rc::new(RefCell::new(BpfAllocator::new(heap.len() as u64, 0))),
             )
             .unwrap();
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2310,7 +2310,10 @@ mod tests {
                     true,
                     true,
                     vec![],
-                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                    Rc::new(RefCell::new(BpfAllocator::new(
+                        heap.len() as u64,
+                        ebpf::MM_HEAP_START,
+                    ))),
                 )
                 .unwrap();
             let mut result = ProgramResult::Ok(0);
@@ -2370,7 +2373,10 @@ mod tests {
                     false,
                     true,
                     vec![],
-                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                    Rc::new(RefCell::new(BpfAllocator::new(
+                        heap.len() as u64,
+                        ebpf::MM_HEAP_START,
+                    ))),
                 )
                 .unwrap();
             for _ in 0..100 {
@@ -2420,7 +2426,10 @@ mod tests {
                     true,
                     true,
                     vec![],
-                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                    Rc::new(RefCell::new(BpfAllocator::new(
+                        heap.len() as u64,
+                        ebpf::MM_HEAP_START,
+                    ))),
                 )
                 .unwrap();
             for _ in 0..12 {
@@ -2472,7 +2481,10 @@ mod tests {
                     true,
                     true,
                     vec![],
-                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                    Rc::new(RefCell::new(BpfAllocator::new(
+                        heap.len() as u64,
+                        ebpf::MM_HEAP_START,
+                    ))),
                 )
                 .unwrap();
             let mut result = ProgramResult::Ok(0);

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -11,9 +11,7 @@ extern crate solana_bpf_loader_program;
 
 use {
     byteorder::{ByteOrder, LittleEndian, WriteBytesExt},
-    solana_bpf_loader_program::{
-        create_ebpf_vm, create_vm, serialization::serialize_parameters, syscalls::create_loader,
-    },
+    solana_bpf_loader_program::{serialization::serialize_parameters, syscalls::create_loader},
     solana_measure::measure::Measure,
     solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
     solana_rbpf::{

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -3,7 +3,7 @@ use {
     serde::{Deserialize, Serialize},
     serde_json::Result,
     solana_bpf_loader_program::{
-        create_ebpf_vm, create_vm, serialization::serialize_parameters, syscalls::create_loader,
+        create_ebpf_vm, serialization::serialize_parameters, syscalls::create_loader,
     },
     solana_program_runtime::{invoke_context::InvokeContext, with_mock_invoke_context},
     solana_rbpf::{


### PR DESCRIPTION
Move heap cost calculation inside create_ebpf_vm macro, so that it happens before the heap is allocated