### PR TITLE
[docs] Add note about txids to signature status RPC method docs

### DIFF
--- a/docs/src/api/methods/_getSignatureStatuses.mdx
+++ b/docs/src/api/methods/_getSignatureStatuses.mdx
@@ -12,7 +12,7 @@ import {
 
 ## getSignatureStatuses
 
-Returns the statuses of a list of signatures.
+Returns the statuses of a list of signatures. Each signature must be a [txid](/terminology#transaction-id), the first signature of a transaction.
 
 :::info
 Unless the `searchTransactionHistory` configuration parameter is included,

--- a/docs/src/api/websocket/_signatureSubscribe.mdx
+++ b/docs/src/api/websocket/_signatureSubscribe.mdx
@@ -13,6 +13,7 @@ import {
 ## signatureSubscribe
 
 Subscribe to a transaction signature to receive notification when a given transaction is committed. On `signatureNotification` - the subscription is automatically cancelled.
+The signature must be a [txid](/terminology#transaction-id), the first signature of a transaction.
 
 <DocSideBySide>
 <CodeParams>


### PR DESCRIPTION
#### Problem

The RPC docs are a little unclear with respect to methods that can be used to fetch information about signatures. These methods can only be called with first signatures, txids, not additional signatures.

#### Summary of Changes

Adds a note to `getSignatureStatuses` and `signatureSubscribe` to clarify that these use txids.