### PR TITLE
Fixing send-transaction-service using quic, tpu address is wrong

### DIFF
--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -28,12 +28,7 @@ impl ClusterTpuInfo {
 }
 
 impl TpuInfo for ClusterTpuInfo {
-    fn refresh_recent_peers(&mut self, use_quic: bool) {
-        let protocol = if use_quic {
-            Protocol::QUIC
-        } else {
-            Protocol::UDP
-        };
+    fn refresh_recent_peers(&mut self, protocol: Protocol) {
         self.recent_peers = self
             .cluster_info
             .tpu_peers()

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -28,12 +28,17 @@ impl ClusterTpuInfo {
 }
 
 impl TpuInfo for ClusterTpuInfo {
-    fn refresh_recent_peers(&mut self) {
+    fn refresh_recent_peers(&mut self, use_quic: bool) {
+        let protocol = if use_quic {
+            Protocol::QUIC
+        } else {
+            Protocol::UDP
+        };
         self.recent_peers = self
             .cluster_info
             .tpu_peers()
             .into_iter()
-            .filter_map(|node| Some((*node.pubkey(), node.tpu(Protocol::UDP).ok()?)))
+            .filter_map(|node| Some((*node.pubkey(), node.tpu(protocol).ok()?)))
             .collect();
     }
 

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -14,7 +14,7 @@ use {
 pub struct ClusterTpuInfo {
     cluster_info: Arc<ClusterInfo>,
     poh_recorder: Arc<RwLock<PohRecorder>>,
-    recent_peers: HashMap<Pubkey, SocketAddr>,
+    recent_peers: HashMap<Pubkey, (SocketAddr, SocketAddr)>, // values are socket address for UDP and QUIC protocols
 }
 
 impl ClusterTpuInfo {
@@ -28,16 +28,24 @@ impl ClusterTpuInfo {
 }
 
 impl TpuInfo for ClusterTpuInfo {
-    fn refresh_recent_peers(&mut self, protocol: Protocol) {
+    fn refresh_recent_peers(&mut self) {
         self.recent_peers = self
             .cluster_info
             .tpu_peers()
             .into_iter()
-            .filter_map(|node| Some((*node.pubkey(), node.tpu(protocol).ok()?)))
+            .filter_map(|node| {
+                Some((
+                    *node.pubkey(),
+                    (
+                        node.tpu(Protocol::UDP).ok()?,
+                        node.tpu(Protocol::QUIC).ok()?,
+                    ),
+                ))
+            })
             .collect();
     }
 
-    fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr> {
+    fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr> {
         let recorder = self.poh_recorder.read().unwrap();
         let leaders: Vec<_> = (0..max_count)
             .filter_map(|i| recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS))
@@ -45,7 +53,10 @@ impl TpuInfo for ClusterTpuInfo {
         drop(recorder);
         let mut unique_leaders = vec![];
         for leader in leaders.iter() {
-            if let Some(addr) = self.recent_peers.get(leader) {
+            if let Some(addr) = self.recent_peers.get(leader).map(|addr| match protocol {
+                Protocol::UDP => &addr.0,
+                Protocol::QUIC => &addr.1,
+            }) {
                 if !unique_leaders.contains(&addr) {
                     unique_leaders.push(addr);
                 }
@@ -71,6 +82,7 @@ mod test {
         },
         solana_sdk::{
             poh_config::PohConfig,
+            quic::QUIC_PORT_OFFSET,
             signature::{Keypair, Signer},
             timing::timestamp,
         },
@@ -119,9 +131,18 @@ mod test {
                 SocketAddrSpace::Unspecified,
             ));
 
-            let validator0_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 1111));
-            let validator1_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 2222));
-            let validator2_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 3333));
+            let validator0_socket = (
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 1111)),
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 1111 + QUIC_PORT_OFFSET)),
+            );
+            let validator1_socket = (
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 2222)),
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 2222 + QUIC_PORT_OFFSET)),
+            );
+            let validator2_socket = (
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 3333)),
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 3333 + QUIC_PORT_OFFSET)),
+            );
             let recent_peers: HashMap<_, _> = vec![
                 (
                     validator_vote_keypairs0.node_keypair.pubkey(),
@@ -149,8 +170,8 @@ mod test {
             let first_leader =
                 solana_ledger::leader_schedule_utils::slot_leader_at(slot, &bank).unwrap();
             assert_eq!(
-                leader_info.get_leader_tpus(1),
-                vec![recent_peers.get(&first_leader).unwrap()]
+                leader_info.get_leader_tpus(1, Protocol::UDP),
+                vec![&recent_peers.get(&first_leader).unwrap().0]
             );
 
             let second_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
@@ -159,11 +180,14 @@ mod test {
             )
             .unwrap();
             let mut expected_leader_sockets = vec![
-                recent_peers.get(&first_leader).unwrap(),
-                recent_peers.get(&second_leader).unwrap(),
+                &recent_peers.get(&first_leader).unwrap().0,
+                &recent_peers.get(&second_leader).unwrap().0,
             ];
             expected_leader_sockets.dedup();
-            assert_eq!(leader_info.get_leader_tpus(2), expected_leader_sockets);
+            assert_eq!(
+                leader_info.get_leader_tpus(2, Protocol::UDP),
+                expected_leader_sockets
+            );
 
             let third_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
                 slot + (2 * NUM_CONSECUTIVE_LEADER_SLOTS),
@@ -171,15 +195,18 @@ mod test {
             )
             .unwrap();
             let mut expected_leader_sockets = vec![
-                recent_peers.get(&first_leader).unwrap(),
-                recent_peers.get(&second_leader).unwrap(),
-                recent_peers.get(&third_leader).unwrap(),
+                &recent_peers.get(&first_leader).unwrap().0,
+                &recent_peers.get(&second_leader).unwrap().0,
+                &recent_peers.get(&third_leader).unwrap().0,
             ];
             expected_leader_sockets.dedup();
-            assert_eq!(leader_info.get_leader_tpus(3), expected_leader_sockets);
+            assert_eq!(
+                leader_info.get_leader_tpus(3, Protocol::UDP),
+                expected_leader_sockets
+            );
 
             for x in 4..8 {
-                assert!(leader_info.get_leader_tpus(x).len() <= recent_peers.len());
+                assert!(leader_info.get_leader_tpus(x, Protocol::UDP).len() <= recent_peers.len());
             }
         }
         Blockstore::destroy(&ledger_path).unwrap();

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,16 +1,16 @@
 use {solana_client::connection_cache::Protocol, std::net::SocketAddr};
 
 pub trait TpuInfo {
-    fn refresh_recent_peers(&mut self, protocol: Protocol);
-    fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr>;
+    fn refresh_recent_peers(&mut self);
+    fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
 }
 
 #[derive(Clone)]
 pub struct NullTpuInfo;
 
 impl TpuInfo for NullTpuInfo {
-    fn refresh_recent_peers(&mut self, _protocol: Protocol) {}
-    fn get_leader_tpus(&self, _max_count: u64) -> Vec<&SocketAddr> {
+    fn refresh_recent_peers(&mut self) {}
+    fn get_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
         vec![]
     }
 }

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,7 +1,7 @@
-use std::net::SocketAddr;
+use {solana_client::connection_cache::Protocol, std::net::SocketAddr};
 
 pub trait TpuInfo {
-    fn refresh_recent_peers(&mut self, use_quic: bool);
+    fn refresh_recent_peers(&mut self, protocol: Protocol);
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr>;
 }
 
@@ -9,7 +9,7 @@ pub trait TpuInfo {
 pub struct NullTpuInfo;
 
 impl TpuInfo for NullTpuInfo {
-    fn refresh_recent_peers(&mut self, _use_quic: bool) {}
+    fn refresh_recent_peers(&mut self, _protocol: Protocol) {}
     fn get_leader_tpus(&self, _max_count: u64) -> Vec<&SocketAddr> {
         vec![]
     }

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 pub trait TpuInfo {
-    fn refresh_recent_peers(&mut self);
+    fn refresh_recent_peers(&mut self, use_quic: bool);
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr>;
 }
 
@@ -9,7 +9,7 @@ pub trait TpuInfo {
 pub struct NullTpuInfo;
 
 impl TpuInfo for NullTpuInfo {
-    fn refresh_recent_peers(&mut self) {}
+    fn refresh_recent_peers(&mut self, _use_quic: bool) {}
     fn get_leader_tpus(&self, _max_count: u64) -> Vec<&SocketAddr> {
         vec![]
     }


### PR DESCRIPTION
#### Problem
Fixing send-transaction-service using quic, tpu address is wrong (using the udp address not quic address) when transaction is retried

#### Summary of Changes

Get tpu address for quic when connection is quic based.

Fixes #
https://github.com/solana-labs/solana/issues/31898

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
