### PR TITLE
Fixes lifetimes on AppendVec::get_type()

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -484,7 +484,7 @@ impl AppendVec {
     /// Return a reference to the type at `offset` if its data doesn't overrun the internal buffer.
     /// Otherwise return None. Also return the offset of the first byte after the requested data
     /// that falls on a 64-byte boundary.
-    fn get_type<'a, T>(&self, offset: usize) -> Option<(&'a T, usize)> {
+    fn get_type<T>(&self, offset: usize) -> Option<(&T, usize)> {
         let (data, next) = self.get_slice(offset, mem::size_of::<T>())?;
         let ptr: *const T = data.as_ptr() as *const T;
         //UNSAFE: The cast is safe because the slice is aligned and fits into the memory
@@ -495,10 +495,10 @@ impl AppendVec {
     /// Return stored account metadata for the account at `offset` if its data doesn't overrun
     /// the internal buffer. Otherwise return None. Also return the offset of the first byte
     /// after the requested data that falls on a 64-byte boundary.
-    pub fn get_account<'a>(&'a self, offset: usize) -> Option<(StoredAccountMeta<'a>, usize)> {
-        let (meta, next): (&'a StoredMeta, _) = self.get_type(offset)?;
-        let (account_meta, next): (&'a AccountMeta, _) = self.get_type(next)?;
-        let (hash, next): (&'a Hash, _) = self.get_type(next)?;
+    pub fn get_account(&self, offset: usize) -> Option<(StoredAccountMeta, usize)> {
+        let (meta, next): (&StoredMeta, _) = self.get_type(offset)?;
+        let (account_meta, next): (&AccountMeta, _) = self.get_type(next)?;
+        let (hash, next): (&Hash, _) = self.get_type(next)?;
         let (data, next) = self.get_slice(next, meta.data_len as usize)?;
         let stored_size = next - offset;
         Some((
@@ -514,7 +514,7 @@ impl AppendVec {
         ))
     }
 
-    fn get_account_meta<'a>(&self, offset: usize) -> Option<&'a AccountMeta> {
+    fn get_account_meta(&self, offset: usize) -> Option<&AccountMeta> {
         // Skip over StoredMeta data in the account
         let offset = offset.checked_add(mem::size_of::<StoredMeta>())?;
         // u64_align! does an unchecked add for alignment. Check that it won't cause an overflow.


### PR DESCRIPTION
#### Problem

The lifetimes on `AppendVec::get_type()` are incorrect. Here's the signature:

```rust
fn get_type<'a, T>(&self, offset: usize) -> Option<(&'a T, usize)>
```

Note that `self` and the returned `T` have *different* lifetimes, even though `T` is memory within the mmap that `self` owns.

Luckily, this is only an internal function, and the places where it is called used the same lifetimes for `self` and `T`, so there was not a misuse via the public API of AppendVec.


#### Summary of Changes

Fix the lifetimes.

- For `get_type()`, the returned `T` is the same lifetime as `self`, so the generic `'a` can be removed.
- For `get_account_meta()`, so the same thing, since it calls `get_type()` internally
- For `get_account()`, all the lifetimes are the same, so a generic one is not required.