### PR TITLE
Eradicate zombie RPC threads

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -930,6 +930,7 @@ impl Validator {
                 genesis_config.hash(),
                 ledger_path,
                 config.validator_exit.clone(),
+                exit.clone(),
                 config.known_validators.clone(),
                 rpc_override_health_check.clone(),
                 startup_verification_complete,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -349,6 +349,7 @@ impl JsonRpcService {
         genesis_hash: Hash,
         ledger_path: &Path,
         validator_exit: Arc<RwLock<Exit>>,
+        exit: Arc<AtomicBool>,
         known_validators: Option<HashSet<Pubkey>>,
         override_health_check: Arc<AtomicBool>,
         startup_verification_complete: Arc<AtomicBool>,
@@ -476,7 +477,6 @@ impl JsonRpcService {
             prioritization_fee_cache,
         );
 
-        let exit = Arc::new(AtomicBool::new(false));
         let leader_info =
             poh_recorder.map(|recorder| ClusterTpuInfo::new(cluster_info.clone(), recorder));
         let _send_transaction_service = Arc::new(SendTransactionService::new_with_config(
@@ -643,6 +643,7 @@ mod tests {
             Hash::default(),
             &PathBuf::from("farf"),
             validator_exit,
+            exit,
             None,
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(true)),

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -576,7 +576,8 @@ impl JsonRpcService {
         }
     }
 
-    pub fn join(self) -> thread::Result<()> {
+    pub fn join(mut self) -> thread::Result<()> {
+        self.exit();
         self.thread_hdl.join()
     }
 }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -560,7 +560,6 @@ impl JsonRpcService {
             .unwrap()
             .register_exit(Box::new(move || {
                 close_handle_.close();
-                exit.store(true, Ordering::Relaxed);
             }));
         Ok(Self {
             thread_hdl,


### PR DESCRIPTION
#### Problem
Cluster simulations still exhibit zombie threads in the rpc_service/send_transaction_service area when the [recently removed](https://github.com/solana-labs/solana/pull/31279) `AccountsHashVerifier::should_halt()` is triggered. This is because [this change](https://github.com/solana-labs/solana/pull/5566) is only exercised when a formal ValidatorExit is triggered, and not when the exit AtomicBool is set to true.

#### Summary of Changes
- Call `JsonRpcService::exit()` inside `JsonRpcService::join()`, to ensure the Server actually closes when cleaning up threads
- Also clean up a slight regression introduced in #5566 and perpetuated in #31261 wherein the SendTransactionService uses an rpc-service-specific exit, instead of the same exit as all the other services. (This did not appear to be causing zombie threads, however.)
