### PR TITLE
add block-sub argument to solana-test-validator

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -154,6 +154,7 @@ fn main() {
 
     let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
     let enable_vote_subscription = matches.is_present("rpc_pubsub_enable_vote_subscription");
+    let enable_block_subscription = matches.is_present("rpc_pubsub_enable_block_subscription");
     let faucet_port = value_t_or_exit!(matches, "faucet_port", u16);
     let ticks_per_slot = value_t!(matches, "ticks_per_slot", u64).ok();
     let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
@@ -440,6 +441,7 @@ fn main() {
         )
         .pubsub_config(PubSubConfig {
             enable_vote_subscription,
+            enable_block_subscription,
             ..PubSubConfig::default()
         })
         .rpc_port(rpc_port)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2148,6 +2148,12 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Enable the unstable RPC PubSub `voteSubscribe` subscription"),
         )
         .arg(
+            Arg::with_name("rpc_pubsub_enable_block_subscription")
+                .long("rpc-pubsub-enable-block-subscription")
+                .takes_value(false)
+                .help("Enable the unstable RPC PubSub `blockSubscribe` subscription"),
+        )
+        .arg(
             Arg::with_name("bpf_program")
                 .long("bpf-program")
                 .value_names(&["ADDRESS_OR_KEYPAIR", "SBF_PROGRAM.SO"])


### PR DESCRIPTION
#### Problem

current test-validator is missing the unstable block-sub argument 

#### Summary of Changes

this pr adds the cli argument and adds it to the pubsub config