### PR TITLE
Return implicit delay visibility tombstone

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -539,11 +539,10 @@ impl solana_frozen_abi::abi_example::AbiExample for LoadedPrograms {
 
 #[cfg(test)]
 mod tests {
-    use crate::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET;
     use {
         crate::loaded_programs::{
             BlockRelation, ForkGraph, LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType,
-            LoadedPrograms, LoadedProgramsForTxBatch, WorkingSlot,
+            LoadedPrograms, LoadedProgramsForTxBatch, WorkingSlot, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         percentage::Percentage,
         solana_rbpf::vm::BuiltInProgram,


### PR DESCRIPTION
#### Problem
The explicit placement of delay visibility tombstone has been removed from the code. Need to update `extract()` to implicitly return the tombstone under correct conditions.

#### Summary of Changes
Return the delay visibility tombstone if the current slot is between deployment and effective slot for the cached program.
Updated the unit tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
