### PR TITLE
Gives lifetimes more descriptive names in append_vec.rs

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -53,13 +53,13 @@ pub fn aligned_stored_size(data_len: usize) -> usize {
 
 pub const MAXIMUM_APPEND_VEC_FILE_SIZE: u64 = 16 * 1024 * 1024 * 1024; // 16 GiB
 
-pub struct AppendVecAccountsIter<'a> {
-    append_vec: &'a AppendVec,
+pub struct AppendVecAccountsIter<'append_vec> {
+    append_vec: &'append_vec AppendVec,
     offset: usize,
 }
 
-impl<'a> AppendVecAccountsIter<'a> {
-    pub fn new(append_vec: &'a AppendVec) -> Self {
+impl<'append_vec> AppendVecAccountsIter<'append_vec> {
+    pub fn new(append_vec: &'append_vec AppendVec) -> Self {
         Self {
             append_vec,
             offset: 0,
@@ -67,8 +67,8 @@ impl<'a> AppendVecAccountsIter<'a> {
     }
 }
 
-impl<'a> Iterator for AppendVecAccountsIter<'a> {
-    type Item = StoredAccountMeta<'a>;
+impl<'append_vec> Iterator for AppendVecAccountsIter<'append_vec> {
+    type Item = StoredAccountMeta<'append_vec>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some((account, next_offset)) = self.append_vec.get_account(self.offset) {
@@ -91,17 +91,17 @@ pub enum MatchAccountOwnerError {
 /// References to account data stored elsewhere. Getting an `Account` requires cloning
 /// (see `StoredAccountMeta::clone_account()`).
 #[derive(PartialEq, Eq, Debug)]
-pub struct AppendVecStoredAccountMeta<'a> {
-    pub meta: &'a StoredMeta,
+pub struct AppendVecStoredAccountMeta<'append_vec> {
+    pub meta: &'append_vec StoredMeta,
     /// account data
-    pub account_meta: &'a AccountMeta,
-    pub(crate) data: &'a [u8],
+    pub account_meta: &'append_vec AccountMeta,
+    pub(crate) data: &'append_vec [u8],
     pub(crate) offset: usize,
     pub(crate) stored_size: usize,
-    pub(crate) hash: &'a Hash,
+    pub(crate) hash: &'append_vec Hash,
 }
 
-impl<'a> AppendVecStoredAccountMeta<'a> {
+impl<'append_vec> AppendVecStoredAccountMeta<'append_vec> {
     pub fn clone_account(&self) -> AccountSharedData {
         AccountSharedData::from(Account {
             lamports: self.account_meta.lamports,
@@ -112,11 +112,11 @@ impl<'a> AppendVecStoredAccountMeta<'a> {
         })
     }
 
-    pub fn pubkey(&self) -> &'a Pubkey {
+    pub fn pubkey(&self) -> &'append_vec Pubkey {
         &self.meta.pubkey
     }
 
-    pub fn hash(&self) -> &'a Hash {
+    pub fn hash(&self) -> &'append_vec Hash {
         self.hash
     }
 
@@ -128,7 +128,7 @@ impl<'a> AppendVecStoredAccountMeta<'a> {
         self.offset
     }
 
-    pub fn data(&self) -> &'a [u8] {
+    pub fn data(&self) -> &'append_vec [u8] {
         self.data
     }
 
@@ -144,7 +144,7 @@ impl<'a> AppendVecStoredAccountMeta<'a> {
         self.meta
     }
 
-    pub fn set_meta(&mut self, meta: &'a StoredMeta) {
+    pub fn set_meta(&mut self, meta: &'append_vec StoredMeta) {
         self.meta = meta;
     }
 
@@ -172,14 +172,14 @@ impl<'a> AppendVecStoredAccountMeta<'a> {
     }
 }
 
-impl<'a> ReadableAccount for AppendVecStoredAccountMeta<'a> {
+impl<'append_vec> ReadableAccount for AppendVecStoredAccountMeta<'append_vec> {
     fn lamports(&self) -> u64 {
         self.account_meta.lamports
     }
-    fn data(&self) -> &'a [u8] {
+    fn data(&self) -> &'append_vec [u8] {
         self.data()
     }
-    fn owner(&self) -> &'a Pubkey {
+    fn owner(&self) -> &'append_vec Pubkey {
         &self.account_meta.owner
     }
     fn executable(&self) -> bool {
@@ -693,7 +693,7 @@ pub mod tests {
         }
     }
 
-    impl<'a> StoredAccountMeta<'a> {
+    impl StoredAccountMeta<'_> {
         pub(crate) fn ref_executable_byte(&self) -> &u8 {
             match self {
                 Self::AppendVec(av) => av.ref_executable_byte(),
@@ -701,7 +701,7 @@ pub mod tests {
         }
     }
 
-    impl<'a> AppendVecStoredAccountMeta<'a> {
+    impl AppendVecStoredAccountMeta<'_> {
         #[allow(clippy::cast_ref_to_mut)]
         fn set_data_len_unsafe(&self, new_data_len: u64) {
             // UNSAFE: cast away & (= const ref) to &mut to force to mutate append-only (=read-only) AppendVec


### PR DESCRIPTION
#### Problem

In preparation for tiered storage, I'm going through the existing AppendVec and account storage code to make sure I understand it. Since there are many types and sub types—`AccountMeta`, `StoredMeta`, and `StoredAccountMeta`, to name a few—that all take lifetimes, I find it hard at times to remember what each `'a` lifetime is referring back to.


#### Summary of Changes

For the lifetimes within `append_vec.rs` that refer back to an AppendVec, change `'a` to `'append_vec`.