### PR TITLE
mark_old_slots_as_dirty is a no-op when ancient append vecs are enabled

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7206,6 +7206,15 @@ impl AccountsDb {
         slots_per_epoch: Slot,
         mut stats: &mut crate::accounts_hash::HashStats,
     ) {
+        // Nothing to do if ancient append vecs are enabled.
+        // Ancient slots will be visited by the ancient append vec code and dealt with correctly.
+        // we expect these ancient append vecs to be old and keeping accounts
+        // We can expect the normal processes will keep them cleaned.
+        // If we included them here then ALL accounts in ALL ancient append vecs will be visited by clean each time.
+        if self.ancient_append_vec_offset.is_some() {
+            return;
+        }
+
         let mut mark_time = Measure::start("mark_time");
         let mut num_dirty_slots: usize = 0;
         let max = storages.max_slot_inclusive();
@@ -7214,13 +7223,8 @@ impl AccountsDb {
         let in_epoch_range_start = max.saturating_sub(sub);
         for (slot, storage) in storages.iter_range(&(..in_epoch_range_start)) {
             if let Some(storage) = storage {
-                if !is_ancient(&storage.accounts) {
-                    // ancient stores are managed separately - we expect them to be old and keeping accounts
-                    // We can expect the normal processes will keep them cleaned.
-                    // If we included them here then ALL accounts in ALL ancient append vecs will be visited by clean each time.
-                    self.dirty_stores.insert(slot, storage.clone());
-                    num_dirty_slots += 1;
-                }
+                self.dirty_stores.insert(slot, storage.clone());
+                num_dirty_slots += 1;
             }
         }
         mark_time.stop();


### PR DESCRIPTION
#### Problem
`is_ancient` alters behavior for several accounts_db algorithms.
These functions are thinking about ancient append vecs that are meant to be appended to. With packed ancient append vecs, writes are one-shot and the resulting ancient append vecs are not identifiable, apart from their slot #. So, the functions that ask `is_ancient` will be modified over time.

#### Summary of Changes
`mark_old_slots_as_dirty` should do nothing if ancient append vecs are enabled. `mark_old_slots_as_dirty` was a backstop to re-seed the clean system in case old accounts were not correctly getting cleaned. Several bugs related to refcounts in accounts_db have been fixed. The backstop isn't necessary anymore. And, ancient append vecs will do a better job of dealing with old accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
