### PR TITLE
ci: make mergify only remove automerge when PR hasn't been merged

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -63,8 +63,10 @@ pull_request_rules:
         method: squash
   - name: remove automerge label on CI failure
     conditions:
-      - label=automerge
-      - "#status-failure!=0"
+      - and:
+        - label=automerge
+        - "#status-failure!=0"
+        - -merged
     actions:
       label:
         remove:


### PR DESCRIPTION
#### Problem

when we try to trigger mergify to an existing PR, it may remove its automerge label.

I do some test for 

https://www.github.com/solana-labs/solana/pull/31196
https://www.github.com/solana-labs/solana/pull/31407 

the status of the latest commit in 31196 is green. mergify just ignore it.
the status of the latest commit in 31407 is red. when we try to trigger mergify again, it scan all rule and remove its `automerge` label

the event log on Mergify
<img width="760" alt="Screenshot 2023-05-10 at 11 42 44 PM" src="https://github.com/solana-labs/solana/assets/8209234/8e9fda96-a3ec-4d55-b576-657674757c06">


#### Summary of Changes

prevent mergify from removing `automerge` label when a PR has been merged.

Close #31562 