### PR TITLE
Performance: Allowed forced inline update_index (no thread pool)

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1315,6 +1315,34 @@ impl Accounts {
         );
     }
 
+    /// Store the accounts into the DB
+    // allow(clippy) needed for various gating flags
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn store_cached_inline_update_index(
+        &self,
+        slot: Slot,
+        txs: &[SanitizedTransaction],
+        res: &[TransactionExecutionResult],
+        loaded: &mut [TransactionLoadResult],
+        rent_collector: &RentCollector,
+        durable_nonce: &DurableNonce,
+        lamports_per_signature: u64,
+        include_slot_in_hash: IncludeSlotInHash,
+    ) {
+        let (accounts_to_store, transactions) = self.collect_accounts_to_store(
+            txs,
+            res,
+            loaded,
+            rent_collector,
+            durable_nonce,
+            lamports_per_signature,
+        );
+        self.accounts_db.store_cached_inline_update_index(
+            (slot, &accounts_to_store[..], include_slot_in_hash),
+            Some(&transactions),
+        );
+    }
+
     pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1309,34 +1309,6 @@ impl Accounts {
             durable_nonce,
             lamports_per_signature,
         );
-        self.accounts_db.store_cached(
-            (slot, &accounts_to_store[..], include_slot_in_hash),
-            Some(&transactions),
-        );
-    }
-
-    /// Store the accounts into the DB
-    // allow(clippy) needed for various gating flags
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn store_cached_inline_update_index(
-        &self,
-        slot: Slot,
-        txs: &[SanitizedTransaction],
-        res: &[TransactionExecutionResult],
-        loaded: &mut [TransactionLoadResult],
-        rent_collector: &RentCollector,
-        durable_nonce: &DurableNonce,
-        lamports_per_signature: u64,
-        include_slot_in_hash: IncludeSlotInHash,
-    ) {
-        let (accounts_to_store, transactions) = self.collect_accounts_to_store(
-            txs,
-            res,
-            loaded,
-            rent_collector,
-            durable_nonce,
-            lamports_per_signature,
-        );
         self.accounts_db.store_cached_inline_update_index(
             (slot, &accounts_to_store[..], include_slot_in_hash),
             Some(&transactions),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8360,7 +8360,10 @@ impl AccountsDb {
         );
     }
 
-    pub fn store_cached_inline_update_index<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
+    pub(crate) fn store_cached_inline_update_index<
+        'a,
+        T: ReadableAccount + Sync + ZeroLamport + 'a,
+    >(
         &self,
         accounts: impl StorableAccounts<'a, T>,
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
@@ -9491,7 +9494,7 @@ impl CalcAccountsHashFlavor {
     }
 }
 
-pub enum UpdateIndexThreadSelection {
+pub(crate) enum UpdateIndexThreadSelection {
     /// Use current thread only
     Inline,
     /// Use a thread-pool if the number of updates exceeds a threshold

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5171,6 +5171,7 @@ impl Bank {
 
         let mut write_time = Measure::start("write_time");
         let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
+        // Store accounts in cache and force update_index to be inlined (no thread pool)
         self.rc.accounts.store_cached_inline_update_index(
             self.slot(),
             sanitized_txs,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5171,7 +5171,7 @@ impl Bank {
 
         let mut write_time = Measure::start("write_time");
         let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
-        self.rc.accounts.store_cached(
+        self.rc.accounts.store_cached_inline_update_index(
             self.slot(),
             sanitized_txs,
             &execution_results,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5171,8 +5171,7 @@ impl Bank {
 
         let mut write_time = Measure::start("write_time");
         let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
-        // Store accounts in cache and force update_index to be inlined (no thread pool)
-        self.rc.accounts.store_cached_inline_update_index(
+        self.rc.accounts.store_cached(
             self.slot(),
             sanitized_txs,
             &execution_results,


### PR DESCRIPTION
#### Problem
Farming work out to a thread-pool works well for a lot of accounts-wide operations but is a bottleneck in the banking-stage and replay stage hot loops (see svg in details below).


#### Summary of Changes
Additional bool argument passed down to allow callers to force inline execution of the `update_index` function.

Still need to do some additional benching, however, this change shows significant improvement in bench-tps numbers when we have a lot of conflict:

Numbers are displayed as "MAX TPS / AVG TPS"
| number of serializable tx-chains | 1 | 4 | 16 | 50000 |
| --- | ---: | ---: | ---: | ---: |
| master | 6715 / 4048 | 13397 / 7541 | 23603 / 12765 | 75637 / 52698 |
| PR | 11699 / 8208 | 24159 / 18601 | 40706 / 31451 | 80685 / 51630 |

<details>
  <summary>Command details</summary>
  Table columns correspond to:

1. `NDEBUG=1 ./multinode-demo/bench-tps.sh --num-conflict-groups 1 --keypair-multiplier 2`
2. `NDEBUG=1 ./multinode-demo/bench-tps.sh --num-conflict-groups 1`
3. `NDEBUG=1 ./multinode-demo/bench-tps.sh --num-conflict-groups 4`
4. `NDEBUG=1 ./multinode-demo/bench-tps.sh`

![flamegraph-single-threaded-bench-tps](https://user-images.githubusercontent.com/13732359/235806433-1d295c48-35b1-47d7-a2c5-7d5fb2eaec13.svg)

(You can download the above .svg and work your way into "solTxWorker-2", and see a large chunk of time is spent in `store_accounts_custom`, about half of that being a rayon operation).
</details>

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
