### PR TITLE
Correct misleading comments for repair test

### DIFF
--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -1242,14 +1242,14 @@ mod test {
                 blockstore.insert_bank_hash(duplicate_confirmed_slot, hash, true);
             }
 
-            // Set up response threads
+            // Set up repair request receiver threads
             let t_request_receiver = streamer::receiver(
                 Arc::new(responder_node.sockets.serve_repair),
                 exit.clone(),
                 requests_sender,
                 Recycler::default(),
                 Arc::new(StreamerReceiveStats::new(
-                    "ancestor_hashes_response_receiver",
+                    "repair_request_receiver",
                 )),
                 Duration::from_millis(1), // coalesce
                 false,

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -1248,9 +1248,7 @@ mod test {
                 exit.clone(),
                 requests_sender,
                 Recycler::default(),
-                Arc::new(StreamerReceiveStats::new(
-                    "repair_request_receiver",
-                )),
+                Arc::new(StreamerReceiveStats::new("repair_request_receiver")),
                 Duration::from_millis(1), // coalesce
                 false,
                 None,


### PR DESCRIPTION
#### Problem

Some of the comments and strings in the tests are misleading...
#### Summary of Changes

Correct misleading comments for repair test. 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
