### PR TITLE
fix: lock spl-token-cli version in v2.3.0

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -144,7 +144,7 @@ mkdir -p "$installDir/bin"
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
+    "$cargo" $maybeRustVersion install --locked spl-token-cli --version 2.3.0 --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
#### Problem

https://buildkite.com/solana-labs/solana-secondary/builds/10071#01878ec1-ce85-4760-9cc3-bbaa02d2bddc
<img width="990" alt="Screenshot 2023-04-17 at 6 50 26 PM" src="https://user-images.githubusercontent.com/8209234/232463536-2e3d45f7-3e9b-46fb-bf04-9a8d92d1feb3.png">

maybe we should make v1.14 branch always use spl-token-cli v2.3.0 which is its pervious version.

#### Summary of Changes

install spl-token-cli 2.3.0 in `scripts/cargo-install-all.sh`
