### PR TITLE
[docs] remove incorrect pubkey param from getEpochInfo

### DIFF
--- a/docs/src/api/methods/_getEpochInfo.mdx
+++ b/docs/src/api/methods/_getEpochInfo.mdx
@@ -20,10 +20,6 @@ Returns information about the current epoch
 
 ### Parameters:
 
-<Parameter type={"string"} required={true}>
-  Pubkey of account to query, as base-58 encoded string
-</Parameter>
-
 <Parameter type={"object"} optional={true}>
 
 Configuration object containing the following fields:


### PR DESCRIPTION
This PR removes an incorrect address parameter from the docs for `getEpochInfo`

Relevant source code: 

https://github.com/solana-labs/solana/blob/bac4d50761ccb96ff1eff3794dc303483ec2c010/rpc-client/src/rpc_client.rs#L2733-L2735

https://github.com/solana-labs/solana/blob/bac4d50761ccb96ff1eff3794dc303483ec2c010/rpc-client/src/rpc_client.rs#L2758-L2763

As far as I can tell there's no path where an address is used in the `getEpochInfo` call

In addition making the RPC call:

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getEpochInfo",
    "params": [
        "H3BRzVGdedrBQD9wFitEbzEBhRoPXTemopuvS8AcNxLy"
    ]
}
```

Gives the error:
```json
    "error": {
        "code": -32602,
        "message": "Invalid params: invalid type: string \"H3BRzVGdedrBQD9wFitEbzEBhRoPXTemopuvS8AcNxLy\", expected struct RpcContextConfig."
    },
```