### PR TITLE
bucket_map: Renames fns to get_slice and get_slice_mut

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -457,7 +457,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
 
                 // write data
                 assert!(!current_bucket.is_free(elem_loc));
-                let slice: &mut [T] = current_bucket.get_mut_cell_slice(
+                let slice: &mut [T] = current_bucket.get_slice_mut(
                     elem_loc,
                     data_len as u64,
                     IncludeHeader::NoHeader,
@@ -511,8 +511,7 @@ impl<'b, T: Clone + Copy + 'static> Bucket<T> {
                 best_bucket.occupy(ix, false).unwrap();
                 if num_slots > 0 {
                     // copy slotlist into the data bucket
-                    let slice =
-                        best_bucket.get_mut_cell_slice(ix, num_slots, IncludeHeader::NoHeader);
+                    let slice = best_bucket.get_slice_mut(ix, num_slots, IncludeHeader::NoHeader);
                     slice.iter_mut().zip(data).for_each(|(dest, src)| {
                         *dest = *src;
                     });

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -266,25 +266,25 @@ impl<O: BucketOccupied> BucketStorage<O> {
     }
 
     pub(crate) fn get_header<T>(&self, ix: u64) -> &T {
-        let slice = self.get_cell_slice::<T>(ix, 1, IncludeHeader::Header);
+        let slice = self.get_slice::<T>(ix, 1, IncludeHeader::Header);
         // SAFETY: `get_cell_slice` ensures there's at least one element in the slice
         unsafe { slice.get_unchecked(0) }
     }
 
     pub(crate) fn get_header_mut<T>(&mut self, ix: u64) -> &mut T {
-        let slice = self.get_mut_cell_slice::<T>(ix, 1, IncludeHeader::Header);
+        let slice = self.get_slice_mut::<T>(ix, 1, IncludeHeader::Header);
         // SAFETY: `get_mut_cell_slice` ensures there's at least one element in the slice
         unsafe { slice.get_unchecked_mut(0) }
     }
 
     pub(crate) fn get<T>(&self, ix: u64) -> &T {
-        let slice = self.get_cell_slice::<T>(ix, 1, IncludeHeader::NoHeader);
+        let slice = self.get_slice::<T>(ix, 1, IncludeHeader::NoHeader);
         // SAFETY: `get_cell_slice` ensures there's at least one element in the slice
         unsafe { slice.get_unchecked(0) }
     }
 
     pub(crate) fn get_mut<T>(&mut self, ix: u64) -> &mut T {
-        let slice = self.get_mut_cell_slice::<T>(ix, 1, IncludeHeader::NoHeader);
+        let slice = self.get_slice_mut::<T>(ix, 1, IncludeHeader::NoHeader);
         // SAFETY: `get_mut_cell_slice` ensures there's at least one element in the slice
         unsafe { slice.get_unchecked_mut(0) }
     }
@@ -301,7 +301,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { &*item }
     }
 
-    pub(crate) fn get_cell_slice<T>(&self, ix: u64, len: u64, header: IncludeHeader) -> &[T] {
+    pub(crate) fn get_slice<T>(&self, ix: u64, len: u64, header: IncludeHeader) -> &[T] {
         let start = self.get_start_offset(ix, header);
         let slice = {
             let size = std::mem::size_of::<T>() * len as usize;
@@ -317,7 +317,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { std::slice::from_raw_parts(ptr, len as usize) }
     }
 
-    pub(crate) fn get_mut_cell_slice<T>(
+    pub(crate) fn get_slice_mut<T>(
         &mut self,
         ix: u64,
         len: u64,

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -404,11 +404,7 @@ impl<T: Copy + 'static> IndexEntryPlaceInBucket<T> {
                 assert!(!data_bucket.is_free(loc));
 
                 ref_count = MultipleSlots::ref_count(data_bucket, loc);
-                data_bucket.get_cell_slice::<T>(
-                    loc,
-                    multiple_slots.num_slots,
-                    IncludeHeader::NoHeader,
-                )
+                data_bucket.get_slice::<T>(loc, multiple_slots.num_slots, IncludeHeader::NoHeader)
             }
             _ => {
                 panic!("trying to read data from a free entry");


### PR DESCRIPTION
#### Problem

The bucket map fn `get_cell_slice` feels out of step with its complementary single-element function `get`. Since `get_cell_slice` returns a slice, how about just `get_slice` instead? The concept of a cell is not in `get`, and `get_cell_slice` takes a `len` param which is the number of items to get, and does not require the caller to pass in the cell size.

And while I was here, it seems that Rust usually puts `_mut` at the end of functions/types[^1]. So since we're returning a slice, it feels like "mut" would be modifying the "slice" part, and thus go after slice.


[^1]: Here are the Vec docs, which include many methods that have `_mut` in the name: https://doc.rust-lang.org/std/vec/struct.Vec.html#



#### Summary of Changes

* Rename `get_cell_slice`/`get_mut_cell_slice` to `get_slice`/`get_slice_mut`