### PR TITLE
Fix keypair multiplier check

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -465,8 +465,8 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
             .to_string()
             .parse()
             .map_err(|_| "can't parse keypair-multiplier")?;
-        if args.keypair_multiplier >= 2 {
-            return Err("args.keypair_multiplier must be lower than 2");
+        if args.keypair_multiplier < 2 {
+            return Err("args.keypair_multiplier must be greater than or equal to 2");
         }
     }
 


### PR DESCRIPTION
#### Problem
`keypair_multiplier` is required to be >= 2, and the check here is doing the opposite.

Bug was introduced [here](https://github.com/solana-labs/solana/pull/30307/files#diff-d14e602d4b2d368407717910683a50eaaee95be475fdd8a1e895297655201430L465) in #30307

The default value of this arg is 8 by the way 😄 

#### Summary of Changes
Reverse the check.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
