### PR TITLE
Clear the account paths before constructing a bank from a snapshot dir

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1666,6 +1666,12 @@ pub fn bank_from_snapshot_dir(
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: &Arc<AtomicBool>,
 ) -> Result<(Bank, BankFromDirTimings)> {
+    // Clear the contents of the account paths run directories.  When constructing the bank, the appendvec
+    // files will be extracted from the snapshot hardlink directories into these run/ directories.
+    for path in account_paths {
+        delete_contents_of_path(path);
+    }
+
     let next_append_vec_id = Arc::new(AtomicAppendVecId::new(0));
 
     let (storage, measure_build_storage) = measure!(
@@ -5419,12 +5425,6 @@ mod tests {
 
         let bank_snapshot = get_highest_bank_snapshot(bank_snapshots_dir).unwrap();
         let account_paths = &bank.rc.accounts.accounts_db.paths;
-
-        // Clear the contents of the account paths run directories.  When constructing the bank, the appendvec
-        // files will be extracted from the snapshot hardlink directories into these run/ directories.
-        for path in account_paths {
-            delete_contents_of_path(path);
-        }
 
         let (bank_constructed, ..) = bank_from_snapshot_dir(
             account_paths,


### PR DESCRIPTION
#### Problem

bank_from_snapshot_dir requires cleaning the <account_path>.  It is cleaner to put this necessary cleaning into the function to avoid duplicate the cleaning code before each call.
This addresses the review comment.  https://github.com/solana-labs/solana/pull/31115#discussion_r1161915681


#### Summary of Changes
Added the cleaning code in the function bank_from_snapshot_dir
Removed the cleaning code in the test.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
