### PR TITLE
Cargo.toml: winapi: List used features

### DIFF
--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -39,7 +39,7 @@ tempfile = { workspace = true }
 url = { workspace = true }
 
 [target."cfg(windows)".dependencies]
-winapi = { workspace = true }
+winapi = { workspace = true, features = ["minwindef", "winuser"] }
 winreg = { workspace = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
#### Problem

`winapi` hides every module behind a feature flag, see here:

  https://github.com/retep998/winapi-rs#why-am-i-getting-errors-about-unresolved-imports

`install` was working by accident as for each package, requested feature set is a superset of all features requested by all packages in the workspace, and `console` used to list features that `install` needs. But after a change in `console` we had build breakages.

#### Summary of Changes

List the necessary features explicitly.