### PR TITLE
ci: use the sccache which installed in the docker image

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -57,7 +57,7 @@ if [[ -n $CI ]]; then
       echo "--- $0 ... (with sccache enabled)"
       # sccache
       ARGS+=(
-        --env "RUSTC_WRAPPER=/home/.cargo/bin/sccache"
+        --env "RUSTC_WRAPPER=/usr/local/cargo/bin/sccache"
         --env AWS_ACCESS_KEY_ID
         --env AWS_SECRET_ACCESS_KEY
         --env SCCACHE_BUCKET

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -36,5 +36,6 @@ RUN set -x \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \
  && cargo install --git https://github.com/rustwasm/wasm-pack --rev b4e619c8a13a8441b804895348afbfd4fb1a68a3 \
+ && cargo install sccache \
  && rustc --version \
  && cargo --version


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
