### PR TITLE
[zk-keygen] create cli utility and add `new` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7346,6 +7346,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-keygen"
+version = "1.16.0"
+dependencies = [
+ "bs58",
+ "clap 3.2.23",
+ "dirs-next",
+ "num_cpus",
+ "solana-clap-v3-utils",
+ "solana-cli-config",
+ "solana-remote-wallet",
+ "solana-sdk 1.16.0",
+ "solana-version",
+ "solana-zk-token-sdk 1.16.0",
+ "tempfile",
+ "tiny-bip39",
+]
+
+[[package]]
 name = "solana-zk-token-proof-program"
 version = "1.16.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "validator",
     "version",
     "watchtower",
+    "zk-keygen",
     "zk-token-sdk",
 ]
 
@@ -358,6 +359,7 @@ solana-transaction-status = { path = "transaction-status", version = "=1.16.0" }
 solana-udp-client = { path = "udp-client", version = "=1.16.0" }
 solana-version = { path = "version", version = "=1.16.0" }
 solana-vote-program = { path = "programs/vote", version = "=1.16.0" }
+solana-zk-keygen = { path = "zk-keygen", version = "=1.16.0" }
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=1.16.0" }
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=1.16.0" }
 spl-associated-token-account = "=1.1.3"

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "solana-zk-keygen"
-description = "Solana privacy-related key generation utility"
+description = """
+Solana privacy-related key generation utility
+
+The tool currently supports two types of encryption keys that are used in the SPL Token-2022 program:
+  - ElGamal keypair that can be used for public key encryption
+  - AES128 key that can be used for an authenticated symmetric encryption (e.g. AES-GCM-SIV)
+"""
 publish = false
 version = { workspace = true }
 authors = { workspace = true }

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -29,7 +29,7 @@ solana-zk-token-sdk = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.5.0"
+tempfile = { workspace = true }
 
 [[bin]]
 name = "solana-zk-keygen"

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solana-zk-keygen"
+description = "Solana privacy-related key generation utility"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bs58 = { workspace = true }
+clap = { version = "3.1.5", features = ["cargo", "derive"] }
+dirs-next = { workspace = true }
+num_cpus = { workspace = true }
+solana-clap-v3-utils = { workspace = true }
+solana-cli-config = { workspace = true }
+solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-sdk = { workspace = true }
+solana-version = { workspace = true }
+solana-zk-token-sdk = { workspace = true }
+tiny-bip39 = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.5.0"
+
+[[bin]]
+name = "solana-zk-keygen"
+path = "src/main.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -215,6 +215,14 @@ mod tests {
     }
 
     #[test]
+    fn test_arguments() {
+        let solana_version = solana_version::version!();
+
+        // run clap internal assert statements
+        app(solana_version).debug_assert();
+    }
+
+    #[test]
     fn test_new_elgamal() {
         let outfile_dir = tempdir().unwrap();
         // use `Pubkey::new_unique()` to generate names for temporary key files

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,9 +1,35 @@
 use {
+    bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},
-    solana_clap_v3_utils::DisplayError,
+    solana_clap_v3_utils::{
+        input_parsers::STDOUT_OUTFILE_TOKEN,
+        keygen::{
+            check_for_overwrite,
+            mnemonic::{acquire_language, acquire_passphrase_and_message, WORD_COUNT_ARG},
+            no_outfile_arg, KeyGenerationCommonArgs, NO_OUTFILE_ARG,
+        },
+        DisplayError,
+    },
     solana_cli_config::CONFIG_FILE,
+    solana_sdk::signer::EncodableKey,
+    solana_zk_token_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     std::error,
 };
+
+fn output_encodable_key<K: EncodableKey>(
+    key: &K,
+    outfile: &str,
+    source: &str,
+) -> Result<(), Box<dyn error::Error>> {
+    if outfile == STDOUT_OUTFILE_TOKEN {
+        let mut stdout = std::io::stdout();
+        key.write(&mut stdout)?;
+    } else {
+        key.write_to_file(outfile)?;
+        println!("Wrote {source} to {outfile}");
+    }
+    Ok(())
+}
 
 fn app(crate_version: &str) -> Command {
     Command::new(crate_name!())
@@ -25,6 +51,43 @@ fn app(crate_version: &str) -> Command {
                 arg
             }
         })
