### PR TITLE
Add a filter_by_type param for purge_old_bank_snapshots

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -473,7 +473,7 @@ fn test_concurrent_snapshot_packaging(
 
     // Purge all the outdated snapshots, including the ones needed to generate the package
     // currently sitting in the channel
-    snapshot_utils::purge_old_bank_snapshots(bank_snapshots_dir, MAX_BANK_SNAPSHOTS_TO_RETAIN);
+    snapshot_utils::purge_old_bank_snapshots(bank_snapshots_dir, MAX_BANK_SNAPSHOTS_TO_RETAIN, None);
 
     let mut bank_snapshots = snapshot_utils::get_bank_snapshots_pre(bank_snapshots_dir);
     bank_snapshots.sort_unstable();

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -473,7 +473,11 @@ fn test_concurrent_snapshot_packaging(
 
     // Purge all the outdated snapshots, including the ones needed to generate the package
     // currently sitting in the channel
-    snapshot_utils::purge_old_bank_snapshots(bank_snapshots_dir, MAX_BANK_SNAPSHOTS_TO_RETAIN, None);
+    snapshot_utils::purge_old_bank_snapshots(
+        bank_snapshots_dir,
+        MAX_BANK_SNAPSHOTS_TO_RETAIN,
+        None,
+    );
 
     let mut bank_snapshots = snapshot_utils::get_bank_snapshots_pre(bank_snapshots_dir);
     bank_snapshots.sort_unstable();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1102,7 +1102,11 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     // To restart, it is not enough to remove the old bank snapshot directories under snapshot/.
     // The old hardlinks under <account_path>/snapshot/<slot> should also be removed.
     // The purge call covers all of them.
-    snapshot_utils::purge_old_bank_snapshots(validator_snapshot_test_config.bank_snapshots_dir, 0, None);
+    snapshot_utils::purge_old_bank_snapshots(
+        validator_snapshot_test_config.bank_snapshots_dir,
+        0,
+        None,
+    );
     cluster.restart_node(
         &validator_identity.pubkey(),
         validator_info,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1102,7 +1102,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     // To restart, it is not enough to remove the old bank snapshot directories under snapshot/.
     // The old hardlinks under <account_path>/snapshot/<slot> should also be removed.
     // The purge call covers all of them.
-    snapshot_utils::purge_old_bank_snapshots(validator_snapshot_test_config.bank_snapshots_dir, 0);
+    snapshot_utils::purge_old_bank_snapshots(validator_snapshot_test_config.bank_snapshots_dir, 0, None);
     cluster.restart_node(
         &validator_identity.pubkey(),
         validator_info,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -402,6 +402,7 @@ impl SnapshotRequestHandler {
         snapshot_utils::purge_old_bank_snapshots(
             &self.snapshot_config.bank_snapshots_dir,
             MAX_BANK_SNAPSHOTS_TO_RETAIN,
+            None,
         );
         purge_old_snapshots_time.stop();
         total_time.stop();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2936,7 +2936,7 @@ pub fn verify_snapshot_archive<P, Q, R>(
 pub fn purge_old_bank_snapshots(
     bank_snapshots_dir: impl AsRef<Path>,
     num_bank_snapshots_to_retain: usize,
-    type_select: Option<BankSnapshotType>,
+    filter_by_type: Option<BankSnapshotType>,
 ) {
     let do_purge = |mut bank_snapshots: Vec<BankSnapshotInfo>| {
         bank_snapshots.sort_unstable();
@@ -2957,7 +2957,7 @@ pub fn purge_old_bank_snapshots(
 
     let mut select_pre = false;
     let mut select_post = false;
-    match type_select {
+    match filter_by_type {
         Some(BankSnapshotType::Pre) => {
             select_pre = true;
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5128,6 +5128,8 @@ mod tests {
         num_total: usize,
         num_posts: usize,
     ) -> Bank {
+        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
+
         let collecter_id = Pubkey::new_unique();
         let snapshot_version = SnapshotVersion::default();
 
@@ -5177,8 +5179,6 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 4, 0);
 
-=======
->>>>>>> f9b76e846c (Let bank_snapshots_dir be TempDir)
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 4);
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2955,24 +2955,10 @@ pub fn purge_old_bank_snapshots(
             })
     };
 
-    let mut select_pre = false;
-    let mut select_post = false;
-    match filter_by_type {
-        Some(BankSnapshotType::Pre) => {
-            select_pre = true;
-        }
-        Some(BankSnapshotType::Post) => {
-            select_post = true;
-        }
-        None => {
-            select_pre = true;
-            select_post = true;
-        }
-    }
-    if select_pre {
+    if matches!(filter_by_type, Some(BankSnapshotType::Pre) | None) {
         do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
     }
-    if select_post {
+    if matches!(filter_by_type, Some(BankSnapshotType::Post) | None) {
         do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2955,12 +2955,12 @@ pub fn purge_old_bank_snapshots(
             })
     };
 
-    if matches!(filter_by_type, Some(BankSnapshotType::Pre) | None) {
-        do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
-    }
-    if matches!(filter_by_type, Some(BankSnapshotType::Post) | None) {
-        do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
-    }
+    let bank_snapshots = match filter_by_type {
+        Some(BankSnapshotType::Pre) => get_bank_snapshots_pre(&bank_snapshots_dir),
+        Some(BankSnapshotType::Post) => get_bank_snapshots_post(&bank_snapshots_dir),
+        None => get_bank_snapshots(&bank_snapshots_dir),
+    };
+    do_purge(bank_snapshots);
 }
 
 /// Get the snapshot storages for this bank
@@ -5616,8 +5616,7 @@ mod tests {
         assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 5);
 
         purge_old_bank_snapshots(bank_snapshots_dir, 2, None);
-        // In the current implementation num_bank_snapshots_to_retain is really per type, so 2 PREs and 2 POSTs are retained
-        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 4);
+        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 2);
 
         purge_old_bank_snapshots(bank_snapshots_dir, 0, None);
         assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 0);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2955,17 +2955,27 @@ pub fn purge_old_bank_snapshots(
             })
     };
 
+    let mut select_pre = false;
+    let mut select_post = false;
     match type_select {
         Some(BankSnapshotType::Pre) => {
+            select_pre = true;
             do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
         }
         Some(BankSnapshotType::Post) => {
+            select_post = true;
             do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
         }
         None => {
-            do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
-            do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
+            select_pre = true;
+            select_post = true;
         }
+    }
+    if select_pre {
+        do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
+    }
+    if select_post {
+        do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
     }
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5600,8 +5600,6 @@ mod tests {
         let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
-        let account_paths = &bank.rc.accounts.accounts_db.paths;
-        info!("account_paths: {:?}", account_paths);
 
         assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 10);
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2936,6 +2936,7 @@ pub fn verify_snapshot_archive<P, Q, R>(
 pub fn purge_old_bank_snapshots(
     bank_snapshots_dir: impl AsRef<Path>,
     num_bank_snapshots_to_retain: usize,
+    type_select: Option<BankSnapshotType>,
 ) {
     let do_purge = |mut bank_snapshots: Vec<BankSnapshotInfo>| {
         bank_snapshots.sort_unstable();
@@ -2954,8 +2955,18 @@ pub fn purge_old_bank_snapshots(
             })
     };
 
-    do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
-    do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
+    match type_select {
+        Some(BankSnapshotType::Pre) => {
+            do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
+        }
+        Some(BankSnapshotType::Post) => {
+            do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
+        }
+        None => {
+            do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
+            do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
+        }
+    }
 }
 
 /// Get the snapshot storages for this bank

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5597,7 +5597,7 @@ mod tests {
 
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5128,8 +5128,6 @@ mod tests {
         num_total: usize,
         num_posts: usize,
     ) -> Bank {
-        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
-
         let collecter_id = Pubkey::new_unique();
         let snapshot_version = SnapshotVersion::default();
 
@@ -5179,6 +5177,8 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 4, 0);
 
+=======
+>>>>>>> f9b76e846c (Let bank_snapshots_dir be TempDir)
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 4);
 
@@ -5563,9 +5563,8 @@ mod tests {
         solana_logger::setup();
 
         let genesis_config = GenesisConfig::default();
-        let tmp_dir = tempfile::TempDir::new().unwrap();
-        let bank_snapshots_dir = tmp_dir.path();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, bank_snapshots_dir, 3, 3);
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, 3);
 
         let account_paths = &bank.rc.accounts.accounts_db.paths;
 
@@ -5597,28 +5596,27 @@ mod tests {
         solana_logger::setup();
 
         let genesis_config = GenesisConfig::default();
-        let tmp_dir = tempfile::TempDir::new().unwrap();
-        let bank_snapshots_dir = tmp_dir.path();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, bank_snapshots_dir, 10, 5);
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
         let account_paths = &bank.rc.accounts.accounts_db.paths;
         info!("account_paths: {:?}", account_paths);
 
-        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 10);
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 10);
 
-        purge_old_bank_snapshots(bank_snapshots_dir, 3, Some(BankSnapshotType::Pre));
-        assert_eq!(get_bank_snapshots_pre(bank_snapshots_dir).len(), 3);
+        purge_old_bank_snapshots(&bank_snapshots_dir, 3, Some(BankSnapshotType::Pre));
+        assert_eq!(get_bank_snapshots_pre(&bank_snapshots_dir).len(), 3);
 
-        purge_old_bank_snapshots(bank_snapshots_dir, 2, Some(BankSnapshotType::Post));
-        assert_eq!(get_bank_snapshots_post(bank_snapshots_dir).len(), 2);
+        purge_old_bank_snapshots(&bank_snapshots_dir, 2, Some(BankSnapshotType::Post));
+        assert_eq!(get_bank_snapshots_post(&bank_snapshots_dir).len(), 2);
 
-        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 5);
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 5);
 
