### PR TITLE
store slot on BlockBatchUpdate

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -441,7 +441,7 @@ impl Consumer {
         self.qos_service.accumulate_actual_execute_time(us);
 
         // reports qos service stats for this batch
-        self.qos_service.report_metrics(bank.clone());
+        self.qos_service.report_metrics(bank.slot());
 
         debug!(
             "bank: {} lock: {}us unlock: {}us txs_len: {}",

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -28,7 +28,7 @@ use {
 };
 
 pub enum QosMetrics {
-    BlockBatchUpdate { bank: Arc<Bank> },
+    BlockBatchUpdate { slot: Slot },
 }
 
 // QosService is local to each banking thread, each instance of QosService provides services to
@@ -244,9 +244,9 @@ impl QosService {
     }
 
     // metrics are reported by bank slot
-    pub fn report_metrics(&self, bank: Arc<Bank>) {
+    pub fn report_metrics(&self, slot: Slot) {
         self.report_sender
-            .send(QosMetrics::BlockBatchUpdate { bank })
+            .send(QosMetrics::BlockBatchUpdate { slot })
             .unwrap_or_else(|err| warn!("qos service report metrics failed: {:?}", err));
     }
 
@@ -427,8 +427,8 @@ impl QosService {
         while running_flag.load(Ordering::Relaxed) {
             for qos_metrics in report_receiver.try_iter() {
                 match qos_metrics {
-                    QosMetrics::BlockBatchUpdate { bank } => {
-                        metrics.report(bank.slot());
+                    QosMetrics::BlockBatchUpdate { slot: bank_slot } => {
+                        metrics.report(bank_slot);
                     }
                 }
             }

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -33,9 +33,9 @@ pub enum QosMetrics {
 
 // QosService is local to each banking thread, each instance of QosService provides services to
 // one banking thread.
-// It hosts a private thread for async metrics reporting, tagged with banking thredas ID. Banking
-// threda calls `report_metrics(&bank)` at end of `process_and_record_tramsaction()`, or any time
-// it wants, QosService sends `&bank` to reporting thread via channel, signalling stats to be
+// It hosts a private thread for async metrics reporting, tagged with banking threads ID. Banking
+// thread calls `report_metrics(slot)` at end of `process_and_record_tramsaction()`, or any time
+// it wants, QosService sends `slot` to reporting thread via channel, signalling stats to be
 // reported if new bank slot has changed.
 //
 pub struct QosService {


### PR DESCRIPTION
#### Problem
We don't need to pass the entire bank, just the slot.

Context: Looking around for places an `Arc<Bank>` could get stuck.

#### Summary of Changes
`BlockBatchUpdate` wraps a `Slot` instead of `Arc<Bank>`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
