### PR TITLE
Refactor remove unnecessary parameter

### DIFF
--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -46,10 +46,7 @@ pub struct ImmutableDeserializedPacket {
 }
 
 impl ImmutableDeserializedPacket {
-    pub fn new(
-        packet: Packet,
-        priority_details: Option<TransactionPriorityDetails>,
-    ) -> Result<Self, DeserializedPacketError> {
+    pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
         let versioned_transaction: VersionedTransaction = packet.deserialize_slice(..)?;
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
@@ -57,8 +54,8 @@ impl ImmutableDeserializedPacket {
         let is_simple_vote = packet.meta().is_simple_vote_tx();
 
         // drop transaction if prioritization fails.
-        let mut priority_details = priority_details
-            .or_else(|| sanitized_transaction.get_transaction_priority_details())
+        let mut priority_details = sanitized_transaction
+            .get_transaction_priority_details()
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
 
         // set priority to zero for vote transactions
@@ -163,7 +160,7 @@ mod tests {
             Hash::new_unique(),
         );
         let packet = Packet::from_data(None, tx).unwrap();
-        let deserialized_packet = ImmutableDeserializedPacket::new(packet, None);
+        let deserialized_packet = ImmutableDeserializedPacket::new(packet);
 
         assert!(matches!(deserialized_packet, Ok(_)));
     }

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -38,7 +38,7 @@ impl LatestValidatorVotePacket {
             return Err(DeserializedPacketError::VoteTransactionError);
         }
 
-        let vote = Arc::new(ImmutableDeserializedPacket::new(packet, None)?);
+        let vote = Arc::new(ImmutableDeserializedPacket::new(packet)?);
         Self::new_from_immutable(vote, vote_source)
     }
 

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -138,7 +138,7 @@ impl PacketDeserializer {
         packet_indexes: &'a [usize],
     ) -> impl Iterator<Item = ImmutableDeserializedPacket> + 'a {
         packet_indexes.iter().filter_map(move |packet_index| {
-            ImmutableDeserializedPacket::new(packet_batch[*packet_index].clone(), None).ok()
+            ImmutableDeserializedPacket::new(packet_batch[*packet_index].clone()).ok()
         })
     }
 }

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -2,7 +2,6 @@ use {
     crate::immutable_deserialized_packet::{DeserializedPacketError, ImmutableDeserializedPacket},
     min_max_heap::MinMaxHeap,
     solana_perf::packet::{Packet, PacketBatch},
-    solana_runtime::transaction_priority_details::TransactionPriorityDetails,
     solana_sdk::{hash::Hash, transaction::Transaction},
     std::{
         cmp::Ordering,
@@ -28,14 +27,7 @@ impl DeserializedPacket {
     }
 
     pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
-        Self::new_internal(packet, None)
-    }
-
-    pub fn new_internal(
-        packet: Packet,
-        priority_details: Option<TransactionPriorityDetails>,
-    ) -> Result<Self, DeserializedPacketError> {
-        let immutable_section = ImmutableDeserializedPacket::new(packet, priority_details)?;
+        let immutable_section = ImmutableDeserializedPacket::new(packet)?;
 
         Ok(Self {
             immutable_section: Arc::new(immutable_section),

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -1194,9 +1194,9 @@ mod tests {
                 thread_type,
             );
             transaction_storage.insert_batch(vec![
-                ImmutableDeserializedPacket::new(small_transfer.clone(), None)?,
-                ImmutableDeserializedPacket::new(vote.clone(), None)?,
-                ImmutableDeserializedPacket::new(big_transfer.clone(), None)?,
+                ImmutableDeserializedPacket::new(small_transfer.clone())?,
+                ImmutableDeserializedPacket::new(vote.clone())?,
+                ImmutableDeserializedPacket::new(big_transfer.clone())?,
             ]);
             let deserialized_packets = transaction_storage
                 .iter()
@@ -1214,9 +1214,9 @@ mod tests {
                 vote_source,
             );
             transaction_storage.insert_batch(vec![
-                ImmutableDeserializedPacket::new(small_transfer.clone(), None)?,
-                ImmutableDeserializedPacket::new(vote.clone(), None)?,
-                ImmutableDeserializedPacket::new(big_transfer.clone(), None)?,
+                ImmutableDeserializedPacket::new(small_transfer.clone())?,
+                ImmutableDeserializedPacket::new(vote.clone())?,
+                ImmutableDeserializedPacket::new(big_transfer.clone())?,
             ]);
             assert_eq!(1, transaction_storage.len());
         }


### PR DESCRIPTION
#### Problem
`None` is always passed as 2nd parameter in calling `ImmutableDeserializedPacket::new(packet, None)`

#### Summary of Changes
- remove unnecessary second parameter
- remove `DeserializedPacket::new_internal()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
