### PR TITLE
Fix warning about unused mut in ledger-tool

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -350,6 +350,8 @@ fn load_program<'a>(
         ..LoadProgramMetrics::default()
     };
     let account_size = contents.len();
+    // Allowing mut here, since it may be needed for jit compile, which is under a config flag
+    #[allow(unused_mut)]
     let mut verified_executable = if is_elf {
         let result = load_program_from_bytes(
             &invoke_context.feature_set,


### PR DESCRIPTION
#### Problem
Seeing the following warning in M1 MacOS builds

```
   --> ledger-tool/src/program.rs:353:9
    |
353 |     let mut verified_executable = if is_elf {
    |         ----^^^^^^^^^^^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```

#### Summary of Changes
The `mut` variable is used under a flag. Added clippy ignore.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
