### PR TITLE
remove unnecessary pub

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1118,7 +1118,7 @@ struct StakeReward {
 }
 
 impl StakeReward {
-    pub fn get_stake_reward(&self) -> i64 {
+    fn get_stake_reward(&self) -> i64 {
         self.stake_reward_info.lamports
     }
 }


### PR DESCRIPTION
#### Problem
`pub` is not necessary. Type is currently private. Soon, type will be `pub(crate)`.

#### Summary of Changes
remove unnecessary `pub` on `fn get_stake_reward`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
