### PR TITLE
Updates priority for which snapshot request to handle next

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -189,7 +189,7 @@ impl AccountsHashVerifier {
                 );
                 assert_eq!(z.len(), 1);
                 let z = z.first().unwrap();
-                let y = &*y; // reborrow to remove `mut`
+                let y: &_ = y; // reborrow to remove `mut`
 
                 // If the highest priority request (`z`) is EpochAccountsHash, we need to check if
                 // there's a FullSnapshot request with a lower slot in `y` that is about to be

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -238,7 +238,7 @@ impl SnapshotRequestHandler {
                     requests.select_nth_unstable_by(requests_len - 2, cmp_requests_by_priority);
                 assert_eq!(z.len(), 1);
                 let z = z.first().unwrap();
-                let y = &*y; // reborrow to remove `mut`
+                let y: &_ = y; // reborrow to remove `mut`
 
                 // If the highest priority request (`z`) is EpochAccountsHash, we need to check if
                 // there's a FullSnapshot request with a lower slot in `y` that is about to be


### PR DESCRIPTION
#### Problem

With the Incremental Accounts Hash feature, it is now invalid to create an incremental snapshot without its base full snapshot. (It was also invalid before, but for different reasons.) Now, when reserializing the bank for incremental snapshots, we need the full snapshot's account hash. If the full snapshot was skipped, then AHV will panic here handling the incremental snapshot request.

When the background services process requests, they employ prioritization, and also drop old requests that will not be handled. This can result in an invalid request ordering when both the Epoch Accounts Hash and Incremental Accounts Hash features are enabled. Specifically if both a full snapshot and an EAH are in the request channel *and* the full snapshot is *older*.

Please refer to #31595 for more information.

#### Summary of Changes

Redo how we pick the next request to handle, both in AccountsBackgroundService and AccountsHashVerifier. If there's both an EAH and a full snapshot, and the full snapshot is older, handle it first.

Fixes #31595