### PR TITLE
Bump console from 0.15.0 to 0.15.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,17 +1103,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
- "regex",
- "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -7724,16 +7722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ cc = "1.0.79"
 chrono = { version = "0.4.24", default-features = false }
 chrono-humanize = "0.2.2"
 clap = "2.33.1"
-console = "0.15.0"
+console = "0.15.5"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.0"
 const_format = "0.2.30"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -993,17 +993,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
- "regex",
- "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6858,16 +6856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:

  https://github.com/console-rs/console/compare/0.15.0...0.15.5

This is a re-application of this change:

    commit 4e3300e7d66a12d4fd377704d1b5c202897d08eb
    Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
    Date:   Thu Apr 20 15:40:14 2023 -0700

        Bump console from 0.15.0 to 0.15.5 (#31289)

        Bumps [console](https://github.com/console-rs/console) from 0.15.0 to 0.15.5.
        - [Release notes](https://github.com/console-rs/console/releases)
        - [Changelog](https://github.com/console-rs/console/blob/master/CHANGELOG.md)
        - [Commits](console-rs/console@0.15.0...0.15.5)

        ---
        updated-dependencies:
        - dependency-name: console
          dependency-type: direct:production
          update-type: version-update:semver-patch
        ...

        Signed-off-by: dependabot[bot] <support@github.com>

It is now safe to upgrade after

    commit b790c129e0a0331901401404c9c19e6b82dbf901
    Author: Illia Bobyr <illia.bobyr@solana.com>
    Date:   Sat Apr 29 01:23:15 2023 -0700

        Cargo.toml: winapi: List used features (#31417)