### PR TITLE
Use async delete to save time and gracefully handle missing dir

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1229,7 +1229,7 @@ pub fn add_bank_snapshot(
                 .join(&slot_str);
             if account_snapshot_path.is_dir() {
                 // remove the account snapshot directory
-                fs::remove_dir_all(&account_snapshot_path)?;
+                move_and_async_delete_path(&account_snapshot_path);
             }
         }
     }
@@ -1354,7 +1354,7 @@ where
         // They should all be removed.
         for entry in fs::read_dir(accounts_hardlinks_dir)? {
             let dst_path = fs::read_link(entry?.path())?;
-            fs::remove_dir_all(dst_path)?;
+            move_and_async_delete_path(&dst_path);
         }
     }
     fs::remove_dir_all(bank_snapshot_dir)?;


### PR DESCRIPTION
#### Problem
When removing a snapshot, if the corresponding account/snapshot/\<slot\> directory is missing, the remove_dir_all can fail with IO error, leading to the unwrap panic when returning from add_bank_snapshot().

#### Summary of Changes
Replace it with async move_and_async_delete_path, which handles the dir missing gracefully, and also save time.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
