### PR TITLE
ledger-tool to print replayed transaction fee details

### DIFF
--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -169,7 +169,7 @@ impl CostTracker {
         );
     }
 
-    fn find_costliest_account(&self) -> (Pubkey, u64) {
+    pub fn find_costliest_account(&self) -> (Pubkey, u64) {
         self.cost_by_writable_accounts
             .iter()
             .max_by_key(|(_, &cost)| cost)


### PR DESCRIPTION
#### Problem
Need to analyze how priority fee are used in mainnet-beta, in relative to block cost limits, and compare to signature fees. I didn't find good leader metrics for the purpose, modifying ledger-tool to print needed information when replay is a method. The alternative is to run modified leader code in mnb on staked nodes.

#### Summary of Changes
- mimic leader's cost tracking in replay
- print transaction fee details
- add a offline bash script to parse log file

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
