### PR TITLE
Make reconstruct_single_storage() returns SnapshotError

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -629,9 +629,7 @@ pub(crate) fn reconstruct_single_storage(
     current_len: usize,
     append_vec_id: AppendVecId,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    let (accounts_file, num_accounts) =
-        AccountsFile::new_from_file(append_vec_path, current_len)
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)))?;
+    let (accounts_file, num_accounts) = AccountsFile::new_from_file(append_vec_path, current_len)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,


### PR DESCRIPTION
#### Problem
The return error type -- io::Error used in reconstruct_single_storage()
isn't suitable to describe all possible errors inside the function such as
AccountsFileError.

#### Summary of Changes
This PR makes it return SnapshotError which can better handle
both AccountsFileError and io::Error.

This small PR depends on #31632.