### PR TITLE
Cleans up imports in bootstrap.rs

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -14,9 +14,8 @@ use {
     solana_metrics::datapoint_info,
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::{
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_package::SnapshotType,
-        snapshot_utils::{self},
+        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::SnapshotType,
+        snapshot_utils,
     },
     solana_sdk::{
         clock::Slot,


### PR DESCRIPTION
#### Problem

I get a "warning" from my editor about the import line:

```rust
snapshot_utils::{self},
```

Because the `{self}` is not needed. Maybe this is a future clippy lint? Regardless, it's not the best.


#### Summary of Changes

Remove the `{self}` part.