### PR TITLE
Toolchain install: Include clippy and fmt.

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -46,6 +46,7 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
     if ! cargo +"$toolchain" -V > /dev/null; then
       echo "$0: Missing toolchain? Installing...: $toolchain" >&2
       rustup install "$toolchain"
+      rustup +"$toolchain" component add clippy rustfmt
       cargo +"$toolchain" -V
     fi
   }


### PR DESCRIPTION
CI seems to be running with a "minimal" profile, missing clippy and fmt, if the toolchain is absent from the docker image.