### PR TITLE
pass include_slot_in_hash through hash calcs to allow rehashing if hash is not stored

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
+
 #[macro_use]
 extern crate log;
 use {
@@ -9,7 +10,7 @@ use {
         accounts::Accounts,
         accounts_db::{
             test_utils::{create_test_accounts, update_accounts_bench},
-            AccountShrinkThreshold, CalcAccountsHashDataSource,
+            AccountShrinkThreshold, CalcAccountsHashDataSource, INCLUDE_SLOT_IN_HASH_TESTS,
         },
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
@@ -133,6 +134,7 @@ fn main() {
                 &EpochSchedule::default(),
                 &RentCollector::default(),
                 true,
+                INCLUDE_SLOT_IN_HASH_TESTS,
             );
             time_store.stop();
             if results != results_store {

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -334,6 +334,7 @@ impl AccountsHashVerifier {
             epoch_schedule: &accounts_package.epoch_schedule,
             rent_collector: &accounts_package.rent_collector,
             store_detailed_debug_info_on_failure: false,
+            include_slot_in_hash: accounts_package.include_slot_in_hash,
         };
 
         let ((accounts_hash, lamports), measure_hash_us) = measure_us!(accounts_package
@@ -428,6 +429,7 @@ impl AccountsHashVerifier {
             epoch_schedule: &accounts_package.epoch_schedule,
             rent_collector: &accounts_package.rent_collector,
             store_detailed_debug_info_on_failure: false,
+            include_slot_in_hash: accounts_package.include_slot_in_hash,
         };
 
         let (incremental_accounts_hash, measure_hash_us) = measure_us!(

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -12,7 +12,9 @@ use {
             AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
-        accounts_db::{AccountShrinkThreshold, CalcAccountsHashDataSource},
+        accounts_db::{
+            AccountShrinkThreshold, CalcAccountsHashDataSource, INCLUDE_SLOT_IN_HASH_TESTS,
+        },
         accounts_hash::CalcAccountsHashConfig,
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankTestConfig},
@@ -317,6 +319,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                         epoch_schedule: bank.epoch_schedule(),
                         rent_collector: bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
+                        include_slot_in_hash: INCLUDE_SLOT_IN_HASH_TESTS,
                     },
                 )
                 .unwrap();

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -11,7 +11,7 @@ use {
         accounts::{AccountAddressFilter, Accounts},
         accounts_db::{
             test_utils::create_test_accounts, AccountShrinkThreshold,
-            VerifyAccountsHashAndLamportsConfig,
+            VerifyAccountsHashAndLamportsConfig, INCLUDE_SLOT_IN_HASH_TESTS,
         },
         accounts_index::{AccountSecondaryIndexes, ScanConfig},
         ancestors::Ancestors,
@@ -114,6 +114,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
                 ignore_mismatch: false,
                 store_detailed_debug_info: false,
                 use_bg_thread_pool: false,
+                include_slot_in_hash: INCLUDE_SLOT_IN_HASH_TESTS,
             }
         ))
     });

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -333,6 +333,7 @@ impl SnapshotRequestHandler {
                         epoch_schedule: snapshot_root_bank.epoch_schedule(),
                         rent_collector: snapshot_root_bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
+                        include_slot_in_hash: snapshot_root_bank.include_slot_in_hash(),
                     },
                 )
                 .unwrap();

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_db::{AccountStorageEntry, PUBKEY_BINS_FOR_CALCULATING_HASHES},
+        accounts_db::{AccountStorageEntry, IncludeSlotInHash, PUBKEY_BINS_FOR_CALCULATING_HASHES},
         ancestors::Ancestors,
         rent_collector::RentCollector,
     },
@@ -101,7 +101,6 @@ pub struct CalcAccountsHashConfig<'a> {
     /// true to use a thread pool dedicated to bg operations
     pub use_bg_thread_pool: bool,
     /// verify every hash in append vec/write cache with a recalculated hash
-    /// this option will be removed
     pub check_hash: bool,
     /// 'ancestors' is used to get storages
     pub ancestors: Option<&'a Ancestors>,
@@ -111,6 +110,7 @@ pub struct CalcAccountsHashConfig<'a> {
     pub rent_collector: &'a RentCollector,
     /// used for tracking down hash mismatches after the fact
     pub store_detailed_debug_info_on_failure: bool,
+    pub include_slot_in_hash: IncludeSlotInHash,
 }
 
 // smallest, 3 quartiles, largest, average

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5565,7 +5565,7 @@ impl Bank {
     }
 
     /// true if we should include the slot in account hash
-    /// This is goverened by a feature.
+    /// This is governed by a feature.
     pub(crate) fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         if self
             .feature_set

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5565,7 +5565,7 @@ impl Bank {
     }
 
     /// true if we should include the slot in account hash
-    /// This is goverend by a feature.
+    /// This is goverened by a feature.
     pub(crate) fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         if self
             .feature_set

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5565,7 +5565,8 @@ impl Bank {
     }
 
     /// true if we should include the slot in account hash
