### PR TITLE
Bump solana_rbpf to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7416,9 +7416,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb31627f86190e2d97f86988f1de1a757b530caa50694244d9d28812611b063"
+checksum = "5c0820fa96c8e644159a308b338465d2a6314b0a71abc92ed3ecf9ad61c906e3"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ signal-hook = "0.3.15"
 smpl_jwt = "0.7.1"
 socket2 = "0.4.9"
 soketto = "0.7"
-solana_rbpf = "=0.3.0"
+solana_rbpf = "=0.4.0"
 solana-account-decoder = { path = "account-decoder", version = "=1.16.0" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.16.0" }
 solana-banks-client = { path = "banks-client", version = "=1.16.0" }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -24,7 +24,10 @@ use {
         tpu_client::{TpuClient, TpuClientConfig},
     },
     solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
-    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::VerifiedExecutable},
+    solana_rbpf::{
+        elf::Executable,
+        verifier::{RequisiteVerifier, TautologyVerifier},
+    },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{
@@ -2026,10 +2029,11 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         false,
     )
     .unwrap();
-    let executable = Executable::<InvokeContext>::from_elf(&program_data, loader)
-        .map_err(|err| format!("ELF error: {err}"))?;
+    let executable =
+        Executable::<TautologyVerifier, InvokeContext>::from_elf(&program_data, loader)
+            .map_err(|err| format!("ELF error: {err}"))?;
 
-    let _ = VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
+    let _ = Executable::<RequisiteVerifier, InvokeContext>::verified(executable)
         .map_err(|err| format!("ELF error: {err}"))?;
 
     Ok(program_data)

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2023,7 +2023,6 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         &FeatureSet::default(),
         &ComputeBudget::default(),
         true,
