### PR TITLE
update stats for packed ancient

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1945,6 +1945,7 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) random_shrink: AtomicU64,
     pub(crate) slots_considered: AtomicU64,
     pub(crate) ancient_scanned: AtomicU64,
+    pub(crate) second_pass_one_ref: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -2226,6 +2227,11 @@ impl ShrinkAncientStats {
                 (
                     "total_us",
                     self.total_us.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "second_pass_one_ref",
+                    self.second_pass_one_ref.swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
             );


### PR DESCRIPTION
#### Problem
packed ancient append vecs is disabled by default.
When enabled, more stats and connected ancient stats would be helpful.

#### Summary of Changes
Add and update stats.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
