### PR TITLE
Uses `_` instead of `-` for datapoint field names

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -118,17 +118,17 @@ impl AccountsHashVerifier {
                     datapoint_info!(
                         "accounts_hash_verifier",
                         (
-                            "num-outstanding-accounts-packages",
+                            "num_outstanding_accounts_packages",
                             num_outstanding_accounts_packages,
                             i64
                         ),
                         (
-                            "num-re-enqueued-accounts-packages",
+                            "num_re_enqueued_accounts_packages",
                             num_re_enqueued_accounts_packages,
                             i64
                         ),
-                        ("enqueued-time-us", enqueued_time.as_micros(), i64),
-                        ("handling-time-us", handling_time_us, i64),
+                        ("enqueued_time_us", enqueued_time.as_micros(), i64),
+                        ("handling_time_us", handling_time_us, i64),
                     );
                 }
                 debug!(

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -108,17 +108,17 @@ impl SnapshotPackagerService {
                     datapoint_info!(
                         "snapshot_packager_service",
                         (
-                            "num-outstanding-snapshot-packages",
+                            "num_outstanding_snapshot_packages",
                             num_outstanding_snapshot_packages,
                             i64
                         ),
                         (
-                            "num-re-enqueued-snapshot-packages",
+                            "num_re_enqueued_snapshot_packages",
                             num_re_enqueued_snapshot_packages,
                             i64
                         ),
-                        ("enqueued-time-us", enqueued_time.as_micros(), i64),
-                        ("handling-time-us", handling_time_us, i64),
+                        ("enqueued_time_us", enqueued_time.as_micros(), i64),
+                        ("handling_time_us", handling_time_us, i64),
                     );
                 }
                 info!("SnapshotPackagerService has stopped");

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -160,19 +160,11 @@ impl SnapshotRequestHandler {
 
         datapoint_info!(
             "handle_snapshot_requests",
+            ("num_outstanding_requests", num_outstanding_requests, i64),
+            ("num_re_enqueued_requests", num_re_enqueued_requests, i64),
             (
-                "num-outstanding-requests",
-                num_outstanding_requests as i64,
-                i64
-            ),
-            (
-                "num-re-enqueued-requests",
-                num_re_enqueued_requests as i64,
-                i64
-            ),
-            (
-                "enqueued-time-us",
-                snapshot_request.enqueued.elapsed().as_micros() as i64,
+                "enqueued_time_us",
+                snapshot_request.enqueued.elapsed().as_micros(),
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem

A nit, using a dash (`-`) as the word separator makes it hard to copy-paste via double-clicking.


#### Summary of Changes

Replace dashes with underscores in datapoints in the background services.