### PR TITLE
Remove Rc and RefCell to carry program cache in invoke_context

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -551,7 +551,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         debug!("Loaded program {}", key);
         loaded_programs.replenish(key, program);
     }
-    invoke_context.programs_loaded_for_tx_batch = Rc::new(RefCell::new(loaded_programs));
+    invoke_context.programs_loaded_for_tx_batch = &loaded_programs;
 
     invoke_context
         .transaction_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -159,9 +159,9 @@ pub struct InvokeContext<'a> {
     current_compute_budget: ComputeBudget,
     compute_meter: RefCell<u64>,
     accounts_data_meter: AccountsDataMeter,
-    pub programs_loaded_for_tx_batch: Rc<RefCell<LoadedProgramsForTxBatch>>,
-    pub programs_modified_by_tx: Rc<RefCell<LoadedProgramsForTxBatch>>,
-    pub programs_updated_only_for_global_cache: Rc<RefCell<LoadedProgramsForTxBatch>>,
+    pub programs_loaded_for_tx_batch: &'a LoadedProgramsForTxBatch,
+    pub programs_modified_by_tx: &'a mut LoadedProgramsForTxBatch,
+    pub programs_updated_only_for_global_cache: &'a mut LoadedProgramsForTxBatch,
     pub feature_set: Arc<FeatureSet>,
     pub timings: ExecuteDetailsTimings,
     pub blockhash: Hash,
@@ -179,9 +179,9 @@ impl<'a> InvokeContext<'a> {
         sysvar_cache: &'a SysvarCache,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
         compute_budget: ComputeBudget,
-        programs_loaded_for_tx_batch: Rc<RefCell<LoadedProgramsForTxBatch>>,
-        programs_modified_by_tx: Rc<RefCell<LoadedProgramsForTxBatch>>,
-        programs_updated_only_for_global_cache: Rc<RefCell<LoadedProgramsForTxBatch>>,
+        programs_loaded_for_tx_batch: &'a LoadedProgramsForTxBatch,
+        programs_modified_by_tx: &'a mut LoadedProgramsForTxBatch,
+        programs_updated_only_for_global_cache: &'a mut LoadedProgramsForTxBatch,
         feature_set: Arc<FeatureSet>,
         blockhash: Hash,
         lamports_per_signature: u64,
@@ -905,7 +905,7 @@ macro_rules! with_mock_invoke_context_and_builtin_programs {
                 account::ReadableAccount, feature_set::FeatureSet, hash::Hash, sysvar::rent::Rent,
                 transaction_context::TransactionContext,
             },
-            std::{cell::RefCell, rc::Rc, sync::Arc},
+            std::sync::Arc,
             $crate::{
                 compute_budget::ComputeBudget, invoke_context::InvokeContext,
                 loaded_programs::LoadedProgramsForTxBatch, log_collector::LogCollector,
@@ -938,6 +938,9 @@ macro_rules! with_mock_invoke_context_and_builtin_programs {
                 }
             }
         });
