### PR TITLE
Suppress warning for unused_mut in rbpf-cli

### DIFF
--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -245,6 +245,8 @@ before execting it in the virtual machine.",
     file.rewind().unwrap();
     let mut contents = Vec::new();
     file.read_to_end(&mut contents).unwrap();
+    // Allowing mut here, since it is needed for jit compile, which is under a config flag
+    #[allow(unused_mut)]
     let mut verified_executable = if magic == [0x7f, 0x45, 0x4c, 0x46] {
         let mut load_program_metrics = LoadProgramMetrics::default();
         let result = load_program_from_bytes(


### PR DESCRIPTION
#### Problem
Seeing this warning when building on MacOS

```
warning: variable does not need to be mutable
   --> rbpf-cli/src/main.rs:248:9
    |
248 |     let mut verified_executable = if magic == [0x7f, 0x45, 0x4c, 0x46] {
    |         ----^^^^^^^^^^^^^^^^^^^
    |         |
    |         help: remove this `mut`
```

#### Summary of Changes
`verified_executable` is JIT compiled under a config flag, for which a `mut` reference is needed.  Updated code to suppress the warning.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
