### PR TITLE
Set deployment slot for non-upgradeable programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1480,7 +1480,7 @@ fn process_loader_instruction(invoke_context: &mut InvokeContext) -> Result<(), 
                 *program.get_key(),
                 program.get_owner(),
                 program.get_data().len(),
-                0,
+                invoke_context.programs_loaded_for_tx_batch.slot(),
                 {},
                 program.get_data(),
             );


### PR DESCRIPTION
#### Problem
The deployment slot for the non-upgradeable programs is set to 0. It's causing issues if a tombstone gets added for these programs at a latter slot during deployment.

#### Summary of Changes
Set the deployment slot to current slot for such programs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
