### PR TITLE
Clean up Spl type conversions

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -1,13 +1,9 @@
 use {
     crate::{
         parse_address_lookup_table::parse_address_lookup_table,
-        parse_bpf_loader::parse_bpf_upgradeable_loader,
-        parse_config::parse_config,
-        parse_nonce::parse_nonce,
-        parse_stake::parse_stake,
-        parse_sysvar::parse_sysvar,
-        parse_token::{parse_token, spl_token_2022_id, spl_token_id},
-        parse_vote::parse_vote,
+        parse_bpf_loader::parse_bpf_upgradeable_loader, parse_config::parse_config,
+        parse_nonce::parse_nonce, parse_stake::parse_stake, parse_sysvar::parse_sysvar,
+        parse_token::parse_token, parse_vote::parse_vote,
     },
     inflector::Inflector,
     serde_json::Value,
@@ -38,8 +34,8 @@ lazy_static! {
         );
         m.insert(*CONFIG_PROGRAM_ID, ParsableAccount::Config);
         m.insert(*SYSTEM_PROGRAM_ID, ParsableAccount::Nonce);
-        m.insert(spl_token_id(), ParsableAccount::SplToken);
-        m.insert(spl_token_2022_id(), ParsableAccount::SplToken2022);
+        m.insert(spl_token::id(), ParsableAccount::SplToken);
+        m.insert(spl_token_2022::id(), ParsableAccount::SplToken2022);
         m.insert(*STAKE_PROGRAM_ID, ParsableAccount::Stake);
         m.insert(*SYSVAR_PROGRAM_ID, ParsableAccount::Sysvar);
         m.insert(*VOTE_PROGRAM_ID, ParsableAccount::Vote);

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -16,18 +16,6 @@ use {
     std::str::FromStr,
 };
 
-// A helper function to convert spl_token::id() as spl_sdk::pubkey::Pubkey to
-// solana_sdk::pubkey::Pubkey
-pub(crate) fn spl_token_id() -> Pubkey {
-    Pubkey::new_from_array(spl_token::id().to_bytes())
-}
-
-// A helper function to convert spl_token_2022::id() as spl_sdk::pubkey::Pubkey to
-// solana_sdk::pubkey::Pubkey
-pub(crate) fn spl_token_2022_id() -> Pubkey {
-    Pubkey::new_from_array(spl_token_2022::id().to_bytes())
-}
-
 // Returns all known SPL Token program ids
 pub fn spl_token_ids() -> Vec<Pubkey> {
     vec![spl_token::id(), spl_token_2022::id()]
@@ -46,7 +34,7 @@ pub fn spl_token_native_mint() -> Pubkey {
 
 // The program id of the `spl_token_native_mint` account
 pub fn spl_token_native_mint_program_id() -> Pubkey {
-    spl_token_id()
+    spl_token::id()
 }
 
 // A helper function to convert a solana_sdk::pubkey::Pubkey to spl_sdk::pubkey::Pubkey

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -38,6 +38,7 @@ pub fn spl_token_native_mint_program_id() -> Pubkey {
 }
 
 // A helper function to convert a solana_sdk::pubkey::Pubkey to spl_sdk::pubkey::Pubkey
+#[deprecated(since = "1.16.0", note = "Pubkey conversions no longer needed")]
 pub fn spl_token_pubkey(pubkey: &Pubkey) -> SplTokenPubkey {
     SplTokenPubkey::new_from_array(pubkey.to_bytes())
 }

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -28,11 +28,19 @@ pub fn is_known_spl_token_id(program_id: &Pubkey) -> bool {
 
 // A helper function to convert spl_token::native_mint::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
+#[deprecated(
+    since = "1.16.0",
+    note = "Pubkey conversions no longer needed. Please use spl_token::native_mint::id() directly"
+)]
 pub fn spl_token_native_mint() -> Pubkey {
     Pubkey::new_from_array(spl_token::native_mint::id().to_bytes())
 }
 
 // The program id of the `spl_token_native_mint` account
+#[deprecated(
+    since = "1.16.0",
+    note = "Pubkey conversions no longer needed. Please use spl_token::id() directly"
+)]
 pub fn spl_token_native_mint_program_id() -> Pubkey {
     spl_token::id()
 }

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -30,12 +30,12 @@ pub(crate) fn spl_token_2022_id() -> Pubkey {
 
 // Returns all known SPL Token program ids
 pub fn spl_token_ids() -> Vec<Pubkey> {
-    vec![spl_token_id(), spl_token_2022_id()]
+    vec![spl_token::id(), spl_token_2022::id()]
 }
 
 // Check if the provided program id as a known SPL Token program id
 pub fn is_known_spl_token_id(program_id: &Pubkey) -> bool {
-    *program_id == spl_token_id() || *program_id == spl_token_2022_id()
+    *program_id == spl_token::id() || *program_id == spl_token_2022::id()
 }
 
 // A helper function to convert spl_token::native_mint::id() as spl_sdk::pubkey::Pubkey to

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -43,6 +43,7 @@ pub fn spl_token_pubkey(pubkey: &Pubkey) -> SplTokenPubkey {
 }
 
 // A helper function to convert a spl_sdk::pubkey::Pubkey to solana_sdk::pubkey::Pubkey
+#[deprecated(since = "1.16.0", note = "Pubkey conversions no longer needed")]
 pub fn pubkey_from_spl_token(pubkey: &SplTokenPubkey) -> Pubkey {
     Pubkey::new_from_array(pubkey.to_bytes())
 }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -23,7 +23,6 @@ use {
         transaction::Transaction,
     },
     solana_streamer::socket::SocketAddrSpace,
-    solana_transaction_status::parse_token::spl_token_instruction,
     std::{
         cmp::min,
         process::exit,
@@ -159,7 +158,7 @@ fn make_create_message(
                 &program_id,
             )];
             if let Some(mint_address) = mint {
-                instructions.push(spl_token_instruction(
+                instructions.push(
                     spl_token::instruction::initialize_account(
                         &spl_token::id(),
                         &to_pubkey,
@@ -167,7 +166,7 @@ fn make_create_message(
                         &base_keypair.pubkey(),
                     )
                     .unwrap(),
-                ));
+                );
             }
 
             instructions
@@ -202,7 +201,7 @@ fn make_close_message(
             let address =
                 Pubkey::create_with_seed(&base_keypair.pubkey(), &seed, &program_id).unwrap();
             if spl_token {
-                Some(spl_token_instruction(
+                Some(
                     spl_token::instruction::close_account(
                         &spl_token::id(),
                         &address,
@@ -211,7 +210,7 @@ fn make_close_message(
                         &[],
                     )
                     .unwrap(),
-                ))
+                )
             } else {
                 Some(system_instruction::transfer_with_seed(
                     &address,
@@ -811,16 +810,14 @@ pub mod test {
                     spl_mint_len as u64,
                     &inline_spl_token::id(),
                 ),
-                spl_token_instruction(
-                    spl_token::instruction::initialize_mint(
-                        &spl_token::id(),
-                        &spl_mint_keypair.pubkey(),
-                        &spl_mint_keypair.pubkey(),
-                        None,
-                        2,
-                    )
-                    .unwrap(),
-                ),
+                spl_token::instruction::initialize_mint(
+                    &spl_token::id(),
+                    &spl_mint_keypair.pubkey(),
+                    &spl_mint_keypair.pubkey(),
+                    None,
+                    2,
+                )
+                .unwrap(),
             ],
             Some(&funder.pubkey()),
             &[&funder, &spl_mint_keypair],

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -4,7 +4,6 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     rayon::prelude::*,
-    solana_account_decoder::parse_token::spl_token_pubkey,
     solana_clap_utils::{
         hidden_unless_forced, input_parsers::pubkey_of, input_validators::is_url_or_moniker,
     },
@@ -163,9 +162,9 @@ fn make_create_message(
                 instructions.push(spl_token_instruction(
                     spl_token::instruction::initialize_account(
                         &spl_token::id(),
-                        &spl_token_pubkey(&to_pubkey),
-                        &spl_token_pubkey(&mint_address),
-                        &spl_token_pubkey(&base_keypair.pubkey()),
+                        &to_pubkey,
+                        &mint_address,
+                        &base_keypair.pubkey(),
                     )
                     .unwrap(),
                 ));
@@ -206,9 +205,9 @@ fn make_close_message(
                 Some(spl_token_instruction(
                     spl_token::instruction::close_account(
                         &spl_token::id(),
-                        &spl_token_pubkey(&address),
-                        &spl_token_pubkey(&keypair.pubkey()),
-                        &spl_token_pubkey(&base_keypair.pubkey()),
+                        &address,
+                        &keypair.pubkey(),
+                        &base_keypair.pubkey(),
                         &[],
                     )
                     .unwrap(),
@@ -815,8 +814,8 @@ pub mod test {
                 spl_token_instruction(
                     spl_token::instruction::initialize_mint(
                         &spl_token::id(),
-                        &spl_token_pubkey(&spl_mint_keypair.pubkey()),
-                        &spl_token_pubkey(&spl_mint_keypair.pubkey()),
+                        &spl_mint_keypair.pubkey(),
+                        &spl_mint_keypair.pubkey(),
                         None,
                         2,
                     )

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -1,6 +1,6 @@
 use {
     solana_account_decoder::parse_token::{
-        is_known_spl_token_id, spl_token_native_mint, token_amount_to_ui_amount, UiTokenAmount,
+        is_known_spl_token_id, token_amount_to_ui_amount, UiTokenAmount,
     },
     solana_measure::measure::Measure,
     solana_metrics::datapoint_debug,
@@ -17,7 +17,7 @@ use {
 };
 
 fn get_mint_decimals(bank: &Bank, mint: &Pubkey) -> Option<u8> {
-    if mint == &spl_token_native_mint() {
+    if mint == &spl_token::native_mint::id() {
         Some(spl_token::native_mint::DECIMALS)
     } else {
         let mint_account = bank.get_account(mint)?;

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -1,7 +1,6 @@
 use {
     solana_account_decoder::parse_token::{
-        is_known_spl_token_id, pubkey_from_spl_token, spl_token_native_mint,
-        token_amount_to_ui_amount, UiTokenAmount,
+        is_known_spl_token_id, spl_token_native_mint, token_amount_to_ui_amount, UiTokenAmount,
     },
     solana_measure::measure::Measure,
     solana_metrics::datapoint_debug,
@@ -101,7 +100,7 @@ fn collect_token_balance_from_account(
     }
 
     let token_account = StateWithExtensions::<TokenAccount>::unpack(account.data()).ok()?;
-    let mint = pubkey_from_spl_token(&token_account.base.mint);
+    let mint = token_account.base.mint;
 
     let decimals = mint_decimals.get(&mint).cloned().or_else(|| {
         let decimals = get_mint_decimals(bank, &mint)?;
@@ -121,7 +120,7 @@ fn collect_token_balance_from_account(
 mod test {
     use {
         super::*,
-        solana_account_decoder::parse_token::{pubkey_from_spl_token, spl_token_pubkey},
+        solana_account_decoder::parse_token::spl_token_pubkey,
         solana_sdk::{account::Account, genesis_config::create_genesis_config},
         spl_token_2022::{
             extension::{
@@ -154,7 +153,7 @@ mod test {
         let mint = Account {
             lamports: 100,
             data: data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token::id()),
+            owner: spl_token::id(),
             executable: false,
             rent_epoch: 0,
         };
@@ -184,7 +183,7 @@ mod test {
         let spl_token_account = Account {
             lamports: 100,
             data: data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token::id()),
+            owner: spl_token::id(),
             executable: false,
             rent_epoch: 0,
         };
@@ -212,7 +211,7 @@ mod test {
         let other_mint_token_account = Account {
             lamports: 100,
             data: data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token::id()),
+            owner: spl_token::id(),
             executable: false,
             rent_epoch: 0,
         };
@@ -317,7 +316,7 @@ mod test {
         let mint = Account {
             lamports: 100,
             data: mint_data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token_2022::id()),
+            owner: spl_token_2022::id(),
             executable: false,
             rent_epoch: 0,
         };
@@ -361,7 +360,7 @@ mod test {
         let spl_token_account = Account {
             lamports: 100,
             data: account_data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token_2022::id()),
+            owner: spl_token_2022::id(),
             executable: false,
             rent_epoch: 0,
         };
@@ -403,7 +402,7 @@ mod test {
         let other_mint_token_account = Account {
             lamports: 100,
             data: account_data.to_vec(),
-            owner: pubkey_from_spl_token(&spl_token_2022::id()),
+            owner: spl_token_2022::id(),
             executable: false,
             rent_epoch: 0,
         };

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -120,7 +120,6 @@ fn collect_token_balance_from_account(
 mod test {
     use {
         super::*,
-        solana_account_decoder::parse_token::spl_token_pubkey,
         solana_sdk::{account::Account, genesis_config::create_genesis_config},
         spl_token_2022::{
             extension::{
@@ -168,8 +167,8 @@ mod test {
 
         let token_owner = Pubkey::new_unique();
         let token_data = TokenAccount {
-            mint: spl_token_pubkey(&mint_pubkey),
-            owner: spl_token_pubkey(&token_owner),
+            mint: mint_pubkey,
+            owner: token_owner,
             amount: 42,
             delegate: COption::None,
             state: spl_token_2022::state::AccountState::Initialized,
@@ -196,8 +195,8 @@ mod test {
         };
 
         let other_mint_data = TokenAccount {
-            mint: spl_token_pubkey(&other_mint_pubkey),
-            owner: spl_token_pubkey(&token_owner),
+            mint: other_mint_pubkey,
+            owner: token_owner,
             amount: 42,
             delegate: COption::None,
             state: spl_token_2022::state::AccountState::Initialized,
@@ -310,7 +309,7 @@ mod test {
             .init_extension::<MintCloseAuthority>(true)
             .unwrap();
         mint_close_authority.close_authority =
-            OptionalNonZeroPubkey::try_from(Some(spl_token_pubkey(&mint_authority))).unwrap();
+            OptionalNonZeroPubkey::try_from(Some(mint_authority)).unwrap();
 
         let mint_pubkey = Pubkey::new_unique();
         let mint = Account {
@@ -331,8 +330,8 @@ mod test {
 
         let token_owner = Pubkey::new_unique();
         let token_base = TokenAccount {
-            mint: spl_token_pubkey(&mint_pubkey),
-            owner: spl_token_pubkey(&token_owner),
+            mint: mint_pubkey,
+            owner: token_owner,
             amount: 42,
             delegate: COption::None,
             state: spl_token_2022::state::AccountState::Initialized,
@@ -373,8 +372,8 @@ mod test {
         };
 
         let other_mint_token_base = TokenAccount {
-            mint: spl_token_pubkey(&other_mint_pubkey),
-            owner: spl_token_pubkey(&token_owner),
+            mint: other_mint_pubkey,
+            owner: token_owner,
             amount: 42,
             delegate: COption::None,
             state: spl_token_2022::state::AccountState::Initialized,

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -1,11 +1,8 @@
 use {
     jsonrpc_core::{Error, Result},
     solana_account_decoder::{
-        parse_account_data::AccountAdditionalData,
-        parse_token::{
-            get_token_account_mint, spl_token_native_mint, spl_token_native_mint_program_id,
-        },
-        UiAccount, UiAccountData, UiAccountEncoding,
+        parse_account_data::AccountAdditionalData, parse_token::get_token_account_mint, UiAccount,
+        UiAccountData, UiAccountEncoding,
     },
     solana_rpc_client_api::response::RpcKeyedAccount,
     solana_runtime::bank::Bank,
@@ -76,11 +73,8 @@ where
 /// Analyze a mint Pubkey that may be the native_mint and get the mint-account owner (token
 /// program_id) and decimals
 pub fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(Pubkey, u8)> {
-    if mint == &spl_token_native_mint() {
-        Ok((
-            spl_token_native_mint_program_id(),
-            spl_token::native_mint::DECIMALS,
-        ))
+    if mint == &spl_token::native_mint::id() {
+        Ok((spl_token::id(), spl_token::native_mint::DECIMALS))
     } else {
         let mint_account = bank.get_account(mint).ok_or_else(|| {
             Error::invalid_params("Invalid param: could not find mint".to_string())

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -14,7 +14,7 @@ use {
     indicatif::{ProgressBar, ProgressStyle},
     pickledb::PickleDb,
     serde::{Deserialize, Serialize},
-    solana_account_decoder::parse_token::{real_number_string, spl_token_pubkey},
+    solana_account_decoder::parse_token::real_number_string,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{
         client_error::{Error as ClientError, Result as ClientResult},
@@ -307,10 +307,7 @@ fn build_messages(
                 .iter()
                 .map(|x| {
                     let wallet_address = x.recipient.parse().unwrap();
-                    get_associated_token_address(
-                        &wallet_address,
-                        &spl_token_pubkey(&spl_token_args.mint),
-                    )
+                    get_associated_token_address(&wallet_address, &spl_token_args.mint)
                 })
                 .collect::<Vec<_>>();
             let mut maybe_accounts = client.get_multiple_accounts(&associated_token_addresses)?;

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -14,9 +14,7 @@ use {
     indicatif::{ProgressBar, ProgressStyle},
     pickledb::PickleDb,
     serde::{Deserialize, Serialize},
-    solana_account_decoder::parse_token::{
-        pubkey_from_spl_token, real_number_string, spl_token_pubkey,
-    },
+    solana_account_decoder::parse_token::{real_number_string, spl_token_pubkey},
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{
         client_error::{Error as ClientError, Result as ClientResult},
@@ -309,11 +307,10 @@ fn build_messages(
                 .iter()
                 .map(|x| {
                     let wallet_address = x.recipient.parse().unwrap();
-                    let associated_token_address = get_associated_token_address(
+                    get_associated_token_address(
                         &wallet_address,
                         &spl_token_pubkey(&spl_token_args.mint),
-                    );
-                    pubkey_from_spl_token(&associated_token_address)
+                    )
                 })
                 .collect::<Vec<_>>();
             let mut maybe_accounts = client.get_multiple_accounts(&associated_token_addresses)?;

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -5,7 +5,7 @@ use {
     },
     console::style,
     solana_account_decoder::parse_token::{
-        pubkey_from_spl_token, real_number_string, real_number_string_trimmed, spl_token_pubkey,
+        real_number_string, real_number_string_trimmed, spl_token_pubkey,
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{instruction::Instruction, message::Message, native_token::lamports_to_sol},
@@ -24,9 +24,7 @@ pub fn update_token_args(client: &RpcClient, args: &mut Option<SplTokenArgs>) ->
         let sender_account = client
             .get_account(&spl_token_args.token_account_address)
             .unwrap_or_default();
-        let mint_address =
-            pubkey_from_spl_token(&SplTokenAccount::unpack(&sender_account.data)?.mint);
-        spl_token_args.mint = mint_address;
+        spl_token_args.mint = SplTokenAccount::unpack(&sender_account.data)?.mint;
         update_decimals(client, args)?;
     }
     Ok(())
@@ -133,7 +131,7 @@ pub fn print_token_balances(
         &spl_token_pubkey(&spl_token_args.mint),
     );
     let recipient_account = client
-        .get_account(&pubkey_from_spl_token(&associated_token_address))
+        .get_account(&associated_token_address)
         .unwrap_or_default();
     let (actual, difference) = if let Ok(recipient_token) =
         SplTokenAccount::unpack(&recipient_account.data)

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -4,9 +4,7 @@ use {
         commands::{get_fee_estimate_for_messages, Allocation, Error, FundingSource},
     },
     console::style,
-    solana_account_decoder::parse_token::{
-        real_number_string, real_number_string_trimmed, spl_token_pubkey,
-    },
+    solana_account_decoder::parse_token::{real_number_string, real_number_string_trimmed},
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{instruction::Instruction, message::Message, native_token::lamports_to_sol},
     solana_transaction_status::parse_token::spl_token_instruction,
@@ -54,13 +52,13 @@ pub fn build_spl_token_instructions(
         .expect("spl_token_args must be some");
     let wallet_address = allocation.recipient.parse().unwrap();
     let associated_token_address =
-        get_associated_token_address(&wallet_address, &spl_token_pubkey(&spl_token_args.mint));
+        get_associated_token_address(&wallet_address, &spl_token_args.mint);
     let mut instructions = vec![];
     if do_create_associated_token_account {
         let create_associated_token_account_instruction = create_associated_token_account(
-            &spl_token_pubkey(&args.fee_payer.pubkey()),
+            &args.fee_payer.pubkey(),
             &wallet_address,
-            &spl_token_pubkey(&spl_token_args.mint),
+            &spl_token_args.mint,
             &spl_token::id(),
         );
         instructions.push(spl_token_instruction(
@@ -69,10 +67,10 @@ pub fn build_spl_token_instructions(
     }
     let spl_instruction = spl_token::instruction::transfer_checked(
         &spl_token::id(),
-        &spl_token_pubkey(&spl_token_args.token_account_address),
-        &spl_token_pubkey(&spl_token_args.mint),
+        &spl_token_args.token_account_address,
+        &spl_token_args.mint,
         &associated_token_address,
-        &spl_token_pubkey(&args.sender_keypair.pubkey()),
+        &args.sender_keypair.pubkey(),
         &[],
         allocation.amount,
         spl_token_args.decimals,
@@ -126,10 +124,7 @@ pub fn print_token_balances(
 ) -> Result<(), Error> {
     let address = allocation.recipient.parse().unwrap();
     let expected = allocation.amount;
-    let associated_token_address = get_associated_token_address(
-        &spl_token_pubkey(&address),
-        &spl_token_pubkey(&spl_token_args.mint),
-    );
+    let associated_token_address = get_associated_token_address(&address, &spl_token_args.mint);
     let recipient_account = client
         .get_account(&associated_token_address)
         .unwrap_or_default();

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -7,7 +7,6 @@ use {
     solana_account_decoder::parse_token::{real_number_string, real_number_string_trimmed},
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{instruction::Instruction, message::Message, native_token::lamports_to_sol},
-    solana_transaction_status::parse_token::spl_token_instruction,
     spl_associated_token_account::{
         get_associated_token_address, instruction::create_associated_token_account,
     },
@@ -55,28 +54,26 @@ pub fn build_spl_token_instructions(
         get_associated_token_address(&wallet_address, &spl_token_args.mint);
     let mut instructions = vec![];
     if do_create_associated_token_account {
-        let create_associated_token_account_instruction = create_associated_token_account(
+        instructions.push(create_associated_token_account(
             &args.fee_payer.pubkey(),
             &wallet_address,
             &spl_token_args.mint,
             &spl_token::id(),
-        );
-        instructions.push(spl_token_instruction(
-            create_associated_token_account_instruction,
         ));
     }
-    let spl_instruction = spl_token::instruction::transfer_checked(
-        &spl_token::id(),
-        &spl_token_args.token_account_address,
-        &spl_token_args.mint,
-        &associated_token_address,
-        &args.sender_keypair.pubkey(),
-        &[],
-        allocation.amount,
-        spl_token_args.decimals,
-    )
-    .unwrap();
-    instructions.push(spl_token_instruction(spl_instruction));
+    instructions.push(
+        spl_token::instruction::transfer_checked(
+            &spl_token::id(),
+            &spl_token_args.token_account_address,
+            &spl_token_args.mint,
+            &associated_token_address,
+            &args.sender_keypair.pubkey(),
+            &[],
+            allocation.amount,
+            spl_token_args.decimals,
+        )
+        .unwrap(),
+    );
     instructions
 }
 

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -94,7 +94,6 @@ mod test {
     use spl_associated_token_account::create_associated_token_account as create_associated_token_account_deprecated;
     use {
         super::*,
-        solana_account_decoder::parse_token::pubkey_from_spl_token,
         spl_associated_token_account::{
             get_associated_token_address, get_associated_token_address_with_program_id,
             instruction::{
@@ -120,14 +119,6 @@ mod test {
             accounts: instruction.accounts.clone(),
             data: instruction.data.clone(),
         }
-    }
-
-    fn convert_account_keys(message: &Message) -> Vec<Pubkey> {
-        message
-            .account_keys
-            .iter()
-            .map(pubkey_from_spl_token)
-            .collect()
     }
 
     #[test]
@@ -159,7 +150,7 @@ mod test {
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             expected_parsed_ix,
@@ -175,7 +166,7 @@ mod test {
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             expected_parsed_ix,
@@ -185,7 +176,7 @@ mod test {
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
             &compiled_instruction,
-            &AccountKeys::new(&convert_account_keys(&message), None)
+            &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
     }
@@ -212,7 +203,7 @@ mod test {
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -230,7 +221,7 @@ mod test {
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
             &compiled_instruction,
-            &AccountKeys::new(&convert_account_keys(&message), None)
+            &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
     }
@@ -257,7 +248,7 @@ mod test {
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -275,7 +266,7 @@ mod test {
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
             &compiled_instruction,
-            &AccountKeys::new(&convert_account_keys(&message), None)
+            &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
     }
@@ -312,7 +303,7 @@ mod test {
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -331,7 +322,7 @@ mod test {
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
             &compiled_instruction,
-            &AccountKeys::new(&convert_account_keys(&message), None)
+            &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
     }

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -697,6 +697,7 @@ fn check_num_token_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInst
     check_num_accounts(accounts, num, ParsableProgram::SplToken)
 }
 
+#[deprecated(since = "1.16.0", note = "Instruction conversions no longer needed")]
 pub fn spl_token_instruction(instruction: SplTokenInstruction) -> Instruction {
     Instruction {
         program_id: instruction.program_id,

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -8,9 +8,7 @@ use {
         transfer_fee::*,
     },
     serde_json::{json, Map, Value},
-    solana_account_decoder::parse_token::{
-        pubkey_from_spl_token, token_amount_to_ui_amount, UiAccountState,
-    },
+    solana_account_decoder::parse_token::{token_amount_to_ui_amount, UiAccountState},
     solana_sdk::{
         instruction::{AccountMeta, CompiledInstruction, Instruction},
         message::AccountKeys,
@@ -701,12 +699,12 @@ fn check_num_token_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInst
 
 pub fn spl_token_instruction(instruction: SplTokenInstruction) -> Instruction {
     Instruction {
-        program_id: pubkey_from_spl_token(&instruction.program_id),
+        program_id: instruction.program_id,
         accounts: instruction
             .accounts
             .iter()
             .map(|meta| AccountMeta {
-                pubkey: pubkey_from_spl_token(&meta.pubkey),
+                pubkey: meta.pubkey,
                 is_signer: meta.is_signer,
                 is_writable: meta.is_writable,
             })
@@ -751,14 +749,6 @@ mod test {
         }
     }
 
-    pub(super) fn convert_account_keys(message: &Message) -> Vec<Pubkey> {
-        message
-            .account_keys
-            .iter()
-            .map(pubkey_from_spl_token)
-            .collect()
-    }
-
     fn test_parse_token(program_id: &SplTokenPubkey) {
         let mint_pubkey = Pubkey::new_unique();
         let mint_authority = Pubkey::new_unique();
@@ -779,7 +769,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -807,7 +797,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -835,7 +825,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -864,7 +854,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -891,7 +881,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -918,7 +908,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -952,7 +942,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -987,7 +977,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1021,7 +1011,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1053,7 +1043,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1086,7 +1076,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1117,7 +1107,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1148,7 +1138,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1176,7 +1166,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1205,7 +1195,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1234,7 +1224,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1263,7 +1253,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1291,7 +1281,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1318,7 +1308,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1345,7 +1335,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1375,7 +1365,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1414,7 +1404,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1455,7 +1445,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1494,7 +1484,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1534,7 +1524,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1569,7 +1559,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1595,7 +1585,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1614,7 +1604,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1637,7 +1627,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1659,7 +1649,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1682,7 +1672,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1702,7 +1692,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -1735,7 +1725,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -66,7 +66,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -97,7 +97,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -126,7 +126,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -157,7 +157,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -78,7 +78,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -105,7 +105,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -138,7 +138,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -68,7 +68,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -99,7 +99,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -128,7 +128,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -159,7 +159,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -43,7 +43,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -66,7 +66,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -39,7 +39,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -62,7 +62,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -98,7 +98,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -188,7 +188,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -217,7 +217,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -254,7 +254,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -304,7 +304,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -348,7 +348,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -378,7 +378,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -412,7 +412,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -447,7 +447,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -480,7 +480,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -510,7 +510,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {
@@ -542,7 +542,7 @@ mod test {
         assert_eq!(
             parse_token(
                 &compiled_instruction,
-                &AccountKeys::new(&convert_account_keys(&message), None)
+                &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
             ParsedInstructionEnum {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -868,7 +868,6 @@ mod tests {
         super::*,
         rand::{distributions::Uniform, thread_rng, Rng},
         serde_json::Value,
-        solana_account_decoder::parse_token::spl_token_pubkey,
         solana_core::tower_storage::NullTowerStorage,
         solana_gossip::cluster_info::ClusterInfo,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -1006,7 +1005,7 @@ mod tests {
             let wallet1_pubkey = Pubkey::new_unique();
             let wallet2_pubkey = Pubkey::new_unique();
             let non_existent_pubkey = Pubkey::new_unique();
-            let delegate = spl_token_pubkey(&Pubkey::new_unique());
+            let delegate = Pubkey::new_unique();
 
             let mut num_default_spl_token_program_accounts = 0;
             let mut num_default_system_program_accounts = 0;
@@ -1068,14 +1067,14 @@ mod tests {
             // Add a token account
             let mut account1_data = vec![0; TokenAccount::get_packed_len()];
             let token_account1 = TokenAccount {
-                mint: spl_token_pubkey(&mint1_pubkey),
-                owner: spl_token_pubkey(&wallet1_pubkey),
+                mint: mint1_pubkey,
+                owner: wallet1_pubkey,
                 delegate: COption::Some(delegate),
                 amount: 420,
                 state: TokenAccountState::Initialized,
                 is_native: COption::None,
                 delegated_amount: 30,
-                close_authority: COption::Some(spl_token_pubkey(&wallet1_pubkey)),
+                close_authority: COption::Some(wallet1_pubkey),
             };
             TokenAccount::pack(token_account1, &mut account1_data).unwrap();
             let token_account1 = AccountSharedData::from(Account {
@@ -1089,11 +1088,11 @@ mod tests {
             // Add the mint
             let mut mint1_data = vec![0; Mint::get_packed_len()];
             let mint1_state = Mint {
-                mint_authority: COption::Some(spl_token_pubkey(&wallet1_pubkey)),
+                mint_authority: COption::Some(wallet1_pubkey),
                 supply: 500,
                 decimals: 2,
                 is_initialized: true,
-                freeze_authority: COption::Some(spl_token_pubkey(&wallet1_pubkey)),
+                freeze_authority: COption::Some(wallet1_pubkey),
             };
             Mint::pack(mint1_state, &mut mint1_data).unwrap();
             let mint_account1 = AccountSharedData::from(Account {
@@ -1107,14 +1106,14 @@ mod tests {
             // Add another token account with the different owner, but same delegate, and mint
             let mut account2_data = vec![0; TokenAccount::get_packed_len()];
             let token_account2 = TokenAccount {
-                mint: spl_token_pubkey(&mint1_pubkey),
-                owner: spl_token_pubkey(&wallet2_pubkey),
+                mint: mint1_pubkey,
+                owner: wallet2_pubkey,
                 delegate: COption::Some(delegate),
                 amount: 420,
                 state: TokenAccountState::Initialized,
                 is_native: COption::None,
                 delegated_amount: 30,
-                close_authority: COption::Some(spl_token_pubkey(&wallet2_pubkey)),
+                close_authority: COption::Some(wallet2_pubkey),
             };
             TokenAccount::pack(token_account2, &mut account2_data).unwrap();
             let token_account2 = AccountSharedData::from(Account {
@@ -1128,14 +1127,14 @@ mod tests {
             // Add another token account with the same owner and delegate but different mint
             let mut account3_data = vec![0; TokenAccount::get_packed_len()];
             let token_account3 = TokenAccount {
-                mint: spl_token_pubkey(&mint2_pubkey),
-                owner: spl_token_pubkey(&wallet2_pubkey),
+                mint: mint2_pubkey,
+                owner: wallet2_pubkey,
                 delegate: COption::Some(delegate),
                 amount: 42,
                 state: TokenAccountState::Initialized,
                 is_native: COption::None,
                 delegated_amount: 30,
-                close_authority: COption::Some(spl_token_pubkey(&wallet2_pubkey)),
+                close_authority: COption::Some(wallet2_pubkey),
             };
             TokenAccount::pack(token_account3, &mut account3_data).unwrap();
             let token_account3 = AccountSharedData::from(Account {
@@ -1149,11 +1148,11 @@ mod tests {
             // Add the new mint
             let mut mint2_data = vec![0; Mint::get_packed_len()];
             let mint2_state = Mint {
-                mint_authority: COption::Some(spl_token_pubkey(&wallet2_pubkey)),
+                mint_authority: COption::Some(wallet2_pubkey),
                 supply: 200,
                 decimals: 3,
                 is_initialized: true,
-                freeze_authority: COption::Some(spl_token_pubkey(&wallet2_pubkey)),
+                freeze_authority: COption::Some(wallet2_pubkey),
             };
             Mint::pack(mint2_state, &mut mint2_data).unwrap();
             let mint_account2 = AccountSharedData::from(Account {
@@ -1365,14 +1364,14 @@ mod tests {
                 let account_pubkey = Pubkey::new_unique();
                 // Add a token account
                 let token_state = TokenAccount {
-                    mint: spl_token_pubkey(&mint_pubkey),
-                    owner: spl_token_pubkey(&owner_pubkey),
-                    delegate: COption::Some(spl_token_pubkey(&delagate_pubkey)),
+                    mint: mint_pubkey,
+                    owner: owner_pubkey,
+                    delegate: COption::Some(delagate_pubkey),
                     amount: 100,
                     state: TokenAccountState::Initialized,
                     is_native: COption::None,
                     delegated_amount: 10,
-                    close_authority: COption::Some(spl_token_pubkey(&owner_pubkey)),
+                    close_authority: COption::Some(owner_pubkey),
                 };
                 TokenAccount::pack(token_state, &mut account_data).unwrap();
                 let token_account = AccountSharedData::from(Account {
@@ -1389,11 +1388,11 @@ mod tests {
                 .next()
                 .unwrap()];
             let mint_state = Mint {
-                mint_authority: COption::Some(spl_token_pubkey(&mint_authority_pubkey)),
+                mint_authority: COption::Some(mint_authority_pubkey),
                 supply: 100 * (num_token_accounts.unwrap_or(1) as u64),
                 decimals: 2,
                 is_initialized: true,
-                freeze_authority: COption::Some(spl_token_pubkey(&mint_authority_pubkey)),
+                freeze_authority: COption::Some(mint_authority_pubkey),
             };
             Mint::pack(mint_state, &mut mint_data).unwrap();
             let mint_account = AccountSharedData::from(Account {


### PR DESCRIPTION
#### Problem
Since #31607, there is only a single `solana-program` in the build tree. As a result, spl-token and spl-token-2022 apis can operate with normal Pubkey and Instruction types, instead of needing to convert to different versions.

#### Summary of Changes
Deprecate type conversion methods and remove their usage. It would be nice to remove the conversion apis altogether, but I'm not sure if any dependents are using those methods (they shouldn't need to). They are part of the public api for `solana-account-decoder` and `solana-transaction-status`, unfortunately.
