### PR TITLE
Use QUIC Retry packets during handshake

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -71,6 +71,7 @@ pub(crate) fn configure_server(
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(server_tls_config));
+    server_config.use_retry(true);
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
     // QUIC_MAX_CONCURRENT_STREAMS doubled, which was found to improve reliability


### PR DESCRIPTION
#### Problem
Client IP control is verified later in the handshake than it could be

#### Summary of Changes
Use QUIC Retry packets to challenge clients' control over their IP upfront
