### PR TITLE
Use current root slot to disambiguate pruning of old programs

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -386,7 +386,7 @@ impl LoadedPrograms {
                         matches!(relation, BlockRelation::Equal | BlockRelation::Descendant)
                     } else if !first_ancestor_found
                         && (matches!(relation, BlockRelation::Ancestor)
-                            || previous_root > entry.deployment_slot)
+                            || entry.deployment_slot < previous_root)
                     {
                         first_ancestor_found = true;
                         first_ancestor_found

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -668,6 +668,10 @@ impl ForkGraph for BankForks {
             })
             .unwrap_or(BlockRelation::Unknown)
     }
+
+    fn root(&self) -> Slot {
+        self.root()
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -668,10 +668,6 @@ impl ForkGraph for BankForks {
             })
             .unwrap_or(BlockRelation::Unknown)
     }
-
-    fn root(&self) -> Slot {
-        self.root()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
`ForkGraph` returns `BlockRelation::Unknown` for programs deployed before current root slot. That causes pruning of such programs from the cache.

#### Summary of Changes
The `bank_forks` retains slot relationship history till the current root. The pruning has the following logic.
1. `BankForks::set_root()` gets called when a new root slot is identified.
2. `set_root()` calls cache's `prune()` method before actually storing the new root slot (i.e. cache's view of ForkGraph still has the old root slot).
3. `prune()` calls `ForkGraph::relationship()` trait method on the BankForks object with new root, and program's deployment slot. 
   - If the deployment slot is descendant of the new root, it's retained in the cache.
   - If the deployment slot is an ancestor of the new root, it's retained in the cache (and first ancestor found flag is set). 
   - Otherwise, it's assumed that the cache entry is on a fork that doesn't connect to the new root, and the entry is pruned.

This logic doesn't work if the deployment slot is older than the current root. Ideally it should be an ancestor of the new root. But the BankForks doesn't have enough history to calculate this relationship, and returns `Unknown`.

3. `prune()` calls `ForkGraph::relationship()` trait method on the BankForks object with new root, and program's deployment slot. 
   - If the deployment slot is descendant of the new root, it's retained in the cache.
   - If the deployment slot is an ancestor of the new root,  
      ***or, the deployment slot is older than the previous root***, 
     it's retained in the cache (and first ancestor found flag is set). 
   - Otherwise, it's assumed that the cache entry is on a fork that doesn't connect to the new root, and the entry is pruned.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
