### PR TITLE
Revert "SnapshotPackagerService purges old bank snapshots (#31511)"

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -94,15 +94,6 @@ impl SnapshotPackagerService {
                                 (snapshot_package.slot(), *snapshot_package.hash()),
                             );
                         }
-
-                        // Now that this snapshot package has been archived, it is safe to remove
-                        // all bank snapshots older than this slot.  We want to keep the bank
-                        // snapshot *at this slot* so that it can be used during restarts, when
-                        // booting from local state.
-                        snapshot_utils::purge_bank_snapshots_older_than_slot(
-                            &snapshot_config.bank_snapshots_dir,
-                            snapshot_package.slot(),
-                        );
                     });
 
                     datapoint_info!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2955,13 +2955,6 @@ pub fn purge_old_bank_snapshots(
     );
 }
 
-/// Purges bank snapshots that are older than `slot`
-pub fn purge_bank_snapshots_older_than_slot(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) {
-    let mut bank_snapshots = get_bank_snapshots(&bank_snapshots_dir);
-    bank_snapshots.retain(|bank_snapshot| bank_snapshot.slot < slot);
-    purge_bank_snapshots(&bank_snapshots);
-}
-
 /// Purges all `bank_snapshots`
 ///
 /// Does not exit early if there is an error while purging a bank snapshot.
@@ -5558,32 +5551,5 @@ mod tests {
 
         purge_old_bank_snapshots(&bank_snapshots_dir, 0, None);
         assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 0);
-    }
-
-    #[test]
-    fn test_purge_bank_snapshots_older_than_slot() {
-        let genesis_config = GenesisConfig::default();
-        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-
-        // The bank must stay in scope to ensure the temp dirs that it holds are not dropped
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 9, 6);
-        let bank_snapshots_before = get_bank_snapshots(&bank_snapshots_dir);
-
-        purge_bank_snapshots_older_than_slot(&bank_snapshots_dir, 0);
-        let bank_snapshots_after = get_bank_snapshots(&bank_snapshots_dir);
-        assert_eq!(bank_snapshots_before.len(), bank_snapshots_after.len());
-
-        purge_bank_snapshots_older_than_slot(&bank_snapshots_dir, 3);
-        let bank_snapshots_after = get_bank_snapshots(&bank_snapshots_dir);
-        assert_eq!(bank_snapshots_before.len(), bank_snapshots_after.len() + 2);
-
-        purge_bank_snapshots_older_than_slot(&bank_snapshots_dir, 8);
-        let bank_snapshots_after = get_bank_snapshots(&bank_snapshots_dir);
-        assert_eq!(bank_snapshots_before.len(), bank_snapshots_after.len() + 7);
-
-        purge_bank_snapshots_older_than_slot(&bank_snapshots_dir, Slot::MAX);
-        let bank_snapshots_after = get_bank_snapshots(&bank_snapshots_dir);
-        assert_eq!(bank_snapshots_before.len(), bank_snapshots_after.len() + 9);
-        assert!(bank_snapshots_after.is_empty());
     }
 }


### PR DESCRIPTION
#### Problem

PR #31511 introduced intermittent test failures like this:

```
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread 'test_epoch_accounts_hash_basic::with_snapshots' panicked at 'send epoch accounts hash request: "SendError(..)"', runtime/src/bank_forks.rs:326:18
stack backtrace:
   0: rust_begin_unwind
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:579:5
   1: core::panicking::panic_fmt
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/result.rs:1750:5
   3: core::result::Result<T,E>::expect
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/result.rs:1047:23
   4: solana_runtime::bank_forks::BankForks::do_set_root_return_metrics
             at /solana/runtime/src/bank_forks.rs:319:13
   5: solana_runtime::bank_forks::BankForks::set_root
             at /solana/runtime/src/bank_forks.rs:427:49
   6: epoch_accounts_hash::test_epoch_accounts_hash_basic
             at ./tests/epoch_accounts_hash.rs:299:13
   7: epoch_accounts_hash::test_epoch_accounts_hash_basic::with_snapshots
             at ./tests/epoch_accounts_hash.rs:257:1
   8: epoch_accounts_hash::test_epoch_accounts_hash_basic::with_snapshots::{{closure}}
             at ./tests/epoch_accounts_hash.rs:257:1
   9: core::ops::function::FnOnce::call_once
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:250:5
  10: core::ops::function::FnOnce::call_once
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
 
failures:
    test_epoch_accounts_hash_basic::with_snapshots
 
test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 30.31s
 
error: test failed, to rerun pass `-p solana-core --test epoch_accounts_hash`
🚨 Error: The command exited with status 101
Running local post-command hook
```

I haven't investigated the tests yet, but I believe they rely on checking the file system for progress. The PR changed how the bank snapshots were cleaned up, so the tests likely need to be updated.


#### Summary of Changes

Revert PR #31511