### PR TITLE
remove unused historical_roots

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -818,8 +818,8 @@ where
         snapshot_version,
         snapshot_slot,
         snapshot_bank_hash_info,
-        snapshot_historical_roots,
-        snapshot_historical_roots_with_hash,
+        _snapshot_historical_roots,
+        _snapshot_historical_roots_with_hash,
     ) = snapshot_accounts_db_fields.collapse_into()?;
 
     // Ensure all account paths exist
@@ -827,12 +827,6 @@ where
         std::fs::create_dir_all(path)
             .unwrap_or_else(|err| panic!("Failed to create directory {}: {}", path.display(), err));
     }
-
-    reconstruct_historical_roots(
-        &accounts_db,
-        snapshot_historical_roots,
-        snapshot_historical_roots_with_hash,
-    );
 
     let StorageAndNextAppendVecId {
         storage,
@@ -913,26 +907,4 @@ where
         Arc::try_unwrap(accounts_db).unwrap(),
         ReconstructedAccountsDbInfo { accounts_data_len },
     ))
-}
-
-/// populate 'historical_roots' from 'snapshot_historical_roots' and 'snapshot_historical_roots_with_hash'
-fn reconstruct_historical_roots(
-    accounts_db: &AccountsDb,
-    mut snapshot_historical_roots: Vec<Slot>,
-    snapshot_historical_roots_with_hash: Vec<(Slot, Hash)>,
-) {
-    // inflate 'historical_roots'
-    // inserting into 'historical_roots' needs to be in order
-    // combine the slots into 1 vec, then sort
-    // dups are ok
-    snapshot_historical_roots.extend(
-        snapshot_historical_roots_with_hash
-            .into_iter()
-            .map(|(root, _)| root),
-    );
-    snapshot_historical_roots.sort_unstable();
-    let mut roots_tracker = accounts_db.accounts_index.roots_tracker.write().unwrap();
-    snapshot_historical_roots.into_iter().for_each(|root| {
-        roots_tracker.historical_roots.insert(root);
-    });
 }

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -294,14 +294,7 @@ impl<'a> TypeContext<'a> for Context {
             stats,
         };
 
-        let historical_roots = serializable_db
-            .accounts_db
-            .accounts_index
-            .roots_tracker
-            .read()
-            .unwrap()
-            .historical_roots
-            .get_all();
+        let historical_roots = Vec::<Slot>::default();
         let historical_roots_with_hash = Vec::<(Slot, Hash)>::default();
 
         let mut serialize_account_storage_timer = Measure::start("serialize_account_storage_ms");

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -752,35 +752,3 @@ mod test_bank_serialize {
         .serialize(s)
     }
 }
-
-#[test]
-fn test_reconstruct_historical_roots() {
-    {
-        let db = AccountsDb::default_for_tests();
-        let historical_roots = vec![];
-        let historical_roots_with_hash = vec![];
-        reconstruct_historical_roots(&db, historical_roots, historical_roots_with_hash);
-        let roots_tracker = db.accounts_index.roots_tracker.read().unwrap();
-        assert!(roots_tracker.historical_roots.is_empty());
-    }
-
-    {
-        let db = AccountsDb::default_for_tests();
-        let historical_roots = vec![1];
-        let historical_roots_with_hash = vec![(0, Hash::default())];
-        reconstruct_historical_roots(&db, historical_roots, historical_roots_with_hash);
-        let roots_tracker = db.accounts_index.roots_tracker.read().unwrap();
-        assert_eq!(roots_tracker.historical_roots.get_all(), vec![0, 1]);
-    }
-    {
-        let db = AccountsDb::default_for_tests();
-        let historical_roots = vec![2, 1];
-        let historical_roots_with_hash = vec![0, 5]
-            .into_iter()
-            .map(|slot| (slot, Hash::default()))
-            .collect();
-        reconstruct_historical_roots(&db, historical_roots, historical_roots_with_hash);
-        let roots_tracker = db.accounts_index.roots_tracker.read().unwrap();
-        assert_eq!(roots_tracker.historical_roots.get_all(), vec![0, 1, 2, 5]);
-    }
-}


### PR DESCRIPTION
#### Problem
`historical_roots` was intended to be used when rehashing old accounts when we stopped doing rewrites. We backed up and went an entirely different direction.
So, this code is orphaned.

#### Summary of Changes
Remove `historical_roots` and its connections.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
