### PR TITLE
Revert "Update CI pipeline to only run `checks` step on version bump …

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -312,29 +312,6 @@ pull_or_push_steps() {
     wait_step
   fi
 
-  # Version bump PRs are an edge case that can skip most of the CI steps
-  if affects .toml$ && affects .lock$ && ! affects_other_than .toml$ .lock$; then
-    optional_old_version_number=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD validator/Cargo.toml | \
-      grep -e "^-version" | sed  's/-version = "\(.*\)"/\1/')
-    echo "optional_old_version_number: ->$optional_old_version_number<-"
-    new_version_number=$(grep -e  "^version = " validator/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-    echo "new_version_number: ->$new_version_number<-"
-
-    # Every line in a version bump diff will match one of these patterns. Since we're using grep -v the output is the
-    # lines that don't match. Any diff that produces output here is not a version bump.
-    # | cat is a no-op. If this pull request is a version bump then grep will output no lines and have an exit code of 1.
-    # Piping the output to cat prevents that non-zero exit code from exiting this script
-    diff_other_than_version_bump=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD | \
-      grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?solana.*$optional_old_version_number|^\+( \")?solana.*$new_version_number|^-version|^\+version"|cat)
-    echo "diff_other_than_version_bump: ->$diff_other_than_version_bump<-"
-
-    if [ -z "$diff_other_than_version_bump" ]; then
-      echo "Diff only contains version bump."
-      command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-      exit 0
-    fi
-  fi
-
   # Run the full test suite by default, skipping only if modifications are local
   # to some particular areas of the tree
   if affects_other_than ^.buildkite ^.mergify .md$ ^docs/ ^.gitbook; then


### PR DESCRIPTION
The change from PR #29243 fails because the git diff command fails. Without a diff we get false positives: For example PR #31563 bumps dependency versions but still gets marked as an internal version bump so [Buildkite only runs the reduced pipeline](https://buildkite.com/solana-labs/solana/builds/95292#01880295-8651-49fc-b146-7bcfdc745263).

We should do something to reduce the pipeline for version bumps but this solution has proven too cumbersome.

For now version bumps will get the full CI pipeline and we can choose to wait for it or merge over yellow checks.