### PR TITLE
sanity check repair requests slots greater than root slot

### DIFF
--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -213,6 +213,7 @@ impl RepairWeight {
         max_closest_completion_repairs: usize,
         repair_timing: &mut RepairTiming,
         stats: &mut BestRepairsStats,
+        root_slot: Slot,
     ) -> Vec<ShredRepairType> {
         let mut repairs = vec![];
         let mut processed_slots = HashSet::from([self.root]);
@@ -241,6 +242,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut best_shreds_repairs,
             max_new_shreds,
+            root_slot,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
         let repair_slots_set: HashSet<Slot> =
@@ -262,6 +264,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut processed_slots,
             max_unknown_last_index_repairs,
+            root_slot,
         );
         let num_unknown_last_index_repairs = unknown_last_index_repairs.len();
         let num_unknown_last_index_slots = processed_slots.len() - pre_num_slots;
@@ -275,6 +278,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut processed_slots,
             max_closest_completion_repairs,
+            root_slot,
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
         let num_closest_completion_slots = processed_slots.len() - pre_num_slots;
@@ -466,7 +470,7 @@ impl RepairWeight {
             .drain()
             .flat_map(|(tree_root, mut pruned_tree)| {
                 if tree_root < new_root {
-                    trace!("pruning tree {} with {}", tree_root, new_root);
+                    error!("pruning tree {} with {}", tree_root, new_root);
                     let (removed, pruned) = pruned_tree.purge_prune((new_root, Hash::default()));
                     for (slot, _) in removed {
                         self.slot_to_tree.remove(&slot);
@@ -505,6 +509,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
+        root_slot: Slot,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
         repair_weighted_traversal::get_best_repair_shreds(
@@ -513,6 +518,7 @@ impl RepairWeight {
             slot_meta_cache,
             repairs,
             max_new_shreds,
+            root_slot,
         );
     }
 
@@ -559,6 +565,7 @@ impl RepairWeight {
                     epoch_schedule,
                 );
                 if let Some(new_orphan_root) = new_orphan_root {
+                    assert!(new_orphan_root >= self.root);
                     if new_orphan_root != self.root && !best_orphans.contains(&new_orphan_root) {
                         best_orphans.insert(new_orphan_root);
                         repairs.push(ShredRepairType::Orphan(new_orphan_root));
@@ -572,6 +579,7 @@ impl RepairWeight {
         // available ones
         if best_orphans.len() < max_new_orphans {
             for new_orphan in blockstore.orphans_iterator(self.root + 1).unwrap() {
+                assert!(new_orphan >= self.root);
                 if !best_orphans.contains(&new_orphan) {
                     repairs.push(ShredRepairType::Orphan(new_orphan));
                     best_orphans.insert(new_orphan);
@@ -593,6 +601,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
+        root_slot: Slot,
     ) -> Vec<ShredRepairType> {
         let mut repairs = Vec::default();
         for (_slot, tree) in self.trees.iter() {
@@ -605,6 +614,7 @@ impl RepairWeight {
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),
+                root_slot,
             );
             repairs.extend(new_repairs);
         }
@@ -621,6 +631,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
+        top_level_root_slot: Slot,
     ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
         let mut repairs = Vec::default();
         let mut total_processed_slots = 0;
@@ -635,6 +646,7 @@ impl RepairWeight {
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),
+                top_level_root_slot,
             );
             repairs.extend(new_repairs);
             total_processed_slots += new_processed_slots;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4167,6 +4167,16 @@ pub(crate) fn verify_shred_slots(slot: Slot, parent: Slot, root: Slot) -> bool {
     if slot == 0 && parent == 0 && root == 0 {
         return true; // valid write to slot zero.
     }
+
+    if parent >= slot {
+        //panic!("parent={parent} slot={slot}");
+        error!("SHRED_CHECK parent={parent} slot={slot}");
+    }
+    if root > parent {
+        //panic!("root={root} parent={parent}");
+        error!("SHRED_CHECK root={root} parent={parent}");
+    }
+
     // Ignore shreds that chain to slots before the root,
     // or have invalid parent >= slot.
     root <= parent && parent < slot

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -735,7 +735,7 @@ fn test_incremental_snapshot_download() {
 #[test]
 #[serial]
 fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    //solana_logger::setup_with_default(RUST_LOG_FILTER);
     // If these intervals change, also make sure to change the loop timers accordingly.
     let accounts_hash_interval = 3;
     let incremental_snapshot_interval = accounts_hash_interval * 3;
@@ -1004,11 +1004,25 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     info!("Waiting for the validator to see enough slots to cross a full snapshot interval ({next_full_snapshot_slot})...");
     let timer = Instant::now();
     loop {
+        /*
         let validator_current_slot = cluster
             .get_validator_client(&validator_identity.pubkey())
             .unwrap()
             .get_slot_with_commitment(CommitmentConfig::finalized())
             .unwrap();
+        */
+        let validator_client = cluster
+            .get_validator_client(&validator_identity.pubkey())
+            .unwrap();
+        let validator_current_slot =
+            validator_client.get_slot_with_commitment(CommitmentConfig::finalized());
+        error!("<<<###>>> {validator_current_slot:?}");
+        assert!(
+            validator_current_slot.is_ok(),
+            "!!!!!! get_slot_result={validator_current_slot:?}"
+        );
+        error!("validator_current_slot={validator_current_slot:?}");
+        let validator_current_slot = validator_current_slot.unwrap();
         trace!("validator current slot: {validator_current_slot}");
         if validator_current_slot > next_full_snapshot_slot {
             break;


### PR DESCRIPTION
#### Problem
Sanity check that new repair requests are for slots greater than the root slot.

See #31787

#### Summary of Changes
Log error message and filter out repair requests for slots `<= root_slot`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
