### PR TITLE
Adjust mmap and FD count for net scripts

### DIFF
--- a/net/scripts/network-config.sh
+++ b/net/scripts/network-config.sh
@@ -10,6 +10,12 @@ sudo sysctl -w net.core.rmem_max=134217728
 sudo sysctl -w net.core.wmem_default=134217728
 sudo sysctl -w net.core.wmem_max=134217728
 
+# Increase memory mapped files limit
+sudo sysctl -w vm.max_map_count=1000000
+
+# Increase number of allowed open file descriptors
+echo "* - nofile 1000000" | sudo tee -a /etc/security/limits.conf
+
 echo "MaxAuthTries 60" | sudo tee -a /etc/ssh/sshd_config
 sudo service sshd restart
 sudo systemctl restart sshd


### PR DESCRIPTION
#### Problem
The `net` scripts fail to start private testnet cluster.

#### Summary of Changes
The `net` scripts were not configuring`vm.max_map_count` and number of open FDs. This PR adds the configuration commands as part of network configuration script.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
