### PR TITLE
Generalize matching criteria for tombstone at boot up

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -318,7 +318,7 @@ impl LoadedProgramsForTxBatch {
 
 pub enum LoadedProgramMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
-    Closed,
+    Tombstone,
     NoCriteria,
 }
 
@@ -410,9 +410,7 @@ impl LoadedPrograms {
             LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(slot) => {
                 program.deployment_slot >= *slot
             }
-            LoadedProgramMatchCriteria::Closed => {
-                matches!(program.program, LoadedProgramType::Closed)
-            }
+            LoadedProgramMatchCriteria::Tombstone => program.is_tombstone(),
             LoadedProgramMatchCriteria::NoCriteria => true,
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4461,7 +4461,7 @@ impl Bank {
                         (
                             *pubkey,
                             self.program_modification_slot(pubkey)
-                                .map_or(LoadedProgramMatchCriteria::Closed, |slot| {
+                                .map_or(LoadedProgramMatchCriteria::Tombstone, |slot| {
                                     LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(slot)
                                 }),
                         )


### PR DESCRIPTION
#### Problem
The tombstones fail to match at start up while running `ledger-tool`

#### Summary of Changes
The criteria to match against closed program is too restrictive. The tombstones were of `LoadedProgramType::FailedVerification` type. This PR generalizes the check to match against any type of tombstone.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