+        .subcommand(
+            Command::new("new")
+                .about("Generate a new encryption key/keypair file from a random seed phrase and optional BIP39 passphrase")
+                .disable_version_flag(true)
+                .arg(
+                    Arg::new("key_type")
+                        .short('t')
+                        .long("key-type")
+                        .takes_value(true)
+                        .possible_values(["elgamal", "symmetric"])
+                        .value_name("TYPE")
+                        .required(true)
+                        .help("The type of encryption key")
+                )
+                .arg(
+                    Arg::new("outfile")
+                        .short('o')
+                        .long("outfile")
+                        .value_name("FILEPATH")
+                        .takes_value(true)
+                        .help("Path to generated file"),
+                )
+                .arg(
+                    Arg::new("force")
+                        .short('f')
+                        .long("force")
+                        .help("Overwrite the output file if it exists"),
+                )
+                .arg(
+                    Arg::new("silent")
+                        .short('s')
+                        .long("silent")
+                        .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
+                )
+                .key_generation_common_args()
+                .arg(no_outfile_arg().conflicts_with_all(&["outfile", "silent"]))
+        )
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
@@ -34,6 +97,101 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }
 
-fn do_main(_matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
-    unimplemented!()
+fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
+    let subcommand = matches.subcommand().unwrap();
+    match subcommand {
+        ("new", matches) => {
+            let key_type = match matches.value_of("key_type").unwrap() {
+                "elgamal" => KeyType::ElGamal,
+                "symmetric" => KeyType::Symmetric,
+                _ => unreachable!(),
+            };
+
+            let mut path = dirs_next::home_dir().expect("home directory");
+            let outfile = if matches.is_present("outfile") {
+                matches.value_of("outfile")
+            } else if matches.is_present(NO_OUTFILE_ARG.name) {
+                None
+            } else {
+                path.extend([".config", "solana", &key_type.default_file_name()]);
+                Some(path.to_str().unwrap())
+            };
+
+            match outfile {
+                Some(STDOUT_OUTFILE_TOKEN) => (),
+                Some(outfile) => check_for_overwrite(outfile, matches)?,
+                None => (),
+            }
+
+            let word_count: usize = matches.value_of_t(WORD_COUNT_ARG.name).unwrap();
+            let mnemonic_type = MnemonicType::for_word_count(word_count)?;
+            let language = acquire_language(matches);
+
+            let mnemonic = Mnemonic::new(mnemonic_type, language);
+            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
+            let seed = Seed::new(&mnemonic, &passphrase);
+
+            match key_type {
+                KeyType::ElGamal => {
+                    let silent = matches.is_present("silent");
+                    if !silent {
+                        println!("Generating a new ElGamal keypair");
+                    }
+
+                    let elgamal_keypair = ElGamalKeypair::from_seed(seed.as_bytes())?;
+                    if let Some(outfile) = outfile {
+                        output_encodable_key(&elgamal_keypair, outfile, "new ElGamal keypair")
+                            .map_err(|err| format!("Unable to write {outfile}: {err}"))?;
+                    }
+
+                    if !silent {
+                        let phrase: &str = mnemonic.phrase();
+                        let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
+                        println!(
+                            "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new ElGamal keypair:\n{}\n{}",
+                            &divider, elgamal_keypair.public, &divider, passphrase_message, phrase, &divider
+                        );
+                    }
+                }
+                KeyType::Symmetric => {
+                    let silent = matches.is_present("silent");
+                    if !silent {
+                        println!("Generating a new symmetric encryption key");
+                    }
+
+                    let symmetric_key = AeKey::from_seed(seed.as_bytes())?;
+                    if let Some(outfile) = outfile {
+                        output_encodable_key(&symmetric_key, outfile, "new symmetric key")
+                            .map_err(|err| format!("Unable to write {outfile}: {err}"))?;
+                    }
+
+                    if !silent {
+                        let phrase: &str = mnemonic.phrase();
+                        let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
+                        println!(
+                            "{}\nSave this seed phrase{} to recover your new symmetric key:\n{}\n{}",
+                            &divider, passphrase_message, phrase, &divider
+                        );
+                    }
+                }
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+enum KeyType {
+    ElGamal,
+    Symmetric,
+}
+
+impl KeyType {
+    fn default_file_name(&self) -> String {
+        match self {
+            KeyType::ElGamal => "elgamal.json".to_string(),
+            KeyType::Symmetric => "symmetric.json".to_string(),
+        }
+    }
 }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -66,7 +66,6 @@ fn app(crate_version: &str) -> Command {
                 )
                 .arg(
                     Arg::new("outfile")
-                        .short('o')
                         .long("outfile")
                         .value_name("FILEPATH")
                         .takes_value(true)
@@ -74,13 +73,11 @@ fn app(crate_version: &str) -> Command {
                 )
                 .arg(
                     Arg::new("force")
-                        .short('f')
                         .long("force")
                         .help("Overwrite the output file if it exists"),
                 )
                 .arg(
                     Arg::new("silent")
-                        .short('s')
                         .long("silent")
                         .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 )

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -51,6 +51,7 @@ fn app(crate_version: &str) -> Command {
                 )
                 .arg(
                     Arg::new("outfile")
+                        .short('o')
                         .long("outfile")
                         .value_name("FILEPATH")
                         .takes_value(true)

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -57,7 +57,6 @@ fn app(crate_version: &str) -> Command {
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("key_type")
-                        .short('t')
                         .long("key-type")
                         .takes_value(true)
                         .possible_values(["elgamal", "aes128"])

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -195,3 +195,177 @@ impl KeyType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::pubkey::Pubkey,
+        tempfile::{tempdir, TempDir},
+    };
+
+    fn process_test_command(args: &[&str]) -> Result<(), Box<dyn error::Error>> {
+        let solana_version = solana_version::version!();
+        let app_matches = app(solana_version).get_matches_from(args);
+        do_main(&app_matches)
+    }
+
+    fn tmp_outfile_path(out_dir: &TempDir, name: &str) -> String {
+        let path = out_dir.path().join(name);
+        path.into_os_string().into_string().unwrap()
+    }
+
+    #[test]
+    fn test_new_elgamal() {
+        let outfile_dir = tempdir().unwrap();
+        // use `Pubkey::new_unique()` to generate names for temporary key files
+        let outfile_path = tmp_outfile_path(&outfile_dir, &Pubkey::new_unique().to_string());
+
+        // general success case
+        process_test_command(&[
+            "solana-zk-keygen",
+            "new",
+            "--key-type",
+            "elgamal",
+            "--outfile",
+            &outfile_path,
+            "--no-bip39-passphrase",
+        ])
+        .unwrap();
+
+        // refuse to overwrite file
+        let result = process_test_command(&[
+            "solana-zk-keygen",
+            "new",
+            "--key-type",
+            "elgamal",
+            "--outfile",
+            &outfile_path,
+            "--no-bip39-passphrase",
+        ])
+        .unwrap_err()
+        .to_string();
+
+        let expected = format!("Refusing to overwrite {outfile_path} without --force flag");
+        assert_eq!(result, expected);
+
+        // no outfile
+        process_test_command(&[
+            "solana-keygen",
+            "new",
+            "--key-type",
+            "elgamal",
+            "--no-bip39-passphrase",
+            "--no-outfile",
+        ])
+        .unwrap();
+
+        // sanity check on languages and word count combinations
+        let languages = [
+            "english",
+            "chinese-simplified",
+            "chinese-traditional",
+            "japanese",
+            "spanish",
+            "korean",
+            "french",
+            "italian",
+        ];
+        let word_counts = ["12", "15", "18", "21", "24"];
+
+        for language in languages {
+            for word_count in word_counts {
+                process_test_command(&[
+                    "solana-keygen",
+                    "new",
+                    "--key-type",
+                    "elgamal",
+                    "--no-outfile",
+                    "--no-bip39-passphrase",
+                    "--language",
+                    language,
+                    "--word-count",
+                    word_count,
+                ])
+                .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_symmetric() {
+        let outfile_dir = tempdir().unwrap();
+        // use `Pubkey::new_unique()` to generate names for temporary key files
+        let outfile_path = tmp_outfile_path(&outfile_dir, &Pubkey::new_unique().to_string());
+
+        // general success case
+        process_test_command(&[
+            "solana-zk-keygen",
+            "new",
+            "--key-type",
+            "symmetric",
+            "--outfile",
+            &outfile_path,
+            "--no-bip39-passphrase",
+        ])
+        .unwrap();
+
+        // refuse to overwrite file
+        let result = process_test_command(&[
+            "solana-zk-keygen",
+            "new",
+            "--key-type",
+            "symmetric",
+            "--outfile",
+            &outfile_path,
+            "--no-bip39-passphrase",
+        ])
+        .unwrap_err()
+        .to_string();
+
+        let expected = format!("Refusing to overwrite {outfile_path} without --force flag");
+        assert_eq!(result, expected);
+
+        // no outfile
+        process_test_command(&[
+            "solana-keygen",
+            "new",
+            "--key-type",
+            "symmetric",
+            "--no-bip39-passphrase",
+            "--no-outfile",
+        ])
+        .unwrap();
+
+        // sanity check on languages and word count combinations
+        let languages = [
+            "english",
+            "chinese-simplified",
+            "chinese-traditional",
+            "japanese",
+            "spanish",
+            "korean",
+            "french",
+            "italian",
+        ];
+        let word_counts = ["12", "15", "18", "21", "24"];
+
+        for language in languages {
+            for word_count in word_counts {
+                process_test_command(&[
+                    "solana-keygen",
+                    "new",
+                    "--key-type",
+                    "symmetric",
+                    "--no-outfile",
+                    "--no-bip39-passphrase",
+                    "--language",
+                    language,
+                    "--word-count",
+                    word_count,
+                ])
+                .unwrap();
+            }
+        }
+    }
+}

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -94,7 +94,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             } else if matches.is_present(NO_OUTFILE_ARG.name) {
                 None
             } else {
-                path.extend([".config", "solana", &key_type.default_file_name()]);
+                path.extend([".config", "solana", key_type.default_file_name()]);
                 Some(path.to_str().unwrap())
             };
 

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -169,10 +169,10 @@ enum KeyType {
 }
 
 impl KeyType {
-    fn default_file_name(&self) -> String {
+    fn default_file_name(&self) -> &str {
         match self {
-            KeyType::ElGamal => "elgamal.json".to_string(),
-            KeyType::Aes128 => "aes128.json".to_string(),
+            KeyType::ElGamal => "elgamal.json",
+            KeyType::Aes128 => "aes128.json",
         }
     }
 }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -134,7 +134,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 KeyType::ElGamal => {
                     let silent = matches.is_present("silent");
                     if !silent {
-                        println!("Generating a new ElGamal keypair");
+                        eprintln!("Generating a new ElGamal keypair");
                     }
 
                     let elgamal_keypair = ElGamalKeypair::from_seed(seed.as_bytes())?;
@@ -155,7 +155,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 KeyType::Aes128 => {
                     let silent = matches.is_present("silent");
                     if !silent {
-                        println!("Generating a new AES128 encryption key");
+                        eprintln!("Generating a new AES128 encryption key");
                     }
 
                     let aes_key = AeKey::from_seed(seed.as_bytes())?;

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,0 +1,39 @@
+use {
+    clap::{crate_description, crate_name, Arg, ArgMatches, Command},
+    solana_clap_v3_utils::DisplayError,
+    solana_cli_config::CONFIG_FILE,
+    std::error,
+};
+
+fn app(crate_version: &str) -> Command {
+    Command::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version)
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .arg({
+            let arg = Arg::new("config_file")
+                .short('C')
+                .long("config")
+                .value_name("FILEPATH")
+                .takes_value(true)
+                .global(true)
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *CONFIG_FILE {
+                arg.default_value(config_file)
+            } else {
+                arg
+            }
+        })
+}
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    let matches = app(solana_version::version!())
+        .try_get_matches()
+        .unwrap_or_else(|e| e.exit());
+    do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
+}
+
+fn do_main(_matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
+    unimplemented!()
+}

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -113,9 +113,10 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
             let seed = Seed::new(&mnemonic, &passphrase);
 
+            let silent = matches.is_present("silent");
+
             match key_type {
                 KeyType::ElGamal => {
-                    let silent = matches.is_present("silent");
                     if !silent {
                         eprintln!("Generating a new ElGamal keypair");
                     }
@@ -136,7 +137,6 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                     }
                 }
                 KeyType::Aes128 => {
-                    let silent = matches.is_present("silent");
                     if !silent {
                         eprintln!("Generating a new AES128 encryption key");
                     }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -60,7 +60,7 @@ fn app(crate_version: &str) -> Command {
                         .short('t')
                         .long("key-type")
                         .takes_value(true)
-                        .possible_values(["elgamal", "symmetric"])
+                        .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
                         .required(true)
                         .help("The type of encryption key")
@@ -103,7 +103,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         ("new", matches) => {
             let key_type = match matches.value_of("key_type").unwrap() {
                 "elgamal" => KeyType::ElGamal,
-                "symmetric" => KeyType::Symmetric,
+                "aes128" => KeyType::Aes128,
                 _ => unreachable!(),
             };
 
@@ -153,15 +153,15 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         );
                     }
                 }
-                KeyType::Symmetric => {
+                KeyType::Aes128 => {
                     let silent = matches.is_present("silent");
                     if !silent {
-                        println!("Generating a new symmetric encryption key");
+                        println!("Generating a new AES128 encryption key");
                     }
 
-                    let symmetric_key = AeKey::from_seed(seed.as_bytes())?;
+                    let aes_key = AeKey::from_seed(seed.as_bytes())?;
                     if let Some(outfile) = outfile {
-                        output_encodable_key(&symmetric_key, outfile, "new symmetric key")
+                        output_encodable_key(&aes_key, outfile, "new AES128 key")
                             .map_err(|err| format!("Unable to write {outfile}: {err}"))?;
                     }
 
@@ -169,7 +169,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         let phrase: &str = mnemonic.phrase();
                         let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                         println!(
-                            "{}\nSave this seed phrase{} to recover your new symmetric key:\n{}\n{}",
+                            "{}\nSave this seed phrase{} to recover your new AES128 key:\n{}\n{}",
                             &divider, passphrase_message, phrase, &divider
                         );
                     }
@@ -184,14 +184,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
 
 enum KeyType {
     ElGamal,
-    Symmetric,
+    Aes128,
 }
 
 impl KeyType {
     fn default_file_name(&self) -> String {
         match self {
             KeyType::ElGamal => "elgamal.json".to_string(),
-            KeyType::Symmetric => "symmetric.json".to_string(),
+            KeyType::Aes128 => "aes128.json".to_string(),
         }
     }
 }
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_symmetric() {
+    fn test_new_aes128() {
         let outfile_dir = tempdir().unwrap();
         // use `Pubkey::new_unique()` to generate names for temporary key files
         let outfile_path = tmp_outfile_path(&outfile_dir, &Pubkey::new_unique().to_string());
@@ -303,7 +303,7 @@ mod tests {
             "solana-zk-keygen",
             "new",
             "--key-type",
-            "symmetric",
+            "aes128",
             "--outfile",
             &outfile_path,
             "--no-bip39-passphrase",
@@ -315,7 +315,7 @@ mod tests {
             "solana-zk-keygen",
             "new",
             "--key-type",
-            "symmetric",
+            "aes128",
             "--outfile",
             &outfile_path,
             "--no-bip39-passphrase",
@@ -331,7 +331,7 @@ mod tests {
             "solana-keygen",
             "new",
             "--key-type",
-            "symmetric",
+            "aes128",
             "--no-bip39-passphrase",
             "--no-outfile",
         ])
@@ -356,7 +356,7 @@ mod tests {
                     "solana-keygen",
                     "new",
                     "--key-type",
-                    "symmetric",
+                    "aes128",
                     "--no-outfile",
                     "--no-bip39-passphrase",
                     "--language",

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -263,37 +263,6 @@ mod tests {
             "--no-outfile",
         ])
         .unwrap();
-
-        // sanity check on languages and word count combinations
-        let languages = [
-            "english",
-            "chinese-simplified",
-            "chinese-traditional",
-            "japanese",
-            "spanish",
-            "korean",
-            "french",
-            "italian",
-        ];
-        let word_counts = ["12", "15", "18", "21", "24"];
-
-        for language in languages {
-            for word_count in word_counts {
-                process_test_command(&[
-                    "solana-keygen",
-                    "new",
-                    "--key-type",
-                    "elgamal",
-                    "--no-outfile",
-                    "--no-bip39-passphrase",
-                    "--language",
-                    language,
-                    "--word-count",
-                    word_count,
-                ])
-                .unwrap();
-            }
-        }
     }
 
     #[test]
@@ -340,36 +309,5 @@ mod tests {
             "--no-outfile",
         ])
         .unwrap();
-
-        // sanity check on languages and word count combinations
-        let languages = [
-            "english",
-            "chinese-simplified",
-            "chinese-traditional",
-            "japanese",
-            "spanish",
-            "korean",
-            "french",
-            "italian",
-        ];
-        let word_counts = ["12", "15", "18", "21", "24"];
-
-        for language in languages {
-            for word_count in word_counts {
-                process_test_command(&[
-                    "solana-keygen",
-                    "new",
-                    "--key-type",
-                    "aes128",
-                    "--no-outfile",
-                    "--no-bip39-passphrase",
-                    "--language",
-                    language,
-                    "--word-count",
-                    word_count,
-                ])
-                .unwrap();
-            }
-        }
     }
 }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -41,8 +41,8 @@ fn app(crate_version: &str) -> Command {
                 .about("Generate a new encryption key/keypair file from a random seed phrase and optional BIP39 passphrase")
                 .disable_version_flag(true)
                 .arg(
-                    Arg::new("key_type")
-                        .long("key-type")
+                    Arg::new("type")
+                        .long("type")
                         .takes_value(true)
                         .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
@@ -83,7 +83,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
     let subcommand = matches.subcommand().unwrap();
     match subcommand {
         ("new", matches) => {
-            let key_type = match matches.value_of("key_type").unwrap() {
+            let key_type = match matches.value_of("type").unwrap() {
                 "elgamal" => KeyType::ElGamal,
                 "aes128" => KeyType::Aes128,
                 _ => unreachable!(),
@@ -215,7 +215,7 @@ mod tests {
         process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--key-type",
+            "--type",
             "elgamal",
             "--outfile",
             &outfile_path,
@@ -227,7 +227,7 @@ mod tests {
         let result = process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--key-type",
+            "--type",
             "elgamal",
             "--outfile",
             &outfile_path,
@@ -243,7 +243,7 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--key-type",
+            "--type",
             "elgamal",
             "--no-bip39-passphrase",
             "--no-outfile",
@@ -261,7 +261,7 @@ mod tests {
         process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--key-type",
+            "--type",
             "aes128",
             "--outfile",
             &outfile_path,
@@ -273,7 +273,7 @@ mod tests {
         let result = process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--key-type",
+            "--type",
             "aes128",
             "--outfile",
             &outfile_path,
@@ -289,7 +289,7 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--key-type",
+            "--type",
             "aes128",
             "--no-bip39-passphrase",
             "--no-outfile",

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -10,7 +10,6 @@ use {
         },
         DisplayError,
     },
-    solana_cli_config::CONFIG_FILE,
     solana_sdk::signer::EncodableKey,
     solana_zk_token_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     std::error,
@@ -37,20 +36,6 @@ fn app(crate_version: &str) -> Command {
         .version(crate_version)
         .subcommand_required(true)
         .arg_required_else_help(true)
-        .arg({
-            let arg = Arg::new("config_file")
-                .short('C')
-                .long("config")
-                .value_name("FILEPATH")
-                .takes_value(true)
-                .global(true)
-                .help("Configuration file to use");
-            if let Some(ref config_file) = *CONFIG_FILE {
-                arg.default_value(config_file)
-            } else {
-                arg
-            }
-        })
         .subcommand(
             Command::new("new")
                 .about("Generate a new encryption key/keypair file from a random seed phrase and optional BIP39 passphrase")


### PR DESCRIPTION
#### Problem
There is currently no cli utility to create encryption keys (ElGamal and authenticated encryption) used for token-2022 and more generally zero-knowledge proofs.

#### Summary of Changes
Create a `zk-keygen` cli tool to generate encryption keys and add the `new` command that randomly generates encryption keys analogously to `keygen`.

Other commands like `recover` (recover key/keypair from passphrase) and `pubkey` (print out pubkey from an ElGamal keypair) will be added in a follow-up PR.

The `solana-zk-keygen` is marked not for publication for now.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
