### PR TITLE
Add minor extensions to Bank API

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7827,6 +7827,11 @@ impl Bank {
             &mut error_counters,
         )
     }
+
+    /// Return reference to builtin_progams
+    pub fn get_builtin_programs(&self) -> &BuiltinPrograms {
+        &self.builtin_programs
+    }
 }
 
 /// Compute how much an account has changed size.  This function is useful when the data size delta

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4149,7 +4149,7 @@ impl Bank {
     }
 
     #[allow(dead_code)] // Preparation for BankExecutorCache rework
-    fn load_program(&self, pubkey: &Pubkey) -> Result<Arc<LoadedProgram>> {
+    pub fn load_program(&self, pubkey: &Pubkey) -> Result<Arc<LoadedProgram>> {
         let program = if let Some(program) = self.get_account_with_fixed_root(pubkey) {
             program
         } else {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4149,7 +4149,11 @@ impl Bank {
     }
 
     #[allow(dead_code)] // Preparation for BankExecutorCache rework
-    pub fn load_program(&self, pubkey: &Pubkey) -> Result<Arc<LoadedProgram>> {
+    pub fn load_program(
+        &self,
+        pubkey: &Pubkey,
+        debugging_features: bool,
+    ) -> Result<Arc<LoadedProgram>> {
         let program = if let Some(program) = self.get_account_with_fixed_root(pubkey) {
             program
         } else {
@@ -4209,7 +4213,7 @@ impl Bank {
             None,
             &program,
             programdata.as_ref().unwrap_or(&program),
-            false, /* debugging_features */
+            debugging_features,
         )
         .map(|(loaded_program, _create_executor_metrics)| loaded_program)
         .map_err(|err| TransactionError::InstructionError(0, err))
@@ -4455,7 +4459,7 @@ impl Bank {
         let missing_programs: Vec<(Pubkey, Arc<LoadedProgram>)> = missing_programs
             .iter()
             .map(|key| {
-                let program = self.load_program(key).unwrap_or_else(|err| {
+                let program = self.load_program(key, false).unwrap_or_else(|err| {
                     // Create a tombstone for the program in the cache
                     debug!("Failed to load program {}, error {:?}", key, err);
                     Arc::new(LoadedProgram::new_tombstone(
@@ -4502,7 +4506,7 @@ impl Bank {
         filter_missing_programs_time.stop();
 
         let executors = missing_executors.iter().map(|pubkey| {
-            let program = self.load_program(pubkey).unwrap_or_else(|err| {
+            let program = self.load_program(pubkey, false).unwrap_or_else(|err| {
                 // Create a tombstone for the program in the cache
                 debug!("Failed to load program {}, error {:?}", pubkey, err);
                 Arc::new(LoadedProgram::new_tombstone(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7498,7 +7498,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1);
+    let program = bank.load_program(&key1, false);
     assert!(program.is_ok());
     let program = program.unwrap();
     assert!(matches!(program.program, LoadedProgramType::LegacyV1(_)));


### PR DESCRIPTION
#### Problem

To use Bank in ledger-tool for off-chain program execution requires minor modifications to Bank API

#### Summary of Changes

- Make load_program method of Bank public for use in ledger-tool
- Add an accessor method to get a reference to builtin_programs of Bank
- Add a parameter to Bank::load_program to control debugging_features