### PR TITLE
runtime: rename executor cache datapoint

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -128,7 +128,7 @@ impl Stats {
         let one_hit_wonders = self.one_hit_wonders.load(Ordering::Relaxed);
         let evictions: u64 = self.evictions.values().sum();
         datapoint_info!(
-            "bank-executor-cache-stats",
+            "loaded-programs-cache-stats",
             ("slot", slot, i64),
             ("hits", hits, i64),
             ("misses", misses, i64),


### PR DESCRIPTION
#### Problem

new loaded programs cache hijacked the old metrics datapoint name, which pollutes both metrics

#### Summary of Changes

rename the datapoint to reflect it's actual source