### PR TITLE
SnapshotPackagerService purges old bank snapshots

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -94,6 +94,15 @@ impl SnapshotPackagerService {
                                 (snapshot_package.slot(), *snapshot_package.hash()),
                             );
                         }
+
+                        // Now that this snapshot package has been archived, it is safe to remove
+                        // all bank snapshots older than this slot.  We want to keep the bank
+                        // snapshot *at this slot* so that it can be used during restarts, when
+                        // booting from local state.
+                        snapshot_utils::purge_bank_snapshots_older_than_slot(
+                            &snapshot_config.bank_snapshots_dir,
+                            snapshot_package.slot(),
+                        );
                     });
 
                     datapoint_info!(


### PR DESCRIPTION
#### Problem

We retain more bank snapshots than we need, longer than we need.

Bank snapshots are currently used for one thing: creating a snapshot archive. And currently in development, we'll also use bank snapshots to speed up restart by booting from a bank snapshot instead of a snapshot archive. In any case, an observation is that once a snapshot has been archived, *all* bank snapshots *older* are no longer useful.

(We want to keep around the bank snapshot that was just archived for the fast boot case mentioned above.)

Also, bank snapshots contain hard-links to account storage files (for fast boot). We should free those up as fast as possible, since they can artificially take up space *if the accounts are stored in a RAM disk*.

Note that we still have an outstanding problem to solve: What about bank snapshots that are not archived? This happens for accounts hash verifier requests, and if a node has disabled snapshots (which still must produce bank snapshots for AHV, but not snapshot archives). I'll be working on that separately from this PR.

#### Summary of Changes

SnapshotPackagerService will purge bank snapshots *older* than the one that was just archived.