### PR TITLE
[docs]cluster restart/optimistically confirmed

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -68,13 +68,13 @@ A measure of the network confirmation for the [block](#block).
 A set of [validators](#validator) maintaining a single [ledger](#ledger).
 
 ## cluster restart
-When a [cluster](#cluster) stops finalizing blocks for a prolonged period of
-time, as determined by social consensus amongst the validator operators, a
-pre-defined set of operations is performed by at least 80% of the stake weight
-to resume block production from the highest optimistically confirmed slot. Any
-processed but non-confirmed blocks may be discarded during the restart
-procedure. This is different from sporadic single validator restart which does
-not impact the cluster. See
+When a [cluster](#cluster) stops finalizing blocks due to an unrecoverable set
+of failures, as determined by social consensus amongst the validator operators,
+a pre-defined set of operations is performed by at least 80% of the stake
+weight to resume block production from the highest optimistically confirmed
+slot. Any processed but non-confirmed blocks may be discarded during the
+restart procedure. This is different from sporadic single validator restart
+which does not impact the cluster. See
 [cluster restart](https://docs.solana.com/running-validator/restart-cluster)
 for details.
 
@@ -92,7 +92,9 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 
 ## confirmed block
 
-See [optimistically confirmed block](#optimistically-confirmed-block).
+A [block](#block) that has received supermajority stake-weighted [votes](#vote)
+should not get rolled back given < 5% malicious. Details can be found at
+[Optimistic Confirmation](optimistic_confirmation.md#Primitives).
 
 ## control plane
 
@@ -230,12 +232,6 @@ A computer participating in a [cluster](#cluster).
 ## node count
 
 The number of [validators](#validator) participating in a [cluster](#cluster).
-
-## optimistically confirmed block
-
-A [block](#block) which got the [ledger votes](#ledger-vote) from
-[validators](#validator) holding more than 2/3 of total [stake](#stake) in a
-[cluster](#cluster). The votes may or may not have been confirmed to a block.
 
 ## PoH
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -68,15 +68,13 @@ A measure of the network confirmation for the [block](#block).
 A set of [validators](#validator) maintaining a single [ledger](#ledger).
 
 ## cluster restart
-When a [cluster](#cluster) stops finalizing blocks due to an unrecoverable set
-of failures, as determined by social consensus amongst the validator operators,
-a pre-defined set of operations is performed by at least 80% of the stake
-weight to resume block production from the highest optimistically confirmed
-slot. Any processed but non-confirmed blocks may be discarded during the
-restart procedure. This is different from sporadic single validator restart
-which does not impact the cluster. See
-[cluster restart](https://docs.solana.com/running-validator/restart-cluster)
-for details.
+When a [cluster](#cluster) is operating with degraded performance to such an
+extent that validator operators representing a superminority of stake deem
+the goodput of the system to be unacceptably low and unlikely to resolve
+itself that [manual intervention](https://docs.solana.com/running-validator/restart-cluster) is preferred.
+
+**NOTE:** This is different from individual validator process restarts
+which does not materially impact the cluster.
 
 ## compute budget
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -67,6 +67,17 @@ A measure of the network confirmation for the [block](#block).
 
 A set of [validators](#validator) maintaining a single [ledger](#ledger).
 
+## cluster restart
+When a [cluster](#cluster) stops finalizing blocks for a prolonged period of
+time, as determined by social consensus amongst the validator operators, a
+pre-defined set of operations is performed by at least 80% of the stake weight
+to resume block production from the highest optimistically confirmed slot. Any
+processed but non-confirmed blocks may be discarded during the restart
+procedure. This is different from sporadic single validator restart which does
+not impact the cluster. See
+[cluster restart](https://docs.solana.com/running-validator/restart-cluster)
+for details.
+
 ## compute budget
 
 The maximum number of [compute units](#compute-units) consumed per transaction.
@@ -81,7 +92,7 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 
 ## confirmed block
 
-A [block](#block) that has received a [super majority](#supermajority) of [ledger votes](#ledger-vote).
+See [optimistically confirmed block](#optimistically-confirmed-block).
 
 ## control plane
 
@@ -219,6 +230,12 @@ A computer participating in a [cluster](#cluster).
 ## node count
 
 The number of [validators](#validator) participating in a [cluster](#cluster).
+
+## optimistically confirmed block
+
+A [block](#block) which got the [ledger votes](#ledger-vote) from
+[validators](#validator) holding more than 2/3 of total [stake](#stake) in a
+[cluster](#cluster). The votes may or may not have been confirmed to a block.
 
 ## PoH
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -95,7 +95,7 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 A [block](#block) that has received [super majority](#supermajority)
 stake-weighted [votes](#vote) should not get rolled back given < 5% malicious. 
 Details can be found at
-[Optimistic Confirmation](optimistic_confirmation.md#Primitives).
+[Optimistic Confirmation](proposals/optimistic_confirmation.md#Primitives).
 
 ## control plane
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -92,8 +92,9 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 
 ## confirmed block
 
-A [block](#block) that has received supermajority stake-weighted [votes](#vote)
-should not get rolled back given < 5% malicious. Details can be found at
+A [block](#block) that has received [super majority](#supermajority)
+stake-weighted [votes](#vote) should not get rolled back given < 5% malicious. 
+Details can be found at
 [Optimistic Confirmation](optimistic_confirmation.md#Primitives).
 
 ## control plane

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -90,8 +90,9 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 
 ## confirmed block
 
-A [block](#block) that has received [super majority](#supermajority)
-stake-weighted [votes](#vote) should not get rolled back given < 5% malicious.
+A [block](#block) for which a [super majority](#supermajority) of
+stake-weighted [votes](#vote) have been observed. Cannot be rolled
+back given < 5% defective stake.
 Details can be found at
 [Optimistic Confirmation](proposals/optimistic_confirmation.md#primitives).
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -93,7 +93,7 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 ## confirmed block
 
 A [block](#block) that has received [super majority](#supermajority)
-stake-weighted [votes](#vote) should not get rolled back given < 5% malicious. 
+stake-weighted [votes](#vote) should not get rolled back given < 5% malicious.
 Details can be found at
 [Optimistic Confirmation](proposals/optimistic_confirmation.md#primitives).
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -95,7 +95,7 @@ The wallclock duration between a [leader](#leader) creating a [tick entry](#tick
 A [block](#block) that has received [super majority](#supermajority)
 stake-weighted [votes](#vote) should not get rolled back given < 5% malicious. 
 Details can be found at
-[Optimistic Confirmation](proposals/optimistic_confirmation.md#Primitives).
+[Optimistic Confirmation](proposals/optimistic_confirmation.md#primitives).
 
 ## control plane
 


### PR DESCRIPTION
Add two terminologies:
- cluster restart
- optimistically confirmed block

Change confirmed block to point to optimistically confirmed block.
