### PR TITLE
Refactor - Share RBPF config and syscall registry globally

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -10,7 +10,7 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
-    solana_bpf_loader_program::syscalls::create_loader,
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment,
     solana_clap_utils::{
         self, hidden_unless_forced, input_parsers::*, input_validators::*, keypair::*,
     },
@@ -2022,16 +2022,18 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         .map_err(|err| format!("Unable to read program file: {err}"))?;
 
     // Verify the program
-    let loader = create_loader(
+    let program_runtime_environment = create_program_runtime_environment(
         &FeatureSet::default(),
         &ComputeBudget::default(),
         true,
         false,
     )
     .unwrap();
-    let executable =
-        Executable::<TautologyVerifier, InvokeContext>::from_elf(&program_data, loader)
-            .map_err(|err| format!("ELF error: {err}"))?;
+    let executable = Executable::<TautologyVerifier, InvokeContext>::from_elf(
+        &program_data,
+        Arc::new(program_runtime_environment),
+    )
+    .map_err(|err| format!("ELF error: {err}"))?;
 
     let _ = Executable::<RequisiteVerifier, InvokeContext>::verified(executable)
         .map_err(|err| format!("ELF error: {err}"))?;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -204,7 +204,7 @@ impl LoadedProgram {
     /// Creates a new user program
     pub fn new(
         loader_key: &Pubkey,
-        loader: Arc<BuiltInProgram<InvokeContext<'static>>>,
+        program_runtime_environment: Arc<BuiltInProgram<InvokeContext<'static>>>,
         deployment_slot: Slot,
         effective_slot: Slot,
         maybe_expiration_slot: Option<Slot>,
@@ -213,7 +213,7 @@ impl LoadedProgram {
         metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut load_elf_time = Measure::start("load_elf_time");
-        let executable = Executable::load(elf_bytes, loader.clone())?;
+        let executable = Executable::load(elf_bytes, program_runtime_environment.clone())?;
         load_elf_time.stop();
         metrics.load_elf_us = load_elf_time.as_us();
 
@@ -337,7 +337,8 @@ pub struct LoadedPrograms {
     ///
     /// Pubkey is the address of a program, multiple versions can coexists simultaneously under the same address (in different slots).
     entries: HashMap<Pubkey, Vec<Arc<LoadedProgram>>>,
-
+    /// Globally shared RBPF config and syscall registry
+    pub program_runtime_environment_v1: Arc<BuiltInProgram<InvokeContext<'static>>>,
     latest_root: Slot,
     pub stats: Stats,
 }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -142,12 +142,12 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn create_loader<'a>(
+pub fn create_program_runtime_environment<'a>(
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
-) -> Result<Arc<BuiltInProgram<InvokeContext<'a>>>, Error> {
+) -> Result<BuiltInProgram<InvokeContext<'a>>, Error> {
     use rand::Rng;
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
@@ -312,7 +312,7 @@ pub fn create_loader<'a>(
     // Log data
     result.register_function(b"sol_log_data", SyscallLogData::call)?;
 
-    Ok(Arc::new(result))
+    Ok(result)
 }
 
 fn translate(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4528,9 +4528,6 @@ impl Bank {
             &self.blockhash_queue.read().unwrap(),
         );
         let native_loader = native_loader::id();
-        for precompile in get_precompiles() {
-            program_accounts_map.remove(&precompile.program_id);
-        }
         for builtin_program in self.builtin_programs.iter() {
             program_accounts_map.insert(*builtin_program, &native_loader);
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -89,6 +89,7 @@ use {
         iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
         ThreadPool, ThreadPoolBuilder,
     },
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment,
     solana_measure::{measure, measure::Measure, measure_us},
     solana_perf::perf_libs,
     solana_program_runtime::{
@@ -4117,11 +4118,7 @@ impl Bank {
         }
     }
 
-    pub fn load_program(
-        &self,
-        pubkey: &Pubkey,
-        debugging_features: bool,
-    ) -> Result<Arc<LoadedProgram>> {
+    pub fn load_program(&self, pubkey: &Pubkey) -> Result<Arc<LoadedProgram>> {
         let program = if let Some(program) = self.get_account_with_fixed_root(pubkey) {
             program
         } else {
@@ -4174,13 +4171,18 @@ impl Bank {
         } else {
             None
         };
+        let program_runtime_environment_v1 = self
+            .loaded_programs_cache
+            .read()
+            .unwrap()
+            .program_runtime_environment_v1
+            .clone();
         solana_bpf_loader_program::load_program_from_account(
             &self.feature_set,
-            &self.runtime_config.compute_budget.unwrap_or_default(),
             None, // log_collector
             &program,
             programdata.as_ref().unwrap_or(&program),
-            debugging_features,
+            program_runtime_environment_v1,
         )
         .map(|(loaded_program, metrics)| {
             let mut timings = ExecuteDetailsTimings::default();
@@ -4428,7 +4430,7 @@ impl Bank {
         let missing_programs: Vec<(Pubkey, Arc<LoadedProgram>)> = missing_programs
             .iter()
             .map(|key| {
-                let program = self.load_program(key, false).unwrap_or_else(|err| {
+                let program = self.load_program(key).unwrap_or_else(|err| {
                     // Create a tombstone for the program in the cache
                     debug!("Failed to load program {}, error {:?}", key, err);
                     Arc::new(LoadedProgram::new_tombstone(
@@ -4525,10 +4527,10 @@ impl Bank {
             &program_owners_refs,
             &self.blockhash_queue.read().unwrap(),
         );
+        let native_loader = native_loader::id();
         for precompile in get_precompiles() {
             program_accounts_map.remove(&precompile.program_id);
         }
-        let native_loader = native_loader::id();
         for builtin_program in self.builtin_programs.iter() {
             program_accounts_map.insert(*builtin_program, &native_loader);
         }
@@ -6265,7 +6267,23 @@ impl Bank {
         self.rewards_pool_pubkeys =
             Arc::new(genesis_config.rewards_pools.keys().cloned().collect());
 
+        self.apply_feature_activations(
+            ApplyFeatureActivationsCaller::FinishInit,
+            debug_do_not_add_builtins,
+        );
+
         if !debug_do_not_add_builtins {
+            let program_runtime_environment_v1 = create_program_runtime_environment(
+                &self.feature_set,
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap();
+            self.loaded_programs_cache
+                .write()
+                .unwrap()
+                .program_runtime_environment_v1 = Arc::new(program_runtime_environment_v1);
             for builtin in BUILTINS
                 .iter()
                 .chain(additional_builtins.unwrap_or(&[]).iter())
@@ -6284,11 +6302,6 @@ impl Bank {
                 }
             }
         }
-
-        self.apply_feature_activations(
-            ApplyFeatureActivationsCaller::FinishInit,
-            debug_do_not_add_builtins,
-        );
 
         if self
             .feature_set

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7388,7 +7388,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1, false);
+    let program = bank.load_program(&key1);
     assert!(program.is_ok());
     let program = program.unwrap();
     assert!(matches!(program.program, LoadedProgramType::LegacyV1(_)));
@@ -7546,7 +7546,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     }
 
     let loaded_program = bank
-        .load_program(&program_keypair.pubkey(), false)
+        .load_program(&program_keypair.pubkey())
         .expect("Failed to load the program");
 
     // Invoke deployed program


### PR DESCRIPTION
#### Problem
Currently the RBPF config and syscall registry are created for each Instruction of a Transaction, which is wasteful and makes it hard to control the config in one place. Note, that this PR does not yet implement the feature activation recompilation phase nor does it adjust the RBPF config based on feature activations.

#### Summary of Changes
- Adds `LoadedPrograms::program_runtime_environment_v1` which is created in `Bank::finish_init()` and used in `Bank::load_program()`.
- Merges `get_programdata_offset_and_deployment_offset()` into `load_program_from_account()`.
- Renames `create_loader()` to `create_program_runtime_environment()`.