### PR TITLE
Refactor the common test snapshot dirs creation code

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5133,6 +5133,8 @@ mod tests {
             // prepare the bank
             bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
             bank.fill_bank_with_ticks_for_tests();
+            bank.squash();
+            bank.force_flush_accounts_cache();
 
             let snapshot_storages = bank.get_snapshot_storages(None);
             let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5117,25 +5117,23 @@ mod tests {
         assert!(matches!(ret, Err(SnapshotError::InvalidAppendVecPath(_))));
     }
 
-    #[test]
-    fn test_get_highest_bank_snapshot() {
-        solana_logger::setup();
+    fn create_snapshot_dirs_for_tests(
+        genesis_config: &GenesisConfig,
+        bank_snapshots_dir: impl AsRef<Path>,
+        num_total: usize,
+        num_posts: usize,
+    ) -> Bank {
+        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
 
-        let genesis_config = GenesisConfig::default();
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
-
-        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let collecter_id = Pubkey::new_unique();
         let snapshot_version = SnapshotVersion::default();
 
-        for _ in 0..4 {
+        // loop to create the banks at slot 1 to num_total
+        for _ in 0..num_total {
             // prepare the bank
             bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
             bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
 
-            // generate the bank snapshot directory for slot+1
             let snapshot_storages = bank.get_snapshot_storages(None);
             let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
             add_bank_snapshot(
@@ -5146,7 +5144,33 @@ mod tests {
                 slot_deltas,
             )
             .unwrap();
+
+            if bank.slot() as usize > num_posts {
+                continue; // leave the snapshot dir at PRE stage
+            }
+
+            // Reserialize the snapshot dir to convert it from PRE to POST, because only the POST type can be used
+            // to construct a bank.
+            assert!(
+                crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
+                    &bank_snapshots_dir,
+                    bank.slot(),
+                    &AccountsHash(Hash::new_unique()),
+                    None
+                )
+            );
         }
+
+        Arc::try_unwrap(bank).unwrap()
+    }
+
+    #[test]
+    fn test_get_highest_bank_snapshot() {
+        solana_logger::setup();
+ 
+        let genesis_config = GenesisConfig::default();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 4, 0);
 
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 4);
@@ -5223,31 +5247,10 @@ mod tests {
     #[test]
     fn test_clean_orphaned_account_snapshot_dirs() {
         solana_logger::setup();
+
         let genesis_config = GenesisConfig::default();
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let collecter_id = Pubkey::new_unique();
-        let snapshot_version = SnapshotVersion::default();
-
-        for _ in 0..2 {
-            // prepare the bank
-            bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
-            bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
-
-            // generate the bank snapshot directory for slot+1
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-            add_bank_snapshot(
-                &bank_snapshots_dir,
-                &bank,
-                &snapshot_storages,
-                snapshot_version,
-                slot_deltas,
-            )
-            .unwrap();
-        }
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, 0);
 
         let snapshot_dir_slot_2 = bank_snapshots_dir.path().join("2");
         let accounts_link_dir_slot_2 = snapshot_dir_slot_2.join("accounts_hardlinks");
@@ -5456,32 +5459,10 @@ mod tests {
     #[test]
     fn test_bank_from_snapshot_dir() {
         solana_logger::setup();
+
         let genesis_config = GenesisConfig::default();
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
-
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let collecter_id = Pubkey::new_unique();
-        let snapshot_version = SnapshotVersion::default();
-
-        for _ in 0..3 {
-            // prepare the bank
-            bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
-            bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
-
-            // generate the bank snapshot directory for slot+1
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-            add_bank_snapshot(
-                &bank_snapshots_dir,
-                &bank,
-                &snapshot_storages,
-                snapshot_version,
-                slot_deltas,
-            )
-            .unwrap();
-        }
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, 0);
 
         let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         let account_paths = &bank.rc.accounts.accounts_db.paths;
@@ -5504,7 +5485,7 @@ mod tests {
         .unwrap();
 
         bank_constructed.wait_for_initial_accounts_hash_verification_completed_for_tests();
-        assert_eq!(bank_constructed, *bank);
+        assert_eq!(bank_constructed, bank);
 
         // Verify that the next_append_vec_id tracking is correct
         let mut max_id = 0;
@@ -5523,42 +5504,10 @@ mod tests {
     #[test]
     fn test_bank_from_latest_snapshot_dir() {
         solana_logger::setup();
+
         let genesis_config = GenesisConfig::default();
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
-
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let collecter_id = Pubkey::new_unique();
-        let snapshot_version = SnapshotVersion::default();
-
-        for _ in 0..3 {
-            // prepare the bank
-            bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
-            bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
-
-            // generate the bank snapshot directory for slot+1
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-            add_bank_snapshot(
-                &bank_snapshots_dir,
-                &bank,
-                &snapshot_storages,
-                snapshot_version,
-                slot_deltas,
-            )
-            .unwrap();
-            // Reserialize the snapshot dir to convert it from PRE to POST, because only the POST type can be used
-            // to construct a bank.
-            assert!(
-                crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                    &bank_snapshots_dir,
-                    bank.slot(),
-                    &AccountsHash(Hash::new_unique()),
-                    None
-                )
-            );
-        }
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, 3);
 
         let account_paths = &bank.rc.accounts.accounts_db.paths;
 
@@ -5580,7 +5529,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            deserialized_bank, *bank,
+            deserialized_bank, bank,
             "Ensure rebuilding bank from the highest snapshot dir results in the highest bank",
         );
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5167,7 +5167,7 @@ mod tests {
     #[test]
     fn test_get_highest_bank_snapshot() {
         solana_logger::setup();
- 
+
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 4, 0);


### PR DESCRIPTION
#### Problem
Multiple test cases have duplicated common code for creating test snapshot dirs in PRE or POST states.

#### Summary of Changes
Created a function create_snapshot_dirs_for_tests to refactor the common code for creating test snapshot dirs in any numbers of PRE or POST states.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
