### PR TITLE
Cleanup - Various feature gates

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -178,7 +178,6 @@ fn simulate_transaction(
         MessageHash::Compute,
         Some(false), // is_simple_vote_tx
         bank,
-        true, // require_static_program_ids
     ) {
         Err(err) => {
             return BanksTransactionResultWithSimulation {
@@ -330,7 +329,6 @@ impl Banks for BanksServer {
             MessageHash::Compute,
             Some(false), // is_simple_vote_tx
             bank.as_ref(),
-            true, // require_static_program_ids
         ) {
             Ok(tx) => tx,
             Err(err) => return Some(Err(err)),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1656,7 +1656,6 @@ mod tests {
             MessageHash::Compute,
             Some(false),
             bank.as_ref(),
-            true, // require_static_program_ids
         )
         .unwrap();
 

--- a/core/src/read_write_account_set.rs
+++ b/core/src/read_write_account_set.rs
@@ -157,7 +157,6 @@ mod tests {
             MessageHash::Compute,
             Some(false),
             bank,
-            true, // require_static_program_ids
         )
         .unwrap()
     }

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -40,7 +40,6 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                     message_hash,
                     None,
                     SimpleAddressLoader::Disabled,
-                    true, // require_static_program_ids
                 )
             }?;
 
@@ -82,7 +81,6 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     message_hash,
                     None,
                     SimpleAddressLoader::Disabled,
-                    true, // require_static_program_ids
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1041,7 +1041,6 @@ mod tests {
                         message_hash,
                         None,
                         SimpleAddressLoader::Disabled,
-                        true, // require_static_program_ids
                     )
                 }?;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -922,7 +922,6 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
                     MessageHash::Compute,
                     None,
                     SimpleAddressLoader::Disabled,
