### PR TITLE
QoS refactor: Allow pre-filtering

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -395,18 +395,24 @@ impl Consumer {
         chunk_offset: usize,
     ) -> ProcessTransactionBatchOutput {
         let (
-            (transaction_costs, transactions_qos_results, cost_model_throttled_transactions_count),
+            (transaction_qos_cost_results, cost_model_throttled_transactions_count),
             cost_model_us,
-        ) = measure_us!(self
-            .qos_service
-            .select_and_accumulate_transaction_costs(bank, txs));
+        ) = measure_us!(self.qos_service.select_and_accumulate_transaction_costs(
+            bank,
+            txs,
+            std::iter::repeat(Ok(())) // no filtering before QoS
+        ));
 
         // Only lock accounts for those transactions are selected for the block;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
         // same account state
-        let (batch, lock_us) = measure_us!(
-            bank.prepare_sanitized_batch_with_results(txs, transactions_qos_results.iter())
-        );
+        let (batch, lock_us) = measure_us!(bank.prepare_sanitized_batch_with_results(
+            txs,
+            transaction_qos_cost_results.iter().map(|r| match r {
+                Ok(_cost) => Ok(()),
+                Err(err) => Err(err.clone()),
+            })
+        ));
 
         // retryable_txs includes AccountInUse, WouldExceedMaxBlockCostLimit
         // WouldExceedMaxAccountCostLimit, WouldExceedMaxVoteCostLimit
@@ -425,8 +431,7 @@ impl Consumer {
         } = execute_and_commit_transactions_output;
 
         QosService::update_or_remove_transaction_costs(
-            transaction_costs.iter(),
-            transactions_qos_results.iter(),
+            transaction_qos_cost_results.iter(),
             commit_transactions_result.as_ref().ok(),
             bank,
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1233,14 +1233,14 @@ impl Accounts {
     pub fn lock_accounts_with_results<'a>(
         &self,
         txs: impl Iterator<Item = &'a SanitizedTransaction>,
-        results: impl Iterator<Item = &'a Result<()>>,
+        results: impl Iterator<Item = Result<()>>,
         tx_account_lock_limit: usize,
     ) -> Vec<Result<()>> {
         let tx_account_locks_results: Vec<Result<_>> = txs
             .zip(results)
             .map(|(tx, result)| match result {
                 Ok(()) => tx.get_account_locks(tx_account_lock_limit),
-                Err(err) => Err(err.clone()),
+                Err(err) => Err(err),
             })
             .collect();
         self.lock_accounts_inner(tx_account_locks_results)
@@ -3160,7 +3160,7 @@ mod tests {
 
         let results = accounts.lock_accounts_with_results(
             txs.iter(),
-            qos_results.iter(),
+            qos_results.into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3780,7 +3780,7 @@ impl Bank {
     pub fn prepare_sanitized_batch_with_results<'a, 'b>(
         &'a self,
         transactions: &'b [SanitizedTransaction],
-        transaction_results: impl Iterator<Item = &'b Result<()>>,
+        transaction_results: impl Iterator<Item = Result<()>>,
     ) -> TransactionBatch<'a, 'b> {
         // this lock_results could be: Ok, AccountInUse, WouldExceedBlockMaxLimit or WouldExceedAccountMaxLimit
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();


### PR DESCRIPTION
#### Problem
In worker PR #30970, between sanitization/scheduling time and when transactions arrive at the worker thread the slot may have changed.
This leads to some filtering of transactions *before* QoS - (crossed epoch boundary, or ALTs were closed).

QoS doesn't currently fit nicely with any filtering before itself.

#### Summary of Changes
* select_and_accumulate_transaction_costs takes in a new `pre_results` argument.
* select_and_accumulate_transaction_costs returns `Vec<Result<TransactionCost>>` where only selected transactions have the costs returned.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
