### PR TITLE
chore: use workspace's tempfile

### DIFF
--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = { workspace = true }
 serial_test = { workspace = true }
 solana-local-cluster = { workspace = true }
 solana-test-validator = { workspace = true }
-tempfile = "3.5.0"
+tempfile = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Summary of Changes

accidentally found a place doesn't use workspace inheritance. just corrected it.