### PR TITLE
Fix - Filter condition in `filter_executable_program_accounts()`

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -651,22 +651,19 @@ impl Accounts {
                     })
                     .is_some()
                 {
-                    tx.message()
-                        .account_keys()
-                        .iter()
-                        .for_each(|key| {
-                            if !result.contains_key(key) {
-                                if let Ok(index) = self.accounts_db.account_matches_owners(
-                                    ancestors,
-                                    key,
-                                    program_owners,
-                                ) {
-                                    program_owners
-                                        .get(index)
-                                        .and_then(|owner| result.insert(*key, *owner));
-                                }
+                    tx.message().account_keys().iter().for_each(|key| {
+                        if !result.contains_key(key) {
+                            if let Ok(index) = self.accounts_db.account_matches_owners(
+                                ancestors,
+                                key,
+                                program_owners,
+                            ) {
+                                program_owners
+                                    .get(index)
+                                    .and_then(|owner| result.insert(*key, *owner));
                             }
-                        });
+                        }
+                    });
                 } else {
                     // If the transaction's nonce account was not valid, and blockhash is not found,
                     // the transaction will fail to process. Let's not load any programs from the


### PR DESCRIPTION
#### Problem
When a program is used in CPI and later upgraded, it is both an instruction account to a transaction-level instruction and writable TX-wide. Currently TX-wide writable accounts are disregarded and not loaded as programs, which is incorrect.

#### Summary of Changes
Removes `!tx.message().is_writable(i) &&` from the filter condition.

Fixes #31365
