### PR TITLE
ci: soft fail trigger_secondary_step

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -125,6 +125,7 @@ trigger_secondary_step() {
     trigger: "solana-secondary"
     branches: "!pull/*"
     async: true
+    soft_fail: true
     build:
       message: "${BUILDKITE_MESSAGE}"
       commit: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
#### Problem

the step which we trigger secondary pipeline usually makes our whole pipeline red. however most of time it just cannot trigger due to it is a private pipeline.

I have two idea for this situation.

#### 1) make it soft fail. (the current PR)

the pipeline will be green but the step is still red. it looks like
<img width="1148" alt="Screenshot 2023-04-21 at 2 57 29 PM" src="https://user-images.githubusercontent.com/8209234/233563397-2375ef2d-4b69-4c93-95fc-88e0ffe147ad.png">

instead of

<img width="1151" alt="Screenshot 2023-04-21 at 4 13 47 PM" src="https://user-images.githubusercontent.com/8209234/233581433-23e7f622-b568-44e5-aa30-33946a53ed4a.png">


#### 2) use buildkite's team

we're in business plan on buildkite so we can use the team feature. there is a env, `BUILDKITE_BUILD_CREATOR_TEAMS`, which we can decide whether we append the trigger step in the end of the pipeline.

I would like to ship 1) atm.
