### PR TITLE
process_get_epoch_info resulting in duration value underflow

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1131,7 +1131,7 @@ pub fn process_get_epoch_info(rpc_client: &RpcClient, config: &CliConfig) -> Pro
                     .get_block_time(first_block_in_epoch)
                     .ok()
                     .map(|time| {
-                        time + (((first_block_in_epoch - epoch_expected_start_slot)
+                        time - (((first_block_in_epoch - epoch_expected_start_slot)
                             * average_slot_time_ms)
                             / 1000) as i64
                     });


### PR DESCRIPTION
#### Problem
When invoking `$ solana epoch-info` against local cluster, it results in the following panic:
```
thread 'main' panicked at 'overflow when adding durations', library/core/src/time.rs:920:31
stack backtrace:
  <skipped>
  15: solana_cli_output::cli_output::OutputFormat::formatted_string
             at ./cli-output/src/cli_output.rs:77:38
  16: solana_cli::cluster_query::process_get_epoch_info
             at ./cli/src/cluster_query.rs:1145:8
  17: solana_cli::cli::process_command
             at ./cli/src/cli.rs:905:37
  18: solana::do_main
             at ./cli/src/main.rs:256:22
  19: solana::main
             at ./cli/src/main.rs:247:5
  20: core::ops::function::FnOnce::call_once
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
Reason:
Because the cluster cleans up old blocks, the [`cli::cluster_query::process_get_epoch_info`](https://github.com/solana-labs/solana/blob/master/cli/src/cluster_query.rs#L1098) function tries to estimate the [`start_block_time`](https://github.com/solana-labs/solana/blob/master/cli/src/cluster_query.rs#L1129) based on the `average_slot_time` however instead of subtracting the estimate from the last available block time it adds the estimate to it resulting in `start_block_time > current_block_time` which causes unsigned integer underflow in [`cli-output::cli_output.rs:370`](https://github.com/solana-labs/solana/blob/master/cli-output/src/cli_output.rs#L370)

#### Summary of Changes
Subtract instead of adding the duration estimate from first available block time.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
