### PR TITLE
big_mod_exp syscall: exclude inputs of numbers larger than 4096-bits

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1721,7 +1721,7 @@ declare_syscall!(
         .ok_or(SyscallError::InvalidLength)?;
 
         if params.base_len > 512 || params.exponent_len > 512 || params.modulus_len > 512 {
-            return Err(SyscallError::InvalidLength);
+            return Err(Box::new(SyscallError::InvalidLength));
         }
 
         let input_len: u64 = std::cmp::max(params.base_len, params.exponent_len);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1720,6 +1720,10 @@ declare_syscall!(
         .get(0)
         .ok_or(SyscallError::InvalidLength)?;
 
+        if params.base_len > 512 || params.exponent_len > 512 || params.modulus_len > 512 {
+            return Err(SyscallError::InvalidLength);
+        }
+
         let input_len: u64 = std::cmp::max(params.base_len, params.exponent_len);
         let input_len: u64 = std::cmp::max(input_len, params.modulus_len);
 


### PR DESCRIPTION
#### Problem
The changes related to Big integer modular exponentiation (EIP-198). The calculation is implemented as syscall.

The formula that was used to approximate the compute budgets for large number exponentiation seems to under-approximate the costs for exponentiation of very large numbers (i.e. >>1000 byte numbers). This could lead to a negative impact on the network if the syscall was to be invoked with very large numbers.
In practice, it seems like any normal/non-adversarial use of the syscall will be on numbers of size less than or equal to 4096-bits (i.e. for RSA-4096)

#### Summary of Changes
Inside syscall all inputs are limited by value 4069 bits (512 bytes).  
If the length is exceeded, an error SyscallError::InvalidLength returned. 
