### PR TITLE
Purges incomplete snapshot dirs at startup

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -554,6 +554,8 @@ impl Validator {
         start.stop();
         info!("done. {}", start);
 
+        snapshot_utils::purge_incomplete_bank_snapshots(&config.snapshot_config.bank_snapshots_dir);
+
         info!("Cleaning orphaned account snapshot directories..");
         if let Err(e) = clean_orphaned_account_snapshot_dirs(
             &config.snapshot_config.bank_snapshots_dir,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -192,6 +192,8 @@ pub fn load_bank_forks(
     measure.stop();
     info!("done. {}", measure);
 
+    snapshot_utils::purge_incomplete_bank_snapshots(&bank_snapshots_dir);
+
     info!(
         "Cleaning contents of account snapshot paths: {:?}",
         account_snapshot_paths


### PR DESCRIPTION
#### Problem

Bank snapshots are not cleaned up properly. 

PR #31511 had to be reverted due to how code in `BankSnapshotInfo::new_from_dir()` deletes directories that it is unable to read. I'd argue `new_from_dir` should never alter the filesystem. Instead, we should purge any/all incomplete bank snapshots at startup. Then (1) we only have to do it once, and (2) I can un-revert #31511. 

#### Summary of Changes

Purge all incomplete bank snapshots at startup for both validator and ledger-tool.

Note: Subsequent PRs will handle changing `new_from_dir` and also un-reverting #31511.