### PR TITLE
v1.14: Hardcode newer rust version for crate publishing

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,6 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
+export RUST_STABLE_VERSION=1.63.0
 source ci/rust-version.sh stable
 
 cargo="$(readlink -f ./cargo)"


### PR DESCRIPTION
#### Problem
Our CI job for publishing crates is broken because v1.14 is on rust v1.60, newer `time` releases have an msrv to v1.63, and cargo package/publish doesn't respect Cargo.lock (which specify an older version of `time`).

#### Summary of Changes
Set the `RUST_STABLE_VERSION` envar to v1.63.0 in publish-crate.sh in v1.14

Should we do this in v1.13 as well, in case of additional patches?
