### PR TITLE
clean up is_ancient in is_candidate_for_shrink

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7940,7 +7940,11 @@ impl AccountsDb {
         store: &Arc<AccountStorageEntry>,
         allow_shrink_ancient: bool,
     ) -> bool {
-        let total_bytes = if is_ancient(&store.accounts) {
+        // appended ancient append vecs should not be shrunk by the normal shrink codepath.
+        // It is not possible to identify ancient append vecs when we pack, so no check for ancient when we are not appending.
+        let total_bytes = if self.create_ancient_storage == CreateAncientStorage::Append
+            && is_ancient(&store.accounts)
+        {
             if !allow_shrink_ancient {
                 return false;
             }


### PR DESCRIPTION
#### Problem
`is_ancient` alters behavior for several accounts_db algorithms.
These functions are thinking about ancient append vecs that are meant to be appended to. With packed ancient append vecs, writes are one-shot and the resulting ancient append vecs are not identifiable, apart from their slot #. So, the functions that ask `is_ancient` will be modified over time.

#### Summary of Changes
clean up `is_ancient` in `is_candidate_for_shrink`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
