### PR TITLE
Cleanup - Removes the CLI option "no-bpf-jit"

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1462,10 +1462,6 @@ fn main() {
         .long("no-snapshot")
         .takes_value(false)
         .help("Do not start from a local snapshot if present");
-    let no_bpf_jit_arg = Arg::with_name("no_bpf_jit")
-        .long("no-bpf-jit")
-        .takes_value(false)
-        .help("Disable the just-in-time compiler and instead use the interpreter for BP");
     let accounts_index_bins = Arg::with_name("accounts_index_bins")
         .long("accounts-index-bins")
         .value_name("BINS")
@@ -1960,7 +1956,6 @@ fn main() {
             .arg(&hard_forks_arg)
             .arg(&accounts_db_test_hash_calculation_arg)
             .arg(&no_os_memory_stats_reporting_arg)
-            .arg(&no_bpf_jit_arg)
             .arg(&allow_dead_slots_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
             .arg(&debug_key_arg)
@@ -2948,10 +2943,7 @@ fn main() {
                     accounts_db_test_hash_calculation: arg_matches
                         .is_present("accounts_db_test_hash_calculation"),
                     accounts_db_skip_shrink: arg_matches.is_present("accounts_db_skip_shrink"),
-                    runtime_config: RuntimeConfig {
-                        bpf_jit: !arg_matches.is_present("no_bpf_jit"),
-                        ..RuntimeConfig::default()
-                    },
+                    runtime_config: RuntimeConfig::default(),
                     ..ProcessOptions::default()
                 };
                 let print_accounts_stats = arg_matches.is_present("print_accounts_stats");

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -213,9 +213,7 @@ fn bank_forks_from_snapshot(
             genesis_config,
             &process_options.runtime_config,
             process_options.debug_keys.clone(),
-            Some(&crate::builtins::get(
-                process_options.runtime_config.bpf_jit,
-            )),
+            Some(&crate::builtins::get(true)),
             process_options.account_indexes.clone(),
             process_options.limit_load_slot_count_from_snapshot,
             process_options.shrink_ratio,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -213,7 +213,7 @@ fn bank_forks_from_snapshot(
             genesis_config,
             &process_options.runtime_config,
             process_options.debug_keys.clone(),
-            Some(&crate::builtins::get(true)),
+            Some(&crate::builtins::get()),
             process_options.account_indexes.clone(),
             process_options.limit_load_slot_count_from_snapshot,
             process_options.shrink_ratio,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -712,7 +712,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         Arc::new(opts.runtime_config.clone()),
         account_paths,
         opts.debug_keys.clone(),
-        Some(&crate::builtins::get(opts.runtime_config.bpf_jit)),
+        Some(&crate::builtins::get(true)),
         opts.account_indexes.clone(),
         opts.shrink_ratio,
         false,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -45,6 +45,7 @@ use {
         genesis_config::GenesisConfig,
         hash::Hash,
         pubkey::Pubkey,
+        saturating_add_assign,
         signature::{Keypair, Signature},
         timing,
         transaction::{

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -712,7 +712,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         Arc::new(opts.runtime_config.clone()),
         account_paths,
         opts.debug_keys.clone(),
-        Some(&crate::builtins::get(true)),
+        Some(&crate::builtins::get()),
         opts.account_indexes.clone(),
         opts.shrink_ratio,
         false,

--- a/ledger/src/builtins.rs
+++ b/ledger/src/builtins.rs
@@ -14,30 +14,11 @@ macro_rules! to_builtin {
 }
 
 /// Builtin programs that are always available
-fn genesis_builtins(bpf_jit: bool) -> Vec<BuiltinProgram> {
-    // Currently JIT is not supported on the SBF VM:
-    // !x86_64: https://github.com/qmonnet/rbpf/issues/48
-    // Windows: https://github.com/solana-labs/rbpf/issues/217
-    #[cfg(any(not(target_arch = "x86_64"), target_family = "windows"))]
-    let bpf_jit = {
-        if bpf_jit {
-            info!("SBF JIT is not supported on this target");
-        }
-        false
-    };
-
+fn genesis_builtins() -> Vec<BuiltinProgram> {
     vec![
         to_builtin!(solana_bpf_loader_deprecated_program!()),
-        if bpf_jit {
-            to_builtin!(solana_bpf_loader_program_with_jit!())
-        } else {
-            to_builtin!(solana_bpf_loader_program!())
-        },
-        if bpf_jit {
-            to_builtin!(solana_bpf_loader_upgradeable_program_with_jit!())
-        } else {
-            to_builtin!(solana_bpf_loader_upgradeable_program!())
-        },
+        to_builtin!(solana_bpf_loader_program!()),
+        to_builtin!(solana_bpf_loader_upgradeable_program!()),
     ]
 }
 
@@ -46,9 +27,9 @@ fn builtin_feature_transitions() -> Vec<BuiltinFeatureTransition> {
     vec![]
 }
 
-pub(crate) fn get(bpf_jit: bool) -> Builtins {
+pub(crate) fn get() -> Builtins {
     Builtins {
-        genesis_builtins: genesis_builtins(bpf_jit),
+        genesis_builtins: genesis_builtins(),
         feature_transitions: builtin_feature_transitions(),
     }
 }

--- a/ledger/src/builtins.rs
+++ b/ledger/src/builtins.rs
@@ -1,24 +1,27 @@
 use {
     solana_program_runtime::builtin_program::BuiltinProgram,
     solana_runtime::builtins::{BuiltinFeatureTransition, Builtins},
+    solana_sdk::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
 };
-
-macro_rules! to_builtin {
-    ($b:expr) => {
-        BuiltinProgram {
-            name: $b.0.to_string(),
-            program_id: $b.1,
-            process_instruction: $b.2,
-        }
-    };
-}
 
 /// Builtin programs that are always available
 fn genesis_builtins() -> Vec<BuiltinProgram> {
     vec![
-        to_builtin!(solana_bpf_loader_deprecated_program!()),
-        to_builtin!(solana_bpf_loader_program!()),
-        to_builtin!(solana_bpf_loader_upgradeable_program!()),
+        BuiltinProgram {
+            name: "solana_bpf_loader_deprecated_program".to_string(),
+            program_id: bpf_loader_deprecated::id(),
+            process_instruction: solana_bpf_loader_program::process_instruction,
+        },
+        BuiltinProgram {
+            name: "solana_bpf_loader_program".to_string(),
+            program_id: bpf_loader::id(),
+            process_instruction: solana_bpf_loader_program::process_instruction,
+        },
+        BuiltinProgram {
+            name: "solana_bpf_loader_upgradeable_program".to_string(),
+            program_id: bpf_loader_upgradeable::id(),
+            process_instruction: solana_bpf_loader_program::process_instruction,
+        },
     ]
 }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
-#[macro_use]
-extern crate solana_bpf_loader_program;
 
 pub mod bank_forks_utils;
 pub mod bigtable_delete;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -157,7 +157,6 @@ impl LoadedProgram {
         maybe_expiration_slot: Option<Slot>,
         elf_bytes: &[u8],
         account_size: usize,
-        _use_jit: bool,
         metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut load_elf_time = Measure::start("load_elf_time");

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -157,7 +157,7 @@ impl LoadedProgram {
         maybe_expiration_slot: Option<Slot>,
         elf_bytes: &[u8],
         account_size: usize,
-        use_jit: bool,
+        _use_jit: bool,
         metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut load_elf_time = Measure::start("load_elf_time");
@@ -181,19 +181,17 @@ impl LoadedProgram {
         verify_code_time.stop();
         metrics.verify_code_us = verify_code_time.as_us();
 
-        if use_jit {
-            #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
-            {
-                let mut jit_compile_time = Measure::start("jit_compile_time");
-                match &mut program {
-                    LoadedProgramType::LegacyV0(executable) => executable.jit_compile(),
-                    LoadedProgramType::LegacyV1(executable) => executable.jit_compile(),
-                    LoadedProgramType::Typed(executable) => executable.jit_compile(),
-                    _ => Err(EbpfError::JitNotCompiled),
-                }?;
-                jit_compile_time.stop();
-                metrics.jit_compile_us = jit_compile_time.as_us();
-            }
+        #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+        {
+            let mut jit_compile_time = Measure::start("jit_compile_time");
+            match &mut program {
+                LoadedProgramType::LegacyV0(executable) => executable.jit_compile(),
+                LoadedProgramType::LegacyV1(executable) => executable.jit_compile(),
+                LoadedProgramType::Typed(executable) => executable.jit_compile(),
+                _ => Err(EbpfError::JitNotCompiled),
+            }?;
+            jit_compile_time.stop();
+            metrics.jit_compile_us = jit_compile_time.as_us();
         }
 
         Ok(Self {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -5,8 +5,6 @@ pub mod deprecated;
 pub mod serialization;
 pub mod syscalls;
 pub mod upgradeable;
-pub mod upgradeable_with_jit;
-pub mod with_jit;
 
 use {
     solana_measure::measure::Measure,
@@ -431,19 +429,6 @@ fn create_memory_mapping<'a, 'b, C: ContextObject>(
 }
 
 pub fn process_instruction(
-    invoke_context: &mut InvokeContext,
-    _arg0: u64,
-    _arg1: u64,
-    _arg2: u64,
-    _arg3: u64,
-    _arg4: u64,
-    _memory_mapping: &mut MemoryMapping,
-    result: &mut ProgramResult,
-) {
-    *result = process_instruction_inner(invoke_context).into();
-}
-
-pub fn process_instruction_jit(
     invoke_context: &mut InvokeContext,
     _arg0: u64,
     _arg1: u64,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -79,7 +79,6 @@ pub fn load_program_from_bytes(
     loader_key: &Pubkey,
     account_size: usize,
     deployment_slot: Slot,
-    use_jit: bool,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
 ) -> Result<LoadedProgram, InstructionError> {
@@ -99,13 +98,11 @@ pub fn load_program_from_bytes(
     })?;
     register_syscalls_time.stop();
     load_program_metrics.register_syscalls_us = register_syscalls_time.as_us();
-
     let effective_slot = if feature_set.is_active(&delay_visibility_of_program_deployment::id()) {
         deployment_slot.saturating_add(1)
     } else {
         deployment_slot
     };
-
     let loaded_program = LoadedProgram::new(
         loader_key,
         loader,
@@ -114,7 +111,6 @@ pub fn load_program_from_bytes(
         None,
         programdata,
         account_size,
-        use_jit,
         load_program_metrics,
     )
     .map_err(|err| {
@@ -160,7 +156,6 @@ pub fn load_program_from_account(
     tx_executor_cache: Option<RefMut<TransactionExecutorCache>>,
     program: &BorrowedAccount,
     programdata: &BorrowedAccount,
-    use_jit: bool,
     debugging_features: bool,
 ) -> Result<(Arc<LoadedProgram>, Option<LoadProgramMetrics>), InstructionError> {
     if !check_loader_id(program.get_owner()) {
@@ -208,7 +203,6 @@ pub fn load_program_from_account(
         program.get_owner(),
         program.get_data().len().saturating_add(programdata_size),
         deployment_slot,
-        use_jit,
         false, /* reject_deployment_of_broken_elfs */
         debugging_features,
     )?);
@@ -226,7 +220,7 @@ pub fn load_program_from_account(
 }
 
 macro_rules! deploy_program {
-    ($invoke_context:expr, $use_jit:expr, $program_id:expr, $loader_key:expr,
+    ($invoke_context:expr, $program_id:expr, $loader_key:expr,
      $account_size:expr, $slot:expr, $drop:expr, $new_programdata:expr $(,)?) => {{
         let delay_visibility_of_program_deployment = $invoke_context
             .feature_set
@@ -241,7 +235,6 @@ macro_rules! deploy_program {
             $loader_key,
             $account_size,
             $slot,
-            $use_jit,
             true, /* reject_deployment_of_broken_elfs */
             false, /* debugging_features */
         )?;
@@ -447,7 +440,7 @@ pub fn process_instruction(
     _memory_mapping: &mut MemoryMapping,
     result: &mut ProgramResult,
 ) {
-    *result = process_instruction_inner(invoke_context, false).into();
+    *result = process_instruction_inner(invoke_context).into();
 }
 
 pub fn process_instruction_jit(
@@ -460,12 +453,11 @@ pub fn process_instruction_jit(
     _memory_mapping: &mut MemoryMapping,
     result: &mut ProgramResult,
 ) {
-    *result = process_instruction_inner(invoke_context, true).into();
+    *result = process_instruction_inner(invoke_context).into();
 }
 
 fn process_instruction_inner(
     invoke_context: &mut InvokeContext,
-    use_jit: bool,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
@@ -562,12 +554,12 @@ fn process_instruction_inner(
             if native_programs_consume_cu {
                 invoke_context.consume_checked(2_370)?;
             }
-            process_loader_upgradeable_instruction(invoke_context, use_jit)
+            process_loader_upgradeable_instruction(invoke_context)
         } else if bpf_loader::check_id(program_id) {
             if native_programs_consume_cu {
                 invoke_context.consume_checked(570)?;
             }
-            process_loader_instruction(invoke_context, use_jit)
+            process_loader_instruction(invoke_context)
         } else if bpf_loader_deprecated::check_id(program_id) {
             if native_programs_consume_cu {
                 invoke_context.consume_checked(1_140)?;
@@ -609,7 +601,6 @@ fn process_instruction_inner(
         Some(invoke_context.tx_executor_cache.borrow_mut()),
         &program_account,
         programdata_account.as_ref().unwrap_or(&program_account),
-        use_jit,
         false, /* debugging_features */
     )?;
     drop(program_account);
@@ -639,7 +630,6 @@ fn process_instruction_inner(
 
 fn process_loader_upgradeable_instruction(
     invoke_context: &mut InvokeContext,
-    use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
@@ -823,7 +813,6 @@ fn process_loader_upgradeable_instruction(
                 instruction_context.try_borrow_instruction_account(transaction_context, 3)?;
             deploy_program!(
                 invoke_context,
-                use_jit,
                 new_program_id,
                 &owner_id,
                 UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
@@ -1012,7 +1001,6 @@ fn process_loader_upgradeable_instruction(
                 instruction_context.try_borrow_instruction_account(transaction_context, 2)?;
             deploy_program!(
                 invoke_context,
-                use_jit,
                 new_program_id,
                 program_id,
                 UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
@@ -1502,10 +1490,7 @@ fn common_close_account(
     Ok(())
 }
 
-fn process_loader_instruction(
-    invoke_context: &mut InvokeContext,
-    use_jit: bool,
-) -> Result<(), InstructionError> {
+fn process_loader_instruction(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
@@ -1535,7 +1520,6 @@ fn process_loader_instruction(
             }
             deploy_program!(
                 invoke_context,
-                use_jit,
                 *program.get_key(),
                 program.get_owner(),
                 program.get_data().len(),
@@ -4044,7 +4028,6 @@ mod tests {
         file.read_to_end(&mut elf).unwrap();
         deploy_program!(
             invoke_context,
-            false,
             program_id,
             &bpf_loader_upgradeable::id(),
             elf.len(),

--- a/programs/bpf_loader/src/upgradeable_with_jit.rs
+++ b/programs/bpf_loader/src/upgradeable_with_jit.rs
@@ -1,6 +1,0 @@
-solana_sdk::declare_builtin!(
-    solana_sdk::bpf_loader_upgradeable::ID,
-    solana_bpf_loader_upgradeable_program_with_jit,
-    solana_bpf_loader_program::process_instruction_jit,
-    upgradeable_with_jit::id
-);

--- a/programs/bpf_loader/src/with_jit.rs
+++ b/programs/bpf_loader/src/with_jit.rs
@@ -1,5 +1,0 @@
-solana_sdk::declare_builtin!(
-    solana_sdk::bpf_loader::ID,
-    solana_bpf_loader_program_with_jit,
-    solana_bpf_loader_program::process_instruction_jit
-);

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -70,7 +70,6 @@ pub fn load_program_from_account(
     compute_budget: &ComputeBudget,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     program: &BorrowedAccount,
-    use_jit: bool,
     debugging_features: bool,
 ) -> Result<(Arc<LoadedProgram>, LoadProgramMetrics), InstructionError> {
     let mut load_program_metrics = LoadProgramMetrics {
@@ -118,7 +117,6 @@ pub fn load_program_from_account(
         None,
         programdata,
         program.get_data().len(),
-        use_jit,
         &mut load_program_metrics,
     )
     .map_err(|err| {
@@ -404,7 +402,6 @@ pub fn process_instruction_truncate(
 
 pub fn process_instruction_deploy(
     invoke_context: &mut InvokeContext,
-    use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
@@ -454,7 +451,6 @@ pub fn process_instruction_deploy(
         invoke_context.get_compute_budget(),
         invoke_context.get_log_collector(),
         buffer,
-        use_jit,
         false, /* debugging_features */
     )?;
     load_program_metrics.submit_datapoint(&mut invoke_context.timings);
@@ -552,7 +548,6 @@ pub fn process_instruction(
 pub fn process_instruction_inner(
     invoke_context: &mut InvokeContext,
 ) -> Result<u64, Box<dyn std::error::Error>> {
-    let use_jit = true;
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -572,7 +567,7 @@ pub fn process_instruction_inner(
             LoaderV3Instruction::Truncate { offset } => {
                 process_instruction_truncate(invoke_context, offset)
             }
-            LoaderV3Instruction::Deploy => process_instruction_deploy(invoke_context, use_jit),
+            LoaderV3Instruction::Deploy => process_instruction_deploy(invoke_context),
             LoaderV3Instruction::Retract => process_instruction_retract(invoke_context),
             LoaderV3Instruction::TransferAuthority => {
                 process_instruction_transfer_authority(invoke_context)
@@ -600,7 +595,6 @@ pub fn process_instruction_inner(
             invoke_context.get_compute_budget(),
             invoke_context.get_log_collector(),
             &program,
-            use_jit,
             false, /* debugging_features */
         )?;
         load_program_metrics.submit_datapoint(&mut invoke_context.timings);

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -258,9 +258,8 @@ before execting it in the virtual machine.",
             &bpf_loader::id(),
             contents.len(),
             Slot::default(),
-            false, /* use_jit */
-            true,  /* reject_deployment_of_broken_elfs */
-            true,  /* debugging_features */
+            true, /* reject_deployment_of_broken_elfs */
+            true, /* debugging_features */
         );
         match result {
             Ok(loaded_program) => match loaded_program.program {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1215,10 +1215,7 @@ impl Bank {
     ) -> Self {
         Self::new_with_paths_for_tests(
             genesis_config,
-            Arc::new(RuntimeConfig {
-                bpf_jit: true,
-                ..RuntimeConfig::default()
-            }),
+            Arc::new(RuntimeConfig::default()),
             Vec::new(),
             account_indexes,
             shrink_ratio,
@@ -4191,7 +4188,6 @@ impl Bank {
             None,
             &program,
             programdata.as_ref().unwrap_or(&program),
-            self.runtime_config.bpf_jit,
             false, /* debugging_features */
         )
         .map(|(loaded_program, _create_executor_metrics)| loaded_program)

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -1,6 +1,6 @@
 use {
     solana_program_runtime::builtin_program::BuiltinProgram,
-    solana_sdk::{feature_set, pubkey::Pubkey, stake},
+    solana_sdk::{feature_set, pubkey::Pubkey},
 };
 
 #[derive(Clone, Debug)]
@@ -86,7 +86,7 @@ fn genesis_builtins() -> Vec<BuiltinProgram> {
         },
         BuiltinProgram {
             name: "stake_program".to_string(),
-            program_id: stake::program::id(),
+            program_id: solana_stake_program::id(),
             process_instruction: solana_stake_program::stake_instruction::process_instruction,
         },
         BuiltinProgram {

--- a/runtime/src/runtime_config.rs
+++ b/runtime/src/runtime_config.rs
@@ -3,7 +3,6 @@ use solana_program_runtime::compute_budget::ComputeBudget;
 /// Encapsulates flags that can be used to tweak the runtime behavior.
 #[derive(AbiExample, Debug, Default, Clone)]
 pub struct RuntimeConfig {
-    pub bpf_jit: bool,
     pub compute_budget: Option<ComputeBudget>,
     pub log_messages_bytes_limit: Option<usize>,
     pub transaction_account_lock_limit: Option<usize>,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -121,7 +121,6 @@ pub struct TestValidatorGenesis {
     pubsub_config: PubSubConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
     warp_slot: Option<Slot>,
-    no_bpf_jit: bool,
     accounts: HashMap<Pubkey, AccountSharedData>,
     #[allow(deprecated)]
     programs: Vec<ProgramInfo>,
@@ -156,7 +155,6 @@ impl Default for TestValidatorGenesis {
             pubsub_config: PubSubConfig::default(),
             rpc_ports: Option::<(u16, u16)>::default(),
             warp_slot: Option::<Slot>::default(),
-            no_bpf_jit: bool::default(),
             accounts: HashMap::<Pubkey, AccountSharedData>::default(),
             #[allow(deprecated)]
             programs: Vec::<ProgramInfo>::default(),
@@ -253,11 +251,6 @@ impl TestValidatorGenesis {
 
     pub fn warp_slot(&mut self, warp_slot: Slot) -> &mut Self {
         self.warp_slot = Some(warp_slot);
-        self
-    }
-
-    pub fn bpf_jit(&mut self, bpf_jit: bool) -> &mut Self {
-        self.no_bpf_jit = !bpf_jit;
         self
     }
 
@@ -910,7 +903,6 @@ impl TestValidator {
         });
 
         let runtime_config = RuntimeConfig {
-            bpf_jit: !config.no_bpf_jit,
             compute_budget: config
                 .compute_unit_limit
                 .map(|compute_unit_limit| ComputeBudget {

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -442,7 +442,6 @@ fn main() {
             enable_vote_subscription,
             ..PubSubConfig::default()
         })
-        .bpf_jit(!matches.is_present("no_bpf_jit"))
         .rpc_port(rpc_port)
         .add_upgradeable_programs_with_path(&upgradeable_programs_to_load)
         .add_accounts_from_json_files(&accounts_to_load)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1124,12 +1124,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ),
         )
         .arg(
-            Arg::with_name("no_bpf_jit")
-                .long("no-bpf-jit")
-                .takes_value(false)
-                .help("Disable the just-in-time compiler and instead use the interpreter for SBF"),
-        )
-        .arg(
             Arg::with_name("poh_pinned_cpu_core")
                 .hidden(hidden_unless_forced())
                 .long("experimental-poh-pinned-cpu-core")
@@ -1691,10 +1685,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Enables faster starting of validators by skipping startup clean and shrink."),
         usage_warning: "Enabled by default",
     );
-    add_arg!(Arg::with_name("bpf_jit")
-        .long("bpf-jit")
-        .takes_value(false)
-        .conflicts_with("no_bpf_jit"));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")
@@ -2197,12 +2187,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                         (see also the `--account` flag). \
                         If the ledger already exists then this parameter is silently ignored",
                 ),
-        )
-        .arg(
-            Arg::with_name("no_bpf_jit")
-                .long("no-bpf-jit")
-                .takes_value(false)
-                .help("Disable the just-in-time compiler and instead use the interpreter for SBF. Windows always disables JIT."),
         )
         .arg(
             Arg::with_name("ticks_per_slot")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1346,7 +1346,6 @@ pub fn main() {
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         accounts_shrink_ratio,
         runtime_config: RuntimeConfig {
-            bpf_jit: !matches.is_present("no_bpf_jit"),
             log_messages_bytes_limit: value_of(&matches, "log_messages_bytes_limit"),
             ..RuntimeConfig::default()
         },


### PR DESCRIPTION
#### Problem
This option is useless in production and for debugging the validator is mostly build from sources. It is routed through the validator code via multiple obscure techniques such as registering multiple versions of the same built-in program. It should be removed because it stands in the way of unifying all built-in programs in one place.

#### Summary of Changes
- Removes the CLI argument "no-bpf-jit".
- Removes its plumbering through out the validator code base.
- Removes the with_jit variants of the bpf_loader programs.
- Removes the `to_builtin!()` macro.