### PR TITLE
Add field for feature-gate-issue deployment considerations

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-gate.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-gate.yml
@@ -47,6 +47,13 @@ body:
         - Staked Validator Vote
     validations:
       required: true
+  - type: textarea
+    id: deployment
+    attributes:
+      label: Deployment Considerations
+      placeholder: Describe any considerations for public-cluster deployment, including needed tests and metrics to be monitored
+    validations:
+      required: true
   - type: input
     id: beta-version
     attributes:


### PR DESCRIPTION
#### Problem
There is no process around feature testing and stabilization to validate feature gates as they are activated on public clusters.

#### Summary of Changes
Add a lightweight mechanism that simply asks for deployment considerations when a feature-gate issue is created.
