### PR TITLE
ci: increase timeout for downstream project tests

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -239,7 +239,7 @@ EOF
     cat >> "$output_file" <<"EOF"
   - command: "scripts/build-downstream-projects.sh"
     name: "downstream-projects"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
     agents:
       queue: "solana"
 EOF


### PR DESCRIPTION
#### Problem

<img width="1029" alt="Screenshot 2023-05-18 at 11 45 57 AM" src="https://github.com/solana-labs/solana/assets/8209234/947a0dd9-723a-4fa4-b3c0-3a9c5600ebb2">

downstream project tests take almost 30mins in last few times build.
I guess the testing speed is related to the setup of NVMe but I haven't had a look at them. 

no matter what, I think we can have more tolerance with this one.

#### Summary of Changes

increase timeout to 40mins for downstream project tests
