### PR TITLE
disable qos adjustment logic when feature apply_cost_tracker_during_replay is activated

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1082,7 +1082,9 @@ mod tests {
             mint_keypair,
             ..
         } = create_slow_genesis_config(10_000);
-        let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        let mut bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
+        bank.deactivate_feature(&feature_set::apply_cost_tracker_during_replay::id());
+        let bank = Arc::new(bank);
         let pubkey = solana_sdk::pubkey::new_rand();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();


### PR DESCRIPTION
#### Problem
Enabling the mentioned feature without first removing the QoS Adjustment Logic (https://github.com/solana-labs/solana/issues/29595#issuecomment-1524087480) breaks cluster test runs off head of Master, where all features are enabled by default. 

#### Summary of Changes
- disables the QoS Adjustment Logic when feature is activated (Will still remove the logic eventually #31379)

Fixes #31340 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
