### PR TITLE
clippy: Removes redundant async blocks

### DIFF
--- a/core/src/tower_storage.rs
+++ b/core/src/tower_storage.rs
@@ -241,25 +241,22 @@ impl EtcdTowerStorage {
             .unwrap();
 
         let client = runtime
-            .block_on(async {
-                etcd_client::Client::connect(
-                    endpoints,
-                    tls_config.map(|tls_config| {
-                        etcd_client::ConnectOptions::default().with_tls(
-                            etcd_client::TlsOptions::new()
-                                .domain_name(tls_config.domain_name)
-                                .ca_certificate(etcd_client::Certificate::from_pem(
-                                    tls_config.ca_certificate,
-                                ))
-                                .identity(etcd_client::Identity::from_pem(
-                                    tls_config.identity_certificate,
-                                    tls_config.identity_private_key,
-                                )),
-                        )
-                    }),
-                )
-                .await
-            })
+            .block_on(etcd_client::Client::connect(
+                endpoints,
+                tls_config.map(|tls_config| {
+                    etcd_client::ConnectOptions::default().with_tls(
+                        etcd_client::TlsOptions::new()
+                            .domain_name(tls_config.domain_name)
+                            .ca_certificate(etcd_client::Certificate::from_pem(
+                                tls_config.ca_certificate,
+                            ))
+                            .identity(etcd_client::Identity::from_pem(
+                                tls_config.identity_certificate,
+                                tls_config.identity_private_key,
+                            )),
+                    )
+                }),
+            ))
             .map_err(Self::etdc_to_tower_error)?;
 
         Ok(Self {

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -36,21 +36,17 @@ fn simulate_fuzz() {
         processor!(process_instruction),
     );
 
-    let (mut banks_client, payer, last_blockhash) =
-        rt.block_on(async { program_test.start().await });
+    let (mut banks_client, payer, last_blockhash) = rt.block_on(program_test.start());
 
     // the honggfuzz `fuzz!` macro does not allow for async closures,
     // so we have to use the runtime directly to run async functions
-    rt.block_on(async {
-        run_fuzz_instructions(
-            &[1, 2, 3, 4, 5],
-            &mut banks_client,
-            &payer,
-            last_blockhash,
-            &program_id,
-        )
-        .await
-    });
+    rt.block_on(run_fuzz_instructions(
+        &[1, 2, 3, 4, 5],
+        &mut banks_client,
+        &payer,
+        last_blockhash,
+        &program_id,
+    ));
 }
 
 #[test]
@@ -64,20 +60,17 @@ fn simulate_fuzz_with_context() {
         processor!(process_instruction),
     );
 
-    let mut context = rt.block_on(async { program_test.start_with_context().await });
+    let mut context = rt.block_on(program_test.start_with_context());
 
     // the honggfuzz `fuzz!` macro does not allow for async closures,
     // so we have to use the runtime directly to run async functions
-    rt.block_on(async {
-        run_fuzz_instructions(
-            &[1, 2, 3, 4, 5],
-            &mut context.banks_client,
-            &context.payer,
-            context.last_blockhash,
-            &program_id,
-        )
-        .await
-    });
+    rt.block_on(run_fuzz_instructions(
+        &[1, 2, 3, 4, 5],
+        &mut context.banks_client,
+        &context.payer,
+        context.last_blockhash,
+        &program_id,
+    ));
 }
 
 async fn run_fuzz_instructions(

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -161,14 +161,14 @@ impl ClientConnection for QuicClientConnection {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
 
-        let _handle = RUNTIME.spawn(async move { send_data_async(inner, data).await });
+        let _handle = RUNTIME.spawn(send_data_async(inner, data));
         Ok(())
     }
 
     fn send_data_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let _lock = ASYNC_TASK_SEMAPHORE.acquire();
         let inner = self.inner.clone();
-        let _handle = RUNTIME.spawn(async move { send_data_batch_async(inner, buffers).await });
+        let _handle = RUNTIME.spawn(send_data_batch_async(inner, buffers));
         Ok(())
     }
 

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -614,16 +614,13 @@ impl LeaderTpuService {
         let t_leader_tpu_service = Some({
             let recent_slots = recent_slots.clone();
             let leader_tpu_cache = leader_tpu_cache.clone();
-            tokio::spawn(async move {
-                Self::run(
-                    rpc_client,
-                    recent_slots,
-                    leader_tpu_cache,
-                    pubsub_client,
-                    exit,
-                )
-                .await
-            })
+            tokio::spawn(Self::run(
+                rpc_client,
+                recent_slots,
+                leader_tpu_cache,
+                pubsub_client,
+                exit,
+            ))
         });
 
         Ok(LeaderTpuService {


### PR DESCRIPTION
#### Problem

Clippy throws warnings on the next nightly version (1.70.0), which blocks upgrading our nightly Rust (see #31381).

Here's an example:
```
warning: this async expression only awaits a single future
    --> rpc/src/rpc.rs:3522:22
     |
3522 |             Box::pin(async move { meta.get_signature_statuses(signatures, config).await })
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `meta.get_signature_statuses(signatures, config)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_async_block
     = note: `#[warn(clippy::redundant_async_block)]` on by default
```

#### Summary of Changes

Remove redundant async away blocks