### PR TITLE
round down compute-unit-price to its nearest 1_000 microlamport

### DIFF
--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -9,6 +9,7 @@ use {
     crossbeam_channel::RecvTimeoutError,
     solana_perf::packet::PacketBatch,
     solana_runtime::bank_forks::BankForks,
+    solana_sdk::feature_set,
     std::{
         sync::{Arc, RwLock},
         time::{Duration, Instant},
@@ -55,8 +56,10 @@ impl PacketDeserializer {
 
         // Note: this can be removed after feature `round_compute_unit_price` is activated in
         // mainnet-beta
-        let _working_bank = self.bank_forks.read().unwrap().working_bank();
-        let round_compute_unit_price_enabled = false; // TODO get from working_bank.feature_set
+        let working_bank = self.bank_forks.read().unwrap().working_bank();
+        let round_compute_unit_price_enabled = working_bank
+            .feature_set
+            .is_active(&feature_set::round_compute_unit_price::id());
 
         Ok(Self::deserialize_and_collect_packets(
             packet_count,

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -285,11 +285,11 @@ impl ComputeBudget {
 
     // https://github.com/solana-labs/solana/issues/31453 to round compute-unit-price, in micro-lamports,
     // down to its nearest 1_000 micro-lamport.
-    const ROUND_DOWN_FACTOR: u64 = 1_000;
+    const PRIORITY_FEE_TICK_SIZE: u64 = 1_000;
     fn round_prioritization_fee(micro_lamports: u64) -> u64 {
         micro_lamports
-            .saturating_div(Self::ROUND_DOWN_FACTOR)
-            .saturating_mul(Self::ROUND_DOWN_FACTOR)
+            .saturating_div(Self::PRIORITY_FEE_TICK_SIZE)
+            .saturating_mul(Self::PRIORITY_FEE_TICK_SIZE)
     }
 }
 
@@ -735,7 +735,7 @@ mod tests {
         }
 
         for support_round_compute_unit_price in [true, false] {
-            let cu_price = ComputeBudget::ROUND_DOWN_FACTOR - 1;
+            let cu_price = ComputeBudget::PRIORITY_FEE_TICK_SIZE - 1;
             let expected_cu_price = if support_round_compute_unit_price {
                 0
             } else {
@@ -754,10 +754,10 @@ mod tests {
         for support_round_compute_unit_price in [true, false] {
             test_set_compute_unit_price(
                 &[ComputeBudgetInstruction::set_compute_unit_price(
-                    ComputeBudget::ROUND_DOWN_FACTOR,
+                    ComputeBudget::PRIORITY_FEE_TICK_SIZE,
                 )],
                 Ok(PrioritizationFeeDetails::new(
-                    PrioritizationFeeType::ComputeUnitPrice(ComputeBudget::ROUND_DOWN_FACTOR),
+                    PrioritizationFeeType::ComputeUnitPrice(ComputeBudget::PRIORITY_FEE_TICK_SIZE),
                     0,
                 )),
                 support_round_compute_unit_price,
@@ -765,9 +765,9 @@ mod tests {
         }
 
         for support_round_compute_unit_price in [true, false] {
-            let cu_price = ComputeBudget::ROUND_DOWN_FACTOR + 1;
+            let cu_price = ComputeBudget::PRIORITY_FEE_TICK_SIZE + 1;
             let expected_cu_price = if support_round_compute_unit_price {
-                ComputeBudget::ROUND_DOWN_FACTOR
+                ComputeBudget::PRIORITY_FEE_TICK_SIZE
             } else {
                 cu_price
             };
@@ -782,9 +782,9 @@ mod tests {
         }
 
         for support_round_compute_unit_price in [true, false] {
-            let cu_price = 3 * ComputeBudget::ROUND_DOWN_FACTOR - 1;
+            let cu_price = 3 * ComputeBudget::PRIORITY_FEE_TICK_SIZE - 1;
             let expected_cu_price = if support_round_compute_unit_price {
-                2 * ComputeBudget::ROUND_DOWN_FACTOR
+                2 * ComputeBudget::PRIORITY_FEE_TICK_SIZE
             } else {
                 cu_price
             };
@@ -970,26 +970,26 @@ mod tests {
         );
 
         assert_eq!(
-            ComputeBudget::round_prioritization_fee(ComputeBudget::ROUND_DOWN_FACTOR - 1),
+            ComputeBudget::round_prioritization_fee(ComputeBudget::PRIORITY_FEE_TICK_SIZE - 1),
             0,
             "less than 1_000 MICRO_LAMPORTS should round down to zero"
         );
 
         assert_eq!(
-            ComputeBudget::round_prioritization_fee(ComputeBudget::ROUND_DOWN_FACTOR),
-            ComputeBudget::ROUND_DOWN_FACTOR,
+            ComputeBudget::round_prioritization_fee(ComputeBudget::PRIORITY_FEE_TICK_SIZE),
+            ComputeBudget::PRIORITY_FEE_TICK_SIZE,
             "1_000 MICRO_LAMPORTS should round to itself"
         );
 
         assert_eq!(
-            ComputeBudget::round_prioritization_fee(ComputeBudget::ROUND_DOWN_FACTOR + 1),
-            ComputeBudget::ROUND_DOWN_FACTOR,
+            ComputeBudget::round_prioritization_fee(ComputeBudget::PRIORITY_FEE_TICK_SIZE + 1),
+            ComputeBudget::PRIORITY_FEE_TICK_SIZE,
             "more than 1_000 MICRO_LAMPORTS should round down to the nearest"
         );
 
         assert_eq!(
-            ComputeBudget::round_prioritization_fee(ComputeBudget::ROUND_DOWN_FACTOR * 3 - 1),
-            ComputeBudget::ROUND_DOWN_FACTOR * 2,
+            ComputeBudget::round_prioritization_fee(ComputeBudget::PRIORITY_FEE_TICK_SIZE * 3 - 1),
+            ComputeBudget::PRIORITY_FEE_TICK_SIZE * 2,
             "more than 1_000 MICRO_LAMPORTS should round down to the nearest"
         );
     }

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -1,5 +1,5 @@
 /// There are 10^6 micro-lamports in one lamport
-pub const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
+const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
 
 type MicroLamports = u128;
 

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -1,5 +1,5 @@
 /// There are 10^6 micro-lamports in one lamport
-const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
+pub const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
 
 type MicroLamports = u128;
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3834,6 +3834,7 @@ fn test_program_fees() {
         true,
         true,
         false,
+        false,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3859,6 +3860,7 @@ fn test_program_fees() {
         true,
         true,
         true,
+        false,
         false,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3833,8 +3833,8 @@ fn test_program_fees() {
         true,
         true,
         true,
-        false,
-        false,
+        true,
+        true,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3845,7 +3845,7 @@ fn test_program_fees() {
     let pre_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     let message = Message::new(
         &[
-            ComputeBudgetInstruction::set_compute_unit_price(1),
+            ComputeBudgetInstruction::set_compute_unit_price(1_000_000_000),
             Instruction::new_with_bytes(program_id, &[], vec![]),
         ],
         Some(&mint_keypair.pubkey()),
@@ -3860,8 +3860,8 @@ fn test_program_fees() {
         true,
         true,
         true,
-        false,
-        false,
+        true,
+        true,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8660,7 +8660,7 @@ pub mod tests {
         let account0 = Pubkey::new_unique();
         let account1 = Pubkey::new_unique();
         let account2 = Pubkey::new_unique();
-        let price0 = 42;
+        let price0 = 4_000_000_000;
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[
@@ -8720,7 +8720,7 @@ pub mod tests {
 
         rpc.advance_bank_to_confirmed_slot(1);
         let slot1 = rpc.working_bank().slot();
-        let price1 = 11;
+        let price1 = 1_000_000_000;
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8660,7 +8660,7 @@ pub mod tests {
         let account0 = Pubkey::new_unique();
         let account1 = Pubkey::new_unique();
         let account2 = Pubkey::new_unique();
-        let price0 = 4_000_000_000;
+        let price0 = 40_000;
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[
@@ -8720,7 +8720,7 @@ pub mod tests {
 
         rpc.advance_bank_to_confirmed_slot(1);
         let slot1 = rpc.working_bank().slot();
-        let price1 = 1_000_000_000;
+        let price1 = 1_000;
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -37,8 +37,8 @@ use {
             self, add_set_tx_loaded_accounts_data_size_instruction, enable_request_heap_frame_ix,
             include_loaded_accounts_data_size_in_fee_calculation,
             remove_congestion_multiplier_from_fee_calculation, remove_deprecated_request_unit_ix,
-            simplify_writable_program_account_check, use_default_units_in_fee_calculation,
-            FeatureSet,
+            round_compute_unit_price, simplify_writable_program_account_check,
+            use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         genesis_config::ClusterType,
@@ -256,6 +256,7 @@ impl Accounts {
                 !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                 true, // don't reject txs that use request heap size ix
                 feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
+                feature_set.is_active(&round_compute_unit_price::id()),
             );
             // sanitize against setting size limit to zero
             NonZeroUsize::new(compute_budget.loaded_accounts_data_size_limit).map_or(
@@ -732,6 +733,7 @@ impl Accounts {
                             feature_set.is_active(&enable_request_heap_frame_ix::id()) || self.accounts_db.expected_cluster_type() != ClusterType::MainnetBeta,
                             feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
                             feature_set.is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
+                            feature_set.is_active(&round_compute_unit_price::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1769,6 +1771,7 @@ mod tests {
             true,
             true,
             true,
+            false,
             false,
         );
         assert_eq!(fee, lamports_per_signature);
@@ -4332,6 +4335,7 @@ mod tests {
             true,
             true,
             true,
+            false,
             false,
         );
         assert_eq!(fee, lamports_per_signature + prioritization_fee);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10488,7 +10488,7 @@ fn test_calculate_prioritization_fee() {
         ),
         fee_structure.lamports_per_signature
             + PrioritizationFeeDetails::new(
-                PrioritizationFeeType::ComputeUnitPrice(2_000_999_999_u64),
+                PrioritizationFeeType::ComputeUnitPrice(2_000_000_000_u64),
                 request_units as u64,
             )
             .get_fee()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10441,7 +10441,7 @@ fn test_calculate_prioritization_fee() {
     };
 
     let request_units = 1_000_000_u32;
-    let request_unit_price = 2_000_999_999_u64;
+    let request_unit_price = 2_000_999_u64;
 
     let message = SanitizedMessage::try_from(Message::new(
         &[
@@ -10488,7 +10488,7 @@ fn test_calculate_prioritization_fee() {
         ),
         fee_structure.lamports_per_signature
             + PrioritizationFeeDetails::new(
-                PrioritizationFeeType::ComputeUnitPrice(2_000_000_000_u64),
+                PrioritizationFeeType::ComputeUnitPrice(2_000_000_u64),
                 request_units as u64,
             )
             .get_fee()

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -15,7 +15,7 @@ use {
         feature_set::{
             add_set_tx_loaded_accounts_data_size_instruction,
             include_loaded_accounts_data_size_in_fee_calculation,
-            remove_deprecated_request_unit_ix, FeatureSet,
+            remove_deprecated_request_unit_ix, round_compute_unit_price, FeatureSet,
         },
         instruction::CompiledInstruction,
         program_utils::limited_deserialize,
@@ -120,6 +120,7 @@ impl CostModel {
             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
             enable_request_heap_frame_ix,
             feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
+            feature_set.is_active(&round_compute_unit_price::id()),
         );
 
         // if failed to process compute_budget instructions, the transaction will not be executed

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -8,7 +8,8 @@ use {
     lru::LruCache,
     solana_measure::measure,
     solana_sdk::{
-        clock::Slot, pubkey::Pubkey, saturating_add_assign, transaction::SanitizedTransaction,
+        clock::Slot, feature_set, pubkey::Pubkey, saturating_add_assign,
+        transaction::SanitizedTransaction,
     },
     std::{
         collections::HashMap,
@@ -212,7 +213,9 @@ impl PrioritizationFeeCache {
                         continue;
                     }
 
-                    let round_compute_unit_price_enabled = false; // TODO: bank.feture_set.is_active(round_compute_unit_price)
+                    let round_compute_unit_price_enabled = bank
+                        .feature_set
+                        .is_active(&feature_set::round_compute_unit_price::id());
                     let priority_details = sanitized_transaction
                         .get_transaction_priority_details(round_compute_unit_price_enabled);
                     let account_locks = sanitized_transaction

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -21,7 +21,7 @@ pub trait GetTransactionPriorityDetails {
 
     fn process_compute_budget_instruction<'a>(
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-        _round_compute_unit_price_enabled: bool,
+        round_compute_unit_price_enabled: bool,
     ) -> Option<TransactionPriorityDetails> {
         let mut compute_budget = ComputeBudget::default();
         let prioritization_fee_details = compute_budget
@@ -31,7 +31,7 @@ pub trait GetTransactionPriorityDetails {
                 false, // stop supporting prioritization by request_units_deprecated instruction
                 true,  // enable request heap frame instruction
                 true,  // enable support set accounts data size instruction
-                       // TODO: round_compute_unit_price_enabled: bool
+                round_compute_unit_price_enabled,
             )
             .ok()?;
         Some(TransactionPriorityDetails {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -672,6 +672,10 @@ pub mod last_restart_slot_sysvar {
     solana_sdk::declare_id!("HooKD5NC9QNxk25QuzCssB8ecrEzGt6eXEPBUxWp1LaR");
 }
 
+pub mod round_compute_unit_price {
+    solana_sdk::declare_id!("6J6GS57v5q4CnPrLgDMsyZLFfpPEBPZ66h8efDEpesPk");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -835,6 +839,7 @@ lazy_static! {
         (checked_arithmetic_in_fee_validation::id(), "checked arithmetic in fee validation #31273"),
         (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
+        (round_compute_unit_price::id(), "round down compute-unit-price to the nearest lamports #31453"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -839,7 +839,7 @@ lazy_static! {
         (checked_arithmetic_in_fee_validation::id(), "checked arithmetic in fee validation #31273"),
         (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
-        (round_compute_unit_price::id(), "round down compute-unit-price to the nearest lamports #31453"),
+        (round_compute_unit_price::id(), "round down compute-unit-price to the nearest 1_000 micro-lamports #31453"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Rounding compute-unit-price down to nearest 1_000 micro-lamport, effectively making its minimum change to be 0.001 lamport.

#### Summary of Changes
1. add feature gate
3. round compute-unit-price down to nearest 1_000 micro-lamports if feature activated;
4. add and update tests


Feature Gate Issue: #31453 
<!-- Don't forget to add the "feature-gate" label -->
