### PR TITLE
refactor: highest_cluster_confirmed_root -> highest_super_majority_root

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -251,7 +251,7 @@ impl Banks for BanksServer {
             optimistically_confirmed_bank.get_signature_status_slot(&signature);
 
         let confirmations = if r_block_commitment_cache.root() >= slot
-            && r_block_commitment_cache.highest_confirmed_root() >= slot
+            && r_block_commitment_cache.highest_super_majority_root() >= slot
         {
             None
         } else {

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -185,7 +185,7 @@ fn test_account_subscription() {
         slot: 2,
         root: 1,
         highest_confirmed_slot: 1,
-        highest_confirmed_root: 1,
+        highest_super_majority_root: 1,
     };
     subscriptions.notify_subscribers(commitment_slots);
 
@@ -390,7 +390,7 @@ fn test_program_subscription() {
         slot: 2,
         root: 1,
         highest_confirmed_slot: 1,
-        highest_confirmed_root: 1,
+        highest_super_majority_root: 1,
     };
     subscriptions.notify_subscribers(commitment_slots);
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2049,18 +2049,18 @@ impl ReplayStage {
             blockstore
                 .set_roots(rooted_slots.iter())
                 .expect("Ledger set roots failed");
-            let highest_confirmed_root = Some(
+            let highest_super_majority_root = Some(
                 block_commitment_cache
                     .read()
                     .unwrap()
-                    .highest_confirmed_root(),
+                    .highest_super_majority_root(),
             );
             Self::handle_new_root(
                 new_root,
                 bank_forks,
                 progress,
                 accounts_background_request_sender,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 heaviest_subtree_fork_choice,
                 duplicate_slots_tracker,
                 gossip_duplicate_confirmed_slots,
@@ -3538,7 +3538,7 @@ impl ReplayStage {
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         accounts_background_request_sender: &AbsRequestSender,
-        highest_confirmed_root: Option<Slot>,
+        highest_super_majority_root: Option<Slot>,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
         gossip_duplicate_confirmed_slots: &mut GossipDuplicateConfirmedSlots,
@@ -3551,7 +3551,7 @@ impl ReplayStage {
         let removed_banks = bank_forks.write().unwrap().set_root(
             new_root,
             accounts_background_request_sender,
-            highest_confirmed_root,
+            highest_super_majority_root,
         );
 
         drop_bank_sender
@@ -4120,7 +4120,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_handle_new_root_ahead_of_highest_confirmed_root() {
+    fn test_handle_new_root_ahead_of_highest_super_majority_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -979,7 +979,7 @@ impl Validator {
             block_commitment_cache
                 .write()
                 .unwrap()
-                .set_highest_confirmed_root(bank_forks.read().unwrap().root());
+                .set_highest_super_majority_root(bank_forks.read().unwrap().root());
 
             // Park with the RPC service running, ready for inspection!
             warn!("Validator halted");

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2512,7 +2512,7 @@ impl Blockstore {
     pub fn get_confirmed_signatures_for_address2(
         &self,
         address: Pubkey,
-        highest_slot: Slot, // highest_confirmed_root or highest_confirmed_slot
+        highest_slot: Slot, // highest_super_majority_root or highest_confirmed_slot
         before: Option<Signature>,
         until: Option<Signature>,
         limit: usize,
@@ -8329,13 +8329,13 @@ pub mod tests {
         blockstore
             .set_roots(vec![1, 2, 4, 5, 6, 7, 8].iter())
             .unwrap();
-        let highest_confirmed_root = 8;
+        let highest_super_majority_root = 8;
 
         // Fetch all rooted signatures for address 0 at once...
         let sig_infos = blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 None,
                 None,
                 usize::MAX,
@@ -8349,7 +8349,7 @@ pub mod tests {
         let all1 = blockstore
             .get_confirmed_signatures_for_address2(
                 address1,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 None,
                 None,
                 usize::MAX,
@@ -8363,7 +8363,7 @@ pub mod tests {
             let sig_infos = blockstore
                 .get_confirmed_signatures_for_address2(
                     address0,
-                    highest_confirmed_root,
+                    highest_super_majority_root,
                     if i == 0 {
                         None
                     } else {
@@ -8383,7 +8383,7 @@ pub mod tests {
             let results = blockstore
                 .get_confirmed_signatures_for_address2(
                     address0,
-                    highest_confirmed_root,
+                    highest_super_majority_root,
                     if i == 0 {
                         None
                     } else {
@@ -8405,7 +8405,7 @@ pub mod tests {
         let sig_infos = blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 Some(all0[all0.len() - 1].signature),
                 None,
                 1,
@@ -8417,7 +8417,7 @@ pub mod tests {
         assert!(blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 None,
                 Some(all0[0].signature),
                 2,
@@ -8432,7 +8432,7 @@ pub mod tests {
             let results = blockstore
                 .get_confirmed_signatures_for_address2(
                     address0,
-                    highest_confirmed_root,
+                    highest_super_majority_root,
                     if i == 0 {
                         None
                     } else {
@@ -8455,7 +8455,7 @@ pub mod tests {
             let results = blockstore
                 .get_confirmed_signatures_for_address2(
                     address1,
-                    highest_confirmed_root,
+                    highest_super_majority_root,
                     if i == 0 {
                         None
                     } else {
@@ -8477,7 +8477,7 @@ pub mod tests {
         let sig_infos = blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 Some(all1[0].signature),
                 None,
                 usize::MAX,
@@ -8492,7 +8492,7 @@ pub mod tests {
         let results2 = blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 Some(all1[0].signature),
                 Some(all1[4].signature),
                 usize::MAX,
@@ -8683,7 +8683,7 @@ pub mod tests {
         let sig_infos = blockstore
             .get_confirmed_signatures_for_address2(
                 address0,
-                highest_confirmed_root,
+                highest_super_majority_root,
                 Some(all0[0].signature),
                 None,
                 usize::MAX,

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -1239,7 +1239,7 @@ mod tests {
             slot: 2,
             root: 1,
             highest_confirmed_slot: 1,
-            highest_confirmed_root: 1,
+            highest_super_majority_root: 1,
         };
         subscriptions.notify_subscribers(commitment_slots);
         let expected = json!({

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -461,7 +461,7 @@ fn initial_last_notified_slot(
                 block_commitment_cache
                     .read()
                     .unwrap()
-                    .highest_confirmed_root()
+                    .highest_super_majority_root()
             } else if params.commitment.is_confirmed() {
                 optimistically_confirmed_bank.read().unwrap().bank.slot()
             } else {
@@ -960,7 +960,7 @@ impl RpcSubscriptions {
         subscriptions.for_each(|(_id, subscription)| {
             let slot = if let Some(commitment) = subscription.commitment() {
                 if commitment.is_finalized() {
-                    Some(commitment_slots.highest_confirmed_root)
+                    Some(commitment_slots.highest_super_majority_root)
                 } else if commitment.is_confirmed() {
                     Some(commitment_slots.highest_confirmed_slot)
                 } else {
@@ -1567,7 +1567,7 @@ pub(crate) mod tests {
             slot,
             root: slot,
             highest_confirmed_slot: slot,
-            highest_confirmed_root: slot,
+            highest_super_majority_root: slot,
         });
         let should_err = receiver.recv_timeout(Duration::from_millis(300));
         assert!(should_err.is_err());
@@ -1769,7 +1769,7 @@ pub(crate) mod tests {
             slot,
             root: slot,
             highest_confirmed_slot: slot,
-            highest_confirmed_root: slot,
+            highest_super_majority_root: slot,
         });
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -97,8 +97,8 @@ impl BlockCommitmentCache {
         self.commitment_slots.highest_confirmed_slot
     }
 
-    pub fn highest_confirmed_root(&self) -> Slot {
-        self.commitment_slots.highest_confirmed_root
+    pub fn highest_super_majority_root(&self) -> Slot {
+        self.commitment_slots.highest_super_majority_root
     }
 
     pub fn commitment_slots(&self) -> CommitmentSlots {
@@ -120,7 +120,7 @@ impl BlockCommitmentCache {
             CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => {
                 self.highest_gossip_confirmed_slot()
             }
-            CommitmentLevel::Max | CommitmentLevel::Finalized => self.highest_confirmed_root(),
+            CommitmentLevel::Max | CommitmentLevel::Finalized => self.highest_super_majority_root(),
         }
     }
 
@@ -180,7 +180,7 @@ impl BlockCommitmentCache {
                 slot,
                 root,
                 highest_confirmed_slot: root,
-                highest_confirmed_root: root,
+                highest_super_majority_root: root,
             },
         }
     }
@@ -189,8 +189,8 @@ impl BlockCommitmentCache {
         self.commitment_slots.highest_confirmed_slot = slot;
     }
 
-    pub fn set_highest_confirmed_root(&mut self, root: Slot) {
-        self.commitment_slots.highest_confirmed_root = root;
+    pub fn set_highest_super_majority_root(&mut self, root: Slot) {
+        self.commitment_slots.highest_super_majority_root = root;
     }
 
     pub fn initialize_slots(&mut self, slot: Slot, root: Slot) {
@@ -202,7 +202,7 @@ impl BlockCommitmentCache {
         self.commitment_slots.slot = slot;
         self.commitment_slots.highest_confirmed_slot = slot;
         self.commitment_slots.root = root;
-        self.commitment_slots.highest_confirmed_root = root;
+        self.commitment_slots.highest_super_majority_root = root;
     }
 }
 
@@ -214,8 +214,8 @@ pub struct CommitmentSlots {
     pub root: Slot,
     /// Highest cluster-confirmed slot
     pub highest_confirmed_slot: Slot,
-    /// Highest cluster-confirmed root
-    pub highest_confirmed_root: Slot,
+    /// Highest slot rooted by a super majority of the cluster
+    pub highest_super_majority_root: Slot,
 }
 
 impl CommitmentSlots {


### PR DESCRIPTION
#### Problem
Name is a bit confusing, `highest_cluster_confirmed_root` implies a root which 2/3+ of cluster has voted for.
It's actually checking for a root that 2/3+ of the cluster has also rooted, so renaming to `highest_super_majority_root`

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