-        purge_old_bank_snapshots(bank_snapshots_dir, 2, None);
-        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 2);
+        purge_old_bank_snapshots(&bank_snapshots_dir, 2, None);
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 2);
 
-        purge_old_bank_snapshots(bank_snapshots_dir, 0, None);
-        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 0);
+        purge_old_bank_snapshots(&bank_snapshots_dir, 0, None);
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 0);
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2960,11 +2960,9 @@ pub fn purge_old_bank_snapshots(
     match type_select {
         Some(BankSnapshotType::Pre) => {
             select_pre = true;
-            do_purge(get_bank_snapshots_pre(&bank_snapshots_dir));
         }
         Some(BankSnapshotType::Post) => {
             select_post = true;
-            do_purge(get_bank_snapshots_post(&bank_snapshots_dir));
         }
         None => {
             select_pre = true;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5508,56 +5508,6 @@ mod tests {
         assert_eq!(max_id, next_id - 1);
     }
 
-    fn create_snapshot_dirs_for_tests(
-        genesis_config: &GenesisConfig,
-        bank_snapshots_dir: impl AsRef<Path>,
-        num_total: usize,
-        num_posts: usize,
-    ) -> Bank {
-        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
-
-        let collecter_id = Pubkey::new_unique();
-        let snapshot_version = SnapshotVersion::default();
-
-        // loop to create the banks at slot 1 to num_total
-        for _ in 0..num_total {
-            // prepare the bank
-            bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
-            bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
-
-            // generate the bank snapshot directory for slot+1
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-            add_bank_snapshot(
-                &bank_snapshots_dir,
-                &bank,
-                &snapshot_storages,
-                snapshot_version,
-                slot_deltas,
-            )
-            .unwrap();
-
-            if bank.slot() as usize > num_posts {
-                continue; // leave the snapshot dir at PRE stage
-            }
-
-            // Reserialize the snapshot dir to convert it from PRE to POST, because only the POST type can be used
-            // to construct a bank.
-            assert!(
-                crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                    &bank_snapshots_dir,
-                    bank.slot(),
-                    &AccountsHash(Hash::new_unique()),
-                    None
-                )
-            );
-        }
-
-        Arc::try_unwrap(bank).unwrap()
-    }
-
     #[test]
     fn test_bank_from_latest_snapshot_dir() {
         solana_logger::setup();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5514,7 +5514,7 @@ mod tests {
         num_total: usize,
         num_posts: usize,
     ) -> Bank {
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
 
         let collecter_id = Pubkey::new_unique();
         let snapshot_version = SnapshotVersion::default();
@@ -5565,7 +5565,7 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let bank_snapshots_dir = tmp_dir.path();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, 3);
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, bank_snapshots_dir, 3, 3);
 
         let account_paths = &bank.rc.accounts.accounts_db.paths;
 
@@ -5599,27 +5599,27 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let bank_snapshots_dir = tmp_dir.path();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, bank_snapshots_dir, 10, 5);
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
         let account_paths = &bank.rc.accounts.accounts_db.paths;
         info!("account_paths: {:?}", account_paths);
 
-        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 10);
+        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 10);
 
