### PR TITLE
allow stake tests to wait for rewards payout

### DIFF
--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -6,7 +6,7 @@ use {
         cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
         spend_utils::SpendAmount,
         stake::StakeAuthorizationIndexed,
-        test_utils::{check_ready, wait_for_next_epoch},
+        test_utils::{check_ready, wait_for_next_epoch_plus_n_slots},
     },
     solana_cli_output::{parse_sign_only_reply_string, OutputFormat},
     solana_faucet::faucet::run_local_faucet,
@@ -158,7 +158,7 @@ fn test_stake_redelegation() {
     process_command(&config).unwrap();
 
     // wait for new epoch
-    wait_for_next_epoch(&rpc_client);
+    wait_for_next_epoch_plus_n_slots(&rpc_client, 0);
 
     // `stake_keypair` should now be delegated to `vote_keypair` and fully activated
     let stake_account = rpc_client.get_account(&stake_keypair.pubkey()).unwrap();
@@ -200,7 +200,7 @@ fn test_stake_redelegation() {
     // wait for a new epoch to ensure the `Redelegate` happens as soon as possible in the epoch
     // to reduce the risk of a race condition when checking the stake account correctly enters the
     // deactivating state for the remainder of the current epoch
-    wait_for_next_epoch(&rpc_client);
+    wait_for_next_epoch_plus_n_slots(&rpc_client, 0);
 
     // Redelegate to `vote2_keypair` via `stake2_keypair
     config.signers = vec![&default_signer, &stake2_keypair];
@@ -251,7 +251,7 @@ fn test_stake_redelegation() {
     check_balance!(50_000_000_000, &rpc_client, &stake2_keypair.pubkey());
 
     // wait for new epoch
-    wait_for_next_epoch(&rpc_client);
+    wait_for_next_epoch_plus_n_slots(&rpc_client, 0);
 
     // `stake_keypair` should now be deactivated
     assert_eq!(


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.
Some stake tests will need to wait a given number of slots AFTER a new epoch for partitioned rewards payout to have completed.

#### Summary of Changes
modify `wait_for_next_epoch` to `wait_for_next_epoch_plus_n_slots` to allow waiting for additional slots. When partitioned rewards are enabled, we'll need to wait several slots after the next epoch.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->