### PR TITLE
Resolve remote $HOME in net.sh

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -232,7 +232,9 @@ build() {
   echo "Build took $SECONDS seconds"
 }
 
+# shellcheck disable=SC2088
 SOLANA_HOME="~/solana"
+# shellcheck disable=SC2088
 CARGO_BIN="~/.cargo/bin"
 
 startCommon() {

--- a/net/net.sh
+++ b/net/net.sh
@@ -232,13 +232,11 @@ build() {
   echo "Build took $SECONDS seconds"
 }
 
-# shellcheck disable=SC2088
-SOLANA_HOME="~/solana"
-# shellcheck disable=SC2088
-CARGO_BIN="~/.cargo/bin"
-
 startCommon() {
   declare ipAddress=$1
+  remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
+  SOLANA_HOME="${remoteHome}/solana"
+  CARGO_BIN="${remoteHome}/.cargo/bin"
   test -d "$SOLANA_ROOT"
   if $skipSetup; then
     # shellcheck disable=SC2029
@@ -266,6 +264,8 @@ startCommon() {
 syncScripts() {
   echo "rsyncing scripts... to $ipAddress"
   declare ipAddress=$1
+  remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
+  SOLANA_HOME="${remoteHome}/solana"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
     --exclude 'net/log*' \
     "$SOLANA_ROOT"/{fetch-perf-libs.sh,fetch-spl.sh,scripts,net,multinode-demo} \
@@ -276,6 +276,9 @@ syncScripts() {
 # binaries from it
 deployBootstrapValidator() {
   declare ipAddress=$1
+
+  remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
+  CARGO_BIN="${remoteHome}/.cargo/bin"
 
   echo "Deploying software to bootstrap validator ($ipAddress)"
   case $deployMethod in
@@ -1181,6 +1184,8 @@ netem)
     remoteNetemConfigFile="$(basename "$netemConfigFile")"
     if [[ $netemCommand = "add" ]]; then
       for ipAddress in "${validatorIpList[@]}"; do
+        remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
+        SOLANA_HOME="${remoteHome}/solana"
         "$here"/scp.sh "$netemConfigFile" solana@"$ipAddress":"$SOLANA_HOME"
       done
     fi

--- a/net/net.sh
+++ b/net/net.sh
@@ -234,7 +234,8 @@ build() {
 
 remoteHomeDir() {
   declare ipAddress=$1
-  local remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
+  declare remoteHome
+  remoteHome="$(ssh "${sshOptions[@]}" "$ipAddress" "echo \$HOME")"
   echo "$remoteHome"
 }
 

--- a/net/net.sh
+++ b/net/net.sh
@@ -241,7 +241,8 @@ remoteHomeDir() {
 
 startCommon() {
   declare ipAddress=$1
-  local remoteHome=$(remoteHomeDir "$ipAddress")
+  declare remoteHome
+  remoteHome=$(remoteHomeDir "$ipAddress")
   local remoteSolanaHome="${remoteHome}/solana"
   local remoteCargoBin="${remoteHome}/.cargo/bin"
   test -d "$SOLANA_ROOT"
@@ -271,7 +272,8 @@ startCommon() {
 syncScripts() {
   echo "rsyncing scripts... to $ipAddress"
   declare ipAddress=$1
-  local remoteHome=$(remoteHomeDir "$ipAddress")
+  declare remoteHome
+  remoteHome=$(remoteHomeDir "$ipAddress")
   local remoteSolanaHome="${remoteHome}/solana"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
     --exclude 'net/log*' \
@@ -284,7 +286,8 @@ syncScripts() {
 deployBootstrapValidator() {
   declare ipAddress=$1
 
-  local remoteHome=$(remoteHomeDir "$ipAddress")
+  declare remoteHome
+  remoteHome=$(remoteHomeDir "$ipAddress")
   local remoteCargoBin="${remoteHome}/.cargo/bin"
 
   echo "Deploying software to bootstrap validator ($ipAddress)"

--- a/net/net.sh
+++ b/net/net.sh
@@ -232,8 +232,8 @@ build() {
   echo "Build took $SECONDS seconds"
 }
 
-SOLANA_HOME="\$HOME/solana"
-CARGO_BIN="\$HOME/.cargo/bin"
+SOLANA_HOME="~/solana"
+CARGO_BIN="~/.cargo/bin"
 
 startCommon() {
   declare ipAddress=$1


### PR DESCRIPTION
#### Problem
`net.sh start` fails with the following error.

```
rsync: mkdir "/home/solana/$HOME/solana" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(681) [Receiver=3.1.3]
+ exit 1
^^^ +++
```

#### Summary of Changes
The script is unable to resolve `$HOME`. Replaced it with `~`. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