+        let programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let mut $invoke_context = InvokeContext::new(
             &mut $transaction_context,
             Rent::default(),
@@ -945,9 +948,9 @@ macro_rules! with_mock_invoke_context_and_builtin_programs {
             &sysvar_cache,
             Some(LogCollector::new_ref()),
             compute_budget,
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             Hash::default(),
             0,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -335,7 +335,7 @@ pub struct LoadedPrograms {
     pub stats: Stats,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LoadedProgramsForTxBatch {
     /// Pubkey is the address of a program.
     /// LoadedProgram is the corresponding program entry valid for the slot in which a transaction is being executed.

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1499,9 +1499,7 @@ mod tests {
         },
         std::{
             borrow::Cow,
-            cell::RefCell,
             convert::TryFrom,
-            rc::Rc,
             sync::atomic::{AtomicBool, AtomicU64, Ordering},
             thread, time,
         },
@@ -1533,10 +1531,8 @@ mod tests {
                 executed_units: 0,
                 accounts_data_len_delta: 0,
             },
-            programs_modified_by_tx: Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            programs_updated_only_for_global_cache: Rc::new(RefCell::new(
-                LoadedProgramsForTxBatch::default(),
-            )),
+            programs_modified_by_tx: LoadedProgramsForTxBatch::default(),
+            programs_updated_only_for_global_cache: LoadedProgramsForTxBatch::default(),
         }
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1531,8 +1531,8 @@ mod tests {
                 executed_units: 0,
                 accounts_data_len_delta: 0,
             },
-            programs_modified_by_tx: LoadedProgramsForTxBatch::default(),
-            programs_updated_only_for_global_cache: LoadedProgramsForTxBatch::default(),
+            programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
+            programs_updated_only_for_global_cache: Box::<LoadedProgramsForTxBatch>::default(),
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -320,8 +320,8 @@ pub struct TransactionExecutionDetails {
 pub enum TransactionExecutionResult {
     Executed {
         details: TransactionExecutionDetails,
-        programs_modified_by_tx: LoadedProgramsForTxBatch,
-        programs_updated_only_for_global_cache: LoadedProgramsForTxBatch,
+        programs_modified_by_tx: Box<LoadedProgramsForTxBatch>,
+        programs_updated_only_for_global_cache: Box<LoadedProgramsForTxBatch>,
     },
     NotExecuted(TransactionError),
 }
@@ -4380,8 +4380,10 @@ impl Bank {
                 executed_units,
                 accounts_data_len_delta,
             },
-            programs_modified_by_tx,
-            programs_updated_only_for_global_cache,
+            programs_modified_by_tx: Box::new(programs_modified_by_tx),
+            programs_updated_only_for_global_cache: Box::new(
+                programs_updated_only_for_global_cache,
+            ),
         }
     }
 
@@ -4615,7 +4617,7 @@ impl Bank {
                         if details.status.is_ok() {
                             programs_loaded_for_tx_batch
                                 .borrow_mut()
-                                .merge(&programs_modified_by_tx);
+                                .merge(programs_modified_by_tx);
                         }
                     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -320,8 +320,8 @@ pub struct TransactionExecutionDetails {
 pub enum TransactionExecutionResult {
     Executed {
         details: TransactionExecutionDetails,
-        programs_modified_by_tx: Rc<RefCell<LoadedProgramsForTxBatch>>,
-        programs_updated_only_for_global_cache: Rc<RefCell<LoadedProgramsForTxBatch>>,
+        programs_modified_by_tx: LoadedProgramsForTxBatch,
+        programs_updated_only_for_global_cache: LoadedProgramsForTxBatch,
     },
     NotExecuted(TransactionError),
 }
@@ -4214,7 +4214,7 @@ impl Bank {
         timings: &mut ExecuteTimings,
         error_counters: &mut TransactionErrorMetrics,
         log_messages_bytes_limit: Option<usize>,
-        programs_loaded_for_tx_batch: Rc<RefCell<LoadedProgramsForTxBatch>>,
+        programs_loaded_for_tx_batch: &LoadedProgramsForTxBatch,
     ) -> TransactionExecutionResult {
         let prev_accounts_data_len = self.load_accounts_data_size();
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
@@ -4264,10 +4264,8 @@ impl Bank {
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
 
         let mut executed_units = 0u64;
-        let programs_modified_by_tx =
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::new(self.slot)));
-        let programs_updated_only_for_global_cache =
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::new(self.slot)));
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(self.slot);
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::new(self.slot);
         let mut process_message_time = Measure::start("process_message_time");
         let process_result = MessageProcessor::process_message(
             &self.builtin_programs,
@@ -4277,8 +4275,8 @@ impl Bank {
             self.rent_collector.rent,
             log_collector.clone(),
             programs_loaded_for_tx_batch,
-            programs_modified_by_tx.clone(),
-            programs_updated_only_for_global_cache.clone(),
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             self.feature_set.clone(),
             compute_budget,
             timings,
@@ -4603,7 +4601,7 @@ impl Bank {
                         timings,
                         &mut error_counters,
                         log_messages_bytes_limit,
-                        programs_loaded_for_tx_batch.clone(),
+                        &programs_loaded_for_tx_batch.borrow(),
                     );
 
                     if let TransactionExecutionResult::Executed {
@@ -4617,7 +4615,7 @@ impl Bank {
                         if details.status.is_ok() {
                             programs_loaded_for_tx_batch
                                 .borrow_mut()
-                                .merge(&programs_modified_by_tx.borrow());
+                                .merge(&programs_modified_by_tx);
                         }
                     }
 
@@ -5112,8 +5110,8 @@ impl Bank {
             {
                 if details.status.is_ok() {
                     let mut cache = self.loaded_programs_cache.write().unwrap();
-                    cache.merge(&programs_modified_by_tx.borrow());
-                    cache.merge(&programs_updated_only_for_global_cache.borrow());
+                    cache.merge(programs_modified_by_tx);
+                    cache.merge(programs_updated_only_for_global_cache);
                 }
             }
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -173,8 +173,8 @@ fn new_execution_result(
             executed_units: 0,
             accounts_data_len_delta: 0,
         },
-        programs_modified_by_tx: LoadedProgramsForTxBatch::default(),
-        programs_updated_only_for_global_cache: LoadedProgramsForTxBatch::default(),
+        programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
+        programs_updated_only_for_global_cache: Box::<LoadedProgramsForTxBatch>::default(),
     }
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -102,12 +102,10 @@ use {
         },
     },
     std::{
-        cell::RefCell,
         collections::{HashMap, HashSet},
         convert::{TryFrom, TryInto},
         fs::File,
         io::Read,
-        rc::Rc,
         str::FromStr,
         sync::{
             atomic::{
@@ -175,10 +173,8 @@ fn new_execution_result(
             executed_units: 0,
             accounts_data_len_delta: 0,
         },
-        programs_modified_by_tx: Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-        programs_updated_only_for_global_cache: Rc::new(RefCell::new(
-            LoadedProgramsForTxBatch::default(),
-        )),
+        programs_modified_by_tx: LoadedProgramsForTxBatch::default(),
+        programs_updated_only_for_global_cache: LoadedProgramsForTxBatch::default(),
     }
 }
 
@@ -7604,9 +7600,12 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         Ok(()),
         solana_bpf_loader_program::process_instruction,
         |invoke_context| {
-            let mut cache = invoke_context.programs_modified_by_tx.borrow_mut();
-            cache.set_slot_for_tests(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
-            cache.replenish(program_keypair.pubkey(), loaded_program.clone());
+            invoke_context
+                .programs_modified_by_tx
+                .set_slot_for_tests(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
+            invoke_context
+                .programs_modified_by_tx
+                .replenish(program_keypair.pubkey(), loaded_program.clone());
         },
         |_invoke_context| {},
     );

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -58,9 +58,9 @@ impl MessageProcessor {
         transaction_context: &mut TransactionContext,
         rent: Rent,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
-        programs_loaded_for_tx_batch: Rc<RefCell<LoadedProgramsForTxBatch>>,
-        programs_modified_by_tx: Rc<RefCell<LoadedProgramsForTxBatch>>,
-        programs_updated_only_for_global_cache: Rc<RefCell<LoadedProgramsForTxBatch>>,
+        programs_loaded_for_tx_batch: &LoadedProgramsForTxBatch,
+        programs_modified_by_tx: &mut LoadedProgramsForTxBatch,
+        programs_updated_only_for_global_cache: &mut LoadedProgramsForTxBatch,
         feature_set: Arc<FeatureSet>,
         compute_budget: ComputeBudget,
         timings: &mut ExecuteTimings,
@@ -276,8 +276,7 @@ mod tests {
         let mut transaction_context =
             TransactionContext::new(accounts, Some(Rent::default()), 1, 3);
         let program_indices = vec![vec![2]];
-        let programs_loaded_for_tx_batch =
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default()));
+        let programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
         let account_keys = (0..transaction_context.get_number_of_accounts())
             .map(|index| {
                 *transaction_context
@@ -306,6 +305,8 @@ mod tests {
                 ]),
             )));
         let sysvar_cache = SysvarCache::default();
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -313,9 +314,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch.clone(),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -358,6 +359,8 @@ mod tests {
                     ),
                 ]),
             )));
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -365,9 +368,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch.clone(),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -400,6 +403,8 @@ mod tests {
                     ),
                 ]),
             )));
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -407,9 +412,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch,
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -507,8 +512,7 @@ mod tests {
         let mut transaction_context =
             TransactionContext::new(accounts, Some(Rent::default()), 1, 3);
         let program_indices = vec![vec![2]];
-        let programs_loaded_for_tx_batch =
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default()));
+        let programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
         let account_metas = vec![
             AccountMeta::new(
                 *transaction_context.get_key_of_account_at_index(0).unwrap(),
@@ -534,6 +538,8 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         )));
         let sysvar_cache = SysvarCache::default();
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -541,9 +547,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch.clone(),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -570,6 +576,8 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         )));
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -577,9 +585,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch.clone(),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -603,6 +611,8 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         )));
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -610,9 +620,9 @@ mod tests {
             &mut transaction_context,
             rent_collector.rent,
             None,
-            programs_loaded_for_tx_batch,
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
@@ -679,6 +689,9 @@ mod tests {
             None,
         )));
         let sysvar_cache = SysvarCache::default();
+        let programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::default();
         let result = MessageProcessor::process_message(
             &builtin_programs,
             &message,
@@ -686,9 +699,9 @@ mod tests {
             &mut transaction_context,
             RentCollector::default().rent,
             None,
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
-            Rc::new(RefCell::new(LoadedProgramsForTxBatch::default())),
+            &programs_loaded_for_tx_batch,
+            &mut programs_modified_by_tx,
+            &mut programs_updated_only_for_global_cache,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),


### PR DESCRIPTION
#### Problem
`InvokeContext` should not require `Rc` and `RefCell` to carry program cache references.

#### Summary of Changes
Clean up the cache references in `InvokeContext` and update surrounding code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
