### PR TITLE
[clap-v3-utils] Fix output type of `ae_key_from_seed_phrase`

### DIFF
--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1210,7 +1210,7 @@ pub fn ae_key_from_seed_phrase(
     skip_validation: bool,
     derivation_path: Option<DerivationPath>,
     legacy: bool,
-) -> Result<ElGamalKeypair, Box<dyn error::Error>> {
+) -> Result<AeKey, Box<dyn error::Error>> {
     encodable_key_from_seed_phrase(keypair_name, skip_validation, derivation_path, legacy)
 }
 


### PR DESCRIPTION
#### Problem
The function `ae_key_from_seed_phrase` in clap-v3-utils `keypair` module returns `ElGamalKeypair` as opposed to `AeKey`. This is a mistake from a previous PR :pray:.

#### Summary of Changes
Change output type of `ae_key_from_seed_phrase` to `AeKey`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
