### PR TITLE
Early Release Account Locks

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -450,7 +450,7 @@ impl Consumer {
         // Only lock accounts for those transactions are selected for the block;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
         // same account state
-        let (batch, lock_us) = measure_us!(bank.prepare_sanitized_batch_with_results(
+        let (mut batch, lock_us) = measure_us!(bank.prepare_sanitized_batch_with_results(
             txs,
             transaction_qos_cost_results.iter().map(|r| match r {
                 Ok(_cost) => Ok(()),
@@ -462,7 +462,7 @@ impl Consumer {
         // WouldExceedMaxAccountCostLimit, WouldExceedMaxVoteCostLimit
         // and WouldExceedMaxAccountDataCostLimit
         let mut execute_and_commit_transactions_output =
-            self.execute_and_commit_transactions_locked(bank, &batch);
+            self.execute_and_commit_transactions_locked(bank, &mut batch);
 
         // Once the accounts are new transactions can enter the pipeline to process them
         let (_, unlock_us) = measure_us!(drop(batch));
@@ -518,7 +518,7 @@ impl Consumer {
     fn execute_and_commit_transactions_locked(
         &self,
         bank: &Arc<Bank>,
-        batch: &TransactionBatch,
+        batch: &mut TransactionBatch,
     ) -> ExecuteAndCommitTransactionsOutput {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -95,10 +95,10 @@ fn process_transaction_and_record_inner(
 ) {
     let signature = tx.signatures.get(0).unwrap().clone();
     let txs = vec![tx];
-    let tx_batch = bank.prepare_batch_for_tests(txs);
+    let mut tx_batch = bank.prepare_batch_for_tests(txs);
     let mut results = bank
         .load_execute_and_commit_transactions(
-            &tx_batch,
+            &mut tx_batch,
             MAX_PROCESSING_AGE,
             false,
             true,
@@ -132,7 +132,7 @@ fn execute_transactions(
     bank: &Bank,
     txs: Vec<Transaction>,
 ) -> Vec<Result<ConfirmedTransactionWithStatusMeta, TransactionError>> {
-    let batch = bank.prepare_batch_for_tests(txs.clone());
+    let mut batch = bank.prepare_batch_for_tests(txs.clone());
     let mut timings = ExecuteTimings::default();
     let mut mint_decimals = HashMap::new();
     let tx_pre_token_balances = collect_token_balances(&bank, &batch, &mut mint_decimals);
@@ -146,7 +146,7 @@ fn execute_transactions(
             ..
         },
     ) = bank.load_execute_and_commit_transactions(
-        &batch,
+        &mut batch,
         std::usize::MAX,
         true,
         true,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1263,7 +1263,7 @@ impl Accounts {
     pub fn unlock_accounts<'a>(
         &self,
         txs: impl Iterator<Item = &'a SanitizedTransaction>,
-        results: &[Result<()>],
+        results: impl Iterator<Item = &'a Result<()>>,
     ) {
         let keys: Vec<_> = txs
             .zip(results)
@@ -2794,7 +2794,7 @@ mod tests {
             let txs = vec![new_sanitized_tx(&[&keypair], message, Hash::default())];
             let results = accounts.lock_accounts(txs.iter(), MAX_TX_ACCOUNT_LOCKS);
             assert_eq!(results[0], Ok(()));
-            accounts.unlock_accounts(txs.iter(), &results);
+            accounts.unlock_accounts(txs.iter(), results.iter());
         }
 
         // Disallow over MAX_TX_ACCOUNT_LOCKS
@@ -2902,8 +2902,8 @@ mod tests {
             2
         );
 
-        accounts.unlock_accounts([tx].iter(), &results0);
-        accounts.unlock_accounts(txs.iter(), &results1);
+        accounts.unlock_accounts([tx].iter(), results0.iter());
+        accounts.unlock_accounts(txs.iter(), results1.iter());
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
         let message = Message::new_with_compiled_instructions(
             1,
@@ -2987,7 +2987,7 @@ mod tests {
                     counter_clone.clone().fetch_add(1, Ordering::SeqCst);
                 }
             }
-            accounts_clone.unlock_accounts(txs.iter(), &results);
+            accounts_clone.unlock_accounts(txs.iter(), results.iter());
             if exit_clone.clone().load(Ordering::Relaxed) {
                 break;
             }
@@ -3003,7 +3003,7 @@ mod tests {
                 thread::sleep(time::Duration::from_millis(50));
                 assert_eq!(counter_value, counter_clone.clone().load(Ordering::SeqCst));
             }
-            accounts_arc.unlock_accounts(txs.iter(), &results);
+            accounts_arc.unlock_accounts(txs.iter(), results.iter());
             thread::sleep(time::Duration::from_millis(50));
         }
         exit.store(true, Ordering::Relaxed);
@@ -3176,7 +3176,7 @@ mod tests {
             .get(&keypair2.pubkey())
             .is_none());
 
-        accounts.unlock_accounts(txs.iter(), &results);
+        accounts.unlock_accounts(txs.iter(), results.iter());
 
         // check all locks to be removed
         assert!(accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3899,9 +3899,10 @@ impl Bank {
     pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {
         if batch.needs_unlock() {
             batch.set_needs_unlock(false);
-            self.rc
-                .accounts
-                .unlock_accounts(batch.sanitized_transactions().iter(), batch.lock_results())
+            self.rc.accounts.unlock_accounts(
+                batch.sanitized_transactions().iter(),
+                batch.lock_results().iter(),
+            )
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4516,10 +4516,7 @@ impl Bank {
         );
         load_time.stop();
 
-        batch.release_locks_early(loaded_transactions.iter().map(|r| match &r.0 {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err.clone()),
-        }));
+        batch.release_locks_early(&loaded_transactions);
 
         let mut execution_time = Measure::start("execution_time");
         let mut signature_count: u64 = 0;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3900,8 +3900,10 @@ impl Bank {
         if batch.needs_unlock() {
             batch.set_needs_unlock(false);
             self.rc.accounts.unlock_accounts(
-                batch.sanitized_transactions().iter(),
-                batch.lock_results().iter(),
+                batch
+                    .sanitized_transactions()
+                    .iter()
+                    .zip(batch.lock_results().iter()),
             )
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3896,18 +3896,6 @@ impl Bank {
         account_overrides
     }
 
-    pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {
-        if batch.needs_unlock() {
-            batch.set_needs_unlock(false);
-            self.rc.accounts.unlock_accounts(
-                batch
-                    .sanitized_transactions()
-                    .iter()
-                    .zip(batch.lock_results().iter()),
-            )
-        }
-    }
-
     pub fn remove_unrooted_slots(&self, slots: &[(Slot, BankId)]) {
         self.rc.accounts.accounts_db.remove_unrooted_slots(slots)
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3396,10 +3396,10 @@ fn test_interleaving_locks() {
     );
     let pay_alice = vec![tx1];
 
-    let lock_result = bank.prepare_batch_for_tests(pay_alice);
+    let mut batch = bank.prepare_batch_for_tests(pay_alice);
     let results_alice = bank
         .load_execute_and_commit_transactions(
-            &lock_result,
+            &mut batch,
             MAX_PROCESSING_AGE,
             false,
             false,
@@ -3424,7 +3424,7 @@ fn test_interleaving_locks() {
         Err(TransactionError::AccountInUse)
     );
 
-    drop(lock_result);
+    drop(batch);
 
     assert!(bank
         .transfer(2 * amount, &mint_keypair, &bob.pubkey())
@@ -6138,10 +6138,10 @@ fn test_pre_post_transaction_balances() {
     let tx2 = system_transaction::transfer(&keypair1, &pubkey2, 912_000, blockhash);
     let txs = vec![tx0, tx1, tx2];
 
-    let lock_result = bank0.prepare_batch_for_tests(txs);
+    let mut batch = bank0.prepare_batch_for_tests(txs);
     let (transaction_results, transaction_balances_set) = bank0
         .load_execute_and_commit_transactions(
-            &lock_result,
+            &mut batch,
             MAX_PROCESSING_AGE,
             true,
             false,
@@ -9461,11 +9461,11 @@ fn test_tx_log_order() {
     let failure_sig = tx1.signatures[0];
     let tx2 = system_transaction::transfer(&sender0, &recipient0, 1, blockhash);
     let txs = vec![tx0, tx1, tx2];
-    let batch = bank.prepare_batch_for_tests(txs);
+    let mut batch = bank.prepare_batch_for_tests(txs);
 
     let execution_results = bank
         .load_execute_and_commit_transactions(
-            &batch,
+            &mut batch,
             MAX_PROCESSING_AGE,
             false,
             false,
@@ -9569,10 +9569,10 @@ fn test_tx_return_data() {
             &[&mint_keypair],
             blockhash,
         )];
-        let batch = bank.prepare_batch_for_tests(txs);
+        let mut batch = bank.prepare_batch_for_tests(txs);
         let return_data = bank
             .load_execute_and_commit_transactions(
-                &batch,
+                &mut batch,
                 MAX_PROCESSING_AGE,
                 false,
                 false,


### PR DESCRIPTION
#### Problem
We grab locks before loading accounts, and hold through batch execution, record, commit.
If the transaction fails to load accounts, perhaps due to insufficient balance to pay fees/rent, all other accounts remain locked until the batch has finished execution.
This is uneccessary, and can cause delays in processing other transactions.

#### Summary of Changes
Allow the batch to release locks earlier in the process if we've already caught errors during loading the accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
