### PR TITLE
support snapshot deserialization with EpochRewardStatus

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -873,6 +873,27 @@ impl AbiExample for OptionalDropCallback {
     }
 }
 
+#[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StartBlockHeightAndRewards {
+    /// the block height of the parent of the slot at which rewards distribution began
+    pub(crate) parent_start_block_height: u64,
+    /// calculated epoch rewards pending distribution
+    pub(crate) calculated_epoch_stake_rewards: Arc<StakeRewards>,
+}
+
+/// Represent whether bank is in the reward phase or not.
+#[derive(AbiExample, AbiEnumVisitor, Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum EpochRewardStatus {
+    /// this bank is in the reward phase.
+    /// Contents are the start point for epoch reward calculation,
+    /// i.e. parent_slot and parent_block height for the starting
+    /// block of the current epoch.
+    Active(StartBlockHeightAndRewards),
+    /// this bank is outside of the rewarding phase.
+    #[default]
+    Inactive,
+}
+
 /// Manager for the state of all accounts and programs after processing its entries.
 /// AbiExample is needed even without Serialize/Deserialize; actual (de-)serialization
 /// are implemented elsewhere for versioning
@@ -1084,7 +1105,7 @@ struct VoteReward {
 }
 
 type VoteRewards = DashMap<Pubkey, VoteReward>;
-type StakeRewards = Vec<StakeReward>;
+pub(crate) type StakeRewards = Vec<StakeReward>;
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {
@@ -1111,7 +1132,8 @@ pub struct CommitTransactionCounts {
     pub signature_count: u64,
 }
 
-struct StakeReward {
+#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub(crate) struct StakeReward {
     stake_pubkey: Pubkey,
     stake_reward_info: RewardInfo,
     stake_account: AccountSharedData,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -874,7 +874,7 @@ impl AbiExample for OptionalDropCallback {
 }
 
 #[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct StartBlockHeightAndRewards {
+pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the parent of the slot at which rewards distribution began
     pub(crate) parent_start_block_height: u64,
     /// calculated epoch rewards pending distribution
@@ -883,7 +883,7 @@ pub struct StartBlockHeightAndRewards {
 
 /// Represent whether bank is in the reward phase or not.
 #[derive(AbiExample, AbiEnumVisitor, Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub enum EpochRewardStatus {
+pub(crate) enum EpochRewardStatus {
     /// this bank is in the reward phase.
     /// Contents are the start point for epoch reward calculation,
     /// i.e. parent_slot and parent_block height for the starting

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -7,6 +7,7 @@ use {
     crate::{
         accounts_hash::AccountsHash,
         ancestors::AncestorsForSerialization,
+        bank::EpochRewardStatus,
         stakes::{serde_stakes_enum_compat, StakesEnum},
     },
     solana_measure::measure::Measure,
@@ -334,8 +335,11 @@ impl<'a> TypeContext<'a> for Context {
         let incremental_snapshot_persistence = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
 
-        let epoch_accounts_hash = ignore_eof_error(deserialize_from(stream))?;
+        let epoch_accounts_hash = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.epoch_accounts_hash = epoch_accounts_hash;
+
+        let _epoch_reward_status: EpochRewardStatus =
+            ignore_eof_error(deserialize_from(&mut stream))?;
 
         Ok((bank_fields, accounts_db_fields))
     }


### PR DESCRIPTION
#### Problem
For supporting partitioned reward distribution, we need to save the rewards to distribute to the snapshot.

#### Summary of Changes
Deserialize and ignore (for the moment) the contents of the newly written field. This allows the future version, which serializes this field, to create snapshots that can be read by the version this change goes into. The field is read and ignored by this change. The field is NOT written by this change.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
