### PR TITLE
Push starting snapshot hashes in SnapshotGossipManager::new()

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -57,11 +57,9 @@ impl SnapshotPackagerService {
                     SnapshotGossipManager::new(
                         cluster_info,
                         max_full_snapshot_hashes,
+                        starting_snapshot_hashes,
                     )
                 );
-                if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
-                    snapshot_gossip_manager.push_starting_snapshot_hashes(starting_snapshot_hashes);
-                }
 
                 loop {
                     if exit.load(Ordering::Relaxed) {


### PR DESCRIPTION
#### Problem

Pushing the starting snapshot hashes is a bit clunky inside of SnapshotPackagerService. Instead, `SnapshotGossipManager::new()` could handle this.


#### Summary of Changes

Push starting snapshot hashes in SnapshotGossipManager::new()