### PR TITLE
clean up delegation errors

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -4230,7 +4230,7 @@ mod tests {
     /// When a destination account already has funds, ensure the minimum split amount reduces
     /// accordingly.
     #[test_case(feature_set_old_behavior(), &[Ok(()), Ok(())]; "old_behavior")]
-    #[test_case(feature_set_new_behavior(), &[ Err(InstructionError::InsufficientFunds), Err(InstructionError::InsufficientFunds) ] ; "new_behavior")]
+    #[test_case(feature_set_new_behavior(), &[ Err(StakeError::InsufficientDelegation.into()), Err(StakeError::InsufficientDelegation.into()) ] ; "new_behavior")]
     fn test_staked_split_destination_minimum_balance(
         feature_set: Arc<FeatureSet>,
         expected_results: &[Result<(), InstructionError>],
@@ -4862,7 +4862,7 @@ mod tests {
             &serialize(&StakeInstruction::Split(stake_lamports / 2)).unwrap(),
             transaction_accounts,
             instruction_accounts,
-            Err(StakeError::InsufficientStake.into()),
+            Err(StakeError::InsufficientDelegation.into()),
         );
     }
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -15,8 +15,8 @@ use {
         account_utils::StateMut,
         clock::{Clock, Epoch},
         feature_set::{
-            self, stake_allow_zero_undelegated_amount, stake_merge_with_unmatched_credits_observed,
-            stake_split_uses_rent_sysvar, FeatureSet,
+            self, clean_up_delegation_errors, stake_allow_zero_undelegated_amount,
+            stake_merge_with_unmatched_credits_observed, stake_split_uses_rent_sysvar, FeatureSet,
         },
         instruction::{checked_add, InstructionError},
         pubkey::Pubkey,
@@ -733,6 +733,15 @@ pub fn split(
                 } else {
                     // Otherwise, the new split stake should reflect the entire split
                     // requested, less any lamports needed to cover the split_rent_exempt_reserve.
+
+                    if invoke_context
+                        .feature_set
+                        .is_active(&clean_up_delegation_errors::id())
+                        && stake.delegation.stake.saturating_sub(lamports) < minimum_delegation
+                    {
+                        return Err(StakeError::InsufficientDelegation.into());
+                    }
+
                     (
                         lamports,
                         lamports.saturating_sub(
@@ -742,6 +751,15 @@ pub fn split(
                         ),
                     )
                 };
+
+            if invoke_context
+                .feature_set
+                .is_active(&clean_up_delegation_errors::id())
+                && split_stake_amount < minimum_delegation
+            {
+                return Err(StakeError::InsufficientDelegation.into());
+            }
+
             let split_stake = stake.split(remaining_stake_delta, split_stake_amount)?;
             let mut split_meta = meta;
             split_meta.rent_exempt_reserve = validated_split_info.destination_rent_exempt_reserve;
@@ -1289,7 +1307,12 @@ fn validate_split_amount(
     // account, the split amount must be at least the minimum stake delegation.  So if the minimum
     // stake delegation was 10 lamports, then a split amount of 1 lamport would not meet the
     // *delegation* requirements.
-    if source_stake.is_some() && lamports < additional_required_lamports {
+    if !invoke_context
+        .feature_set
+        .is_active(&clean_up_delegation_errors::id())
+        && source_stake.is_some()
+        && lamports < additional_required_lamports
+    {
         return Err(InstructionError::InsufficientFunds);
     }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -650,6 +650,10 @@ pub mod stop_truncating_strings_in_syscalls {
     solana_sdk::declare_id!("16FMCmgLzCNNz6eTwGanbyN2ZxvTBSLuQ6DZhgeMshg");
 }
 
+pub mod clean_up_delegation_errors {
+    solana_sdk::declare_id!("Bj2jmUsM2iRhfdLLDSTkhM5UQRQvQHm57HSmPibPtEyu");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -807,6 +811,7 @@ lazy_static! {
         (native_programs_consume_cu::id(), "Native program should consume compute units #30620"),
         (simplify_writable_program_account_check::id(), "Simplify checks performed for writable upgradeable program accounts #30559"),
         (stop_truncating_strings_in_syscalls::id(), "Stop truncating strings in syscalls #31029"),
+        (clean_up_delegation_errors::id(), "Return InsufficientDelegation instead of InsufficientFunds or InsufficientStake where applicable #31206"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
when `split` violates the minimum delegation, sometimes it returns `InstructionError::InsufficientFunds`, and other times it returns `StakeError::InsufficientStake`. the description for the second error is "split amount is more than is staked," which isnt really whats happening

#### Summary of Changes
this changes it to use `StakeError::InsufficientDelegation` in all cases, the correct error for this condition

Feature Gate Issue: #31206