### PR TITLE
Refactors the Full/Incremental SnapshotHash types

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -731,7 +731,7 @@ impl Validator {
         let pruned_banks_request_handler = PrunedBanksRequestHandler {
             pruned_banks_receiver,
         };
-        let last_full_snapshot_slot = starting_snapshot_hashes.map(|x| x.full.hash.0);
+        let last_full_snapshot_slot = starting_snapshot_hashes.map(|x| x.full.0 .0);
         let accounts_background_service = AccountsBackgroundService::new(
             bank_forks.clone(),
             &exit,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3449,7 +3449,7 @@ fn main() {
                                 eprintln!("Unable to create incremental snapshot without a base full snapshot");
                                 exit(1);
                             }
-                            let full_snapshot_slot = starting_snapshot_hashes.unwrap().full.hash.0;
+                            let full_snapshot_slot = starting_snapshot_hashes.unwrap().full.0 .0;
                             if bank.slot() <= full_snapshot_slot {
                                 eprintln!(
                                     "Unable to create incremental snapshot: Slot must be greater than full snapshot slot. slot: {}, full snapshot slot: {}",

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -227,20 +227,16 @@ fn bank_forks_from_snapshot(
         deserialized_bank.set_shrink_paths(shrink_paths);
     }
 
-    let full_snapshot_hash = FullSnapshotHash {
-        hash: (
-            full_snapshot_archive_info.slot(),
-            *full_snapshot_archive_info.hash(),
-        ),
-    };
+    let full_snapshot_hash = FullSnapshotHash((
+        full_snapshot_archive_info.slot(),
+        *full_snapshot_archive_info.hash(),
+    ));
     let starting_incremental_snapshot_hash =
         incremental_snapshot_archive_info.map(|incremental_snapshot_archive_info| {
-            IncrementalSnapshotHash {
-                hash: (
-                    incremental_snapshot_archive_info.slot(),
-                    *incremental_snapshot_archive_info.hash(),
-                ),
-            }
+            IncrementalSnapshotHash((
+                incremental_snapshot_archive_info.slot(),
+                *incremental_snapshot_archive_info.hash(),
+            ))
         });
     let starting_snapshot_hashes = StartingSnapshotHashes {
         full: full_snapshot_hash,

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -20,32 +20,12 @@ pub struct StartingSnapshotHashes {
 /// Used by SnapshotPackagerService and SnapshotGossipManager, this struct adds type safety to
 /// ensure a full snapshot hash is pushed to the right CRDS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FullSnapshotHash {
-    pub hash: (Slot, SnapshotHash),
-}
+pub struct FullSnapshotHash(pub (Slot, SnapshotHash));
 
 /// Used by SnapshotPackagerService and SnapshotGossipManager, this struct adds type safety to
 /// ensure an incremental snapshot hash is pushed to the right CRDS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IncrementalSnapshotHash {
-    pub hash: (Slot, SnapshotHash),
-}
-
-/// FullSnapshotHashes is used by SnapshotPackagerService to collect the snapshot hashes from full
-/// snapshots and then push those hashes to CRDS.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FullSnapshotHashes {
-    pub hashes: Vec<(Slot, SnapshotHash)>,
-}
-
-/// IncrementalSnapshotHashes is used by SnapshotPackagerService to collect the snapshot hashes
-/// from incremental snapshots and then push those hashes to CRDS.  `base` is the (full) snapshot
-/// all the incremental snapshots (`hashes`) are based on.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IncrementalSnapshotHashes {
-    pub base: (Slot, SnapshotHash),
-    pub hashes: Vec<(Slot, SnapshotHash)>,
-}
+pub struct IncrementalSnapshotHash(pub (Slot, SnapshotHash));
 
 /// The hash used for snapshot archives
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
#### Problem

In previous refactoring PRs, SnapshotGossipManager went from using strong types (`FullSnapshotHash` and `IncrementalSnapshotHash`) for everything, to only using it for the legacy snapshot hashes. Lets get back to those strong types to make it impossible to mix up sending full and incremental snapshot hashes around.


#### Summary of Changes

* Refactor `FullSnapshotHash` and `IncrementalSnapshotHash` to be tuple-structs
* Use these new types within SGM for the (non-legacy) SnapshotHashes
* Remove the no-longer-used `FullSnapshotHashes` and `IncrementalSnapshotHashes` (note the plural in the name)

I really wanted to split this PR up into smaller pieces, but they kind of all intermix. Since there's no behavior change (just refactoring), I'm hoping that's OK. Happy to answer any comments/questions too!

(This it the last refactoring PR for SGM too, yay!)