### PR TITLE
use memcpy to write hash cache files

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -279,7 +279,7 @@ impl HashStats {
 /// Note this can be saved/loaded during hash calculation to a memory mapped file whose contents are
 /// [CalculateHashIntermediate]
 #[repr(C)]
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct CalculateHashIntermediate {
     pub hash: Hash,
     pub lamports: u64,


### PR DESCRIPTION
#### Problem
writing cache hash data files is currently done element by element

#### Summary of Changes
It is more efficient to memcpy an entire vec of results at a time.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
