### PR TITLE
[zk-token-sdk] Generalize encryption key derivation from signers and update random AeKey generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,6 +7128,7 @@ dependencies = [
  "solana-sdk",
  "subtle",
  "thiserror",
+ "tiny-bip39",
  "zeroize",
 ]
 

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -14,6 +14,9 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-program = { workspace = true }
 
+[dev-dependencies]
+tiny-bip39 = { workspace = true }
+
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
 arrayref = { workspace = true }

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -7,7 +7,7 @@ use {
         aead::{Aead, NewAead},
         Aes128GcmSiv,
     },
-    rand::{rngs::OsRng, CryptoRng, Rng, RngCore},
+    rand::{rngs::OsRng, Rng},
     thiserror::Error,
 };
 use {
@@ -43,8 +43,8 @@ pub enum AuthenticatedEncryptionError {
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {
     #[cfg(not(target_os = "solana"))]
-    fn keygen<T: RngCore + CryptoRng>(rng: &mut T) -> AeKey {
-        AeKey(rng.gen::<[u8; 16]>())
+    fn keygen() -> AeKey {
+        AeKey(OsRng.gen::<[u8; 16]>())
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -104,8 +104,8 @@ impl AeKey {
         Ok(result.to_vec())
     }
 
-    pub fn random<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        AuthenticatedEncryption::keygen(rng)
+    pub fn new_rand() -> Self {
+        AuthenticatedEncryption::keygen()
     }
 
     pub fn encrypt(&self, amount: u64) -> AeCiphertext {
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_aes_encrypt_decrypt_correctness() {
-        let key = AeKey::random(&mut OsRng);
+        let key = AeKey::new_rand();
         let amount = 55;
 
         let ct = key.encrypt(amount);

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -1,6 +1,7 @@
 //! Authenticated encryption implementation.
 //!
-//! This module is a simple wrapper of the `Aes128GcmSiv` implementation.
+//! This module is a simple wrapper of the `Aes128GcmSiv` implementation specialized for SPL
+//! token-2022 where the plaintext is always `u64`.
 #[cfg(not(target_os = "solana"))]
 use {
     aes_gcm_siv::{
@@ -42,11 +43,16 @@ pub enum AuthenticatedEncryptionError {
 
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {
+    /// Generates an authenticated encryption key.
+    ///
+    /// This function is randomized. It internally samples a 128-bit key using `OsRng`.
     #[cfg(not(target_os = "solana"))]
     fn keygen() -> AeKey {
         AeKey(OsRng.gen::<[u8; 16]>())
     }
 
+    /// On input an authenticated encryption key and an amount, the function returns a
+    /// corresponding authenticated encryption ciphertext.
     #[cfg(not(target_os = "solana"))]
     fn encrypt(key: &AeKey, balance: u64) -> AeCiphertext {
         let mut plaintext = balance.to_le_bytes();
@@ -65,6 +71,8 @@ impl AuthenticatedEncryption {
         }
     }
 
+    /// On input an authenticated encryption key and a ciphertext, the function returns the
+    /// originally encrypted amount.
     #[cfg(not(target_os = "solana"))]
     fn decrypt(key: &AeKey, ct: &AeCiphertext) -> Option<u64> {
         let plaintext =
@@ -82,11 +90,17 @@ impl AuthenticatedEncryption {
 #[derive(Debug, Zeroize)]
 pub struct AeKey([u8; 16]);
 impl AeKey {
+    /// Deterministically derives an authenticated encryption key from a Solana signer and a tag.
+    ///
+    /// This function exists for applications where a user may not wish to maintain a Solana signer
+    /// and an authenticated encryption key separately. Instead, a user can derive the ElGamal
+    /// keypair on-the-fly whenever encrytion/decryption is needed.
     pub fn new_from_signer(signer: &dyn Signer, tag: &[u8]) -> Result<Self, Box<dyn error::Error>> {
         let seed = Self::seed_from_signer(signer, tag)?;
         Self::from_seed(&seed)
     }
 
+    /// Derive a seed from a Solana signer used to generate an authenticated encryption key.
     pub fn seed_from_signer(signer: &dyn Signer, tag: &[u8]) -> Result<Vec<u8>, SignerError> {
         let message = [b"AeKey", tag].concat();
         let signature = signer.try_sign_message(&message)?;
@@ -104,14 +118,19 @@ impl AeKey {
         Ok(result.to_vec())
     }
 
+    /// Generates a random authenticated encryption key.
+    ///
+    /// This function is randomized. It internally samples a scalar element using `OsRng`.
     pub fn new_rand() -> Self {
         AuthenticatedEncryption::keygen()
     }
 
+    /// Encrypts an amount under the authenticated encryption key.
     pub fn encrypt(&self, amount: u64) -> AeCiphertext {
         AuthenticatedEncryption::encrypt(self, amount)
     }
 
+    /// Recovers an encrypted amount from an authenticated encryption ciphertext.
     pub fn decrypt(&self, ct: &AeCiphertext) -> Option<u64> {
         AuthenticatedEncryption::decrypt(self, ct)
     }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -28,9 +28,6 @@ use {
     serde::{Deserialize, Serialize},
     solana_sdk::{
         derivation_path::DerivationPath,
-        instruction::Instruction,
-        message::Message,
-        pubkey::Pubkey,
         signature::Signature,
         signer::{
             keypair::generate_seed_from_seed_phrase_and_passphrase, EncodableKey, EncodableKeypair,
@@ -45,7 +42,7 @@ use {
 #[cfg(not(target_os = "solana"))]
 use {
     rand::rngs::OsRng,
-    sha3::Sha3_512,
+    sha3::{Digest, Sha3_512},
     std::{
         error, fmt,
         io::{Read, Write},
@@ -162,24 +159,22 @@ pub struct ElGamalKeypair {
 }
 
 impl ElGamalKeypair {
-    /// Deterministically derives an ElGamal keypair from an Ed25519 signing key and a Solana
-    /// address.
+    /// Deterministically derives an ElGamal keypair from a Solana signer and a tag.
     ///
-    /// This function exists for applications where a user may not wish to maintin a Solana
-    /// (Ed25519) keypair and an ElGamal keypair separately. A user may wish to solely maintain the
-    /// Solana keypair and then derive the ElGamal keypair on-the-fly whenever
-    /// encryption/decryption is needed.
+    /// This function exists for applications where a user may not wish to maintain a Solana signer
+    /// and an ElGamal keypair separately. Instead, a user can derive the ElGamal keypair
+    /// on-the-fly whenever encryption/decryption is needed.
     ///
-    /// For the spl token-2022 confidential extension application, the ElGamal encryption public
-    /// key is specified in a token account address. A natural way to derive an ElGamal keypair is
-    /// then to define it from the hash of a Solana keypair and a Solana address. However, for
-    /// general hardware wallets, the signing key is not exposed in the API. Therefore, this
-    /// function uses a signer to sign a pre-specified message with respect to a Solana address.
-    /// The resulting signature is then hashed to derive an ElGamal keypair.
+    /// For the spl-token-2022 confidential extension, the ElGamal public key is
+    /// specified in a token account. A natural way to derive an ElGamal keypair is to define it
+    /// from the hash of a Solana keypair and a Solana address as the tag. However, for general
+    /// hardware wallets, the signing key is not exposed in the API. Therefore, this function uses
+    /// a signer to sign a pre-specified message with respect to a Solana address. The resulting
+    /// signature is then hashed to derive an ElGamal keypair.
     #[cfg(not(target_os = "solana"))]
     #[allow(non_snake_case)]
-    pub fn new(signer: &dyn Signer, address: &Pubkey) -> Result<Self, SignerError> {
-        let secret = ElGamalSecretKey::new(signer, address)?;
+    pub fn new_from_signer(signer: &dyn Signer, tag: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        let secret = ElGamalSecretKey::new_from_signer(signer, tag)?;
         let public = ElGamalPubkey::new(&secret);
         Ok(ElGamalKeypair { public, secret })
     }
@@ -367,20 +362,18 @@ impl fmt::Display for ElGamalPubkey {
 #[zeroize(drop)]
 pub struct ElGamalSecretKey(Scalar);
 impl ElGamalSecretKey {
-    /// Deterministically derives an ElGamal keypair from an Ed25519 signing key and a Solana
-    /// address.
+    /// Deterministically derives an ElGamal secret key from a Solana signer and a tag.
     ///
-    /// See `ElGamalKeypair::new` for more context on the key derivation.
-    pub fn new(signer: &dyn Signer, address: &Pubkey) -> Result<Self, SignerError> {
-        let message = Message::new(
-            &[Instruction::new_with_bytes(
-                *address,
-                b"ElGamalSecretKey",
-                vec![],
-            )],
-            Some(&signer.try_pubkey()?),
-        );
-        let signature = signer.try_sign_message(&message.serialize())?;
+    /// See `ElGamalKeypair::new_from_signer` for more context on the key derivation.
+    pub fn new_from_signer(signer: &dyn Signer, tag: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signer(signer, tag)?;
+        Self::from_seed(&seed)
+    }
+
+    /// Derive a seed from a Solana signer used to generate an ElGamal secret key.
+    pub fn seed_from_signer(signer: &dyn Signer, tag: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let message = [b"ElGamalSecretKey", tag].concat();
+        let signature = signer.try_sign_message(&message)?;
 
         // Some `Signer` implementations return the default signature, which is not suitable for
         // use as key material
@@ -388,9 +381,11 @@ impl ElGamalSecretKey {
             return Err(SignerError::Custom("Rejecting default signatures".into()));
         }
 
-        Ok(ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(
-            signature.as_ref(),
-        )))
+        let mut hasher = Sha3_512::new();
+        hasher.update(signature.as_ref());
+        let result = hasher.finalize();
+
+        Ok(result.to_vec())
     }
 
     /// Randomly samples an ElGamal secret key.
@@ -714,7 +709,8 @@ mod tests {
     use {
         super::*,
         crate::encryption::pedersen::Pedersen,
-        solana_sdk::{signature::Keypair, signer::null_signer::NullSigner},
+        bip39::{Language, Mnemonic, MnemonicType, Seed},
+        solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::null_signer::NullSigner},
         std::fs::{self, File},
     };
 
@@ -949,21 +945,43 @@ mod tests {
     }
 
     #[test]
-    fn test_secret_key_new() {
+    fn test_secret_key_new_from_signer() {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
 
         assert_ne!(
-            ElGamalSecretKey::new(&keypair1, &Pubkey::default())
+            ElGamalSecretKey::new_from_signer(&keypair1, Pubkey::default().as_ref())
                 .unwrap()
                 .0,
-            ElGamalSecretKey::new(&keypair2, &Pubkey::default())
+            ElGamalSecretKey::new_from_signer(&keypair2, Pubkey::default().as_ref())
                 .unwrap()
                 .0,
         );
 
         let null_signer = NullSigner::new(&Pubkey::default());
-        assert!(ElGamalSecretKey::new(&null_signer, &Pubkey::default()).is_err());
+        assert!(
+            ElGamalSecretKey::new_from_signer(&null_signer, Pubkey::default().as_ref()).is_err()
+        );
+    }
+
+    #[test]
+    fn test_keypair_from_seed() {
+        let good_seed = vec![0; 32];
+        assert!(ElGamalKeypair::from_seed(&good_seed).is_ok());
+
+        let too_short_seed = vec![0; 31];
+        assert!(ElGamalKeypair::from_seed(&too_short_seed).is_err());
+    }
+
+    #[test]
+    fn test_keypair_from_seed_phrase_and_passphrase() {
+        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+        let passphrase = "42";
+        let seed = Seed::new(&mnemonic, passphrase);
+        let expected_keypair = ElGamalKeypair::from_seed(seed.as_bytes()).unwrap();
+        let keypair =
+            ElGamalKeypair::from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+        assert_eq!(keypair.public, expected_keypair.public);
     }
 
     #[test]

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -157,7 +157,8 @@ mod test {
             .is_ok());
 
         // derived ElGamal keypair
-        let keypair = ElGamalKeypair::new(&Keypair::new(), &Pubkey::default()).unwrap();
+        let keypair =
+            ElGamalKeypair::new_from_signer(&Keypair::new(), Pubkey::default().as_ref()).unwrap();
 
         let mut prover_transcript = Transcript::new(b"test");
         let mut verifier_transcript = Transcript::new(b"test");


### PR DESCRIPTION
#### Problem
The way ElGamal and Ae keys are currently generated in the zk-token-sdk can be improved.

##### Derivation from signer
The constructor functions that derive ElGamal and Ae keys from a `Signer` takes in a `Pubkey` as input. It signs a fixed instruction with the pubkey input as the program_id and hashes the resulting signature to derive ElGamal or Ae keys.

However, this could be generalized. Instead of these constructors taking in a Pubkey as input, the constructor functions can take in an arbitrary byte array as a tag. The ElGamal and Ae keys can be derived from signing the tag and hashing the signature. This adds (1) more flexibility to the way keys are derived from signers and (2) can also prevent potential confusion from signing an instruction to derive encryption keys.

##### Random authenticated encryption key generation
Currently, there is an inconsistency between the way ElGamal and Ae keys are randomly sampled. `fn ElGamalKeypair::new_rand() -> ElGamalKeypair` uses `OsRng` to sample a a new keypair. `fn random<T: RngCore + CryptoRng>(rng: &mut T) -> AeKey` takes in an external random generator and samples a new key.

#### Summary of Changes
- Update the ElGamal keypair derivation so that keypairs can be derived from (signer + arbitrary tag) as opposed to (signer + pubkey)
- Update the authenticated encryption key derivation so that keys can be derived from (signer + arbitrary tag) as opposed to (signer + pubkey)
- Update `AeKey::random` function to `AeKey::new_rand` so that it is consistent with how `ElGamalKeypair` is randomly generated
- Add function docs to the `encryption::auth_encryption` module

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
