### PR TITLE
Purge snapshot dirs before loading from an archive

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -202,7 +202,7 @@ fn bank_forks_from_snapshot(
     // Given that we are going to boot from an archive, the accountvecs held in the snapshot dirs for fast-boot should
     // be released.  They will be released by the account_background_service anyway.  But in the case of the account_paths
     // using memory-mounted file system, they are not released early enough to give space for the new append-vecs from
-    // the archives.  So, purge the snapshot dirs upfront before loading the archives.
+    // the archives, causing the out-of-memory problem.  So, purge the snapshot dirs upfront before loading from the archive.
     snapshot_utils::purge_old_bank_snapshots(&snapshot_config.bank_snapshots_dir, 0, None);
 
     let (deserialized_bank, full_snapshot_archive_info, incremental_snapshot_archive_info) =

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -199,6 +199,12 @@ fn bank_forks_from_snapshot(
         process::exit(1);
     }
 
+    // Given that we are going to boot from an archive, the accountvecs held in the snapshot dirs for fast-boot should
+    // be released.  They will be released by the account_background_service anyway.  But in the case of the account_paths
+    // using memory-mounted file system, they are not released early enough to give space for the new append-vecs from
+    // the archives.  So, purge the snapshot dirs upfront before loading the archives.
+    snapshot_utils::purge_old_bank_snapshots(&snapshot_config.bank_snapshots_dir, 0, None);
+
     let (deserialized_bank, full_snapshot_archive_info, incremental_snapshot_archive_info) =
         snapshot_utils::bank_from_latest_snapshot_archives(
             &snapshot_config.bank_snapshots_dir,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -97,7 +97,6 @@ pub fn load_bank_forks(
             "Initializing bank snapshot path: {}",
             snapshot_config.bank_snapshots_dir.display()
         );
-        let _ = fs::remove_dir_all(&snapshot_config.bank_snapshots_dir);
         fs::create_dir_all(&snapshot_config.bank_snapshots_dir)
             .expect("Couldn't create snapshot directory");
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/31241
When boot from an archive, out-of-memory(OOM) happens when --account is using a memory mapped path

#### Summary of Changes
Purge the snapshot dirs to release the memory before loading from an archive.

Fixes #31241 

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
