### PR TITLE
Refactor pass feature status to deserialized packet via packet meta

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -390,7 +390,8 @@ impl BankingStage {
                         ),
                     };
 
-                let mut packet_receiver = PacketReceiver::new(id, packet_receiver);
+                let mut packet_receiver =
+                    PacketReceiver::new(id, packet_receiver, bank_forks.clone());
                 let poh_recorder = poh_recorder.clone();
 
                 let committer = Committer::new(

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -10,8 +10,12 @@ use {
     },
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
+    solana_runtime::bank_forks::BankForks,
     solana_sdk::{saturating_add_assign, timing::timestamp},
-    std::{sync::atomic::Ordering, time::Duration},
+    std::{
+        sync::{atomic::Ordering, Arc, RwLock},
+        time::Duration,
+    },
 };
 
 pub struct PacketReceiver {
@@ -20,10 +24,14 @@ pub struct PacketReceiver {
 }
 
 impl PacketReceiver {
-    pub fn new(id: u32, banking_packet_receiver: BankingPacketReceiver) -> Self {
+    pub fn new(
+        id: u32,
+        banking_packet_receiver: BankingPacketReceiver,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> Self {
         Self {
             id,
-            packet_deserializer: PacketDeserializer::new(banking_packet_receiver),
+            packet_deserializer: PacketDeserializer::new(banking_packet_receiver, bank_forks),
         }
     }
 

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -55,7 +55,7 @@ impl ImmutableDeserializedPacket {
 
         // drop transaction if prioritization fails.
         let mut priority_details = sanitized_transaction
-            .get_transaction_priority_details()
+            .get_transaction_priority_details(packet.meta().round_compute_unit_price())
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
 
         // set priority to zero for vote transactions

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -54,8 +54,8 @@ impl PacketDeserializer {
         let (packet_count, packet_batches) = self.receive_until(recv_timeout, capacity)?;
 
         // get current root bank to get feature gate status
-        let _root_bank = self.bank_forks.read().unwrap().root_bank();
-        let round_compute_unit_price_enabled = false; // TODO get from root_bank.feature_set
+        let _working_bank = self.bank_forks.read().unwrap().working_bank();
+        let round_compute_unit_price_enabled = false; // TODO get from working_bank.feature_set
 
         Ok(Self::deserialize_and_collect_packets(
             packet_count,

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -53,7 +53,8 @@ impl PacketDeserializer {
     ) -> Result<ReceivePacketResults, RecvTimeoutError> {
         let (packet_count, packet_batches) = self.receive_until(recv_timeout, capacity)?;
 
-        // get current root bank to get feature gate status
+        // Note: this can be removed after feature `round_compute_unit_price` is activated in
+        // mainnet-beta
         let _working_bank = self.bank_forks.read().unwrap().working_bank();
         let round_compute_unit_price_enabled = false; // TODO get from working_bank.feature_set
 

--- a/core/src/packet_deserializer.rs
+++ b/core/src/packet_deserializer.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_and_collect_packets_empty() {
-        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[]);
+        let results = PacketDeserializer::deserialize_and_collect_packets(0, &[], false);
         assert_eq!(results.deserialized_packets.len(), 0);
         assert!(results.new_tracer_stats_option.is_none());
         assert_eq!(results.passed_sigverify_count, 0);
@@ -202,6 +202,7 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
+            false,
         );
         assert_eq!(results.deserialized_packets.len(), 2);
         assert!(results.new_tracer_stats_option.is_none());
@@ -220,6 +221,7 @@ mod tests {
         let results = PacketDeserializer::deserialize_and_collect_packets(
             packet_count,
             &[BankingPacketBatch::new((packet_batches, None))],
+            false,
         );
         assert_eq!(results.deserialized_packets.len(), 1);
         assert!(results.new_tracer_stats_option.is_none());

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -212,7 +212,9 @@ impl PrioritizationFeeCache {
                         continue;
                     }
 
-                    let priority_details = sanitized_transaction.get_transaction_priority_details();
+                    let round_compute_unit_price_enabled = false; // TODO: bank.feture_set.is_active(...)
+                    let priority_details = sanitized_transaction
+                        .get_transaction_priority_details(round_compute_unit_price_enabled);
                     let account_locks = sanitized_transaction
                         .get_account_locks(bank.get_transaction_account_lock_limit());
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -212,7 +212,7 @@ impl PrioritizationFeeCache {
                         continue;
                     }
 
-                    let round_compute_unit_price_enabled = false; // TODO: bank.feture_set.is_active(...)
+                    let round_compute_unit_price_enabled = false; // TODO: bank.feture_set.is_active(round_compute_unit_price)
                     let priority_details = sanitized_transaction
                         .get_transaction_priority_details(round_compute_unit_price_enabled);
                     let account_locks = sanitized_transaction

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -29,6 +29,10 @@ bitflags! {
         const REPAIR         = 0b0000_0100;
         const SIMPLE_VOTE_TX = 0b0000_1000;
         const TRACER_PACKET  = 0b0001_0000;
+        /// to be set by bank.feature_set.is_active(round_compute_unit_price::id()) at the moment
+        /// the packet is built.
+        /// This field can be removed when the above feature gate is adopted by mainnet-beta.
+        const ROUND_COMPUTE_UNIT_PRICE = 0b0010_0000;
     }
 }
 
@@ -215,6 +219,14 @@ impl Meta {
     }
 
     #[inline]
+    pub fn set_round_compute_unit_price(&mut self, round_compute_unit_price: bool) {
+        self.flags.set(
+            PacketFlags::ROUND_COMPUTE_UNIT_PRICE,
+            round_compute_unit_price,
+        );
+    }
+
+    #[inline]
     pub fn forwarded(&self) -> bool {
         self.flags.contains(PacketFlags::FORWARDED)
     }
@@ -232,6 +244,11 @@ impl Meta {
     #[inline]
     pub fn is_tracer_packet(&self) -> bool {
         self.flags.contains(PacketFlags::TRACER_PACKET)
+    }
+
+    #[inline]
+    pub fn round_compute_unit_price(&self) -> bool {
+        self.flags.contains(PacketFlags::ROUND_COMPUTE_UNIT_PRICE)
     }
 }
 


### PR DESCRIPTION
#### Problem
Passing current root_bank's feature status from packet_receiver to ImmutableDeserializedPacket is cumbersome. The plumbing go through many level call stacks (poc #31543). 

Another possibility is to add an additional flag to `Packet`, which is set by root bank feature status at the moment of packet deserialization. So the feature status goes with packet instead of passing multiple layers of calls. It'd also make removing feature code easier when it's fully activated.

#### Summary of Changes
- add `round-compute-unit-price` flag to `Packet`
- `PacketDeserializer` uses `bank_fork` to get root_bank's feature set status

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
