### PR TITLE
Do not purge bank snapshots in AccountsBackgroundService

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -329,9 +329,18 @@ impl AccountsHashVerifier {
         //
         // If we are *not* generating snapshots, then purge old bank snapshots here.
         if !snapshot_config.should_generate_snapshots() {
-            snapshot_utils::purge_bank_snapshots_older_than_slot(
-                &snapshot_config.bank_snapshots_dir,
-                accounts_package.slot,
+            let (_, purge_bank_snapshots_time_us) =
+                measure_us!(snapshot_utils::purge_bank_snapshots_older_than_slot(
+                    &snapshot_config.bank_snapshots_dir,
+                    accounts_package.slot,
+                ));
+            datapoint_info!(
+                "accounts_hash_verifier",
+                (
+                    "purge_old_snapshots_time_us",
+                    purge_bank_snapshots_time_us,
+                    i64
+                ),
             );
         }
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -16,7 +16,6 @@ use {
     crossbeam_channel::{Receiver, SendError, Sender},
     log::*,
     rand::{thread_rng, Rng},
-    snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN,
     solana_measure::measure::Measure,
     solana_sdk::clock::{BankId, Slot},
     stats::StatsManager,
@@ -389,14 +388,6 @@ impl SnapshotRequestHandler {
             snapshot_root_bank.hash(),
         );
 
-        // Cleanup outdated snapshots
-        let mut purge_old_snapshots_time = Measure::start("purge_old_snapshots_time");
-        snapshot_utils::purge_old_bank_snapshots(
-            &self.snapshot_config.bank_snapshots_dir,
-            MAX_BANK_SNAPSHOTS_TO_RETAIN,
-            None,
-        );
-        purge_old_snapshots_time.stop();
         total_time.stop();
 
         datapoint_info!(
@@ -409,11 +400,6 @@ impl SnapshotRequestHandler {
             ("shrink_time", shrink_time.as_us(), i64),
             ("clean_time", clean_time.as_us(), i64),
             ("snapshot_time", snapshot_time.as_us(), i64),
-            (
-                "purge_old_snapshots_time",
-                purge_old_snapshots_time.as_us(),
-                i64
-            ),
             ("total_us", total_time.as_us(), i64),
             ("non_snapshot_time_us", non_snapshot_time_us, i64),
         );


### PR DESCRIPTION
#### Problem

AccountsBackgroundService can purge bank snapshots that are still in use by AccountsHashVerifier and/or SnapshotPackagerService.

Right now we are relying on AHV and SPS processing their requests quickly enough *and* ABS taking bank snapshots slowly enough so that ABS never rugs AHV/SPS. Since AHV and SPS both have code to purge old bank snapshots once they are no longer needed, ABS should not be in charge.


#### Summary of Changes

* Do not purge bank snapshots in ABS
* Add/move metrics for how long it takes to purge the old bank snapshots into AHV and SPS