### PR TITLE
Cleanup - `Bank::reconfigure_token2_native_mint()`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,7 +60,6 @@ use {
         cost_tracker::CostTracker,
         epoch_accounts_hash::{self, EpochAccountsHash},
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
-        inline_spl_token,
         message_processor::MessageProcessor,
         partitioned_rewards::PartitionedEpochRewardsConfig,
         rent_collector::{CollectedInfo, RentCollector},
@@ -142,7 +141,7 @@ use {
         loader_v4,
         message::{AccountKeys, SanitizedMessage},
         native_loader,
-        native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
+        native_token::LAMPORTS_PER_SOL,
         nonce::{self, state::DurableNonce, NONCED_TX_MARKER_IX_INDEX},
         nonce_account,
         packet::PACKET_DATA_SIZE,
@@ -7494,7 +7493,6 @@ impl Bank {
                 allow_new_activations,
                 &new_feature_activations,
             );
-            self.reconfigure_token2_native_mint();
         }
 
         if new_feature_activations.contains(&feature_set::cap_accounts_data_len::id()) {
@@ -7661,54 +7659,6 @@ impl Bank {
                 self.calculate_and_update_accounts_data_size_delta_off_chain(
                     old_account.data().len(),
                     new_account.data().len(),
-                );
-            }
-        }
-    }
-
-    fn reconfigure_token2_native_mint(&mut self) {
-        let reconfigure_token2_native_mint = match self.cluster_type() {
-            ClusterType::Development => true,
-            ClusterType::Devnet => true,
-            ClusterType::Testnet => self.epoch() == 93,
-            ClusterType::MainnetBeta => self.epoch() == 75,
-        };
-
-        if reconfigure_token2_native_mint {
-            let mut native_mint_account = solana_sdk::account::AccountSharedData::from(Account {
-                owner: inline_spl_token::id(),
-                data: inline_spl_token::native_mint::ACCOUNT_DATA.to_vec(),
-                lamports: sol_to_lamports(1.),
-                executable: false,
-                rent_epoch: self.epoch() + 1,
-            });
-
-            // As a workaround for
-            // https://github.com/solana-labs/solana-program-library/issues/374, ensure that the
-            // spl-token 2 native mint account is owned by the spl-token 2 program.
-            let old_account_data_size;
-            let store = if let Some(existing_native_mint_account) =
-                self.get_account_with_fixed_root(&inline_spl_token::native_mint::id())
-            {
-                old_account_data_size = existing_native_mint_account.data().len();
-                if existing_native_mint_account.owner() == &solana_sdk::system_program::id() {
-                    native_mint_account.set_lamports(existing_native_mint_account.lamports());
-                    true
-                } else {
-                    false
-                }
-            } else {
-                old_account_data_size = 0;
-                self.capitalization
-                    .fetch_add(native_mint_account.lamports(), Relaxed);
-                true
-            };
-
-            if store {
-                self.store_account(&inline_spl_token::native_mint::id(), &native_mint_account);
-                self.calculate_and_update_accounts_data_size_delta_off_chain(
-                    old_account_data_size,
-                    native_mint_account.data().len(),
                 );
             }
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6914,7 +6914,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![16, 1, 7]);
+    assert_eq!(alive_counts, vec![15, 1, 7]);
 }
 
 #[test]
@@ -7299,61 +7299,17 @@ fn test_add_precompiled_account_after_frozen() {
 fn test_reconfigure_token2_native_mint() {
     solana_logger::setup();
 
-    let mut genesis_config =
+    let genesis_config =
         create_genesis_config_with_leader(5, &solana_sdk::pubkey::new_rand(), 0).genesis_config;
-
-    // ClusterType::Development - Native mint exists immediately
-    assert_eq!(genesis_config.cluster_type, ClusterType::Development);
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     assert_eq!(
         bank.get_balance(&inline_spl_token::native_mint::id()),
         1000000000
     );
-
-    // Testnet - Native mint blinks into existence at epoch 93
-    genesis_config.cluster_type = ClusterType::Testnet;
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    assert_eq!(bank.get_balance(&inline_spl_token::native_mint::id()), 0);
-    bank.deposit(&inline_spl_token::native_mint::id(), 4200000000)
-        .unwrap();
-
-    let bank = Bank::new_from_parent(
-        &bank,
-        &Pubkey::default(),
-        genesis_config.epoch_schedule.get_first_slot_in_epoch(93),
-    );
-
     let native_mint_account = bank
         .get_account(&inline_spl_token::native_mint::id())
         .unwrap();
     assert_eq!(native_mint_account.data().len(), 82);
-    assert_eq!(
-        bank.get_balance(&inline_spl_token::native_mint::id()),
-        4200000000
-    );
-    assert_eq!(native_mint_account.owner(), &inline_spl_token::id());
-
-    // MainnetBeta - Native mint blinks into existence at epoch 75
-    genesis_config.cluster_type = ClusterType::MainnetBeta;
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    assert_eq!(bank.get_balance(&inline_spl_token::native_mint::id()), 0);
-    bank.deposit(&inline_spl_token::native_mint::id(), 4200000000)
-        .unwrap();
-
-    let bank = Bank::new_from_parent(
-        &bank,
-        &Pubkey::default(),
-        genesis_config.epoch_schedule.get_first_slot_in_epoch(75),
-    );
-
-    let native_mint_account = bank
-        .get_account(&inline_spl_token::native_mint::id())
-        .unwrap();
-    assert_eq!(native_mint_account.data().len(), 82);
-    assert_eq!(
-        bank.get_balance(&inline_spl_token::native_mint::id()),
-        4200000000
-    );
     assert_eq!(native_mint_account.owner(), &inline_spl_token::id());
 }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,10 +1,12 @@
 use {
+    crate::inline_spl_token,
     solana_sdk::{
         account::{Account, AccountSharedData},
         feature::{self, Feature},
         feature_set::FeatureSet,
         fee_calculator::FeeRateGovernor,
         genesis_config::{ClusterType, GenesisConfig},
+        native_token::sol_to_lamports,
         pubkey::Pubkey,
         rent::Rent,
         signature::{Keypair, Signer},
@@ -252,6 +254,15 @@ pub fn create_genesis_config_with_leader_ex(
     ));
     initial_accounts.push((*validator_vote_account_pubkey, validator_vote_account));
     initial_accounts.push((*validator_stake_account_pubkey, validator_stake_account));
+
+    let native_mint_account = solana_sdk::account::AccountSharedData::from(Account {
+        owner: inline_spl_token::id(),
+        data: inline_spl_token::native_mint::ACCOUNT_DATA.to_vec(),
+        lamports: sol_to_lamports(1.),
+        executable: false,
+        rent_epoch: 1,
+    });
+    initial_accounts.push((inline_spl_token::native_mint::id(), native_mint_account));
 
     let mut genesis_config = GenesisConfig {
         accounts: initial_accounts


### PR DESCRIPTION
#### Problem
The epochs for this transition code have long passed, so it can be cleaned up.
See https://github.com/solana-labs/solana/pull/13461#issuecomment-1560981002 .

#### Summary of Changes
Removes `Bank::reconfigure_token2_native_mint()`.
