### PR TITLE
Use a hot spin-loop to avoid sleeping for too long

### DIFF
--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -113,7 +113,11 @@ mod tests {
             Res: PartialOrd + Debug,
         {
             let measure = Measure::start("test");
-            sleep(Duration::from_millis(sleep_ms));
+            let wait_duration = Duration::from_millis(sleep_ms);
+            let start = Instant::now();
+            while start.elapsed() < wait_duration {
+                core::hint::spin_loop();
+            }
             let result = method(measure);
             assert!(
                 result >= lower,


### PR DESCRIPTION
#### Problem
#31585 - test is flaky on the CI.

My guess is that sleep is not accurate here so we're sleeping for too long, and missing the time window.

#### Summary of Changes
spin-loop

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
