### PR TITLE
remove inaccurate comment about system instructions

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -298,20 +298,16 @@
 //!
 //!     let payer = next_account_info(account_info_iter)?;
 //!     let recipient = next_account_info(account_info_iter)?;
-//!     // The system program is a required account to invoke a system
-//!     // instruction, even though we don't use it directly.
-//!     let system_account = next_account_info(account_info_iter)?;
 //!
 //!     assert!(payer.is_writable);
 //!     assert!(payer.is_signer);
 //!     assert!(recipient.is_writable);
-//!     assert!(system_program::check_id(system_account.key));
 //!
 //!     let lamports = 1000000;
 //!
 //!     invoke(
 //!         &system_instruction::transfer(payer.key, recipient.key, lamports),
-//!         &[payer.clone(), recipient.clone(), system_account.clone()],
+//!         &[payer.clone(), recipient.clone()],
 //!     )
 //! }
 //! ```


### PR DESCRIPTION
#### Problem
AFAICT invoking `system_instruction::transfer` does not require passing `system_program` in `account_infos` and that seems to be how Anchor does it (see https://github.com/coral-xyz/anchor/blob/c3625c8cf2ea1cb5f94859f6234c2d73c6f17928/lang/src/system_program.rs#L298-L313)

#### Summary of Changes
Removed comment stating the system_program is required for the instruction and updated the doc's code sample.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
