### PR TITLE
removes wallclock from LegacyContactInfo public interface

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -119,12 +119,12 @@ impl<T> ClusterNodes<T> {
             if node.stake != 0u64 {
                 num_nodes_staked += 1;
             }
-            match node.contact_info() {
+            match node.contact_info().map(ContactInfo::wallclock) {
                 None => {
                     num_nodes_dead += 1;
                     stake_dead += node.stake;
                 }
-                Some(&ContactInfo { wallclock, .. }) => {
+                Some(wallclock) => {
                     let age = now.saturating_sub(wallclock);
                     if age > CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS {
                         num_nodes_stale += 1;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2100,7 +2100,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         .all_tvu_peers()
         .into_iter()
         .filter(|node| {
-            let age = now.saturating_sub(node.wallclock);
+            let age = now.saturating_sub(node.wallclock());
             // Contact infos are refreshed twice during this period.
             age < CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS
         })

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1393,10 +1393,10 @@ impl ClusterInfo {
             };
             if !pulls.is_empty() {
                 let now = timestamp();
-                if now <= entrypoint.wallclock.saturating_add(THROTTLE_DELAY) {
+                if now <= entrypoint.wallclock().saturating_add(THROTTLE_DELAY) {
                     return;
                 }
-                entrypoint.wallclock = now;
+                entrypoint.set_wallclock(now);
                 if let Ok(entrypoint_gossip) = entrypoint.gossip() {
                     if self
                         .time_gossip_read_lock("entrypoint", &self.stats.entrypoint)
@@ -4329,7 +4329,7 @@ RPC Enabled Nodes: 1"#;
 
         // Pull request 2: pretend it's been a while since we've pulled from `entrypoint`.  There should
         // now be two pull requests
-        cluster_info.entrypoints.write().unwrap()[0].wallclock = 0;
+        cluster_info.entrypoints.write().unwrap()[0].set_wallclock(0);
         let (pings, pulls) = cluster_info.new_pull_requests(&thread_pool, None, &stakes);
         assert!(pings.is_empty());
         assert_eq!(pulls.len(), 2 * MIN_NUM_BLOOM_FILTERS);
@@ -4766,7 +4766,7 @@ RPC Enabled Nodes: 1"#;
             peers.push(keypair.pubkey());
             let mut rand_ci = LegacyContactInfo::new_rand(&mut rng, Some(keypair.pubkey()));
             rand_ci.shred_version = shred_version;
-            rand_ci.wallclock = timestamp();
+            rand_ci.set_wallclock(timestamp());
             CrdsValue::new_signed(CrdsData::LegacyContactInfo(rand_ci), &keypair)
         })
         .take(NO_ENTRIES)

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -1284,7 +1284,7 @@ mod tests {
         assert_eq!(crds.get_shred_version(&pubkey), None);
         // Initial insertion of a node with shred version:
         let mut node = ContactInfo::new_rand(&mut rng, Some(pubkey));
-        let wallclock = node.wallclock;
+        let wallclock = node.wallclock();
         node.shred_version = 42;
         let node = CrdsData::LegacyContactInfo(node);
         let node = CrdsValue::new_unsigned(node);
@@ -1295,7 +1295,7 @@ mod tests {
         assert_eq!(crds.get_shred_version(&pubkey), Some(42));
         // An outdated  value should not update shred-version:
         let mut node = ContactInfo::new_rand(&mut rng, Some(pubkey));
-        node.wallclock = wallclock - 1; // outdated.
+        node.set_wallclock(wallclock - 1); // outdated.
         node.shred_version = 8;
         let node = CrdsData::LegacyContactInfo(node);
         let node = CrdsValue::new_unsigned(node);
@@ -1306,7 +1306,7 @@ mod tests {
         assert_eq!(crds.get_shred_version(&pubkey), Some(42));
         // Update shred version:
         let mut node = ContactInfo::new_rand(&mut rng, Some(pubkey));
-        node.wallclock = wallclock + 1; // so that it overrides the prev one.
+        node.set_wallclock(wallclock + 1); // so that it overrides the prev one.
         node.shred_version = 8;
         let node = CrdsData::LegacyContactInfo(node);
         let node = CrdsValue::new_unsigned(node);

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -330,7 +330,7 @@ mod tests {
         let crds = RwLock::<Crds>::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ci.wallclock = 1;
+        ci.set_wallclock(1);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci.clone()));
 
         // push a new message
@@ -340,7 +340,7 @@ mod tests {
         );
 
         // push an old version
-        ci.wallclock = 0;
+        ci.set_wallclock(0);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0)
@@ -354,14 +354,14 @@ mod tests {
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
 
         // push a version to far in the future
-        ci.wallclock = timeout + 1;
+        ci.set_wallclock(timeout + 1);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci.clone()));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0)
             .is_empty());
 
         // push a version to far in the past
-        ci.wallclock = 0;
+        ci.set_wallclock(0);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], timeout + 1)
@@ -373,7 +373,7 @@ mod tests {
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         let origin = ci.id;
-        ci.wallclock = 0;
+        ci.set_wallclock(0);
         let value_old = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci.clone()));
 
         // push a new message
@@ -383,7 +383,7 @@ mod tests {
         );
 
         // push an old version
-        ci.wallclock = 1;
+        ci.set_wallclock(1);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci));
         assert_eq!(
             push.process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0),
