### PR TITLE
Display validator commit

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -307,7 +307,7 @@ pub struct RpcContactInfo {
     /// Shred version
     pub shred_version: Option<u16>,
     /// First 4 bytes of the sha1 commit hash
-    pub commit: Option<u32>,
+    pub commit: Option<String>,
 }
 
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot
@@ -336,7 +336,7 @@ pub struct RpcVersionInfo {
     /// first 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
     // first 4 bytes of the sha1 commit hash
-    pub commit: Option<u32>,
+    pub commit: Option<String>,
 }
 impl fmt::Debug for RpcVersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -335,8 +335,9 @@ pub struct RpcVersionInfo {
     pub solana_core: String,
     /// first 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
+    // first 4 bytes of the sha1 commit hash
+    pub commit: Option<u32>,
 }
-
 impl fmt::Debug for RpcVersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.solana_core)

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -306,6 +306,8 @@ pub struct RpcContactInfo {
     pub feature_set: Option<u32>,
     /// Shred version
     pub shred_version: Option<u16>,
+    /// First 4 bytes of the sha1 commit hash
+    pub commit: Option<u32>,
 }
 
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -357,7 +357,7 @@ impl RpcSender for MockSender {
                 json!(RpcVersionInfo {
                     solana_core: version.to_string(),
                     feature_set: Some(version.feature_set),
-                    commit: Some(version.commit),
+                    commit: Some(format!("{:x}", version.commit)),
                 })
             }
             "getLatestBlockhash" => serde_json::to_value(Response {

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -357,6 +357,7 @@ impl RpcSender for MockSender {
                 json!(RpcVersionInfo {
                     solana_core: version.to_string(),
                     feature_set: Some(version.feature_set),
+                    commit: Some(version.commit),
                 })
             }
             "getLatestBlockhash" => serde_json::to_value(Response {

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -379,6 +379,7 @@ impl RpcSender for MockSender {
                 version: Some("1.0.0 c375ce1f".to_string()),
                 feature_set: None,
                 shred_version: None,
+                commit: None,
             }])?,
             "getBlock" => serde_json::to_value(EncodedConfirmedBlock {
                 previous_blockhash: "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B".to_string(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3457,12 +3457,12 @@ pub mod rpc_full {
                     if my_shred_version == contact_info.shred_version
                         && ContactInfo::is_valid_address(&contact_info.gossip, socket_addr_space)
                     {
-                        let (version, feature_set) = if let Some(version) =
+                        let (version, feature_set, commit) = if let Some(version) =
                             cluster_info.get_node_version(&contact_info.id)
                         {
-                            (Some(version.to_string()), Some(version.feature_set))
+                            (Some(version.to_string()), Some(version.feature_set), version.commit)
                         } else {
-                            (None, None)
+                            (None, None, None)
                         };
                         Some(RpcContactInfo {
                             pubkey: contact_info.id.to_string(),
@@ -3473,6 +3473,7 @@ pub mod rpc_full {
                             version,
                             feature_set,
                             shred_version: Some(my_shred_version),
+                            commit: commit,
                         })
                     } else {
                         None // Exclude spy nodes

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5138,6 +5138,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
             "version": null,
             "featureSet": null,
+            "commit": null,
         }, {
             "pubkey": rpc.leader_pubkey().to_string(),
             "gossip": "127.0.0.1:1235",
@@ -5147,6 +5148,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
             "version": null,
             "featureSet": null,
+            "commit": null,
         }]);
         assert_eq!(result, expected);
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3461,7 +3461,11 @@ pub mod rpc_full {
                         let (version, feature_set, commit) = if let Some(version) =
                             cluster_info.get_node_version(&contact_info.id)
                         {
-                            (Some(version.to_string()), Some(version.feature_set), version.commit)
+                            (
+                                Some(version.to_string()),
+                                Some(version.feature_set),
+                                version.commit,
+                            )
                         } else {
                             (None, None, None)
                         };
@@ -3474,7 +3478,7 @@ pub mod rpc_full {
                             version,
                             feature_set,
                             shred_version: Some(my_shred_version),
-                            commit: commit,
+                            commit,
                         })
                     } else {
                         None // Exclude spy nodes

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2668,6 +2668,7 @@ pub mod rpc_minimal {
             Ok(RpcVersionInfo {
                 solana_core: version.to_string(),
                 feature_set: Some(version.feature_set),
+                commit: Some(version.commit),
             })
         }
 
@@ -6640,6 +6641,7 @@ pub mod tests {
             json!({
                 "solana-core": version.to_string(),
                 "feature-set": version.feature_set,
+                "commit": version.commit,
             })
         };
         assert_eq!(result, expected);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2668,7 +2668,7 @@ pub mod rpc_minimal {
             Ok(RpcVersionInfo {
                 solana_core: version.to_string(),
                 feature_set: Some(version.feature_set),
-                commit: Some(version.commit),
+                commit: Some(format!("{:x}", version.commit)),
             })
         }
 
@@ -3464,7 +3464,7 @@ pub mod rpc_full {
                             (
                                 Some(version.to_string()),
                                 Some(version.feature_set),
-                                version.commit,
+                                version.commit.map(|commit| format!("{commit:x}")),
                             )
                         } else {
                             (None, None, None)
@@ -6647,7 +6647,7 @@ pub mod tests {
             json!({
                 "solana-core": version.to_string(),
                 "feature-set": version.feature_set,
-                "commit": version.commit,
+                "commit": format!("{:x}", version.commit),
             })
         };
         assert_eq!(result, expected);

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -595,7 +595,7 @@ impl RpcSolPubSubInternal for RpcSolPubSubImpl {
         Ok(RpcVersionInfo {
             solana_core: version.to_string(),
             feature_set: Some(version.feature_set),
-            commit: Some(version.commit),
+            commit: Some(format!("{:x}", version.commit)),
         })
     }
 }

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -595,6 +595,7 @@ impl RpcSolPubSubInternal for RpcSolPubSubImpl {
         Ok(RpcVersionInfo {
             solana_core: version.to_string(),
             feature_set: Some(version.feature_set),
+            commit: Some(version.commit),
         })
     }
 }


### PR DESCRIPTION
#### Problem
There's no way to determine what commit a node is running. There are ways to query what version a node is running but those version numbers don't guarantee a node is running the tagged build. With the current build process all commits between two releases will report the version number of the later release.

#### Summary of Changes
There's already a commit field in Version. This change exposes that field in the getClusterNodes and getVersion RPC methods.