### PR TITLE
v1.13: ci: use preinstalled openssl (backport of #31107)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -47,8 +47,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          choco install openssl
-          export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
+          export OPENSSL_DIR="C:\Program Files\OpenSSL"
           choco install protoc
           source /tmp/env.sh
           echo "::set-output name=tag::$CI_TAG"


### PR DESCRIPTION
#### Summary of Changes

fix Windows building

(backport of #31107)
