### PR TITLE
Parallelize epoch reward summation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2428,7 +2428,7 @@ impl Bank {
                 self.rewards
                     .read()
                     .unwrap()
-                    .iter()
+                    .par_iter()
                     .map(|(_address, reward_info)| {
                         match reward_info.reward_type {
                             RewardType::Voting | RewardType::Staking => reward_info.lamports,


### PR DESCRIPTION
#### Problem

Sequential sum of all epoch rewards is bad. 


#### Summary of Changes

Parallelize epoch rewards summation.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
