### PR TITLE
[zk-keygen] Add `pubkey` and `recover` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7076,6 +7076,7 @@ dependencies = [
  "solana-version",
  "solana-zk-token-sdk",
  "tempfile",
+ "thiserror",
  "tiny-bip39",
 ]
 

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -27,6 +27,7 @@ solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
 tiny-bip39 = { workspace = true }
+thiserror = { worskapce = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -26,8 +26,8 @@ solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
-tiny-bip39 = { workspace = true }
 thiserror = { worskapce = true }
+tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -110,7 +110,6 @@ fn app(crate_version: &str) -> Command {
                 )
                 .arg(
                     Arg::new("force")
-                        .short('f')
                         .long("force")
                         .help("Overwrite the output file if it exists"),
                 )

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -283,32 +283,25 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 check_for_overwrite(outfile, matches)?;
             }
 
+            let name = "recover";
             match key_type {
                 KeyType::ElGamal => {
-                    let keypair_name = "recover";
                     let keypair = if let Some(path) = matches.value_of("prompt_signer") {
-                        elgamal_keypair_from_path(matches, path, keypair_name, true)?
+                        elgamal_keypair_from_path(matches, path, name, true)?
                     } else {
                         let skip_validation =
                             matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-                        elgamal_keypair_from_seed_phrase(
-                            keypair_name,
-                            skip_validation,
-                            true,
-                            None,
-                            true,
-                        )?
+                        elgamal_keypair_from_seed_phrase(name, skip_validation, true, None, true)?
                     };
                     output_encodable_key(&keypair, outfile, "recovered ElGamal keypair")?;
                 }
                 KeyType::Aes128 => {
-                    let key_name = "recover";
                     let key = if let Some(path) = matches.value_of("prompt_signer") {
-                        ae_key_from_path(matches, path, key_name)?
+                        ae_key_from_path(matches, path, name)?
                     } else {
                         let skip_validation =
                             matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-                        ae_key_from_seed_phrase(key_name, skip_validation, None, true)?
+                        ae_key_from_seed_phrase(name, skip_validation, None, true)?
                     };
                     output_encodable_key(&key, outfile, "recovered AES128 key")?;
                 }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -48,7 +48,7 @@ fn app(crate_version: &str) -> Command {
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("type")
-                        .long("type")
+                        .index(1)
                         .takes_value(true)
                         .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
@@ -81,8 +81,17 @@ fn app(crate_version: &str) -> Command {
                 .about("Display the pubkey from a keypair file")
                 .disable_version_flag(true)
                 .arg(
-                    Arg::new("keypair")
+                    Arg::new("type")
                         .index(1)
+                        .takes_value(true)
+                        .possible_values(["elgamal"])
+                        .value_name("TYPE")
+                        .required(true)
+                        .help("The type of keypair")
+                )
+                .arg(
+                    Arg::new("keypair")
+                        .index(2)
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .help("Filepath or URL to a keypair"),
@@ -92,36 +101,27 @@ fn app(crate_version: &str) -> Command {
                         .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
                         .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
                 )
-                .arg(
-                    Arg::new("type")
-                        .long("type")
-                        .takes_value(true)
-                        .possible_values(["elgamal"])
-                        .value_name("TYPE")
-                        .required(true)
-                        .help("The type of keypair")
-                )
         )
         .subcommand(
             Command::new("recover")
                 .about("Recover keypair from seed phrase and optional BIP39 passphrase")
                 .disable_version_flag(true)
                 .arg(
-                    Arg::new("prompt_signer")
-                        .index(1)
-                        .value_name("KEYPAIR")
-                        .takes_value(true)
-                        .validator(is_prompt_signer_source)
-                        .help("`prompt:` URI scheme or `ASK` keyword"),
-                )
-                .arg(
                     Arg::new("type")
-                        .long("type")
+                        .index(1)
                         .takes_value(true)
                         .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
                         .required(true)
                         .help("The type of keypair")
+                )
+                .arg(
+                    Arg::new("prompt_signer")
+                        .index(2)
+                        .value_name("KEYPAIR")
+                        .takes_value(true)
+                        .validator(is_prompt_signer_source)
+                        .help("`prompt:` URI scheme or `ASK` keyword"),
                 )
                 .arg(
                     Arg::new("outfile")
@@ -360,7 +360,6 @@ mod tests {
         process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--type",
             "elgamal",
             "--outfile",
             &outfile_path,
@@ -372,7 +371,6 @@ mod tests {
         let result = process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--type",
             "elgamal",
             "--outfile",
             &outfile_path,
@@ -388,7 +386,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--type",
             "elgamal",
             "--no-bip39-passphrase",
             "--no-outfile",
@@ -406,7 +403,6 @@ mod tests {
         process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--type",
             "aes128",
             "--outfile",
             &outfile_path,
@@ -418,7 +414,6 @@ mod tests {
         let result = process_test_command(&[
             "solana-zk-keygen",
             "new",
-            "--type",
             "aes128",
             "--outfile",
             &outfile_path,
@@ -434,7 +429,6 @@ mod tests {
         process_test_command(&[
             "solana-keygen",
             "new",
-            "--type",
             "aes128",
             "--no-bip39-passphrase",
             "--no-outfile",
@@ -451,13 +445,6 @@ mod tests {
         let keypair = ElGamalKeypair::new_rand();
         keypair.write_to_file(&keypair_path).unwrap();
 
-        process_test_command(&[
-            "solana-keygen",
-            "pubkey",
-            &keypair_path,
-            "--type",
-            "elgamal",
-        ])
-        .unwrap();
+        process_test_command(&["solana-keygen", "pubkey", "elgamal", &keypair_path]).unwrap();
     }
 }


### PR DESCRIPTION
#### Problem
The `solana-zk-keygen` tool does not yet have commands for recovering encryption keys from seed phrases and ElGamal pubkey from an ElGamal keypair file.

#### Summary of Changes
Add the `pubkey` and `recover` commands.

For the `pubkey` command, the key-type argument `--type` is required even if `elgamal` is the only possible option. I can change this if anyone has an opinion against this.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
