### PR TITLE
Use Arc instead of &Arc in AccountsBackgroundService::new

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -734,7 +734,7 @@ impl Validator {
         let last_full_snapshot_slot = starting_snapshot_hashes.map(|x| x.full.0 .0);
         let accounts_background_service = AccountsBackgroundService::new(
             bank_forks.clone(),
-            &exit,
+            exit.clone(),
             AbsRequestHandlers {
                 snapshot_request_handler,
                 pruned_banks_request_handler,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -217,7 +217,7 @@ impl BackgroundServices {
         };
         let accounts_background_service = AccountsBackgroundService::new(
             bank_forks,
-            &exit,
+            exit.clone(),
             AbsRequestHandlers {
                 snapshot_request_handler,
                 pruned_banks_request_handler,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1009,8 +1009,13 @@ fn test_snapshots_with_background_services(
         snapshot_test_config.snapshot_config.clone(),
     );
 
-    let accounts_background_service =
-        AccountsBackgroundService::new(bank_forks.clone(), &exit, abs_request_handler, false, None);
+    let accounts_background_service = AccountsBackgroundService::new(
+        bank_forks.clone(),
+        exit.clone(),
+        abs_request_handler,
+        false,
+        None,
+    );
 
     let mut last_full_snapshot_slot = None;
     let mut last_incremental_snapshot_slot = None;

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1282,7 +1282,7 @@ fn load_bank_forks(
     let exit = Arc::new(AtomicBool::new(false));
     let accounts_background_service = AccountsBackgroundService::new(
         bank_forks.clone(),
-        &exit,
+        exit.clone(),
         abs_request_handler,
         process_options.accounts_db_test_hash_calculation,
         None,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -529,12 +529,11 @@ pub struct AccountsBackgroundService {
 impl AccountsBackgroundService {
     pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
         request_handlers: AbsRequestHandlers,
         test_hash_calculation: bool,
         mut last_full_snapshot_slot: Option<Slot>,
     ) -> Self {
-        let exit = exit.clone();
         let mut last_cleaned_block_height = 0;
         let mut removed_slots_count = 0;
         let mut total_remove_slots_time = 0;


### PR DESCRIPTION
#### Problem

Using `&Arc<T>` for a function parameter types is an anti-pattern. Use `Arc<T>` or `&T` instead.


#### Summary of Changes

Replace `&Arc` with `Arc` in `AccountsBackgroundService::new()`