### PR TITLE
clarify AccountsIndexScanResult::OnlyKeepInMemoryIfDirty

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3301,7 +3301,7 @@ impl AccountsDb {
                                     useful += 1;
                                 }
                                 if useless {
-                                    AccountsIndexScanResult::None
+                                    AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                                 } else {
                                     AccountsIndexScanResult::KeepInMemory
                                 }
@@ -3798,7 +3798,7 @@ impl AccountsDb {
         self.accounts_index.scan(
             accounts.iter().map(|account| account.pubkey()),
             |pubkey, slots_refs, entry| {
-                let mut result = AccountsIndexScanResult::None;
+                let mut result = AccountsIndexScanResult::OnlyKeepInMemoryIfDirty;
                 if let Some((slot_list, ref_count)) = slots_refs {
                     let stored_account = &accounts[index];
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -668,8 +668,8 @@ impl ScanSlotTracker {
 
 #[derive(Copy, Clone)]
 pub enum AccountsIndexScanResult {
-    /// if the entry is not in the in-memory index, do not add it, make no modifications to it
-    None,
+    /// if the entry is not in the in-memory index, do not add it unless the entry becomes dirty
+    OnlyKeepInMemoryIfDirty,
     /// keep the entry in the in-memory index
     KeepInMemory,
     /// reduce refcount by 1
@@ -1411,7 +1411,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                 true
                             }
                             AccountsIndexScanResult::KeepInMemory => true,
-                            AccountsIndexScanResult::None => false,
+                            AccountsIndexScanResult::OnlyKeepInMemoryIfDirty => false,
                         };
                     }
                     None => {

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -347,7 +347,7 @@ impl AccountsDb {
                             if let Some(entry) = entry {
                                 entry.addref();
                             }
-                            AccountsIndexScanResult::None
+                            AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                         },
                         None,
                         true,
@@ -656,7 +656,7 @@ impl AccountsDb {
                         index -= 1;
                     }
                 }
-                AccountsIndexScanResult::None
+                AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
             },
             None,
             false,
@@ -3093,7 +3093,7 @@ pub mod tests {
                 unrefed_pubkeys.iter(),
                 |k, slot_refs, _entry| {
                     assert_eq!(expected_ref_counts.remove(k).unwrap(), slot_refs.unwrap().1);
-                    AccountsIndexScanResult::None
+                    AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                 },
                 None,
                 false,


### PR DESCRIPTION
#### Problem
It was possible to scan accounts index, addref, and then throw away the fact we addref'd. This results in a refcount issue.

#### Summary of Changes
Apply dirty accounts index changes to the durable index.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
