### PR TITLE
Register SendTransactionService exit

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -33,7 +33,7 @@ use {
         convert::TryFrom,
         io,
         net::{Ipv4Addr, SocketAddr},
-        sync::{Arc, RwLock},
+        sync::{atomic::AtomicBool, Arc, RwLock},
         thread::Builder,
         time::Duration,
     },
@@ -433,6 +433,7 @@ pub async fn start_tcp_server(
     bank_forks: Arc<RwLock<BankForks>>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     connection_cache: Arc<ConnectionCache>,
+    exit: Arc<AtomicBool>,
 ) -> io::Result<()> {
     // Note: These settings are copied straight from the tarpc example.
     let server = tcp::listen(listen_addr, Bincode::default)
@@ -460,6 +461,7 @@ pub async fn start_tcp_server(
                 &connection_cache,
                 5_000,
                 0,
+                exit.clone(),
             );
 
             let server = BanksServer::new(

--- a/banks-server/src/rpc_banks_service.rs
+++ b/banks-server/src/rpc_banks_service.rs
@@ -39,6 +39,7 @@ async fn start_abortable_tcp_server(
         bank_forks.clone(),
         block_commitment_cache.clone(),
         connection_cache,
+        exit.clone(),
     )
     .fuse();
     let interval = IntervalStream::new(time::interval(Duration::from_millis(100))).fuse();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -365,6 +365,7 @@ impl JsonRpcRequestProcessor {
             &connection_cache,
             1000,
             1,
+            exit.clone(),
         );
 
         Self {
@@ -6429,6 +6430,7 @@ pub mod tests {
             &connection_cache,
             1000,
             1,
+            exit,
         );
 
         let mut bad_transaction = system_transaction::transfer(
@@ -6697,6 +6699,7 @@ pub mod tests {
             &connection_cache,
             1000,
             1,
+            exit,
         );
         assert_eq!(
             request_processor.get_block_commitment(0),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -778,7 +778,7 @@ mod test {
     use {
         super::*,
         crate::tpu_info::NullTpuInfo,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::{bounded, unbounded},
         solana_sdk::{
             account::AccountSharedData,
             genesis_config::create_genesis_config,
@@ -818,7 +818,7 @@ mod test {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let bank = Bank::default_for_tests();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let (_sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let connection_cache = Arc::new(ConnectionCache::default());
@@ -832,6 +832,18 @@ mod test {
             1,
             exit.clone(),
         );
+
+        sender
+            .send(TransactionInfo {
+                signature: Signature::default(),
+                wire_transaction: vec![0; 128],
+                last_valid_block_height: 0,
+                durable_nonce_info: None,
+                max_retries: None,
+                retries: 0,
+                last_sent_time: None,
+            })
+            .unwrap();
 
         exit.store(true, Ordering::Relaxed);
     }


### PR DESCRIPTION
#### Problem
The SendTransactionService doesn't receive exit signals from the validator, allowing the threads to continue in zombie mode when the validator has otherwise halted.

#### Summary of Changes
Extend the JsonRpcService exit block to signal SendTransactionService when the validator exits, by passing in an AtomicBool instead of creating on inside SendTransactionService

Fixes #31079