### PR TITLE
Refactor pass feature status to deserialized packet ctor

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -88,7 +88,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
 
         let tx = test_tx();
         let transactions = vec![tx; 4194304];
-        let batches = transactions_to_deserialized_packets(&transactions).unwrap();
+        let batches = transactions_to_deserialized_packets(&transactions, false).unwrap();
         let batches_len = batches.len();
         let mut transaction_buffer = UnprocessedTransactionStorage::new_transaction_storage(
             UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len),

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -53,7 +53,7 @@ fn insert_packet_batches(
 
     (0..batch_count).for_each(|_| {
         let (packet_batch, packet_indexes) = build_packet_batch(packet_per_batch_count, None);
-        let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes);
+        let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes, false);
         unprocessed_packet_batches.insert_batch(deserialized_packets);
     });
 }
@@ -129,7 +129,7 @@ fn buffer_iter_desc_and_forward(
         (0..batch_count).for_each(|_| {
             let (packet_batch, packet_indexes) =
                 build_packet_batch(packet_per_batch_count, Some(genesis_config.hash()));
-            let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes);
+            let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes, false);
             unprocessed_packet_batches.insert_batch(deserialized_packets);
         });
     }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -390,7 +390,8 @@ impl BankingStage {
                         ),
                     };
 
-                let mut packet_receiver = PacketReceiver::new(id, packet_receiver);
+                let mut packet_receiver =
+                    PacketReceiver::new(id, packet_receiver, bank_forks.clone());
                 let poh_recorder = poh_recorder.clone();
 
                 let committer = Committer::new(

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1713,8 +1713,11 @@ mod tests {
             let recorder = poh_recorder.read().unwrap().new_recorder();
             let num_conflicting_transactions = transactions.len();
             let deserialized_packets =
-                unprocessed_packet_batches::transactions_to_deserialized_packets(&transactions)
-                    .unwrap();
+                unprocessed_packet_batches::transactions_to_deserialized_packets(
+                    &transactions,
+                    false,
+                )
+                .unwrap();
             assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
             let mut buffered_packet_batches =
                 UnprocessedTransactionStorage::new_transaction_storage(
@@ -1793,8 +1796,11 @@ mod tests {
             let recorder = poh_recorder.read().unwrap().new_recorder();
             let num_conflicting_transactions = transactions.len();
             let deserialized_packets =
-                unprocessed_packet_batches::transactions_to_deserialized_packets(&transactions)
-                    .unwrap();
+                unprocessed_packet_batches::transactions_to_deserialized_packets(
+                    &transactions,
+                    false,
+                )
+                .unwrap();
             assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
             let mut buffered_packet_batches =
                 UnprocessedTransactionStorage::new_transaction_storage(
@@ -1846,8 +1852,11 @@ mod tests {
             let recorder = poh_recorder.read().unwrap().new_recorder();
             let num_conflicting_transactions = transactions.len();
             let deserialized_packets =
-                unprocessed_packet_batches::transactions_to_deserialized_packets(&transactions)
-                    .unwrap();
+                unprocessed_packet_batches::transactions_to_deserialized_packets(
+                    &transactions,
+                    false,
+                )
+                .unwrap();
             assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
             let retryable_packet = deserialized_packets[0].clone();
             let mut buffered_packet_batches =

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -356,7 +356,7 @@ mod tests {
             Hash::new_unique(),
         );
         let packet = Packet::from_data(None, tx).unwrap();
-        let deserialized_packet = DeserializedPacket::new(packet).unwrap();
+        let deserialized_packet = DeserializedPacket::new(packet, false).unwrap();
 
         let test_cases = vec![
             ("budget-restricted", DataBudget::restricted(), 0),
@@ -425,14 +425,14 @@ mod tests {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, fwd_block_hash);
             let mut packet = Packet::from_data(None, transaction).unwrap();
             packet.meta_mut().flags |= PacketFlags::FORWARDED;
-            DeserializedPacket::new(packet).unwrap()
+            DeserializedPacket::new(packet, false).unwrap()
         };
 
         let normal_block_hash = Hash::new_unique();
         let normal_packet = {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, normal_block_hash);
             let packet = Packet::from_data(None, transaction).unwrap();
-            DeserializedPacket::new(packet).unwrap()
+            DeserializedPacket::new(packet, false).unwrap()
         };
 
         let mut unprocessed_packet_batches = UnprocessedTransactionStorage::new_transaction_storage(

--- a/core/src/forward_packet_batches_by_accounts.rs
+++ b/core/src/forward_packet_batches_by_accounts.rs
@@ -163,7 +163,7 @@ mod tests {
         let tx_cost = CostModel::calculate_cost(&sanitized_transaction, &FeatureSet::all_enabled());
         let cost = tx_cost.sum();
         let deserialized_packet =
-            DeserializedPacket::new(Packet::from_data(None, transaction).unwrap()).unwrap();
+            DeserializedPacket::new(Packet::from_data(None, transaction).unwrap(), false).unwrap();
 
         // set limit ratio so each batch can only have one test transaction
         let limit_ratio: u32 =

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -46,7 +46,13 @@ pub struct ImmutableDeserializedPacket {
 }
 
 impl ImmutableDeserializedPacket {
-    pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
+    pub fn new(
+        packet: Packet,
+        // current working or root bank's feature gate status for supporting rounding
+        // compute-unit-price. This parameter can be removed once the feature is fully adapted in
+        // mainnet-beta.
+        support_round_compute_unit_price: bool,
+    ) -> Result<Self, DeserializedPacketError> {
         let versioned_transaction: VersionedTransaction = packet.deserialize_slice(..)?;
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
@@ -55,7 +61,7 @@ impl ImmutableDeserializedPacket {
 
         // drop transaction if prioritization fails.
         let mut priority_details = sanitized_transaction
-            .get_transaction_priority_details()
+            .get_transaction_priority_details(support_round_compute_unit_price)
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
 
         // set priority to zero for vote transactions

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -166,7 +166,7 @@ mod tests {
             Hash::new_unique(),
         );
         let packet = Packet::from_data(None, tx).unwrap();
-        let deserialized_packet = ImmutableDeserializedPacket::new(packet);
+        let deserialized_packet = ImmutableDeserializedPacket::new(packet, false);
 
         assert!(matches!(deserialized_packet, Ok(_)));
     }

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -33,12 +33,19 @@ pub struct LatestValidatorVotePacket {
 }
 
 impl LatestValidatorVotePacket {
-    pub fn new(packet: Packet, vote_source: VoteSource) -> Result<Self, DeserializedPacketError> {
+    pub fn new(
+        packet: Packet,
+        vote_source: VoteSource,
+        support_round_compute_unit_price: bool,
+    ) -> Result<Self, DeserializedPacketError> {
         if !packet.meta().is_simple_vote_tx() {
             return Err(DeserializedPacketError::VoteTransactionError);
         }
 
-        let vote = Arc::new(ImmutableDeserializedPacket::new(packet)?);
+        let vote = Arc::new(ImmutableDeserializedPacket::new(
+            packet,
+            support_round_compute_unit_price,
+        )?);
         Self::new_from_immutable(vote, vote_source)
     }
 

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -358,7 +358,7 @@ mod tests {
             .meta_mut()
             .flags
             .set(PacketFlags::SIMPLE_VOTE_TX, true);
-        LatestValidatorVotePacket::new(packet, vote_source).unwrap()
+        LatestValidatorVotePacket::new(packet, vote_source, false).unwrap()
     }
 
     fn deserialize_packets<'a>(
@@ -367,7 +367,8 @@ mod tests {
         vote_source: VoteSource,
     ) -> impl Iterator<Item = LatestValidatorVotePacket> + 'a {
         packet_indexes.iter().filter_map(move |packet_index| {
-            LatestValidatorVotePacket::new(packet_batch[*packet_index].clone(), vote_source).ok()
+            LatestValidatorVotePacket::new(packet_batch[*packet_index].clone(), vote_source, false)
+                .ok()
         })
     }
 

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_and_collect_packets_empty() {
-        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[]);
+        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[], false);
         assert_eq!(results.deserialized_packets.len(), 0);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 0);
@@ -188,6 +188,7 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
+            false,
         );
         assert_eq!(results.deserialized_packets.len(), 2);
         assert!(results.new_tracer_stats_option.is_none());
@@ -206,6 +207,7 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
+            false,
         );
         assert_eq!(results.deserialized_packets.len(), 1);
         assert!(results.new_tracer_stats_option.is_none());

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -26,8 +26,12 @@ impl DeserializedPacket {
         }
     }
 
-    pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
-        let immutable_section = ImmutableDeserializedPacket::new(packet)?;
+    pub fn new(
+        packet: Packet,
+        support_round_compute_unit_price: bool,
+    ) -> Result<Self, DeserializedPacketError> {
+        let immutable_section =
+            ImmutableDeserializedPacket::new(packet, support_round_compute_unit_price)?;
 
         Ok(Self {
             immutable_section: Arc::new(immutable_section),
@@ -293,20 +297,26 @@ impl UnprocessedPacketBatches {
 pub fn deserialize_packets<'a>(
     packet_batch: &'a PacketBatch,
     packet_indexes: &'a [usize],
+    support_round_compute_unit_price: bool,
 ) -> impl Iterator<Item = DeserializedPacket> + 'a {
     packet_indexes.iter().filter_map(move |packet_index| {
-        DeserializedPacket::new(packet_batch[*packet_index].clone()).ok()
+        DeserializedPacket::new(
+            packet_batch[*packet_index].clone(),
+            support_round_compute_unit_price,
+        )
+        .ok()
     })
 }
 
 pub fn transactions_to_deserialized_packets(
     transactions: &[Transaction],
+    support_round_compute_unit_price: bool,
 ) -> Result<Vec<DeserializedPacket>, DeserializedPacketError> {
     transactions
         .iter()
         .map(|transaction| {
             let packet = Packet::from_data(None, transaction)?;
-            DeserializedPacket::new(packet)
+            DeserializedPacket::new(packet, support_round_compute_unit_price)
         })
         .collect()
 }

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -345,7 +345,7 @@ mod tests {
             Hash::new_unique(),
         );
         let packet = Packet::from_data(None, tx).unwrap();
-        DeserializedPacket::new(packet).unwrap()
+        DeserializedPacket::new(packet, false).unwrap()
     }
 
     fn packet_with_priority_details(priority: u64, compute_unit_limit: u64) -> DeserializedPacket {
@@ -358,7 +358,7 @@ mod tests {
             ],
             Some(&from_account),
         ));
-        DeserializedPacket::new(Packet::from_data(None, tx).unwrap()).unwrap()
+        DeserializedPacket::new(Packet::from_data(None, tx).unwrap(), false).unwrap()
     }
 
     #[test]
@@ -474,7 +474,7 @@ mod tests {
 
         packet_vector
             .into_iter()
-            .map(|p| DeserializedPacket::new(p).unwrap())
+            .map(|p| DeserializedPacket::new(p, false).unwrap())
             .collect()
     }
 

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -1049,7 +1049,7 @@ mod tests {
                 let mut p = Packet::from_data(None, transaction).unwrap();
                 p.meta_mut().port = packets_id as u16;
                 p.meta_mut().set_tracer(true);
-                DeserializedPacket::new(p).unwrap()
+                DeserializedPacket::new(p, false).unwrap()
             })
             .collect_vec();
 
@@ -1194,9 +1194,9 @@ mod tests {
                 thread_type,
             );
             transaction_storage.insert_batch(vec![
-                ImmutableDeserializedPacket::new(small_transfer.clone())?,
-                ImmutableDeserializedPacket::new(vote.clone())?,
-                ImmutableDeserializedPacket::new(big_transfer.clone())?,
+                ImmutableDeserializedPacket::new(small_transfer.clone(), false)?,
+                ImmutableDeserializedPacket::new(vote.clone(), false)?,
+                ImmutableDeserializedPacket::new(big_transfer.clone(), false)?,
             ]);
             let deserialized_packets = transaction_storage
                 .iter()
@@ -1214,9 +1214,9 @@ mod tests {
                 vote_source,
             );
             transaction_storage.insert_batch(vec![
-                ImmutableDeserializedPacket::new(small_transfer.clone())?,
-                ImmutableDeserializedPacket::new(vote.clone())?,
-                ImmutableDeserializedPacket::new(big_transfer.clone())?,
+                ImmutableDeserializedPacket::new(small_transfer.clone(), false)?,
+                ImmutableDeserializedPacket::new(vote.clone(), false)?,
+                ImmutableDeserializedPacket::new(big_transfer.clone(), false)?,
             ]);
             assert_eq!(1, transaction_storage.len());
         }
@@ -1253,7 +1253,7 @@ mod tests {
                 let mut p = Packet::from_data(None, transaction).unwrap();
                 p.meta_mut().port = packets_id as u16;
                 p.meta_mut().set_tracer(true);
-                DeserializedPacket::new(p).unwrap()
+                DeserializedPacket::new(p, false).unwrap()
             })
             .collect_vec();
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -212,7 +212,9 @@ impl PrioritizationFeeCache {
                         continue;
                     }
 
-                    let priority_details = sanitized_transaction.get_transaction_priority_details();
+                    let support_round_compute_unit_price = false; // TODO read feature status from `bank`
+                    let priority_details = sanitized_transaction
+                        .get_transaction_priority_details(support_round_compute_unit_price);
                     let account_locks = sanitized_transaction
                         .get_account_locks(bank.get_transaction_account_lock_limit());
 

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -94,7 +94,7 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(),
+            sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: 0,
                 compute_unit_limit:
@@ -107,7 +107,7 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(),
+            sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: 0,
                 compute_unit_limit:
@@ -134,7 +134,7 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(),
+            sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: 0,
                 compute_unit_limit: requested_cu as u64,
@@ -145,7 +145,7 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(),
+            sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: 0,
                 compute_unit_limit: requested_cu as u64,
@@ -170,7 +170,7 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(),
+            sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: requested_price,
                 compute_unit_limit:
@@ -183,7 +183,7 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(),
+            sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
                 priority: requested_price,
                 compute_unit_limit:

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -14,10 +14,14 @@ pub struct TransactionPriorityDetails {
 }
 
 pub trait GetTransactionPriorityDetails {
-    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails>;
+    fn get_transaction_priority_details(
+        &self,
+        support_round_compute_unit_price: bool,
+    ) -> Option<TransactionPriorityDetails>;
 
     fn process_compute_budget_instruction<'a>(
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
+        _support_round_compute_unit_price: bool, // a feature gate status will be used by compute_budget.
     ) -> Option<TransactionPriorityDetails> {
         let mut compute_budget = ComputeBudget::default();
         let prioritization_fee_details = compute_budget
@@ -37,14 +41,26 @@ pub trait GetTransactionPriorityDetails {
 }
 
 impl GetTransactionPriorityDetails for SanitizedVersionedTransaction {
-    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails> {
-        Self::process_compute_budget_instruction(self.get_message().program_instructions_iter())
+    fn get_transaction_priority_details(
+        &self,
+        support_round_compute_unit_price: bool,
+    ) -> Option<TransactionPriorityDetails> {
+        Self::process_compute_budget_instruction(
+            self.get_message().program_instructions_iter(),
+            support_round_compute_unit_price,
+        )
     }
 }
 
 impl GetTransactionPriorityDetails for SanitizedTransaction {
-    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails> {
-        Self::process_compute_budget_instruction(self.message().program_instructions_iter())
+    fn get_transaction_priority_details(
+        &self,
+        support_round_compute_unit_price: bool,
+    ) -> Option<TransactionPriorityDetails> {
+        Self::process_compute_budget_instruction(
+            self.message().program_instructions_iter(),
+            support_round_compute_unit_price,
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem
Need to plumb bank feature status down to DeserializedPacket constructor to load priority details according to feature gate.

#### Summary of Changes
- plumbs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
