### PR TITLE
[zk-token-sdk] Add encryption error variant `SeedLengthTooShort` and remove variant `PubkeyDoesNotExist`

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -36,10 +36,6 @@ use {
 pub enum AuthenticatedEncryptionError {
     #[error("key derivation method not supported")]
     DerivationMethodNotSupported,
-
-    #[error("pubkey does not exist")]
-    PubkeyDoesNotExist,
-
     #[error("seed length too short for derivation")]
     SeedLengthTooShort,
 }

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -39,6 +39,9 @@ pub enum AuthenticatedEncryptionError {
 
     #[error("pubkey does not exist")]
     PubkeyDoesNotExist,
+
+    #[error("seed length too short for derivation")]
+    SeedLengthTooShort,
 }
 
 struct AuthenticatedEncryption;
@@ -163,7 +166,7 @@ impl SeedDerivable for AeKey {
         const MINIMUM_SEED_LEN: usize = 16;
 
         if seed.len() < MINIMUM_SEED_LEN {
-            return Err("Seed is too short".into());
+            return Err(AuthenticatedEncryptionError::SeedLengthTooShort.into());
         }
 
         let mut hasher = Sha3_512::new();


### PR DESCRIPTION
#### Problem
1. The `ElGamalKeypair::from_seed()` function returns a boxed error, although there is one possible choice of error: seed is too short.

2. The `AuthenticatedEncryptionError::SeedLengthTooShort` variant was added to return a suitable error type when `EncodableKey::pubkey_string()` is called on `AeKey`. However, the trait function `EncodableKey::pubkey_string()` ended up being removed (https://github.com/solana-labs/solana/pull/30947#discussion_r1157838687).

#### Summary of Changes
1. Add `{ElGamalError, AuthenticatedEncryptionError}::SeedLengthTooShort` error variant and use it for `from_seed` functions
2. Remove `AuthenticatedEncryptionError::SeedLengthTooShort` error variant

There are no downstream projects currently using `AuthenticatedEncryptionError`, so removing the variant`SeedLengthTooShort` should be okay. Technically, 1 and 2 could be separate PRs, but I thought I might  combine the two together as they are very simple changes modifying the same error type (but I can also split it...).

This is a follow-up to https://github.com/solana-labs/solana/pull/31784#discussion_r1203225230

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
