### PR TITLE
Remove noisy counters from bank.rs (v1.14)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4277,7 +4277,6 @@ impl Bank {
     ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
         debug!("processing transactions: {}", sanitized_txs.len());
-        inc_new_counter_info!("bank-process_transactions", sanitized_txs.len());
         let mut error_counters = TransactionErrorMetrics::default();
 
         let retryable_transaction_indexes: Vec<_> = batch
@@ -4796,12 +4795,6 @@ impl Bank {
 
         self.increment_transaction_count(tx_count);
         self.increment_signature_count(signature_count);
-
-        inc_new_counter_info!(
-            "bank-process_transactions-txs",
-            committed_transactions_count as usize
-        );
-        inc_new_counter_info!("bank-process_transactions-sigs", signature_count as usize);
 
         if committed_with_failure_result_count > 0 {
             self.transaction_error_count


### PR DESCRIPTION
#### Problem
Not only are these counters noisy from perspective of reporting to metrics database, but they were also observed to have a non-trivial perf impact.

#### Summary of Changes
Rip out these counters.

This is a manual, targeted backport of https://github.com/solana-labs/solana/pull/31398.