### PR TITLE
Add stats for LoadedPrograms

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -150,7 +150,7 @@ pub fn load_program_from_account(
     program: &BorrowedAccount,
     programdata: &BorrowedAccount,
     debugging_features: bool,
-) -> Result<(Arc<LoadedProgram>, Option<LoadProgramMetrics>), InstructionError> {
+) -> Result<(Arc<LoadedProgram>, LoadProgramMetrics), InstructionError> {
     if !check_loader_id(program.get_owner()) {
         ic_logger_msg!(
             log_collector,
@@ -189,7 +189,7 @@ pub fn load_program_from_account(
         debugging_features,
     )?);
 
-    Ok((loaded_program, Some(load_program_metrics)))
+    Ok((loaded_program, load_program_metrics))
 }
 
 fn find_program_in_cache(


### PR DESCRIPTION
#### Problem
The new `LoadedPrograms` cache does not have stats.

#### Summary of Changes
Reimplemented stats from `ExecutorCache` in `LoadedPrograms`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
