### PR TITLE
ci: fix publish crate version checking

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -26,14 +26,27 @@ expectedCrateVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
   exit 1
 }
 
+# check workspace.version for worksapce root
+workspace_cargo_tomls=(Cargo.toml programs/sbf/Cargo.toml)
+for cargo_toml in "${workspace_cargo_tomls[@]}"; do
+  if ! grep -q "^version = \"$expectedCrateVersion\"$" "$cargo_toml"; then
+    echo "Error: Cargo.toml version is not $expectedCrateVersion"
+    exit 1
+  fi
+done
+
 Cargo_tomls=$(ci/order-crates-for-publishing.py)
 
 for Cargo_toml in $Cargo_tomls; do
   echo "--- $Cargo_toml"
-  grep -q "^version = \"$expectedCrateVersion\"$" "$Cargo_toml" || {
-    echo "Error: $Cargo_toml version is not $expectedCrateVersion"
-    exit 1
-  }
+
+  # check the version which doesn't inherit from worksapce
+  if ! grep -q "^version = { workspace = true }$" "$Cargo_toml"; then
+    grep -q "^version = \"$expectedCrateVersion\"$" "$Cargo_toml" || {
+      echo "Error: $Cargo_toml version is not $expectedCrateVersion"
+      exit 1
+    }
+  fi
 
   crate_name=$(grep -m 1 '^name = ' "$Cargo_toml" | cut -f 3 -d ' ' | tr -d \")
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -42,6 +42,7 @@ for Cargo_toml in $Cargo_tomls; do
 
   # check the version which doesn't inherit from worksapce
   if ! grep -q "^version = { workspace = true }$" "$Cargo_toml"; then
+    echo "Warn: $Cargo_toml doesn't use the inherited version"
     grep -q "^version = \"$expectedCrateVersion\"$" "$Cargo_toml" || {
       echo "Error: $Cargo_toml version is not $expectedCrateVersion"
       exit 1


### PR DESCRIPTION
#### Problem

our crates publish failed cuz our version is inherited from workspace.
<img width="413" alt="Screenshot 2023-05-31 at 4 11 56 PM" src="https://github.com/solana-labs/solana/assets/8209234/f05829be-c262-4973-ae20-370406748e30">


#### Summary of Changes

- check workspace.version in `Cargo.toml` and `programs/sbf/Cargo.toml`
- do old version check when the version isn't `{ workspace = true }`, 
