### PR TITLE
Revert: Bump console from 0.15.0 to 0.15.5 (#31289)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,15 +1103,17 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
  "unicode-width",
- "windows-sys 0.42.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7720,6 +7722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ cc = "1.0.79"
 chrono = { version = "0.4.24", default-features = false }
 chrono-humanize = "0.2.2"
 clap = "2.33.1"
-console = "0.15.5"
+console = "0.15.0"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.0"
 const_format = "0.2.30"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -993,15 +993,17 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
  "unicode-width",
- "windows-sys 0.42.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6838,6 +6840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
Windows build is broken after https://github.com/solana-labs/solana/pull/31289
Error:

    Compiling solana-genesis-utils v1.16.0 (D:\a\solana\solana\genesis-utils)
    error[E0432]: unresolved import `winapi::um::winuser`
       --> install\src\command.rs:385:17
        |
    385 |             um::winuser::{
        |                 ^^^^^^^ could not find `winuser` in `um`

    For more information about this error, try `rustc --explain E0432`.

https://github.com/solana-labs/solana/actions/runs/4759519915/jobs/8458877323

#### Summary of Changes
Revert https://github.com/solana-labs/solana/pull/31289