### PR TITLE
fix: `addressTableLookups` no longer serialized unless version set

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -1275,6 +1275,7 @@ pub struct UiParsedMessage {
     pub account_keys: Vec<ParsedAccount>,
     pub recent_blockhash: String,
     pub instructions: Vec<UiInstruction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address_table_lookups: Option<Vec<UiAddressTableLookup>>,
 }
 


### PR DESCRIPTION
#### Problem

While developing the spec for the new web3.js RPC I noticed that despite this message in the docs:

> List of address table lookups used by a transaction to dynamically load addresses from on-chain address lookup tables. Undefined if `maxSupportedTransactionVersion` is not set.

…that `"addressTableLookups": null` would appear in the response for `getTransaction`.

#### Summary of Changes

Just like for `"encoding": "json"`, make it so that we don't serialize `addressTableLookups` when the encoding is `jsonParsed`.

#### Test plan

1. Airdropped myself
2. Looked up the transaction with `jsonParsed` encoding

```json
{
  "jsonrpc": "2.0",
  "result": {
    "blockTime": 1684520057,
    "meta": {
      "computeUnitsConsumed": 150,
      "err": null,
      "fee": 5000,
      "innerInstructions": [],
      "logMessages": [
        "Program 11111111111111111111111111111111 invoke [1]",
        "Program 11111111111111111111111111111111 success"
      ],
      "postBalances": [
        999998999995000,
        500000001000000000,
        1
      ],
      "postTokenBalances": [],
      "preBalances": [
        1000000000000000,
        5e+17,
        1
      ],
      "preTokenBalances": [],
      "rewards": [],
      "status": {
        "Ok": null
      }
    },
    "slot": 473,
    "transaction": {
      "message": {
        "accountKeys": [
          {
            "pubkey": "ZCsBZtjYWu7CThgGSJrWX9RmfrhWTtRPaXX5e7riG3F",
            "signer": true,
            "source": "transaction",
            "writable": true
          },
          {
            "pubkey": "Du7GGHHoRadMkbcf2XsddagGR2L5aPgJWqWWpTCCG9QH",
            "signer": false,
            "source": "transaction",
            "writable": true
          },
          {
            "pubkey": "11111111111111111111111111111111",
            "signer": false,
            "source": "transaction",
            "writable": false
          }
        ],
        "instructions": [
          {
            "parsed": {
              "info": {
                "destination": "Du7GGHHoRadMkbcf2XsddagGR2L5aPgJWqWWpTCCG9QH",
                "lamports": 1000000000,
                "source": "ZCsBZtjYWu7CThgGSJrWX9RmfrhWTtRPaXX5e7riG3F"
              },
              "type": "transfer"
            },
            "program": "system",
            "programId": "11111111111111111111111111111111",
            "stackHeight": null
          }
        ],
        "recentBlockhash": "5f5n21yjnwMFNNkjeh7DChSmAEQodu2tdpTKYwkcfFpE"
      },
      "signatures": [
        "2s64R5BF1KfZ56FcdozwcUHfYKFYh6kcC2HhrNGMVRgopqV3MYusTvth8479PDxUtPSrAVvY539CGJUwaWeWKeUs"
      ]
    }
  },
  "id": 1
}
```