-    fn include_slot_in_hash(&self) -> IncludeSlotInHash {
+    /// This is goverend by a feature.
+    pub(crate) fn include_slot_in_hash(&self) -> IncludeSlotInHash {
         if self
             .feature_set
             .is_active(&feature_set::account_hash_ignore_slot::id())
@@ -6662,6 +6663,7 @@ impl Bank {
         let cap = self.capitalization();
         let epoch_schedule = self.epoch_schedule();
         let rent_collector = self.rent_collector();
+        let include_slot_in_hash = self.include_slot_in_hash();
         if config.run_in_background {
             let ancestors = ancestors.clone();
             let accounts = Arc::clone(accounts);
@@ -6687,6 +6689,7 @@ impl Bank {
                                 ignore_mismatch: config.ignore_mismatch,
                                 store_detailed_debug_info: config.store_hash_raw_data_for_debug,
                                 use_bg_thread_pool: true,
+                                include_slot_in_hash,
                             },
                         );
                         accounts_
@@ -6711,6 +6714,7 @@ impl Bank {
                     ignore_mismatch: config.ignore_mismatch,
                     store_detailed_debug_info: config.store_hash_raw_data_for_debug,
                     use_bg_thread_pool: false, // fg is waiting for this to run, so we can use the fg thread pool
+                    include_slot_in_hash,
                 },
             );
             self.set_initial_accounts_hash_verification_completed();
@@ -6848,6 +6852,7 @@ impl Bank {
                 self.epoch_schedule(),
                 &self.rent_collector,
                 is_startup,
+                self.include_slot_in_hash(),
             )
             .1
     }
@@ -6936,6 +6941,7 @@ impl Bank {
             self.epoch_schedule(),
             &self.rent_collector,
             is_startup,
+            self.include_slot_in_hash(),
         );
         if total_lamports != self.capitalization() {
             datapoint_info!(
@@ -6958,6 +6964,7 @@ impl Bank {
                     self.epoch_schedule(),
                     &self.rent_collector,
                     is_startup,
+                    self.include_slot_in_hash(),
                 );
             }
 
@@ -6984,6 +6991,7 @@ impl Bank {
             epoch_schedule: &self.epoch_schedule,
             rent_collector: &self.rent_collector,
             store_detailed_debug_info_on_failure: false,
+            include_slot_in_hash: self.include_slot_in_hash(),
         };
         let storages = self.get_snapshot_storages(Some(base_slot));
         let sorted_storages = SortedStorages::new(&storages);

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         accounts::Accounts,
-        accounts_db::AccountStorageEntry,
+        accounts_db::{AccountStorageEntry, IncludeSlotInHash, INCLUDE_SLOT_IN_HASH_TESTS},
         accounts_hash::{AccountsHash, AccountsHashEnum},
         bank::Bank,
         epoch_accounts_hash::EpochAccountsHash,
@@ -41,6 +41,7 @@ pub struct AccountsPackage {
     /// The instant this accounts package was send to the queue.
     /// Used to track how long accounts packages wait before processing.
     pub enqueued: Instant,
+    pub include_slot_in_hash: IncludeSlotInHash,
 }
 
 impl AccountsPackage {
@@ -133,6 +134,7 @@ impl AccountsPackage {
             is_incremental_accounts_hash_feature_enabled,
             snapshot_info,
             enqueued: Instant::now(),
+            include_slot_in_hash: bank.include_slot_in_hash(),
         }
     }
 
@@ -159,6 +161,7 @@ impl AccountsPackage {
                 epoch_accounts_hash: Option::default(),
             }),
             enqueued: Instant::now(),
+            include_slot_in_hash: INCLUDE_SLOT_IN_HASH_TESTS,
         }
     }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -132,9 +132,9 @@ impl AccountsPackage {
             epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
             is_incremental_accounts_hash_feature_enabled,
+            include_slot_in_hash: bank.include_slot_in_hash(),
             snapshot_info,
             enqueued: Instant::now(),
-            include_slot_in_hash: bank.include_slot_in_hash(),
         }
     }
 
@@ -152,6 +152,7 @@ impl AccountsPackage {
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),
             is_incremental_accounts_hash_feature_enabled: bool::default(),
+            include_slot_in_hash: INCLUDE_SLOT_IN_HASH_TESTS,
             snapshot_info: Some(SupplementalSnapshotInfo {
                 bank_snapshot_dir: PathBuf::default(),
                 archive_format: ArchiveFormat::Tar,
@@ -161,7 +162,6 @@ impl AccountsPackage {
                 epoch_accounts_hash: Option::default(),
             }),
             enqueued: Instant::now(),
-            include_slot_in_hash: INCLUDE_SLOT_IN_HASH_TESTS,
         }
     }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -34,6 +34,7 @@ pub struct AccountsPackage {
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
     pub is_incremental_accounts_hash_feature_enabled: bool,
+    pub include_slot_in_hash: IncludeSlotInHash,
 
     /// Supplemental information needed for snapshots
     pub snapshot_info: Option<SupplementalSnapshotInfo>,
@@ -41,7 +42,6 @@ pub struct AccountsPackage {
     /// The instant this accounts package was send to the queue.
     /// Used to track how long accounts packages wait before processing.
     pub enqueued: Instant,
-    pub include_slot_in_hash: IncludeSlotInHash,
 }
 
 impl AccountsPackage {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5508,6 +5508,7 @@ mod tests {
                     epoch_schedule: deserialized_bank.epoch_schedule(),
                     rent_collector: deserialized_bank.rent_collector(),
                     store_detailed_debug_info_on_failure: false,
+                    include_slot_in_hash: bank.include_slot_in_hash(),
                 },
                 &SortedStorages::new(&other_incremental_snapshot_storages),
                 HashStats::default(),


### PR DESCRIPTION
#### Problem
We want to stop storing an account's hash in append vecs. But, we still need the hash for the full accounts hash calculation.

#### Summary of Changes
Pass through `include_slot_in_hash` to all accounts hash calculation functions so we can correctly calculate an account's hash.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
