### PR TITLE
Do not evict unloaded programs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4718,7 +4718,7 @@ impl Bank {
         self.loaded_programs_cache
             .write()
             .unwrap()
-            .sort_and_evict(Percentage::from(EVICT_CACHE_TO_PERCENTAGE));
+            .sort_and_unload(Percentage::from(EVICT_CACHE_TO_PERCENTAGE));
 
         debug!(
             "check: {}us load: {}us execute: {}us txs_len={}",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4714,11 +4714,11 @@ impl Bank {
 
         execution_time.stop();
 
-        const EVICT_CACHE_TO_PERCENTAGE: u8 = 90;
+        const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
         self.loaded_programs_cache
             .write()
             .unwrap()
-            .sort_and_unload(Percentage::from(EVICT_CACHE_TO_PERCENTAGE));
+            .sort_and_unload(Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE));
 
         debug!(
             "check: {}us load: {}us execute: {}us txs_len={}",


### PR DESCRIPTION
#### Problem
Delay visible tombstones could be inferred by the presence of unloaded/loaded programs. Removing the explicit tombstone will simplify the handling of program management instructions.

#### Summary of Changes
This PR updates program eviction logic to not remove unloaded programs. This will enable the cache to always have either a loaded or unloaded cache entry for an upgraded program. This cache entry will imply that the older/outdated program is expired and should not be accessible after the given slot. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
