### PR TITLE
EpochAccountsHash tests no longer ignore shutdown errors

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -237,11 +237,16 @@ impl Drop for BackgroundServices {
         info!("Stopping background services...");
         self.exit.store(true, Ordering::Relaxed);
 
-        // Join the background threads, and ignore any errors.
         // SAFETY: We do not use any of the `ManuallyDrop` fields again, so `.take()` is OK here.
-        _ = unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }.join();
-        _ = unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }.join();
-        _ = unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }.join();
+        unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }
+            .join()
+            .expect("stop AccountsBackgroundService");
+        unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }
+            .join()
+            .expect("stop AccountsHashVerifier");
+        unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }
+            .join()
+            .expect("stop SnapshotPackagerService");
 
         info!("Stopping background services... DONE");
     }


### PR DESCRIPTION
#### Problem

The Epoch Accounts Hash tests currently swallow errors when shutting down the background services.

There have been many improvements to the handling shutdown gracefully (including https://github.com/solana-labs/solana/issues/31872), and I think it's worthwhile to have tests that exercise this behavior to catch any new bugs.


#### Summary of Changes

No longer swallow errors when shutting down background services.


#### Other Testing

I've been running these EAH tests locally in a loop for ~20 hours so far (approx. 30-60 seconds per run) with a 100% success rate. Often these failures would exhibit by now, but that's not always a given. The CI agents often have the perfect combination of limited resources and high contention to cause abnormal scheduling issues with the background services in tests 😸. Worst case, if we see these tests fail again while shutting down the background services, then we can revert back to ignoring errors.