### PR TITLE
bucket_map: get_from_bytes should check alignment

### DIFF
--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -426,12 +426,14 @@ impl<T: Copy + 'static> IndexEntryPlaceInBucket<T> {
 fn get_from_bytes<T>(item_slice: &[u8]) -> &T {
     debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
     let item = item_slice.as_ptr() as *const T;
+    debug_assert!(item as usize % std::mem::align_of::<T>() == 0);
     unsafe { &*item }
 }
 
 fn get_mut_from_bytes<T>(item_slice: &mut [u8]) -> &mut T {
     debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
     let item = item_slice.as_mut_ptr() as *mut T;
+    debug_assert!(item as usize % std::mem::align_of::<T>() == 0);
     unsafe { &mut *item }
 }
 


### PR DESCRIPTION
#### Problem

Bucket map's `get_from_bytes()` does not check that the alignment of the byte slice meets the alignment requirements of the `T` it is casting to.

#### Summary of Changes

Add a debug assert to check alignment.