-        purge_old_bank_snapshots(&bank_snapshots_dir, 3, Some(BankSnapshotType::Pre));
-        assert_eq!(get_bank_snapshots_pre(&bank_snapshots_dir).len(), 3);
+        purge_old_bank_snapshots(bank_snapshots_dir, 3, Some(BankSnapshotType::Pre));
+        assert_eq!(get_bank_snapshots_pre(bank_snapshots_dir).len(), 3);
 
-        purge_old_bank_snapshots(&bank_snapshots_dir, 2, Some(BankSnapshotType::Post));
-        assert_eq!(get_bank_snapshots_post(&bank_snapshots_dir).len(), 2);
+        purge_old_bank_snapshots(bank_snapshots_dir, 2, Some(BankSnapshotType::Post));
+        assert_eq!(get_bank_snapshots_post(bank_snapshots_dir).len(), 2);
 
-        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 5);
+        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 5);
 
-        purge_old_bank_snapshots(&bank_snapshots_dir, 2, None);
+        purge_old_bank_snapshots(bank_snapshots_dir, 2, None);
         // In the current implementation num_bank_snapshots_to_retain is really per type, so 2 PREs and 2 POSTs are retained
-        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 4);
+        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 4);
 
-        purge_old_bank_snapshots(&bank_snapshots_dir, 0, None);
-        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 0);
+        purge_old_bank_snapshots(bank_snapshots_dir, 0, None);
+        assert_eq!(get_bank_snapshots(bank_snapshots_dir).len(), 0);
     }
 }


### PR DESCRIPTION
#### Problem
In https://github.com/solana-labs/solana/pull/30978, we need more refined control of the snapshot dir purging behavior.
Before booting, we want to purge all PRE snapshot dirs.
During run time, we should purge only the POST snapshot dirs, letting AHV to process PRE snapshot dirs into POST.

#### Summary of Changes
Add the filter_by_type param.  Call purging by type.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
