### PR TITLE
Slot for tombstones of non-upgradeable programs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4411,8 +4411,17 @@ impl Bank {
                 let program = self.load_program(key).unwrap_or_else(|err| {
                     // Create a tombstone for the program in the cache
                     debug!("Failed to load program {}, error {:?}", key, err);
+                    let slot = if let Some(program) = self.get_account_with_fixed_root(key) {
+                        if bpf_loader_upgradeable::check_id(program.owner()) {
+                            self.slot
+                        } else {
+                            0
+                        }
+                    } else {
+                        self.slot
+                    };
                     Arc::new(LoadedProgram::new_tombstone(
-                        self.slot,
+                        slot,
                         LoadedProgramType::FailedVerification,
                     ))
                 });


### PR DESCRIPTION
#### Problem
The tombstones of the programs owned by non-upgradeable loader is incorrect.

#### Summary of Changes
Set the tombstone's slot to 0 if the program is owned by non-upgradeable loader.

Fixes https://github.com/solana-labs/solana-web3.js/issues/1308
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
