### PR TITLE
bootstrap: Refactor retaining the highest snapshot hashes

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1138,6 +1138,9 @@ fn retain_peer_snapshot_hashes_with_highest_full_snapshot_slot(
         .map(|peer_snapshot_hash| peer_snapshot_hash.snapshot_hash.full)
         .max_by_key(|(slot, _hash)| *slot);
     let Some(highest_full_snapshot_hash) = highest_full_snapshot_hash else {
+        // `max_by_key` will only be `None` IFF the input `peer_snapshot_hashes` is empty.
+        // In that case there's nothing to do (additionally, without a valid 'max' value, there
+        // will be nothing to compare against within the `retain()` predicate).
         return;
     };
 


### PR DESCRIPTION
#### Problem

The bootstrap `retain_highest_snapshot_hashes` functions re-implement [`max_by()`](https://doc.rust-lang.org/stable/std/cmp/fn.max_by.html) unnecessarily.


#### Summary of Changes

Refactor to use `max_by()` instead.

