### PR TITLE
accumulate counters

### DIFF
--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -266,11 +266,11 @@ mod tests {
             inc_counter!(COUNTER, Level::Info, 2);
         }
         unsafe {
-            assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 397);
+            assert_eq!(COUNTER.counts.load(Ordering::Relaxed), 399);
         }
         inc_counter!(COUNTER, Level::Info, 2);
         unsafe {
-            assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 399);
+            assert_eq!(COUNTER.counts.load(Ordering::Relaxed), 401);
         }
     }
 

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -71,6 +71,12 @@ pub struct AtomicInterval {
 }
 
 impl AtomicInterval {
+    pub const fn const_default() -> Self {
+        Self {
+            last_update: AtomicU64::new(0),
+        }
+    }
+
     /// true if 'interval_time_ms' has elapsed since last time we returned true as long as it has been 'interval_time_ms' since this struct was created
     pub fn should_update(&self, interval_time_ms: u64) -> bool {
         self.should_update_ext(interval_time_ms, true)


### PR DESCRIPTION
#### Problem
Our inline counter macros are not lightweight. They are sending a crossbeam message on every call.
They should be avoided in performance sensitive code, or in new code (please).

This PR is an attempt to make these calls better w/o changing or removing the macros that we've already got in the code.

#### Summary of Changes
Accumulate counts, and only send `CounterPoint` once per interval.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
