### PR TITLE
ci: use stable wasm-pack version in docker

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x \
  && cargo install mdbook \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \
- && cargo install --git https://github.com/rustwasm/wasm-pack --rev b4e619c8a13a8441b804895348afbfd4fb1a68a3 \
+ && cargo install wasm-pack \
  && cargo install sccache \
  && rustc --version \
  && cargo --version

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -48,6 +48,8 @@ echo --- build environment
   grcov --version
 
   sccache --version
+
+  wasm-pack --version
 )
 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
#### Problem

the latest wasm-pack (v0.11.0) has already included workspace inheritance support. we don't need to specific the commit anymore!
