### PR TITLE
[zk-token-sdk] Generate proof transcript directly from proof contexts

### DIFF
--- a/zk-token-sdk/src/instruction/ctxt_ctxt_equality.rs
+++ b/zk-token-sdk/src/instruction/ctxt_ctxt_equality.rs
@@ -78,12 +78,7 @@ impl CiphertextCiphertextEqualityProofData {
             destination_ciphertext: pod_destination_ciphertext,
         };
 
-        let mut transcript = CiphertextCiphertextEqualityProof::transcript_new(
-            &pod_source_pubkey,
-            &pod_destination_pubkey,
-            &pod_source_ciphertext,
-            &pod_destination_ciphertext,
-        );
+        let mut transcript = context.new_transcript();
 
         let proof = CiphertextCiphertextEqualityProof::new(
             source_keypair,
@@ -110,12 +105,7 @@ impl ZkProofData<CiphertextCiphertextEqualityProofContext>
 
     #[cfg(not(target_os = "solana"))]
     fn verify_proof(&self) -> Result<(), ProofError> {
-        let mut transcript = CiphertextCiphertextEqualityProof::transcript_new(
-            &self.context.source_pubkey,
-            &self.context.destination_pubkey,
-            &self.context.source_ciphertext,
-            &self.context.destination_ciphertext,
-        );
+        let mut transcript = self.context.new_transcript();
 
         let source_pubkey = self.context.source_pubkey.try_into()?;
         let destination_pubkey = self.context.destination_pubkey.try_into()?;
@@ -137,20 +127,15 @@ impl ZkProofData<CiphertextCiphertextEqualityProofContext>
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
-impl CiphertextCiphertextEqualityProof {
-    fn transcript_new(
-        source_pubkey: &pod::ElGamalPubkey,
-        destination_pubkey: &pod::ElGamalPubkey,
-        source_ciphertext: &pod::ElGamalCiphertext,
-        destination_ciphertext: &pod::ElGamalCiphertext,
-    ) -> Transcript {
+impl CiphertextCiphertextEqualityProofContext {
+    fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"CiphertextCiphertextEqualityProof");
 
-        transcript.append_pubkey(b"pubkey-source", source_pubkey);
-        transcript.append_pubkey(b"pubkey-dest", destination_pubkey);
+        transcript.append_pubkey(b"source-pubkey", &self.source_pubkey);
+        transcript.append_pubkey(b"destination-pubkey", &self.destination_pubkey);
 
-        transcript.append_ciphertext(b"ciphertext-source", source_ciphertext);
-        transcript.append_ciphertext(b"ciphertext-dest", destination_ciphertext);
+        transcript.append_ciphertext(b"source-ciphertext", &self.source_ciphertext);
+        transcript.append_ciphertext(b"destination-ciphertext", &self.destination_ciphertext);
 
         transcript
     }

--- a/zk-token-sdk/src/instruction/pubkey_validity.rs
+++ b/zk-token-sdk/src/instruction/pubkey_validity.rs
@@ -52,7 +52,7 @@ impl PubkeyValidityData {
 
         let context = PubkeyValidityProofContext { pubkey: pod_pubkey };
 
-        let mut transcript = PubkeyValidityProof::transcript_new(&pod_pubkey);
+        let mut transcript = context.new_transcript();
         let proof = PubkeyValidityProof::new(keypair, &mut transcript).into();
 
         Ok(PubkeyValidityData { context, proof })
@@ -68,7 +68,7 @@ impl ZkProofData<PubkeyValidityProofContext> for PubkeyValidityData {
 
     #[cfg(not(target_os = "solana"))]
     fn verify_proof(&self) -> Result<(), ProofError> {
-        let mut transcript = PubkeyValidityProof::transcript_new(&self.context.pubkey);
+        let mut transcript = self.context.new_transcript();
         let pubkey = self.context.pubkey.try_into()?;
         let proof: PubkeyValidityProof = self.proof.try_into()?;
         proof.verify(&pubkey, &mut transcript).map_err(|e| e.into())
@@ -77,10 +77,10 @@ impl ZkProofData<PubkeyValidityProofContext> for PubkeyValidityData {
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
-impl PubkeyValidityProof {
-    fn transcript_new(pubkey: &pod::ElGamalPubkey) -> Transcript {
+impl PubkeyValidityProofContext {
+    fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"PubkeyProof");
-        transcript.append_pubkey(b"pubkey", pubkey);
+        transcript.append_pubkey(b"pubkey", &self.pubkey);
         transcript
     }
 }

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -247,7 +247,7 @@ impl TransferProofContext {
         let mut transcript = Transcript::new(b"transfer-proof");
         transcript.append_message(b"ciphertext-lo", bytes_of(&self.ciphertext_lo));
         transcript.append_message(b"ciphertext-hi", bytes_of(&self.ciphertext_hi));
-        transcript.append_message(b"transfer_pubkeys", bytes_of(&self.transfer_pubkeys));
+        transcript.append_message(b"transfer-pubkeys", bytes_of(&self.transfer_pubkeys));
         transcript.append_message(
             b"new-source-ciphertext",
             bytes_of(&self.new_source_ciphertext),

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -17,6 +17,7 @@ use {
         transcript::TranscriptProtocol,
     },
     arrayref::{array_ref, array_refs},
+    bytemuck::bytes_of,
     merlin::Transcript,
     std::convert::TryInto,
 };
@@ -139,13 +140,7 @@ impl TransferData {
             new_source_ciphertext: pod_new_source_ciphertext,
         };
 
-        let mut transcript = TransferProof::transcript_new(
-            &pod_transfer_pubkeys,
-            &pod_ciphertext_lo,
-            &pod_ciphertext_hi,
-            &pod_new_source_ciphertext,
-        );
-
+        let mut transcript = context.new_transcript();
         let proof = TransferProof::new(
             (amount_lo, amount_hi),
             source_keypair,
@@ -228,12 +223,7 @@ impl ZkProofData<TransferProofContext> for TransferData {
     #[cfg(not(target_os = "solana"))]
     fn verify_proof(&self) -> Result<(), ProofError> {
         // generate transcript and append all public inputs
-        let mut transcript = TransferProof::transcript_new(
-            &self.context.transfer_pubkeys,
-            &self.context.ciphertext_lo,
-            &self.context.ciphertext_hi,
-            &self.context.new_source_ciphertext,
-        );
+        let mut transcript = self.context.new_transcript();
 
         let ciphertext_lo = self.context.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.context.ciphertext_hi.try_into()?;
@@ -247,6 +237,22 @@ impl ZkProofData<TransferProofContext> for TransferData {
             &new_spendable_ciphertext,
             &mut transcript,
         )
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl TransferProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"transfer-proof");
+        transcript.append_message(b"ciphertext-lo", bytes_of(&self.ciphertext_lo));
+        transcript.append_message(b"ciphertext_hi", bytes_of(&self.ciphertext_hi));
+        transcript.append_message(b"transfer_pubkeys", bytes_of(&self.transfer_pubkeys));
+        transcript.append_message(
+            b"new-source-ciphertext",
+            bytes_of(&self.new_source_ciphertext),
+        );
+        transcript
     }
 }
 
@@ -270,33 +276,6 @@ pub struct TransferProof {
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
 impl TransferProof {
-    fn transcript_new(
-        transfer_pubkeys: &pod::TransferPubkeys,
-        ciphertext_lo: &pod::TransferAmountEncryption,
-        ciphertext_hi: &pod::TransferAmountEncryption,
-        new_source_ciphertext: &pod::ElGamalCiphertext,
-    ) -> Transcript {
-        let mut transcript = Transcript::new(b"transfer-proof");
-
-        transcript.append_pubkey(b"pubkey-source", &transfer_pubkeys.source_pubkey);
-        transcript.append_pubkey(b"pubkey-dest", &transfer_pubkeys.destination_pubkey);
-        transcript.append_pubkey(b"pubkey-auditor", &transfer_pubkeys.auditor_pubkey);
-
-        transcript.append_commitment(b"comm-lo-amount", &ciphertext_lo.commitment);
-        transcript.append_handle(b"handle-lo-source", &ciphertext_lo.source_handle);
-        transcript.append_handle(b"handle-lo-dest", &ciphertext_lo.destination_handle);
-        transcript.append_handle(b"handle-lo-auditor", &ciphertext_lo.auditor_handle);
-
-        transcript.append_commitment(b"comm-hi-amount", &ciphertext_hi.commitment);
-        transcript.append_handle(b"handle-hi-source", &ciphertext_hi.source_handle);
-        transcript.append_handle(b"handle-hi-dest", &ciphertext_hi.destination_handle);
-        transcript.append_handle(b"handle-hi-auditor", &ciphertext_hi.auditor_handle);
-
-        transcript.append_ciphertext(b"ciphertext-new-source", new_source_ciphertext);
-
-        transcript
-    }
-
     pub fn new(
         (transfer_amount_lo, transfer_amount_hi): (u64, u64),
         source_keypair: &ElGamalKeypair,

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -246,7 +246,7 @@ impl TransferProofContext {
     fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"transfer-proof");
         transcript.append_message(b"ciphertext-lo", bytes_of(&self.ciphertext_lo));
-        transcript.append_message(b"ciphertext_hi", bytes_of(&self.ciphertext_hi));
+        transcript.append_message(b"ciphertext-hi", bytes_of(&self.ciphertext_hi));
         transcript.append_message(b"transfer_pubkeys", bytes_of(&self.transfer_pubkeys));
         transcript.append_message(
             b"new-source-ciphertext",

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -62,7 +62,7 @@ impl ZeroBalanceProofData {
             ciphertext: pod_ciphertext,
         };
 
-        let mut transcript = ZeroBalanceProof::transcript_new(&pod_pubkey, &pod_ciphertext);
+        let mut transcript = context.new_transcript();
         let proof = ZeroBalanceProof::new(keypair, ciphertext, &mut transcript).into();
 
         Ok(ZeroBalanceProofData { context, proof })
@@ -78,9 +78,7 @@ impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
 
     #[cfg(not(target_os = "solana"))]
     fn verify_proof(&self) -> Result<(), ProofError> {
-        let mut transcript =
-            ZeroBalanceProof::transcript_new(&self.context.pubkey, &self.context.ciphertext);
-
+        let mut transcript = self.context.new_transcript();
         let pubkey = self.context.pubkey.try_into()?;
         let ciphertext = self.context.ciphertext.try_into()?;
         let proof: ZeroBalanceProof = self.proof.try_into()?;
@@ -92,15 +90,12 @@ impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
-impl ZeroBalanceProof {
-    fn transcript_new(
-        pubkey: &pod::ElGamalPubkey,
-        ciphertext: &pod::ElGamalCiphertext,
-    ) -> Transcript {
+impl ZeroBalanceProofContext {
+    fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"ZeroBalanceProof");
 
-        transcript.append_pubkey(b"pubkey", pubkey);
-        transcript.append_ciphertext(b"ciphertext", ciphertext);
+        transcript.append_pubkey(b"pubkey", &self.pubkey);
+        transcript.append_ciphertext(b"ciphertext", &self.ciphertext);
 
         transcript
     }


### PR DESCRIPTION
#### Problem
Currently, the function used to generate transcripts for zero-knowledge proofs `transcript_new` lives as an associated function of the individual proof types, taking in all the proof context fields as input. This can be simplified by making `transcript_new` as an associated function of the proof context types instead.

#### Summary of Changes
- Refactor the `transcript_new` functions in each proof instructions module to be an associated function of the proof context types
- Rename `transcript_new` to `new_transcript` to make the funciton name slightly more natural
- For `TransferWithFee`, also include the fee parameters in the transcript. It is okay not to include the fee parameters, but it could be safer and more complete to append the entire proof context information in the transcript.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
