### PR TITLE
Add an excludeAddresses parameter to the getBlock RPC call

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -309,6 +309,7 @@ fn test_block_subscription() {
                         transaction_details: TransactionDetails::Signatures,
                         show_rewards: false,
                         max_supported_transaction_version: None,
+                        exclude_addresses: None,
                     },
                 )
                 .unwrap();

--- a/docs/src/api/methods/_getBlock.mdx
+++ b/docs/src/api/methods/_getBlock.mdx
@@ -97,6 +97,20 @@ the max transaction version to return in responses.
   default includes rewards.
 </Field>
 
+<Field name="excludeAddresses" type="array" optional={true}>
+
+a list of addresses whose transactions should be excluded from the response.
+
+<details>
+
+- If the requested block contains transactions which involve the excluded addresses,
+  then these transactions will be excluded from the response.
+- If this parameter is omitted, no transactions will be excluded (all will be returned).
+
+</details>
+
+</Field>
+
 </Parameter>
 
 ### Result:

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -127,6 +127,7 @@ async fn block(
                 transaction_details: TransactionDetails::Full,
                 show_rewards: true,
                 max_supported_transaction_version: None,
+                exclude_addresses: None,
             },
         )
         .map_err(|err| match err {

--- a/rpc-client-api/src/deprecated_config.rs
+++ b/rpc-client-api/src/deprecated_config.rs
@@ -72,6 +72,7 @@ impl From<RpcConfirmedBlockConfig> for RpcBlockConfig {
             rewards: config.rewards,
             commitment: config.commitment,
             max_supported_transaction_version: None,
+            exclude_addresses: None,
         }
     }
 }

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2553,6 +2553,7 @@ impl RpcClient {
     ///     rewards: Some(true),
     ///     commitment: None,
     ///     max_supported_transaction_version: Some(0),
+    ///     exclude_addresses: None,
     /// };
     /// let block = rpc_client.get_block_with_config(
     ///     slot,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -2105,6 +2105,7 @@ impl RpcClient {
     ///     rewards: Some(true),
     ///     commitment: None,
     ///     max_supported_transaction_version: Some(0),
+    ///     exclude_addresses: None,
     /// };
     /// let block = rpc_client.get_block_with_config(
     ///     slot,

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -349,6 +349,7 @@ fn filter_block_result_txs(
                 transaction_details: params.transaction_details,
                 show_rewards: params.show_rewards,
                 max_supported_transaction_version: params.max_supported_transaction_version,
+                exclude_addresses: None,
             },
         )
         .map_err(|err| match err {
@@ -1541,6 +1542,7 @@ pub(crate) mod tests {
                     transaction_details: params.transaction_details,
                     show_rewards: false,
                     max_supported_transaction_version: None,
+                    exclude_addresses: None,
                 },
             )
             .unwrap();
@@ -1669,6 +1671,7 @@ pub(crate) mod tests {
                     transaction_details: params.transaction_details,
                     show_rewards: false,
                     max_supported_transaction_version: None,
+                    exclude_addresses: None,
                 },
             )
             .unwrap();
@@ -1783,6 +1786,7 @@ pub(crate) mod tests {
                     transaction_details: params.transaction_details,
                     show_rewards: false,
                     max_supported_transaction_version: None,
+                    exclude_addresses: None,
                 },
             )
             .unwrap();


### PR DESCRIPTION
#### Problem

Calling getBlock returns a lot of data and for many use-cases it is mostly not relevant.  The most obvious example is voting transactions.  In many cases the voting transactions are of no interest to the caller, but make up the majority of the response.  Excluding these transactions would significantly reduce the size of response, making it quicker to transmit and process.  More generally there may be other program addresses or even account addresses which are of no interest.

There is already a filter object that can be applied to the getProgramAccounts, and this feature could have been implemented by adding a parameter to the getProgramAccounts filter object, but address filtering doesn't really make sense in the context of getProgramAccounts (although it could be implemented), and I'm not sure how much the existing getProgramAccounts filter options would be used in the context of getBlock (again, they could be implemented).

#### Summary of Changes

Add a new optional parameter called excludeAddresses to the getBlock RPC call.  The new parameter takes a list of addresses, and any transaction involving any of the addresses listed will be excluded form the returned data.

#### Resolves

 #29856 - Add a flag to omit vote transactions
 #25340 - Slow getBlock responce