### PR TITLE
Add enum AppendVecError

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -3,7 +3,7 @@ use {
         account_storage::meta::{
             StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredAccountMeta,
         },
-        append_vec::{AppendVec, MatchAccountOwnerError},
+        append_vec::{AppendVec, AppendVecError, MatchAccountOwnerError},
         storable_accounts::StorableAccounts,
         tiered_storage::error::TieredStorageError,
     },
@@ -31,6 +31,9 @@ macro_rules! u64_align {
 pub enum AccountsFileError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("AppendVecError: {0}")]
+    AppendVecError(#[from] AppendVecError),
 
     #[error("TieredStorageError: {0}")]
     TieredStorageError(#[from] TieredStorageError),

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -56,16 +56,16 @@ pub const MAXIMUM_APPEND_VEC_FILE_SIZE: u64 = 16 * 1024 * 1024 * 1024; // 16 GiB
 #[derive(Error, Debug)]
 /// An enum for AppendVec related errors.
 pub enum AppendVecError {
-    #[error("File size too small: too small file size {0} for AppendVec")]
+    #[error("too small file size {0} for AppendVec")]
     FileSizeTooSmall(usize),
 
-    #[error("File size too large: too large file size {0} for AppendVec")]
+    #[error("too large file size {0} for AppendVec")]
     FileSizeTooLarge(usize),
 
-    #[error("Incorrect layout: incorrect layout/length/data in the appendvec at path {}", .0.display())]
+    #[error("incorrect layout/length/data in the appendvec at path {}", .0.display())]
     IncorrectLayout(PathBuf),
 
-    #[error("Offset out of bounds: {0} is larger than file size ({1})")]
+    #[error("{0} is larger than file size ({1})")]
     OffsetOutOfBounds(usize, usize),
 }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -65,7 +65,7 @@ pub enum AppendVecError {
     #[error("incorrect layout/length/data in the appendvec at path {}", .0.display())]
     IncorrectLayout(PathBuf),
 
-    #[error("{0} is larger than file size ({1})")]
+    #[error("offset ({0}) is larger than file size ({1})")]
     OffsetOutOfBounds(usize, usize),
 }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -986,7 +986,7 @@ pub mod tests {
         const LEN: usize = 1024 * 1024 + 1;
         const SIZE: usize = 1024 * 1024;
         let result = AppendVec::sanitize_len_and_size(LEN, SIZE);
-        assert_matches!(result, Err(ref message) if message.to_string().contains("current_len is larger than file size (1048576)"));
+        assert_matches!(result, Err(ref message) if message.to_string().contains("is larger than file size (1048576)"));
     }
 
     #[test]

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -927,7 +927,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "too small file size 0 for AppendVec")]
+    #[should_panic(expected = "AppendVecError(FileSizeTooSmall(0))")]
     fn test_append_vec_new_bad_size() {
         let path = get_append_vec_path("test_append_vec_new_bad_size");
         let _av = AppendVec::new(&path.path, true, 0);


### PR DESCRIPTION
#### Problem
AppendVec currently uses std::io::ErrorKind::Other for its own errors.

#### Summary of Changes
This PR introduces AppendVecError and has AppendVec use it. 
