### PR TITLE
Add origin/ prefix for git diff when building CI pipeline.

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -304,7 +304,7 @@ pull_or_push_steps() {
 
   # Version bump PRs are an edge case that can skip most of the CI steps
   if affects .toml$ && affects .lock$ && ! affects_other_than .toml$ .lock$; then
-    optional_old_version_number=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD validator/Cargo.toml | \
+    optional_old_version_number=$(git diff origin/"$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD validator/Cargo.toml | \
       grep -e "^-version" | sed  's/-version = "\(.*\)"/\1/')
     echo "optional_old_version_number: ->$optional_old_version_number<-"
     new_version_number=$(grep -e  "^version = " validator/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
@@ -314,7 +314,7 @@ pull_or_push_steps() {
     # lines that don't match. Any diff that produces output here is not a version bump.
     # | cat is a no-op. If this pull request is a version bump then grep will output no lines and have an exit code of 1.
     # Piping the output to cat prevents that non-zero exit code from exiting this script
-    diff_other_than_version_bump=$(git diff "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD | \
+    diff_other_than_version_bump=$(git diff origin/"$BUILDKITE_PULL_REQUEST_BASE_BRANCH"..HEAD | \
       grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?solana.*$optional_old_version_number|^\+( \")?solana.*$new_version_number|^-version|^\+version"|cat)
     echo "diff_other_than_version_bump: ->$diff_other_than_version_bump<-"
 


### PR DESCRIPTION
#### Problem
```
++git branch
--
  | * (HEAD detached at 06b7ccc3b4)
  | master
  | >++git status
  | HEAD detached at 06b7ccc3b4
  | Untracked files:
  | (use "git add <file>..." to include in what will be committed)
  | pipeline.yml
  |  
  | nothing added to commit but untracked files present (use "git add" to track)
  | +++git diff v1.14..HEAD validator/Cargo.toml
  | +++grep -e '^-version'
  | +++sed 's/-version = "\(.*\)"/\1/'
  | fatal: ambiguous argument 'v1.14..HEAD': unknown revision or path not in the working tree.
```

The current implementation fails because `BUILDKITE_PULL_REQUEST_BASE_BRANCH` is `v1.14` branches like `v1.14` don't exist in the Buildkite clone. The fully qualified `origin/v1.14` branches exist, so adding the `origin/` prefix should resolve this.

### Related PRs
Similar PR against master: #31636
Debugging PRs: master: #30914  v1.14: #31612
Test case: #31563 (after this PR is merged a rebase should give 31563 the entire CI pipeline)