### PR TITLE
remove unused solana-net-utils dep from solana-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,7 +5409,6 @@ dependencies = [
  "solana-connection-cache",
  "solana-measure",
  "solana-metrics",
- "solana-net-utils",
  "solana-pubsub-client",
  "solana-quic-client",
  "solana-rpc-client",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,7 +23,6 @@ rayon = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
-solana-net-utils = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4709,7 +4709,6 @@ dependencies = [
  "solana-connection-cache",
  "solana-measure",
  "solana-metrics",
- "solana-net-utils",
  "solana-pubsub-client",
  "solana-quic-client",
  "solana-rpc-client",


### PR DESCRIPTION
#### Problem

solana-net-utils isn't used anywhere in solana-client despite being a dependency.

#### Summary of Changes

remove it