### PR TITLE
Batch rpc calls in `solana-tokens distribute-spl-tokens`

### DIFF
--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         args::{DistributeTokensArgs, SplTokenArgs},
-        commands::{get_fees_for_messages, Allocation, Error, FundingSource},
+        commands::{get_fee_estimate_for_messages, Allocation, Error, FundingSource},
     },
     console::style,
     solana_account_decoder::parse_token::{
@@ -96,7 +96,7 @@ pub fn check_spl_token_balances(
         .as_ref()
         .expect("spl_token_args must be some");
     let allocation_amount: u64 = allocations.iter().map(|x| x.amount).sum();
-    let fees = get_fees_for_messages(messages, client)?;
+    let fees = get_fee_estimate_for_messages(messages, client)?;
 
     let token_account_rent_exempt_balance =
         client.get_minimum_balance_for_rent_exemption(SplTokenAccount::LEN)?;


### PR DESCRIPTION
#### Problem
As stated in #27318, there are excessive RPC calls in `solana-tokens distribute-spl-tokens` that cause RPC rate-limiting leading to expired blockhashes and failed transactions.

#### Summary of Changes
There are 3 changes to the code to reduce RPC rate-limits and blockhash expiry.

1. Batch accounts in calls to `get_multiple_accounts` instead of hitting the RPC once per account when looking to see if an ATA needs to be created.
2. Refactor `get_fees_for_messages` into `get_fee_estimate_for_messages`, where the RPC is queried for a single fee (and the fee is multiplied by the number of transactions) instead of querying the RPC for a fee for each message
3. ~~Transaction blockhashes are updated before transactions are sent~~
