### PR TITLE
Don't needlessly expose Slot from solana-poh

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -10,7 +10,6 @@
 //! For Entries:
 //! * recorded entry must be >= WorkingBank::min_tick_height && entry must be < WorkingBank::max_tick_height
 //!
-pub use solana_sdk::clock::Slot;
 use {
     crate::{leader_bank_notifier::LeaderBankNotifier, poh_service::PohService},
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
@@ -28,8 +27,12 @@ use {
     solana_metrics::poh_timing_point::{send_poh_timing_point, PohTimingSender, SlotPohTimingInfo},
     solana_runtime::bank::Bank,
     solana_sdk::{
-        clock::NUM_CONSECUTIVE_LEADER_SLOTS, hash::Hash, poh_config::PohConfig, pubkey::Pubkey,
-        saturating_add_assign, transaction::VersionedTransaction,
+        clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+        hash::Hash,
+        poh_config::PohConfig,
+        pubkey::Pubkey,
+        saturating_add_assign,
+        transaction::VersionedTransaction,
     },
     std::{
         cmp,


### PR DESCRIPTION
#### Problem

#4961 oddly started to re-expose `Slot` from the mod: https://github.com/solana-labs/solana/pull/4961#discussion_r1206264120, confusing rust/human a bit like this: https://github.com/solana-labs/solana/pull/30976#discussion_r1170825849:

![image](https://github.com/solana-labs/solana/assets/117807/adb26ea3-cada-4874-9552-a98879329e88)


#### Summary of Changes

Fix it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
