### PR TITLE
Add snapshot incomplete log message

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -208,6 +208,10 @@ impl BankSnapshotInfo {
             // There are also possible hardlink files under <account_path>/snapshot/<slot>/, referred by this
             // snapshot dir's symlinks.  They are cleaned up in clean_orphaned_account_snapshot_dirs() at the
             // boot time.
+            info!(
+                "This snapshot dir: {} is incomplete, removing it, and returning IncompleteDir error",
+                &bank_snapshot_dir.display()
+            );
             fs::remove_dir_all(bank_snapshot_dir)?;
             return Err(SnapshotNewFromDirError::IncompleteDir(completion_flag_file));
         }


### PR DESCRIPTION
#### Problem
An incomplete snapshot dir can happen when the process is killed in the middle of generating the account files.  The incomplete dir is deleted when found, and an error is returned for the BankSnapshot::new_from_dir function, causing the error message "Unable to read bank snapshot for slot".  This log message helps explain the cause of that error message.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
