### PR TITLE
Remove redundant clone

### DIFF
--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -486,7 +486,7 @@ impl JsonRpcService {
             receiver,
             &connection_cache,
             send_transaction_service_config,
-            exit.clone(),
+            exit,
         ));
 
         #[cfg(test)]


### PR DESCRIPTION
#### Problem
As of #31381, CI doesn't catch redundant clones, but running clippy locally does.

#### Summary of Changes
Remove redundant clone that I neglected to remove in #31688 (no backport needed; bundled with #31689)
