### PR TITLE
[zk-token-sdk] Update random `AeKey` generation to use `OsRng` internally

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -7,7 +7,7 @@ use {
         aead::{Aead, NewAead},
         Aes128GcmSiv,
     },
-    rand::{rngs::OsRng, CryptoRng, Rng, RngCore},
+    rand::{rngs::OsRng, Rng},
     thiserror::Error,
 };
 use {
@@ -46,8 +46,8 @@ pub enum AuthenticatedEncryptionError {
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {
     #[cfg(not(target_os = "solana"))]
-    fn keygen<T: RngCore + CryptoRng>(rng: &mut T) -> AeKey {
-        AeKey(rng.gen::<[u8; 16]>())
+    fn keygen() -> AeKey {
+        AeKey(OsRng.gen::<[u8; 16]>())
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -101,8 +101,8 @@ impl AeKey {
         }
     }
 
-    pub fn random<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        AuthenticatedEncryption::keygen(rng)
+    pub fn new_rand() -> Self {
+        AuthenticatedEncryption::keygen()
     }
 
     pub fn encrypt(&self, amount: u64) -> AeCiphertext {
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_aes_encrypt_decrypt_correctness() {
-        let key = AeKey::random(&mut OsRng);
+        let key = AeKey::new_rand();
         let amount = 55;
 
         let ct = key.encrypt(amount);


### PR DESCRIPTION
#### Problem
Currently, there is an inconsistency between the way ElGamal and Ae keys are randomly generated. `ElGamalKeypair::new_rand() -> ElGamalKeypair` uses `OsRng` internally to sample a new keypair. `AeKey::random<T: RngCore + CryptoRng>(rng: &mut T) -> AeKey` takes in an external random generator and samples a new key.

#### Summary of Changes
Update `AeKey::random` function to `AeKey::new_rand` so that it is consistent with how `ElGamalKeypair` is randomly generated.

Split from https://github.com/solana-labs/solana/pull/31586

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
