### PR TITLE
derive Debug for multi_iterator_scanner::ProcessingDecision

### DIFF
--- a/core/src/multi_iterator_scanner.rs
+++ b/core/src/multi_iterator_scanner.rs
@@ -14,6 +14,7 @@
 //!
 
 /// Output from the element checker used in `MultiIteratorScanner::iterate`.
+#[derive(Debug)]
 pub enum ProcessingDecision {
     /// Should be processed by the scanner.
     Now,


### PR DESCRIPTION
#### Problem
Doing a traced debug of an issue in scheduler - couldn't print out decisions for each packet.

#### Summary of Changes
Derive Debug for the ProcessingDecision so it can be printed out when debugging

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
