### PR TITLE
Combine AccountsHashVerifier metrics

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -567,10 +567,10 @@ impl AccountsHashVerifier {
                 }
             }
         }
-        inc_new_counter_info!("accounts_hash_verifier-hashes_verified", verified_count);
         datapoint_info!(
             "accounts_hash_verifier",
             ("highest_slot_verified", highest_slot, i64),
+            ("num_verified", verified_count, i64),
         );
         false
     }


### PR DESCRIPTION
#### Problem
It is more efficient to submit the metrics together, and there is no reason for them to be separate.

#### Summary of Changes
Combine the fields into one datapoint which also removes a `inc_new_counter_info` instance

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
