### PR TITLE
avoid incorrect internal assert in purge_slot_cache_pubkeys

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5912,7 +5912,10 @@ impl AccountsDb {
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
     ) {
         // Slot purged from cache should not exist in the backing store
-        assert!(self.storage.get_slot_storage_entry(purged_slot).is_none());
+        assert!(self
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(purged_slot)
+            .is_none());
         let num_purged_keys = pubkey_to_slot_set.len();
         let (reclaims, _) = self.purge_keys_exact(pubkey_to_slot_set.iter());
         assert_eq!(reclaims.len(), num_purged_keys);


### PR DESCRIPTION
#### Problem
Asserting is triggering an internal assert in a race condition.
https://discord.com/channels/428295358100013066/439194979856809985/1100451218171637923

This code asserts there are no storages for a given slot. This can be correctly asserted. However, the default api is expected to only run during a time when it is not possible to be running concurrently with shrink. Shrink has side effects on the data structures that map slot -> append vec. During shrink there can temporarily be 2 storages for that slot. But, during all normal operations, there should only be a single append vec (or none) for a given slot. This is a race condition between a rare feature (dumping a duplicate slot) with the accounts background service performing a shrink.

#### Summary of Changes
Remove the ability to trigger an internal assert while maintaining the intended assert.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
