### PR TITLE
Fix flaky measure test by increasing the tolerance

### DIFF
--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -129,7 +129,7 @@ mod tests {
             );
         }
 
-        test_end_as(Measure::end_as_s, 100, 0.09f32, 0.11f32);
+        test_end_as(Measure::end_as_s, 100, 0.09f32, 0.15f32);
         test_end_as(Measure::end_as_ms, 100, 90, 110);
         test_end_as(Measure::end_as_us, 100, 90_000, 110_000);
         test_end_as(Measure::end_as_ns, 100, 90_000_000, 110_000_000);


### PR DESCRIPTION
#### Problem

measure_end_as test is flaky because it hits the tolerance of measurement

#### Summary of Changes

Increase the tolerance

Fixes #31585
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
