### PR TITLE
fix cli args

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1541,15 +1541,15 @@ fn main() {
                     .help("After 'verify' completes, run a final accounts hash calculation. Final hash calculation could race with accounts background service tasks and assert."),
             )
             .arg(
-                Arg::with_name("partitioned-epoch-rewards-compare-calculation")
-                    .long("partitioned_epoch_rewards_compare_calculation")
+                Arg::with_name("partitioned_epoch_rewards_compare_calculation")
+                    .long("partitioned-epoch-rewards-compare-calculation")
                     .takes_value(false)
                     .help("Do normal epoch rewards distribution, but also calculate rewards using the partitioned rewards code path and compare the resulting vote and stake accounts")
                     .hidden(hidden_unless_forced())
             )
             .arg(
-                Arg::with_name("partitioned-epoch-rewards-force-enable-single-slot")
-                    .long("partitioned_epoch_rewards_force_enable_single_slot")
+                Arg::with_name("partitioned_epoch_rewards_force_enable_single_slot")
+                    .long("partitioned-epoch-rewards-force-enable-single-slot")
                     .takes_value(false)
                     .help("Force the partitioned rewards distribution, but distribute all rewards in the first slot in the epoch. This should match consensus with the normal rewards distribution.")
                     .conflicts_with("partitioned_epoch_rewards_compare_calculation")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1244,15 +1244,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Number of bins to divide the accounts index into"),
         )
         .arg(
-            Arg::with_name("partitioned-epoch-rewards-compare-calculation")
-                .long("partitioned_epoch_rewards_compare_calculation")
+            Arg::with_name("partitioned_epoch_rewards_compare_calculation")
+                .long("partitioned-epoch-rewards-compare-calculation")
                 .takes_value(false)
                 .help("Do normal epoch rewards distribution, but also calculate rewards using the partitioned rewards code path and compare the resulting vote and stake accounts")
                 .hidden(hidden_unless_forced())
         )
         .arg(
-            Arg::with_name("partitioned-epoch-rewards-force-enable-single-slot")
-                .long("partitioned_epoch_rewards_force_enable_single_slot")
+            Arg::with_name("partitioned_epoch_rewards_force_enable_single_slot")
+                .long("partitioned-epoch-rewards-force-enable-single-slot")
                 .takes_value(false)
                 .help("Force the partitioned rewards distribution, but distribute all rewards in the first slot in the epoch. This should match consensus with the normal rewards distribution.")
                 .conflicts_with("partitioned_epoch_rewards_compare_calculation")


### PR DESCRIPTION
#### Problem
when submitting earlier, #31800, I switched up the -/_ symbols in the long and name arguments of the cli args for ledger-tool and validator. Problem is, I got them backwards. TIL.

#### Summary of Changes
reverse -/_ in name vs long

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
