### PR TITLE
Replace improper &Arc<...> with Arc<...> in Bank and Accounts

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1644,7 +1644,7 @@ fn load_blockstore(
                 .as_ref()
                 .map(|service| service.sender()),
             accounts_update_notifier,
-            exit,
+            exit.clone(),
         );
 
     // Before replay starts, set the callbacks in each of the banks in BankForks so that

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -460,7 +460,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
                 true,
                 None,
                 None,
-                &Arc::new(AtomicBool::new(false)),
+                Arc::new(AtomicBool::new(false)),
             )
             .unwrap()
             .0;

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -179,7 +179,7 @@ fn restore_from_snapshot(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
     deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -895,7 +895,7 @@ fn restore_from_snapshots_and_check_banks_are_equal(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )?;
     deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
 
@@ -1114,7 +1114,7 @@ fn test_snapshots_with_background_services(
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &exit,
+        exit.clone(),
     )
     .unwrap();
     deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -236,7 +236,7 @@ pub fn load_bank_forks(
             None,
             None, // Maybe support this later, though
             accounts_update_notifier,
-            &exit,
+            exit.clone(),
         );
     let block_verification_method = value_t!(
         arg_matches,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -52,7 +52,7 @@ pub fn load(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> LoadResult {
     let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) = load_bank_forks(
         genesis_config,
@@ -91,7 +91,7 @@ pub fn load_bank_forks(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> (
     Arc<RwLock<BankForks>>,
     LeaderScheduleCache,
@@ -196,7 +196,7 @@ fn bank_forks_from_snapshot(
     snapshot_config: &SnapshotConfig,
     process_options: &ProcessOptions,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> (Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>) {
     // Fail hard here if snapshot fails to load, don't silently continue
     if account_paths.is_empty() {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -638,7 +638,7 @@ pub fn test_process_blockstore(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     opts: &ProcessOptions,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> (Arc<RwLock<BankForks>>, LeaderScheduleCache) {
     // Spin up a thread to be a fake Accounts Background Service.  Need to intercept and handle all
     // EpochAccountsHash requests so future rooted banks do not hang in Bank::freeze() waiting for
@@ -711,7 +711,7 @@ pub(crate) fn process_blockstore_for_bank_0(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Arc<RwLock<BankForks>> {
     // Setup bank for slot 0
     let bank0 = Bank::new_with_paths(
@@ -1902,7 +1902,7 @@ pub mod tests {
             AccessType::Primary | AccessType::PrimaryForMaintenance => {
                 // Attempting to open a second Primary access would fail, so
                 // just pass the original session if it is a Primary variant
-                test_process_blockstore(genesis_config, blockstore, opts, &Arc::default())
+                test_process_blockstore(genesis_config, blockstore, opts, Arc::default())
             }
             AccessType::Secondary => {
                 let secondary_blockstore = Blockstore::open_with_options(
@@ -1913,12 +1913,7 @@ pub mod tests {
                     },
                 )
                 .expect("Unable to open access to blockstore");
-                test_process_blockstore(
-                    genesis_config,
-                    &secondary_blockstore,
-                    opts,
-                    &Arc::default(),
-                )
+                test_process_blockstore(genesis_config, &secondary_blockstore, opts, Arc::default())
             }
         }
     }
@@ -2027,7 +2022,7 @@ pub mod tests {
                 run_verification: true,
                 ..ProcessOptions::default()
             },
-            &Arc::default(),
+            Arc::default(),
         );
         assert_eq!(frozen_bank_slots(&bank_forks.read().unwrap()), vec![0]);
 
@@ -2042,7 +2037,7 @@ pub mod tests {
                 run_verification: true,
                 ..ProcessOptions::default()
             },
-            &Arc::default(),
+            Arc::default(),
         );
 
         // One valid fork, one bad fork.  process_blockstore() should only return the valid fork
@@ -2098,7 +2093,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         assert_eq!(frozen_bank_slots(&bank_forks.read().unwrap()), vec![0]);
     }
 
@@ -2163,7 +2158,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
 
         assert_eq!(frozen_bank_slots(&bank_forks.read().unwrap()), vec![0]); // slot 1 isn't "full", we stop at slot zero
 
@@ -2183,7 +2178,7 @@ pub mod tests {
         fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 3, 0, blockhash);
         // Slot 0 should not show up in the ending bank_forks_info
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
 
         // slot 1 isn't "full", we stop at slot zero
         assert_eq!(frozen_bank_slots(&bank_forks.read().unwrap()), vec![0, 3]);
@@ -2250,7 +2245,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         // One fork, other one is ignored b/c not a descendant of the root
@@ -2330,7 +2325,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         assert_eq!(frozen_bank_slots(&bank_forks), vec![1, 2, 3, 4]);
@@ -2390,7 +2385,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions::default(),
-            &Arc::default(),
+            Arc::default(),
         );
         let bank_forks = bank_forks.read().unwrap();
 
@@ -2439,7 +2434,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions::default(),
-            &Arc::default(),
+            Arc::default(),
         );
         let bank_forks = bank_forks.read().unwrap();
 
@@ -2491,7 +2486,7 @@ pub mod tests {
             &genesis_config,
             &blockstore,
             &ProcessOptions::default(),
-            &Arc::default(),
+            Arc::default(),
         );
         let bank_forks = bank_forks.read().unwrap();
 
@@ -2544,7 +2539,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         // There is one fork, head is last_slot + 1
@@ -2689,7 +2684,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         assert_eq!(frozen_bank_slots(&bank_forks), vec![0, 1]);
@@ -2720,7 +2715,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         assert_eq!(frozen_bank_slots(&bank_forks), vec![0]);
@@ -2740,7 +2735,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (_bank_forks, leader_schedule) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         assert_eq!(leader_schedule.max_schedules(), std::usize::MAX);
     }
 
@@ -3539,7 +3534,7 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, &Arc::default());
+            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
         let bank_forks = bank_forks.read().unwrap();
 
         // Should be able to fetch slot 0 because we specified halting at slot 0, even

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2189,7 +2189,7 @@ fn create_snapshot_to_hard_fork(
         None,
         None,
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
     let bank = bank_forks.read().unwrap().get(snapshot_slot).unwrap();

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -26,7 +26,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     let mut reclaims = vec![];
     let index = AccountsIndex::<AccountInfo, AccountInfo>::new(
         Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
-        &Arc::default(),
+        Arc::default(),
     );
     for f in 0..NUM_FORKS {
         for pubkey in pubkeys.iter().take(NUM_PUBKEYS) {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -171,7 +171,7 @@ impl Accounts {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -188,7 +188,7 @@ impl Accounts {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -199,7 +199,7 @@ impl Accounts {
         shrink_ratio: AccountShrinkThreshold,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
     ) -> Self {
         Self::new_empty(AccountsDb::new_with_config(
             paths,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2462,7 +2462,7 @@ impl AccountsDb {
             AccountShrinkThreshold::default(),
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -2474,7 +2474,7 @@ impl AccountsDb {
             AccountShrinkThreshold::default(),
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -2485,7 +2485,7 @@ impl AccountsDb {
         shrink_ratio: AccountShrinkThreshold,
         mut accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts_index = AccountsIndex::new(
             accounts_db_config.as_mut().and_then(|x| x.index.take()),
@@ -9448,7 +9448,7 @@ impl AccountsDb {
             shrink_ratio,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -17230,7 +17230,7 @@ pub mod tests {
                     ..ACCOUNTS_DB_CONFIG_FOR_TESTING
                 }),
                 None,
-                &Arc::default(),
+                Arc::default(),
             );
             // before any roots are added, we expect the oldest non-ancient slot to be 0
             assert_eq!(0, db.get_oldest_non_ancient_slot(&epoch_schedule));
@@ -17264,7 +17264,7 @@ pub mod tests {
                 ..ACCOUNTS_DB_CONFIG_FOR_TESTING
             }),
             None,
-            &Arc::default(),
+            Arc::default(),
         );
         // before any roots are added, we expect the oldest non-ancient slot to be 0
         assert_eq!(0, db.get_oldest_non_ancient_slot(&epoch_schedule));
@@ -17319,7 +17319,7 @@ pub mod tests {
                         ..ACCOUNTS_DB_CONFIG_FOR_TESTING
                     }),
                     None,
-                    &Arc::default(),
+                    Arc::default(),
                 );
                 // before any roots are added, we expect the oldest non-ancient slot to be 0
                 assert_eq!(0, db.get_oldest_non_ancient_slot(&epoch_schedule));

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -711,10 +711,10 @@ pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     pub fn default_for_tests() -> Self {
-        Self::new(Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING), &Arc::default())
+        Self::new(Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING), Arc::default())
     }
 
-    pub fn new(config: Option<AccountsIndexConfig>, exit: &Arc<AtomicBool>) -> Self {
+    pub fn new(config: Option<AccountsIndexConfig>, exit: Arc<AtomicBool>) -> Self {
         let scan_results_limit_bytes = config
             .as_ref()
             .and_then(|config| config.scan_results_limit_bytes);
@@ -746,7 +746,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     fn allocate_accounts_index(
         config: Option<AccountsIndexConfig>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
     ) -> (
         LockMapType<T, U>,
         PubkeyBinCalculator24,
@@ -2421,7 +2421,7 @@ pub mod tests {
         } else {
             IndexLimitMb::InMemOnly // in-mem only
         };
-        let index = AccountsIndex::<T, T>::new(Some(config), &Arc::default());
+        let index = AccountsIndex::<T, T>::new(Some(config), Arc::default());
         let mut gc = Vec::new();
 
         if upsert {
@@ -4106,7 +4106,7 @@ pub mod tests {
     fn test_illegal_bins() {
         let mut config = AccountsIndexConfig::default();
         config.bins = Some(3);
-        AccountsIndex::<bool, bool>::new(Some(config), &Arc::default());
+        AccountsIndex::<bool, bool>::new(Some(config), Arc::default());
     }
 
     #[test]

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -154,7 +154,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
     }
 
     /// allocate BucketMapHolder and InMemAccountsIndex[]
-    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>, exit: &Arc<AtomicBool>) -> Self {
+    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>, exit: Arc<AtomicBool>) -> Self {
         let threads = config
             .as_ref()
             .and_then(|config| config.flush_threads)
@@ -167,11 +167,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
             .collect::<Vec<_>>();
 
         Self {
-            _bg_threads: BgThreads::new(&storage, &in_mem, threads, true, exit),
+            _bg_threads: BgThreads::new(&storage, &in_mem, threads, true, &exit),
             storage,
             in_mem,
             startup_worker_threads: Mutex::default(),
-            exit: Arc::clone(exit),
+            exit,
         }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1324,7 +1324,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -1340,7 +1340,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
     }
 
@@ -1356,7 +1356,7 @@ impl Bank {
         debug_do_not_add_builtins: bool,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts = Accounts::new_with_config(
             paths,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9306,7 +9306,7 @@ where
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         }),
         None,
-        &Arc::default(),
+        Arc::default(),
     ));
     let vote_and_stake_accounts =
         load_vote_and_stake_accounts(&bank).vote_with_stake_delegations_map;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -362,7 +362,7 @@ pub(crate) fn bank_from_streams<R>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -572,7 +572,7 @@ fn reconstruct_bank_from_fields<E>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -719,7 +719,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
     epoch_accounts_hash: Option<Hash>,
     capitalizations: (u64, Option<u64>),
     incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -122,7 +122,7 @@ where
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
         None,
         (u64::default(), None),
         None,
@@ -410,7 +410,7 @@ fn test_bank_serialize_style(
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
     dbank.status_cache = Arc::new(RwLock::new(status_cache));
@@ -570,7 +570,7 @@ fn test_extra_fields_eof() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
 
@@ -632,7 +632,7 @@ fn test_extra_fields_full_snapshot_archive() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
 
@@ -705,7 +705,7 @@ fn test_blank_extra_fields() {
         false,
         Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
-        &Arc::default(),
+        Arc::default(),
     )
     .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1492,7 +1492,7 @@ pub fn bank_from_snapshot_archives(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     let (unarchived_full_snapshot, mut unarchived_incremental_snapshot, next_append_vec_id) =
         verify_and_unarchive_snapshots(
@@ -1611,7 +1611,7 @@ pub fn bank_from_latest_snapshot_archives(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<(
     Bank,
     FullSnapshotArchiveInfo,
@@ -1704,7 +1704,7 @@ pub fn bank_from_snapshot_dir(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<(Bank, BankFromDirTimings)> {
     // Clear the contents of the account paths run directories.  When constructing the bank, the appendvec
     // files will be extracted from the snapshot hardlink directories into these run/ directories.
@@ -1772,7 +1772,7 @@ pub fn bank_from_latest_snapshot_dir(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<Bank> {
     info!("Loading bank from snapshot dir");
     let bank_snapshot = get_highest_bank_snapshot_post(&bank_snapshots_dir).ok_or_else(|| {
@@ -2614,7 +2614,7 @@ fn rebuild_bank_from_unarchived_snapshots(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<Bank> {
     let (full_snapshot_version, full_snapshot_root_paths) =
         verify_unpacked_snapshots_dir_and_version(
@@ -2710,7 +2710,7 @@ fn rebuild_bank_from_snapshot(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: &Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
 ) -> Result<Bank> {
     info!(
         "Rebuilding bank from snapshot {}",
@@ -4356,7 +4356,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -4467,7 +4467,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -4598,7 +4598,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -4719,7 +4719,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -4856,7 +4856,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -4921,7 +4921,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -5489,7 +5489,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
         deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
@@ -5562,7 +5562,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
 
@@ -5604,7 +5604,7 @@ mod tests {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
-            &Arc::default(),
+            Arc::default(),
         )
         .unwrap();
 


### PR DESCRIPTION
#### Problem
    The callstack updated in this PR passed an &Arc<...> down only to have
    the bottom level clone the reference. Thus, we are giving shared
    ownership so the reference is a bit redundant and arguably obscures the
    intention to clone further down the callstack.

#### Summary of Changes
Perform the clone of Arc<...> at the top level, and pass the owned Arc through the callstack. Noticed this while reviewing 31870
