### PR TITLE
Use Arc instead of &Arc in SnapshotPackagerService::new

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -34,13 +34,11 @@ impl SnapshotPackagerService {
         snapshot_package_sender: Sender<SnapshotPackage>,
         snapshot_package_receiver: Receiver<SnapshotPackage>,
         starting_snapshot_hashes: Option<StartingSnapshotHashes>,
-        exit: &Arc<AtomicBool>,
-        cluster_info: &Arc<ClusterInfo>,
+        exit: Arc<AtomicBool>,
+        cluster_info: Arc<ClusterInfo>,
         snapshot_config: SnapshotConfig,
         enable_gossip_push: bool,
     ) -> Self {
-        let exit = exit.clone();
-        let cluster_info = cluster_info.clone();
         let max_full_snapshot_hashes = std::cmp::min(
             MAX_LEGACY_SNAPSHOT_HASHES,
             snapshot_config

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -693,8 +693,8 @@ impl Validator {
                     snapshot_package_sender.clone(),
                     snapshot_package_receiver,
                     starting_snapshot_hashes,
-                    &exit,
-                    &cluster_info,
+                    exit.clone(),
+                    cluster_info.clone(),
                     config.snapshot_config.clone(),
                     enable_gossip_push,
                 );

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -184,8 +184,8 @@ impl BackgroundServices {
             snapshot_package_sender.clone(),
             snapshot_package_receiver,
             None,
-            &exit,
-            &cluster_info,
+            exit.clone(),
+            cluster_info.clone(),
             snapshot_config.clone(),
             false,
         );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -509,8 +509,8 @@ fn test_concurrent_snapshot_packaging(
         snapshot_package_sender.clone(),
         snapshot_package_receiver,
         None,
-        &exit,
-        &cluster_info,
+        exit.clone(),
+        cluster_info,
         snapshot_config.clone(),
         true,
     );
@@ -991,8 +991,8 @@ fn test_snapshots_with_background_services(
         snapshot_package_sender.clone(),
         snapshot_package_receiver,
         None,
-        &exit,
-        &cluster_info,
+        exit.clone(),
+        cluster_info.clone(),
         snapshot_test_config.snapshot_config.clone(),
         false,
     );


### PR DESCRIPTION
#### Problem

Using `&Arc<T>` for a function parameter types is an anti-pattern. Use `Arc<T>` or `&T` instead.


#### Summary of Changes

Replace `&Arc` with `Arc` in `SnapshotPackagerService::new()`