### PR TITLE
[keygen] Use workspace version for `tempfile`

### DIFF
--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -22,7 +22,7 @@ solana-version = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.5.0"
+tempfile = { workspace = true }
 
 [[bin]]
 name = "solana-keygen"


### PR DESCRIPTION
#### Problem
The `tempfile` crate dependency uses a concrete version as opposed to workspace shared version.

#### Summary of Changes
Use workspace version for `tempfile` crate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