@@ -449,7 +449,7 @@ mod tests {
             .into_iter()
             .map(|wallclock| {
                 let mut peer = ContactInfo::new_rand(&mut rng, /*pubkey=*/ None);
-                peer.wallclock = wallclock;
+                peer.set_wallclock(wallclock);
                 ping_cache.mock_pong(peer.id, peer.gossip().unwrap(), Instant::now());
                 CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(peer))
             })
@@ -575,7 +575,7 @@ mod tests {
         );
 
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ci.wallclock = 1;
+        ci.set_wallclock(1);
         let new_msg = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci));
         let expected = HashMap::new();
         let origin = new_msg.pubkey();
@@ -600,7 +600,7 @@ mod tests {
         let crds = RwLock::<Crds>::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ci.wallclock = 0;
+        ci.set_wallclock(0);
         let value = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci));
         let label = value.label();
         // push a new message

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -582,7 +582,7 @@ impl CrdsValue {
     /// This is used to time out push messages.
     pub fn wallclock(&self) -> u64 {
         match &self.data {
-            CrdsData::LegacyContactInfo(contact_info) => contact_info.wallclock,
+            CrdsData::LegacyContactInfo(contact_info) => contact_info.wallclock(),
             CrdsData::Vote(_, vote) => vote.wallclock,
             CrdsData::LowestSlot(_, obj) => obj.wallclock,
             CrdsData::LegacySnapshotHashes(hash) => hash.wallclock,

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -41,7 +41,7 @@ pub struct LegacyContactInfo {
     /// address to send repair requests to
     serve_repair: SocketAddr,
     /// latest wallclock picked
-    pub wallclock: u64,
+    wallclock: u64,
     /// node shred version
     pub shred_version: u16,
 }
@@ -153,6 +153,15 @@ impl LegacyContactInfo {
             wallclock: timestamp(),
             ..LegacyContactInfo::default()
         }
+    }
+
+    #[inline]
+    pub fn wallclock(&self) -> u64 {
+        self.wallclock
+    }
+
+    pub fn set_wallclock(&mut self, wallclock: u64) {
+        self.wallclock = wallclock;
     }
 
     get_socket!(gossip);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -288,7 +288,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
                 let node_crds = node.gossip.crds.read().unwrap();
                 node_crds.get::<&ContactInfo>(node_pubkey).cloned().unwrap()
             };
-            m.wallclock = now;
+            m.set_wallclock(now);
             node.gossip.process_push_message(
                 vec![(
                     Pubkey::default(),

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -162,7 +162,7 @@ fn gossip_ring() {
             let x = (n + 1) % listen.len();
             let yv = &listen[y].0;
             let mut d = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
-            d.wallclock = timestamp();
+            d.set_wallclock(timestamp());
             listen[x].0.insert_legacy_info(d);
         }
     });
@@ -180,7 +180,7 @@ fn gossip_ring_large() {
             let x = (n + 1) % listen.len();
             let yv = &listen[y].0;
             let mut d = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
-            d.wallclock = timestamp();
+            d.set_wallclock(timestamp());
             listen[x].0.insert_legacy_info(d);
         }
     });
@@ -196,7 +196,7 @@ fn gossip_star() {
             let y = (n + 1) % listen.len();
             let yv = &listen[y].0;
             let mut yd = yv.lookup_contact_info(&yv.id(), |ci| ci.clone()).unwrap();
-            yd.wallclock = timestamp();
+            yd.set_wallclock(timestamp());
             let xv = &listen[x].0;
             xv.insert_legacy_info(yd);
             trace!("star leader {}", &xv.id());


### PR DESCRIPTION

#### Problem
Working towards `LegacyContactInfo` => `ContactInfo` migration. 

#### Summary of Changes
* removed `wallclock` from `LegacyContactInfo` public interface.
* expand api parity between `LegacyContactInfo` and `ContactInfo`.
