### PR TITLE
More metrics for LoadedPrograms cache

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -117,6 +117,9 @@ pub struct Stats {
     pub insertions: AtomicU64,
     pub replacements: AtomicU64,
     pub one_hit_wonders: AtomicU64,
+    pub prunes: AtomicU64,
+    pub expired: AtomicU64,
+    pub empty_entries: AtomicU64,
 }
 
 impl Stats {
@@ -128,6 +131,9 @@ impl Stats {
         let replacements = self.replacements.load(Ordering::Relaxed);
         let one_hit_wonders = self.one_hit_wonders.load(Ordering::Relaxed);
         let evictions: u64 = self.evictions.values().sum();
+        let prunes = self.prunes.load(Ordering::Relaxed);
+        let expired = self.expired.load(Ordering::Relaxed);
+        let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         datapoint_info!(
             "loaded-programs-cache-stats",
             ("slot", slot, i64),
@@ -137,10 +143,13 @@ impl Stats {
             ("insertions", insertions, i64),
             ("replacements", replacements, i64),
             ("one_hit_wonders", one_hit_wonders, i64),
+            ("prunes", prunes, i64),
+            ("evict_expired", expired, i64),
+            ("evict_empty_entries", empty_entries, i64),
         );
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Insertions: {}, Replacements: {}, One-Hit-Wonders: {}",
-            hits, misses, evictions, insertions, replacements, one_hit_wonders,
+            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes: {}, Expired: {}, Empty: {}",
+            hits, misses, evictions, insertions, replacements, one_hit_wonders, prunes, expired, empty_entries
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
@@ -479,6 +488,7 @@ impl LoadedPrograms {
                         first_ancestor_found = true;
                         first_ancestor_found
                     } else {
+                        self.stats.prunes.fetch_add(1, Ordering::Relaxed);
                         false
                     }
                 })
@@ -635,7 +645,14 @@ impl LoadedPrograms {
             entry.retain(|program| {
                 program
                     .maybe_expiration_slot
-                    .map(|expiration| expiration > current_slot)
+                    .map(|expiration| {
+                        if expiration > current_slot {
+                            true
+                        } else {
+                            self.stats.expired.fetch_add(1, Ordering::Relaxed);
+                            false
+                        }
+                    })
                     .unwrap_or(true)
             });
         }
@@ -646,6 +663,11 @@ impl LoadedPrograms {
             entries.iter_mut().for_each(|entry| {
                 if entry.is_loaded() {
                     *entry = Arc::new(entry.to_unloaded());
+                    self.stats
+                        .evictions
+                        .entry(*id)
+                        .and_modify(|c| saturating_add_assign!(*c, 1))
+                        .or_insert(1);
                 }
             });
         }
@@ -678,7 +700,14 @@ impl LoadedPrograms {
     }
 
     fn remove_programs_with_no_entries(&mut self) {
-        self.entries.retain(|_, programs| !programs.is_empty())
+        let num_programs_before_removal = self.entries.len();
+        self.entries.retain(|_, programs| !programs.is_empty());
+        if self.entries.len() < num_programs_before_removal {
+            self.stats.empty_entries.fetch_add(
+                num_programs_before_removal.saturating_sub(self.entries.len()) as u64,
+                Ordering::Relaxed,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Missing metrics datapoints for prune and a few other use-cases.

#### Summary of Changes
Added datapoint for Prune, and eviction.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
