### PR TITLE
add optional ignore to `calculate_accounts_delta_hash`

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7772,8 +7772,23 @@ impl AccountsDb {
     /// As part of calculating the accounts delta hash, get a list of accounts modified this slot
     /// (aka dirty pubkeys) and add them to `self.uncleaned_pubkeys` for future cleaning.
     pub fn calculate_accounts_delta_hash(&self, slot: Slot) -> AccountsDeltaHash {
+        self.calculate_accounts_delta_hash_internal(slot, None)
+    }
+
+    /// Calculate accounts delta hash for `slot`
+    ///
+    /// As part of calculating the accounts delta hash, get a list of accounts modified this slot
+    /// (aka dirty pubkeys) and add them to `self.uncleaned_pubkeys` for future cleaning.
+    pub(crate) fn calculate_accounts_delta_hash_internal(
+        &self,
+        slot: Slot,
+        ignore: Option<Pubkey>,
+    ) -> AccountsDeltaHash {
         let (mut hashes, scan_us, mut accumulate) = self.get_pubkey_hash_for_slot(slot);
         let dirty_keys = hashes.iter().map(|(pubkey, _hash)| *pubkey).collect();
+        if let Some(ignore) = ignore {
+            hashes.retain(|k| k.0 != ignore);
+        }
 
         if self.filler_accounts_enabled() {
             // filler accounts must be added to 'dirty_keys' above but cannot be used to calculate hash


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

#### Summary of Changes
Allow delta hash to skip accounts. This is specifically useful when we are [forcing partitioned epoch rewards to occur in a single slot](https://github.com/solana-labs/solana/pull/31354#issuecomment-1561292446) for testing against the unactivated feature (ie. status quo). We need to ignore the sys var for epoch rewards.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->