### PR TITLE
Check program modification slots during cold start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,6 +6707,7 @@ dependencies = [
  "solana-config-program",
  "solana-frozen-abi 1.16.0",
  "solana-frozen-abi-macro 1.16.0",
+ "solana-loader-v3-program",
  "solana-logger 1.16.0",
  "solana-measure",
  "solana-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ solana-genesis-utils = { path = "genesis-utils", version = "=1.16.0" }
 solana-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=1.16.0" }
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=1.16.0" }
 solana-gossip = { path = "gossip", version = "=1.16.0" }
+solana-loader-v3-program = { path = "programs/loader-v3", version = "=1.16.0" }
 solana-ledger = { path = "ledger", version = "=1.16.0" }
 solana-local-cluster = { path = "local-cluster", version = "=1.16.0" }
 solana-logger = { path = "logger", version = "=1.16.0" }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1434,7 +1434,7 @@ fn load_frozen_forks(
             let mut progress = ConfirmationProgress::new(last_entry_hash);
 
             let mut m = Measure::start("process_single_slot");
-            let bank = bank_forks.write().unwrap().insert(bank);
+            let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
             if process_single_slot(
                 blockstore,
                 &bank,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -525,10 +525,10 @@ impl LoadedPrograms {
 
 #[cfg(test)]
 mod tests {
-    use crate::loaded_programs::LoadedProgramMatchCriteria;
     use {
         crate::loaded_programs::{
-            BlockRelation, ForkGraph, LoadedProgram, LoadedProgramType, LoadedPrograms, WorkingSlot,
+            BlockRelation, ForkGraph, LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType,
+            LoadedPrograms, WorkingSlot,
         },
         percentage::Percentage,
         solana_rbpf::vm::BuiltInProgram,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -351,11 +351,11 @@ impl LoadedPrograms {
     pub fn extract<S: WorkingSlot>(
         &self,
         working_slot: &S,
-        keys: impl Iterator<Item = Pubkey>,
+        keys: impl Iterator<Item = (Pubkey, Slot)>,
     ) -> (HashMap<Pubkey, Arc<LoadedProgram>>, Vec<Pubkey>) {
         let mut missing = Vec::new();
         let found = keys
-            .filter_map(|key| {
+            .filter_map(|(key, modified_on_or_after_slot)| {
                 if let Some(second_level) = self.entries.get(&key) {
                     for entry in second_level.iter().rev() {
                         let current_slot = working_slot.current_slot();
@@ -370,6 +370,14 @@ impl LoadedPrograms {
                                 // Found an entry that's already expired. Any further entries in the list
                                 // are older than the current one. So treat the program as missing in the
                                 // cache and return early.
+                                missing.push(key);
+                                return None;
+                            }
+
+                            if entry.deployment_slot < modified_on_or_after_slot {
+                                // Found an entry that was deployed earlier than the expected modification slot.
+                                // Any further entries in the list are older than the current one.
+                                // So treat the program as missing in the cache and return early.
                                 missing.push(key);
                                 return None;
                             }
@@ -1153,7 +1161,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(22, &[0, 10, 20, 22]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 20));
@@ -1166,7 +1174,7 @@ mod tests {
         let mut working_slot = TestWorkingSlot::new(16, &[0, 5, 11, 15, 16, 18, 19, 23]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1181,7 +1189,7 @@ mod tests {
         working_slot.update_slot(18);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1196,7 +1204,7 @@ mod tests {
         working_slot.update_slot(23);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1211,7 +1219,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(11, &[0, 5, 11, 15, 16]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1235,7 +1243,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(19, &[0, 5, 11, 15, 16, 18, 19, 21, 23]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1250,7 +1258,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(21, &[0, 5, 11, 15, 16, 18, 19, 21, 23]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1285,7 +1293,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(22, &[0, 10, 20, 22]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         // Since the fork was pruned, we should not find the entry deployed at slot 20.
@@ -1299,7 +1307,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(27, &[0, 5, 11, 25, 27]);
         let (found, _missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1328,7 +1336,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(27, &[0, 5, 11, 25, 27]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3, program4].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0), (program4, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program1, 0));
@@ -1336,6 +1344,65 @@ mod tests {
         assert!(match_slot(&found, &program4, 5));
 
         // program3 was deployed on slot 25, which has been pruned
+        assert!(missing.contains(&program3));
+    }
+
+    #[test]
+    fn test_extract_using_deployment_slot() {
+        let mut cache = LoadedPrograms::default();
+
+        // Fork graph created for the test
+        //                   0
+        //                 /   \
+        //                10    5
+        //                |     |
+        //                20    11
+        //                |     | \
+        //                22   15  25
+        //                      |   |
+        //                     16  27
+        //                      |
+        //                     19
+        //                      |
+        //                     23
+
+        let mut fork_graph = TestForkGraphSpecific::default();
+        fork_graph.insert_fork(&[0, 10, 20, 22]);
+        fork_graph.insert_fork(&[0, 5, 11, 15, 16, 19, 21, 23]);
+        fork_graph.insert_fork(&[0, 5, 11, 25, 27]);
+
+        let program1 = Pubkey::new_unique();
+        assert!(!cache.replenish(program1, new_test_loaded_program(0, 1)).0);
+        assert!(!cache.replenish(program1, new_test_loaded_program(20, 21)).0);
+
+        let program2 = Pubkey::new_unique();
+        assert!(!cache.replenish(program2, new_test_loaded_program(5, 6)).0);
+        assert!(!cache.replenish(program2, new_test_loaded_program(11, 12)).0);
+
+        let program3 = Pubkey::new_unique();
+        assert!(!cache.replenish(program3, new_test_loaded_program(25, 26)).0);
+
+        // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
+        let working_slot = TestWorkingSlot::new(12, &[0, 5, 11, 12, 15, 16, 18, 19, 21, 23]);
+        let (found, missing) = cache.extract(
+            &working_slot,
+            vec![(program1, 0), (program2, 0), (program3, 0)].into_iter(),
+        );
+
+        assert!(match_slot(&found, &program1, 0));
+        assert!(match_slot(&found, &program2, 11));
+
+        assert!(missing.contains(&program3));
+
+        // Test the same fork, but request the program modified at a later slot than what's in the cache.
+        let (found, missing) = cache.extract(
+            &working_slot,
+            vec![(program1, 5), (program2, 5), (program3, 0)].into_iter(),
+        );
+
+        assert!(match_slot(&found, &program2, 11));
+
+        assert!(missing.contains(&program1));
         assert!(missing.contains(&program3));
     }
 
@@ -1389,7 +1456,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(12, &[0, 5, 11, 12, 15, 16, 18, 19, 21, 23]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0)].into_iter(),
         );
 
         // Program1 deployed at slot 11 should not be expired yet
@@ -1403,7 +1470,7 @@ mod tests {
         let working_slot = TestWorkingSlot::new(15, &[0, 5, 11, 15, 16, 18, 19, 21, 23]);
         let (found, missing) = cache.extract(
             &working_slot,
-            vec![program1, program2, program3].into_iter(),
+            vec![(program1, 0), (program2, 0), (program3, 0)].into_iter(),
         );
 
         assert!(match_slot(&found, &program2, 11));
@@ -1462,7 +1529,7 @@ mod tests {
         cache.prune(&fork_graph, 10);
 
         let working_slot = TestWorkingSlot::new(20, &[0, 10, 20]);
-        let (found, _missing) = cache.extract(&working_slot, vec![program1].into_iter());
+        let (found, _missing) = cache.extract(&working_slot, vec![(program1, 0)].into_iter());
 
         // The cache should have the program deployed at slot 0
         assert_eq!(

--- a/programs/loader-v3/src/lib.rs
+++ b/programs/loader-v3/src/lib.rs
@@ -37,7 +37,7 @@ use {
     },
 };
 
-fn get_state(data: &[u8]) -> Result<&LoaderV3State, InstructionError> {
+pub fn get_state(data: &[u8]) -> Result<&LoaderV3State, InstructionError> {
     unsafe {
         let data = data
             .get(0..LoaderV3State::program_data_offset())

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5117,6 +5117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-loader-v3-program"
+version = "1.16.0"
+dependencies = [
+ "log",
+ "rand 0.7.3",
+ "solana-measure",
+ "solana-program-runtime",
+ "solana-sdk 1.16.0",
+ "solana_rbpf",
+]
+
+[[package]]
 name = "solana-logger"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,6 +5623,7 @@ dependencies = [
  "solana-config-program",
  "solana-frozen-abi 1.16.0",
  "solana-frozen-abi-macro 1.16.0",
+ "solana-loader-v3-program",
  "solana-measure",
  "solana-metrics",
  "solana-perf",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -49,6 +49,7 @@ solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
+solana-loader-v3-program = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4155,13 +4155,14 @@ impl Bank {
                     return Ok(slot);
                 }
             }
-            return Err(TransactionError::ProgramAccountNotFound);
+            Err(TransactionError::ProgramAccountNotFound)
         } else if loader_v3::check_id(program.owner()) {
             let state = solana_loader_v3_program::get_state(program.data())
                 .map_err(|_| TransactionError::ProgramAccountNotFound)?;
-            return Ok(state.slot);
+            Ok(state.slot)
+        } else {
+            Ok(0)
         }
-        Ok(0)
     }
 
     #[allow(dead_code)] // Preparation for BankExecutorCache rework


### PR DESCRIPTION
#### Problem
During cold start, the program cache could have an incomplete view of the deployed/modified programs. The cache relies on program management instructions to update and manage program cache entries during regular run time. But, at the startup ledger may have modifications to the program that are not yet rooted (i.e. only valid on certain forks). This can lead to execution of an outdated program.

#### Summary of Changes
- Compute the highest slot in the startup/snapshot ledger
- Until the root slot moves past the highest slot, do the following
   - Read the program state to find the deployment slot. 
   - If the deployment slot is in future compared to the program entry in the cache, treat the program as missing in the cache.
   - This will trigger the reloading of the program by reading the program account visible on the current slot.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
