### PR TITLE
Rewards Optimization: Optimize Epoch Reward Compute Code - no join of vote accounts with stake accounts

### DIFF
--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -35,8 +35,6 @@ use {
 
 #[test]
 fn test_stake_redelegation() {
-    //solana_logger::setup();
-
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let authorized_withdrawer = Keypair::new().pubkey();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -35,6 +35,8 @@ use {
 
 #[test]
 fn test_stake_redelegation() {
+    //solana_logger::setup();
+
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let authorized_withdrawer = Keypair::new().pubkey();

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -286,7 +286,7 @@ async fn stake_rewards_filter_bench_100() {
 
 #[tokio::test]
 async fn stake_rewards_bench_550_k() {
-    stake_rewards_filter_bench_core(55 * 1000, false).await;
+    stake_rewards_filter_bench_core(550_000, false).await;
 }
 
 async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) {
@@ -316,7 +316,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) 
             &vote_address,
             &vote_account,
             &Rent::default(),
-            TEST_FILTER_STAKE,
+            lamports,
         ));
         program_test.add_account(stake_pubkey, stake_account);
         if lamports == TEST_FILTER_STAKE {

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -285,7 +285,7 @@ async fn stake_rewards_filter_bench_100() {
 }
 
 #[tokio::test]
-async fn stake_rewards_bench_550_K() {
+async fn stake_rewards_bench_550_k() {
     stake_rewards_filter_bench_core(55 * 1000, false).await;
 }
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -285,7 +285,7 @@ async fn stake_rewards_filter_bench_100() {
 }
 
 #[tokio::test]
-async fn stake_rewards_filter_bench_550_K() {
+async fn stake_rewards_bench_550_K() {
     stake_rewards_filter_bench_core(55 * 1000, false).await;
 }
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -281,7 +281,7 @@ async fn stake_rewards_from_warp() {
 
 #[tokio::test]
 async fn stake_rewards_filter_bench_100() {
-    stake_rewards_filter_bench_core(100).await;
+    stake_rewards_filter_bench_core(550 * 1000).await;
 }
 
 async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
@@ -296,7 +296,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
     program_test.add_account(vote_address, vote_account.clone().into());
 
     // create stake accounts with 0.9 sol to test min-stake filtering
-    const TEST_FILTER_STAKE: u64 = 900_000_000; // 0.9 sol
+    const TEST_FILTER_STAKE: u64 = 99900_000_000; // 0.9 sol
     let mut to_filter = vec![];
     for i in 0..num_stake_accounts {
         let stake_pubkey = Pubkey::new_unique();
@@ -357,16 +357,16 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         .unwrap();
     assert!(account.lamports > stake_lamports);
 
-    // check that filtered stake accounts are excluded from receiving epoch rewards
-    for stake_address in to_filter {
-        let account = context
-            .banks_client
-            .get_account(stake_address)
-            .await
-            .expect("account exists")
-            .unwrap();
-        assert_eq!(account.lamports, TEST_FILTER_STAKE);
-    }
+    // // check that filtered stake accounts are excluded from receiving epoch rewards
+    // for stake_address in to_filter {
+    //     let account = context
+    //         .banks_client
+    //         .get_account(stake_address)
+    //         .await
+    //         .expect("account exists")
+    //         .unwrap();
+    //     assert_eq!(account.lamports, TEST_FILTER_STAKE);
+    // }
 
     // check that stake is fully active
     let stake_history_account = context

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -302,7 +302,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) 
 
     // create stake accounts with 0.9 sol to test min-stake filtering
     const TEST_FILTER_STAKE: u64 = 900_000_000; // 0.9 sol
-    const TEST_UNFILTER_STAKE: u64 = 1100_000_000; // 1.1 sol
+    const TEST_UNFILTER_STAKE: u64 = 1_100_000_000; // 1.1 sol
     let mut to_filter = vec![];
     for i in 0..num_stake_accounts {
         let stake_pubkey = Pubkey::new_unique();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1106,7 +1106,7 @@ struct LoadVoteAndStakeAccountsResult {
 type VoteRewards = DashMap<Pubkey, (AccountSharedData, u8, u64, bool)>;
 type StakeRewards = Vec<StakeReward>;
 
-struct EpochRewardCalculatePramInfo<'a> {
+struct EpochRewardCalculateParamInfo<'a> {
     stake_history: StakeHistory,
     stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
     cached_vote_accounts: &'a VoteAccounts,
@@ -2818,14 +2818,14 @@ impl Bank {
     fn get_epoch_reward_calculate_param_info<'a>(
         &self,
         stakes: &'a Stakes<StakeAccount<Delegation>>,
-    ) -> EpochRewardCalculatePramInfo<'a> {
+    ) -> EpochRewardCalculateParamInfo<'a> {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
         let stake_delegations = self.filter_stake_delegations(&stakes);
 
         let cached_vote_accounts = stakes.vote_accounts();
 
-        EpochRewardCalculatePramInfo {
+        EpochRewardCalculateParamInfo {
             stake_history: stake_history,
             stake_delegations,
             cached_vote_accounts: cached_vote_accounts,
@@ -2953,12 +2953,12 @@ impl Bank {
 
     fn calculate_reward_points2<'a>(
         &self,
-        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
         rewards: u64,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
-        let EpochRewardCalculatePramInfo {
+        let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
             cached_vote_accounts,
@@ -3054,7 +3054,7 @@ impl Bank {
 
     fn redeem_rewards2<'a>(
         &self,
-        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
@@ -3062,7 +3062,7 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
-        let EpochRewardCalculatePramInfo {
+        let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
             cached_vote_accounts,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2416,8 +2416,6 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        println!("haha start rewarding");
-
         if self
             .feature_set
             .is_active(&feature_set::update_rewards_no_join::id())
@@ -2441,7 +2439,6 @@ impl Bank {
                 update_rewards_from_cached_accounts,
             );
         }
-        println!("haha end rewarding");
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
@@ -2851,10 +2848,7 @@ impl Bank {
         let point_value =
             self.calculate_reward_points2(&reward_calculate_param, rewards, thread_pool, metrics);
 
-        println!("haha point_value: {:?}", point_value);
-
         if let Some(point_value) = point_value {
-            println!("haha redeem start");
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
                 &reward_calculate_param,
                 rewarded_epoch,
@@ -2898,8 +2892,6 @@ impl Bank {
             metrics,
         );
 
-        println!("haha point_value: {:?}", point_value);
-
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
                 vote_with_stake_delegations_map,
@@ -2911,7 +2903,6 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
-            println!("haha redeem end");
 
             drop(reward_calculate_param);
             drop(stakes);
@@ -3265,8 +3256,6 @@ impl Bank {
     }
 
     fn store_stake_accounts(&self, stake_rewards: &[StakeReward], metrics: &mut RewardsMetrics) {
-        println!("haha store stake start: {}", stake_rewards.len());
-
         // store stake account even if stake_reward is 0
         // because credits observed has changed
         let (_, measure) = measure!({
@@ -3275,8 +3264,6 @@ impl Bank {
         metrics
             .store_stake_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
-
-        println!("haha store stake end");
     }
 
     fn store_vote_accounts(
@@ -3284,8 +3271,6 @@ impl Bank {
         vote_account_rewards: VoteRewards,
         metrics: &mut RewardsMetrics,
     ) -> Vec<(Pubkey, RewardInfo)> {
-        println!("haha store vote start");
-
         let (vote_rewards, measure) = measure!(vote_account_rewards
             .into_iter()
             .filter_map(
@@ -3315,8 +3300,6 @@ impl Bank {
         metrics
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
-
-        println!("haha store vote end: {}", vote_rewards.len());
 
         vote_rewards
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2409,7 +2409,17 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        self.pay_validator_rewards_with_thread_pool(
+        // self.pay_validator_rewards_with_thread_pool(
+        //     prev_epoch,
+        //     validator_rewards,
+        //     reward_calc_tracer,
+        //     self.credits_auto_rewind(),
+        //     thread_pool,
+        //     metrics,
+        //     update_rewards_from_cached_accounts,
+        // );
+
+        self.pay_validator_rewards_with_thread_pool2(
             prev_epoch,
             validator_rewards,
             reward_calc_tracer,
@@ -2795,6 +2805,49 @@ impl Bank {
     }
 
     /// Load, calculate and payout epoch rewards for stake and vote accounts
+    fn pay_validator_rewards_with_thread_pool2(
+        &mut self,
+        rewarded_epoch: Epoch,
+        rewards: u64,
+        reward_calc_tracer: Option<impl RewardCalcTracer>,
+        credits_auto_rewind: bool,
+        thread_pool: &ThreadPool,
+        metrics: &mut RewardsMetrics,
+        _update_rewards_from_cached_accounts: bool,
+    ) {
+        let point_value = self.calculate_reward_points2(rewards, thread_pool, metrics);
+
+        if let Some(point_value) = point_value {
+            info!("haha start redeem_rewards2");
+            let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
+                rewarded_epoch,
+                point_value,
+                credits_auto_rewind,
+                thread_pool,
+                reward_calc_tracer.as_ref(),
+                metrics,
+            );
+
+            self.store_stake_accounts(&stake_rewards, metrics);
+            let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
+            self.update_reward_history(stake_rewards, vote_rewards);
+
+            // let mut rewards = self.redeem_rewards2(
+            //     rewarded_epoch,
+            //     point_value,
+            //     credits_auto_rewind,
+            //     thread_pool,
+            //     reward_calc_tracer.as_ref(),
+            //     metrics,
+            // );
+            info!("haha finish redeem_rewards2");
+
+            //info!("rewards_len: {}", rewards.len());
+            //self.update_reward_history2(&mut rewards);
+        }
+    }
+
+    /// Load, calculate and payout epoch rewards for stake and vote accounts
     fn pay_validator_rewards_with_thread_pool(
         &mut self,
         rewarded_epoch: Epoch,
@@ -2819,11 +2872,11 @@ impl Bank {
             metrics,
         );
 
-        let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
+        // let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
 
-        assert!(point_value == point_value2);
+        // assert!(point_value == point_value2);
 
-        info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
+        // info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
 
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
@@ -2836,39 +2889,39 @@ impl Bank {
                 metrics,
             );
 
-            let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
-                rewarded_epoch,
-                point_value2.unwrap(),
-                credits_auto_rewind,
-                thread_pool,
-                reward_calc_tracer.as_ref(),
-                metrics,
-            );
+            // let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
+            //     rewarded_epoch,
+            //     point_value2.unwrap(),
+            //     credits_auto_rewind,
+            //     thread_pool,
+            //     reward_calc_tracer.as_ref(),
+            //     metrics,
+            // );
 
-            info!(
-                "vote_account_rewards_len: {}, {}",
-                vote_account_rewards.len(),
-                vote_account_rewards2.len()
-            );
+            // info!(
+            //     "vote_account_rewards_len: {}, {}",
+            //     vote_account_rewards.len(),
+            //     vote_account_rewards2.len()
+            // );
 
-            info!(
-                "vote_account_rewards: {:?}, {:?}",
-                vote_account_rewards, vote_account_rewards2
-            );
+            // info!(
+            //     "vote_account_rewards: {:?}, {:?}",
+            //     vote_account_rewards, vote_account_rewards2
+            // );
 
-            info!(
-                "stake_rewards_len: {}, {}",
-                stake_rewards.len(),
-                stake_rewards2.len()
-            );
+            // info!(
+            //     "stake_rewards_len: {}, {}",
+            //     stake_rewards.len(),
+            //     stake_rewards2.len()
+            // );
 
-            let vote_len1: usize = vote_account_rewards
-                .iter()
-                .map(|I| if I.3 { 1 } else { 0 })
-                .sum();
+            // let vote_len1: usize = vote_account_rewards
+            //     .iter()
+            //     .map(|I| if I.3 { 1 } else { 0 })
+            //     .sum();
 
-            assert!(vote_len1 == vote_account_rewards2.len());
-            assert!(stake_rewards.len() == stake_rewards2.len());
+            // assert!(vote_len1 == vote_account_rewards2.len());
+            // assert!(stake_rewards.len() == stake_rewards2.len());
 
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
@@ -3025,6 +3078,7 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
+        //) -> Vec<(Pubkey, RewardInfo)> {
     ) -> (VoteRewards, StakeRewards) {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
@@ -3043,7 +3097,7 @@ impl Bank {
         };
 
         let vote_account_rewards: VoteRewards = DashMap::new();
-        let (stake_rewards, measure) = measure!(thread_pool.install(|| {
+        let (mut stake_rewards, measure) = measure!(thread_pool.install(|| {
             stake_delegations
                 .par_iter()
                 .filter_map(|(stake_pubkey, stake_account)| {
@@ -3120,9 +3174,14 @@ impl Bank {
                     None
                 })
                 .collect()
+            //.collect::<Vec<(Pubkey, RewardInfo)>>()
         }));
         metrics.redeem_rewards2_us += measure.as_us();
         (vote_account_rewards, stake_rewards)
+
+        //let mut rewards = self.store_vote_accounts(vote_account_rewards, metrics);
+        //rewards.append(&mut stake_rewards);
+        //rewards
     }
 
     fn redeem_rewards(
@@ -3201,6 +3260,18 @@ impl Bank {
                             },
                             stake_account,
                         });
+
+                        //self.store_account(&stake_pubkey, &stake_account);
+
+                        // (stakers_reward > 0).then_some((
+                        //     stake_pubkey,
+                        //     RewardInfo {
+                        //         reward_type: RewardType::Staking,
+                        //         lamports: i64::try_from(stakers_reward).unwrap(),
+                        //         post_balance,
+                        //         commission: Some(vote_state.commission),
+                        //     },
+                        // ));
                     } else {
                         debug!(
                             "stake_state::redeem_rewards() failed for {}: {:?}",
@@ -3261,6 +3332,13 @@ impl Bank {
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
         vote_rewards
+    }
+
+    fn update_reward_history2(&self, new_rewards: &mut Vec<(Pubkey, RewardInfo)>) {
+        let additional_reserve = new_rewards.len();
+        let mut rewards = self.rewards.write().unwrap();
+        rewards.reserve(additional_reserve);
+        rewards.append(new_rewards);
     }
 
     fn update_reward_history(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2416,6 +2416,8 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
+        println!("haha start rewarding");
+
         if self
             .feature_set
             .is_active(&feature_set::update_rewards_no_join::id())
@@ -2439,6 +2441,7 @@ impl Bank {
                 update_rewards_from_cached_accounts,
             );
         }
+        println!("haha end rewarding");
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
@@ -2848,7 +2851,10 @@ impl Bank {
         let point_value =
             self.calculate_reward_points2(&reward_calculate_param, rewards, thread_pool, metrics);
 
+        println!("haha point_value: {:?}", point_value);
+
         if let Some(point_value) = point_value {
+            println!("haha redeem start");
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
                 &reward_calculate_param,
                 rewarded_epoch,
@@ -2892,6 +2898,8 @@ impl Bank {
             metrics,
         );
 
+        println!("haha point_value: {:?}", point_value);
+
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
                 vote_with_stake_delegations_map,
@@ -2903,8 +2911,13 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
+            println!("haha redeem end");
+
+            drop(reward_calculate_param);
+            drop(stakes);
 
             self.store_stake_accounts(&stake_rewards, metrics);
+
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
             self.update_reward_history(stake_rewards, vote_rewards);
         }
@@ -3252,6 +3265,8 @@ impl Bank {
     }
 
     fn store_stake_accounts(&self, stake_rewards: &[StakeReward], metrics: &mut RewardsMetrics) {
+        println!("haha store stake start: {}", stake_rewards.len());
+
         // store stake account even if stake_reward is 0
         // because credits observed has changed
         let (_, measure) = measure!({
@@ -3260,6 +3275,8 @@ impl Bank {
         metrics
             .store_stake_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
+
+        println!("haha store stake end");
     }
 
     fn store_vote_accounts(
@@ -3267,6 +3284,8 @@ impl Bank {
         vote_account_rewards: VoteRewards,
         metrics: &mut RewardsMetrics,
     ) -> Vec<(Pubkey, RewardInfo)> {
+        println!("haha store vote start");
+
         let (vote_rewards, measure) = measure!(vote_account_rewards
             .into_iter()
             .filter_map(
@@ -3296,6 +3315,9 @@ impl Bank {
         metrics
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
+
+        println!("haha store vote end: {}", vote_rewards.len());
+
         vote_rewards
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2819,6 +2819,12 @@ impl Bank {
             metrics,
         );
 
+        let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
+
+        assert!(point_value == point_value2);
+
+        info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
+
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
                 vote_with_stake_delegations_map,
@@ -2829,6 +2835,40 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
+
+            let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
+                rewarded_epoch,
+                point_value2.unwrap(),
+                credits_auto_rewind,
+                thread_pool,
+                reward_calc_tracer.as_ref(),
+                metrics,
+            );
+
+            info!(
+                "vote_account_rewards_len: {}, {}",
+                vote_account_rewards.len(),
+                vote_account_rewards2.len()
+            );
+
+            info!(
+                "vote_account_rewards: {:?}, {:?}",
+                vote_account_rewards, vote_account_rewards2
+            );
+
+            info!(
+                "stake_rewards_len: {}, {}",
+                stake_rewards.len(),
+                stake_rewards2.len()
+            );
+
+            let vote_len1: usize = vote_account_rewards
+                .iter()
+                .map(|I| if I.3 { 1 } else { 0 })
+                .sum();
+
+            assert!(vote_len1 == vote_account_rewards2.len());
+            assert!(stake_rewards.len() == stake_rewards2.len());
 
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
@@ -2877,6 +2917,67 @@ impl Bank {
         vote_with_stake_delegations_map
     }
 
+    fn calculate_reward_points2(
+        &self,
+        rewards: u64,
+        thread_pool: &ThreadPool,
+        metrics: &mut RewardsMetrics,
+    ) -> Option<PointValue> {
+        let stake_history = self.stakes_cache.stakes().history().clone();
+
+        let stakes = self.stakes_cache.stakes();
+        let stake_delegations = self.filter_stake_delegations(&stakes);
+
+        let cached_vote_accounts = stakes.vote_accounts();
+        let solana_vote_program: Pubkey = solana_vote_program::id();
+
+        let get_vote_account = |vote_pubkey: &Pubkey| -> Option<VoteAccount> {
+            if let Some(vote_account) = cached_vote_accounts.get(vote_pubkey) {
+                return Some(vote_account.clone());
+            }
+            let account = self.get_account_with_fixed_root(vote_pubkey)?;
+            VoteAccount::try_from(account).ok()
+        };
+
+        let (points, measure) = measure!(thread_pool.install(|| {
+            stake_delegations
+                .par_iter()
+                .map(|(_stake_pubkey, stake_account)| {
+                    let delegation = stake_account.delegation();
+                    let vote_pubkey = delegation.voter_pubkey;
+
+                    let vote_account = match get_vote_account(&vote_pubkey) {
+                        Some(vote_account) => vote_account,
+                        None => {
+                            return 0;
+                        }
+                    };
+                    if vote_account.owner() != &solana_vote_program {
+                        return 0;
+                    }
+                    let vote_state = match vote_account.vote_state().deref() {
+                        Ok(vote_state) => vote_state.clone(),
+                        Err(_) => {
+                            return 0;
+                        }
+                    };
+
+                    stake_state::calculate_points(
+                        stake_account.stake_state(),
+                        &vote_state,
+                        Some(&stake_history),
+                    )
+                    .unwrap_or(0)
+                })
+                .sum::<u128>()
+        }));
+        metrics
+            .calculate_points2_us
+            .fetch_add(measure.as_us(), Relaxed);
+
+        (points > 0).then_some(PointValue { rewards, points })
+    }
+
     fn calculate_reward_points(
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
@@ -2914,6 +3015,114 @@ impl Bank {
             .fetch_add(measure.as_us(), Relaxed);
 
         (points > 0).then_some(PointValue { rewards, points })
+    }
+
+    fn redeem_rewards2(
+        &self,
+        rewarded_epoch: Epoch,
+        point_value: PointValue,
+        credits_auto_rewind: bool,
+        thread_pool: &ThreadPool,
+        reward_calc_tracer: Option<impl RewardCalcTracer>,
+        metrics: &mut RewardsMetrics,
+    ) -> (VoteRewards, StakeRewards) {
+        let stake_history = self.stakes_cache.stakes().history().clone();
+
+        let stakes = self.stakes_cache.stakes();
+        let stake_delegations = self.filter_stake_delegations(&stakes);
+
+        let cached_vote_accounts = stakes.vote_accounts();
+        let solana_vote_program: Pubkey = solana_vote_program::id();
+
+        let get_vote_account = |vote_pubkey: &Pubkey| -> Option<VoteAccount> {
+            if let Some(vote_account) = cached_vote_accounts.get(vote_pubkey) {
+                return Some(vote_account.clone());
+            }
+            let account = self.get_account_with_fixed_root(vote_pubkey)?;
+            VoteAccount::try_from(account).ok()
+        };
+
+        let vote_account_rewards: VoteRewards = DashMap::new();
+        let (stake_rewards, measure) = measure!(thread_pool.install(|| {
+            stake_delegations
+                .par_iter()
+                .filter_map(|(stake_pubkey, stake_account)| {
+                    // curry closure to add the contextual stake_pubkey
+                    let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
+                        // inner
+                        move |inner_event: &_| {
+                            outer(&RewardCalculationEvent::Staking(&stake_pubkey, inner_event))
+                        }
+                    });
+
+                    let stake_pubkey = **stake_pubkey;
+                    let stake_account = StakeAccount::from((*stake_account).clone());
+
+                    let delegation = stake_account.delegation();
+                    let (mut stake_account, stake_state) =
+                        <(AccountSharedData, StakeState)>::from(stake_account);
+                    let vote_pubkey = delegation.voter_pubkey;
+                    let vote_account = match get_vote_account(&vote_pubkey) {
+                        Some(vote_account) => vote_account,
+                        None => {
+                            return None;
+                        }
+                    };
+                    if vote_account.owner() != &solana_vote_program {
+                        return None;
+                    }
+                    let vote_state = match vote_account.vote_state().deref() {
+                        Ok(vote_state) => vote_state.clone(),
+                        Err(_) => {
+                            return None;
+                        }
+                    };
+                    let redeemed = stake_state::redeem_rewards(
+                        rewarded_epoch,
+                        stake_state,
+                        &mut stake_account,
+                        &vote_state,
+                        &point_value,
+                        Some(&stake_history),
+                        reward_calc_tracer.as_ref(),
+                        credits_auto_rewind,
+                    );
+
+                    if let Ok((stakers_reward, voters_reward)) = redeemed {
+                        // track voter rewards
+                        let mut entry = vote_account_rewards.entry(vote_pubkey).or_insert((
+                            vote_account.into(),
+                            vote_state.commission,
+                            0,
+                            false,
+                        ));
+
+                        entry.3 = true;
+                        entry.2 = entry.2.saturating_add(voters_reward);
+
+                        let post_balance = stake_account.lamports();
+                        return Some(StakeReward {
+                            stake_pubkey,
+                            stake_reward_info: RewardInfo {
+                                reward_type: RewardType::Staking,
+                                lamports: i64::try_from(stakers_reward).unwrap(),
+                                post_balance,
+                                commission: Some(vote_state.commission),
+                            },
+                            stake_account,
+                        });
+                    } else {
+                        debug!(
+                            "stake_state::redeem_rewards() failed for {}: {:?}",
+                            stake_pubkey, redeemed
+                        );
+                    }
+                    None
+                })
+                .collect()
+        }));
+        metrics.redeem_rewards2_us += measure.as_us();
+        (vote_account_rewards, stake_rewards)
     }
 
     fn redeem_rewards(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -68,6 +68,7 @@ use {
         snapshot_hash::SnapshotHash,
         sorted_storages::SortedStorages,
         stake_account::{self, StakeAccount},
+        stake_history::StakeHistory,
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -2847,6 +2848,7 @@ impl Bank {
         metrics: &mut RewardsMetrics,
         update_rewards_from_cached_accounts: bool,
     ) {
+        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_with_stake_delegations_map = self.load_vote_and_stake_accounts(
             thread_pool,
             reward_calc_tracer.as_ref(),
@@ -2857,6 +2859,7 @@ impl Bank {
         let point_value = self.calculate_reward_points(
             &vote_with_stake_delegations_map,
             rewards,
+            &stake_history,
             thread_pool,
             metrics,
         );
@@ -2867,6 +2870,7 @@ impl Bank {
                 rewarded_epoch,
                 point_value,
                 credits_auto_rewind,
+                &stake_history,
                 thread_pool,
                 reward_calc_tracer.as_ref(),
                 metrics,
@@ -2983,10 +2987,10 @@ impl Bank {
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
         rewards: u64,
+        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
-        let stake_history = self.stakes_cache.stakes().history().clone();
         let (points, measure) = measure!(thread_pool.install(|| {
             vote_with_stake_delegations_map
                 .par_iter()
@@ -3003,7 +3007,7 @@ impl Bank {
                             stake_state::calculate_points(
                                 stake_account.stake_state(),
                                 vote_state,
-                                Some(&stake_history),
+                                Some(stake_history),
                             )
                             .unwrap_or(0)
                         })
@@ -3132,11 +3136,11 @@ impl Bank {
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
+        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
-        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_account_rewards: VoteRewards =
             DashMap::with_capacity(vote_with_stake_delegations_map.len());
         let stake_delegation_iterator = vote_with_stake_delegations_map.into_par_iter().flat_map(
@@ -3174,7 +3178,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(&stake_history),
+                        Some(stake_history),
                         reward_calc_tracer.as_ref(),
                         credits_auto_rewind,
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2970,8 +2970,8 @@ impl Bank {
         let solana_vote_program: Pubkey = solana_vote_program::id();
         cached_vote_accounts.get(vote_pubkey).cloned().or_else(|| {
             self.get_account_with_fixed_root(vote_pubkey)
-                .and_then(|account| VoteAccount::try_from(account).ok())
                 .filter(|vote_account| vote_account.owner() == &solana_vote_program)
+                .and_then(|account| VoteAccount::try_from(account).ok())
         })
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2409,25 +2409,29 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        // self.pay_validator_rewards_with_thread_pool(
-        //     prev_epoch,
-        //     validator_rewards,
-        //     reward_calc_tracer,
-        //     self.credits_auto_rewind(),
-        //     thread_pool,
-        //     metrics,
-        //     update_rewards_from_cached_accounts,
-        // );
-
-        self.pay_validator_rewards_with_thread_pool2(
-            prev_epoch,
-            validator_rewards,
-            reward_calc_tracer,
-            self.credits_auto_rewind(),
-            thread_pool,
-            metrics,
-            update_rewards_from_cached_accounts,
-        );
+        if self
+            .feature_set
+            .is_active(&feature_set::update_rewards_no_join::id())
+        {
+            self.pay_validator_rewards_with_thread_pool_no_join(
+                prev_epoch,
+                validator_rewards,
+                reward_calc_tracer,
+                self.credits_auto_rewind(),
+                thread_pool,
+                metrics,
+            );
+        } else {
+            self.pay_validator_rewards_with_thread_pool(
+                prev_epoch,
+                validator_rewards,
+                reward_calc_tracer,
+                self.credits_auto_rewind(),
+                thread_pool,
+                metrics,
+                update_rewards_from_cached_accounts,
+            );
+        }
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2859,6 +2859,9 @@ impl Bank {
                 metrics,
             );
 
+            drop(reward_calculate_param);
+            drop(stakes);
+
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
             self.update_reward_history(stake_rewards, vote_rewards);
@@ -2903,9 +2906,6 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
-
-            drop(reward_calculate_param);
-            drop(stakes);
 
             self.store_stake_accounts(&stake_rewards, metrics);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -68,7 +68,6 @@ use {
         snapshot_hash::SnapshotHash,
         sorted_storages::SortedStorages,
         stake_account::{self, StakeAccount},
-        stake_history::StakeHistory,
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -2806,7 +2805,6 @@ impl Bank {
         metrics: &mut RewardsMetrics,
         update_rewards_from_cached_accounts: bool,
     ) {
-        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_with_stake_delegations_map = self.load_vote_and_stake_accounts(
             thread_pool,
             reward_calc_tracer.as_ref(),
@@ -2817,7 +2815,6 @@ impl Bank {
         let point_value = self.calculate_reward_points(
             &vote_with_stake_delegations_map,
             rewards,
-            &stake_history,
             thread_pool,
             metrics,
         );
@@ -2828,7 +2825,6 @@ impl Bank {
                 rewarded_epoch,
                 point_value,
                 credits_auto_rewind,
-                &stake_history,
                 thread_pool,
                 reward_calc_tracer.as_ref(),
                 metrics,
@@ -2885,10 +2881,10 @@ impl Bank {
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
         rewards: u64,
-        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
+        let stake_history = self.stakes_cache.stakes().history().clone();
         let (points, measure) = measure!(thread_pool.install(|| {
             vote_with_stake_delegations_map
                 .par_iter()
@@ -2905,7 +2901,7 @@ impl Bank {
                             stake_state::calculate_points(
                                 stake_account.stake_state(),
                                 vote_state,
-                                Some(stake_history),
+                                Some(&stake_history),
                             )
                             .unwrap_or(0)
                         })
@@ -2926,11 +2922,11 @@ impl Bank {
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
-        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
+        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_account_rewards: VoteRewards =
             DashMap::with_capacity(vote_with_stake_delegations_map.len());
         let stake_delegation_iterator = vote_with_stake_delegations_map.into_par_iter().flat_map(
@@ -2968,7 +2964,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(stake_history),
+                        Some(&stake_history),
                         reward_calc_tracer.as_ref(),
                         credits_auto_rewind,
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2416,9 +2416,10 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        if self
-            .feature_set
-            .is_active(&feature_set::update_rewards_no_join::id())
+        if update_rewards_from_cached_accounts
+            && self
+                .feature_set
+                .is_active(&feature_set::update_rewards_no_join::id())
         {
             self.pay_validator_rewards_with_thread_pool_no_join(
                 prev_epoch,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2955,6 +2955,14 @@ impl Bank {
         vote_with_stake_delegations_map
     }
 
+    /// Calculates epoch reward points from stake/vote accounts with reward calculate parameter struct.
+    ///
+    /// * reward_calculate_params: reward calculate parameter struct - stake history, delegation and vote accounts.
+    /// * rewards: epoch rewards in lamports
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * metrics: reward metrics
+    ///
+    /// Returns reward lamports and points for the epoch.
     fn calculate_reward_points2(
         &self,
         reward_calculate_params: &EpochRewardCalculateParamInfo,
@@ -3017,6 +3025,15 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
+    /// Calculates epoch reward points from stake/vote accounts using joined vote/stake account map
+    ///
+    /// * vote_with_stake_delegation_map: joined map of vote_accounts and stake_accounts
+    /// * rewards: epoch rewards in lamports
+    /// * stake_history: stake history
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * metrics: reward metrics
+    ///
+    /// Returns reward lamports and points for the epoch.
     fn calculate_reward_points(
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
@@ -3056,6 +3073,17 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
+    /// Calculates epoch rewards for stake/vote accounts
+    ///
+    /// * reward_calculate_params: reward calculate parameter struct - stake history, delegation and vote accounts.
+    /// * rewarded_epoch: reward epoch
+    /// * point_value: reward PointValue
+    /// * credits_auto_rewind: boolean flag for auto rewind vote credits during reward calculation
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * reward_calc_tracer: tracer fn for reward calculation
+    /// * metrics: reward metrics
+    ///
+    /// Returns vote rewards and stake rewards
     fn redeem_rewards2(
         &self,
         reward_calculate_params: &EpochRewardCalculateParamInfo,
@@ -3165,6 +3193,17 @@ impl Bank {
         (vote_account_rewards, stake_rewards)
     }
 
+    /// Calculates epoch reward for stake/vote accounts using joined vote/stake account map
+    ///
+    /// * vote_with_stake_delegation_map: joined map of vote_accounts and stake_accounts
+    /// * rewarded_epoch: reward epoch
+    /// * point_value: reward PointValue
+    /// * credits_auto_rewind: boolean flag for auto rewind vote credits during reward calculation
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * reward_calc_tracer: tracer fn for reward calculation
+    /// * metrics: reward metrics
+    ///
+    /// Returns vote rewards and stake rewards
     fn redeem_rewards(
         &self,
         vote_with_stake_delegations_map: DashMap<Pubkey, VoteWithStakeDelegations>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3003,10 +3003,7 @@ impl Bank {
                     let vote_pubkey = stake_account.delegation().voter_pubkey;
 
                     self.get_vote_account_with_cache(cached_vote_accounts, &vote_pubkey)
-                        .and_then(|vote_account| match vote_account.vote_state().deref() {
-                            Ok(vote_state) => Some(vote_state.clone()),
-                            Err(_) => None,
-                        })
+                        .and_then(|vote_account| vote_account.vote_state().cloned().ok())
                         .and_then(|vote_state| {
                             stake_state::calculate_points(
                                 stake_account.stake_state(),
@@ -3123,8 +3120,8 @@ impl Bank {
 
                     let (vote_account, vote_state) = self
                         .get_vote_account_with_cache(cached_vote_accounts, &vote_pubkey)
-                        .and_then(|vote_account| match vote_account.vote_state().deref() {
-                            Ok(vote_state) => Some((vote_account.clone(), vote_state.clone())),
+                        .and_then(|vote_account| match vote_account.vote_state().cloned() {
+                            Ok(vote_state) => Some((vote_account.clone(), vote_state)),
                             Err(_) => None,
                         })?;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2979,11 +2979,16 @@ impl Bank {
         let solana_vote_program: Pubkey = solana_vote_program::id();
 
         let get_vote_account = |vote_pubkey: &Pubkey| -> Option<VoteAccount> {
-            if let Some(vote_account) = cached_vote_accounts.get(vote_pubkey) {
-                return Some(vote_account.clone());
-            }
-            let account = self.get_account_with_fixed_root(vote_pubkey)?;
-            VoteAccount::try_from(account).ok()
+            cached_vote_accounts
+                .get(vote_pubkey)
+                .cloned()
+                .or_else(|| {
+                    self
+                        .get_account_with_fixed_root(vote_pubkey)
+                        .and_then(|account| {
+                            VoteAccount::try_from(account).ok()
+                        })
+                })
         };
 
         let (points, measure) = measure!(thread_pool.install(|| {

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -15,7 +15,9 @@ pub(crate) struct NewEpochTimings {
 pub(crate) struct RewardsMetrics {
     pub(crate) load_vote_and_stake_accounts_us: AtomicU64,
     pub(crate) calculate_points_us: AtomicU64,
+    pub(crate) calculate_points2_us: AtomicU64,
     pub(crate) redeem_rewards_us: u64,
+    pub(crate) redeem_rewards2_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) invalid_cached_vote_accounts: usize,
@@ -83,7 +85,13 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.calculate_points_us.load(Relaxed),
             i64
         ),
+        (
+            "calculate_points2_us",
+            metrics.calculate_points2_us.load(Relaxed),
+            i64
+        ),
         ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
+        ("redeem_rewards2_us", metrics.redeem_rewards2_us, i64),
         (
             "store_stake_accounts_us",
             metrics.store_stake_accounts_us.load(Relaxed),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -368,6 +368,9 @@ pub mod fix_recent_blockhashes {
 pub mod update_rewards_from_cached_accounts {
     solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
+pub mod update_rewards_no_join {
+    solana_sdk::declare_id!("DhaAhXU9kGosmZQhSm3jWYR7x9p4scgN69P5dwHavSj8");
+}
 
 pub mod spl_token_v3_4_0 {
     solana_sdk::declare_id!("Ftok4njE8b7tDffYkC5bAbCaQv5sL6jispYrprzatUwN");
@@ -740,6 +743,7 @@ lazy_static! {
         (executables_incur_cpi_data_cost::id(), "Executables incur CPI data costs"),
         (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
         (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
+        (update_rewards_no_join::id(), "update rewards avoid joining vote accounts and stake accounts"),
         (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
         (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
         (default_units_per_instruction::id(), "Default max tx-wide compute units calculated per instruction"),


### PR DESCRIPTION
#### Problem

Joining vote accounts and stake accounts before reward calculation is expensive. 

Historically, this joining was introduced initially because the stake_delegation in stake_cache is `im.Hashmap`, which doesn't support parallel iterators. Hence, a join of vote account and stake accounts is added to turn it into a Dashmap, which can then be processed in parallel. 

However, after stake filtering feature added in https://github.com/solana-labs/solana/pull/29618, the stake_delegations after filtering are already in a Vec. This Vec of stake_delegations can be processed in parallel directly. 

Joining vote accounts with stake accounts after filtering can be avoided. Avoiding this joining speeds up the rewards time. 

Benchmark from leger replay for the most recent epoch shows an overall **58%** improvement over mainnet with this change + https://github.com/solana-labs/solana/pull/24200, and **24%** improvement over https://github.com/solana-labs/solana/pull/24200 only.

Furthermore, this change reduced the reward point calculation time down to **40ms**, which will help the https://github.com/solana-foundation/solana-improvement-documents/pull/15 work.

#### Summary of Changes

- optimize reward time by avoiding unnecessary joining


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
