### PR TITLE
bucket_map: Length must be 1 if including header in get_slice()

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -92,9 +92,9 @@ impl<O: BucketOccupied> Drop for BucketStorage<O> {
     }
 }
 
-#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub(crate) enum IncludeHeader {
-    /// caller wants header
+    /// caller wants header included
     Header,
     /// caller wants header skipped
     NoHeader,
@@ -302,6 +302,10 @@ impl<O: BucketOccupied> BucketStorage<O> {
     }
 
     pub(crate) fn get_slice<T>(&self, ix: u64, len: u64, header: IncludeHeader) -> &[T] {
+        // If the caller is including the header, then `len` *must* be 1
+        debug_assert!(
+            (header == IncludeHeader::NoHeader) || (header == IncludeHeader::Header && len == 1)
+        );
         let start = self.get_start_offset(ix, header);
         let slice = {
             let size = std::mem::size_of::<T>() * len as usize;
@@ -323,6 +327,10 @@ impl<O: BucketOccupied> BucketStorage<O> {
         len: u64,
         header: IncludeHeader,
     ) -> &mut [T] {
+        // If the caller is including the header, then `len` *must* be 1
+        debug_assert!(
+            (header == IncludeHeader::NoHeader) || (header == IncludeHeader::Header && len == 1)
+        );
         let start = self.get_start_offset(ix, header);
         let slice = {
             let size = std::mem::size_of::<T>() * len as usize;


### PR DESCRIPTION
#### Problem

`get_slice` is used to both get the header and the `T` via `get`. But, we should not call `get_slice` with a length greater than one when including the header; as the data likely will not be correct (and is likely a programmer bug).


#### Summary of Changes

Add a debug assert that ensures if the header is included, then length must be 1.