### PR TITLE
remove feature gate code using default units per instructions

### DIFF
--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -171,7 +171,6 @@ impl ComputeBudget {
     pub fn process_instructions<'a>(
         &mut self,
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-        default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
         enable_request_heap_frame_ix: bool,
         support_set_loaded_accounts_data_size_limit_ix: bool,
@@ -255,17 +254,10 @@ impl ComputeBudget {
             self.heap_size = Some(bytes as usize);
         }
 
-        self.compute_unit_limit = if default_units_per_instruction {
-            updated_compute_unit_limit.or_else(|| {
-                Some(
+        self.compute_unit_limit = updated_compute_unit_limit.or_else(|| {
                     (num_non_compute_budget_instructions as u32)
                         .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
-                )
             })
-        } else {
-            updated_compute_unit_limit
-        }
-        .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
         .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
 
         self.loaded_accounts_data_size_limit = updated_loaded_accounts_data_size_limit

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4882,7 +4882,6 @@ impl Bank {
         message: &SanitizedMessage,
         lamports_per_signature: u64,
         fee_structure: &FeeStructure,
-        use_default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
         remove_congestion_multiplier: bool,
         enable_request_heap_frame_ix: bool,
@@ -4904,7 +4903,6 @@ impl Bank {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 message.program_instructions_iter(),
-                use_default_units_per_instruction,
                 support_request_units_deprecated,
                 enable_request_heap_frame_ix,
                 support_set_accounts_data_size_limit_ix,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10426,7 +10426,6 @@ fn test_calculate_prioritization_fee() {
         &message,
         fee_structure.lamports_per_signature,
         &fee_structure,
-        true,  // use_default_units_per_instruction
         false, // not support_request_units_deprecated
         true,  // remove_congestion_multiplier
         true,  // enable_request_heap_frame_ix


### PR DESCRIPTION
#### Problem
feature gate use_default_units_per_instruction has been enabled on all cluster. 
```
$ solana feature status J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q -um
Feature                                      | Status                  | Activation Slot | Description
J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q | active since epoch 327  | 141264004       | Default max tx-wide compute units calculated per instruction

$ solana feature status J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q -ut
Feature                                      | Status                  | Activation Slot | Description
J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q | active since epoch 326  | 135308256       | Default max tx-wide compute units calculated per instruction

$ solana feature status J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q -ud
Feature                                      | Status                  | Activation Slot | Description
J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q | active since epoch 328  | 141696000       | Default max tx-wide compute units calculated per instruction
```

#### Summary of Changes
- remove feature gate code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
