### PR TITLE
ledger-tool: fix program disassemble

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -332,7 +332,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     }
     let (action, matches) = match matches.subcommand() {
         ("cfg", Some(arg_matches)) => (Action::Cfg, arg_matches),
-        ("disassembler", Some(arg_matches)) => (Action::Dis, arg_matches),
+        ("disassemble", Some(arg_matches)) => (Action::Dis, arg_matches),
         ("run", Some(arg_matches)) => (Action::Run, arg_matches),
         _ => unreachable!(),
     };

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
         r##"rbpf-cli is replaced by solana-ledger-tool run subcommand.
-Please, use 'solana-ledger-tool run --help' for more information."##
+Please, use 'solana-ledger-tool program run --help' for more information."##
     );
 }


### PR DESCRIPTION
#### Problem

- error message in rbpf-cli is wrong
- ledger-tool program disassemble subcommand is broken (clap checks for "disassemble", solana checks for "disassembler")

#### Summary of Changes

- fixes rbpf-cli error message
- fixes ledger-tool program disassemble cli handling

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
