### PR TITLE
remove counters in hotpath

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -74,11 +74,6 @@ impl Committer {
         executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
     ) -> (u64, Vec<CommitTransactionDetails>) {
-        inc_new_counter_info!(
-            "banking_stage-record_transactions_num_to_commit",
-            executed_transactions_count
-        );
-
         let (last_blockhash, lamports_per_signature) =
             bank.last_blockhash_and_lamports_per_signature();
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -520,13 +520,6 @@ impl Consumer {
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
 
-        if !executed_transactions.is_empty() {
-            inc_new_counter_info!("banking_stage-record_count", 1);
-            inc_new_counter_info!(
-                "banking_stage-record_transactions",
-                executed_transactions_count
-            );
-        }
         let (record_transactions_summary, record_us) = measure_us!(self
             .transaction_recorder
             .record_transactions(bank.slot(), executed_transactions));
@@ -543,12 +536,6 @@ impl Consumer {
         };
 
         if let Err(recorder_err) = record_transactions_result {
-            inc_new_counter_info!("banking_stage-max_height_reached", 1);
-            inc_new_counter_info!(
-                "banking_stage-max_height_reached_num_to_commit",
-                executed_transactions_count
-            );
-
             retryable_transaction_indexes.extend(execution_results.iter().enumerate().filter_map(
                 |(index, execution_result)| execution_result.was_executed().then_some(index),
             ));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4536,7 +4536,6 @@ impl Bank {
     ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
         debug!("processing transactions: {}", sanitized_txs.len());
-        inc_new_counter_info!("bank-process_transactions", sanitized_txs.len());
         let mut error_counters = TransactionErrorMetrics::default();
 
         let retryable_transaction_indexes: Vec<_> = batch
@@ -5118,16 +5117,6 @@ impl Bank {
             committed_non_vote_transactions_count,
         );
         self.increment_signature_count(signature_count);
-
-        inc_new_counter_info!(
-            "bank-process_transactions-txs",
-            committed_transactions_count as usize
-        );
-        inc_new_counter_info!(
-            "bank-process_non_vote_transactions-txs",
-            committed_non_vote_transactions_count as usize
-        );
-        inc_new_counter_info!("bank-process_transactions-sigs", signature_count as usize);
 
         if committed_with_failure_result_count > 0 {
             self.transaction_error_count


### PR DESCRIPTION
#### Problem
Counters are non-negligible in timing when we have small batches of transactions.
Profiling (see below svg) we see nearly 12% of the solTxWorker-2 time is spent just incrementing counters.

<details>
<summary>Flamegraph</summary>

![flamegraph-single-threaded-bench-tps](https://user-images.githubusercontent.com/13732359/235809206-ac3d29cc-95f2-4522-8ebc-9e9b3d8d201c.svg)


This profile is from a scheduler branch w/ worker - but uses the same functions for execute, commit, record.
</details>

#### Summary of Changes
Remove several counters from banking stage hot loop.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
