### PR TITLE
Do not remove bank snapshots in new_from_dir()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -191,14 +191,7 @@ impl BankSnapshotInfo {
 
         // There is a time window from the slot directory being created, and the content being completely
         // filled.  Check the completion to avoid using a highest found slot directory with missing content.
-        let completion_flag_file = bank_snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
-        if !completion_flag_file.is_file() {
-            // If the directory is incomplete, it should be removed.
-            // There are also possible hardlink files under <account_path>/snapshot/<slot>/, referred by this
-            // snapshot dir's symlinks.  They are cleaned up in clean_orphaned_account_snapshot_dirs() at the
-            // boot time.
-            info!("Removing incomplete snapshot dir: {:?}", bank_snapshot_dir);
-            fs::remove_dir_all(&bank_snapshot_dir)?;
+        if !is_bank_snapshot_complete(&bank_snapshot_dir) {
             return Err(SnapshotNewFromDirError::IncompleteDir(bank_snapshot_dir));
         }
 
@@ -5224,8 +5217,6 @@ mod tests {
         assert!(snapshot_dir_4.exists());
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 3);
-        // The incomplete snapshot dir should have been deleted
-        assert!(!snapshot_dir_4.exists());
 
         let snapshot_version_file = snapshot.snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
         fs::remove_file(snapshot_version_file).unwrap();


### PR DESCRIPTION
#### Problem

#31511 was reverted because `BankSnapshotInfo::new_from_dir()` also removes bank snapshot directories. There is (was, in 31511) a race condition where AccountsBackgroundService is taking a new bank snapshot, and SnapshotPackagerService is looking up all the current bank snapshots. This lookup calls `new_from_dir()`, which sees an "incomplete" bank snapshot dir and tries to delete it, which then causes ABS to fail because it wasn't able to take the snapshot.

Now that we have #31555, there will not be any incomplete bank snapshots (as they will be cleaned up at startup), so we don't need to check/remove inside of `new_from_dir()`.

#### Summary of Changes

Remove the code in `BankSnapshotInfo::new_from_dir()` that would delete incomplete snapshot dirs.