### PR TITLE
Test must flush accounts cache before calculating accounts hash from storages

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -587,11 +587,7 @@ fn test_epoch_accounts_hash_and_warping() {
         None,
     );
     // flush the write cache so warping can calculate the accounts hash from storages
-    bank_forks
-        .read()
-        .unwrap()
-        .working_bank()
-        .force_flush_accounts_cache();
+    bank.force_flush_accounts_cache();
     let bank = bank_forks.write().unwrap().insert(Bank::warp_from_parent(
         &bank,
         &Pubkey::default(),
@@ -625,11 +621,7 @@ fn test_epoch_accounts_hash_and_warping() {
     let eah_start_slot_in_next_epoch =
         epoch_schedule.get_first_slot_in_epoch(bank.epoch() + 1) + eah_start_offset;
     // flush the write cache so warping can calculate the accounts hash from storages
-    bank_forks
-        .read()
-        .unwrap()
-        .working_bank()
-        .force_flush_accounts_cache();
+    bank.force_flush_accounts_cache();
     let bank = bank_forks.write().unwrap().insert(Bank::warp_from_parent(
         &bank,
         &Pubkey::default(),


### PR DESCRIPTION
#### Problem

The Epoch Accounts Hash test, `test_epoch_accounts_hash_and_warping()`, assumes that no accounts are modified in between the two calls to `warp_from_parent()`. This is no longer true when partition epoch rewards is enabled (as the epoch rewards sysvar is closed, removing 1 lamport in the process), and causes an accounts hash calculation mismatch.

Since warping performs an accounts hash calculation, and the EAH test uses storages, we end up with out-of-sync storages, which then incorrectly calculate the accounts hash and total lamports.


#### Summary of Changes

Flush the accounts cache before both/all warps.