### PR TITLE
remove redundant `mut`s

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7193,7 +7193,7 @@ impl AccountsDb {
         &self,
         storages: &SortedStorages,
         slots_per_epoch: Slot,
-        mut stats: &mut crate::accounts_hash::HashStats,
+        stats: &mut crate::accounts_hash::HashStats,
     ) {
         // Nothing to do if ancient append vecs are enabled.
         // Ancient slots will be visited by the ancient append vec code and dealt with correctly.
@@ -7428,7 +7428,7 @@ impl AccountsDb {
         &self,
         cache_hash_data: &CacheHashData,
         storages: &SortedStorages,
-        mut stats: &mut crate::accounts_hash::HashStats,
+        stats: &mut crate::accounts_hash::HashStats,
         bins: usize,
         bin_range: &Range<usize>,
         config: &CalcAccountsHashConfig<'_>,

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -86,7 +86,7 @@ impl AccountHashesFile {
             // we have hashes to write but no file yet, so create a file that will auto-delete on drop
             self.count_and_writer = Some((0, BufWriter::new(tempfile().unwrap())));
         }
-        let mut count_and_writer = self.count_and_writer.as_mut().unwrap();
+        let count_and_writer = self.count_and_writer.as_mut().unwrap();
         assert_eq!(
             std::mem::size_of::<Hash>(),
             count_and_writer.1.write(hash.as_ref()).unwrap()
@@ -1041,7 +1041,7 @@ impl AccountsHasher {
     pub fn rest_of_hash_calculation(
         &self,
         data_sections_by_pubkey: Vec<SortedDataByPubkey<'_>>,
-        mut stats: &mut HashStats,
+        stats: &mut HashStats,
     ) -> (Hash, u64) {
         let (hashes, total_lamports) = self.de_dup_accounts(
             &data_sections_by_pubkey,

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -321,7 +321,7 @@ impl CacheHashData {
             capacity,
         };
 
-        let mut header = cache_file.get_header_mut();
+        let header = cache_file.get_header_mut();
         header.count = entries;
 
         stats.cache_file_size = capacity as usize;


### PR DESCRIPTION
#### Problem
building with nighly reports some warnings.

#### Summary of Changes
remove redundant uses of `mut`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
