### PR TITLE
v1.14: Hardcode even newer rust version for crate publishing

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
-export RUST_STABLE_VERSION=1.64.0
+export RUST_STABLE_VERSION=1.65.0
 source ci/rust-version.sh stable
 
 cargo="$(readlink -f ./cargo)"

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
-export RUST_STABLE_VERSION=1.63.0
+export RUST_STABLE_VERSION=1.64.0
 source ci/rust-version.sh stable
 
 cargo="$(readlink -f ./cargo)"


### PR DESCRIPTION
#### Problem
Our CI job for publishing crates is broken because it specifies rust v1.63, newer winnow releases have an msrv of v1.64, and cargo package/publish doesn't respect Cargo.lock (which specify an older version of winnow).

But wait, there's more: time just published a new version with an msrv of v1.65

#### Summary of Changes
Set the `RUST_STABLE_VERSION` envar to ~~v1.64.0~~ v1.65.0 in publish-crate.sh in v1.14
