### PR TITLE
check for prior discard in shred_fetch_stage

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -88,7 +88,7 @@ impl ShredFetchStage {
             let should_drop_merkle_shreds =
                 |shred_slot| should_drop_merkle_shreds(shred_slot, &root_bank);
             let turbine_disabled = turbine_disabled.load(Ordering::Relaxed);
-            for packet in packet_batch.iter_mut() {
+            for packet in packet_batch.iter_mut().filter(|p| !p.meta().discard()) {
                 if turbine_disabled
                     || should_discard_shred(
                         packet,


### PR DESCRIPTION
#### Problem
In `ShredFetchStage::modify_packets` ping response packets will be marked `set_discard(true)` after processing. The subsequent call to `should_discard_packet()` will call `packet.data()` which will fail because the packet is set for `discard`. This will cause an `index_overrun` error to erroneously be recorded.

#### Summary of Changes
Check for `packet.meta().discard()` prior to calling `should_discard_packet()`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
