### PR TITLE
remove an irrelevant ancient stat

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6997,11 +6997,7 @@ impl AccountsDb {
     fn update_old_slot_stats(&self, stats: &HashStats, storage: Option<&Arc<AccountStorageEntry>>) {
         if let Some(storage) = storage {
             stats.roots_older_than_epoch.fetch_add(1, Ordering::Relaxed);
-            let mut ancients = 0;
             let num_accounts = storage.count();
-            if is_ancient(&storage.accounts) {
-                ancients += 1;
-            }
             let sizes = storage.capacity();
             stats
                 .append_vec_sizes_older_than_epoch
@@ -7009,9 +7005,6 @@ impl AccountsDb {
             stats
                 .accounts_in_roots_older_than_epoch
                 .fetch_add(num_accounts, Ordering::Relaxed);
-            stats
-                .ancient_append_vecs
-                .fetch_add(ancients, Ordering::Relaxed);
         }
     }
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -138,8 +138,6 @@ pub struct HashStats {
     pub roots_older_than_epoch: AtomicUsize,
     pub accounts_in_roots_older_than_epoch: AtomicUsize,
     pub append_vec_sizes_older_than_epoch: AtomicUsize,
-    /// # ancient append vecs encountered
-    pub ancient_append_vecs: AtomicUsize,
     pub longest_ancient_scan_us: AtomicU64,
     pub sum_ancient_scans_us: AtomicU64,
     pub count_ancient_scans: AtomicU64,
@@ -239,11 +237,6 @@ impl HashStats {
                 i64
             ),
             ("oldest_root", self.oldest_root as i64, i64),
-            (
-                "ancient_append_vecs",
-                self.ancient_append_vecs.load(Ordering::Relaxed) as i64,
-                i64
-            ),
             (
                 "longest_ancient_scan_us",
                 self.longest_ancient_scan_us.load(Ordering::Relaxed) as i64,


### PR DESCRIPTION
#### Problem
`is_ancient` alters behavior for several accounts_db algorithms.
These functions are thinking about ancient append vecs that are meant to be appended to. With packed ancient append vecs, writes are one-shot and the resulting ancient append vecs are not identifiable, apart from their slot #. So, the functions that ask `is_ancient` will be modified over time.

#### Summary of Changes
Eliminate some stats which don't make sense anymore.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
