### PR TITLE
Do not overwrite builtin program in the same slot

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -427,10 +427,7 @@ impl LoadedPrograms {
             if existing.deployment_slot == entry.deployment_slot
                 && existing.effective_slot == entry.effective_slot
             {
-                if matches!(existing.program, LoadedProgramType::Builtin(_)) {
-                    // Allow built-ins to be overwritten
-                    second_level.swap_remove(entry_index);
-                } else if matches!(existing.program, LoadedProgramType::Unloaded) {
+                if matches!(existing.program, LoadedProgramType::Unloaded) {
                     // The unloaded program is getting reloaded
                     // Copy over the usage counter to the new entry
                     entry.usage_counter.store(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7315,7 +7315,7 @@ impl Bank {
         self.add_builtin(
             program_id,
             "mockup".to_string(),
-            LoadedProgram::new_builtin(0, 0, entrypoint),
+            LoadedProgram::new_builtin(self.slot, 0, entrypoint),
         );
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4857,7 +4857,7 @@ fn test_add_duplicate_static_program() {
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
 
     declare_process_instruction!(process_instruction, 1, |_invoke_context| {
         Err(InstructionError::Custom(42))
@@ -4885,6 +4885,9 @@ fn test_add_duplicate_static_program() {
         message,
         bank.last_blockhash(),
     );
+
+    let slot = bank.slot().saturating_add(1);
+    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), slot);
 
     let vote_loader_account = bank.get_account(&solana_vote_program::id()).unwrap();
     bank.add_mockup_builtin(solana_vote_program::id(), process_instruction);


### PR DESCRIPTION
#### Problem
The builtin programs are allowed to be overwritten in the same slot as initial deployment.

#### Summary of Changes
The test added builtin as part of bank initialization. It was later adding an existing builtin in the same bank. This PR updates the test to create a child bank to overwrite the builtin. Also removes the special handling of overwriting the builtin in the same slot as the initial deployment.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
