### PR TITLE
Ensure remove_bank_snapshot success

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1353,13 +1353,18 @@ pub fn remove_bank_snapshot(slot: Slot, bank_snapshots_dir: impl AsRef<Path>) {
     if accounts_hardlinks_dir.is_dir() {
         // This directory contain symlinks to all accounts snapshot directories.
         // They should all be removed.
-        for entry in fs::read_dir(accounts_hardlinks_dir).expect("read dir failed") {
-            let dst_path =
-                fs::read_link(entry.expect("dir entry").path()).expect("readlink failed");
+        for entry in
+            fs::read_dir(accounts_hardlinks_dir).expect("read dir should return an iterator")
+        {
+            let symlink = entry
+                .expect("a entry from the iterator should be a DirEntry")
+                .path();
+            let dst_path = fs::read_link(&symlink)
+                .unwrap_or_else(|e| panic!("read_link error {} on {}", e, symlink.display()));
             move_and_async_delete_path(&dst_path);
         }
     }
-    fs::remove_dir_all(bank_snapshot_dir).expect("remove dir");
+    fs::remove_dir_all(bank_snapshot_dir).expect("remove dir should succeed");
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1362,10 +1362,7 @@ pub fn remove_bank_snapshot(slot: Slot, bank_snapshots_dir: impl AsRef<Path>) {
             match fs::read_link(&symlink) {
                 Ok(dst_path) => move_and_async_delete_path(dst_path),
                 Err(e) => {
-                    warn!(
-                        "{}",
-                        format!("read_link error {} on {}", e, symlink.display())
-                    );
+                    warn!("read_link error {} on {}", e, symlink.display());
                 }
             }
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1359,9 +1359,15 @@ pub fn remove_bank_snapshot(slot: Slot, bank_snapshots_dir: impl AsRef<Path>) {
             let symlink = entry
                 .expect("an entry from the iterator should be a DirEntry")
                 .path();
-            let dst_path = fs::read_link(&symlink)
-                .unwrap_or_else(|e| panic!("read_link error {} on {}", e, symlink.display()));
-            move_and_async_delete_path(&dst_path);
+            match fs::read_link(&symlink) {
+                Ok(dst_path) => move_and_async_delete_path(dst_path),
+                Err(e) => {
+                    warn!(
+                        "{}",
+                        format!("read_link error {} on {}", e, symlink.display())
+                    );
+                }
+            }
         }
     }
     fs::remove_dir_all(bank_snapshot_dir).expect("remove dir should succeed");

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1357,7 +1357,7 @@ pub fn remove_bank_snapshot(slot: Slot, bank_snapshots_dir: impl AsRef<Path>) {
             fs::read_dir(accounts_hardlinks_dir).expect("read dir should return an iterator")
         {
             let symlink = entry
-                .expect("a entry from the iterator should be a DirEntry")
+                .expect("an entry from the iterator should be a DirEntry")
                 .path();
             let dst_path = fs::read_link(&symlink)
                 .unwrap_or_else(|e| panic!("read_link error {} on {}", e, symlink.display()));

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5569,6 +5569,7 @@ mod tests {
         let account_paths = &bank.rc.accounts.accounts_db.paths;
 
         let mut bank_snapshots = get_bank_snapshots(&bank_snapshots_dir);
+        bank_snapshots.sort_unstable();
 
         // remove the top PRE snapshot dir
         let bank_snapshot = bank_snapshots.pop().unwrap();
@@ -5611,7 +5612,9 @@ mod tests {
                 .unwrap()
                 .join("snapshot")
                 .join(bank_snapshot.slot.to_string());
-            fs::remove_dir_all(account_snapshot_path).unwrap();
+            if account_snapshot_path.exists() {
+                fs::remove_dir_all(account_snapshot_path).unwrap();
+            }
         });
         remove_bank_snapshot(bank_snapshot.slot, &bank_snapshots_dir);
         assert!(!bank_snapshot.snapshot_dir.exists());


### PR DESCRIPTION
#### Problem
fn remove_bank_snapshot may fail with an IO error, causing an error! log, and leave the snapshot dir on disk.  This is unsafe, may cause uncertain subsequent behaviors, and leak the disk space.

#### Summary of Changes

Make this function not return an IO error.  In unlikely file system error cases, it panic via expect().  Otherwise, it succeeds with that dir cleanly removed and the corresponding account_path/snapshot/\<slot\> removed.

Add a test function to verify the removing result for different cases;

Call it to remove the dir whenever any error is returned from BankSnapshotInfo::new_from_dir().

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
