### PR TITLE
Add ability to manage public TPU Forwards address

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -684,6 +684,16 @@ impl ClusterInfo {
         Ok(())
     }
 
+    pub fn set_tpu_forwards(&self, tpu_forwards_addr: SocketAddr) -> Result<(), ContactInfoError> {
+        self.my_contact_info
+            .write()
+            .unwrap()
+            .set_tpu_forwards(tpu_forwards_addr)?;
+        self.insert_self();
+        self.push_self();
+        Ok(())
+    }
+
     pub fn lookup_contact_info<F, Y>(&self, id: &Pubkey, map: F) -> Option<Y>
     where
         F: FnOnce(&LegacyContactInfo) -> Y,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3008,6 +3008,7 @@ impl Node {
         port_range: PortRange,
         bind_ip_addr: IpAddr,
         public_tpu_addr: Option<SocketAddr>,
+        public_tpu_forwards_addr: Option<SocketAddr>,
     ) -> Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
@@ -3062,7 +3063,9 @@ impl Node {
         let _ = info.set_tvu_forwards((addr, tvu_forwards_port));
         let _ = info.set_repair((addr, repair_port));
         let _ = info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)));
-        let _ = info.set_tpu_forwards((addr, tpu_forwards_port));
+        let _ = info.set_tpu_forwards(
+            public_tpu_forwards_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_forwards_port)),
+        );
         let _ = info.set_tpu_vote((addr, tpu_vote_port));
         let _ = info.set_serve_repair((addr, serve_repair_port));
         trace!("new ContactInfo: {:?}", info);
@@ -3738,6 +3741,7 @@ RPC Enabled Nodes: 1"#;
             VALIDATOR_PORT_RANGE,
             IpAddr::V4(ip),
             None,
+            None,
         );
 
         check_node_sockets(&node, IpAddr::V4(ip), VALIDATOR_PORT_RANGE);
@@ -3759,6 +3763,7 @@ RPC Enabled Nodes: 1"#;
             &socketaddr!(Ipv4Addr::LOCALHOST, port),
             port_range,
             ip,
+            None,
             None,
         );
 

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -233,6 +233,62 @@ pub trait AdminRpc {
         meta: Self::Metadata,
         public_tpu_addr: SocketAddr,
     ) -> Result<()>;
+
+    #[rpc(meta, name = "setPublicTpuForwardsAddress")]
+    fn set_public_tpu_forwards_address(
+        &self,
+        meta: Self::Metadata,
+        public_tpu_forwards_addr: SocketAddr,
+    ) -> Result<()>;
+}
+
+macro_rules! set_public_address {
+    (
+        $set_public_address_name:ident,
+        $set_socket:ident,
+        $address_name:literal,
+        $get_socket:ident,
+        $get_socket_quic:ident
+    ) => {
+        fn $set_public_address_name(
+            &self,
+            meta: Self::Metadata,
+            public_addr: SocketAddr,
+        ) -> Result<()> {
+            debug!(
+                "{} rpc request received: {public_addr}",
+                stringify!($set_public_address_name)
+            );
+
+            meta.with_post_init(|post_init| {
+                post_init
+                    .cluster_info
+                    .$set_socket(public_addr)
+                    .map_err(|err| {
+                        error!(
+                            "Failed to set public {} address to {public_addr}: {err}",
+                            $address_name
+                        );
+                        jsonrpc_core::error::Error::internal_error()
+                    })?;
+                warn!(
+                    "Public {} addresses set to {} (udp) and {} (quic)",
+                    $address_name,
+                    post_init
+                        .cluster_info
+                        .my_contact_info()
+                        .$get_socket()
+                        .unwrap(),
+                    post_init
+                        .cluster_info
+                        .my_contact_info()
+                        .$get_socket_quic()
+                        .unwrap(),
+                );
+                Ok(())
+            })
+        }
+    };
 }
 
 pub struct AdminRpcImpl;
@@ -596,29 +652,14 @@ impl AdminRpc for AdminRpcImpl {
         })
     }
 
-    fn set_public_tpu_address(
-        &self,
-        meta: Self::Metadata,
-        public_tpu_addr: SocketAddr,
-    ) -> Result<()> {
-        debug!("set_public_tpu_address rpc request received: {public_tpu_addr}");
-
-        meta.with_post_init(|post_init| {
-            post_init
-                .cluster_info
-                .set_tpu(public_tpu_addr)
-                .map_err(|err| {
-                    error!("Failed to set public TPU address to {public_tpu_addr}: {err}");
-                    jsonrpc_core::error::Error::internal_error()
-                })?;
-            warn!(
-                "Public TPU addresses set to {} (udp) and {} (quic)",
-                post_init.cluster_info.my_contact_info().tpu().unwrap(),
-                post_init.cluster_info.my_contact_info().tpu_quic().unwrap(),
-            );
-            Ok(())
-        })
-    }
+    set_public_address!(set_public_tpu_address, set_tpu, "TPU", tpu, tpu_quic);
+    set_public_address!(
+        set_public_tpu_forwards_address,
+        set_tpu_forwards,
+        "TPU Forwards",
+        tpu_forwards,
+        tpu_forwards_quic
+    );
 }
 
 impl AdminRpcImpl {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -631,10 +631,11 @@ impl AdminRpc for AdminRpcImpl {
                     error!("Failed to set public TPU address to {public_tpu_addr}: {err}");
                     jsonrpc_core::error::Error::internal_error()
                 })?;
