### PR TITLE
Removes needless borrows

### DIFF
--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -1449,7 +1449,7 @@ mod tests {
         let ping = ping_pong::Ping::<[u8; 32]>::new_rand(&mut rng, &keypair).unwrap();
         let pong = Pong::new(&ping, &keypair).unwrap();
         let request = RepairProtocol::Pong(pong);
-        let mut pkt = Packet::from_data(None, &request).unwrap();
+        let mut pkt = Packet::from_data(None, request).unwrap();
         let mut batch = PacketBatch::new(vec![pkt.clone()]);
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -1466,7 +1466,7 @@ mod tests {
             slot: 123,
             shred_index: 456,
         };
-        let mut pkt = Packet::from_data(None, &request).unwrap();
+        let mut pkt = Packet::from_data(None, request).unwrap();
         let mut batch = PacketBatch::new(vec![pkt.clone()]);
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -1482,7 +1482,7 @@ mod tests {
             header: repair_request_header_for_tests(),
             slot: 123,
         };
-        let mut pkt = Packet::from_data(None, &request).unwrap();
+        let mut pkt = Packet::from_data(None, request).unwrap();
         let mut batch = PacketBatch::new(vec![pkt.clone()]);
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -1495,7 +1495,7 @@ mod tests {
         assert_eq!(stats.err_malformed, 1);
 
         let request = RepairProtocol::LegacyOrphan(LegacyContactInfo::default(), 123);
-        let mut pkt = Packet::from_data(None, &request).unwrap();
+        let mut pkt = Packet::from_data(None, request).unwrap();
         let mut batch = PacketBatch::new(vec![pkt.clone()]);
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);


### PR DESCRIPTION
#### Problem

While working on https://github.com/solana-labs/solana/pull/31487 to upgrade our nightly Rust version, we ran into clippy lint errors like this one:

```
error: the borrowed expression implements the required traits
  | --> core/src/serve_repair.rs:1452:47
  | \|
  | 1452 \|         let mut pkt = Packet::from_data(None, &request).unwrap();
  | \|                                               ^^^^^^^^ help: change this to: `request`
  | \|
  | = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
  | = note: `-D clippy::needless-borrow` implied by `-D warnings`
```

Here's the build log: https://buildkite.com/solana-labs/solana/builds/95022#0187e79f-b4ed-4e24-b5d1-926696b8d1a3

Looks like there are a few needless borrows in `serve_repair.rs` that can be removed.

#### Summary of Changes

Remove needless borrows.