### PR TITLE
Cleanup - `add_compute_budget_program` and `versioned_tx_message_enabled`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7461,11 +7461,6 @@ impl Bank {
             .is_active(&feature_set::prevent_rent_paying_rent_recipients::id())
     }
 
-    pub fn versioned_tx_message_enabled(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::versioned_tx_message_enabled::id())
-    }
-
     pub fn credits_auto_rewind(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::credits_auto_rewind::id())

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -15,10 +15,6 @@ impl AddressLoader for &Bank {
         self,
         address_table_lookups: &[MessageAddressTableLookup],
     ) -> Result<LoadedAddresses, AddressLoaderError> {
-        if !self.versioned_tx_message_enabled() {
-            return Err(AddressLoaderError::Disabled);
-        }
-
         let slot_hashes = self
             .sysvar_cache
             .read()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6697,25 +6697,25 @@ fn test_bank_hash_consistency() {
         if bank.slot == 0 {
             assert_eq!(
                 bank.hash().to_string(),
-                "FVZwMQ5YJiivwGctYDvPcoQrTECbUaNcmTnJeFDdb1a3"
+                "3kzRo3M5q9j47Dxfdp9ZeEXfUTA5rxVud7jRKuttHxFz"
             );
         }
         if bank.slot == 32 {
             assert_eq!(
                 bank.hash().to_string(),
-                "5AMuFif3LzgsBV8JXGVwdJpHbpZpYKRtcvyrfZjhMGvx"
+                "bWPR5AQjsfhMypn1nLUjugmitbjHwV4rmnyTDFqCdv1"
             );
         }
         if bank.slot == 64 {
             assert_eq!(
                 bank.hash().to_string(),
-                "GDmYzhnPdXoFLvbr88vPoVF5EYyUbCZJLMWBG9JJv8DQ"
+                "74hNYEVcvKU5JZwSNBYUcUWgf9Jw2Mag4b55967VPVjG"
             );
         }
         if bank.slot == 128 {
             assert_eq!(
                 bank.hash().to_string(),
-                "J6Q2ng27mQMyDF2g7CbKSQDwZAeeaNnkUUZifax3FR9Y"
+                "BvYViztQiksU8vDvMqZYBo9Lc4cgjJEmijPpqktBRMkS"
             );
             break;
         }
@@ -6942,7 +6942,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![14, 1, 7]);
+    assert_eq!(alive_counts, vec![16, 1, 7]);
 }
 
 #[test]

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -133,37 +133,33 @@ fn genesis_builtins() -> Vec<(Pubkey, Arc<LoadedProgram>)> {
                 solana_bpf_loader_program::process_instruction,
             ),
         ),
+        (
+            solana_sdk::compute_budget::id(),
+            create_builtin(
+                "compute_budget_program".to_string(),
+                solana_compute_budget_program::process_instruction,
+            ),
+        ),
+        (
+            solana_address_lookup_table_program::id(),
+            create_builtin(
+                "address_lookup_table_program".to_string(),
+                solana_address_lookup_table_program::processor::process_instruction,
+            ),
+        ),
     ]
 }
 
 /// Dynamic feature transitions for builtin programs
 fn builtin_feature_transitions() -> Vec<BuiltinFeatureTransition> {
-    vec![
-        BuiltinFeatureTransition::Add {
-            program_id: solana_sdk::compute_budget::id(),
-            builtin: create_builtin(
-                "compute_budget_program".to_string(),
-                solana_compute_budget_program::process_instruction,
-            ),
-            feature_id: feature_set::add_compute_budget_program::id(),
-        },
-        BuiltinFeatureTransition::Add {
-            program_id: solana_address_lookup_table_program::id(),
-            builtin: create_builtin(
-                "address_lookup_table_program".to_string(),
-                solana_address_lookup_table_program::processor::process_instruction,
-            ),
-            feature_id: feature_set::versioned_tx_message_enabled::id(),
-        },
-        BuiltinFeatureTransition::Add {
-            program_id: solana_zk_token_sdk::zk_token_proof_program::id(),
-            builtin: create_builtin(
-                "zk_token_proof_program".to_string(),
-                solana_zk_token_proof_program::process_instruction,
-            ),
-            feature_id: feature_set::zk_token_sdk_enabled::id(),
-        },
-    ]
+    vec![BuiltinFeatureTransition::Add {
+        program_id: solana_zk_token_sdk::zk_token_proof_program::id(),
+        builtin: create_builtin(
+            "zk_token_proof_program".to_string(),
+            solana_zk_token_proof_program::process_instruction,
+        ),
+        feature_id: feature_set::zk_token_sdk_enabled::id(),
+    }]
 }
 
 pub(crate) fn get() -> Builtins {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -26,7 +26,7 @@ pub fn bootstrap_validator_stake_lamports() -> u64 {
 
 // Number of lamports automatically used for genesis accounts
 pub const fn genesis_sysvar_and_builtin_program_lamports() -> u64 {
-    const NUM_BUILTIN_PROGRAMS: u64 = 7;
+    const NUM_BUILTIN_PROGRAMS: u64 = 9;
     const NUM_PRECOMPILES: u64 = 2;
     const FEES_SYSVAR_MIN_BALANCE: u64 = 946_560;
     const STAKE_HISTORY_MIN_BALANCE: u64 = 114_979_200;


### PR DESCRIPTION
#### Problem
`add_compute_budget_program` and `versioned_tx_message_enabled` are enabled on MNB and their feature gates can be removed.

#### Summary of Changes
- Moves `compute_budget_program` and `address_lookup_table_program` into `genesis_builtins()`.
- Removes feature gate of `versioned_tx_message_enabled`.