### PR TITLE
Rename accounts_file::Result to accounts_file::AccountsFileResult

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -32,7 +32,7 @@ pub enum AccountsFileError {
     Io(#[from] std::io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, AccountsFileError>;
+pub type AccountsFileResult<T> = std::result::Result<T, AccountsFileError>;
 
 #[derive(Debug)]
 /// An enum for accessing an accounts file which can be implemented
@@ -46,7 +46,10 @@ impl AccountsFile {
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
-    pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> Result<(Self, usize)> {
+    pub fn new_from_file(
+        path: impl AsRef<Path>,
+        current_len: usize,
+    ) -> AccountsFileResult<(Self, usize)> {
         let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }
@@ -60,7 +63,7 @@ impl AccountsFile {
         }
     }
 
-    pub fn flush(&self) -> Result<()> {
+    pub fn flush(&self) -> AccountsFileResult<()> {
         match self {
             Self::AppendVec(av) => av.flush(),
         }

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -10,7 +10,7 @@ use {
             AccountMeta, StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo,
             StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
         },
-        accounts_file::{AccountsFileError, Result, ALIGN_BOUNDARY_OFFSET},
+        accounts_file::{AccountsFileError, AccountsFileResult as AfResult, ALIGN_BOUNDARY_OFFSET},
         storable_accounts::StorableAccounts,
         u64_align,
     },
@@ -295,7 +295,7 @@ impl AppendVec {
         self.remove_on_drop = false;
     }
 
-    fn sanitize_len_and_size(current_len: usize, file_size: usize) -> Result<()> {
+    fn sanitize_len_and_size(current_len: usize, file_size: usize) -> AfResult<()> {
         if file_size == 0 {
             Err(AccountsFileError::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -319,7 +319,7 @@ impl AppendVec {
         }
     }
 
-    pub fn flush(&self) -> Result<()> {
+    pub fn flush(&self) -> AfResult<()> {
         self.map.flush()?;
         Ok(())
     }
@@ -352,7 +352,7 @@ impl AppendVec {
         format!("{slot}.{id}")
     }
 
-    pub fn new_from_file<P: AsRef<Path>>(path: P, current_len: usize) -> Result<(Self, usize)> {
+    pub fn new_from_file<P: AsRef<Path>>(path: P, current_len: usize) -> AfResult<(Self, usize)> {
         let new = Self::new_from_file_unchecked(&path, current_len)?;
 
         let (sanitized, num_accounts) = new.sanitize_layout_and_length();
@@ -373,7 +373,7 @@ impl AppendVec {
     }
 
     /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts
-    pub fn new_from_file_unchecked<P: AsRef<Path>>(path: P, current_len: usize) -> Result<Self> {
+    pub fn new_from_file_unchecked<P: AsRef<Path>>(path: P, current_len: usize) -> AfResult<Self> {
         let file_size = std::fs::metadata(&path)?.len();
         Self::sanitize_len_and_size(current_len, file_size as usize)?;
 


### PR DESCRIPTION
#### Summary of Changes
Rename accounts_file::Result to accounts_file::AccountsFileResult instead.
For code that imports AccountsFileResult, it can use `import as` syntax
to rename to a shorter term.