-                    true, // require_static_program_ids
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {:?}", err);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1984,12 +1984,7 @@ impl Blockstore {
                     .into_iter()
                     .flat_map(|entry| entry.transactions)
                     .map(|transaction| {
-                        if let Err(err) = transaction.sanitize(
-                            // Don't enable additional sanitization checks until
-                            // all clusters have activated the static program id
-                            // feature gate so that bigtable upload isn't affected
-                            false, // require_static_program_ids
-                        ) {
+                        if let Err(err) = transaction.sanitize() {
                             warn!(
                                 "Blockstore::get_block sanitize failed: {:?}, \
                                 slot: {:?}, \
@@ -2376,9 +2371,7 @@ impl Blockstore {
             .cloned()
             .flat_map(|entry| entry.transactions)
             .map(|transaction| {
-                if let Err(err) = transaction.sanitize(
-                    true, // require_static_program_ids
-                ) {
+                if let Err(err) = transaction.sanitize() {
                     warn!(
                         "Blockstore::find_transaction_in_slot sanitize failed: {:?}, \
                         slot: {:?}, \

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -38,9 +38,8 @@ use {
             disable_deploy_of_alloc_free_syscall, disable_fees_sysvar, enable_alt_bn128_syscall,
             enable_big_mod_exp_syscall, enable_early_verification_of_account_modifications,
             error_on_syscall_bpf_function_hash_collisions, libsecp256k1_0_5_upgrade_enabled,
-            limit_secp256k1_recovery_id, reject_callx_r10,
-            stop_sibling_instruction_search_at_parent, stop_truncating_strings_in_syscalls,
-            switch_to_new_elf_parser,
+            reject_callx_r10, stop_sibling_instruction_search_at_parent,
+            stop_truncating_strings_in_syscalls, switch_to_new_elf_parser,
         },
         hash::{Hasher, HASH_BYTES},
         instruction::{
@@ -873,18 +872,11 @@ declare_syscall!(
                 return Ok(Secp256k1RecoverError::InvalidHash.into());
             }
         };
-        let adjusted_recover_id_val = if invoke_context
-            .feature_set
-            .is_active(&limit_secp256k1_recovery_id::id())
-        {
-            match recovery_id_val.try_into() {
-                Ok(adjusted_recover_id_val) => adjusted_recover_id_val,
-                Err(_) => {
-                    return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
-                }
+        let adjusted_recover_id_val = match recovery_id_val.try_into() {
+            Ok(adjusted_recover_id_val) => adjusted_recover_id_val,
+            Err(_) => {
+                return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
             }
-        } else {
-            recovery_id_val as u8
         };
         let recovery_id = match libsecp256k1::RecoveryId::parse(adjusted_recover_id_val) {
             Ok(id) => id,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -33,10 +33,10 @@ use {
         feature_set::bpf_account_data_direct_mapping,
         feature_set::FeatureSet,
         feature_set::{
-            self, blake3_syscall_enabled, check_syscall_outputs_do_not_overlap,
-            curve25519_syscall_enabled, disable_cpi_setting_executable_and_rent_epoch,
-            disable_deploy_of_alloc_free_syscall, disable_fees_sysvar, enable_alt_bn128_syscall,
-            enable_big_mod_exp_syscall, enable_early_verification_of_account_modifications,
+            self, blake3_syscall_enabled, curve25519_syscall_enabled,
+            disable_cpi_setting_executable_and_rent_epoch, disable_deploy_of_alloc_free_syscall,
+            disable_fees_sysvar, enable_alt_bn128_syscall, enable_big_mod_exp_syscall,
+            enable_early_verification_of_account_modifications,
             error_on_syscall_bpf_function_hash_collisions, libsecp256k1_0_5_upgrade_enabled,
             reject_callx_r10, stop_sibling_instruction_search_at_parent,
             stop_truncating_strings_in_syscalls, switch_to_new_elf_parser,
@@ -685,10 +685,7 @@ declare_syscall!(
                         std::mem::size_of_val(bump_seed_ref),
                         address.as_ptr() as usize,
                         std::mem::size_of::<Pubkey>(),
-                    ) && invoke_context
-                        .feature_set
-                        .is_active(&check_syscall_outputs_do_not_overlap::id())
-                    {
+                    ) {
                         return Err(SyscallError::CopyOverlapping.into());
                     }
                     *bump_seed_ref = bump_seed[0];
@@ -1438,10 +1435,7 @@ declare_syscall!(
                 length as usize,
                 program_id_result as *const _ as usize,
                 std::mem::size_of::<Pubkey>(),
-            ) && invoke_context
-                .feature_set
-                .is_active(&check_syscall_outputs_do_not_overlap::id())
-            {
+            ) {
                 return Err(SyscallError::CopyOverlapping.into());
             }
 
@@ -1530,7 +1524,7 @@ declare_syscall!(
                     invoke_context.get_check_size(),
                 )?;
 
-                if (!is_nonoverlapping(
+                if !is_nonoverlapping(
                     result_header as *const _ as usize,
                     std::mem::size_of::<ProcessedSiblingInstruction>(),
                     program_id as *const _ as usize,
@@ -1563,10 +1557,7 @@ declare_syscall!(
                     accounts.as_ptr() as usize,
                     std::mem::size_of::<AccountMeta>()
                         .saturating_mul(result_header.accounts_len as usize),
-                )) && invoke_context
-                    .feature_set
-                    .is_active(&check_syscall_outputs_do_not_overlap::id())
-                {
+                ) {
                     return Err(SyscallError::CopyOverlapping.into());
                 }
 

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1066,14 +1066,6 @@ mod tests {
             instruction_accounts.clone(),
             Ok(()),
         );
-
-        // should fail, if vote_withdraw_authority_may_change_authorized_voter is disabled
-        process_instruction_disabled_features(
-            &instruction_data,
-            transaction_accounts,
-            instruction_accounts,
-            Err(InstructionError::MissingRequiredSignature),
-        );
     }
 
     #[test]

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -218,15 +218,7 @@ declare_process_instruction!(process_instruction, 2100, |invoke_context| {
         VoteInstruction::Withdraw(lamports) => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             let rent_sysvar = invoke_context.get_sysvar_cache().get_rent()?;
-
-            let clock_if_feature_active = if invoke_context
-                .feature_set
-                .is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id())
-            {
-                Some(invoke_context.get_sysvar_cache().get_clock()?)
-            } else {
-                None
-            };
+            let clock_sysvar = invoke_context.get_sysvar_cache().get_clock()?;
 
             drop(me);
             vote_state::withdraw(
@@ -237,7 +229,7 @@ declare_process_instruction!(process_instruction, 2100, |invoke_context| {
                 1,
                 &signers,
                 &rent_sysvar,
-                clock_if_feature_active.as_deref(),
+                &clock_sysvar,
                 &invoke_context.feature_set,
             )
         }
@@ -1225,30 +1217,9 @@ mod tests {
         instruction_accounts[0].pubkey = vote_pubkey_2;
         process_instruction(
             &serialize(&VoteInstruction::Withdraw(lamports)).unwrap(),
-            transaction_accounts.clone(),
-            instruction_accounts.clone(),
-            Err(VoteError::ActiveVoteAccountClose.into()),
-        );
-
-        // Following features disabled:
-        // reject_vote_account_close_unless_zero_credit_epoch
-
-        // full withdraw, with 0 credit epoch
-        instruction_accounts[0].pubkey = vote_pubkey_1;
-        process_instruction_disabled_features(
-            &serialize(&VoteInstruction::Withdraw(lamports)).unwrap(),
-            transaction_accounts.clone(),
-            instruction_accounts.clone(),
-            Ok(()),
-        );
-
-        // full withdraw, without 0 credit epoch
-        instruction_accounts[0].pubkey = vote_pubkey_2;
-        process_instruction_disabled_features(
-            &serialize(&VoteInstruction::Withdraw(lamports)).unwrap(),
             transaction_accounts,
             instruction_accounts,
-            Ok(()),
+            Err(VoteError::ActiveVoteAccountClose.into()),
         );
     }
 

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -28,12 +28,6 @@ fn process_authorize_with_seed_instruction(
     current_authority_derived_key_owner: &Pubkey,
     current_authority_derived_key_seed: &str,
 ) -> Result<(), InstructionError> {
-    if !invoke_context
-        .feature_set
-        .is_active(&feature_set::vote_authorize_with_seed::id())
-    {
-        return Err(InstructionError::InvalidInstructionData);
-    }
     let clock = get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
     let mut expected_authority_keys: HashSet<Pubkey> = HashSet::default();
     if instruction_context.is_instruction_account_signer(2)? {
@@ -1352,22 +1346,6 @@ mod tests {
                 VoteAuthorizeWithSeedArgs {
                     authorization_type,
                     current_authority_derived_key_owner: current_authority_owner,
-                    current_authority_derived_key_seed: current_authority_seed.clone(),
-                    new_authority: new_authority_pubkey,
-                },
-            ))
-            .unwrap(),
-            transaction_accounts.clone(),
-            instruction_accounts.clone(),
-            Ok(()),
-        );
-
-        // Should fail when the `vote_authorize_with_seed` feature is disabled
-        process_instruction_disabled_features(
-            &serialize(&VoteInstruction::AuthorizeWithSeed(
-                VoteAuthorizeWithSeedArgs {
-                    authorization_type,
-                    current_authority_derived_key_owner: current_authority_owner,
                     current_authority_derived_key_seed: current_authority_seed,
                     new_authority: new_authority_pubkey,
                 },
@@ -1375,7 +1353,7 @@ mod tests {
             .unwrap(),
             transaction_accounts,
             instruction_accounts,
-            Err(InstructionError::InvalidInstructionData),
+            Ok(()),
         );
     }
 
@@ -1493,28 +1471,13 @@ mod tests {
                 VoteAuthorizeCheckedWithSeedArgs {
                     authorization_type,
                     current_authority_derived_key_owner: current_authority_owner,
-                    current_authority_derived_key_seed: current_authority_seed.clone(),
-                },
-            ))
-            .unwrap(),
-            transaction_accounts.clone(),
-            instruction_accounts.clone(),
-            Ok(()),
-        );
-
-        // Should fail when the `vote_authorize_with_seed` feature is disabled
-        process_instruction_disabled_features(
-            &serialize(&VoteInstruction::AuthorizeCheckedWithSeed(
-                VoteAuthorizeCheckedWithSeedArgs {
-                    authorization_type,
-                    current_authority_derived_key_owner: current_authority_owner,
                     current_authority_derived_key_seed: current_authority_seed,
                 },
             ))
             .unwrap(),
             transaction_accounts,
             instruction_accounts,
-            Err(InstructionError::InvalidInstructionData),
+            Ok(()),
         );
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -801,13 +801,8 @@ pub fn authorize<S: std::hash::BuildHasher>(
 
     match vote_authorize {
         VoteAuthorize::Voter => {
-            let authorized_withdrawer_signer = if feature_set
-                .is_active(&feature_set::vote_withdraw_authority_may_change_authorized_voter::id())
-            {
-                verify_authorized_signer(&vote_state.authorized_withdrawer, signers).is_ok()
-            } else {
-                false
-            };
+            let authorized_withdrawer_signer =
+                verify_authorized_signer(&vote_state.authorized_withdrawer, signers).is_ok();
 
             vote_state.set_new_authorized_voter(
                 authorized,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -10,7 +10,7 @@ use {
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::{Epoch, Slot, UnixTimestamp},
         epoch_schedule::EpochSchedule,
-        feature_set::{self, filter_votes_outside_slot_hashes, FeatureSet},
+        feature_set::{self, FeatureSet},
         hash::Hash,
         instruction::InstructionError,
         pubkey::Pubkey,
@@ -727,26 +727,23 @@ pub fn process_vote(
     vote: &Vote,
     slot_hashes: &[SlotHash],
     epoch: Epoch,
-    feature_set: Option<&FeatureSet>,
+    filter_vote_slots: bool,
 ) -> Result<(), VoteError> {
     if vote.slots.is_empty() {
         return Err(VoteError::EmptySlots);
     }
-    let filtered_vote_slots = feature_set.and_then(|feature_set| {
-        if feature_set.is_active(&filter_votes_outside_slot_hashes::id()) {
-            let earliest_slot_in_history =
-                slot_hashes.last().map(|(slot, _hash)| *slot).unwrap_or(0);
-            Some(
-                vote.slots
-                    .iter()
-                    .filter(|slot| **slot >= earliest_slot_in_history)
-                    .cloned()
-                    .collect::<Vec<Slot>>(),
-            )
-        } else {
-            None
-        }
-    });
+    let filtered_vote_slots = if filter_vote_slots {
+        let earliest_slot_in_history = slot_hashes.last().map(|(slot, _hash)| *slot).unwrap_or(0);
+        Some(
+            vote.slots
+                .iter()
+                .filter(|slot| **slot >= earliest_slot_in_history)
+                .cloned()
+                .collect::<Vec<Slot>>(),
+        )
+    } else {
+        None
+    };
 
     let vote_slots = filtered_vote_slots.as_ref().unwrap_or(&vote.slots);
     if vote_slots.is_empty() {
@@ -769,7 +766,7 @@ pub fn process_vote_unchecked(vote_state: &mut VoteState, vote: Vote) {
         &vote,
         &slot_hashes,
         vote_state.current_epoch(),
-        None,
+        false,
     );
 }
 
@@ -1016,13 +1013,7 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
 ) -> Result<(), InstructionError> {
     let mut vote_state = verify_and_get_vote_state(vote_account, clock, signers)?;
 
-    process_vote(
-        &mut vote_state,
-        vote,
-        slot_hashes,
-        clock.epoch,
-        Some(feature_set),
-    )?;
+    process_vote(&mut vote_state, vote, slot_hashes, clock.epoch, true)?;
     if let Some(timestamp) = vote.timestamp {
         vote.slots
             .iter()
@@ -1179,19 +1170,19 @@ mod tests {
         vote_state.increment_credits(0, 100);
         assert_eq!(
             vote_state
-                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 0, 1, |_pubkey| Ok(()),),
+                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 0, 1, |_pubkey| Ok(())),
             Ok(())
         );
         vote_state.increment_credits(1, 200);
         assert_eq!(
             vote_state
-                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 1, 2, |_pubkey| Ok(()),),
+                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 1, 2, |_pubkey| Ok(())),
             Ok(())
         );
         vote_state.increment_credits(2, 300);
         assert_eq!(
             vote_state
-                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 2, 3, |_pubkey| Ok(()),),
+                .set_new_authorized_voter(&solana_sdk::pubkey::new_rand(), 2, 3, |_pubkey| Ok(())),
             Ok(())
         );
         // Simulate votes having occurred
@@ -1493,23 +1484,11 @@ mod tests {
         let slot_hashes: Vec<_> = vote.slots.iter().rev().map(|x| (*x, vote.hash)).collect();
 
         assert_eq!(
-            process_vote(
-                &mut vote_state_a,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state_a, &vote, &slot_hashes, 0, true),
             Ok(())
         );
         assert_eq!(
-            process_vote(
-                &mut vote_state_b,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state_b, &vote, &slot_hashes, 0, true),
             Ok(())
         );
         assert_eq!(recent_votes(&vote_state_a), recent_votes(&vote_state_b));
@@ -1522,24 +1501,12 @@ mod tests {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(0, vote.hash)];
         assert_eq!(
-            process_vote(
-                &mut vote_state,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Ok(())
         );
         let recent = recent_votes(&vote_state);
         assert_eq!(
-            process_vote(
-                &mut vote_state,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Err(VoteError::VoteTooOld)
         );
         assert_eq!(recent, recent_votes(&vote_state));
@@ -1599,13 +1566,7 @@ mod tests {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
-            process_vote(
-                &mut vote_state,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Ok(())
         );
         assert_eq!(
@@ -1621,13 +1582,7 @@ mod tests {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
-            process_vote(
-                &mut vote_state,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Ok(())
         );
 
@@ -1646,13 +1601,7 @@ mod tests {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
-            process_vote(
-                &mut vote_state,
-                &vote,
-                &slot_hashes,
-                0,
-                Some(&FeatureSet::default())
-            ),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Ok(())
         );
 
@@ -1669,7 +1618,7 @@ mod tests {
 
         let vote = Vote::new(vec![], Hash::default());
         assert_eq!(
-            process_vote(&mut vote_state, &vote, &[], 0, Some(&FeatureSet::default())),
+            process_vote(&mut vote_state, &vote, &[], 0, true),
             Err(VoteError::EmptySlots)
         );
     }
@@ -1787,7 +1736,7 @@ mod tests {
 
         let current_epoch = vote_state1.current_epoch();
         assert_eq!(
-            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None,),
+            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None),
             Err(VoteError::TooManyVotes)
         );
     }
@@ -1848,7 +1797,7 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(
-            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None,),
+            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None),
             Err(VoteError::ZeroConfirmations)
         );
 
@@ -1859,7 +1808,7 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(
-            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None,),
+            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None),
             Err(VoteError::ZeroConfirmations)
         );
     }
@@ -2012,7 +1961,7 @@ mod tests {
 
         // Slot 7 should have expired slot 0
         assert_eq!(
-            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None,),
+            process_new_vote_state(&mut vote_state1, bad_votes, None, None, current_epoch, None),
             Err(VoteError::NewVoteStateLockoutMismatch)
         );
     }
@@ -2315,10 +2264,6 @@ mod tests {
 
     #[test]
     fn test_filter_old_votes() {
-        // Enable feature
-        let mut feature_set = FeatureSet::default();
-        feature_set.activate(&filter_votes_outside_slot_hashes::id(), 0);
-
         let mut vote_state = VoteState::default();
         let old_vote_slot = 1;
         let vote = Vote::new(vec![old_vote_slot], Hash::default());
@@ -2327,7 +2272,7 @@ mod tests {
         // error with `VotesTooOldAllFiltered`
         let slot_hashes = vec![(3, Hash::new_unique()), (2, Hash::new_unique())];
         assert_eq!(
-            process_vote(&mut vote_state, &vote, &slot_hashes, 0, Some(&feature_set),),
+            process_vote(&mut vote_state, &vote, &slot_hashes, 0, true),
             Err(VoteError::VotesTooOldAllFiltered)
         );
 
@@ -2341,7 +2286,7 @@ mod tests {
             .1;
 
         let vote = Vote::new(vec![old_vote_slot, vote_slot], vote_slot_hash);
-        process_vote(&mut vote_state, &vote, &slot_hashes, 0, Some(&feature_set)).unwrap();
+        process_vote(&mut vote_state, &vote, &slot_hashes, 0, true).unwrap();
         assert_eq!(
             vote_state
                 .votes
@@ -2374,7 +2319,7 @@ mod tests {
                 &Vote::new(vote_slots, vote_hash),
                 slot_hashes,
                 0,
-                None,
+                false,
             )
             .unwrap();
         }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -905,7 +905,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
     to_account_index: IndexOfAccount,
     signers: &HashSet<Pubkey, S>,
     rent_sysvar: &Rent,
-    clock: Option<&Clock>,
+    clock: &Clock,
     feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let mut vote_account = instruction_context
@@ -922,9 +922,10 @@ pub fn withdraw<S: std::hash::BuildHasher>(
         .ok_or(InstructionError::InsufficientFunds)?;
 
     if remaining_balance == 0 {
-        let reject_active_vote_account_close = clock
-            .zip(vote_state.epoch_credits.last())
-            .map(|(clock, (last_epoch_with_credits, _, _))| {
+        let reject_active_vote_account_close = vote_state
+            .epoch_credits
+            .last()
+            .map(|(last_epoch_with_credits, _, _)| {
                 let current_epoch = clock.epoch;
                 // if current_epoch - last_epoch_with_credits < 2 then the validator has received credits
                 // either in the current epoch or the previous epoch. If it's >= 2 then it has been at least

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4516,14 +4516,8 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
 ) -> Result<SanitizedTransaction> {
-    SanitizedTransaction::try_create(
-        transaction,
-        MessageHash::Compute,
-        None,
-        address_loader,
-        true, // require_static_program_ids
-    )
-    .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
+    SanitizedTransaction::try_create(transaction, MessageHash::Compute, None, address_loader)
+        .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
 }
 
 pub fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<Exit>> {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -350,7 +350,6 @@ pub(crate) mod tests {
             MessageHash::Compute,
             None,
             SimpleAddressLoader::Disabled,
-            true, // require_static_program_ids
         )
         .unwrap();
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -623,9 +623,7 @@ impl Accounts {
             &payer_post_rent_state,
             payer_address,
             payer_account,
-            feature_set
-                .is_active(&feature_set::include_account_index_in_rent_error::ID)
-                .then_some(payer_index),
+            payer_index,
         )
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7478,14 +7478,6 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
-        if new_feature_activations.contains(&feature_set::spl_token_v3_4_0::id()) {
-            self.replace_program_account(
-                &inline_spl_token::id(),
-                &inline_spl_token::program_v3_4_0::id(),
-                "bank-apply_spl_token_v3_4_0",
-            );
-        }
-
         if new_feature_activations.contains(&feature_set::spl_associated_token_account_v1_1_0::id())
         {
             self.replace_program_account(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3719,16 +3719,7 @@ impl Bank {
     pub fn prepare_entry_batch(&self, txs: Vec<VersionedTransaction>) -> Result<TransactionBatch> {
         let sanitized_txs = txs
             .into_iter()
-            .map(|tx| {
-                SanitizedTransaction::try_create(
-                    tx,
-                    MessageHash::Compute,
-                    None,
-                    self,
-                    self.feature_set
-                        .is_active(&feature_set::require_static_program_ids_in_transaction::ID),
-                )
-            })
+            .map(|tx| SanitizedTransaction::try_create(tx, MessageHash::Compute, None, self))
             .collect::<Result<Vec<_>>>()?;
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();
         let lock_results = self
@@ -6807,14 +6798,7 @@ impl Bank {
                 tx.message.hash()
             };
 
-            SanitizedTransaction::try_create(
-                tx,
-                message_hash,
-                None,
-                self,
-                self.feature_set
-                    .is_active(&feature_set::require_static_program_ids_in_transaction::ID),
-            )
+            SanitizedTransaction::try_create(tx, message_hash, None, self)
         }?;
 
         if verification_mode == TransactionVerificationMode::HashAndVerifyPrecompiles

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,7 +60,7 @@ use {
         cost_tracker::CostTracker,
         epoch_accounts_hash::{self, EpochAccountsHash},
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
-        inline_spl_associated_token_account, inline_spl_token,
+        inline_spl_token,
         message_processor::MessageProcessor,
         rent_collector::{CollectedInfo, RentCollector},
         rent_debits::RentDebits,
@@ -4080,14 +4080,6 @@ impl Bank {
         balances
     }
 
-    /// Unload a program from the bank's cache
-    fn remove_program_from_cache(&self, pubkey: &Pubkey) {
-        self.loaded_programs_cache
-            .write()
-            .unwrap()
-            .remove_programs([*pubkey].into_iter());
-    }
-
     fn program_modification_slot(&self, pubkey: &Pubkey) -> Result<Slot> {
         let program = self
             .get_account_with_fixed_root(pubkey)
@@ -7478,15 +7470,6 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
-        if new_feature_activations.contains(&feature_set::spl_associated_token_account_v1_1_0::id())
-        {
-            self.replace_program_account(
-                &inline_spl_associated_token_account::id(),
-                &inline_spl_associated_token_account::program_v1_1_0::id(),
-                "bank-apply_spl_associated_token_account_v1_1_0",
-            );
-        }
-
         if !debug_do_not_add_builtins {
             self.apply_builtin_program_feature_transitions(
                 allow_new_activations,
@@ -7602,6 +7585,8 @@ impl Bank {
         }
     }
 
+    /// Use to replace programs by feature activation
+    #[allow(dead_code)]
     fn replace_program_account(
         &mut self,
         old_address: &Pubkey,
@@ -7622,7 +7607,11 @@ impl Bank {
                 // Clear new account
                 self.store_account(new_address, &AccountSharedData::default());
 
-                self.remove_program_from_cache(old_address);
+                // Unload a program from the bank's cache
+                self.loaded_programs_cache
+                    .write()
+                    .unwrap()
+                    .remove_programs([*old_address].into_iter());
 
                 self.calculate_and_update_accounts_data_size_delta_off_chain(
                     old_account.data().len(),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2663,8 +2663,7 @@ fn test_insufficient_funds() {
 fn test_executed_transaction_count_post_bank_transaction_count_fix() {
     let mint_amount = sol_to_lamports(1.);
     let (genesis_config, mint_keypair) = create_genesis_config(mint_amount);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.activate_feature(&feature_set::bank_transaction_count_fix::id());
+    let bank = Bank::new_for_tests(&genesis_config);
     let pubkey = solana_sdk::pubkey::new_rand();
     let amount = genesis_config.rent.minimum_balance(0);
     bank.transfer(amount, &mint_keypair, &pubkey).unwrap();

--- a/runtime/src/bank/transaction_account_state_info.rs
+++ b/runtime/src/bank/transaction_account_state_info.rs
@@ -5,7 +5,6 @@ use {
     },
     solana_sdk::{
         account::ReadableAccount,
-        feature_set,
         message::SanitizedMessage,
         native_loader,
         transaction::Result,
@@ -61,9 +60,6 @@ impl Bank {
         post_state_infos: &[TransactionAccountStateInfo],
         transaction_context: &TransactionContext,
     ) -> Result<()> {
-        let include_account_index_in_err = self
-            .feature_set
-            .is_active(&feature_set::include_account_index_in_rent_error::id());
         for (i, (pre_state_info, post_state_info)) in
             pre_state_infos.iter().zip(post_state_infos).enumerate()
         {
@@ -72,7 +68,6 @@ impl Bank {
                 post_state_info.rent_state.as_ref(),
                 transaction_context,
                 i as IndexOfAccount,
-                include_account_index_in_err,
             )?;
         }
         Ok(())

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -367,7 +367,6 @@ mod tests {
             MessageHash::Compute,
             Some(true),
             SimpleAddressLoader::Disabled,
-            true, // require_static_program_ids
         )
         .unwrap();
         let mut tx_cost = TransactionCost::new_with_capacity(1);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -12,7 +12,7 @@ use {
         accounts_hash::{AccountsDeltaHash, AccountsHash},
         bank::{Bank, BankTestConfig},
         epoch_accounts_hash,
-        genesis_utils::{self, activate_all_features, activate_feature},
+        genesis_utils::{activate_all_features, activate_feature},
         snapshot_utils::{
             create_tmp_accounts_dir_for_tests, get_storages_to_serialize, ArchiveFormat,
         },
@@ -23,7 +23,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        feature_set::{self, disable_fee_calculator},
+        feature_set,
         genesis_config::{create_genesis_config, ClusterType},
         hash::Hash,
         pubkey::Pubkey,
@@ -236,7 +236,7 @@ fn test_bank_serialize_style(
 ) {
     solana_logger::setup();
     let (mut genesis_config, _) = create_genesis_config(500);
-    genesis_utils::activate_feature(&mut genesis_config, feature_set::epoch_accounts_hash::id());
+    activate_feature(&mut genesis_config, feature_set::epoch_accounts_hash::id());
     genesis_config.epoch_schedule = EpochSchedule::custom(400, 400, false);
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     let eah_start_slot = epoch_accounts_hash::calculation_start(&bank0);
@@ -509,8 +509,7 @@ fn add_root_and_flush_write_cache(bank: &Bank) {
 #[test]
 fn test_extra_fields_eof() {
     solana_logger::setup();
-    let (mut genesis_config, _) = create_genesis_config(500);
-    activate_feature(&mut genesis_config, disable_fee_calculator::id());
+    let (genesis_config, _) = create_genesis_config(500);
 
     let bank0 = Arc::new(Bank::new_for_tests_with_config(
         &genesis_config,
@@ -646,8 +645,7 @@ fn test_extra_fields_full_snapshot_archive() {
 #[test]
 fn test_blank_extra_fields() {
     solana_logger::setup();
-    let (mut genesis_config, _) = create_genesis_config(500);
-    activate_feature(&mut genesis_config, disable_fee_calculator::id());
+    let (genesis_config, _) = create_genesis_config(500);
 
     let bank0 = Arc::new(Bank::new_for_tests_with_config(
         &genesis_config,

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -39,10 +39,10 @@ pub enum VersionedMessage {
 }
 
 impl VersionedMessage {
-    pub fn sanitize(&self, require_static_program_ids: bool) -> Result<(), SanitizeError> {
+    pub fn sanitize(&self) -> Result<(), SanitizeError> {
         match self {
             Self::Legacy(message) => message.sanitize(),
-            Self::V0(message) => message.sanitize(require_static_program_ids),
+            Self::V0(message) => message.sanitize(),
         }
     }
 

--- a/sdk/program/src/message/versions/sanitized.rs
+++ b/sdk/program/src/message/versions/sanitized.rs
@@ -18,7 +18,7 @@ impl TryFrom<VersionedMessage> for SanitizedVersionedMessage {
 
 impl SanitizedVersionedMessage {
     pub fn try_new(message: VersionedMessage) -> Result<Self, SanitizeError> {
-        message.sanitize(true /* require_static_program_ids */)?;
+        message.sanitize()?;
         Ok(Self { message })
     }
 

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -89,7 +89,7 @@ pub struct Message {
 
 impl Message {
     /// Sanitize message fields and compiled instruction indexes
-    pub fn sanitize(&self, reject_dynamic_program_ids: bool) -> Result<(), SanitizeError> {
+    pub fn sanitize(&self) -> Result<(), SanitizeError> {
         let num_static_account_keys = self.account_keys.len();
         if usize::from(self.header.num_required_signatures)
             .saturating_add(usize::from(self.header.num_readonly_unsigned_accounts))
@@ -143,18 +143,15 @@ impl Message {
             .checked_sub(1)
             .expect("message doesn't contain any account keys");
 
-        // switch to rejecting program ids loaded from lookup tables so that
-        // static analysis on program instructions can be performed without
-        // loading on-chain data from a bank
-        let max_program_id_ix = if reject_dynamic_program_ids {
+        // reject program ids loaded from lookup tables so that
+        // static analysis on program instructions can be performed
+        // without loading on-chain data from a bank
+        let max_program_id_ix =
             // `expect` is safe because of earlier check that
             // `num_static_account_keys` is non-zero
             num_static_account_keys
                 .checked_sub(1)
-                .expect("message doesn't contain any static account keys")
-        } else {
-            max_account_ix
-        };
+                .expect("message doesn't contain any static account keys");
 
         for ci in &self.instructions {
             if usize::from(ci.program_id_index) > max_program_id_ix {
@@ -375,9 +372,7 @@ mod tests {
             account_keys: vec![Pubkey::new_unique()],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -396,9 +391,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -417,9 +410,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -444,13 +435,7 @@ mod tests {
             ..Message::default()
         };
 
-        assert!(message.sanitize(
-            false, // require_static_program_ids
-        ).is_ok());
-
-        assert!(message.sanitize(
-            true, // require_static_program_ids
-        ).is_err());
+        assert!(message.sanitize().is_err());
     }
 
     #[test]
@@ -473,9 +458,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -486,9 +469,7 @@ mod tests {
             account_keys: vec![Pubkey::new_unique()],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 
@@ -503,9 +484,7 @@ mod tests {
             account_keys: vec![Pubkey::new_unique()],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 
@@ -524,9 +503,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 
@@ -540,9 +517,7 @@ mod tests {
             account_keys: (0..=u8::MAX).map(|_| Pubkey::new_unique()).collect(),
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -556,9 +531,7 @@ mod tests {
             account_keys: (0..=256).map(|_| Pubkey::new_unique()).collect(),
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 
@@ -577,9 +550,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_ok());
     }
 
@@ -598,9 +569,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 
@@ -625,12 +594,7 @@ mod tests {
             ..Message::default()
         };
 
-        assert!(message
-            .sanitize(true /* require_static_program_ids */)
-            .is_err());
-        assert!(message
-            .sanitize(false /* require_static_program_ids */)
-            .is_err());
+        assert!(message.sanitize().is_err());
     }
 
     #[test]
@@ -653,9 +617,7 @@ mod tests {
             }],
             ..Message::default()
         }
-        .sanitize(
-            true, // require_static_program_ids
-        )
+        .sanitize()
         .is_err());
     }
 

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -128,21 +128,12 @@ impl From<NonceErrorAdapter> for NonceError {
     }
 }
 
-pub fn nonce_to_instruction_error(error: NonceError, use_system_variant: bool) -> InstructionError {
-    if use_system_variant {
-        match error {
-            NonceError::NoRecentBlockhashes => SystemError::NonceNoRecentBlockhashes.into(),
-            NonceError::NotExpired => SystemError::NonceBlockhashNotExpired.into(),
-            NonceError::UnexpectedValue => SystemError::NonceUnexpectedBlockhashValue.into(),
-            NonceError::BadAccountState => InstructionError::InvalidAccountData,
-        }
-    } else {
-        match error {
-            NonceError::NoRecentBlockhashes => NonceErrorAdapter::NoRecentBlockhashes.into(),
-            NonceError::NotExpired => NonceErrorAdapter::NotExpired.into(),
-            NonceError::UnexpectedValue => NonceErrorAdapter::UnexpectedValue.into(),
-            NonceError::BadAccountState => NonceErrorAdapter::BadAccountState.into(),
-        }
+pub fn nonce_to_instruction_error(error: NonceError) -> InstructionError {
+    match error {
+        NonceError::NoRecentBlockhashes => SystemError::NonceNoRecentBlockhashes.into(),
+        NonceError::NotExpired => SystemError::NonceBlockhashNotExpired.into(),
+        NonceError::UnexpectedValue => SystemError::NonceUnexpectedBlockhashValue.into(),
+        NonceError::BadAccountState => InstructionError::InvalidAccountData,
     }
 }
 
@@ -1945,35 +1936,19 @@ mod tests {
     #[test]
     fn test_nonce_to_instruction_error() {
         assert_eq!(
-            nonce_to_instruction_error(NonceError::NoRecentBlockhashes, false),
-            NonceError::NoRecentBlockhashes.into(),
-        );
-        assert_eq!(
-            nonce_to_instruction_error(NonceError::NotExpired, false),
-            NonceError::NotExpired.into(),
-        );
-        assert_eq!(
-            nonce_to_instruction_error(NonceError::UnexpectedValue, false),
-            NonceError::UnexpectedValue.into(),
-        );
-        assert_eq!(
-            nonce_to_instruction_error(NonceError::BadAccountState, false),
-            NonceError::BadAccountState.into(),
-        );
-        assert_eq!(
-            nonce_to_instruction_error(NonceError::NoRecentBlockhashes, true),
+            nonce_to_instruction_error(NonceError::NoRecentBlockhashes),
             SystemError::NonceNoRecentBlockhashes.into(),
         );
         assert_eq!(
-            nonce_to_instruction_error(NonceError::NotExpired, true),
+            nonce_to_instruction_error(NonceError::NotExpired),
             SystemError::NonceBlockhashNotExpired.into(),
         );
         assert_eq!(
-            nonce_to_instruction_error(NonceError::UnexpectedValue, true),
+            nonce_to_instruction_error(NonceError::UnexpectedValue),
             SystemError::NonceUnexpectedBlockhashValue.into(),
         );
         assert_eq!(
-            nonce_to_instruction_error(NonceError::BadAccountState, true),
+            nonce_to_instruction_error(NonceError::BadAccountState),
             InstructionError::InvalidAccountData,
         );
     }

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -95,9 +95,8 @@ impl SanitizedTransaction {
         message_hash: impl Into<MessageHash>,
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
-        require_static_program_ids: bool,
     ) -> Result<Self> {
-        tx.sanitize(require_static_program_ids)?;
+        tx.sanitize()?;
 
         let message_hash = match message_hash.into() {
             MessageHash::Compute => tx.message.hash(),

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -115,11 +115,8 @@ impl VersionedTransaction {
         })
     }
 
-    pub fn sanitize(
-        &self,
-        require_static_program_ids: bool,
-    ) -> std::result::Result<(), SanitizeError> {
-        self.message.sanitize(require_static_program_ids)?;
+    pub fn sanitize(&self) -> std::result::Result<(), SanitizeError> {
+        self.message.sanitize()?;
         self.sanitize_signatures()?;
         Ok(())
     }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -1131,13 +1131,7 @@ impl EncodedTransaction {
                 .and_then(|bytes| bincode::deserialize(&bytes).ok()),
         };
 
-        transaction.filter(|transaction| {
-            transaction
-                .sanitize(
-                    true, // require_static_program_ids
-                )
-                .is_ok()
-        })
+        transaction.filter(|transaction| transaction.sanitize().is_ok())
     }
 }
 


### PR DESCRIPTION
#### Problem
Since epoch 321 (almost a year ago) various features were activated (on all three clusters) but their feature gating logic was never cleaned up.

#### Summary of Changes
Removes feature gating logic of the following features:

1. vote_withdraw_authority_may_change_authorized_voter
2. limit_secp256k1_recovery_id
3. spl_token_v3_4_0
4. spl_associated_token_account_v1_1_0
5. disable_fee_calculator
6. vote_authorize_with_seed
7. merge_nonce_error_into_system_error
8. instructions_sysvar_owned_by_sysvar
9. require_static_program_ids_in_transaction
10. include_account_index_in_rent_error
11. filter_votes_outside_slot_hashes
12. reject_vote_account_close_unless_zero_credit_epoch
13. bank_transaction_count_fix
14. check_syscall_outputs_do_not_overlap
