### PR TITLE
Set loaded_addresses in getTransaction when using jsonParsed encoding

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -462,7 +462,9 @@ impl UiTransactionStatusMeta {
                 .map(|balance| balance.into_iter().map(Into::into).collect())
                 .into(),
             rewards: if show_rewards { meta.rewards } else { None }.into(),
-            loaded_addresses: OptionSerializer::Skip,
+            loaded_addresses: OptionSerializer::Some(UiLoadedAddresses::from(
+                &meta.loaded_addresses,
+            )),
             return_data: OptionSerializer::or_skip(
                 meta.return_data.map(|return_data| return_data.into()),
             ),


### PR DESCRIPTION
#### Problem

When calling `getTransaction` with the `jsonParsed` encoding, the `loaded_addresses` was skipped

#### Summary of Changes

The `loaded_addresses` are now included when using the `jsonParsed` encoding. This matches the behaviour of all other encodings, and [the documentation](https://docs.solana.com/api/http#gettransaction) which doesn't indicate any change to the presence of this field based on encoding.

Fixes #31390 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->