+            let my_contact_info = post_init.cluster_info.my_contact_info();
             warn!(
                 "Public TPU addresses set to {} (udp) and {} (quic)",
-                post_init.cluster_info.my_contact_info().tpu().unwrap(),
-                post_init.cluster_info.my_contact_info().tpu_quic().unwrap(),
+                my_contact_info.tpu().unwrap(),
+                my_contact_info.tpu_quic().unwrap(),
             );
             Ok(())
         })
@@ -668,18 +669,11 @@ impl AdminRpc for AdminRpcImpl {
                     error!("Failed to set public TPU address to {public_tpu_forwards_addr}: {err}");
                     jsonrpc_core::error::Error::internal_error()
                 })?;
+            let my_contact_info = post_init.cluster_info.my_contact_info();
             warn!(
                 "Public TPU Forwards addresses set to {} (udp) and {} (quic)",
-                post_init
-                    .cluster_info
-                    .my_contact_info()
-                    .tpu_forwards()
-                    .unwrap(),
-                post_init
-                    .cluster_info
-                    .my_contact_info()
-                    .tpu_forwards_quic()
-                    .unwrap(),
+                my_contact_info.tpu_forwards().unwrap(),
+                my_contact_info.tpu_forwards_quic().unwrap(),
             );
             Ok(())
         })

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -633,9 +633,9 @@ impl AdminRpc for AdminRpcImpl {
                 })?;
             let my_contact_info = post_init.cluster_info.my_contact_info();
             warn!(
-                "Public TPU addresses set to {} (udp) and {} (quic)",
-                my_contact_info.tpu().unwrap(),
-                my_contact_info.tpu_quic().unwrap(),
+                "Public TPU addresses set to {:?} (udp) and {:?} (quic)",
+                my_contact_info.tpu(),
+                my_contact_info.tpu_quic(),
             );
             Ok(())
         })
@@ -671,9 +671,9 @@ impl AdminRpc for AdminRpcImpl {
                 })?;
             let my_contact_info = post_init.cluster_info.my_contact_info();
             warn!(
-                "Public TPU Forwards addresses set to {} (udp) and {} (quic)",
-                my_contact_info.tpu_forwards().unwrap(),
-                my_contact_info.tpu_forwards_quic().unwrap(),
+                "Public TPU Forwards addresses set to {:?} (udp) and {:?} (quic)",
+                my_contact_info.tpu_forwards(),
+                my_contact_info.tpu_forwards_quic(),
             );
             Ok(())
         })

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -261,6 +261,18 @@ macro_rules! set_public_address {
             );
 
             meta.with_post_init(|post_init| {
+                if post_init
+                    .cluster_info
+                    .my_contact_info()
+                    .$get_socket()
+                    .is_err()
+                {
+                    error!(
+                        "The public {} address isn't being published. The node is likely in repair mode \n\
+                        (see help for --restricted-repair-only-mode for more information)",
+                        $address_name
+                    );
+                }
                 post_init
                     .cluster_info
                     .$set_socket(public_addr)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -382,6 +382,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     when --entrypoint is not provided]"),
         )
         .arg(
+            Arg::with_name("public_tpu_forwards_addr")
+                .long("public-tpu-forwards-address")
+                .value_name("HOST:PORT")
+                .takes_value(true)
+                .validator(solana_net_utils::is_host_port)
+                .help("Specify TPU Forwards address to advertise in gossip [default: ask --entrypoint or localhost\
+                    when --entrypoint is not provided]"),
+        )
+        .arg(
             Arg::with_name("public_rpc_addr")
                 .long("public-rpc-address")
                 .value_name("HOST:PORT")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1,5 +1,7 @@
 use {
-    clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
+    clap::{
+        crate_description, crate_name, App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand,
+    },
     log::warn,
     solana_clap_utils::{
         hidden_unless_forced,
@@ -1626,17 +1628,31 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                          then this not a good time for a restart")
         ).
         subcommand(
-            SubCommand::with_name("set-public-tpu-address")
-                .about("Specify TPU address to advertise in gossip")
+            SubCommand::with_name("set-public-address")
+                .about("Specify addresses to advertise in gossip")
                 .arg(
-                    Arg::with_name("public_tpu_addr")
-                        .index(1)
+                    Arg::with_name("tpu_addr")
+                        .long("tpu")
                         .value_name("HOST:PORT")
                         .takes_value(true)
-                        .required(true)
                         .validator(solana_net_utils::is_host_port)
                         .help("TPU address to advertise in gossip")
-                ),
+                )
+                .arg(
+                    Arg::with_name("tpu_forwards_addr")
+                        .long("tpu-forwards")
+                        .value_name("HOST:PORT")
+                        .takes_value(true)
+                        .validator(solana_net_utils::is_host_port)
+                        .help("TPU Forwards address to advertise in gossip")
+                )
+                .group(
+                    ArgGroup::with_name("set_public_address_details")
+                        .args(&["tpu_addr", "tpu_forwards_addr"])
+                        .required(true)
+                        .multiple(true)
+                )
+                .after_help("Note: At least one arg must be used. Using multiple is ok"),
         );
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -835,30 +835,39 @@ pub fn main() {
                 _ => unreachable!(),
             }
         }
