### PR TITLE
Removes MAX_BANK_SNAPSHOTS_TO_RETAIN constant

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -31,7 +31,6 @@ use {
         snapshot_utils::{
             self, ArchiveFormat,
             SnapshotVersion::{self, V1_2_0},
-            MAX_BANK_SNAPSHOTS_TO_RETAIN,
         },
         status_cache::MAX_CACHE_ENTRIES,
     },
@@ -329,6 +328,7 @@ fn test_concurrent_snapshot_packaging(
     cluster_type: ClusterType,
 ) {
     solana_logger::setup();
+    const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8;
 
     // Set up snapshotting config
     let mut snapshot_test_config =
@@ -373,7 +373,7 @@ fn test_concurrent_snapshot_packaging(
     let saved_slot = 4;
     let mut saved_archive_path = None;
 
-    for forks in 0..snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
+    for forks in 0..MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
         let bank = Bank::new_from_parent(
             &bank_forks[forks as u64],
             &Pubkey::default(),
@@ -484,7 +484,7 @@ fn test_concurrent_snapshot_packaging(
     assert!(bank_snapshots
         .into_iter()
         .map(|path| path.slot)
-        .eq(3..=snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN as u64 + 2));
+        .eq(3..=MAX_BANK_SNAPSHOTS_TO_RETAIN as u64 + 2));
 
     // Create a SnapshotPackagerService to create tarballs from all the pending
     // SnapshotPackage's on the channel. By the time this service starts, we have already

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -86,8 +86,6 @@ const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 const VERSION_STRING_V1_2_0: &str = "1.2.0";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
-// Save some bank snapshots but not too many
-pub const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8;
 // The following unsafes are
 // - Safe because the values are fixed, known non-zero constants
 // - Necessary in order to have a plain NonZeroUsize as the constant, NonZeroUsize


### PR DESCRIPTION
#### Problem

The `MAX_BANK_SNAPSHOTS_TO_RETAIN` constant in `snapshot_utils.rs` is no longer used and can be removed.

(The constant is used in tests, and can be moved there.)

#### Summary of Changes

Remove the constant.