### PR TITLE
race condition when running solana-program-test

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -85,19 +85,16 @@ impl BanksServer {
                 .into_iter()
                 .map(|info| deserialize(&info.wire_transaction).unwrap())
                 .collect();
-            'inner: loop {
+            loop {
                 let bank = bank_forks.read().unwrap().working_bank();
                 // bank forks lock released, now verify bank hasn't been frozen yet
                 // in the mean-time the bank can not be frozen until this tx batch
-                // has been processed, this replicates BankingStage behaviour
+                // has been processed
                 let lock = bank.freeze_lock();
-                if *lock != Hash::default() {
-                    // retry reading working bank if bank is already frozen
-                    continue;
-                } else {
+                if *lock == Hash::default() {
                     let _ = bank.try_process_transactions(transactions.iter());
                     // break out of inner loop and release bank freeze lock
-                    break 'inner;
+                    break;
                 }
             }
         }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -85,8 +85,21 @@ impl BanksServer {
                 .into_iter()
                 .map(|info| deserialize(&info.wire_transaction).unwrap())
                 .collect();
-            let bank = bank_forks.read().unwrap().working_bank();
-            let _ = bank.try_process_transactions(transactions.iter());
+            'inner: loop {
+                let bank = bank_forks.read().unwrap().working_bank();
+                // bank forks lock released, now verify bank hasn't been frozen yet
+                // in the mean-time the bank can not be frozen until this tx batch
+                // has been processed, this replicates BankingStage behaviour
+                let lock = bank.freeze_lock();
+                if *lock != Hash::default() {
+                    // retry reading working bank if bank is already frozen
+                    continue;
+                } else {
+                    let _ = bank.try_process_transactions(transactions.iter());
+                    // break out of inner loop and release bank freeze lock
+                    break 'inner;
+                }
+            }
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3187,8 +3187,8 @@ impl Bank {
 
     pub fn freeze(&self) {
         // This lock prevents any new commits from BankingStage
-        // `process_and_record_transactions_locked()` from coming
-        // in after the last tick is observed. This is because in
+        // `Consumer::execute_and_commit_transactions_locked()` from
+        // coming in after the last tick is observed. This is because in
         // BankingStage, any transaction successfully recorded in
         // `record_transactions()` is recorded after this `hash` lock
         // is grabbed. At the time of the successful record,


### PR DESCRIPTION
#### Problem

The banks-server transaction execution used by solana-program-test hits a race condition when executing large test suites. Here's [an example](https://github.com/blockworks-foundation/mango-v4/actions/runs/4966814314/) of such a run, which only succeeded on the 3rd attempt.

```
2023-05-13T12:26:36.4991091Z thread 'solBankForksCli' panicked at 'assertion failed: !self.freeze_started()', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/solana-runtime-1.14.17/src/bank.rs:6201:9
2023-05-13T12:26:36.4991704Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-05-13T12:26:36.4992796Z thread 'cases::test_perp_settle::test_perp_settle_pnl' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/solana-banks-server-1.14.17/src/banks_server.rs:333:44
2023-05-13T12:26:36.4994208Z thread 'cases::test_perp_settle::test_perp_settle_pnl' panicked at 'called `Result::unwrap()` on an `Err` value: IoError(Custom { kind: Other, error: "the request exceeded its deadline" })', programs/mango-v4/tests/program_test/mango_client.rs:391:6
```

The issue here is that the highest slot bank is sometimes frozen by the time `try_process_transactions` is called.

#### Summary of Changes

Unlike BankingStage, BanksServer does not stop to schedule shortly before the end of the slot. I didn't port this behavior as a slow block shouldn't really hurt a solana-program-test run, but instead acquired the bank's freeze lock for the duration of the processing.

This problem is very difficult to reproduce, so I didn't add a test (yet). Would be grateful for ideas how to test it using a unit test as this kind of issue can re-appear anytime given the complexity of locks hierarchies around the Bank.