### PR TITLE
Move reference-holding last_snapshot_storages from ABS to AHV

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -84,8 +84,6 @@ impl AccountsHashVerifier {
                         continue;
                     };
                     info!("handling accounts package: {accounts_package:?}");
-                    // Update the option, so the older one is released, causing the release of
-                    // its reference counts of the appendvecs
                     let snapshot_storages = accounts_package.snapshot_storages.clone();
                     let enqueued_time = accounts_package.enqueued.elapsed();
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -9,7 +9,7 @@ use {
     solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES},
     solana_measure::measure_us,
     solana_runtime::{
-        accounts_db::{AccountStorageEntry, CalcAccountsHashFlavor},
+        accounts_db::CalcAccountsHashFlavor,
         accounts_hash::{
             AccountsHash, AccountsHashEnum, CalcAccountsHashConfig, HashStats,
             IncrementalAccountsHash,
@@ -66,7 +66,7 @@ impl AccountsHashVerifier {
                 // To support fastboot, we must ensure the storages used in the latest POST snapshot are
                 // not recycled nor removed early.  Hold an Arc of their AppendVecs to prevent them from
                 // expiring.
-                let mut last_snapshot_storages: Option<Vec<Arc<AccountStorageEntry>>> = None;
+                let mut last_snapshot_storages = None;
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         break;

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -100,6 +100,20 @@ impl AccountsHashVerifier {
                         &snapshot_config,
                     ));
 
+                    // Done processing the current snapshot, so the current snapshot dir
+                    // has been converted to POST state.  It is the time to update
+                    // last_snapshot_storages to release the reference counts for the
+                    // previous POST snapshot dir, and save the new ones for the new
+                    // POST snapshot dir.
+                    last_snapshot_storages = Some(snapshot_storages);
+                    debug!(
+                        "Number of snapshot storages kept alive for fastboot: {}",
+                        last_snapshot_storages
+                            .as_ref()
+                            .map(|storages| storages.len())
+                            .unwrap_or(0)
+                    );
+
                     datapoint_info!(
                         "accounts_hash_verifier",
                         (
@@ -115,23 +129,9 @@ impl AccountsHashVerifier {
                         ("enqueued-time-us", enqueued_time.as_micros(), i64),
                         ("handling-time-us", handling_time_us, i64),
                     );
-
-                    // Done processing the current snapshot, so the current snapshot dir
-                    // has been converted to POST state.  It is the time to update
-                    // last_snapshot_storages to release the reference counts for the
-                    // previous POST snapshot dir, and save the new ones for the new
-                    // POST snapshot dir.
-                    last_snapshot_storages = Some(snapshot_storages);
-                    debug!(
-                        "Number of snapshot storages kept alive for fastboot: {}",
-                        last_snapshot_storages
-                            .as_ref()
-                            .map(|storages| storages.len())
-                            .unwrap_or(0)
-                    );
                 }
                 debug!(
-                    "Storages kept alive for fastboot: {}",
+                    "Number of snapshot storages kept alive for fastboot: {}",
                     last_snapshot_storages
                         .as_ref()
                         .map(|storages| storages.len())

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -84,8 +84,9 @@ impl AccountsHashVerifier {
                         continue;
                     };
                     info!("handling accounts package: {accounts_package:?}");
-                    let snapshot_storages = accounts_package.snapshot_storages.clone();
                     let enqueued_time = accounts_package.enqueued.elapsed();
+
+                    let snapshot_storages = accounts_package.snapshot_storages.clone();
 
                     let (_, handling_time_us) = measure_us!(Self::process_accounts_package(
                         accounts_package,


### PR DESCRIPTION
#### Problem
Constructing a bank should be done from a POST snapshot (to have the calculated hash).  So the reference counts should be held for the latest POST snapshot dir, not just the latest dir.  AHV is the right place, because it converts PRE to POST.

#### Summary of Changes
Move last_snapshot_storage from ABS to AHV
Remove storages cloning inside ABS, because there is no need to return a copy from handle_snapshot_request
There is a new cloning in AHV at the start of AHV handling a new accounts_package.  The total number of cloning is not changed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
