### PR TITLE
Bump librocksdb-sys to 0.8.3 and bindgen to 0.64.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -624,6 +624,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2780,9 +2781,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
  "bindgen",
  "bzip2-sys",


### PR DESCRIPTION
Fixes builds when using llvm16 systems

#### Problem
Would get error:
```
thread 'main' panicked at '"enum_(unnamed_at_rocksdb/include/rocksdb/c_h_981_1)" is not a valid Ident'
```
when attempting to build the bins.

Ref:
https://github.com/rust-rocksdb/rust-rocksdb/issues/713


#### Summary of Changes
Bumps librocksdb-sys to 0.8.3
and bindgen to 0.64.0
in the Cargo.lock
