### PR TITLE
Eliminate dependency on Open SSL in cargo-build-sbf

### DIFF
--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -15,7 +15,7 @@ cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 semver = { workspace = true }
 solana-download-utils = { workspace = true }
 solana-logger = { workspace = true }


### PR DESCRIPTION
#### Problem

cargo-build-sbf uses reqwest crate and it depends on OpenSSL 1.1.1 which is deprecated on more recent Linux systems.

#### Summary of Changes

Use a feature of reqwest that enables TLS functionality provided by rustls.

Fixes #31128
