### PR TITLE
Remove special handling of builtin while pruning

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -473,9 +473,7 @@ impl LoadedPrograms {
                 .rev()
                 .filter(|entry| {
                     let relation = fork_graph.relationship(entry.deployment_slot, new_root);
-                    if matches!(entry.program, LoadedProgramType::Builtin(_)) {
-                        true
-                    } else if entry.deployment_slot >= new_root {
+                    if entry.deployment_slot >= new_root {
                         matches!(relation, BlockRelation::Equal | BlockRelation::Descendant)
                     } else if !first_ancestor_found
                         && (matches!(relation, BlockRelation::Ancestor)

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -477,7 +477,7 @@ impl LoadedPrograms {
                         matches!(relation, BlockRelation::Equal | BlockRelation::Descendant)
                     } else if !first_ancestor_found
                         && (matches!(relation, BlockRelation::Ancestor)
-                            || entry.deployment_slot < previous_root)
+                            || entry.deployment_slot <= previous_root)
                     {
                         first_ancestor_found = true;
                         first_ancestor_found


### PR DESCRIPTION
#### Problem
The builtin's are not being pruned from the program cache.

#### Summary of Changes
Remove the special handling of builtin in `prune()` that prevents removal of the entries.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
