### PR TITLE
Fix merge issues: Arc::clone and ConnectionCache construction

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -287,7 +287,7 @@ mod tests {
             ..
         } = &test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder.write().unwrap().set_bank(bank, false);
+        poh_recorder.write().unwrap().set_bank(bank.clone(), false);
 
         let pubkey1 = Pubkey::new_unique();
 
@@ -329,7 +329,7 @@ mod tests {
             ..
         } = &test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder.write().unwrap().set_bank(bank, false);
+        poh_recorder.write().unwrap().set_bank(bank.clone(), false);
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -374,7 +374,7 @@ mod tests {
             ..
         } = &test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder.write().unwrap().set_bank(bank, false);
+        poh_recorder.write().unwrap().set_bank(bank.clone(), false);
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();

--- a/core/src/banking_stage/forward_worker.rs
+++ b/core/src/banking_stage/forward_worker.rs
@@ -92,6 +92,7 @@ mod tests {
             immutable_deserialized_packet::ImmutableDeserializedPacket,
         },
         crossbeam_channel::unbounded,
+        solana_client::connection_cache::ConnectionCache,
         solana_ledger::{
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
@@ -157,7 +158,7 @@ mod tests {
             poh_recorder,
             bank_forks,
             cluster_info,
-            Arc::default(),
+            Arc::new(ConnectionCache::new("test")),
             Arc::default(),
         );
 


### PR DESCRIPTION
#### Problem
#30970 broke builds due to changes from #31803 and #31717

#### Summary of Changes
* #31717 - `Arc::clone` bank for set_bank in consumer tests
* #31803 - `ConnectionCache` no longer has a default implementation, construct it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
