### PR TITLE
bench-tps: rename tx_count arg to tx-count for consistency

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -242,7 +242,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
         )
         .arg(
             Arg::with_name("tx_count")
-                .long("tx_count")
+                .long("tx-count")
                 .value_name("NUM")
                 .takes_value(true)
                 .help("Number of transactions to send per batch")

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -243,6 +243,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
         .arg(
             Arg::with_name("tx_count")
                 .long("tx-count")
+                .alias("tx_count")
                 .value_name("NUM")
                 .takes_value(true)
                 .help("Number of transactions to send per batch")

--- a/multinode-demo/bench-tps.sh
+++ b/multinode-demo/bench-tps.sh
@@ -23,7 +23,7 @@ args=("$@")
 default_arg --entrypoint "127.0.0.1:8001"
 default_arg --faucet "127.0.0.1:9900"
 default_arg --duration 90
-default_arg --tx_count 50000
+default_arg --tx-count 50000
 default_arg --thread-batch-sleep-ms 0
 
 $solana_bench_tps "${args[@]}"


### PR DESCRIPTION
#### Problem
tx_count is snake_case while the rest of the args are kebab-case

#### Summary of Changes
* Change long argument name from "tx_count" to "tx-count"
* Add alias "tx_count" to avoid breaking scripts

Blocked by #31210 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
