### PR TITLE
adds tpu_quic field to RpcContactInfo

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -521,7 +521,7 @@ pub(crate) fn sanitize_quic_offset(
 }
 
 // Returns the socket at QUIC_PORT_OFFSET from the given one.
-fn get_quic_socket(socket: &SocketAddr) -> Result<SocketAddr, Error> {
+pub(crate) fn get_quic_socket(socket: &SocketAddr) -> Result<SocketAddr, Error> {
     Ok(SocketAddr::new(
         socket.ip(),
         socket

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
         contact_info::{
-            sanitize_quic_offset, sanitize_socket, socket_addr_unspecified, ContactInfo, Error,
+            get_quic_socket, sanitize_quic_offset, sanitize_socket, socket_addr_unspecified,
+            ContactInfo, Error,
         },
         crds_value::MAX_WALLCLOCK,
     },
@@ -168,6 +169,10 @@ impl LegacyContactInfo {
 
     set_socket!(set_gossip, gossip);
     set_socket!(set_rpc, rpc);
+
+    pub fn tpu_quic(&self) -> Result<SocketAddr, Error> {
+        self.tpu().and_then(|addr| get_quic_socket(&addr))
+    }
 
     fn is_valid_ip(addr: IpAddr) -> bool {
         !(addr.is_unspecified() || addr.is_multicast())

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -294,8 +294,10 @@ pub struct RpcContactInfo {
     pub pubkey: String,
     /// Gossip port
     pub gossip: Option<SocketAddr>,
-    /// Tpu port
+    /// Tpu UDP port
     pub tpu: Option<SocketAddr>,
+    /// Tpu QUIC port
+    pub tpu_quic: Option<SocketAddr>,
     /// JSON RPC port
     pub rpc: Option<SocketAddr>,
     /// WebSocket PubSub port

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -374,6 +374,7 @@ impl RpcSender for MockSender {
                 pubkey: PUBKEY.to_string(),
                 gossip: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
                 tpu: Some(SocketAddr::from(([10, 239, 6, 48], 8856))),
+                tpu_quic: Some(SocketAddr::from(([10, 239, 6, 48], 8862))),
                 rpc: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
                 pubsub: Some(SocketAddr::from(([10, 239, 6, 48], 8900))),
                 version: Some("1.0.0 c375ce1f".to_string()),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3472,6 +3472,10 @@ pub mod rpc_full {
                                 .tpu()
                                 .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
+                            tpu_quic: contact_info
+                                .tpu_quic()
+                                .ok()
+                                .filter(|addr| socket_addr_space.check(addr)),
                             rpc: contact_info
                                 .rpc()
                                 .ok()
@@ -5138,6 +5142,7 @@ pub mod tests {
             "gossip": "127.0.0.1:8000",
             "shredVersion": 0u16,
             "tpu": "127.0.0.1:8003",
+            "tpuQuic": "127.0.0.1:8009",
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
             "version": null,
@@ -5147,6 +5152,7 @@ pub mod tests {
             "gossip": "127.0.0.1:1235",
             "shredVersion": 0u16,
             "tpu": "127.0.0.1:1234",
+            "tpuQuic": "127.0.0.1:1240",
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
             "version": null,


### PR DESCRIPTION

#### Problem
New `ContactInfo` implemented in https://github.com/solana-labs/solana/pull/29596
specifies sockets for QUIC protocols explicitly.
The commit adds `tpu_quic` field to `RpcContactInfo` in preparation of `LegacyContactInfo` => `ContactInfo` migration.


#### Summary of Changes
added `tpu_quic` field to `RpcContactInfo`.