-        ("set-public-tpu-address", Some(subcommand_matches)) => {
-            let public_tpu_addr: SocketAddr = subcommand_matches
-                .value_of("public_tpu_addr")
-                .map(|public_tpu_addr| {
-                    solana_net_utils::parse_host_port(public_tpu_addr).unwrap_or_else(|err| {
-                        eprintln!("Failed to parse --set-public-tpu-address HOST:PORT {err}");
-                        exit(1);
+        ("set-public-address", Some(subcommand_matches)) => {
+            let parse_arg_addr = |arg_name: &str, arg_long: &str| -> Option<SocketAddr> {
+                subcommand_matches.value_of(arg_name).map(|host_port| {
+                        solana_net_utils::parse_host_port(host_port).unwrap_or_else(|err| {
+                            eprintln!("Failed to parse --{arg_long} address. It must be in the HOST:PORT format. {err}");
+                            exit(1);
+                        })
                     })
-                })
-                .unwrap();
+            };
+            let tpu_addr = parse_arg_addr("tpu_addr", "tpu");
+            let tpu_forwards_addr = parse_arg_addr("tpu_forwards_addr", "tpu-forwards");
 
-            let admin_client = admin_rpc_service::connect(&ledger_path);
-            admin_rpc_service::runtime()
-                .block_on(async move {
-                    admin_client
-                        .await?
-                        .set_public_tpu_address(public_tpu_addr)
-                        .await
-                })
-                .unwrap_or_else(|err| {
-                    println!("setPublicTpuAddress request failed: {err}");
-                    exit(1);
-                });
-
+            macro_rules! set_public_address {
+                ($public_addr:expr, $set_public_address:ident, $request:literal) => {
+                    if let Some(public_addr) = $public_addr {
+                        let admin_client = admin_rpc_service::connect(&ledger_path);
+                        admin_rpc_service::runtime()
+                            .block_on(async move {
+                                admin_client.await?.$set_public_address(public_addr).await
+                            })
+                            .unwrap_or_else(|err| {
+                                println!("{} request failed: {err}", $request);
+                                exit(1);
+                            });
+                    }
+                };
+            }
+            set_public_address!(tpu_addr, set_public_tpu_address, "setPublicTpuAddress");
+            set_public_address!(
+                tpu_forwards_addr,
+                set_public_tpu_forwards_address,
+                "setPublicTpuForwardsAddress"
+            );
             return;
         }
         _ => unreachable!(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1709,6 +1709,16 @@ pub fn main() {
         })
     });
 
+    let public_tpu_forwards_addr =
+        matches
+            .value_of("public_tpu_forwards_addr")
+            .map(|public_tpu_forwards_addr| {
+                solana_net_utils::parse_host_port(public_tpu_forwards_addr).unwrap_or_else(|err| {
+                    eprintln!("Failed to parse --public-tpu-forwards-address: {err}");
+                    exit(1);
+                })
+            });
+
     let cluster_entrypoints = entrypoint_addrs
         .iter()
         .map(ContactInfo::new_gossip_entry_point)
@@ -1720,6 +1730,7 @@ pub fn main() {
         dynamic_port_range,
         bind_address,
         public_tpu_addr,
+        public_tpu_forwards_addr,
     );
 
     if restricted_repair_only_mode {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -856,7 +856,7 @@ pub fn main() {
                                 admin_client.await?.$set_public_address(public_addr).await
                             })
                             .unwrap_or_else(|err| {
-                                println!("{} request failed: {err}", $request);
+                                eprintln!("{} request failed: {err}", $request);
                                 exit(1);
                             });
                     }


### PR DESCRIPTION
This PR is a continuation of the work on issue #30451

#### Problem

A node operator can manage a public `TPU` address (at node startup and while it's running), but doesn't have the ability to manage the `TPU Forwards` address as well.

This PR adds that functionality.

#### Summary of Changes

1) Added the start argument `--public-tpu-forwards-address`
2) Reworked the `set-public-tpu-address` subcommand into the `set-public-address` subcommand

