### PR TITLE
rework assert_no_shrink_in_progress to get assert stack easily

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8091,7 +8091,7 @@ impl AccountsDb {
     where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
-        self.storage.assert_no_shrink_in_progress();
+        assert!(self.storage.no_shrink_in_progress());
 
         let mut dead_slots = HashSet::new();
         let mut new_shrink_candidates: ShrinkCandidates = HashMap::new();


### PR DESCRIPTION
#### Problem
assert doesn't include line # of failure and inlining can eliminate stack.

#### Summary of Changes
move assert into individual functions to easily identify which fn hits the assert.
@yhchiang-sol ran into this while working on cold storage format. Pulling it out separately for clarity.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
