### PR TITLE
Handle errors when sending an accounts package during shutdown

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -233,7 +233,12 @@ fn run_bank_forks_snapshot_n<F>(
         if slot % set_root_interval == 0 || slot == last_slot {
             // set_root should send a snapshot request
             bank_forks.set_root(bank.slot(), &request_sender, None);
-            snapshot_request_handler.handle_snapshot_requests(false, 0, &mut None);
+            snapshot_request_handler.handle_snapshot_requests(
+                false,
+                0,
+                &mut None,
+                &AtomicBool::new(false),
+            );
         }
     }
 
@@ -753,6 +758,7 @@ fn test_bank_forks_incremental_snapshot(
                 false,
                 0,
                 &mut last_full_snapshot_slot,
+                &AtomicBool::new(false),
             );
         }
 


### PR DESCRIPTION
#### Problem

AccountsBackgroundService sends accounts packages to AccountsHashVerifier after it has completed processing the snapshot request. However, if AHV has stopped, then the accounts package channel will be disconnected, and sending to it will fail. ABS calls `expect` on `send`, so if during shutdown AHV stops before ABS, then `expect` can panic.

Please refer to https://github.com/solana-labs/solana/issues/31872 for more information.

#### Summary of Changes

If `send` fails, check the `exit` flag. Swallow the error if we're shutting down.