### PR TITLE
bucket_map: Moves get_from_bytes() to index_entry.rs

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -289,18 +289,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
         unsafe { slice.get_unchecked_mut(0) }
     }
 
-    pub(crate) fn get_mut_from_parts<T>(item_slice: &mut [u8]) -> &mut T {
-        debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
-        let item = item_slice.as_mut_ptr() as *mut T;
-        unsafe { &mut *item }
-    }
-
-    pub(crate) fn get_from_parts<T>(item_slice: &[u8]) -> &T {
-        debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
-        let item = item_slice.as_ptr() as *const T;
-        unsafe { &*item }
-    }
-
     pub(crate) fn get_slice<T>(&self, ix: u64, len: u64, header: IncludeHeader) -> &[T] {
         let start = self.get_start_offset(ix, header);
         let slice = {


### PR DESCRIPTION
#### Problem

* The fns `BucketStorage::get_from_parts()` aren't used within BucketStorage, only in `index_entry.rs`
* The fns take a slice of bytes, not a pointer and length, so the "from parts" name feels slightly off to me


#### Summary of Changes

* Move the fns to `index_entry.rs`
* Rename the fns to `get_from_bytes()`

Note: No functional changes to the code.

