### PR TITLE
[zk-token-sdk] add range-proof proof instruction

### DIFF
--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -337,7 +337,7 @@ async fn test_pubkey_validity() {
 #[tokio::test]
 async fn test_range_proof_u64() {
     let amount = 123_u64;
-    let (comm, open) = Pedersen::new(amount);
+    let (commitment, opening) = Pedersen::new(amount);
 
     let success_proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
 

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -28,7 +28,7 @@ const VERIFY_INSTRUCTION_TYPES: [ProofInstruction; 7] = [
     ProofInstruction::VerifyTransfer,
     ProofInstruction::VerifyTransferWithFee,
     ProofInstruction::VerifyPubkeyValidity,
-    ProofInstruction::VerifyRangeProof64,
+    ProofInstruction::VerifyRangeProofU64,
 ];
 
 #[tokio::test]
@@ -335,24 +335,24 @@ async fn test_pubkey_validity() {
 }
 
 #[tokio::test]
-async fn test_range_proof_64() {
+async fn test_range_proof_u64() {
     let amount = 123_u64;
     let (comm, open) = Pedersen::new(amount);
 
-    let success_proof_data = RangeProof64Data::new(&comm, amount, &open).unwrap();
+    let success_proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
 
     let incorrect_amount = 124_u64;
-    let fail_proof_data = RangeProof64Data::new(&comm, incorrect_amount, &open).unwrap();
+    let fail_proof_data = RangeProofU64Data::new(&comm, incorrect_amount, &open).unwrap();
 
     test_verify_proof_without_context(
-        ProofInstruction::VerifyRangeProof64,
+        ProofInstruction::VerifyRangeProofU64,
         &success_proof_data,
         &fail_proof_data,
     )
     .await;
 
     test_verify_proof_with_context(
-        ProofInstruction::VerifyRangeProof64,
+        ProofInstruction::VerifyRangeProofU64,
         size_of::<ProofContextState<RangeProofContext>>(),
         &success_proof_data,
         &fail_proof_data,
@@ -360,7 +360,7 @@ async fn test_range_proof_64() {
     .await;
 
     test_close_context_state(
-        ProofInstruction::VerifyRangeProof64,
+        ProofInstruction::VerifyRangeProofU64,
         size_of::<ProofContextState<RangeProofContext>>(),
         &success_proof_data,
     )

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -339,10 +339,10 @@ async fn test_range_proof_u64() {
     let amount = 123_u64;
     let (commitment, opening) = Pedersen::new(amount);
 
-    let success_proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
+    let success_proof_data = RangeProofU64Data::new(&commitment, amount, &opening).unwrap();
 
     let incorrect_amount = 124_u64;
-    let fail_proof_data = RangeProofU64Data::new(&comm, incorrect_amount, &open).unwrap();
+    let fail_proof_data = RangeProofU64Data::new(&commitment, incorrect_amount, &opening).unwrap();
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyRangeProofU64,

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -192,5 +192,14 @@ declare_process_instruction!(process_instruction, 0, |invoke_context| {
             ic_msg!(invoke_context, "VerifyPubkeyValidity");
             process_verify_proof::<PubkeyValidityData, PubkeyValidityProofContext>(invoke_context)
         }
+        ProofInstruction::VerifyRangeProof64 => {
+            if native_programs_consume_cu {
+                invoke_context
+                    .consume_checked(105_066)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            }
+            ic_msg!(invoke_context, "VerifyRangeProof");
+            process_verify_proof::<RangeProof64Data, RangeProofContext>(invoke_context)
+        }
     }
 });

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -192,14 +192,14 @@ declare_process_instruction!(process_instruction, 0, |invoke_context| {
             ic_msg!(invoke_context, "VerifyPubkeyValidity");
             process_verify_proof::<PubkeyValidityData, PubkeyValidityProofContext>(invoke_context)
         }
-        ProofInstruction::VerifyRangeProof64 => {
+        ProofInstruction::VerifyRangeProofU64 => {
             if native_programs_consume_cu {
                 invoke_context
                     .consume_checked(105_066)
                     .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             }
             ic_msg!(invoke_context, "VerifyRangeProof");
-            process_verify_proof::<RangeProof64Data, RangeProofContext>(invoke_context)
+            process_verify_proof::<RangeProofU64Data, RangeProofContext>(invoke_context)
         }
     }
 });

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -24,7 +24,7 @@ pub use {
         CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
     },
     pubkey_validity::{PubkeyValidityData, PubkeyValidityProofContext},
-    range_proof::{RangeProof64Data, RangeProofContext},
+    range_proof::{RangeProofContext, RangeProofU64Data},
     transfer::{TransferData, TransferProofContext},
     transfer_with_fee::{FeeParameters, TransferWithFeeData, TransferWithFeeProofContext},
     withdraw::{WithdrawData, WithdrawProofContext},
@@ -42,7 +42,7 @@ pub enum ProofType {
     Transfer,
     TransferWithFee,
     PubkeyValidity,
-    RangeProof64,
+    RangeProofU64,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -1,5 +1,6 @@
 pub mod ctxt_ctxt_equality;
 pub mod pubkey_validity;
+pub mod range_proof;
 pub mod transfer;
 pub mod transfer_with_fee;
 pub mod withdraw;
@@ -23,6 +24,7 @@ pub use {
         CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
     },
     pubkey_validity::{PubkeyValidityData, PubkeyValidityProofContext},
+    range_proof::{RangeProof64Data, RangeProofContext},
     transfer::{TransferData, TransferProofContext},
     transfer_with_fee::{FeeParameters, TransferWithFeeData, TransferWithFeeProofContext},
     withdraw::{WithdrawData, WithdrawProofContext},
@@ -40,6 +42,7 @@ pub enum ProofType {
     Transfer,
     TransferWithFee,
     PubkeyValidity,
+    RangeProof64,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -60,7 +60,7 @@ impl RangeProof64Data {
             commitment: pod_commitment,
         };
 
-        let mut transcript = context.transcript_new();
+        let mut transcript = context.new_transcript();
 
         let proof = RangeProof::new(
             vec![amount],
@@ -83,7 +83,7 @@ impl ZkProofData<RangeProofContext> for RangeProof64Data {
 
     #[cfg(not(target_os = "solana"))]
     fn verify_proof(&self) -> Result<(), ProofError> {
-        let mut transcript = self.context_data().transcript_new();
+        let mut transcript = self.context_data().new_transcript();
         let commitment = self.context.commitment.try_into()?;
         let proof: RangeProof = self.proof.try_into()?;
 
@@ -100,7 +100,7 @@ impl ZkProofData<RangeProofContext> for RangeProof64Data {
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
 impl RangeProofContext {
-    fn transcript_new(&self) -> Transcript {
+    fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"RangeProof");
         transcript.append_commitment(b"commitment", &self.commitment);
         transcript

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -108,7 +108,7 @@ mod test {
     #[test]
     fn test_range_proof_64_instruction_correctness() {
         let amount = std::u64::MAX;
-        let (comm, open) = Pedersen::new(amount);
+        let (commitment, opening) = Pedersen::new(amount);
 
         let proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
         assert!(proof_data.verify_proof().is_ok());

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -1,7 +1,7 @@
 //! The range proof instruction.
 //!
 //! A range proof certifies that a committed value in a Pedersen commitment is a number from a
-//! certain range. Currently, only 64-bit range proof `VerifyRangeProof64` is supported in the
+//! certain range. Currently, only 64-bit range proof `VerifyRangeProofU64` is supported in the
 //! proof program. It certifies that a committed number is an unsigned 64-bit number.
 
 #[cfg(not(target_os = "solana"))]
@@ -24,7 +24,7 @@ use {
 };
 
 #[cfg(not(target_os = "solana"))]
-const RANGEPROOF64_BIT_LENGTH: usize = 64;
+const RANGEPROOFU64_BIT_LENGTH: usize = 64;
 
 /// The context data needed to verify a range-proof for a committed value in a Pedersen commitment.
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -33,13 +33,13 @@ pub struct RangeProofContext {
     pub commitment: pod::PedersenCommitment, // 32 bytes
 }
 
-/// The instruction data that is needed for the `ProofInstruction::VerifyRangeProof64` instruction.
+/// The instruction data that is needed for the `ProofInstruction::VerifyRangeProofU64` instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct RangeProof64Data {
+pub struct RangeProofU64Data {
     /// The context data for a range proof
     pub context: RangeProofContext,
 
@@ -48,7 +48,7 @@ pub struct RangeProof64Data {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl RangeProof64Data {
+impl RangeProofU64Data {
     pub fn new(
         commitment: &PedersenCommitment,
         amount: u64,
@@ -64,7 +64,7 @@ impl RangeProof64Data {
 
         let proof = RangeProof::new(
             vec![amount],
-            vec![RANGEPROOF64_BIT_LENGTH],
+            vec![RANGEPROOFU64_BIT_LENGTH],
             vec![opening],
             &mut transcript,
         )
@@ -74,8 +74,8 @@ impl RangeProof64Data {
     }
 }
 
-impl ZkProofData<RangeProofContext> for RangeProof64Data {
-    const PROOF_TYPE: ProofType = ProofType::RangeProof64;
+impl ZkProofData<RangeProofContext> for RangeProofU64Data {
+    const PROOF_TYPE: ProofType = ProofType::RangeProofU64;
 
     fn context_data(&self) -> &RangeProofContext {
         &self.context
@@ -90,7 +90,7 @@ impl ZkProofData<RangeProofContext> for RangeProof64Data {
         proof
             .verify(
                 vec![&commitment],
-                vec![RANGEPROOF64_BIT_LENGTH],
+                vec![RANGEPROOFU64_BIT_LENGTH],
                 &mut transcript,
             )
             .map_err(|e| e.into())
@@ -116,7 +116,7 @@ mod test {
         let amount = std::u64::MAX;
         let (comm, open) = Pedersen::new(amount);
 
-        let proof_data = RangeProof64Data::new(&comm, amount, &open).unwrap();
+        let proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
         assert!(proof_data.verify_proof().is_ok());
     }
 }

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -23,6 +23,7 @@ use {
     bytemuck::{Pod, Zeroable},
 };
 
+#[cfg(not(target_os = "solana"))]
 const RANGEPROOF64_BIT_LENGTH: usize = 64;
 
 /// The context data needed to verify a range-proof for a committed value in a Pedersen commitment.

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -1,0 +1,121 @@
+//! The range proof instruction.
+//!
+//! A range proof certifies that a committed value in a Pedersen commitment is a number from a
+//! certain range. Currently, only 64-bit range proof `VerifyRangeProof64` is supported in the
+//! proof program. It certifies that a committed number is an unsigned 64-bit number.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::ProofError,
+        range_proof::RangeProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+const RANGEPROOF64_BIT_LENGTH: usize = 64;
+
+/// The context data needed to verify a range-proof for a committed value in a Pedersen commitment.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct RangeProofContext {
+    pub commitment: pod::PedersenCommitment, // 32 bytes
+}
+
+/// The instruction data that is needed for the `ProofInstruction::VerifyRangeProof64` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct RangeProof64Data {
+    /// The context data for a range proof
+    pub context: RangeProofContext,
+
+    /// The proof that a committed value in a Pedersen commitment is a 64-bit value
+    pub proof: pod::RangeProof64,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl RangeProof64Data {
+    pub fn new(
+        commitment: &PedersenCommitment,
+        amount: u64,
+        opening: &PedersenOpening,
+    ) -> Result<Self, ProofError> {
+        let pod_commitment = pod::PedersenCommitment(commitment.to_bytes());
+
+        let context = RangeProofContext {
+            commitment: pod_commitment,
+        };
+
+        let mut transcript = context.transcript_new();
+
+        let proof = RangeProof::new(
+            vec![amount],
+            vec![RANGEPROOF64_BIT_LENGTH],
+            vec![opening],
+            &mut transcript,
+        )
+        .try_into()?;
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<RangeProofContext> for RangeProof64Data {
+    const PROOF_TYPE: ProofType = ProofType::RangeProof64;
+
+    fn context_data(&self) -> &RangeProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofError> {
+        let mut transcript = self.context_data().transcript_new();
+        let commitment = self.context.commitment.try_into()?;
+        let proof: RangeProof = self.proof.try_into()?;
+
+        proof
+            .verify(
+                vec![&commitment],
+                vec![RANGEPROOF64_BIT_LENGTH],
+                &mut transcript,
+            )
+            .map_err(|e| e.into())
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl RangeProofContext {
+    fn transcript_new(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"RangeProof");
+        transcript.append_commitment(b"commitment", &self.commitment);
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::encryption::pedersen::Pedersen};
+
+    #[test]
+    fn test_range_proof_64_instruction_correctness() {
+        let amount = std::u64::MAX;
+        let (comm, open) = Pedersen::new(amount);
+
+        let proof_data = RangeProof64Data::new(&comm, amount, &open).unwrap();
+        assert!(proof_data.verify_proof().is_ok());
+    }
+}

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -110,7 +110,7 @@ mod test {
         let amount = std::u64::MAX;
         let (commitment, opening) = Pedersen::new(amount);
 
-        let proof_data = RangeProofU64Data::new(&comm, amount, &open).unwrap();
+        let proof_data = RangeProofU64Data::new(&commitment, amount, &opening).unwrap();
         assert!(proof_data.verify_proof().is_ok());
     }
 }

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -153,7 +153,7 @@ pub enum ProofInstruction {
     ///   None
     ///
     /// Data expected by this instruction:
-    ///   `VerifyRangeProof64Data`
+    ///   `RangeProofU64Data`
     ///
     VerifyRangeProofU64,
 }

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -155,7 +155,7 @@ pub enum ProofInstruction {
     /// Data expected by this instruction:
     ///   `VerifyRangeProof64Data`
     ///
-    VerifyRangeProof64,
+    VerifyRangeProofU64,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.
@@ -235,11 +235,11 @@ pub fn verify_pubkey_validity(
 }
 
 /// Create a `VerifyRangeProof64` instruction.
-pub fn verify_range_proof_64(
+pub fn verify_range_proof_u64(
     context_state_info: Option<ContextStateInfo>,
-    proof_data: &RangeProof64Data,
+    proof_data: &RangeProofU64Data,
 ) -> Instruction {
-    ProofInstruction::VerifyRangeProof64.encode_verify_proof(context_state_info, proof_data)
+    ProofInstruction::VerifyRangeProofU64.encode_verify_proof(context_state_info, proof_data)
 }
 
 impl ProofInstruction {

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -228,6 +228,14 @@ pub fn verify_pubkey_validity(
     ProofInstruction::VerifyPubkeyValidity.encode_verify_proof(context_state_info, proof_data)
 }
 
+/// Create a `VerifyRangeProof64` instruction.
+pub fn verify_range_proof_64(
+    context_state_info: Option<ContextStateInfo>,
+    proof_data: &RangeProof64Data,
+) -> Instruction {
+    ProofInstruction::VerifyRangeProof64.encode_verify_proof(context_state_info, proof_data)
+}
+
 impl ProofInstruction {
     pub fn encode_verify_proof<T, U>(
         &self,

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -132,6 +132,24 @@ pub enum ProofInstruction {
     ///   `PubkeyValidityData`
     ///
     VerifyPubkeyValidity,
+
+    /// Verify a 64-bit range proof.
+    ///
+    /// This instruction can be configured to optionally create a proof context state account.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Creating a proof context account
+    ///   0. `[writable]` The proof context account
+    ///   1. `[]` The proof context account owner
+    ///
+    ///   * Otherwise
+    ///   None
+    ///
+    /// Data expected by this instruction:
+    ///   `VerifyRangeProof64Data`
+    ///
+    VerifyRangeProof64,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -135,6 +135,9 @@ pub enum ProofInstruction {
 
     /// Verify a 64-bit range proof.
     ///
+    /// A range proof is defined with respect to a Pedersen commitment. The 64-bit range proof
+    /// certifies that a Pedersen commitment holds an unsigned 64-bit number.
+    ///
     /// This instruction can be configured to optionally initialize a proof context state account.
     /// If creating a context state account, an account must be pre-allocated to the exact size of
     /// `ProofContextState<RangeProofContext>` and assigned to the ZkToken proof program prior to

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -234,7 +234,7 @@ pub fn verify_pubkey_validity(
     ProofInstruction::VerifyPubkeyValidity.encode_verify_proof(context_state_info, proof_data)
 }
 
-/// Create a `VerifyRangeProof64` instruction.
+/// Create a `VerifyRangeProofU64` instruction.
 pub fn verify_range_proof_u64(
     context_state_info: Option<ContextStateInfo>,
     proof_data: &RangeProofU64Data,

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -135,7 +135,10 @@ pub enum ProofInstruction {
 
     /// Verify a 64-bit range proof.
     ///
-    /// This instruction can be configured to optionally create a proof context state account.
+    /// This instruction can be configured to optionally initialize a proof context state account.
+    /// If creating a context state account, an account must be pre-allocated to the exact size of
+    /// `ProofContextState<RangeProofContext>` and assigned to the ZkToken proof program prior to
+    /// the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///


### PR DESCRIPTION
#### Problem
The zk-token-proof program does not yet have an instruction that can verify range proof on a Pedersen commitment.

#### Summary of Changes
Add `VerifyRangeProof64` instruction. This instruction can be used to prove that a committed value is in a certain range.

The verification for these instruction was benched in the devserver and CU units were computed assuming that 1 CU should take roughly 33ns (as per https://github.com/solana-labs/solana/pull/25464#issuecomment-1142598915).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
