### PR TITLE
remove zero staked nodes from shred propogation

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -307,7 +307,9 @@ pub fn new_cluster_nodes<T: 'static>(
 ) -> ClusterNodes<T> {
     let self_pubkey = cluster_info.id();
     let nodes: Vec<_> = get_nodes(cluster_info, stakes)
-        .into_iter().filter(|node| node.stake > 0).collect();
+        .into_iter()
+        .filter(|node| node.stake > 0)
+        .collect();
     let index: HashMap<_, _> = nodes
         .iter()
         .enumerate()

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -306,7 +306,8 @@ pub fn new_cluster_nodes<T: 'static>(
     stakes: &HashMap<Pubkey, u64>,
 ) -> ClusterNodes<T> {
     let self_pubkey = cluster_info.id();
-    let nodes = get_nodes(cluster_info, stakes);
+    let nodes: Vec<_> = get_nodes(cluster_info, stakes)
+        .into_iter().filter(|node| node.stake > 0).collect();
     let index: HashMap<_, _> = nodes
         .iter()
         .enumerate()


### PR DESCRIPTION
#### Problem

the `new_cluster_nodes` is used to get a list of nodes to forward shreds to in both the `retransmit` and `broadcast_shreds` phases through the `cluster_nodes_cache.get` call

the current impl includes gossip nodes which have zero stake which probs shouldnt be included? (they have a very low chance of being selected in the `WeightedShuffle` anyways)

#### Summary of Changes

filter out nodes who have zero stake