### PR TITLE
[zk-token-sdk] Refactor `zk-token-elgamal` conversion code for `elgamal` and `pedersen` pod types

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -52,11 +52,7 @@ mod target_arch {
         super::pod,
         crate::{
             curve25519::scalar::PodScalar,
-            encryption::{
-                auth_encryption::AeCiphertext,
-                elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
-                pedersen::PedersenCommitment,
-            },
+            encryption::auth_encryption::AeCiphertext,
             errors::{ProofError, ProofVerificationError},
             instruction::{
                 transfer::{TransferAmountEncryption, TransferPubkeys},
@@ -100,29 +96,6 @@ mod target_arch {
     impl From<pod::CompressedRistretto> for CompressedRistretto {
         fn from(pod: pod::CompressedRistretto) -> Self {
             Self(pod.0)
-        }
-    }
-
-    impl From<PedersenCommitment> for pod::PedersenCommitment {
-        fn from(comm: PedersenCommitment) -> Self {
-            Self(comm.to_bytes())
-        }
-    }
-
-    // For proof verification, interpret pod::PedersenComm directly as CompressedRistretto
-    #[cfg(not(target_os = "solana"))]
-    impl From<pod::PedersenCommitment> for CompressedRistretto {
-        fn from(pod: pod::PedersenCommitment) -> Self {
-            Self(pod.0)
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    impl TryFrom<pod::PedersenCommitment> for PedersenCommitment {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::PedersenCommitment) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }
 

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -91,34 +91,6 @@ mod target_arch {
         }
     }
 
-    impl From<ElGamalCiphertext> for pod::ElGamalCiphertext {
-        fn from(ct: ElGamalCiphertext) -> Self {
-            Self(ct.to_bytes())
-        }
-    }
-
-    impl TryFrom<pod::ElGamalCiphertext> for ElGamalCiphertext {
-        type Error = ProofError;
-
-        fn try_from(ct: pod::ElGamalCiphertext) -> Result<Self, Self::Error> {
-            Self::from_bytes(&ct.0).ok_or(ProofError::CiphertextDeserialization)
-        }
-    }
-
-    impl From<ElGamalPubkey> for pod::ElGamalPubkey {
-        fn from(pk: ElGamalPubkey) -> Self {
-            Self(pk.to_bytes())
-        }
-    }
-
-    impl TryFrom<pod::ElGamalPubkey> for ElGamalPubkey {
-        type Error = ProofError;
-
-        fn try_from(pk: pod::ElGamalPubkey) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pk.0).ok_or(ProofError::CiphertextDeserialization)
-        }
-    }
-
     impl From<CompressedRistretto> for pod::CompressedRistretto {
         fn from(cr: CompressedRistretto) -> Self {
             Self(cr.to_bytes())
@@ -150,30 +122,6 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(pod: pod::PedersenCommitment) -> Result<Self, Self::Error> {
-            Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    impl From<DecryptHandle> for pod::DecryptHandle {
-        fn from(handle: DecryptHandle) -> Self {
-            Self(handle.to_bytes())
-        }
-    }
-
-    // For proof verification, interpret pod::PedersenDecHandle as CompressedRistretto
-    #[cfg(not(target_os = "solana"))]
-    impl From<pod::DecryptHandle> for CompressedRistretto {
-        fn from(pod: pod::DecryptHandle) -> Self {
-            Self(pod.0)
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    impl TryFrom<pod::DecryptHandle> for DecryptHandle {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::DecryptHandle) -> Result<Self, Self::Error> {
             Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -101,7 +101,7 @@ impl From<decoded::DecryptHandle> for DecryptHandle {
     }
 }
 
-// For proof verification, interpret pod::PedersenDecHandle as CompressedRistretto
+// For proof verification, interpret pod::DecryptHandle as CompressedRistretto
 #[cfg(not(target_os = "solana"))]
 impl From<DecryptHandle> for CompressedRistretto {
     fn from(pod_handle: DecryptHandle) -> Self {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -33,8 +33,8 @@ impl Default for ElGamalCiphertext {
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
-    fn from(ct: decoded::ElGamalCiphertext) -> Self {
-        Self(ct.to_bytes())
+    fn from(decoded_ciphertext: decoded::ElGamalCiphertext) -> Self {
+        Self(decoded_ciphertext.to_bytes())
     }
 }
 
@@ -42,8 +42,8 @@ impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
 impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
     type Error = ProofError;
 
-    fn try_from(ct: ElGamalCiphertext) -> Result<Self, Self::Error> {
-        Self::from_bytes(&ct.0).ok_or(ProofError::CiphertextDeserialization)
+    fn try_from(pod_ciphertext: ElGamalCiphertext) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_ciphertext.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }
 
@@ -65,8 +65,8 @@ impl fmt::Display for ElGamalPubkey {
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::ElGamalPubkey> for ElGamalPubkey {
-    fn from(pk: decoded::ElGamalPubkey) -> Self {
-        Self(pk.to_bytes())
+    fn from(decoded_pubkey: decoded::ElGamalPubkey) -> Self {
+        Self(decoded_pubkey.to_bytes())
     }
 }
 
@@ -74,8 +74,8 @@ impl From<decoded::ElGamalPubkey> for ElGamalPubkey {
 impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
     type Error = ProofError;
 
-    fn try_from(pk: ElGamalPubkey) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pk.0).ok_or(ProofError::CiphertextDeserialization)
+    fn try_from(pod_pubkey: ElGamalPubkey) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_pubkey.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }
 
@@ -91,16 +91,16 @@ impl fmt::Debug for DecryptHandle {
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::DecryptHandle> for DecryptHandle {
-    fn from(handle: decoded::DecryptHandle) -> Self {
-        Self(handle.to_bytes())
+    fn from(decoded_handle: decoded::DecryptHandle) -> Self {
+        Self(decoded_handle.to_bytes())
     }
 }
 
 // For proof verification, interpret pod::PedersenDecHandle as CompressedRistretto
 #[cfg(not(target_os = "solana"))]
 impl From<DecryptHandle> for CompressedRistretto {
-    fn from(pod: DecryptHandle) -> Self {
-        Self(pod.0)
+    fn from(pod_handle: DecryptHandle) -> Self {
+        Self(pod_handle.0)
     }
 }
 
@@ -108,7 +108,7 @@ impl From<DecryptHandle> for CompressedRistretto {
 impl TryFrom<DecryptHandle> for decoded::DecryptHandle {
     type Error = ProofError;
 
-    fn try_from(pod: DecryptHandle) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
+    fn try_from(pod_handle: DecryptHandle) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_handle.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -1,3 +1,5 @@
+//! Plain Old Data types for the ElGamal encryption scheme.
+
 use {
     crate::zk_token_elgamal::pod::{Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -9,6 +11,7 @@ use {
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 
+/// The `ElGamalCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ElGamalCiphertext(pub [u8; 64]);
@@ -47,6 +50,7 @@ impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
     }
 }
 
+/// The `ElGamalPubkey` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ElGamalPubkey(pub [u8; 32]);
@@ -79,6 +83,7 @@ impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
     }
 }
 
+/// The `DecryptHandle` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct DecryptHandle(pub [u8; 32]);

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -41,3 +41,13 @@ impl fmt::Display for ElGamalPubkey {
         write!(f, "{}", BASE64_STANDARD.encode(self.0))
     }
 }
+
+#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct DecryptHandle(pub [u8; 32]);
+
+impl fmt::Debug for DecryptHandle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -3,6 +3,11 @@ use {
     base64::{prelude::BASE64_STANDARD, Engine},
     std::fmt,
 };
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{encryption::elgamal as decoded, errors::ProofError},
+    curve25519_dalek::ristretto::CompressedRistretto,
+};
 
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
@@ -26,6 +31,22 @@ impl Default for ElGamalCiphertext {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
+impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
+    fn from(ct: decoded::ElGamalCiphertext) -> Self {
+        Self(ct.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
+    type Error = ProofError;
+
+    fn try_from(ct: ElGamalCiphertext) -> Result<Self, Self::Error> {
+        Self::from_bytes(&ct.0).ok_or(ProofError::CiphertextDeserialization)
+    }
+}
+
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ElGamalPubkey(pub [u8; 32]);
@@ -42,6 +63,22 @@ impl fmt::Display for ElGamalPubkey {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
+impl From<decoded::ElGamalPubkey> for ElGamalPubkey {
+    fn from(pk: decoded::ElGamalPubkey) -> Self {
+        Self(pk.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
+    type Error = ProofError;
+
+    fn try_from(pk: ElGamalPubkey) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pk.0).ok_or(ProofError::CiphertextDeserialization)
+    }
+}
+
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct DecryptHandle(pub [u8; 32]);
@@ -49,5 +86,29 @@ pub struct DecryptHandle(pub [u8; 32]);
 impl fmt::Debug for DecryptHandle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl From<decoded::DecryptHandle> for DecryptHandle {
+    fn from(handle: decoded::DecryptHandle) -> Self {
+        Self(handle.to_bytes())
+    }
+}
+
+// For proof verification, interpret pod::PedersenDecHandle as CompressedRistretto
+#[cfg(not(target_os = "solana"))]
+impl From<DecryptHandle> for CompressedRistretto {
+    fn from(pod: DecryptHandle) -> Self {
+        Self(pod.0)
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<DecryptHandle> for decoded::DecryptHandle {
+    type Error = ProofError;
+
+    fn try_from(pod: DecryptHandle) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -13,12 +13,12 @@ use {
 pub use {
     auth_encryption::AeCiphertext,
     bytemuck::{Pod, Zeroable},
-    elgamal::{ElGamalCiphertext, ElGamalPubkey},
+    elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     instruction::{
         FeeEncryption, FeeParameters, TransferAmountEncryption, TransferPubkeys,
         TransferWithFeePubkeys,
     },
-    pedersen::{DecryptHandle, PedersenCommitment},
+    pedersen::PedersenCommitment,
     range_proof::{RangeProof128, RangeProof256, RangeProof64},
     sigma_proofs::{
         AggregatedValidityProof, CiphertextCiphertextEqualityProof,

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -1,3 +1,5 @@
+//! Plain Old Data type for the Pedersen commitment scheme.
+
 use {
     crate::zk_token_elgamal::pod::{Pod, Zeroable},
     std::fmt,
@@ -8,6 +10,7 @@ use {
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 
+/// The `PedersenCommitment` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PedersenCommitment(pub [u8; 32]);

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -20,16 +20,16 @@ impl fmt::Debug for PedersenCommitment {
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::PedersenCommitment> for PedersenCommitment {
-    fn from(comm: decoded::PedersenCommitment) -> Self {
-        Self(comm.to_bytes())
+    fn from(decoded_commitment: decoded::PedersenCommitment) -> Self {
+        Self(decoded_commitment.to_bytes())
     }
 }
 
 // For proof verification, interpret pod::PedersenComm directly as CompressedRistretto
 #[cfg(not(target_os = "solana"))]
 impl From<PedersenCommitment> for CompressedRistretto {
-    fn from(pod: PedersenCommitment) -> Self {
-        Self(pod.0)
+    fn from(pod_commitment: PedersenCommitment) -> Self {
+        Self(pod_commitment.0)
     }
 }
 
@@ -37,7 +37,7 @@ impl From<PedersenCommitment> for CompressedRistretto {
 impl TryFrom<PedersenCommitment> for decoded::PedersenCommitment {
     type Error = ProofError;
 
-    fn try_from(pod: PedersenCommitment) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
+    fn try_from(pod_commitment: PedersenCommitment) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_commitment.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -2,6 +2,11 @@ use {
     crate::zk_token_elgamal::pod::{Pod, Zeroable},
     std::fmt,
 };
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{encryption::pedersen as decoded, errors::ProofError},
+    curve25519_dalek::ristretto::CompressedRistretto,
+};
 
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
@@ -10,5 +15,29 @@ pub struct PedersenCommitment(pub [u8; 32]);
 impl fmt::Debug for PedersenCommitment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl From<decoded::PedersenCommitment> for PedersenCommitment {
+    fn from(comm: decoded::PedersenCommitment) -> Self {
+        Self(comm.to_bytes())
+    }
+}
+
+// For proof verification, interpret pod::PedersenComm directly as CompressedRistretto
+#[cfg(not(target_os = "solana"))]
+impl From<PedersenCommitment> for CompressedRistretto {
+    fn from(pod: PedersenCommitment) -> Self {
+        Self(pod.0)
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<PedersenCommitment> for decoded::PedersenCommitment {
+    type Error = ProofError;
+
+    fn try_from(pod: PedersenCommitment) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod.0).ok_or(ProofError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -28,7 +28,7 @@ impl From<decoded::PedersenCommitment> for PedersenCommitment {
     }
 }
 
-// For proof verification, interpret pod::PedersenComm directly as CompressedRistretto
+// For proof verification, interpret pod::PedersenCommitment directly as CompressedRistretto
 #[cfg(not(target_os = "solana"))]
 impl From<PedersenCommitment> for CompressedRistretto {
     fn from(pod_commitment: PedersenCommitment) -> Self {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -12,13 +12,3 @@ impl fmt::Debug for PedersenCommitment {
         write!(f, "{:?}", self.0)
     }
 }
-
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct DecryptHandle(pub [u8; 32]);
-
-impl fmt::Debug for DecryptHandle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.0)
-    }
-}


### PR DESCRIPTION
#### Problem
As pointed out in https://github.com/solana-labs/solana/issues/31813, the code in `zk-token-elgamal` is quite messy. In particular, the types in `pod.rs` and the conversion logic in `convert.rs` can be re-organized into submodules following the module structure of the rest of `zk-token-sdk`.

The `pod` types were refactored in https://github.com/solana-labs/solana/pull/31814. The `convert.rs` can now be refactored.

#### Summary of Changes
- Moved pod `DecryptHandle` from `pod::pedersen` to `pod::elgamal`. This was a miss from the previous refactor (https://github.com/solana-labs/solana/pull/31814) since `Decrypt` handle lives in `encryption::elgamal` as opposed to `encryption::pedersen`.
- The conversion logic for `elgamal` and `pedersen` typs are refactored into their respective `pod` submodules from `convert.rs`
- Updated variable names
- Added brief one-liner docs for the types and submodule

If this looks good, then I will go ahead and refactor `convert.rs` for the rest of the pod types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
