### PR TITLE
Upgrade Rust to 1.68.2

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.67.1
+FROM solanalabs/rust:1.68.2
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/rust-version.sh to pick up the new image tag
-FROM rust:1.67.1
+FROM rust:1.68.2
 
 RUN set -x \
  && apt update \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.68.2"


### PR DESCRIPTION
Dependabot now needs 1.68: https://github.com/dependabot/dependabot-core/pull/7066