### PR TITLE
Quic limit early-stage resource consumption

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -160,7 +160,9 @@ impl Future for ConnectionHandshakeHandler {
                             .push(Box::pin(timeout(QUIC_CONNECTION_HANDSHAKE_TIMEOUT, future)));
                         num_added += 1;
                     } else {
-                        break;
+                        // The stream returning Poll::Ready(None) means
+                        // the channel's closed
+                        return Poll::Ready(());
                     }
                 } else {
                     will_awake = true;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -74,7 +74,7 @@ const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 // Maybe we can limit connection attempts per IP?
 const MAX_CONNECTION_HANDSHAKES: usize = 1024;
 // Max number of Connecting tasks for ConnectionHandshakeHandler
-// to add per poll call
+// to add per poll call before
 // polling the Connecting tasks, to prevent being
 // rendered unresponsive from being spammed with
 // incoming connection initiations

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -235,6 +235,7 @@ pub fn spawn_server(
     Ok((endpoint, handle))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_handle_conn(
     exit: Arc<AtomicBool>,
     conn_recv: AsyncReceiver<Connection>,
@@ -664,7 +665,7 @@ async fn setup_connection(
             // connection from the unstaked connection table.
             if let Ok(()) = prune_unstaked_connections_and_add_new_connection(
                 new_connection,
-                unstaked_connection_table.clone(),
+                unstaked_connection_table,
                 max_unstaked_connections,
                 &params,
                 wait_for_chunk_timeout,
@@ -683,7 +684,7 @@ async fn setup_connection(
         }
     } else if let Ok(()) = prune_unstaked_connections_and_add_new_connection(
         new_connection,
-        unstaked_connection_table.clone(),
+        unstaked_connection_table,
         max_unstaked_connections,
         &params,
         wait_for_chunk_timeout,


### PR DESCRIPTION
#### Problem
There is a possibility that early-stage Quic connection steps may consume excessive resources.

#### Summary of Changes
First draft of a strategy to limit resource consumption by having a single Tokio task to "drive" all the early-stage work for all connections.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
