### PR TITLE
Optimize vote rewards: part 1

### DIFF
--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -35,8 +35,6 @@ use {
 
 #[test]
 fn test_stake_redelegation() {
-    //solana_logger::setup();
-
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let authorized_withdrawer = Keypair::new().pubkey();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -35,6 +35,8 @@ use {
 
 #[test]
 fn test_stake_redelegation() {
+    //solana_logger::setup();
+
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let authorized_withdrawer = Keypair::new().pubkey();

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -286,7 +286,7 @@ async fn stake_rewards_filter_bench_100() {
 
 #[tokio::test]
 async fn stake_rewards_bench_550_k() {
-    stake_rewards_filter_bench_core(55 * 1000, false).await;
+    stake_rewards_filter_bench_core(550_000, false).await;
 }
 
 async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) {
@@ -316,7 +316,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) 
             &vote_address,
             &vote_account,
             &Rent::default(),
-            TEST_FILTER_STAKE,
+            lamports,
         ));
         program_test.add_account(stake_pubkey, stake_account);
         if lamports == TEST_FILTER_STAKE {

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -285,7 +285,7 @@ async fn stake_rewards_filter_bench_100() {
 }
 
 #[tokio::test]
-async fn stake_rewards_bench_550_K() {
+async fn stake_rewards_bench_550_k() {
     stake_rewards_filter_bench_core(55 * 1000, false).await;
 }
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -285,7 +285,7 @@ async fn stake_rewards_filter_bench_100() {
 }
 
 #[tokio::test]
-async fn stake_rewards_filter_bench_550_K() {
+async fn stake_rewards_bench_550_K() {
     stake_rewards_filter_bench_core(55 * 1000, false).await;
 }
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -281,7 +281,7 @@ async fn stake_rewards_from_warp() {
 
 #[tokio::test]
 async fn stake_rewards_filter_bench_100() {
-    stake_rewards_filter_bench_core(100).await;
+    stake_rewards_filter_bench_core(550 * 1000).await;
 }
 
 async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
@@ -296,7 +296,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
     program_test.add_account(vote_address, vote_account.clone().into());
 
     // create stake accounts with 0.9 sol to test min-stake filtering
-    const TEST_FILTER_STAKE: u64 = 900_000_000; // 0.9 sol
+    const TEST_FILTER_STAKE: u64 = 99900_000_000; // 0.9 sol
     let mut to_filter = vec![];
     for i in 0..num_stake_accounts {
         let stake_pubkey = Pubkey::new_unique();
@@ -357,16 +357,16 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         .unwrap();
     assert!(account.lamports > stake_lamports);
 
-    // check that filtered stake accounts are excluded from receiving epoch rewards
-    for stake_address in to_filter {
-        let account = context
-            .banks_client
-            .get_account(stake_address)
-            .await
-            .expect("account exists")
-            .unwrap();
-        assert_eq!(account.lamports, TEST_FILTER_STAKE);
-    }
+    // // check that filtered stake accounts are excluded from receiving epoch rewards
+    // for stake_address in to_filter {
+    //     let account = context
+    //         .banks_client
+    //         .get_account(stake_address)
+    //         .await
+    //         .expect("account exists")
+    //         .unwrap();
+    //     assert_eq!(account.lamports, TEST_FILTER_STAKE);
+    // }
 
     // check that stake is fully active
     let stake_history_account = context

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -302,7 +302,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64, filter: bool) 
 
     // create stake accounts with 0.9 sol to test min-stake filtering
     const TEST_FILTER_STAKE: u64 = 900_000_000; // 0.9 sol
-    const TEST_UNFILTER_STAKE: u64 = 1100_000_000; // 1.1 sol
+    const TEST_UNFILTER_STAKE: u64 = 1_100_000_000; // 1.1 sol
     let mut to_filter = vec![];
     for i in 0..num_stake_accounts {
         let stake_pubkey = Pubkey::new_unique();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2888,14 +2888,14 @@ impl Bank {
     ) -> EpochRewardCalculateParamInfo<'a> {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
-        let stake_delegations = self.filter_stake_delegations(&stakes);
+        let stake_delegations = self.filter_stake_delegations(stakes);
 
         let cached_vote_accounts = stakes.vote_accounts();
 
         EpochRewardCalculateParamInfo {
-            stake_history: stake_history,
+            stake_history,
             stake_delegations,
-            cached_vote_accounts: cached_vote_accounts,
+            cached_vote_accounts,
         }
     }
 
@@ -3018,9 +3018,9 @@ impl Bank {
         vote_with_stake_delegations_map
     }
 
-    fn calculate_reward_points2<'a>(
+    fn calculate_reward_points2(
         &self,
-        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo,
         rewards: u64,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
@@ -3067,7 +3067,7 @@ impl Bank {
                     stake_state::calculate_points(
                         stake_account.stake_state(),
                         &vote_state,
-                        Some(&stake_history),
+                        Some(stake_history),
                     )
                     .unwrap_or(0)
                 })
@@ -3119,9 +3119,9 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
-    fn redeem_rewards2<'a>(
+    fn redeem_rewards2(
         &self,
-        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo,
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
@@ -3154,12 +3154,12 @@ impl Bank {
                     let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
                         // inner
                         move |inner_event: &_| {
-                            outer(&RewardCalculationEvent::Staking(&stake_pubkey, inner_event))
+                            outer(&RewardCalculationEvent::Staking(stake_pubkey, inner_event))
                         }
                     });
 
                     let stake_pubkey = **stake_pubkey;
-                    let stake_account = StakeAccount::from((*stake_account).clone());
+                    let stake_account = (*stake_account).clone();
 
                     let delegation = stake_account.delegation();
                     let (mut stake_account, stake_state) =
@@ -3186,7 +3186,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(&stake_history),
+                        Some(stake_history),
                         reward_calc_tracer.as_ref(),
                         credits_auto_rewind,
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2476,7 +2476,17 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        self.pay_validator_rewards_with_thread_pool(
+        // self.pay_validator_rewards_with_thread_pool(
+        //     prev_epoch,
+        //     validator_rewards,
+        //     reward_calc_tracer,
+        //     self.credits_auto_rewind(),
+        //     thread_pool,
+        //     metrics,
+        //     update_rewards_from_cached_accounts,
+        // );
+
+        self.pay_validator_rewards_with_thread_pool2(
             prev_epoch,
             validator_rewards,
             reward_calc_tracer,
@@ -2862,6 +2872,49 @@ impl Bank {
     }
 
     /// Load, calculate and payout epoch rewards for stake and vote accounts
+    fn pay_validator_rewards_with_thread_pool2(
+        &mut self,
+        rewarded_epoch: Epoch,
+        rewards: u64,
+        reward_calc_tracer: Option<impl RewardCalcTracer>,
+        credits_auto_rewind: bool,
+        thread_pool: &ThreadPool,
+        metrics: &mut RewardsMetrics,
+        _update_rewards_from_cached_accounts: bool,
+    ) {
+        let point_value = self.calculate_reward_points2(rewards, thread_pool, metrics);
+
+        if let Some(point_value) = point_value {
+            info!("haha start redeem_rewards2");
+            let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
+                rewarded_epoch,
+                point_value,
+                credits_auto_rewind,
+                thread_pool,
+                reward_calc_tracer.as_ref(),
+                metrics,
+            );
+
+            self.store_stake_accounts(&stake_rewards, metrics);
+            let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
+            self.update_reward_history(stake_rewards, vote_rewards);
+
+            // let mut rewards = self.redeem_rewards2(
+            //     rewarded_epoch,
+            //     point_value,
+            //     credits_auto_rewind,
+            //     thread_pool,
+            //     reward_calc_tracer.as_ref(),
+            //     metrics,
+            // );
+            info!("haha finish redeem_rewards2");
+
+            //info!("rewards_len: {}", rewards.len());
+            //self.update_reward_history2(&mut rewards);
+        }
+    }
+
+    /// Load, calculate and payout epoch rewards for stake and vote accounts
     fn pay_validator_rewards_with_thread_pool(
         &mut self,
         rewarded_epoch: Epoch,
@@ -2886,11 +2939,11 @@ impl Bank {
             metrics,
         );
 
-        let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
+        // let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
 
-        assert!(point_value == point_value2);
+        // assert!(point_value == point_value2);
 
-        info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
+        // info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
 
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
@@ -2903,39 +2956,39 @@ impl Bank {
                 metrics,
             );
 
-            let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
-                rewarded_epoch,
-                point_value2.unwrap(),
-                credits_auto_rewind,
-                thread_pool,
-                reward_calc_tracer.as_ref(),
-                metrics,
-            );
+            // let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
+            //     rewarded_epoch,
+            //     point_value2.unwrap(),
+            //     credits_auto_rewind,
+            //     thread_pool,
+            //     reward_calc_tracer.as_ref(),
+            //     metrics,
+            // );
 
-            info!(
-                "vote_account_rewards_len: {}, {}",
-                vote_account_rewards.len(),
-                vote_account_rewards2.len()
-            );
+            // info!(
+            //     "vote_account_rewards_len: {}, {}",
+            //     vote_account_rewards.len(),
+            //     vote_account_rewards2.len()
+            // );
 
-            info!(
-                "vote_account_rewards: {:?}, {:?}",
-                vote_account_rewards, vote_account_rewards2
-            );
+            // info!(
+            //     "vote_account_rewards: {:?}, {:?}",
+            //     vote_account_rewards, vote_account_rewards2
+            // );
 
-            info!(
-                "stake_rewards_len: {}, {}",
-                stake_rewards.len(),
-                stake_rewards2.len()
-            );
+            // info!(
+            //     "stake_rewards_len: {}, {}",
+            //     stake_rewards.len(),
+            //     stake_rewards2.len()
+            // );
 
-            let vote_len1: usize = vote_account_rewards
-                .iter()
-                .map(|I| if I.3 { 1 } else { 0 })
-                .sum();
+            // let vote_len1: usize = vote_account_rewards
+            //     .iter()
+            //     .map(|I| if I.3 { 1 } else { 0 })
+            //     .sum();
 
-            assert!(vote_len1 == vote_account_rewards2.len());
-            assert!(stake_rewards.len() == stake_rewards2.len());
+            // assert!(vote_len1 == vote_account_rewards2.len());
+            // assert!(stake_rewards.len() == stake_rewards2.len());
 
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
@@ -3092,6 +3145,7 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
+        //) -> Vec<(Pubkey, RewardInfo)> {
     ) -> (VoteRewards, StakeRewards) {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
@@ -3110,7 +3164,7 @@ impl Bank {
         };
 
         let vote_account_rewards: VoteRewards = DashMap::new();
-        let (stake_rewards, measure) = measure!(thread_pool.install(|| {
+        let (mut stake_rewards, measure) = measure!(thread_pool.install(|| {
             stake_delegations
                 .par_iter()
                 .filter_map(|(stake_pubkey, stake_account)| {
@@ -3178,6 +3232,18 @@ impl Bank {
                             },
                             stake_account,
                         });
+
+                        //self.store_account(&stake_pubkey, &stake_account);
+
+                        // (stakers_reward > 0).then_some((
+                        //     stake_pubkey,
+                        //     RewardInfo {
+                        //         reward_type: RewardType::Staking,
+                        //         lamports: i64::try_from(stakers_reward).unwrap(),
+                        //         post_balance,
+                        //         commission: Some(vote_state.commission),
+                        //     },
+                        // ));
                     } else {
                         debug!(
                             "stake_state::redeem_rewards() failed for {}: {:?}",
@@ -3187,9 +3253,14 @@ impl Bank {
                     None
                 })
                 .collect()
+            //.collect::<Vec<(Pubkey, RewardInfo)>>()
         }));
         metrics.redeem_rewards2_us += measure.as_us();
         (vote_account_rewards, stake_rewards)
+
+        //let mut rewards = self.store_vote_accounts(vote_account_rewards, metrics);
+        //rewards.append(&mut stake_rewards);
+        //rewards
     }
 
     fn redeem_rewards(
@@ -3328,6 +3399,13 @@ impl Bank {
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
         vote_rewards
+    }
+
+    fn update_reward_history2(&self, new_rewards: &mut Vec<(Pubkey, RewardInfo)>) {
+        let additional_reserve = new_rewards.len();
+        let mut rewards = self.rewards.write().unwrap();
+        rewards.reserve(additional_reserve);
+        rewards.append(new_rewards);
     }
 
     fn update_reward_history(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3022,6 +3022,14 @@ impl Bank {
         vote_with_stake_delegations_map
     }
 
+    /// Calculates epoch reward points from stake/vote accounts with reward calculate parameter struct.
+    ///
+    /// * reward_calculate_params: reward calculate parameter struct - stake history, delegation and vote accounts.
+    /// * rewards: epoch rewards in lamports
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * metrics: reward metrics
+    ///
+    /// Returns reward lamports and points for the epoch.
     fn calculate_reward_points2(
         &self,
         reward_calculate_params: &EpochRewardCalculateParamInfo,
@@ -3084,6 +3092,15 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
+    /// Calculates epoch reward points from stake/vote accounts using joined vote/stake account map
+    ///
+    /// * vote_with_stake_delegation_map: joined map of vote_accounts and stake_accounts
+    /// * rewards: epoch rewards in lamports
+    /// * stake_history: stake history
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * metrics: reward metrics
+    ///
+    /// Returns reward lamports and points for the epoch.
     fn calculate_reward_points(
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
@@ -3123,6 +3140,17 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
+    /// Calculates epoch rewards for stake/vote accounts
+    ///
+    /// * reward_calculate_params: reward calculate parameter struct - stake history, delegation and vote accounts.
+    /// * rewarded_epoch: reward epoch
+    /// * point_value: reward PointValue
+    /// * credits_auto_rewind: boolean flag for auto rewind vote credits during reward calculation
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * reward_calc_tracer: tracer fn for reward calculation
+    /// * metrics: reward metrics
+    ///
+    /// Returns vote rewards and stake rewards
     fn redeem_rewards2(
         &self,
         reward_calculate_params: &EpochRewardCalculateParamInfo,
@@ -3232,6 +3260,17 @@ impl Bank {
         (vote_account_rewards, stake_rewards)
     }
 
+    /// Calculates epoch reward for stake/vote accounts using joined vote/stake account map
+    ///
+    /// * vote_with_stake_delegation_map: joined map of vote_accounts and stake_accounts
+    /// * rewarded_epoch: reward epoch
+    /// * point_value: reward PointValue
+    /// * credits_auto_rewind: boolean flag for auto rewind vote credits during reward calculation
+    /// * thread_pool: instance of thread_pool for parallel processing
+    /// * reward_calc_tracer: tracer fn for reward calculation
+    /// * metrics: reward metrics
+    ///
+    /// Returns vote rewards and stake rewards
     fn redeem_rewards(
         &self,
         vote_with_stake_delegations_map: DashMap<Pubkey, VoteWithStakeDelegations>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2483,6 +2483,8 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
+        println!("haha start rewarding");
+
         if self
             .feature_set
             .is_active(&feature_set::update_rewards_no_join::id())
@@ -2506,6 +2508,7 @@ impl Bank {
                 update_rewards_from_cached_accounts,
             );
         }
+        println!("haha end rewarding");
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
@@ -2915,7 +2918,10 @@ impl Bank {
         let point_value =
             self.calculate_reward_points2(&reward_calculate_param, rewards, thread_pool, metrics);
 
+        println!("haha point_value: {:?}", point_value);
+
         if let Some(point_value) = point_value {
+            println!("haha redeem start");
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
                 &reward_calculate_param,
                 rewarded_epoch,
@@ -2925,8 +2931,13 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
+            println!("haha redeem end");
+
+            drop(reward_calculate_param);
+            drop(stakes);
 
             self.store_stake_accounts(&stake_rewards, metrics);
+
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
             self.update_reward_history(stake_rewards, vote_rewards);
         }
@@ -2958,6 +2969,8 @@ impl Bank {
             thread_pool,
             metrics,
         );
+
+        println!("haha point_value: {:?}", point_value);
 
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
@@ -3319,6 +3332,8 @@ impl Bank {
     }
 
     fn store_stake_accounts(&self, stake_rewards: &[StakeReward], metrics: &mut RewardsMetrics) {
+        println!("haha store stake start: {}", stake_rewards.len());
+
         // store stake account even if stake_reward is 0
         // because credits observed has changed
         let (_, measure) = measure!({
@@ -3327,6 +3342,8 @@ impl Bank {
         metrics
             .store_stake_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
+
+        println!("haha store stake end");
     }
 
     fn store_vote_accounts(
@@ -3334,6 +3351,8 @@ impl Bank {
         vote_account_rewards: VoteRewards,
         metrics: &mut RewardsMetrics,
     ) -> Vec<(Pubkey, RewardInfo)> {
+        println!("haha store vote start");
+
         let (vote_rewards, measure) = measure!(vote_account_rewards
             .into_iter()
             .filter_map(
@@ -3363,6 +3382,9 @@ impl Bank {
         metrics
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
+
+        println!("haha store vote end: {}", vote_rewards.len());
+
         vote_rewards
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -67,6 +67,7 @@ use {
         snapshot_hash::SnapshotHash,
         sorted_storages::SortedStorages,
         stake_account::{self, StakeAccount},
+        stake_history::StakeHistory,
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -2914,6 +2915,7 @@ impl Bank {
         metrics: &mut RewardsMetrics,
         update_rewards_from_cached_accounts: bool,
     ) {
+        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_with_stake_delegations_map = self.load_vote_and_stake_accounts(
             thread_pool,
             reward_calc_tracer.as_ref(),
@@ -2924,6 +2926,7 @@ impl Bank {
         let point_value = self.calculate_reward_points(
             &vote_with_stake_delegations_map,
             rewards,
+            &stake_history,
             thread_pool,
             metrics,
         );
@@ -2934,6 +2937,7 @@ impl Bank {
                 rewarded_epoch,
                 point_value,
                 credits_auto_rewind,
+                &stake_history,
                 thread_pool,
                 reward_calc_tracer.as_ref(),
                 metrics,
@@ -3050,10 +3054,10 @@ impl Bank {
         &self,
         vote_with_stake_delegations_map: &VoteWithStakeDelegationsMap,
         rewards: u64,
+        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
-        let stake_history = self.stakes_cache.stakes().history().clone();
         let (points, measure) = measure!(thread_pool.install(|| {
             vote_with_stake_delegations_map
                 .par_iter()
@@ -3070,7 +3074,7 @@ impl Bank {
                             stake_state::calculate_points(
                                 stake_account.stake_state(),
                                 vote_state,
-                                Some(&stake_history),
+                                Some(stake_history),
                             )
                             .unwrap_or(0)
                         })
@@ -3199,11 +3203,11 @@ impl Bank {
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
+        stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
-        let stake_history = self.stakes_cache.stakes().history().clone();
         let vote_account_rewards: VoteRewards =
             DashMap::with_capacity(vote_with_stake_delegations_map.len());
         let stake_delegation_iterator = vote_with_stake_delegations_map.into_par_iter().flat_map(
@@ -3241,7 +3245,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(&stake_history),
+                        Some(stake_history),
                         reward_calc_tracer.as_ref(),
                         credits_auto_rewind,
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1173,7 +1173,7 @@ struct LoadVoteAndStakeAccountsResult {
 type VoteRewards = DashMap<Pubkey, (AccountSharedData, u8, u64, bool)>;
 type StakeRewards = Vec<StakeReward>;
 
-struct EpochRewardCalculatePramInfo<'a> {
+struct EpochRewardCalculateParamInfo<'a> {
     stake_history: StakeHistory,
     stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
     cached_vote_accounts: &'a VoteAccounts,
@@ -2885,14 +2885,14 @@ impl Bank {
     fn get_epoch_reward_calculate_param_info<'a>(
         &self,
         stakes: &'a Stakes<StakeAccount<Delegation>>,
-    ) -> EpochRewardCalculatePramInfo<'a> {
+    ) -> EpochRewardCalculateParamInfo<'a> {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
         let stake_delegations = self.filter_stake_delegations(&stakes);
 
         let cached_vote_accounts = stakes.vote_accounts();
 
-        EpochRewardCalculatePramInfo {
+        EpochRewardCalculateParamInfo {
             stake_history: stake_history,
             stake_delegations,
             cached_vote_accounts: cached_vote_accounts,
@@ -3020,12 +3020,12 @@ impl Bank {
 
     fn calculate_reward_points2<'a>(
         &self,
-        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
         rewards: u64,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
-        let EpochRewardCalculatePramInfo {
+        let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
             cached_vote_accounts,
@@ -3121,7 +3121,7 @@ impl Bank {
 
     fn redeem_rewards2<'a>(
         &self,
-        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
+        reward_calculate_params: &EpochRewardCalculateParamInfo<'a>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
@@ -3129,7 +3129,7 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
-        let EpochRewardCalculatePramInfo {
+        let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
             cached_vote_accounts,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2871,8 +2871,8 @@ impl Bank {
         }
     }
 
-    /// Load, calculate and payout epoch rewards for stake and vote accounts
-    fn pay_validator_rewards_with_thread_pool2(
+    /// Load, calculate and payout epoch rewards for stake and vote accounts (no join of vote/stake accounts)
+    fn pay_validator_rewards_with_thread_pool_no_join(
         &mut self,
         rewarded_epoch: Epoch,
         rewards: u64,
@@ -2880,12 +2880,10 @@ impl Bank {
         credits_auto_rewind: bool,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
-        _update_rewards_from_cached_accounts: bool,
     ) {
         let point_value = self.calculate_reward_points2(rewards, thread_pool, metrics);
 
         if let Some(point_value) = point_value {
-            info!("haha start redeem_rewards2");
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
                 rewarded_epoch,
                 point_value,
@@ -2898,19 +2896,6 @@ impl Bank {
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
             self.update_reward_history(stake_rewards, vote_rewards);
-
-            // let mut rewards = self.redeem_rewards2(
-            //     rewarded_epoch,
-            //     point_value,
-            //     credits_auto_rewind,
-            //     thread_pool,
-            //     reward_calc_tracer.as_ref(),
-            //     metrics,
-            // );
-            info!("haha finish redeem_rewards2");
-
-            //info!("rewards_len: {}", rewards.len());
-            //self.update_reward_history2(&mut rewards);
         }
     }
 
@@ -2939,12 +2924,6 @@ impl Bank {
             metrics,
         );
 
-        // let point_value2 = self.calculate_reward_points2(rewards, thread_pool, metrics);
-
-        // assert!(point_value == point_value2);
-
-        // info!("calc_point_val: {:?}, {:?}", point_value, point_value2);
-
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
                 vote_with_stake_delegations_map,
@@ -2955,40 +2934,6 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
-
-            // let (vote_account_rewards2, stake_rewards2) = self.redeem_rewards2(
-            //     rewarded_epoch,
-            //     point_value2.unwrap(),
-            //     credits_auto_rewind,
-            //     thread_pool,
-            //     reward_calc_tracer.as_ref(),
-            //     metrics,
-            // );
-
-            // info!(
-            //     "vote_account_rewards_len: {}, {}",
-            //     vote_account_rewards.len(),
-            //     vote_account_rewards2.len()
-            // );
-
-            // info!(
-            //     "vote_account_rewards: {:?}, {:?}",
-            //     vote_account_rewards, vote_account_rewards2
-            // );
-
-            // info!(
-            //     "stake_rewards_len: {}, {}",
-            //     stake_rewards.len(),
-            //     stake_rewards2.len()
-            // );
-
-            // let vote_len1: usize = vote_account_rewards
-            //     .iter()
-            //     .map(|I| if I.3 { 1 } else { 0 })
-            //     .sum();
-
-            // assert!(vote_len1 == vote_account_rewards2.len());
-            // assert!(stake_rewards.len() == stake_rewards2.len());
 
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
@@ -3044,7 +2989,6 @@ impl Bank {
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
         let stake_history = self.stakes_cache.stakes().history().clone();
-
         let stakes = self.stakes_cache.stakes();
         let stake_delegations = self.filter_stake_delegations(&stakes);
 
@@ -3145,7 +3089,6 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
-        //) -> Vec<(Pubkey, RewardInfo)> {
     ) -> (VoteRewards, StakeRewards) {
         let stake_history = self.stakes_cache.stakes().history().clone();
 
@@ -3164,7 +3107,7 @@ impl Bank {
         };
 
         let vote_account_rewards: VoteRewards = DashMap::new();
-        let (mut stake_rewards, measure) = measure!(thread_pool.install(|| {
+        let (stake_rewards, measure) = measure!(thread_pool.install(|| {
             stake_delegations
                 .par_iter()
                 .filter_map(|(stake_pubkey, stake_account)| {
@@ -3232,18 +3175,6 @@ impl Bank {
                             },
                             stake_account,
                         });
-
-                        //self.store_account(&stake_pubkey, &stake_account);
-
-                        // (stakers_reward > 0).then_some((
-                        //     stake_pubkey,
-                        //     RewardInfo {
-                        //         reward_type: RewardType::Staking,
-                        //         lamports: i64::try_from(stakers_reward).unwrap(),
-                        //         post_balance,
-                        //         commission: Some(vote_state.commission),
-                        //     },
-                        // ));
                     } else {
                         debug!(
                             "stake_state::redeem_rewards() failed for {}: {:?}",
@@ -3253,14 +3184,9 @@ impl Bank {
                     None
                 })
                 .collect()
-            //.collect::<Vec<(Pubkey, RewardInfo)>>()
         }));
         metrics.redeem_rewards2_us += measure.as_us();
         (vote_account_rewards, stake_rewards)
-
-        //let mut rewards = self.store_vote_accounts(vote_account_rewards, metrics);
-        //rewards.append(&mut stake_rewards);
-        //rewards
     }
 
     fn redeem_rewards(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2476,25 +2476,29 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        // self.pay_validator_rewards_with_thread_pool(
-        //     prev_epoch,
-        //     validator_rewards,
-        //     reward_calc_tracer,
-        //     self.credits_auto_rewind(),
-        //     thread_pool,
-        //     metrics,
-        //     update_rewards_from_cached_accounts,
-        // );
-
-        self.pay_validator_rewards_with_thread_pool2(
-            prev_epoch,
-            validator_rewards,
-            reward_calc_tracer,
-            self.credits_auto_rewind(),
-            thread_pool,
-            metrics,
-            update_rewards_from_cached_accounts,
-        );
+        if self
+            .feature_set
+            .is_active(&feature_set::update_rewards_no_join::id())
+        {
+            self.pay_validator_rewards_with_thread_pool_no_join(
+                prev_epoch,
+                validator_rewards,
+                reward_calc_tracer,
+                self.credits_auto_rewind(),
+                thread_pool,
+                metrics,
+            );
+        } else {
+            self.pay_validator_rewards_with_thread_pool(
+                prev_epoch,
+                validator_rewards,
+                reward_calc_tracer,
+                self.credits_auto_rewind(),
+                thread_pool,
+                metrics,
+                update_rewards_from_cached_accounts,
+            );
+        }
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -78,7 +78,7 @@ use {
         system_instruction_processor::{get_system_account_kind, SystemAccountKind},
         transaction_batch::TransactionBatch,
         transaction_error_metrics::TransactionErrorMetrics,
-        vote_account::{VoteAccount, VoteAccountsHashMap},
+        vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     },
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
@@ -1172,6 +1172,12 @@ struct LoadVoteAndStakeAccountsResult {
 
 type VoteRewards = DashMap<Pubkey, (AccountSharedData, u8, u64, bool)>;
 type StakeRewards = Vec<StakeReward>;
+
+struct EpochRewardCalculatePramInfo<'a> {
+    stake_history: StakeHistory,
+    stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+    cached_vote_accounts: &'a VoteAccounts,
+}
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {
@@ -2876,6 +2882,23 @@ impl Bank {
         }
     }
 
+    fn get_epoch_reward_calculate_param_info<'a>(
+        &self,
+        stakes: &'a Stakes<StakeAccount<Delegation>>,
+    ) -> EpochRewardCalculatePramInfo<'a> {
+        let stake_history = self.stakes_cache.stakes().history().clone();
+
+        let stake_delegations = self.filter_stake_delegations(&stakes);
+
+        let cached_vote_accounts = stakes.vote_accounts();
+
+        EpochRewardCalculatePramInfo {
+            stake_history: stake_history,
+            stake_delegations,
+            cached_vote_accounts: cached_vote_accounts,
+        }
+    }
+
     /// Load, calculate and payout epoch rewards for stake and vote accounts (no join of vote/stake accounts)
     fn pay_validator_rewards_with_thread_pool_no_join(
         &mut self,
@@ -2886,10 +2909,15 @@ impl Bank {
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) {
-        let point_value = self.calculate_reward_points2(rewards, thread_pool, metrics);
+        let stakes = self.stakes_cache.stakes();
+        let reward_calculate_param = self.get_epoch_reward_calculate_param_info(&stakes);
+
+        let point_value =
+            self.calculate_reward_points2(&reward_calculate_param, rewards, thread_pool, metrics);
 
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
+                &reward_calculate_param,
                 rewarded_epoch,
                 point_value,
                 credits_auto_rewind,
@@ -2990,17 +3018,19 @@ impl Bank {
         vote_with_stake_delegations_map
     }
 
-    fn calculate_reward_points2(
+    fn calculate_reward_points2<'a>(
         &self,
+        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
         rewards: u64,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<PointValue> {
-        let stake_history = self.stakes_cache.stakes().history().clone();
-        let stakes = self.stakes_cache.stakes();
-        let stake_delegations = self.filter_stake_delegations(&stakes);
+        let EpochRewardCalculatePramInfo {
+            stake_history,
+            stake_delegations,
+            cached_vote_accounts,
+        } = reward_calculate_params;
 
-        let cached_vote_accounts = stakes.vote_accounts();
         let solana_vote_program: Pubkey = solana_vote_program::id();
 
         let get_vote_account = |vote_pubkey: &Pubkey| -> Option<VoteAccount> {
@@ -3089,8 +3119,9 @@ impl Bank {
         (points > 0).then_some(PointValue { rewards, points })
     }
 
-    fn redeem_rewards2(
+    fn redeem_rewards2<'a>(
         &self,
+        reward_calculate_params: &EpochRewardCalculatePramInfo<'a>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
         credits_auto_rewind: bool,
@@ -3098,12 +3129,12 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewards, StakeRewards) {
-        let stake_history = self.stakes_cache.stakes().history().clone();
+        let EpochRewardCalculatePramInfo {
+            stake_history,
+            stake_delegations,
+            cached_vote_accounts,
+        } = reward_calculate_params;
 
-        let stakes = self.stakes_cache.stakes();
-        let stake_delegations = self.filter_stake_delegations(&stakes);
-
-        let cached_vote_accounts = stakes.vote_accounts();
         let solana_vote_program: Pubkey = solana_vote_program::id();
 
         let get_vote_account = |vote_pubkey: &Pubkey| -> Option<VoteAccount> {
@@ -3333,13 +3364,6 @@ impl Bank {
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
         vote_rewards
-    }
-
-    fn update_reward_history2(&self, new_rewards: &mut Vec<(Pubkey, RewardInfo)>) {
-        let additional_reserve = new_rewards.len();
-        let mut rewards = self.rewards.write().unwrap();
-        rewards.reserve(additional_reserve);
-        rewards.append(new_rewards);
     }
 
     fn update_reward_history(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2483,8 +2483,6 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::update_rewards_from_cached_accounts::id());
 
-        println!("haha start rewarding");
-
         if self
             .feature_set
             .is_active(&feature_set::update_rewards_no_join::id())
@@ -2508,7 +2506,6 @@ impl Bank {
                 update_rewards_from_cached_accounts,
             );
         }
-        println!("haha end rewarding");
 
         let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
         let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
@@ -2918,10 +2915,7 @@ impl Bank {
         let point_value =
             self.calculate_reward_points2(&reward_calculate_param, rewards, thread_pool, metrics);
 
-        println!("haha point_value: {:?}", point_value);
-
         if let Some(point_value) = point_value {
-            println!("haha redeem start");
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards2(
                 &reward_calculate_param,
                 rewarded_epoch,
@@ -2931,7 +2925,6 @@ impl Bank {
                 reward_calc_tracer.as_ref(),
                 metrics,
             );
-            println!("haha redeem end");
 
             drop(reward_calculate_param);
             drop(stakes);
@@ -2969,8 +2962,6 @@ impl Bank {
             thread_pool,
             metrics,
         );
-
-        println!("haha point_value: {:?}", point_value);
 
         if let Some(point_value) = point_value {
             let (vote_account_rewards, stake_rewards) = self.redeem_rewards(
@@ -3332,8 +3323,6 @@ impl Bank {
     }
 
     fn store_stake_accounts(&self, stake_rewards: &[StakeReward], metrics: &mut RewardsMetrics) {
-        println!("haha store stake start: {}", stake_rewards.len());
-
         // store stake account even if stake_reward is 0
         // because credits observed has changed
         let (_, measure) = measure!({
@@ -3342,8 +3331,6 @@ impl Bank {
         metrics
             .store_stake_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
-
-        println!("haha store stake end");
     }
 
     fn store_vote_accounts(
@@ -3351,8 +3338,6 @@ impl Bank {
         vote_account_rewards: VoteRewards,
         metrics: &mut RewardsMetrics,
     ) -> Vec<(Pubkey, RewardInfo)> {
-        println!("haha store vote start");
-
         let (vote_rewards, measure) = measure!(vote_account_rewards
             .into_iter()
             .filter_map(
@@ -3382,8 +3367,6 @@ impl Bank {
         metrics
             .store_vote_accounts_us
             .fetch_add(measure.as_us(), Relaxed);
-
-        println!("haha store vote end: {}", vote_rewards.len());
 
         vote_rewards
     }

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -15,7 +15,9 @@ pub(crate) struct NewEpochTimings {
 pub(crate) struct RewardsMetrics {
     pub(crate) load_vote_and_stake_accounts_us: AtomicU64,
     pub(crate) calculate_points_us: AtomicU64,
+    pub(crate) calculate_points2_us: AtomicU64,
     pub(crate) redeem_rewards_us: u64,
+    pub(crate) redeem_rewards2_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) invalid_cached_vote_accounts: usize,
@@ -83,7 +85,13 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.calculate_points_us.load(Relaxed),
             i64
         ),
+        (
+            "calculate_points2_us",
+            metrics.calculate_points2_us.load(Relaxed),
+            i64
+        ),
         ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
+        ("redeem_rewards2_us", metrics.redeem_rewards2_us, i64),
         (
             "store_stake_accounts_us",
             metrics.store_stake_accounts_us.load(Relaxed),

--- a/runtime/src/storable_accounts.rs
+++ b/runtime/src/storable_accounts.rs
@@ -122,6 +122,32 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a, T>
 
 /// The last parameter exists until this feature is activated:
 ///  ignore slot when calculating an account hash #28420
+impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a, T>
+    for (Slot, &'a [&'a (Pubkey, T)], IncludeSlotInHash)
+{
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        &self.1[index].0
+    }
+    fn account(&self, index: usize) -> &T {
+        &self.1[index].1
+    }
+    fn slot(&self, _index: usize) -> Slot {
+        // per-index slot is not unique per slot when per-account slot is not included in the source data
+        self.target_slot()
+    }
+    fn target_slot(&self) -> Slot {
+        self.0
+    }
+    fn len(&self) -> usize {
+        self.1.len()
+    }
+    fn include_slot_in_hash(&self) -> IncludeSlotInHash {
+        self.2
+    }
+}
+
+/// The last parameter exists until this feature is activated:
+///  ignore slot when calculating an account hash #28420
 impl<'a> StorableAccounts<'a, StoredAccountMeta<'a>>
     for (Slot, &'a [&'a StoredAccountMeta<'a>], IncludeSlotInHash)
 {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -368,6 +368,9 @@ pub mod fix_recent_blockhashes {
 pub mod update_rewards_from_cached_accounts {
     solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
+pub mod update_rewards_no_join {
+    solana_sdk::declare_id!("DhaAhXU9kGosmZQhSm3jWYR7x9p4scgN69P5dwHavSj8");
+}
 
 pub mod spl_token_v3_4_0 {
     solana_sdk::declare_id!("Ftok4njE8b7tDffYkC5bAbCaQv5sL6jispYrprzatUwN");
@@ -736,6 +739,7 @@ lazy_static! {
         (executables_incur_cpi_data_cost::id(), "Executables incur CPI data costs"),
         (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
         (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
+        (update_rewards_no_join::id(), "update rewards avoid joining vote accounts and stake accounts"),
         (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
         (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
         (default_units_per_instruction::id(), "Default max tx-wide compute units calculated per instruction"),


### PR DESCRIPTION
#### Problem

Prepare vote rewards optimization (https://github.com/solana-labs/solana/pull/31227)

Parallelize vote rewards pass `&Vec<(pubkey, T)>` to accounts db to store vote accounts, which requires storable traits support on `&[&(pubkey, T)]` variant. 


#### Summary of Changes

- add storable traits for &[&(pubkey, T)] variant

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
