### PR TITLE
Remove obsolete code for lazily loading programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1752,7 +1752,7 @@ mod tests {
         let mut load_program_metrics = LoadProgramMetrics::default();
 
         load_program_from_bytes(
-            &FeatureSet::default(),
+            &FeatureSet::all_enabled(),
             &ComputeBudget::default(),
             None,
             &mut load_program_metrics,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -15,11 +15,8 @@ use {
     solana_account_decoder::parse_bpf_loader::{
         parse_bpf_upgradeable_loader, BpfUpgradeableLoaderAccountType,
     },
-    solana_bpf_loader_program::load_program_from_bytes,
     solana_ledger::token_balances::collect_token_balances,
-    solana_program_runtime::{
-        compute_budget::ComputeBudget, loaded_programs::LoadProgramMetrics, timings::ExecuteTimings,
-    },
+    solana_program_runtime::{compute_budget::ComputeBudget, timings::ExecuteTimings},
     solana_rbpf::vm::ContextObject,
     solana_runtime::{
         bank::{
@@ -1387,26 +1384,10 @@ fn assert_instruction_count() {
             is_signer: false,
             is_writable: false,
         }];
-        let program_data = load_program_from_file(program_name);
-        transaction_accounts[0].1.set_data_from_slice(&program_data);
+        transaction_accounts[0]
+            .1
+            .set_data_from_slice(&load_program_from_file(program_name));
         transaction_accounts[0].1.set_executable(true);
-
-        let mut load_program_metrics = LoadProgramMetrics::default();
-        let loaded_program = Arc::new(
-            load_program_from_bytes(
-                &FeatureSet::all_enabled(),
-                &ComputeBudget::default(),
-                None,
-                &mut load_program_metrics,
-                &program_data,
-                &loader_id,
-                program_data.len(),
-                0,
-                true,
-                false,
-            )
-            .expect("Failed to load the program"),
-        );
 
         let prev_compute_meter = RefCell::new(0);
         print!("  {:36} {:8}", program_name, *expected_consumption);
@@ -1420,8 +1401,7 @@ fn assert_instruction_count() {
             solana_bpf_loader_program::process_instruction,
             |invoke_context| {
                 *prev_compute_meter.borrow_mut() = invoke_context.get_remaining();
-                let mut cache = invoke_context.tx_executor_cache.borrow_mut();
-                cache.set(program_key, loaded_program.clone(), true, false, 0);
+                solana_bpf_loader_program::test_utils::load_all_invoked_programs(invoke_context);
             },
             |invoke_context| {
                 let consumption = prev_compute_meter

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1394,7 +1394,7 @@ fn assert_instruction_count() {
         let mut load_program_metrics = LoadProgramMetrics::default();
         let loaded_program = Arc::new(
             load_program_from_bytes(
-                &FeatureSet::default(),
+                &FeatureSet::all_enabled(),
                 &ComputeBudget::default(),
                 None,
                 &mut load_program_metrics,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4210,7 +4210,6 @@ impl Bank {
             &self.feature_set,
             &self.runtime_config.compute_budget.unwrap_or_default(),
             None, // log_collector
-            None,
             &program,
             programdata.as_ref().unwrap_or(&program),
             debugging_features,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7713,7 +7713,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     }
 
     let loaded_program = bank
-        .load_program(&program_keypair.pubkey())
+        .load_program(&program_keypair.pubkey(), false)
         .expect("Failed to load the program");
 
     // Invoke deployed program

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7712,6 +7712,10 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(*elf.get(i).unwrap(), *byte);
     }
 
+    let loaded_program = bank
+        .load_program(&program_keypair.pubkey())
+        .expect("Failed to load the program");
+
     // Invoke deployed program
     mock_process_instruction(
         &bpf_loader_upgradeable::id(),
@@ -7724,7 +7728,16 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         Vec::new(),
         Ok(()),
         solana_bpf_loader_program::process_instruction,
-        |_invoke_context| {},
+        |invoke_context| {
+            let mut cache = invoke_context.tx_executor_cache.borrow_mut();
+            cache.set(
+                program_keypair.pubkey(),
+                loaded_program.clone(),
+                true,
+                false,
+                0,
+            );
+        },
         |_invoke_context| {},
     );
 


### PR DESCRIPTION
#### Problem
`bpf_loader` still has code to lazily load programs, but its obsolete now. The `bank` loads all the programs in a transaction batch before the loader is called. The obsolete code should be removed.

#### Summary of Changes
Removed the obsolete code, and updated the tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
