### PR TITLE
add `is_recyclable` to `AccountsFile`

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5543,7 +5543,10 @@ impl AccountsDb {
                 min = std::cmp::min(store.accounts.capacity(), min);
                 avail += 1;
 
-                if store.accounts.capacity() >= min_size && store.accounts.capacity() < max_size {
+                if store.accounts.is_recyclable()
+                    && store.accounts.capacity() >= min_size
+                    && store.accounts.capacity() < max_size
+                {
                     let ret = recycle_stores.remove_entry(i);
                     drop(recycle_stores);
                     let old_id = ret.append_vec_id();

--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -86,6 +86,12 @@ impl AccountsFile {
         }
     }
 
+    pub fn is_recyclable(&self) -> bool {
+        match self {
+            Self::AppendVec(_) => true,
+        }
+    }
+
     pub fn file_name(slot: Slot, id: impl std::fmt::Display) -> String {
         format!("{slot}.{id}")
     }


### PR DESCRIPTION
#### Problem
Working on tiered storage.
Not every type of storage is recyclable.

#### Summary of Changes
add `is_recyclable` to `AccountsFile`
@yhchiang-sol found and will need this.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
