### PR TITLE
Fix bug where ReplayStage holds an Arc<Bank> for process lifetime

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2380,10 +2380,8 @@ impl ReplayStage {
         } else {
             "I am not in the leader schedule yet".to_owned()
         };
-
         info!(
-            "{} reset PoH to tick {} (within slot {}). {}",
-            my_pubkey, tick_height, slot, next_leader_msg,
+            "{my_pubkey} reset PoH to tick {tick_height} (within slot {slot}). {next_leader_msg}",
         );
     }
 


### PR DESCRIPTION
#### Problem
When ReplayStage::new() kicks off, it needs to do some setup with the working bank prior to entering the main processing loop. This setup is done before entering the main processing loop; however, a bug made it such that an Arc<Bank> remained in scope after the processing loop had been entered. The processing loop is only exited when the process exits, so this means that Bank was being held for the lifetime of the process. This is a waste of resources and prevents background cleanup.

#### Summary of Changes
Rework the `ReplayStage:: reset_poh_recorder()` to more properly take an `Arc<Bank>` over `&Arc<Bank>`; this makes is such that the `Arc<Bank>` is moved out of scope from `ReplayStage::new()`

This is a very simple change for something that took quite a bit of work to track down. ~~I believe this bug is the cause of memory growth across epoch boundaries. By having a bank on either side of the epoch boundary, we have to maintain two copies of the stakes cache which is a non-trivial amount of memory. This is a bug that should be fixed regardless, but I have several test nodes setup that will confirm if this change aids with memory usage across the epoch boundary.~~ As @behzadnouri pointed out in a comment below, this bug explains memory growth across the **FIRST** epoch boundary, but not necessarily subsequent boundaries.
- Supposing a node starts in epoch `N`, it would have a bank alive in epoch `N` for the process lifetime.
- When the node gets to epoch `N+1`, it will have at least one bank in epoch `N` and more in epoch `N+1`.
- But when we get to epoch `N+2`, the node in epoch `N` will still be around but this bug wouldn't result in any banks from epoch `N+1` lingering.

This is a bug that should be fixed regardless, but I have several test nodes setup that will continue to monitor the situation across epoch boundaries. At the very least, this fix will peel back a layer to allow for more useful memory profiling across epoch bounds.