### PR TITLE
Add multiple URL support to watchtower

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -191,6 +191,23 @@ where
     }
 }
 
+// Gets a string of multiple urls and uses the already defined function to check whether the string
+// is a url
+pub fn are_urls(string: String) -> Result<(), String>
+{
+    let mut split_string = string.split(" ");
+
+    loop {
+        let val = split_string.next();
+
+        if val == None { break; }
+
+        return is_url(val.unwrap());
+    }
+
+    Ok(())
+}
+
 pub fn is_url_or_moniker<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -7,7 +7,7 @@ use {
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::pubkeys_of,
-        input_validators::{is_parsable, is_pubkey_or_keypair, is_url},
+        input_validators::{is_parsable, is_pubkey_or_keypair, are_urls},
     },
     solana_cli_output::display::format_labeled_address,
     solana_metrics::{datapoint_error, datapoint_info},
@@ -84,7 +84,7 @@ fn get_config() -> Config {
                 .long("url")
                 .value_name("URL")
                 .takes_value(true)
-                .validator(is_url)
+                .validator(are_urls)
                 .help("JSON RPC URL for the cluster"),
         )
         .arg(
@@ -200,7 +200,7 @@ fn get_config() -> Config {
         name_suffix,
     };
 
-    info!("RPC URL: {}", config.json_rpc_url);
+    info!("RPC URLs: {}", config.json_rpc_url);
     info!(
         "Monitored validators: {:?}",
         config.validator_identity_pubkeys

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -271,7 +271,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
             if val == None { break; }
 
-            let latency = get_latency(val.unwrap().to_string(), config.rpc_timeout).unwrap();
+            let latency_option = get_latency(val.unwrap().to_string(), config.rpc_timeout);
+
+            if latency_option == None { continue; }
+
+            let latency = latency_option.unwrap();
+                
             if latency < lowest_latency {
                 lowest_latency = latency;
                 lowest_latency_url = val.unwrap().to_string();

--- a/watchtower/start.sh
+++ b/watchtower/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo run -- --url "https://api.mainnet-beta.solana.com https://api.mainnet-beta.solana.com"

--- a/watchtower/start.sh
+++ b/watchtower/start.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cargo run -- --url "https://api.mainnet-beta.solana.com https://api.mainnet-beta.solana.com"


### PR DESCRIPTION
#### Problem
Solana Watchtower could only use one RPC URL.

#### Summary of Changes
- Add functionality to use multiple URLs and watchtower will pick the one with the lowest latency

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
