### PR TITLE
Downgrades log to warn if reading bank snapshot from dir fails

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -860,12 +860,8 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
             })
             .for_each(
                 |slot| match BankSnapshotInfo::new_from_dir(&bank_snapshots_dir, slot) {
-                    Ok(snapshot_info) => {
-                        bank_snapshots.push(snapshot_info);
-                    }
-                    Err(err) => {
-                        error!("Unable to read bank snapshot for slot {}: {}", slot, err);
-                    }
+                    Ok(snapshot_info) => bank_snapshots.push(snapshot_info),
+                    Err(err) => warn!("Unable to read bank snapshot for slot {slot}: {err}"),
                 },
             ),
     }


### PR DESCRIPTION
#### Problem

The `Unable to read bank snapshot for slot` log is very noisy in tests[^1], since errors are logged by default whenever `solana_logger` is setup. For normal validators, I'd argue this log shouldn't be `error` to begin with. A node operator will see a `warn` message in the log, and can respond in the same way as today. Also, the validator's operation today doesn't exit/abort if there's an error here. Usually we reserve `error` for unrecoverable events.

[^1]: Here's a buildkite log that illustrates the issue in CI: https://buildkite.com/solana-labs/solana/builds/96566#01886eaa-a2c9-4ff7-9fc4-7686c009e95c

#### Summary of Changes

Downgrades log from `error` to `warn`.