### PR TITLE
measure: `as_*`/`end_as_*` tests: Increase margins to 20%

### DIFF
--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -95,10 +95,15 @@ mod tests {
         let mut measure = Measure::start("test");
         sleep(Duration::from_millis(100));
         measure.stop();
-        assert!(measure.as_s() >= 0.09f32 && measure.as_s() <= 0.11f32);
-        assert!(measure.as_ms() >= 90 && measure.as_ms() <= 110);
-        assert!(measure.as_us() >= 99_000 && measure.as_us() <= 110_000);
-        assert!(measure.as_ns() >= 99_000_000 && measure.as_ns() <= 110_000_000);
+
+        // We have observed failures with margins of 10%, when CI machines are very busy, running
+        // multiple tests in parallel.  As we are not testing the timer functionality itself, it is
+        // probably OK to increase the margins to 20%.
+
+        assert!(measure.as_s() >= 0.08f32 && measure.as_s() <= 0.12f32);
+        assert!(measure.as_ms() >= 80 && measure.as_ms() <= 120);
+        assert!(measure.as_us() >= 80_000 && measure.as_us() <= 120_000);
+        assert!(measure.as_ns() >= 80_000_000 && measure.as_ns() <= 120_000_000);
         assert!(
             measure.as_duration() >= Duration::from_millis(90)
                 && measure.as_duration() <= Duration::from_millis(110)
@@ -129,15 +134,19 @@ mod tests {
             );
         }
 
-        test_end_as(Measure::end_as_s, 100, 0.09f32, 0.11f32);
-        test_end_as(Measure::end_as_ms, 100, 90, 110);
-        test_end_as(Measure::end_as_us, 100, 90_000, 110_000);
-        test_end_as(Measure::end_as_ns, 100, 90_000_000, 110_000_000);
+        // We have observed failures with margins of 10%, when CI machines are very busy, running
+        // multiple tests in parallel.  As we are not testing the timer functionality itself, it is
+        // probably OK to increase the margins to 20%.
+
+        test_end_as(Measure::end_as_s, 100, 0.08f32, 0.12f32);
+        test_end_as(Measure::end_as_ms, 100, 80, 120);
+        test_end_as(Measure::end_as_us, 100, 80_000, 120_000);
+        test_end_as(Measure::end_as_ns, 100, 80_000_000, 120_000_000);
         test_end_as(
             Measure::end_as_duration,
             100,
-            Duration::from_millis(90),
-            Duration::from_millis(110),
+            Duration::from_millis(80),
+            Duration::from_millis(120),
         );
     }
 


### PR DESCRIPTION
#### Problem
`measure::tests::test_measure_end_as` is flaky.
Report: https://github.com/solana-labs/solana/issues/31585

#### Summary of Changes
Increase measurement margins to 20%.