### PR TITLE
remove unused hashbrown dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5677,7 +5677,6 @@ dependencies = [
  "either",
  "generic-array 0.14.7",
  "getrandom 0.1.16",
- "hashbrown 0.12.3",
  "im",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,6 @@ generic-array = { version = "0.14.7", default-features = false }
 gethostname = "0.2.3"
 getrandom = "0.1.14"
 goauth = "0.13.1"
-hashbrown = "0.12"
 hex = "0.4.3"
 hidapi = { version = "2.2.0", default-features = false }
 histogram = "0.6.9"

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -32,7 +32,6 @@ cc = { workspace = true, features = ["jobserver", "parallel"] }
 either = { workspace = true, features = ["use_std"] }
 generic-array = { workspace = true, features = ["serde", "more_lengths"] }
 getrandom = { workspace = true, features = ["dummy"] }
-hashbrown = { workspace = true, features = ["raw"] }
 im = { workspace = true, features = ["rayon", "serde"] }
 memmap2 = { workspace = true }
 once_cell = { workspace = true, features = ["alloc", "race"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4899,7 +4899,6 @@ dependencies = [
  "either",
  "generic-array 0.14.7",
  "getrandom 0.1.14",
- "hashbrown 0.12.3",
  "im",
  "lazy_static",
  "log",


### PR DESCRIPTION
#### Problem
We never use this dependency in our code (directly), so we should remove it.

Noticed there was an upgrade PR (#31123), and was curious where we used it since from the repo's [readme](https://github.com/rust-lang/hashbrown):

> Since Rust 1.36, this is now the HashMap implementation for the Rust standard library.

#### Summary of Changes
Remove it.

Closes #31123
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
