### PR TITLE
removes pubkey from LegacyContactInfo public interface

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -156,7 +156,7 @@ fn create_client(
                     info!("Searching for target_node: {:?}", target_node);
                     let mut target_client = None;
                     for node in nodes {
-                        if node.id == target_node {
+                        if node.pubkey() == &target_node {
                             target_client = Some(get_client(
                                 &[node],
                                 &SocketAddrSpace::Unspecified,

--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -63,7 +63,7 @@ fn get_retransmit_peers_deterministic_wrapper(b: &mut Bencher, unstaked_ratio: O
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
     let (nodes, cluster_nodes) = make_cluster_nodes(&mut rng, unstaked_ratio);
-    let slot_leader = nodes[1..].choose(&mut rng).unwrap().id;
+    let slot_leader = *nodes[1..].choose(&mut rng).unwrap().pubkey();
     let slot = rand::random::<u64>();
     b.iter(|| {
         get_retransmit_peers_deterministic(

--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -314,10 +314,10 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     .unwrap()
                     .remove(shred.signature())
                 {
-                    if cluster_partition.contains(&node.id) {
+                    if cluster_partition.contains(node.pubkey()) {
                         info!(
                             "skipping node {} for original shred index {}, slot {}",
-                            node.id,
+                            node.pubkey(),
                             shred.index(),
                             shred.slot()
                         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2104,7 +2104,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
             // Contact infos are refreshed twice during this period.
             age < CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS
         })
-        .map(|node| (node.id, node))
+        .map(|node| (*node.pubkey(), node))
         .collect();
     let my_shred_version = cluster_info.my_shred_version();
     let my_id = cluster_info.id();

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -430,13 +430,13 @@ fn get_target(
             if node.gossip().ok() == Some(entrypoint_addr) {
                 info!("{:?}", node.gossip());
                 target = match mode {
-                    Mode::Gossip => Some((node.id, node.gossip().unwrap())),
-                    Mode::Tvu => Some((node.id, node.tvu().unwrap())),
-                    Mode::TvuForwards => Some((node.id, node.tvu_forwards().unwrap())),
-                    Mode::Tpu => Some((node.id, node.tpu().unwrap())),
-                    Mode::TpuForwards => Some((node.id, node.tpu_forwards().unwrap())),
-                    Mode::Repair => Some((node.id, node.repair().unwrap())),
-                    Mode::ServeRepair => Some((node.id, node.serve_repair().unwrap())),
+                    Mode::Gossip => Some((*node.pubkey(), node.gossip().unwrap())),
+                    Mode::Tvu => Some((*node.pubkey(), node.tvu().unwrap())),
+                    Mode::TvuForwards => Some((*node.pubkey(), node.tvu_forwards().unwrap())),
+                    Mode::Tpu => Some((*node.pubkey(), node.tpu().unwrap())),
+                    Mode::TpuForwards => Some((*node.pubkey(), node.tpu_forwards().unwrap())),
+                    Mode::Repair => Some((*node.pubkey(), node.repair().unwrap())),
+                    Mode::ServeRepair => Some((*node.pubkey(), node.serve_repair().unwrap())),
                     Mode::Rpc => None,
                 };
                 break;

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -563,7 +563,7 @@ impl ClusterInfo {
                     //    there's not much point in saving entrypoint ContactInfo since by
                     //    definition that information is already available
                     let contact_info = v.value.contact_info().unwrap();
-                    if contact_info.id != self_pubkey
+                    if contact_info.pubkey() != &self_pubkey
                         && contact_info
                             .gossip()
                             .map(|addr| !entrypoint_gossip_addrs.contains(&addr))
@@ -759,7 +759,7 @@ impl ClusterInfo {
                     .rpc()
                     .ok()
                     .filter(|addr| self.socket_addr_space.check(addr))?;
-                let node_version = self.get_node_version(&node.id);
+                let node_version = self.get_node_version(node.pubkey());
                 if my_shred_version != 0
                     && (node.shred_version() != 0 && node.shred_version() != my_shred_version)
                 {
@@ -769,9 +769,13 @@ impl ClusterInfo {
                 Some(format!(
                     "{:15} {:2}| {:5} | {:44} |{:^9}| {:5}| {:5}| {}\n",
                     rpc_addr.to_string(),
-                    if node.id == my_pubkey { "me" } else { "" },
+                    if node.pubkey() == &my_pubkey {
+                        "me"
+                    } else {
+                        ""
+                    },
                     now.saturating_sub(last_updated),
-                    node.id,
+                    node.pubkey(),
                     if let Some(node_version) = node_version {
                         node_version.to_string()
                     } else {
@@ -812,7 +816,7 @@ impl ClusterInfo {
                     total_spy_nodes = total_spy_nodes.saturating_add(1);
                 }
 
-                let node_version = self.get_node_version(&node.id);
+                let node_version = self.get_node_version(node.pubkey());
                 if my_shred_version != 0 && (node.shred_version() != 0 && node.shred_version() != my_shred_version) {
                     different_shred_nodes = different_shred_nodes.saturating_add(1);
                     None
@@ -831,9 +835,9 @@ impl ClusterInfo {
                             .as_ref()
                             .map(IpAddr::to_string)
                             .unwrap_or_else(|| String::from("none")),
-                        if node.id == my_pubkey { "me" } else { "" },
+                        if node.pubkey() == &my_pubkey { "me" } else { "" },
                         now.saturating_sub(last_updated),
-                        node.id,
+                        node.pubkey(),
                         if let Some(node_version) = node_version {
                             node_version.to_string()
                         } else {
@@ -1277,7 +1281,9 @@ impl ClusterInfo {
         let gossip_crds = self.gossip.crds.read().unwrap();
         gossip_crds
             .get_nodes_contact_info()
-            .filter(|node| node.id != self_pubkey && self.check_socket_addr_space(&node.rpc()))
+            .filter(|node| {
+                node.pubkey() != &self_pubkey && self.check_socket_addr_space(&node.rpc())
+            })
             .cloned()
             .collect()
     }
@@ -1297,7 +1303,7 @@ impl ClusterInfo {
         gossip_crds
             .get_nodes_contact_info()
             // shred_version not considered for gossip peers (ie, spy nodes do not set shred_version)
-            .filter(|node| node.id != me && self.check_socket_addr_space(&node.gossip()))
+            .filter(|node| node.pubkey() != &me && self.check_socket_addr_space(&node.gossip()))
             .cloned()
             .collect()
     }
@@ -1307,7 +1313,9 @@ impl ClusterInfo {
         let self_pubkey = self.id();
         self.time_gossip_read_lock("all_tvu_peers", &self.stats.all_tvu_peers)
             .get_nodes_contact_info()
-            .filter(|node| node.id != self_pubkey && self.check_socket_addr_space(&node.tvu()))
+            .filter(|node| {
+                node.pubkey() != &self_pubkey && self.check_socket_addr_space(&node.tvu())
+            })
             .cloned()
             .collect()
     }
@@ -1319,7 +1327,7 @@ impl ClusterInfo {
         self.time_gossip_read_lock("tvu_peers", &self.stats.tvu_peers)
             .get_nodes_contact_info()
             .filter(|node| {
-                node.id != self_pubkey
+                node.pubkey() != &self_pubkey
                     && node.shred_version() == self_shred_version
                     && self.check_socket_addr_space(&node.tvu())
             })
@@ -1336,11 +1344,11 @@ impl ClusterInfo {
         gossip_crds
             .get_nodes_contact_info()
             .filter(|node| {
-                node.id != self_pubkey
+                node.pubkey() != &self_pubkey
                     && node.shred_version() == self_shred_version
                     && self.check_socket_addr_space(&node.tvu())
                     && self.check_socket_addr_space(&node.serve_repair())
-                    && match gossip_crds.get::<&LowestSlot>(node.id) {
+                    && match gossip_crds.get::<&LowestSlot>(*node.pubkey()) {
                         None => true, // fallback to legacy behavior
                         Some(lowest_slot) => lowest_slot.lowest <= slot,
                     }
@@ -1364,7 +1372,9 @@ impl ClusterInfo {
         let gossip_crds = self.gossip.crds.read().unwrap();
         gossip_crds
             .get_nodes_contact_info()
-            .filter(|node| node.id != self_pubkey && self.check_socket_addr_space(&node.tpu()))
+            .filter(|node| {
+                node.pubkey() != &self_pubkey && self.check_socket_addr_space(&node.tpu())
+            })
             .cloned()
             .collect()
     }
@@ -1660,7 +1670,7 @@ impl ClusterInfo {
             return true;
         }
         for entrypoint in entrypoints.iter_mut() {
-            if entrypoint.id == Pubkey::default() {
+            if entrypoint.pubkey() == &Pubkey::default() {
                 // If a pull from the entrypoint was successful it should exist in the CRDS table
                 if let Some(entrypoint_from_gossip) = entrypoint
                     .gossip()
@@ -1681,7 +1691,7 @@ impl ClusterInfo {
                 info!(
                     "Setting shred version to {:?} from entrypoint {:?}",
                     entrypoint.shred_version(),
-                    entrypoint.id
+                    entrypoint.pubkey()
                 );
                 self.my_contact_info
                     .write()
@@ -1692,7 +1702,7 @@ impl ClusterInfo {
         self.my_shred_version() != 0
             && entrypoints
                 .iter()
-                .all(|entrypoint| entrypoint.id != Pubkey::default())
+                .all(|entrypoint| entrypoint.pubkey() != &Pubkey::default())
     }
 
     fn handle_purge(
@@ -1725,7 +1735,8 @@ impl ClusterInfo {
             .read()
             .unwrap()
             .iter()
-            .map(|k| k.id)
+            .map(LegacyContactInfo::pubkey)
+            .copied()
             .chain(std::iter::once(self.id()))
             .collect();
         self.stats.trim_crds_table.add_relaxed(1);
@@ -1913,7 +1924,7 @@ impl ClusterInfo {
                 .with_min_len(1024)
                 .filter(|(_, _, caller)| match caller.contact_info() {
                     None => false,
-                    Some(caller) if caller.id == self_pubkey => {
+                    Some(caller) if caller.pubkey() == &self_pubkey => {
                         warn!("PullRequest ignored, I'm talking to myself");
                         self.stats.window_request_loopback.add_relaxed(1);
                         false
@@ -3146,7 +3157,7 @@ fn filter_on_shred_version(
             values.retain(|value| match &value.data {
                 // Allow node to update its own contact info in case their
                 // shred-version changes
-                CrdsData::LegacyContactInfo(node) => node.id == *from,
+                CrdsData::LegacyContactInfo(node) => node.pubkey() == from,
                 CrdsData::NodeInstance(_) => true,
                 _ => false,
             })

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -829,7 +829,7 @@ pub(crate) mod tests {
         ping_cache
             .lock()
             .unwrap()
-            .mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+            .mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         crds.write()
             .unwrap()
@@ -893,12 +893,12 @@ pub(crate) mod tests {
         let node = CrdsGossipPull::default();
         crds.insert(entry, now, GossipRoute::LocalMessage).unwrap();
         let old = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ping_cache.mock_pong(old.id, old.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*old.pubkey(), old.gossip().unwrap(), Instant::now());
         let old = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(old));
         crds.insert(old.clone(), now, GossipRoute::LocalMessage)
             .unwrap();
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ping_cache.mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         crds.insert(new, now, GossipRoute::LocalMessage).unwrap();
         let crds = RwLock::new(crds);
@@ -956,7 +956,7 @@ pub(crate) mod tests {
             .insert(entry, now, GossipRoute::LocalMessage)
             .unwrap();
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), now);
-        ping_cache.mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         node_crds
             .insert(new, now, GossipRoute::LocalMessage)
@@ -1058,7 +1058,7 @@ pub(crate) mod tests {
             128,                               // capacity
         );
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ping_cache.mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
         let node_crds = RwLock::new(node_crds);
@@ -1118,14 +1118,14 @@ pub(crate) mod tests {
             128,                               // capacity
         );
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 1);
-        ping_cache.mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
 
         let mut dest_crds = Crds::default();
         let new_id = solana_sdk::pubkey::new_rand();
         let new = ContactInfo::new_localhost(&new_id, 1);
-        ping_cache.mock_pong(new.id, new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(new));
         dest_crds
             .insert(new.clone(), 0, GossipRoute::LocalMessage)
@@ -1134,7 +1134,11 @@ pub(crate) mod tests {
 
         // node contains a key from the dest node, but at an older local timestamp
         let same_key = ContactInfo::new_localhost(&new_id, 0);
-        ping_cache.mock_pong(same_key.id, same_key.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(
+            *same_key.pubkey(),
+            same_key.gossip().unwrap(),
+            Instant::now(),
+        );
         let same_key = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(same_key));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -272,7 +272,7 @@ impl CrdsGossipPush {
         );
         let nodes = crds_gossip::dedup_gossip_addresses(nodes, stakes)
             .into_values()
-            .map(|(_stake, node)| node.id)
+            .map(|(_stake, node)| *node.pubkey())
             .collect::<Vec<_>>();
         if nodes.is_empty() {
             return;
@@ -336,7 +336,7 @@ mod tests {
         // push a new message
         assert_eq!(
             push.process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0),
-            [ci.id].into_iter().collect()
+            [*ci.pubkey()].into_iter().collect()
         );
 
         // push an old version
@@ -372,7 +372,7 @@ mod tests {
         let crds = RwLock::<Crds>::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        let origin = ci.id;
+        let origin = *ci.pubkey();
         ci.set_wallclock(0);
         let value_old = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ci.clone()));
 
@@ -398,7 +398,7 @@ mod tests {
         let push = CrdsGossipPush::default();
         let mut ping_cache = new_ping_cache();
         let peer = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
-        ping_cache.mock_pong(peer.id, peer.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
         let peer = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(peer));
         assert_eq!(
             crds.insert(peer.clone(), now, GossipRoute::LocalMessage),
@@ -450,7 +450,7 @@ mod tests {
             .map(|wallclock| {
                 let mut peer = ContactInfo::new_rand(&mut rng, /*pubkey=*/ None);
                 peer.set_wallclock(wallclock);
-                ping_cache.mock_pong(peer.id, peer.gossip().unwrap(), Instant::now());
+                ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
                 CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(peer))
             })
             .collect();

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -598,7 +598,7 @@ impl CrdsValue {
     }
     pub fn pubkey(&self) -> Pubkey {
         match &self.data {
-            CrdsData::LegacyContactInfo(contact_info) => contact_info.id,
+            CrdsData::LegacyContactInfo(contact_info) => *contact_info.pubkey(),
             CrdsData::Vote(_, vote) => vote.from,
             CrdsData::LowestSlot(_, slots) => slots.from,
             CrdsData::LegacySnapshotHashes(hash) => hash.from,
@@ -719,7 +719,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let v = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(LegacyContactInfo::default()));
         assert_eq!(v.wallclock(), 0);
-        let key = v.contact_info().unwrap().id;
+        let key = *v.contact_info().unwrap().pubkey();
         assert_eq!(v.label(), CrdsValueLabel::LegacyContactInfo(key));
 
         let v = Vote::new(Pubkey::default(), new_test_vote_tx(&mut rng), 0).unwrap();

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -254,7 +254,7 @@ fn spy(
         tvu_peers = spy_ref.all_tvu_peers();
 
         let found_node_by_pubkey = if let Some(pubkey) = find_node_by_pubkey {
-            all_peers.iter().any(|x| x.id == pubkey)
+            all_peers.iter().any(|node| node.pubkey() == &pubkey)
         } else {
             false
         };

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -20,7 +20,7 @@ use {
     Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, AbiExample, Deserialize, Serialize,
 )]
 pub struct LegacyContactInfo {
-    pub id: Pubkey,
+    id: Pubkey,
     /// gossip address
     gossip: SocketAddr,
     /// address to connect to for replication
@@ -157,6 +157,11 @@ impl LegacyContactInfo {
     }
 
     #[inline]
+    pub fn pubkey(&self) -> &Pubkey {
+        &self.id
+    }
+
+    #[inline]
     pub fn wallclock(&self) -> u64 {
         self.wallclock
     }
@@ -164,6 +169,10 @@ impl LegacyContactInfo {
     #[inline]
     pub fn shred_version(&self) -> u16 {
         self.shred_version
+    }
+
+    pub fn set_pubkey(&mut self, pubkey: Pubkey) {
+        self.id = pubkey
     }
 
     pub fn set_wallclock(&mut self, wallclock: u64) {

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -197,7 +197,7 @@ fn process_spy_results(
             }
         }
         if let Some(node) = pubkey {
-            if !validators.iter().any(|x| x.id == node) {
+            if !validators.iter().any(|x| x.pubkey() == &node) {
                 eprintln!("Error: Could not find node {node:?}");
                 exit(1);
             }

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -518,7 +518,7 @@ fn network_run_pull(
                     let self_info = gossip_crds.get::<&CrdsValue>(&label).unwrap().clone();
                     requests
                         .into_iter()
-                        .map(move |(peer, filters)| (peer.id, filters, self_info.clone()))
+                        .map(move |(peer, filters)| (*peer.pubkey(), filters, self_info.clone()))
                 })
                 .collect()
         };
@@ -764,7 +764,7 @@ fn test_prune_errors() {
     //incorrect dest
     let mut res = crds_gossip.process_prune_msg(
         &id,                                      // self_pubkey
-        &ci.id,                                   // peer
+        ci.pubkey(),                              // peer
         &Pubkey::from(hash(&[1; 32]).to_bytes()), // destination
         &[prune_pubkey],                          // origins
         now,
@@ -775,7 +775,7 @@ fn test_prune_errors() {
     //correct dest
     res = crds_gossip.process_prune_msg(
         &id,             // self_pubkey
-        &ci.id,          // peer
+        ci.pubkey(),     // peer
         &id,             // destination
         &[prune_pubkey], // origins
         now,
@@ -787,7 +787,7 @@ fn test_prune_errors() {
     let timeout = now + crds_gossip.push.prune_timeout * 2;
     res = crds_gossip.process_prune_msg(
         &id,             // self_pubkey
-        &ci.id,          // peer
+        ci.pubkey(),     // peer
         &id,             // destination
         &[prune_pubkey], // origins
         now,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -214,12 +214,12 @@ fn gossip_rstar() {
             let xv = &listen[0].0;
             xv.lookup_contact_info(&xv.id(), |ci| ci.clone()).unwrap()
         };
-        trace!("rstar leader {}", xd.id);
+        trace!("rstar leader {}", xd.pubkey());
         for n in 0..(num - 1) {
             let y = (n + 1) % listen.len();
             let yv = &listen[y].0;
             yv.insert_legacy_info(xd.clone());
-            trace!("rstar insert {} into {}", xd.id, yv.id());
+            trace!("rstar insert {} into {}", xd.pubkey(), yv.id());
         }
     });
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -352,7 +352,7 @@ fn test_forwarding() {
 
     let validator_info = cluster_nodes
         .iter()
-        .find(|c| c.id != leader_pubkey)
+        .find(|c| c.pubkey() != &leader_pubkey)
         .unwrap();
 
     // Confirm that transactions were forwarded to and processed by the leader.
@@ -1359,7 +1359,7 @@ fn test_snapshots_blockstore_floor() {
     )
     .unwrap();
     let mut known_validators = HashSet::new();
-    known_validators.insert(cluster_nodes[0].id);
+    known_validators.insert(*cluster_nodes[0].pubkey());
     validator_snapshot_test_config
         .validator_config
         .known_validators = Some(known_validators);

--- a/local-cluster/tests/local_cluster_slow_2.rs
+++ b/local-cluster/tests/local_cluster_slow_2.rs
@@ -115,7 +115,7 @@ fn test_consistency_halt() {
         setup_snapshot_validator_config(snapshot_interval_slots, num_account_paths);
 
     let mut known_validators = HashSet::new();
-    known_validators.insert(cluster_nodes[0].id);
+    known_validators.insert(*cluster_nodes[0].pubkey());
 
     validator_snapshot_test_config
         .validator_config

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -33,7 +33,7 @@ impl TpuInfo for ClusterTpuInfo {
             .cluster_info
             .tpu_peers()
             .into_iter()
-            .filter_map(|node| Some((node.id, node.tpu().ok()?)))
+            .filter_map(|node| Some((*node.pubkey(), node.tpu().ok()?)))
             .collect();
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3459,14 +3459,14 @@ pub mod rpc_full {
                             .unwrap_or_default()
                     {
                         let (version, feature_set) = if let Some(version) =
-                            cluster_info.get_node_version(&contact_info.id)
+                            cluster_info.get_node_version(contact_info.pubkey())
                         {
                             (Some(version.to_string()), Some(version.feature_set))
                         } else {
                             (None, None)
                         };
                         Some(RpcContactInfo {
-                            pubkey: contact_info.id.to_string(),
+                            pubkey: contact_info.pubkey().to_string(),
                             gossip: contact_info.gossip().ok(),
                             tpu: contact_info
                                 .tpu()


### PR DESCRIPTION
#### Problem
Working towards `LegacyContactInfo` => `ContactInfo` migration. 

#### Summary of Changes
* removed `pubkey` from `LegacyContactInfo` public interface.
* expand api parity between `LegacyContactInfo` and `ContactInfo`.
