### PR TITLE
Update fn create_and_verify_snapshot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -249,7 +249,6 @@ mod tests {
         let full_archive = snapshot_utils::package_and_archive_full_snapshot(
             &bank,
             &bank_snapshot_info,
-            &bank_snapshots_dir,
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             snapshot_storages,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -187,7 +187,7 @@ mod tests {
             snapshot_archive_info::SnapshotArchiveInfo,
             snapshot_hash::SnapshotHash,
             snapshot_package::{SnapshotPackage, SnapshotType},
-            snapshot_utils::{self, purge_old_bank_snapshots, ArchiveFormat, SnapshotVersion},
+            snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
         },
         solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash},
         std::{

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -231,7 +231,7 @@ mod tests {
         fs::create_dir_all(&full_snapshot_archives_dir).unwrap();
         fs::create_dir_all(&incremental_snapshot_archives_dir).unwrap();
 
-        let num_snapshots = 4;
+        let num_snapshots = 1;
 
         let genesis_config = GenesisConfig::default();
         let bank = snapshot_utils::create_snapshot_dirs_for_tests(
@@ -240,7 +240,6 @@ mod tests {
             num_snapshots,
             num_snapshots,
         );
-        purge_old_bank_snapshots(&bank_snapshots_dir, 1, None);
 
         let bank_snapshot_info =
             snapshot_utils::get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -231,22 +231,21 @@ mod tests {
         fs::create_dir_all(&full_snapshot_archives_dir).unwrap();
         fs::create_dir_all(&incremental_snapshot_archives_dir).unwrap();
 
-        let slot = 4;
+        let num_snapshots = 4;
 
         let genesis_config = GenesisConfig::default();
         let bank = snapshot_utils::create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
-            slot,
-            slot,
+            num_snapshots,
+            num_snapshots,
         );
+        purge_old_bank_snapshots(&bank_snapshots_dir, 1, None);
 
         let bank_snapshot_info =
             snapshot_utils::get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         let snapshot_storages = bank.get_snapshot_storages(None);
         let archive_format = ArchiveFormat::TarBzip2;
-
-        purge_old_bank_snapshots(&bank_snapshots_dir, 1, None);
 
         let full_archive = snapshot_utils::package_and_archive_full_snapshot(
             &bank,
@@ -268,7 +267,7 @@ mod tests {
             bank_snapshots_dir,
             archive_format,
             snapshot_utils::VerifyBank::Deterministic,
-            slot as Slot,
+            bank_snapshot_info.slot,
         );
     }
 

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -241,8 +241,6 @@ mod tests {
             slot,
         );
 
-        let account_paths = &bank.rc.accounts.accounts_db.paths;
-
         let bank_snapshot_info =
             snapshot_utils::get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         let snapshot_storages = bank.get_snapshot_storages(None);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -562,9 +562,9 @@ fn test_concurrent_snapshot_packaging(
     snapshot_utils::verify_snapshot_archive(
         saved_archive_path.unwrap(),
         saved_snapshots_dir.path(),
-        saved_accounts_dir.path(),
         ArchiveFormat::TarBzip2,
-        snapshot_utils::VerifyBank::NonDeterministic(saved_slot),
+        snapshot_utils::VerifyBank::NonDeterministic,
+        saved_slot,
     );
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1404,7 +1404,7 @@ pub struct AccountsDb {
     pub(crate) write_version: AtomicU64,
 
     /// Set of storage paths to pick from
-    pub(crate) paths: Vec<PathBuf>,
+    pub paths: Vec<PathBuf>,
 
     full_accounts_hash_cache_path: PathBuf,
     incremental_accounts_hash_cache_path: PathBuf,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1404,7 +1404,7 @@ pub struct AccountsDb {
     pub(crate) write_version: AtomicU64,
 
     /// Set of storage paths to pick from
-    pub paths: Vec<PathBuf>,
+    pub(crate) paths: Vec<PathBuf>,
 
     full_accounts_hash_cache_path: PathBuf,
     incremental_accounts_hash_cache_path: PathBuf,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3279,7 +3279,6 @@ pub fn create_snapshot_dirs_for_tests(
         bank.force_flush_accounts_cache();
         bank.clean_accounts(Some(bank.slot()));
         bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
-        bank.rehash(); // Bank accounts may have been manually modified by the caller
 
         let snapshot_storages = bank.get_snapshot_storages(None);
         let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3277,7 +3277,6 @@ pub fn create_snapshot_dirs_for_tests(
         bank.fill_bank_with_ticks_for_tests();
         bank.squash();
         bank.force_flush_accounts_cache();
-        bank.clean_accounts(Some(bank.slot()));
         bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
 
         let snapshot_storages = bank.get_snapshot_storages(None);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3302,7 +3302,7 @@ pub fn create_snapshot_dirs_for_tests(
             crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
                 &bank_snapshots_dir,
                 bank.slot(),
-                &AccountsHash(Hash::new_unique()),
+                &bank.get_accounts_hash().unwrap(),
                 None
             )
         );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2876,7 +2876,7 @@ pub fn verify_snapshot_archive<P, Q>(
     // Check snapshots are the same
     let unpacked_snapshots = unpack_dir.join("snapshots");
 
-    // Since the unpack code collects all the appenedvecs into one directory unpack_account_dir, we need to
+    // Since the unpack code collects all the appendvecs into one directory unpack_account_dir, we need to
     // collect all the appendvecs in account_paths/<slot>/snapshot/ into one directory for later comparison.
     let storages_to_verify = unpack_dir.join("storages_to_verify");
     // Create the directory if it doesn't exist

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2846,7 +2846,7 @@ fn get_io_error(error: &str) -> SnapshotError {
 pub enum VerifyBank {
     /// the bank's serialized format is expected to be identical to what we are comparing against
     Deterministic,
-    /// the serialized bank was 'reserialized' into a non-deterministic format at the specified slot
+    /// the serialized bank was 'reserialized' into a non-deterministic format
     /// so, deserialize both files and compare deserialized results
     NonDeterministic,
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3016,9 +3016,7 @@ pub fn bank_to_full_snapshot_archive(
     assert!(bank.is_complete());
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
-    bank.clean_accounts(Some(bank.slot()));
     bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
-    bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
     let snapshot_storages = bank.get_snapshot_storages(None);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3016,7 +3016,9 @@ pub fn bank_to_full_snapshot_archive(
     assert!(bank.is_complete());
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
+    bank.clean_accounts(Some(bank.slot()));
     bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+    bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
     let snapshot_storages = bank.get_snapshot_storages(None);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2848,27 +2848,26 @@ pub enum VerifyBank {
     Deterministic,
     /// the serialized bank was 'reserialized' into a non-deterministic format at the specified slot
     /// so, deserialize both files and compare deserialized results
-    NonDeterministic(Slot),
+    NonDeterministic,
 }
 
-pub fn verify_snapshot_archive<P, Q, R>(
+pub fn verify_snapshot_archive<P, Q>(
     snapshot_archive: P,
     snapshots_to_verify: Q,
-    storages_to_verify: R,
     archive_format: ArchiveFormat,
     verify_bank: VerifyBank,
+    slot: Slot,
 ) where
     P: AsRef<Path>,
     Q: AsRef<Path>,
-    R: AsRef<Path>,
 {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let unpack_dir = temp_dir.path();
-    let account_dir = create_accounts_run_and_snapshot_dirs(unpack_dir).unwrap().0;
+    let unpack_account_dir = create_accounts_run_and_snapshot_dirs(unpack_dir).unwrap().0;
     untar_snapshot_in(
         snapshot_archive,
         unpack_dir,
-        &[account_dir.clone()],
+        &[unpack_account_dir.clone()],
         archive_format,
         1,
     )
@@ -2876,52 +2875,64 @@ pub fn verify_snapshot_archive<P, Q, R>(
 
     // Check snapshots are the same
     let unpacked_snapshots = unpack_dir.join("snapshots");
-    if let VerifyBank::NonDeterministic(slot) = verify_bank {
+
+    // Since the unpack code collects all the appenedvecs into one directory unpack_account_dir, we need to
+    // collect all the appendvecs in account_paths/<slot>/snapshot/ into one directory for later comparison.
+    let storages_to_verify = unpack_dir.join("storages_to_verify");
+    // Create the directory if it doesn't exist
+    std::fs::create_dir_all(&storages_to_verify).unwrap();
+
+    let slot = slot.to_string();
+    let snapshot_slot_dir = snapshots_to_verify.as_ref().join(&slot);
+
+    if let VerifyBank::NonDeterministic = verify_bank {
         // file contents may be different, but deserialized structs should be equal
-        let slot = slot.to_string();
-        let snapshot_slot_dir = snapshots_to_verify.as_ref().join(&slot);
         let p1 = snapshots_to_verify.as_ref().join(&slot).join(&slot);
         let p2 = unpacked_snapshots.join(&slot).join(&slot);
         assert!(crate::serde_snapshot::compare_two_serialized_banks(&p1, &p2).unwrap());
         std::fs::remove_file(p1).unwrap();
         std::fs::remove_file(p2).unwrap();
+    }
 
-        // The new the status_cache file is inside the slot directory together with the snapshot file.
-        // When unpacking an archive, the status_cache file from the archive is one-level up outside of
-        //  the slot direcotry.
-        // The unpacked status_cache file need to be put back into the slot directory for the directory
-        // comparison to pass.
-        let existing_unpacked_status_cache_file =
-            unpacked_snapshots.join(SNAPSHOT_STATUS_CACHE_FILENAME);
-        let new_unpacked_status_cache_file = unpacked_snapshots
-            .join(&slot)
-            .join(SNAPSHOT_STATUS_CACHE_FILENAME);
-        fs::rename(
-            existing_unpacked_status_cache_file,
-            new_unpacked_status_cache_file,
-        )
-        .unwrap();
+    // The new the status_cache file is inside the slot directory together with the snapshot file.
+    // When unpacking an archive, the status_cache file from the archive is one-level up outside of
+    //  the slot direcotry.
+    // The unpacked status_cache file need to be put back into the slot directory for the directory
+    // comparison to pass.
+    let existing_unpacked_status_cache_file =
+        unpacked_snapshots.join(SNAPSHOT_STATUS_CACHE_FILENAME);
+    let new_unpacked_status_cache_file = unpacked_snapshots
+        .join(&slot)
+        .join(SNAPSHOT_STATUS_CACHE_FILENAME);
+    fs::rename(
+        existing_unpacked_status_cache_file,
+        new_unpacked_status_cache_file,
+    )
+    .unwrap();
 
-        let accounts_hardlinks_dir = snapshot_slot_dir.join("accounts_hardlinks");
-        if accounts_hardlinks_dir.is_dir() {
-            // This directory contain symlinks to all <account_path>/snapshot/<slot> directories.
-            // They should all be removed.
-            for entry in fs::read_dir(&accounts_hardlinks_dir).unwrap() {
-                let dst_path = fs::read_link(entry.unwrap().path()).unwrap();
-                fs::remove_dir_all(dst_path).unwrap();
+    let accounts_hardlinks_dir = snapshot_slot_dir.join("accounts_hardlinks");
+    if accounts_hardlinks_dir.is_dir() {
+        // This directory contain symlinks to all <account_path>/snapshot/<slot> directories.
+        for entry in fs::read_dir(&accounts_hardlinks_dir).unwrap() {
+            let link_dst_path = fs::read_link(entry.unwrap().path()).unwrap();
+            // Copy all the files in dst_path into the storages_to_verify directory.
+            for entry in fs::read_dir(&link_dst_path).unwrap() {
+                let src_path = entry.unwrap().path();
+                let dst_path = storages_to_verify.join(src_path.file_name().unwrap());
+                fs::copy(src_path, dst_path).unwrap();
             }
-            std::fs::remove_dir_all(accounts_hardlinks_dir).unwrap();
         }
+        std::fs::remove_dir_all(accounts_hardlinks_dir).unwrap();
+    }
 
-        let version_path = snapshot_slot_dir.join(SNAPSHOT_VERSION_FILENAME);
-        if version_path.is_file() {
-            std::fs::remove_file(version_path).unwrap();
-        }
+    let version_path = snapshot_slot_dir.join(SNAPSHOT_VERSION_FILENAME);
+    if version_path.is_file() {
+        std::fs::remove_file(version_path).unwrap();
+    }
 
-        let state_complete_path = snapshot_slot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
-        if state_complete_path.is_file() {
-            std::fs::remove_file(state_complete_path).unwrap();
-        }
+    let state_complete_path = snapshot_slot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
+    if state_complete_path.is_file() {
+        std::fs::remove_file(state_complete_path).unwrap();
     }
 
     assert!(!dir_diff::is_different(&snapshots_to_verify, unpacked_snapshots).unwrap());
@@ -2931,9 +2942,9 @@ pub fn verify_snapshot_archive<P, Q, R>(
     // Remove the empty "accounts" directory for the directory comparison below.
     // In some test cases the directory to compare do not come from unarchiving.
     // Ignore the error when this directory does not exist.
-    _ = std::fs::remove_dir(account_dir.join("accounts"));
+    _ = std::fs::remove_dir(unpack_account_dir.join("accounts"));
     // Check the account entries are the same
-    assert!(!dir_diff::is_different(&storages_to_verify, account_dir).unwrap());
+    assert!(!dir_diff::is_different(&storages_to_verify, unpack_account_dir).unwrap());
 }
 
 /// Remove outdated bank snapshots
@@ -3268,6 +3279,9 @@ pub fn create_snapshot_dirs_for_tests(
         bank.fill_bank_with_ticks_for_tests();
         bank.squash();
         bank.force_flush_accounts_cache();
+        bank.clean_accounts(Some(bank.slot()));
+        bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+        bank.rehash(); // Bank accounts may have been manually modified by the caller
 
         let snapshot_storages = bank.get_snapshot_storages(None);
         let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();


### PR DESCRIPTION
#### Problem
Per suggestion in https://github.com/solana-labs/solana/pull/30978#discussion_r1160744478, split the changes in the test function create_and_verify_snapshot into a new PR.

See https://github.com/solana-labs/solana/pull/31245#issuecomment-1513786773.  The files for testing is not in sync in the current real snapshot dirs.

#### Summary of Changes
Update the implementation of fn create_and_verify_snapshot:
  Replace the test snapshot creation code with the new create_snapshot_dirs_for_tests function from https://github.com/solana-labs/solana/pull/31223
  Replace the archiving code with package_and_archive_full_snapshot.

Move create_snapshot_dirs_for_tests out of mod tests for sharing across the files

Update verify_snapshot_archive to add the slot parameter 
It is needed in both the Deterministic and NonDeterministic cases.

Update  verify_snapshot_archive to remove the storages_to_verify parameter
The storage paths should be derived from the snapshot account_hardlinks symlinks.


Fixes 

In create_snapshot_dirs_for_tests() add  the following to fix the get_accounts_hash None error in packaging code
bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false); 


<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
