### PR TITLE
Fixed typo: worskapce ==> workspace

### DIFF
--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -26,7 +26,7 @@ solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
-thiserror = { worskapce = true }
+thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
#### Problem
Minor typo in `Cargo.toml` that yielded warnings when building:

```
$ cargo build --release --bin solana-validator
warning: /home/sol/src/solana/zk-keygen/Cargo.toml: dependency (thiserror) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
warning: /home/sol/src/solana/zk-keygen/Cargo.toml: unused manifest key: dependencies.thiserror.worskapce
```

#### Summary of Changes
Fix the typo
