### PR TITLE
Simplify using additional arguments in bench-tps.sh

### DIFF
--- a/multinode-demo/bench-tps.sh
+++ b/multinode-demo/bench-tps.sh
@@ -19,14 +19,11 @@ usage() {
   exit 1
 }
 
-if [[ -z $1 ]]; then # default behavior
-  $solana_bench_tps \
-    --entrypoint 127.0.0.1:8001 \
-    --faucet 127.0.0.1:9900 \
-    --duration 90 \
-    --tx_count 50000 \
-    --thread-batch-sleep-ms 0 \
+args=("$@")
+default_arg --entrypoint "127.0.0.1:8001"
+default_arg --faucet "127.0.0.1:9900"
+default_arg --duration 90
+default_arg --tx_count 50000
+default_arg --thread-batch-sleep-ms 0
 
-else
-  $solana_bench_tps "$@"
-fi
+$solana_bench_tps "${args[@]}"


### PR DESCRIPTION
#### Problem
Using additional arguments to bench-tps.sh is annoying - it requires specifying all the default arguments.
I run it locally, with additional arguments quite often; my approach so far has always been to just modify the bench-tps.sh to include my args so I don't have to specify all the defaults via cli.

#### Summary of Changes
Use `default_arg` from common to add defaults if they are not specified via args

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
