### PR TITLE
Add new CreateVoteAccount instruction-set builders

### DIFF
--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -46,7 +46,7 @@ pub(crate) mod tests {
         process_instructions(
             bank,
             &[from_account, vote_account, validator_identity_account],
-            &vote_instruction::create_account(
+            &vote_instruction::create_account_with_config(
                 &from_account.pubkey(),
                 &vote_pubkey,
                 &VoteInit {
@@ -56,6 +56,10 @@ pub(crate) mod tests {
                     commission: 0,
                 },
                 amount,
+                vote_instruction::CreateVoteAccountConfig {
+                    space: VoteStateVersions::vote_state_size_of(true) as u64,
+                    ..vote_instruction::CreateVoteAccountConfig::default()
+                },
             ),
         );
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -653,7 +653,7 @@ impl LocalCluster {
         {
             // 1) Create vote account
 
-            let instructions = vote_instruction::create_account(
+            let instructions = vote_instruction::create_account_with_config(
                 &from_account.pubkey(),
                 &vote_account_pubkey,
                 &VoteInit {
@@ -663,6 +663,10 @@ impl LocalCluster {
                     commission: 0,
                 },
                 amount,
+                vote_instruction::CreateVoteAccountConfig {
+                    space: vote_state::VoteStateVersions::vote_state_size_of(true) as u64,
+                    ..vote_instruction::CreateVoteAccountConfig::default()
+                },
             );
             let message = Message::new(&instructions, Some(&from_account.pubkey()));
             let mut transaction = Transaction::new(

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -82,7 +82,7 @@ async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
     let vote_lamports = Rent::default().minimum_balance(VoteState::size_of());
     let vote_keypair = Keypair::new();
     let user_keypair = Keypair::new();
-    instructions.append(&mut vote_instruction::create_account(
+    instructions.append(&mut vote_instruction::create_account_with_config(
         &context.payer.pubkey(),
         &vote_keypair.pubkey(),
         &VoteInit {
@@ -91,6 +91,10 @@ async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
             ..VoteInit::default()
         },
         vote_lamports,
+        vote_instruction::CreateVoteAccountConfig {
+            space: vote_state::VoteStateVersions::vote_state_size_of(true) as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
     ));
 
     let transaction = Transaction::new_signed_with_payer(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1796,6 +1796,80 @@ mod tests {
     }
 
     #[test]
+    fn test_create_account_vote_state_1_14_11() {
+        let node_pubkey = Pubkey::new_unique();
+        let vote_pubkey = Pubkey::new_unique();
+        let instructions = create_account(
+            &node_pubkey,
+            &vote_pubkey,
+            &VoteInit {
+                node_pubkey,
+                authorized_voter: vote_pubkey,
+                authorized_withdrawer: vote_pubkey,
+                commission: 0,
+            },
+            101,
+        );
+        // grab the `space` value from SystemInstruction::CreateAccount by directly indexing, for
+        // expediency
+        let space = usize::from_le_bytes(instructions[0].data[12..20].try_into().unwrap());
+        assert_ne!(space, vote_state::VoteState1_14_11::size_of());
+        let empty_vote_account = AccountSharedData::new(101, space, &id());
+
+        let transaction_accounts = vec![
+            (vote_pubkey, empty_vote_account),
+            (node_pubkey, AccountSharedData::default()),
+            (sysvar::clock::id(), create_default_clock_account()),
+            (sysvar::rent::id(), create_default_rent_account()),
+        ];
+
+        // should fail, if vote_state_add_vote_latency is disabled
+        process_instruction_disabled_features(
+            &instructions[1].data,
+            transaction_accounts,
+            instructions[1].accounts.clone(),
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_create_account_vote_state_current() {
+        let node_pubkey = Pubkey::new_unique();
+        let vote_pubkey = Pubkey::new_unique();
+        let instructions = create_account(
+            &node_pubkey,
+            &vote_pubkey,
+            &VoteInit {
+                node_pubkey,
+                authorized_voter: vote_pubkey,
+                authorized_withdrawer: vote_pubkey,
+                commission: 0,
+            },
+            101,
+        );
+        // grab the `space` value from SystemInstruction::CreateAccount by directly indexing, for
+        // expediency
+        let space = usize::from_le_bytes(instructions[0].data[12..20].try_into().unwrap());
+        assert_eq!(space, vote_state::VoteState::size_of());
+        let empty_vote_account = AccountSharedData::new(101, space, &id());
+
+        let transaction_accounts = vec![
+            (vote_pubkey, empty_vote_account),
+            (node_pubkey, AccountSharedData::default()),
+            (sysvar::clock::id(), create_default_clock_account()),
+            (sysvar::rent::id(), create_default_rent_account()),
+        ];
+
+        // succeeds, since vote_state_add_vote_latency is enabled
+        process_instruction(
+            &instructions[1].data,
+            transaction_accounts,
+            instructions[1].accounts.clone(),
+            Ok(()),
+        );
+    }
+
+    #[test]
     fn test_vote_process_instruction() {
         solana_logger::setup();
         let instructions = create_account(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1893,12 +1893,15 @@ mod tests {
     #[test]
     fn test_vote_process_instruction() {
         solana_logger::setup();
-        let instructions = create_account(
+        let instructions = create_account_with_config(
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
             &VoteInit::default(),
             101,
+            CreateVoteAccountConfig::default(),
         );
+        // this case fails regardless of CreateVoteAccountConfig::space, because
+        // process_instruction_as_one_arg passes a default (empty) account
         process_instruction_as_one_arg(&instructions[1], Err(InstructionError::InvalidAccountData));
         process_instruction_as_one_arg(
             &vote(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4439,7 +4439,7 @@ fn test_bank_vote_accounts() {
                                         // to have a vote account
 
     let vote_keypair = Keypair::new();
-    let instructions = vote_instruction::create_account(
+    let instructions = vote_instruction::create_account_with_config(
         &mint_keypair.pubkey(),
         &vote_keypair.pubkey(),
         &VoteInit {
@@ -4449,6 +4449,10 @@ fn test_bank_vote_accounts() {
             commission: 0,
         },
         10,
+        vote_instruction::CreateVoteAccountConfig {
+            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
     );
 
     let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -4503,7 +4507,7 @@ fn test_bank_cloned_stake_delegations() {
     };
 
     let vote_keypair = Keypair::new();
-    let mut instructions = vote_instruction::create_account(
+    let mut instructions = vote_instruction::create_account_with_config(
         &mint_keypair.pubkey(),
         &vote_keypair.pubkey(),
         &VoteInit {
@@ -4513,6 +4517,10 @@ fn test_bank_cloned_stake_delegations() {
             commission: 0,
         },
         vote_balance,
+        vote_instruction::CreateVoteAccountConfig {
+            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
     );
 
     let stake_keypair = Keypair::new();
@@ -4817,7 +4825,7 @@ fn test_add_builtin() {
 
     let mock_account = Keypair::new();
     let mock_validator_identity = Keypair::new();
-    let mut instructions = vote_instruction::create_account(
+    let mut instructions = vote_instruction::create_account_with_config(
         &mint_keypair.pubkey(),
         &mock_account.pubkey(),
         &VoteInit {
@@ -4825,6 +4833,10 @@ fn test_add_builtin() {
             ..VoteInit::default()
         },
         1,
+        vote_instruction::CreateVoteAccountConfig {
+            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
     );
     instructions[1].program_id = mock_vote_program_id();
 
@@ -4859,7 +4871,7 @@ fn test_add_duplicate_static_program() {
 
     let mock_account = Keypair::new();
     let mock_validator_identity = Keypair::new();
-    let instructions = vote_instruction::create_account(
+    let instructions = vote_instruction::create_account_with_config(
         &mint_keypair.pubkey(),
         &mock_account.pubkey(),
         &VoteInit {
@@ -4867,6 +4879,10 @@ fn test_add_duplicate_static_program() {
             ..VoteInit::default()
         },
         1,
+        vote_instruction::CreateVoteAccountConfig {
+            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
     );
 
     let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -9504,7 +9520,7 @@ fn test_vote_epoch_panic() {
 
     let mut setup_ixs = Vec::new();
     setup_ixs.extend(
-        vote_instruction::create_account(
+        vote_instruction::create_account_with_config(
             &mint_keypair.pubkey(),
             &vote_keypair.pubkey(),
             &VoteInit {
@@ -9514,6 +9530,10 @@ fn test_vote_epoch_panic() {
                 commission: 0,
             },
             1_000_000_000,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
         )
         .into_iter(),
     );

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -304,7 +304,7 @@ fn test_stake_account_lifetime() {
 
     // Create Vote Account
     let message = Message::new(
-        &vote_instruction::create_account(
+        &vote_instruction::create_account_with_config(
             &mint_pubkey,
             &vote_pubkey,
             &VoteInit {
@@ -314,6 +314,10 @@ fn test_stake_account_lifetime() {
                 commission: 50,
             },
             vote_balance,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
         ),
         Some(&mint_pubkey),
     );
@@ -569,7 +573,7 @@ fn test_create_stake_account_from_seed() {
 
     // Create Vote Account
     let message = Message::new(
-        &vote_instruction::create_account(
+        &vote_instruction::create_account_with_config(
             &mint_pubkey,
             &vote_pubkey,
             &VoteInit {
@@ -579,6 +583,10 @@ fn test_create_stake_account_from_seed() {
                 commission: 50,
             },
             10,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
         ),
         Some(&mint_pubkey),
     );

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -216,6 +216,10 @@ impl<'a> Default for CreateVoteAccountConfig<'a> {
     }
 }
 
+#[deprecated(
+    since = "1.16.0",
+    note = "Please use `create_account_with_config()` instead."
+)]
 pub fn create_account(
     from_pubkey: &Pubkey,
     vote_pubkey: &Pubkey,
@@ -231,6 +235,10 @@ pub fn create_account(
     )
 }
 
+#[deprecated(
+    since = "1.16.0",
+    note = "Please use `create_account_with_config()` instead."
+)]
 pub fn create_account_with_seed(
     from_pubkey: &Pubkey,
     vote_pubkey: &Pubkey,

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -12,7 +12,7 @@ use {
             state::{
                 serde_compact_vote_state_update, Vote, VoteAuthorize,
                 VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit, VoteState,
-                VoteStateUpdate,
+                VoteStateUpdate, VoteStateVersions,
             },
         },
     },
@@ -200,6 +200,20 @@ fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction
         &VoteInstruction::InitializeAccount(*vote_init),
         account_metas,
     )
+}
+
+pub struct CreateVoteAccountConfig<'a> {
+    pub space: u64,
+    pub with_seed: Option<(&'a Pubkey, &'a str)>,
+}
+
+impl<'a> Default for CreateVoteAccountConfig<'a> {
+    fn default() -> Self {
+        Self {
+            space: VoteStateVersions::vote_state_size_of(false) as u64,
+            with_seed: None,
+        }
+    }
 }
 
 pub fn create_account(

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -11,7 +11,7 @@ use {
             program::id,
             state::{
                 serde_compact_vote_state_update, Vote, VoteAuthorize,
-                VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit, VoteState,
+                VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit,
                 VoteStateUpdate, VoteStateVersions,
             },
         },
@@ -222,11 +222,13 @@ pub fn create_account(
     vote_init: &VoteInit,
     lamports: u64,
 ) -> Vec<Instruction> {
-    let space = VoteState::size_of() as u64;
-    let create_ix =
-        system_instruction::create_account(from_pubkey, vote_pubkey, lamports, space, &id());
-    let init_ix = initialize_account(vote_pubkey, vote_init);
-    vec![create_ix, init_ix]
+    create_account_with_config(
+        from_pubkey,
+        vote_pubkey,
+        vote_init,
+        lamports,
+        CreateVoteAccountConfig::default(),
+    )
 }
 
 pub fn create_account_with_seed(
@@ -237,16 +239,27 @@ pub fn create_account_with_seed(
     vote_init: &VoteInit,
     lamports: u64,
 ) -> Vec<Instruction> {
-    let space = VoteState::size_of() as u64;
-    let create_ix = system_instruction::create_account_with_seed(
+    create_account_with_config(
         from_pubkey,
         vote_pubkey,
-        base,
-        seed,
+        vote_init,
         lamports,
-        space,
-        &id(),
-    );
+        CreateVoteAccountConfig {
+            with_seed: Some((base, seed)),
+            ..CreateVoteAccountConfig::default()
+        },
+    )
+}
+
+pub fn create_account_with_config(
+    from_pubkey: &Pubkey,
+    vote_pubkey: &Pubkey,
+    vote_init: &VoteInit,
+    lamports: u64,
+    config: CreateVoteAccountConfig,
+) -> Vec<Instruction> {
+    let create_ix =
+        system_instruction::create_account(from_pubkey, vote_pubkey, lamports, config.space, &id());
     let init_ix = initialize_account(vote_pubkey, vote_init);
     vec![create_ix, init_ix]
 }

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -255,7 +255,7 @@ mod test {
             sysvar,
             vote::{
                 instruction as vote_instruction,
-                state::{Vote, VoteAuthorize, VoteInit, VoteStateUpdate},
+                state::{Vote, VoteAuthorize, VoteInit, VoteStateUpdate, VoteStateVersions},
             },
         },
     };
@@ -276,11 +276,15 @@ mod test {
             commission,
         };
 
-        let instructions = vote_instruction::create_account(
+        let instructions = vote_instruction::create_account_with_config(
             &Pubkey::new_unique(),
             &vote_pubkey,
             &vote_init,
             lamports,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
         );
         let mut message = Message::new(&instructions, None);
         assert_eq!(


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/30831 added a new VoteState version that requires a different amount of account space. This version will be enabled on activation of feature `vote_state_add_vote_latency`.
The instruction builders in solana_program::vote::instruction use `VoteState::size_of()` to determine the amount of space to request the system program allocate for a new vote account; ie. always the new size. This means `solana create-vote-account` on an edge `solana-cli` fails against all current clusters, where the `vote_state_add_vote_latency` feature gate isn't active.

#### Summary of Changes
Add new instruction-set builders that take as input a config struct with a `space` field. Opted for a config struct so that additional parameters can be added in the future without breaking the builder methods.
Deprecate old builders
Query `vote_state_add_vote_latency` feature status in solana-cli to unbreak `solana create-vote-account`
