### PR TITLE
async delete contents but leave directory

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -93,7 +93,9 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path},
+        snapshot_utils::{
+            self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
+        },
     },
     solana_sdk::{
         clock::Slot,
@@ -2235,11 +2237,11 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 
 fn cleanup_accounts_paths(config: &ValidatorConfig) {
     for accounts_path in &config.account_paths {
-        move_and_async_delete_path(accounts_path);
+        move_and_async_delete_path_contents(accounts_path);
     }
     if let Some(ref shrink_paths) = config.account_shrink_paths {
         for accounts_path in shrink_paths {
-            move_and_async_delete_path(accounts_path);
+            move_and_async_delete_path_contents(accounts_path);
         }
     }
 }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -35,7 +35,7 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
             self, clean_orphaned_account_snapshot_dirs, create_all_accounts_run_and_snapshot_dirs,
-            move_and_async_delete_path,
+            move_and_async_delete_path_contents,
         },
     },
     solana_sdk::{
@@ -186,7 +186,7 @@ pub fn load_bank_forks(
     let mut measure = Measure::start("clean_accounts_paths");
     account_paths.iter().for_each(|path| {
         if path.exists() {
-            move_and_async_delete_path(path);
+            move_and_async_delete_path_contents(path);
         }
     });
     measure.stop();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -465,8 +465,8 @@ fn delete_contents_of_path(path: impl AsRef<Path>) {
     }
 }
 
-/// Deletes the contents of a directory asynchronously to avoid blocking on it,
-/// but leaves the top directory in place.
+/// Moves and asynchronously deletes the contents of a directory to avoid blocking on it.
+/// The directory is re-created after the move, and should now be empty.
 pub fn move_and_async_delete_path_contents(path: impl AsRef<Path>) {
     move_and_async_delete_path(&path);
     // The following could fail if the rename failed.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -465,8 +465,18 @@ fn delete_contents_of_path(path: impl AsRef<Path>) {
     }
 }
 
+/// Deletes the contents of a directory asynchronously to avoid blocking on it,
+/// but leaves the top directory in place.
+pub fn move_and_async_delete_path_contents(path: impl AsRef<Path>) {
+    move_and_async_delete_path(&path);
+    // The following could fail if the rename failed.
+    // If that happens, the directory should be left as is.
+    // So we ignore errors here.
+    let _ = std::fs::create_dir(path);
+}
+
 /// Delete directories/files asynchronously to avoid blocking on it.
-/// Fist, in sync context, rename the original path to *_deleted,
+/// First, in sync context, rename the original path to *_deleted,
 /// then spawn a thread to delete the renamed path.
 /// If the process is killed and the deleting process is not done,
 /// the leftover path will be deleted in the next process life, so


### PR DESCRIPTION
#### Problem
In ledger-tool, we delete the `<account_path>/run` directory at start up.
Creating a bank from disk expects these directories exist in order to perform hard linking from the `<account_path>/snapshot/XX/*` files into `run`.
We prevously made changes to ensure the run and snapshot directories exist, and but then immediately remove them.

#### Summary of Changes
Only delete contents of run dirs on startup, not the directories themselves.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
