### PR TITLE
Send messages to EntryNotifierService from blockstore_processor

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -152,8 +152,8 @@ pub struct EntrySummary {
     pub num_transactions: u64,
 }
 
-impl From<Entry> for EntrySummary {
-    fn from(entry: Entry) -> Self {
+impl From<&Entry> for EntrySummary {
+    fn from(entry: &Entry) -> Self {
         Self {
             num_hashes: entry.num_hashes,
             hash: entry.hash,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1149,7 +1149,7 @@ fn confirm_slot_entries(
                     index: entry_index,
                     entry: entry.into(),
                 }) {
-                    trace!(
+                    warn!(
                         "Slot {}, entry {} entry_notification_sender send failed: {:?}",
                         slot, entry_index, err
                     );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1132,15 +1132,15 @@ fn confirm_slot_entries(
     let slot = bank.slot();
     let (entries, num_shreds, slot_full) = slot_entries_load_result;
     let num_entries = entries.len();
-    let mut entry_starting_indexes = Vec::with_capacity(num_entries);
-    let mut entry_starting_index = progress.num_txs;
+    let mut entry_tx_starting_indexes = Vec::with_capacity(num_entries);
+    let mut entry_tx_starting_index = progress.num_txs;
     let num_txs = entries
         .iter()
         .map(|e| {
             let num_txs = e.transactions.len();
-            let next_starting_index = entry_starting_index.saturating_add(num_txs);
-            entry_starting_indexes.push(entry_starting_index);
-            entry_starting_index = next_starting_index;
+            let next_tx_starting_index = entry_tx_starting_index.saturating_add(num_txs);
+            entry_tx_starting_indexes.push(entry_tx_starting_index);
+            entry_tx_starting_index = next_tx_starting_index;
             num_txs
         })
         .sum::<usize>();
@@ -1222,10 +1222,10 @@ fn confirm_slot_entries(
     let mut replay_timer = Measure::start("replay_elapsed");
     let mut replay_entries: Vec<_> = entries
         .into_iter()
-        .zip(entry_starting_indexes)
-        .map(|(entry, starting_index)| ReplayEntry {
+        .zip(entry_tx_starting_indexes)
+        .map(|(entry, tx_starting_index)| ReplayEntry {
             entry,
-            starting_index,
+            starting_index: tx_starting_index,
         })
         .collect();
     // Note: This will shuffle entries' transactions in-place.


### PR DESCRIPTION
#### Problem
#31290 adds an entry notification service -- only for nodes running with a geyser plugin that wants entry notifications -- but there isn't anywhere sending Entry messages to the service.

#### Summary of Changes
Hook up the Tvu path, sending Entry messages from `blockstore_processor`

~~Needs rebase on #31290~~ ✅ 
