### PR TITLE
accessor for reading blockhash queue

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7745,6 +7745,10 @@ impl Bank {
             .is_active(&feature_set::send_to_tpu_vote_port::id())
     }
 
+    pub fn read_blockhash_queue(&self) -> LockResult<RwLockReadGuard<BlockhashQueue>> {
+        self.blockhash_queue.read()
+    }
+
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {
         self.cost_tracker.read()
     }


### PR DESCRIPTION
#### Problem
Want a way to check age of transactions in scheduler/worker and need the blockhash queue to do so.
Because of the way the multi-iterator works we go transaction-by-transaction so the currently exposed interface(s) are not sufficient.

#### Summary of Changes
Add accessor for read lock on bank's blockhash queue.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
