### PR TITLE
Add a hidden flag to keygen pubkey subcommand.

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -538,6 +538,13 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .long("force")
                         .help("Overwrite the output file if it exists"),
                 )
+                .arg(
+                    Arg::new("confirm_key")
+                        .long("confirm-key")
+                        .takes_value(false)
+                        .hide(true)
+                        .help("Confirm key on device; only relevant if using remote wallet"),
+                ),
         )
         .subcommand(
             Command::new("recover")


### PR DESCRIPTION
#### Problem

The flag named confirm_key is checked in clap-v3-utils when pubkey is read from a remote ledger. Missing this flag triggers an error.

#### Summary of Changes

This change adds the flag as a hidden arg to resolve the error.