-        true,
         false,
     )
     .unwrap();

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -22,7 +22,7 @@ use {
     },
     solana_rbpf::{
         assembler::assemble, elf::Executable, static_analysis::Analysis,
-        verifier::RequisiteVerifier, vm::VerifiedExecutable,
+        verifier::RequisiteVerifier,
     },
     solana_runtime::{bank::Bank, runtime_config::RuntimeConfig},
     solana_sdk::{
@@ -281,11 +281,11 @@ impl Debug for Output {
 // https://github.com/rust-lang/rust/issues/74465
 struct LazyAnalysis<'a, 'b> {
     analysis: Option<Analysis<'a>>,
-    executable: &'a Executable<InvokeContext<'b>>,
+    executable: &'a Executable<RequisiteVerifier, InvokeContext<'b>>,
 }
 
 impl<'a, 'b> LazyAnalysis<'a, 'b> {
-    fn new(executable: &'a Executable<InvokeContext<'b>>) -> Self {
+    fn new(executable: &'a Executable<RequisiteVerifier, InvokeContext<'b>>) -> Self {
         Self {
             analysis: None,
             executable,
@@ -530,14 +530,14 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         let executable =
             assemble::<InvokeContext>(std::str::from_utf8(contents.as_slice()).unwrap(), loader)
                 .unwrap();
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
+        Executable::<RequisiteVerifier, InvokeContext>::verified(executable)
             .map_err(|err| format!("Assembling executable failed: {err:?}"))
     }
     .unwrap();
 
     #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     verified_executable.jit_compile().unwrap();
-    let mut analysis = LazyAnalysis::new(verified_executable.get_executable());
+    let mut analysis = LazyAnalysis::new(&verified_executable);
 
     match action {
         Action::Cfg => {

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -525,7 +525,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             invoke_context.get_compute_budget(),
             true,
             true,
-            true,
         )
         .unwrap();
         let executable =

--- a/program-runtime/src/builtin_program.rs
+++ b/program-runtime/src/builtin_program.rs
@@ -15,7 +15,7 @@ pub fn create_builtin(
 ) -> Arc<LoadedProgram> {
     let mut program = BuiltInProgram::default();
     program
-        .register_function_by_name("entrypoint", process_instruction)
+        .register_function(b"entrypoint", process_instruction)
         .unwrap();
     Arc::new(LoadedProgram::new_builtin(name, 0, program))
 }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -6,11 +6,7 @@ use {
     log::{debug, log_enabled, trace},
     percentage::PercentageInteger,
     solana_measure::measure::Measure,
-    solana_rbpf::{
-        elf::Executable,
-        verifier::RequisiteVerifier,
-        vm::{BuiltInProgram, VerifiedExecutable},
-    },
+    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::BuiltInProgram},
     solana_sdk::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock::Slot, loader_v4,
         pubkey::Pubkey, saturating_add_assign,
@@ -67,9 +63,9 @@ pub enum LoadedProgramType {
     DelayVisibility,
     /// Successfully verified but not currently compiled, used to track usage statistics when a compiled program is evicted from memory.
     Unloaded,
-    LegacyV0(VerifiedExecutable<RequisiteVerifier, InvokeContext<'static>>),
-    LegacyV1(VerifiedExecutable<RequisiteVerifier, InvokeContext<'static>>),
-    Typed(VerifiedExecutable<RequisiteVerifier, InvokeContext<'static>>),
+    LegacyV0(Executable<RequisiteVerifier, InvokeContext<'static>>),
+    LegacyV1(Executable<RequisiteVerifier, InvokeContext<'static>>),
+    Typed(Executable<RequisiteVerifier, InvokeContext<'static>>),
     #[cfg(test)]
     TestLoaded,
     Builtin(String, BuiltInProgram<InvokeContext<'static>>),
@@ -225,11 +221,11 @@ impl LoadedProgram {
         // Allowing mut here, since it may be needed for jit compile, which is under a config flag
         #[allow(unused_mut)]
         let mut program = if bpf_loader_deprecated::check_id(loader_key) {
-            LoadedProgramType::LegacyV0(VerifiedExecutable::from_executable(executable)?)
+            LoadedProgramType::LegacyV0(Executable::verified(executable)?)
         } else if bpf_loader::check_id(loader_key) || bpf_loader_upgradeable::check_id(loader_key) {
-            LoadedProgramType::LegacyV1(VerifiedExecutable::from_executable(executable)?)
+            LoadedProgramType::LegacyV1(Executable::verified(executable)?)
         } else if loader_v4::check_id(loader_key) {
-            LoadedProgramType::Typed(VerifiedExecutable::from_executable(executable)?)
+            LoadedProgramType::Typed(Executable::verified(executable)?)
         } else {
             panic!();
         };

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -35,10 +35,9 @@ use {
         feature_set::{
             bpf_account_data_direct_mapping, cap_accounts_data_allocations_per_transaction,
             cap_bpf_program_instruction_accounts, delay_visibility_of_program_deployment,
-            disable_deploy_of_alloc_free_syscall, enable_bpf_loader_extend_program_ix,
-            enable_bpf_loader_set_authority_checked_ix, enable_program_redeployment_cooldown,
-            limit_max_instruction_trace_length, native_programs_consume_cu,
-            remove_bpf_loader_incorrect_program_id, FeatureSet,
+            enable_bpf_loader_extend_program_ix, enable_bpf_loader_set_authority_checked_ix,
+            enable_program_redeployment_cooldown, limit_max_instruction_trace_length,
+            native_programs_consume_cu, remove_bpf_loader_incorrect_program_id, FeatureSet,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -77,13 +76,10 @@ pub fn load_program_from_bytes(
     debugging_features: bool,
 ) -> Result<LoadedProgram, InstructionError> {
     let mut register_syscalls_time = Measure::start("register_syscalls_time");
-    let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
-        && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
     let loader = syscalls::create_loader(
         feature_set,
         compute_budget,
         reject_deployment_of_broken_elfs,
-        disable_deploy_of_alloc_free_syscall,
         debugging_features,
     )
     .map_err(|e| {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -24,7 +24,7 @@ use {
         error::EbpfError,
         memory_region::{AccessType, MemoryCowCallback, MemoryMapping, MemoryRegion},
         verifier::RequisiteVerifier,
-        vm::{ContextObject, EbpfVm, ProgramResult, VerifiedExecutable},
+        vm::{ContextObject, EbpfVm, ProgramResult},
     },
     solana_sdk::{
         account::WritableAccount,
@@ -281,7 +281,7 @@ pub fn calculate_heap_cost(heap_size: u64, heap_cost: u64, enable_rounding_fix: 
 
 /// Only used in macro, do not use directly!
 pub fn create_vm<'a, 'b>(
-    program: &'a VerifiedExecutable<RequisiteVerifier, InvokeContext<'b>>,
+    program: &'a Executable<RequisiteVerifier, InvokeContext<'b>>,
     regions: Vec<MemoryRegion>,
     orig_account_lengths: Vec<usize>,
     invoke_context: &'a mut InvokeContext<'b>,
@@ -292,7 +292,7 @@ pub fn create_vm<'a, 'b>(
     let heap_size = heap.len();
     let accounts = Arc::clone(invoke_context.transaction_context.accounts());
     let memory_mapping = create_memory_mapping(
-        program.get_executable(),
+        program,
         stack,
         heap,
         regions,
@@ -333,7 +333,7 @@ pub fn create_vm<'a, 'b>(
 macro_rules! create_vm {
     ($vm:ident, $program:expr, $regions:expr, $orig_account_lengths:expr, $invoke_context:expr $(,)?) => {
         let invoke_context = &*$invoke_context;
-        let stack_size = $program.get_executable().get_config().stack_size();
+        let stack_size = $program.get_config().stack_size();
         let heap_size = invoke_context
             .get_compute_budget()
             .heap_size
@@ -378,17 +378,14 @@ macro_rules! mock_create_vm {
             solana_rbpf::vm::Config::default(),
         ));
         let function_registry = solana_rbpf::vm::FunctionRegistry::default();
-        let executable = solana_rbpf::elf::Executable::<InvokeContext>::from_text_bytes(
-            &[0x95, 0, 0, 0, 0, 0, 0, 0],
-            loader,
-            function_registry,
+        let executable = solana_rbpf::elf::Executable::<
+            solana_rbpf::verifier::TautologyVerifier,
+            InvokeContext,
+        >::from_text_bytes(
+            &[0x95, 0, 0, 0, 0, 0, 0, 0], loader, function_registry
         )
         .unwrap();
-        let verified_executable = solana_rbpf::vm::VerifiedExecutable::<
-            solana_rbpf::verifier::RequisiteVerifier,
-            InvokeContext,
-        >::from_executable(executable)
-        .unwrap();
+        let verified_executable = solana_rbpf::elf::Executable::verified(executable).unwrap();
         $crate::create_vm!(
             $vm,
             &verified_executable,
@@ -400,7 +397,7 @@ macro_rules! mock_create_vm {
 }
 
 fn create_memory_mapping<'a, 'b, C: ContextObject>(
-    executable: &'a Executable<C>,
+    executable: &'a Executable<RequisiteVerifier, C>,
     stack: &'b mut AlignedMemory<{ HOST_ALIGN }>,
     heap: &'b mut AlignedMemory<{ HOST_ALIGN }>,
     additional_regions: Vec<MemoryRegion>,
@@ -1522,7 +1519,7 @@ fn process_loader_instruction(invoke_context: &mut InvokeContext) -> Result<(), 
 }
 
 fn execute<'a, 'b: 'a>(
-    executable: &'a VerifiedExecutable<RequisiteVerifier, InvokeContext<'static>>,
+    executable: &'a Executable<RequisiteVerifier, InvokeContext<'static>>,
     invoke_context: &'a mut InvokeContext<'b>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();
@@ -1532,7 +1529,7 @@ fn execute<'a, 'b: 'a>(
     #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
     let use_jit = false;
     #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
-    let use_jit = executable.get_executable().get_compiled_program().is_some();
+    let use_jit = executable.get_compiled_program().is_some();
     let bpf_account_data_direct_mapping = invoke_context
         .feature_set
         .is_active(&bpf_account_data_direct_mapping::id());
@@ -1566,7 +1563,7 @@ fn execute<'a, 'b: 'a>(
             // We dropped the lifetime tracking in the Executor by setting it to 'static,
             // thus we need to reintroduce the correct lifetime of InvokeContext here again.
             unsafe {
-                mem::transmute::<_, &'a VerifiedExecutable<RequisiteVerifier, InvokeContext<'b>>>(
+                mem::transmute::<_, &'a Executable<RequisiteVerifier, InvokeContext<'b>>>(
                     executable,
                 )
             },
@@ -1735,7 +1732,7 @@ mod tests {
             invoke_context::mock_process_instruction, with_mock_invoke_context,
         },
         solana_rbpf::{
-            verifier::{Verifier, VerifierError},
+            verifier::Verifier,
             vm::{Config, ContextObject, FunctionRegistry},
         },
         solana_sdk::{
@@ -1799,17 +1796,6 @@ mod tests {
         program_account.set_data(elf);
         program_account.set_executable(true);
         program_account
-    }
-
-    struct TautologyVerifier {}
-    impl Verifier for TautologyVerifier {
-        fn verify(
-            _prog: &[u8],
-            _config: &Config,
-            _function_registry: &FunctionRegistry,
-        ) -> std::result::Result<(), VerifierError> {
-            Ok(())
-        }
     }
 
     #[test]

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -135,7 +135,7 @@ fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<
 macro_rules! register_feature_gated_function {
     ($result:expr, $is_feature_active:expr, $name:expr, $call:expr $(,)?) => {
         if $is_feature_active {
-            $result.register_function_by_name($name, $call)
+            $result.register_function($name, $call)
         } else {
             Ok(())
         }
@@ -152,6 +152,7 @@ pub fn create_loader<'a>(
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
+        enable_address_translation: true,
         enable_stack_frame_gaps: true,
         instruction_meter_checkpoint_distance: 10000,
         enable_instruction_meter: true,
@@ -189,41 +190,41 @@ pub fn create_loader<'a>(
     let mut result = BuiltInProgram::new_loader(config);
 
     // Abort
-    result.register_function_by_name("abort", SyscallAbort::call)?;
+    result.register_function(b"abort", SyscallAbort::call)?;
 
     // Panic
-    result.register_function_by_name("sol_panic_", SyscallPanic::call)?;
+    result.register_function(b"sol_panic_", SyscallPanic::call)?;
 
     // Logging
-    result.register_function_by_name("sol_log_", SyscallLog::call)?;
-    result.register_function_by_name("sol_log_64_", SyscallLogU64::call)?;
-    result.register_function_by_name("sol_log_compute_units_", SyscallLogBpfComputeUnits::call)?;
-    result.register_function_by_name("sol_log_pubkey", SyscallLogPubkey::call)?;
+    result.register_function(b"sol_log_", SyscallLog::call)?;
+    result.register_function(b"sol_log_64_", SyscallLogU64::call)?;
+    result.register_function(b"sol_log_compute_units_", SyscallLogBpfComputeUnits::call)?;
+    result.register_function(b"sol_log_pubkey", SyscallLogPubkey::call)?;
 
     // Program defined addresses (PDA)
-    result.register_function_by_name(
-        "sol_create_program_address",
+    result.register_function(
+        b"sol_create_program_address",
         SyscallCreateProgramAddress::call,
     )?;
-    result.register_function_by_name(
-        "sol_try_find_program_address",
+    result.register_function(
+        b"sol_try_find_program_address",
         SyscallTryFindProgramAddress::call,
     )?;
 
     // Sha256
-    result.register_function_by_name("sol_sha256", SyscallSha256::call)?;
+    result.register_function(b"sol_sha256", SyscallSha256::call)?;
 
     // Keccak256
-    result.register_function_by_name("sol_keccak256", SyscallKeccak256::call)?;
+    result.register_function(b"sol_keccak256", SyscallKeccak256::call)?;
 
     // Secp256k1 Recover
-    result.register_function_by_name("sol_secp256k1_recover", SyscallSecp256k1Recover::call)?;
+    result.register_function(b"sol_secp256k1_recover", SyscallSecp256k1Recover::call)?;
 
     // Blake3
     register_feature_gated_function!(
         result,
         blake3_syscall_enabled,
-        "sol_blake3",
+        b"sol_blake3",
         SyscallBlake3::call,
     )?;
 
@@ -231,64 +232,64 @@ pub fn create_loader<'a>(
     register_feature_gated_function!(
         result,
         curve25519_syscall_enabled,
-        "sol_curve_validate_point",
+        b"sol_curve_validate_point",
         SyscallCurvePointValidation::call,
     )?;
     register_feature_gated_function!(
         result,
         curve25519_syscall_enabled,
-        "sol_curve_group_op",
+        b"sol_curve_group_op",
         SyscallCurveGroupOps::call,
     )?;
     register_feature_gated_function!(
         result,
         curve25519_syscall_enabled,
-        "sol_curve_multiscalar_mul",
+        b"sol_curve_multiscalar_mul",
         SyscallCurveMultiscalarMultiplication::call,
     )?;
 
     // Sysvars
-    result.register_function_by_name("sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
-    result.register_function_by_name(
-        "sol_get_epoch_schedule_sysvar",
+    result.register_function(b"sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
+    result.register_function(
+        b"sol_get_epoch_schedule_sysvar",
         SyscallGetEpochScheduleSysvar::call,
     )?;
     register_feature_gated_function!(
         result,
         !disable_fees_sysvar,
-        "sol_get_fees_sysvar",
+        b"sol_get_fees_sysvar",
         SyscallGetFeesSysvar::call,
     )?;
-    result.register_function_by_name("sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
+    result.register_function(b"sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
 
     // Memory ops
-    result.register_function_by_name("sol_memcpy_", SyscallMemcpy::call)?;
-    result.register_function_by_name("sol_memmove_", SyscallMemmove::call)?;
-    result.register_function_by_name("sol_memcmp_", SyscallMemcmp::call)?;
-    result.register_function_by_name("sol_memset_", SyscallMemset::call)?;
+    result.register_function(b"sol_memcpy_", SyscallMemcpy::call)?;
+    result.register_function(b"sol_memmove_", SyscallMemmove::call)?;
+    result.register_function(b"sol_memcmp_", SyscallMemcmp::call)?;
+    result.register_function(b"sol_memset_", SyscallMemset::call)?;
 
     // Processed sibling instructions
-    result.register_function_by_name(
-        "sol_get_processed_sibling_instruction",
+    result.register_function(
+        b"sol_get_processed_sibling_instruction",
         SyscallGetProcessedSiblingInstruction::call,
     )?;
 
     // Stack height
-    result.register_function_by_name("sol_get_stack_height", SyscallGetStackHeight::call)?;
+    result.register_function(b"sol_get_stack_height", SyscallGetStackHeight::call)?;
 
     // Return data
-    result.register_function_by_name("sol_set_return_data", SyscallSetReturnData::call)?;
-    result.register_function_by_name("sol_get_return_data", SyscallGetReturnData::call)?;
+    result.register_function(b"sol_set_return_data", SyscallSetReturnData::call)?;
+    result.register_function(b"sol_get_return_data", SyscallGetReturnData::call)?;
 
     // Cross-program invocation
-    result.register_function_by_name("sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
-    result.register_function_by_name("sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
+    result.register_function(b"sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
+    result.register_function(b"sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
 
     // Memory allocator
     register_feature_gated_function!(
         result,
         !disable_deploy_of_alloc_free_syscall,
-        "sol_alloc_free_",
+        b"sol_alloc_free_",
         SyscallAllocFree::call,
     )?;
 
@@ -296,7 +297,7 @@ pub fn create_loader<'a>(
     register_feature_gated_function!(
         result,
         enable_alt_bn128_syscall,
-        "sol_alt_bn128_group_op",
+        b"sol_alt_bn128_group_op",
         SyscallAltBn128::call,
     )?;
 
@@ -304,12 +305,12 @@ pub fn create_loader<'a>(
     register_feature_gated_function!(
         result,
         enable_big_mod_exp_syscall,
-        "sol_big_mod_exp",
+        b"sol_big_mod_exp",
         SyscallBigModExp::call,
     )?;
 
     // Log data
-    result.register_function_by_name("sol_log_data", SyscallLogData::call)?;
+    result.register_function(b"sol_log_data", SyscallLogData::call)?;
 
     Ok(Arc::new(result))
 }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -35,8 +35,8 @@ use {
         feature_set::{
             self, blake3_syscall_enabled, check_syscall_outputs_do_not_overlap,
             curve25519_syscall_enabled, disable_cpi_setting_executable_and_rent_epoch,
-            disable_fees_sysvar, enable_alt_bn128_syscall, enable_big_mod_exp_syscall,
-            enable_early_verification_of_account_modifications,
+            disable_deploy_of_alloc_free_syscall, disable_fees_sysvar, enable_alt_bn128_syscall,
+            enable_big_mod_exp_syscall, enable_early_verification_of_account_modifications,
             error_on_syscall_bpf_function_hash_collisions, libsecp256k1_0_5_upgrade_enabled,
             limit_secp256k1_recovery_id, reject_callx_r10,
             stop_sibling_instruction_search_at_parent, stop_truncating_strings_in_syscalls,
@@ -146,7 +146,6 @@ pub fn create_loader<'a>(
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,
     reject_deployment_of_broken_elfs: bool,
-    disable_deploy_of_alloc_free_syscall: bool,
     debugging_features: bool,
 ) -> Result<Arc<BuiltInProgram<InvokeContext<'a>>>, Error> {
     use rand::Rng;
@@ -184,6 +183,8 @@ pub fn create_loader<'a>(
     let blake3_syscall_enabled = feature_set.is_active(&blake3_syscall_enabled::id());
     let curve25519_syscall_enabled = feature_set.is_active(&curve25519_syscall_enabled::id());
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
+    let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
+        && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
     let is_abi_v2 = false;
 
     let mut result = BuiltInProgram::new_loader(config);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -185,7 +185,6 @@ pub fn create_loader<'a>(
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
-    let is_abi_v2 = false;
 
     let mut result = BuiltInProgram::new_loader(config);
 
@@ -268,49 +267,46 @@ pub fn create_loader<'a>(
     result.register_function_by_name("sol_memcmp_", SyscallMemcmp::call)?;
     result.register_function_by_name("sol_memset_", SyscallMemset::call)?;
 
-    if !is_abi_v2 {
-        // Processed sibling instructions
-        result.register_function_by_name(
-            "sol_get_processed_sibling_instruction",
-            SyscallGetProcessedSiblingInstruction::call,
-        )?;
+    // Processed sibling instructions
+    result.register_function_by_name(
+        "sol_get_processed_sibling_instruction",
+        SyscallGetProcessedSiblingInstruction::call,
+    )?;
 
-        // Stack height
-        result.register_function_by_name("sol_get_stack_height", SyscallGetStackHeight::call)?;
+    // Stack height
+    result.register_function_by_name("sol_get_stack_height", SyscallGetStackHeight::call)?;
 
-        // Return data
-        result.register_function_by_name("sol_set_return_data", SyscallSetReturnData::call)?;
-        result.register_function_by_name("sol_get_return_data", SyscallGetReturnData::call)?;
+    // Return data
+    result.register_function_by_name("sol_set_return_data", SyscallSetReturnData::call)?;
+    result.register_function_by_name("sol_get_return_data", SyscallGetReturnData::call)?;
 
-        // Cross-program invocation
-        result.register_function_by_name("sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
-        result
-            .register_function_by_name("sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
+    // Cross-program invocation
+    result.register_function_by_name("sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
+    result.register_function_by_name("sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
 
-        // Memory allocator
-        register_feature_gated_function!(
-            result,
-            !disable_deploy_of_alloc_free_syscall,
-            "sol_alloc_free_",
-            SyscallAllocFree::call,
-        )?;
+    // Memory allocator
+    register_feature_gated_function!(
+        result,
+        !disable_deploy_of_alloc_free_syscall,
+        "sol_alloc_free_",
+        SyscallAllocFree::call,
+    )?;
 
-        // Alt_bn128
-        register_feature_gated_function!(
-            result,
-            enable_alt_bn128_syscall,
-            "sol_alt_bn128_group_op",
-            SyscallAltBn128::call,
-        )?;
+    // Alt_bn128
+    register_feature_gated_function!(
+        result,
+        enable_alt_bn128_syscall,
+        "sol_alt_bn128_group_op",
+        SyscallAltBn128::call,
+    )?;
 
-        // Big_mod_exp
-        register_feature_gated_function!(
-            result,
-            enable_big_mod_exp_syscall,
-            "sol_big_mod_exp",
-            SyscallBigModExp::call,
-        )?;
-    }
+    // Big_mod_exp
+    register_feature_gated_function!(
+        result,
+        enable_big_mod_exp_syscall,
+        "sol_big_mod_exp",
+        SyscallBigModExp::call,
+    )?;
 
     // Log data
     result.register_function_by_name("sol_log_data", SyscallLogData::call)?;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb31627f86190e2d97f86988f1de1a757b530caa50694244d9d28812611b063"
+checksum = "5c0820fa96c8e644159a308b338465d2a6314b0a71abc92ed3ecf9ad61c906e3"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 rand = "0.7"
 serde = "1.0.112"
 serde_json = "1.0.56"
-solana_rbpf = "=0.3.0"
+solana_rbpf = "=0.4.0"
 solana-account-decoder = { path = "../../account-decoder", version = "=1.16.0" }
 solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.16.0" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.16.0" }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -93,7 +93,6 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
         &FeatureSet::default(),
         &ComputeBudget::default(),
         true,
-        true,
         false,
     )
     .unwrap();
@@ -117,7 +116,6 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let loader = create_loader(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
-        true,
         true,
         false,
     )
@@ -236,7 +234,6 @@ fn bench_create_vm(bencher: &mut Bencher) {
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
-        true,
         false,
     )
     .unwrap();
@@ -296,7 +293,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     let loader = create_loader(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
-        true,
         true,
         false,
     )

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -21,8 +21,8 @@ use {
         ebpf::MM_INPUT_START,
         elf::Executable,
         memory_region::MemoryRegion,
-        verifier::RequisiteVerifier,
-        vm::{ContextObject, VerifiedExecutable},
+        verifier::{RequisiteVerifier, TautologyVerifier},
+        vm::ContextObject,
     },
     solana_runtime::{
         bank::Bank,
@@ -97,7 +97,8 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
     )
     .unwrap();
     bencher.iter(|| {
-        let _ = Executable::<InvokeContext>::from_elf(&elf, loader.clone()).unwrap();
+        let _ =
+            Executable::<TautologyVerifier, InvokeContext>::from_elf(&elf, loader.clone()).unwrap();
     });
 }
 
@@ -120,11 +121,11 @@ fn bench_program_alu(bencher: &mut Bencher) {
         false,
     )
     .unwrap();
-    let executable = Executable::<InvokeContext>::from_elf(&elf, loader).unwrap();
+    let executable =
+        Executable::<TautologyVerifier, InvokeContext>::from_elf(&elf, loader).unwrap();
 
     let mut verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
-            .unwrap();
+        Executable::<RequisiteVerifier, InvokeContext>::verified(executable).unwrap();
 
     verified_executable.jit_compile().unwrap();
     create_vm!(
@@ -237,11 +238,11 @@ fn bench_create_vm(bencher: &mut Bencher) {
         false,
     )
     .unwrap();
-    let executable = Executable::<InvokeContext>::from_elf(&elf, loader).unwrap();
+    let executable =
+        Executable::<TautologyVerifier, InvokeContext>::from_elf(&elf, loader).unwrap();
 
     let verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
-            .unwrap();
+        Executable::<RequisiteVerifier, InvokeContext>::verified(executable).unwrap();
 
     // Serialize account data
     let (_serialized, regions, account_lengths) = serialize_parameters(
@@ -297,11 +298,11 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         false,
     )
     .unwrap();
-    let executable = Executable::<InvokeContext>::from_elf(&elf, loader).unwrap();
+    let executable =
+        Executable::<TautologyVerifier, InvokeContext>::from_elf(&elf, loader).unwrap();
 
     let verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, InvokeContext>::from_executable(executable)
-            .unwrap();
+        Executable::<RequisiteVerifier, InvokeContext>::verified(executable).unwrap();
 
     create_vm!(
         vm,


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.4.0](https://github.com/solana-labs/rbpf/releases/tag/v0.4.0) was released.

#### Summary of Changes
- Moves `disable_deploy_of_alloc_free_syscall` parameter inside `create_loader()`.
- Removes the `is_abi_v2` flag in `create_loader()`, because there will be no syscalls at all in program-runtime-v2.
- Dissolves the wrapper `vm::VerifiedExecutable` into `elf::Executable`.
- Has `vm::BuiltInProgram::register_function()` accept raw byte strings instead of UTF-8 strings.