### PR TITLE
persist EpochRewardStatus::Active

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7730,6 +7730,13 @@ impl Bank {
         Some(epoch_accounts_hash)
     }
 
+    /// Return the epoch_reward_status field on the bank to serialize
+    /// Returns none if we are NOT in the reward interval.
+    pub(crate) fn get_epoch_reward_status_to_serialize(&self) -> Option<&EpochRewardStatus> {
+        matches!(self.epoch_reward_status, EpochRewardStatus::Active(_))
+            .then_some(&self.epoch_reward_status)
+    }
+
     /// Convenience fn to get the Epoch Accounts Hash
     pub fn epoch_accounts_hash(&self) -> Option<EpochAccountsHash> {
         self.rc

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -202,7 +202,9 @@ impl<'a> TypeContext<'a> for Context {
         let ancestors = HashMap::from(&serializable_bank.bank.ancestors);
         let fields = serializable_bank.bank.get_fields_to_serialize(&ancestors);
         let lamports_per_signature = fields.fee_rate_governor.lamports_per_signature;
-        let epoch_reward_status = None;
+        let epoch_reward_status = serializable_bank
+            .bank
+            .get_epoch_reward_status_to_serialize();
         match get_serialize_bank_fields(
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'a, Self> {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -721,7 +721,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "GbEcrk8sgqbQ5kJ8mAaHTh2REmHyESQ6GXnGWxkGbxDe")]
+    #[frozen_abi(digest = "8aBQnNxnfKDxGEmMwaq9uLeMh3fw5sKsMGZBsCp15Dmv")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem
write EpochRewardStatus to snapshot if it is not default `Inactive`, based on the bank's `epoch_reward_status`. However, that field will ALWAYS be `Inactive` until the feature is activated for partitioned rewards. This approach allows us to leave snapshot persistence UNCHANGED unless `epoch_reward_status` is `Active`. This means we can easily test this feature on clusters without having to backport the change that reads_eof the `epoch_reward_status` field.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
