### PR TITLE
`borrow_mut` -> `borrow` in two places

### DIFF
--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -621,8 +621,7 @@ fn process_instruction(
             msg!("Test writable deescalation writable");
             const NUM_BYTES: usize = 10;
             let mut buffer = [0; NUM_BYTES];
-            buffer
-                .copy_from_slice(&accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]);
+            buffer.copy_from_slice(&accounts[INVOKED_ARGUMENT_INDEX].data.borrow()[..NUM_BYTES]);
 
             let instruction = create_instruction(
                 *accounts[INVOKED_PROGRAM_INDEX].key,
@@ -633,7 +632,7 @@ fn process_instruction(
 
             assert_eq!(
                 buffer,
-                accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]
+                accounts[INVOKED_ARGUMENT_INDEX].data.borrow()[..NUM_BYTES]
             );
         }
         TEST_NESTED_INVOKE_TOO_DEEP => {


### PR DESCRIPTION
#### Problem

In two places in `programs/sbf/rust/invoke/src/processor.rs`, `RefCell::borrow_mut` is used where `RefCell::borrow` could be used instead.

#### Summary of Changes

The two calls were changed to `RefCell::borrow`.

Found with [a Dylint lint](https://github.com/trailofbits/dylint/tree/master/examples/supplementary/unnecessary_borrow_mut#readme), if interested.