### PR TITLE
[docs] add error response for getBlockTime RPC call

### DIFF
--- a/docs/src/api/methods/_getBlockTime.mdx
+++ b/docs/src/api/methods/_getBlockTime.mdx
@@ -34,7 +34,6 @@ in a set of recent blocks recorded on the ledger.
 ### Result:
 
 - `<i64>` - estimated production time, as Unix timestamp (seconds since the Unix epoch)
-- `<null>` - timestamp is not available for this block
 
 </CodeParams>
 
@@ -54,10 +53,25 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 
 ### Response:
 
+When a block time is available:
+
 ```json
 {
   "jsonrpc": "2.0",
   "result": 1574721591,
+  "id": 1
+}
+```
+
+When a block time is not available:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32004,
+    "message": "Block not available for slot 150"
+  },
   "id": 1
 }
 ```


### PR DESCRIPTION
This PR updates the response type in the docs for `getBlockTime` and adds an extra example response 

As far as I can tell there is no path where the function returns null, it either returns a block time for the requested slot or an error. Source code: https://github.com/solana-labs/solana/blob/694099bbe3891d2168e6abb226e5202cc9190fed/rpc-client/src/nonblocking/rpc_client.rs#L3292-L3302

I've added an example response showing the error, in a similar way to [getHealth](https://docs.solana.com/api/http#gethealth)