### PR TITLE
deserialize epoch_reward_status into BankFieldsToDeserialize

### DIFF
--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -343,8 +343,8 @@ impl<'a> TypeContext<'a> for Context {
         let epoch_accounts_hash = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.epoch_accounts_hash = epoch_accounts_hash;
 
-        let _epoch_reward_status: EpochRewardStatus =
-            ignore_eof_error(deserialize_from(&mut stream))?;
+        let epoch_reward_status = ignore_eof_error(deserialize_from(&mut stream))?;
+        bank_fields.epoch_reward_status = epoch_reward_status;
 
         Ok((bank_fields, accounts_db_fields))
     }


### PR DESCRIPTION
#### Problem
partitioned reward feature is making its way into reality, behind a feature gate.
In the meantime, peristance into snapshot has to be reworked to deal with `EpochRewardStatus`.

#### Summary of Changes
Apply the loaded `epoch_reward_status` into `BankFieldsToDeserialize`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
