### PR TITLE
Byte-blocks utils for TieredStorage (1/N)

### DIFF
--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -1,3 +1,4 @@
+pub mod byte_block;
 pub mod error;
 pub mod file;
 pub mod footer;

--- a/runtime/src/tiered_storage/byte_block.rs
+++ b/runtime/src/tiered_storage/byte_block.rs
@@ -1,0 +1,165 @@
+use {
+    crate::tiered_storage::footer::ByteBlockFormat,
+    std::{
+        io::{Cursor, Write},
+        mem,
+    },
+};
+
+enum ByteBlockEncoder {
+    Raw(Cursor<Vec<u8>>),
+}
+
+pub struct ByteBlockWriter {
+    len: usize,
+    encoder: ByteBlockEncoder,
+}
+
+impl ByteBlockWriter {
+    pub fn new(encoding: ByteBlockFormat) -> Self {
+        Self {
+            len: 0,
+            encoder: match encoding {
+                ByteBlockFormat::AlignedRaw => ByteBlockEncoder::Raw(Cursor::new(Vec::new())),
+                ByteBlockFormat::Lz4 => todo!(),
+            },
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn write_type<T>(&mut self, value: &T) -> std::io::Result<usize> {
+        let len = mem::size_of::<T>();
+        let value_ptr = (value as *const T) as *const u8;
+        let ptr = unsafe { std::slice::from_raw_parts(value_ptr, len) };
+        self.write(ptr, len)?;
+        Ok(len)
+    }
+
+    pub fn write(&mut self, buf: &[u8], len: usize) -> std::io::Result<()> {
+        let result = match &mut self.encoder {
+            ByteBlockEncoder::Raw(cursor) => cursor.write_all(&buf[0..len]),
+        };
+        if result.is_ok() {
+            self.len += len;
+        }
+        result
+    }
+
+    pub fn finish(self) -> std::io::Result<(Vec<u8>, usize)> {
+        match self.encoder {
+            ByteBlockEncoder::Raw(cursor) => Ok((cursor.into_inner(), self.len)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_type<T>(buffer: &[u8], offset: usize) -> (&T, usize) {
+        let size = std::mem::size_of::<T>();
+        let (next, overflow) = offset.overflowing_add(size);
+        if overflow || next > buffer.len() {
+            panic!();
+        }
+        let data = &buffer[offset..next];
+        let ptr = data.as_ptr() as *const u8;
+
+        let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+        let slice_ptr = slice.as_ptr() as *const T;
+        (unsafe { &*slice_ptr }, next)
+    }
+
+    #[test]
+    fn test_write_single_raw_format() {
+        let mut writer = ByteBlockWriter::new(ByteBlockFormat::AlignedRaw);
+        let value: u32 = 42;
+
+        writer.write_type(&value).unwrap();
+        assert_eq!(writer.len(), mem::size_of::<u32>());
+
+        let (buffer, len) = writer.finish().unwrap();
+        assert_eq!(len, mem::size_of::<u32>());
+        assert_eq!(buffer.len(), mem::size_of::<u32>());
+
+        let (value_from_buffer, next): (&u32, usize) = read_type(&buffer, 0);
+        assert_eq!(value, *value_from_buffer);
+        assert_eq!(next, mem::size_of::<u32>());
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TestMetaStruct {
+        lamports: u64,
+        owner_index: u32,
+        data_len: usize,
+    }
+
+    #[test]
+    fn test_write_multiple_raw_format() {
+        let mut writer = ByteBlockWriter::new(ByteBlockFormat::AlignedRaw);
+        let test_metas: Vec<TestMetaStruct> = vec![
+            TestMetaStruct {
+                lamports: 10,
+                owner_index: 0,
+                data_len: 100,
+            },
+            TestMetaStruct {
+                lamports: 20,
+                owner_index: 1,
+                data_len: 200,
+            },
+            TestMetaStruct {
+                lamports: 30,
+                owner_index: 2,
+                data_len: 300,
+            },
+        ];
+        let test_data1 = [11u8; 100];
+        let test_data2 = [22u8; 200];
+        let test_data3 = [33u8; 300];
+
+        // Write the above meta and data in an interleaving way.
+        writer.write_type(&test_metas[0]).unwrap();
+        writer.write_type(&test_data1).unwrap();
+        writer.write_type(&test_metas[1]).unwrap();
+        writer.write_type(&test_data2).unwrap();
+        writer.write_type(&test_metas[2]).unwrap();
+        writer.write_type(&test_data3).unwrap();
+
+        let (buffer, len) = writer.finish().unwrap();
+        assert_eq!(len, mem::size_of::<TestMetaStruct>() * 3 + 600);
+
+        // verify meta1 and its data
+        let (meta1_from_buffer, next1): (&TestMetaStruct, usize) = read_type(&buffer, 0);
+        assert_eq!(test_metas[0], *meta1_from_buffer);
+        assert_eq!(
+            test_data1,
+            buffer[next1..next1 + meta1_from_buffer.data_len]
+        );
+
+        // verify meta2 and its data
+        let (meta2_from_buffer, next2): (&TestMetaStruct, usize) =
+            read_type(&buffer, next1 + meta1_from_buffer.data_len);
+        assert_eq!(test_metas[1], *meta2_from_buffer);
+        assert_eq!(
+            test_data2,
+            buffer[next2..next2 + meta2_from_buffer.data_len]
+        );
+
+        // verify meta3 and its data
+        let (meta3_from_buffer, next3): (&TestMetaStruct, usize) =
+            read_type(&buffer, next2 + meta2_from_buffer.data_len);
+        assert_eq!(test_metas[2], *meta3_from_buffer);
+        assert_eq!(
+            test_data3,
+            buffer[next3..next3 + meta3_from_buffer.data_len]
+        );
+    }
+}

--- a/runtime/src/tiered_storage/byte_block.rs
+++ b/runtime/src/tiered_storage/byte_block.rs
@@ -52,7 +52,7 @@ mod tests {
         let data = &buffer[offset..next];
         let ptr = data.as_ptr() as *const T;
 
-        (unsafe {std::ptr::read_unaligned(ptr)}, next)
+        (unsafe { std::ptr::read_unaligned(ptr) }, next)
     }
 
     #[test]

--- a/runtime/src/tiered_storage/byte_block.rs
+++ b/runtime/src/tiered_storage/byte_block.rs
@@ -21,7 +21,7 @@ impl ByteBlockWriter {
 
     pub fn write_type<T>(&mut self, value: &T) -> std::io::Result<usize> {
         let size = mem::size_of::<T>();
-        let ptr = (value as *const T) as *const u8;
+        let ptr = value as *const _ as *const u8;
         let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
         self.write(slice)?;
         Ok(size)
@@ -29,7 +29,7 @@ impl ByteBlockWriter {
 
     pub fn write(&mut self, buf: &[u8]) -> std::io::Result<()> {
         match self {
-            Self::Raw(cursor) => cursor.write_all(&buf)?,
+            Self::Raw(cursor) => cursor.write_all(buf)?,
         };
         Ok(())
     }

--- a/runtime/src/tiered_storage/byte_block.rs
+++ b/runtime/src/tiered_storage/byte_block.rs
@@ -1,60 +1,42 @@
 use {
-    crate::tiered_storage::footer::ByteBlockFormat,
+    crate::tiered_storage::footer::AccountBlockFormat,
     std::{
         io::{Cursor, Write},
         mem,
     },
 };
 
-enum ByteBlockEncoder {
+#[derive(Debug)]
+pub enum ByteBlockWriter {
     Raw(Cursor<Vec<u8>>),
 }
 
-pub struct ByteBlockWriter {
-    len: usize,
-    encoder: ByteBlockEncoder,
-}
-
 impl ByteBlockWriter {
-    pub fn new(encoding: ByteBlockFormat) -> Self {
-        Self {
-            len: 0,
-            encoder: match encoding {
-                ByteBlockFormat::AlignedRaw => ByteBlockEncoder::Raw(Cursor::new(Vec::new())),
-                ByteBlockFormat::Lz4 => todo!(),
-            },
+    pub fn new(encoding: AccountBlockFormat) -> Self {
+        match encoding {
+            AccountBlockFormat::AlignedRaw => Self::Raw(Cursor::new(Vec::new())),
+            AccountBlockFormat::Lz4 => todo!(),
         }
-    }
-
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
     }
 
     pub fn write_type<T>(&mut self, value: &T) -> std::io::Result<usize> {
-        let len = mem::size_of::<T>();
-        let value_ptr = (value as *const T) as *const u8;
-        let ptr = unsafe { std::slice::from_raw_parts(value_ptr, len) };
-        self.write(ptr, len)?;
-        Ok(len)
+        let size = mem::size_of::<T>();
+        let ptr = (value as *const T) as *const u8;
+        let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+        self.write(slice)?;
+        Ok(size)
     }
 
-    pub fn write(&mut self, buf: &[u8], len: usize) -> std::io::Result<()> {
-        let result = match &mut self.encoder {
-            ByteBlockEncoder::Raw(cursor) => cursor.write_all(&buf[0..len]),
+    pub fn write(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Raw(cursor) => cursor.write_all(&buf)?,
         };
-        if result.is_ok() {
-            self.len += len;
-        }
-        result
+        Ok(())
     }
 
-    pub fn finish(self) -> std::io::Result<(Vec<u8>, usize)> {
-        match self.encoder {
-            ByteBlockEncoder::Raw(cursor) => Ok((cursor.into_inner(), self.len)),
+    pub fn finish(self) -> std::io::Result<Vec<u8>> {
+        match self {
+            Self::Raw(cursor) => Ok(cursor.into_inner()),
         }
     }
 }
@@ -66,9 +48,7 @@ mod tests {
     fn read_type<T>(buffer: &[u8], offset: usize) -> (&T, usize) {
         let size = std::mem::size_of::<T>();
         let (next, overflow) = offset.overflowing_add(size);
-        if overflow || next > buffer.len() {
-            panic!();
-        }
+        assert!(!overflow && next <= buffer.len());
         let data = &buffer[offset..next];
         let ptr = data.as_ptr() as *const u8;
 
@@ -79,17 +59,15 @@ mod tests {
 
     #[test]
     fn test_write_single_raw_format() {
-        let mut writer = ByteBlockWriter::new(ByteBlockFormat::AlignedRaw);
+        let mut writer = ByteBlockWriter::new(AccountBlockFormat::AlignedRaw);
         let value: u32 = 42;
 
         writer.write_type(&value).unwrap();
-        assert_eq!(writer.len(), mem::size_of::<u32>());
 
-        let (buffer, len) = writer.finish().unwrap();
-        assert_eq!(len, mem::size_of::<u32>());
+        let buffer = writer.finish().unwrap();
         assert_eq!(buffer.len(), mem::size_of::<u32>());
 
-        let (value_from_buffer, next): (&u32, usize) = read_type(&buffer, 0);
+        let (value_from_buffer, next) = read_type::<u32>(&buffer, 0);
         assert_eq!(value, *value_from_buffer);
         assert_eq!(next, mem::size_of::<u32>());
     }
@@ -103,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_write_multiple_raw_format() {
-        let mut writer = ByteBlockWriter::new(ByteBlockFormat::AlignedRaw);
+        let mut writer = ByteBlockWriter::new(AccountBlockFormat::AlignedRaw);
         let test_metas: Vec<TestMetaStruct> = vec![
             TestMetaStruct {
                 lamports: 10,
@@ -133,33 +111,30 @@ mod tests {
         writer.write_type(&test_metas[2]).unwrap();
         writer.write_type(&test_data3).unwrap();
 
-        let (buffer, len) = writer.finish().unwrap();
-        assert_eq!(len, mem::size_of::<TestMetaStruct>() * 3 + 600);
+        let buffer = writer.finish().unwrap();
+        assert_eq!(
+            buffer.len(),
+            mem::size_of::<TestMetaStruct>() * 3
+                + mem::size_of_val(&test_data1)
+                + mem::size_of_val(&test_data2)
+                + mem::size_of_val(&test_data3)
+        );
 
         // verify meta1 and its data
-        let (meta1_from_buffer, next1): (&TestMetaStruct, usize) = read_type(&buffer, 0);
+        let (meta1_from_buffer, next1) = read_type::<TestMetaStruct>(&buffer, 0);
         assert_eq!(test_metas[0], *meta1_from_buffer);
-        assert_eq!(
-            test_data1,
-            buffer[next1..next1 + meta1_from_buffer.data_len]
-        );
+        assert_eq!(test_data1, buffer[next1..][..meta1_from_buffer.data_len]);
 
         // verify meta2 and its data
-        let (meta2_from_buffer, next2): (&TestMetaStruct, usize) =
-            read_type(&buffer, next1 + meta1_from_buffer.data_len);
+        let (meta2_from_buffer, next2) =
+            read_type::<TestMetaStruct>(&buffer, next1 + meta1_from_buffer.data_len);
         assert_eq!(test_metas[1], *meta2_from_buffer);
-        assert_eq!(
-            test_data2,
-            buffer[next2..next2 + meta2_from_buffer.data_len]
-        );
+        assert_eq!(test_data2, buffer[next2..][..meta2_from_buffer.data_len]);
 
         // verify meta3 and its data
-        let (meta3_from_buffer, next3): (&TestMetaStruct, usize) =
-            read_type(&buffer, next2 + meta2_from_buffer.data_len);
+        let (meta3_from_buffer, next3) =
+            read_type::<TestMetaStruct>(&buffer, next2 + meta2_from_buffer.data_len);
         assert_eq!(test_metas[2], *meta3_from_buffer);
-        assert_eq!(
-            test_data3,
-            buffer[next3..next3 + meta3_from_buffer.data_len]
-        );
+        assert_eq!(test_data3, buffer[next3..][..meta3_from_buffer.data_len]);
     }
 }

--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -62,7 +62,7 @@ pub enum AccountMetaFormat {
     num_enum::IntoPrimitive,
     num_enum::TryFromPrimitive,
 )]
-pub enum ByteBlockFormat {
+pub enum AccountBlockFormat {
     #[default]
     AlignedRaw = 0,
     Lz4 = 1,
@@ -118,7 +118,7 @@ pub struct TieredStorageFooter {
     /// The format of the account index block.
     pub account_index_format: AccountIndexFormat,
     /// The format of the account block.
-    pub account_block_format: ByteBlockFormat,
+    pub account_block_format: AccountBlockFormat,
 
     // Account-block related
     /// The number of account entries.
@@ -171,7 +171,7 @@ impl Default for TieredStorageFooter {
             account_meta_format: AccountMetaFormat::default(),
             owners_block_format: OwnersBlockFormat::default(),
             account_index_format: AccountIndexFormat::default(),
-            account_block_format: ByteBlockFormat::default(),
+            account_block_format: AccountBlockFormat::default(),
             account_entry_count: 0,
             account_meta_entry_size: 0,
             account_block_size: 0,
@@ -263,7 +263,7 @@ mod tests {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
             account_index_format: AccountIndexFormat::Linear,
-            account_block_format: ByteBlockFormat::AlignedRaw,
+            account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,
             account_block_size: 4096,

--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -62,7 +62,7 @@ pub enum AccountMetaFormat {
     num_enum::IntoPrimitive,
     num_enum::TryFromPrimitive,
 )]
-pub enum AccountBlockFormat {
+pub enum ByteBlockFormat {
     #[default]
     AlignedRaw = 0,
     Lz4 = 1,
@@ -118,7 +118,7 @@ pub struct TieredStorageFooter {
     /// The format of the account index block.
     pub account_index_format: AccountIndexFormat,
     /// The format of the account block.
-    pub account_block_format: AccountBlockFormat,
+    pub account_block_format: ByteBlockFormat,
 
     // Account-block related
     /// The number of account entries.
@@ -171,7 +171,7 @@ impl Default for TieredStorageFooter {
             account_meta_format: AccountMetaFormat::default(),
             owners_block_format: OwnersBlockFormat::default(),
             account_index_format: AccountIndexFormat::default(),
-            account_block_format: AccountBlockFormat::default(),
+            account_block_format: ByteBlockFormat::default(),
             account_entry_count: 0,
             account_meta_entry_size: 0,
             account_block_size: 0,
@@ -263,7 +263,7 @@ mod tests {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
             account_index_format: AccountIndexFormat::Linear,
-            account_block_format: AccountBlockFormat::AlignedRaw,
+            account_block_format: ByteBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,
             account_block_size: 4096,


### PR DESCRIPTION
#### Summary of Changes
This PR includes the util structs for writing byte blocks, which will be used
by the TieredStorage writer (currently used in the prototype #30626).

The PR only includes the Raw encoding format.  Will add more in subsequent PRs.

#### Test Plan
Tested in mnb with the prototype implementation of the tiered-storage (#30626)
Unit tests are also included in this PR.