### PR TITLE
Update SBF bench to account for delay visibility

### DIFF
--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -196,9 +196,12 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     } = create_genesis_config(50);
     let bank = Bank::new_for_benches(&genesis_config);
     let bank = Arc::new(bank);
-    let bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(&bank);
 
     let invoke_program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
+    let bank = bank_client
+        .advance_slot(1, &Pubkey::default())
+        .expect("Failed to advance the slot");
 
     let mint_pubkey = mint_keypair.pubkey();
     let account_metas = vec![AccountMeta::new(mint_pubkey, true)];


### PR DESCRIPTION
#### Problem
SBF bench fails to execute transactions using the loaded program with the new LoadedPrograms cache. 

#### Summary of Changes
This is similar to https://github.com/solana-labs/solana/pull/31491. The loaded program is not effective till the next slot. This PR updates bank_client to next slot's bank as the program is available in the next slot's bank.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
