### PR TITLE
Fixes name of snapshot_utils::get_bank_snapshot_dir()

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -320,7 +320,7 @@ fn test_bank_serialize_style(
 
     if reserialize_accounts_hash || incremental_snapshot_persistence {
         let temp_dir = TempDir::new().unwrap();
-        let slot_dir = snapshot_utils::get_bank_snapshots_dir(&temp_dir, slot);
+        let slot_dir = snapshot_utils::get_bank_snapshot_dir(&temp_dir, slot);
         let post_path = slot_dir.join(slot.to_string());
         let pre_path = post_path.with_extension(BANK_SNAPSHOT_PRE_FILENAME_EXTENSION);
         std::fs::create_dir(&slot_dir).unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -178,7 +178,7 @@ impl BankSnapshotInfo {
     ) -> std::result::Result<BankSnapshotInfo, SnapshotNewFromDirError> {
         // check this directory to see if there is a BankSnapshotPre and/or
         // BankSnapshotPost file
-        let bank_snapshot_dir = get_bank_snapshots_dir(&bank_snapshots_dir, slot);
+        let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
 
         if !bank_snapshot_dir.is_dir() {
             return Err(SnapshotNewFromDirError::InvalidBankSnapshotDir(
@@ -1206,7 +1206,7 @@ pub fn add_bank_snapshot(
     let mut add_snapshot_time = Measure::start("add-snapshot-ms");
     let slot = bank.slot();
     // bank_snapshots_dir/slot
-    let bank_snapshot_dir = get_bank_snapshots_dir(&bank_snapshots_dir, slot);
+    let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
     if bank_snapshot_dir.is_dir() {
         // There is a time window from when a snapshot directory is created to when its content
         // is fully filled to become a full state good to construct a bank from.  At the init time,
@@ -1329,7 +1329,7 @@ fn serialize_status_cache(slot_deltas: &[BankSlotDelta], status_cache_path: &Pat
 
 /// Remove the snapshot directory for this slot
 pub fn remove_bank_snapshot(slot: Slot, bank_snapshots_dir: impl AsRef<Path>) -> Result<()> {
-    let bank_snapshot_dir = get_bank_snapshots_dir(&bank_snapshots_dir, slot);
+    let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
     let accounts_hardlinks_dir = bank_snapshot_dir.join("accounts_hardlinks");
     if fs::metadata(&accounts_hardlinks_dir).is_ok() {
         // This directory contain symlinks to all accounts snapshot directories.
@@ -2830,12 +2830,16 @@ fn verify_slot_deltas_with_history(
     Ok(())
 }
 
-pub(crate) fn get_snapshot_file_name(slot: Slot) -> String {
+/// Returns the file name of the bank snapshot for `slot`
+pub fn get_snapshot_file_name(slot: Slot) -> String {
     slot.to_string()
 }
 
-pub(crate) fn get_bank_snapshots_dir(path: impl AsRef<Path>, slot: Slot) -> PathBuf {
-    path.as_ref().join(slot.to_string())
+/// Constructs the path to the bank snapshot directory for `slot` within `bank_snapshots_dir`
+pub fn get_bank_snapshot_dir(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) -> PathBuf {
+    bank_snapshots_dir
+        .as_ref()
+        .join(get_snapshot_file_name(slot))
 }
 
 fn get_io_error(error: &str) -> SnapshotError {
@@ -3703,7 +3707,7 @@ mod tests {
         max_slot: Slot,
     ) {
         for slot in min_slot..max_slot {
-            let snapshot_dir = get_bank_snapshots_dir(bank_snapshots_dir, slot);
+            let snapshot_dir = get_bank_snapshot_dir(bank_snapshots_dir, slot);
             fs::create_dir_all(&snapshot_dir).unwrap();
 
             let snapshot_filename = get_snapshot_file_name(slot);
@@ -5116,7 +5120,7 @@ mod tests {
         .unwrap();
 
         let accounts_hardlinks_dir =
-            get_bank_snapshots_dir(&bank_snapshots_dir, bank.slot()).join("accounts_hardlinks");
+            get_bank_snapshot_dir(&bank_snapshots_dir, bank.slot()).join("accounts_hardlinks");
         assert!(fs::metadata(&accounts_hardlinks_dir).is_ok());
 
         let mut hardlink_dirs: Vec<PathBuf> = Vec::new();


### PR DESCRIPTION
#### Problem

The function `snapshot_utils::get_bank_snapshots_dir()` (note the plural) actually gets the path to the bank snapshot (non-plural) dir. I've always found this confusing, and should be updated.


#### Summary of Changes

* Rename fn to `get_bank_snapshot_dir`
* Add doc comments to it
* Fix the impl to reuse `get_snapshot_file_name`
* Add doc comments to `get_snapshot_file_name`
* Make these two functions `pub` so they can be called from non-runtime code

Note: This PR purposely does not update existing code that *could* use the now-public functions. That will happen in a subsequent PR.