### PR TITLE
Explain use of nightly clippy over whole monorepo

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -77,7 +77,12 @@ _ ci/order-crates-for-publishing.py
 
 nightly_clippy_allows=(--allow=clippy::redundant_clone)
 
-# run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there
+# use nightly clippy as frozen-abi proc-macro generates a lot of code across
+# various crates in this whole mono-repo. Likewise, frozen-abi(-macro) crates'
+# unit tests are only compiled under nightly.
+# similarly nightly is desired to run clippy over all of bench files because
+# the bench itself isn't stabilized yet...
+#   ref: https://github.com/rust-lang/rust/issues/66287
 _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" clippy --workspace --all-targets --features dummy-for-ci-check -- \
   --deny=warnings \
   --deny=clippy::default_trait_access \

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -78,7 +78,7 @@ _ ci/order-crates-for-publishing.py
 nightly_clippy_allows=(--allow=clippy::redundant_clone)
 
 # use nightly clippy as frozen-abi proc-macro generates a lot of code across
-# various crates in this whole mono-repo. Likewise, frozen-abi(-macro) crates'
+# various crates in this whole monorepo. Likewise, frozen-abi(-macro) crates'
 # unit tests are only compiled under nightly.
 # similarly nightly is desired to run clippy over all of bench files because
 # the bench itself isn't stabilized yet...
@@ -92,7 +92,7 @@ _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" clippy --workspace -
 
 # temporarily run stable clippy as well to scan the codebase for
 # `redundant_clone`s, which is disabled as nightly clippy is buggy:
-#   https://github.com/rust-lang/rust-clippy/issues/10577
+#   https://github.com/solana-labs/solana/issues/31834
 #
 # can't use --all-targets:
 #   error[E0554]: `#![feature]` may not be used on the stable release channel

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -77,10 +77,11 @@ _ ci/order-crates-for-publishing.py
 
 nightly_clippy_allows=(--allow=clippy::redundant_clone)
 
-# use nightly clippy as frozen-abi proc-macro generates a lot of code across
-# various crates in this whole monorepo. Likewise, frozen-abi(-macro) crates'
+# Use nightly clippy, as frozen-abi proc-macro generates a lot of code across
+# various crates in this whole monorepo (frozen-abi is enabled only under nightly
+# due to the use of unstable rust feature). Likewise, frozen-abi(-macro) crates'
 # unit tests are only compiled under nightly.
-# similarly nightly is desired to run clippy over all of bench files because
+# Similarly, nightly is desired to run clippy over all of bench files because
 # the bench itself isn't stabilized yet...
 #   ref: https://github.com/rust-lang/rust/issues/66287
 _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" clippy --workspace --all-targets --features dummy-for-ci-check -- \


### PR DESCRIPTION
Add proper and updated explanation as to _nightly_ clippy (https://github.com/solana-labs/solana/pull/31692#pullrequestreview-1431649685):

> What's the argument for running nightly clippy everywhere, incidentally? The comment only refers to sdk. It would also be nice to document what nightly-only code we're actually using there.

... so that I can hide my real desire (hint: branch name) from public scrutiny. :)

ref: https://github.com/rust-lang/rust/issues/66287