### PR TITLE
banks-client: Add `get_fee_for_message`

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -497,14 +497,37 @@ impl BanksClient {
             .map_err(Into::into)
     }
 
+    pub fn get_fee_for_message(
+        &mut self,
+        message: Message,
+    ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
+        self.get_fee_for_message_with_commitment_and_context(
+            context::current(),
+            message,
+            CommitmentLevel::default(),
+        )
+    }
+
+    pub fn get_fee_for_message_with_commitment(
+        &mut self,
+        message: Message,
+        commitment: CommitmentLevel,
+    ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
+        self.get_fee_for_message_with_commitment_and_context(
+            context::current(),
+            message,
+            commitment,
+        )
+    }
+
     pub fn get_fee_for_message_with_commitment_and_context(
         &mut self,
         ctx: Context,
-        commitment: CommitmentLevel,
         message: Message,
+        commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
         self.inner
-            .get_fee_for_message_with_commitment_and_context(ctx, commitment, message)
+            .get_fee_for_message_with_commitment_and_context(ctx, message, commitment)
             .map_err(Into::into)
     }
 }

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -97,8 +97,8 @@ pub trait Banks {
         commitment: CommitmentLevel,
     ) -> Option<(Hash, u64)>;
     async fn get_fee_for_message_with_commitment_and_context(
-        commitment: CommitmentLevel,
         message: Message,
+        commitment: CommitmentLevel,
     ) -> Option<u64>;
 }
 

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -412,8 +412,8 @@ impl Banks for BanksServer {
     async fn get_fee_for_message_with_commitment_and_context(
         self,
         _: Context,
-        commitment: CommitmentLevel,
         message: Message,
+        commitment: CommitmentLevel,
     ) -> Option<u64> {
         let bank = self.bank(commitment);
         let sanitized_message = SanitizedMessage::try_from(message).ok()?;


### PR DESCRIPTION
#### Problem

`BanksClient` has `get_fee_for_message_with_commitment_and_context`, but no actual implementations that clients can use since they can't access the context!

#### Summary of Changes

Add implementations for `get_fee_for_message` and `get_fee_for_message_with_commitment`. I also moved around the parameters since commitment typically goes at the end, which should be ok since no one's been able to use this.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
