### PR TITLE
[zk-keygen] import `SeedDerivable` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7072,9 +7072,9 @@ dependencies = [
  "solana-clap-v3-utils",
  "solana-cli-config",
  "solana-remote-wallet",
- "solana-sdk 1.16.0",
+ "solana-sdk",
  "solana-version",
- "solana-zk-token-sdk 1.16.0",
+ "solana-zk-token-sdk",
  "tempfile",
  "tiny-bip39",
 ]

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -10,7 +10,7 @@ use {
         },
         DisplayError,
     },
-    solana_sdk::signer::EncodableKey,
+    solana_sdk::signer::{EncodableKey, SeedDerivable},
     solana_zk_token_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     std::error,
 };


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/31641 was merged without rebasing https://github.com/solana-labs/solana/pull/31668, which splits `EncodableKey` trait into `EncodableKey` and `SeedDerivable`. This prevents `zk-keygen` from building and causes ci error. Sorry! :pray:

#### Summary of Changes
Import `SeedDerivable` trait in `zk-keygen`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
