### PR TITLE
Removes `base` from `IncrementalSnapshotHash`

### DIFF
--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -47,7 +47,7 @@ impl SnapshotGossipManager {
         if let Some(starting_incremental_snapshot_hash) = starting_snapshot_hashes.incremental {
             self.update_latest_incremental_snapshot_hash(
                 starting_incremental_snapshot_hash.hash,
-                starting_incremental_snapshot_hash.base.0,
+                starting_snapshot_hashes.full.hash.0,
             );
         }
         self.push_latest_snapshot_hashes_to_cluster();

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -236,7 +236,6 @@ fn bank_forks_from_snapshot(
     let starting_incremental_snapshot_hash =
         incremental_snapshot_archive_info.map(|incremental_snapshot_archive_info| {
             IncrementalSnapshotHash {
-                base: full_snapshot_hash.hash,
                 hash: (
                     incremental_snapshot_archive_info.slot(),
                     *incremental_snapshot_archive_info.hash(),

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -25,11 +25,9 @@ pub struct FullSnapshotHash {
 }
 
 /// Used by SnapshotPackagerService and SnapshotGossipManager, this struct adds type safety to
-/// ensure an incremental snapshot hash is pushed to the right CRDS.  `base` is the (full) snapshot
-/// this incremental snapshot (`hash`) is based on.
+/// ensure an incremental snapshot hash is pushed to the right CRDS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IncrementalSnapshotHash {
-    pub base: (Slot, SnapshotHash),
     pub hash: (Slot, SnapshotHash),
 }
 


### PR DESCRIPTION
#### Problem

The starting snapshot hashes have a full and incremental component. The incremental component currently has a 'base' field, which is always populated by the *full* snapshot's info. Since we always have the full snapshot, the base field does not actually give us any additional information (and now I think it might be more confusing to have the 'base' field at all).


#### Summary of Changes

Remove the `base` field from `IncrementalSnapshotHash`.