### PR TITLE
include cost of transaction's requested loaded accounts size in cost model

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4970,7 +4970,7 @@ impl Bank {
     // to set limit, `compute_budget.loaded_accounts_data_size_limit` is set to default
     // limit of 64MB; which will convert to (64M/32K)*8CU = 16_000 CUs
     //
-    fn calculate_loaded_accounts_data_size_cost(compute_budget: &ComputeBudget) -> u64 {
+    pub fn calculate_loaded_accounts_data_size_cost(compute_budget: &ComputeBudget) -> u64 {
         const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
         (compute_budget.loaded_accounts_data_size_limit as u64)
             .saturating_add(ACCOUNT_DATA_COST_PAGE_SIZE.saturating_sub(1))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -57,6 +57,7 @@ use {
         bank::metrics::*,
         blockhash_queue::BlockhashQueue,
         builtins::{BuiltinPrototype, BUILTINS},
+        cost_model::CostModel,
         cost_tracker::CostTracker,
         epoch_accounts_hash::{self, EpochAccountsHash},
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
@@ -4934,7 +4935,7 @@ impl Bank {
         // `compute_fee` covers costs for both requested_compute_units and
         // requested_loaded_account_data_size
         let loaded_accounts_data_size_cost = if include_loaded_account_data_size_in_fee {
-            Self::calculate_loaded_accounts_data_size_cost(&compute_budget)
+            CostModel::calculate_loaded_accounts_data_size_cost(&compute_budget)
         } else {
             0_u64
         };
@@ -4959,23 +4960,6 @@ impl Bank {
             .saturating_add(compute_fee) as f64)
             * congestion_multiplier)
             .round() as u64
-    }
-
-    // Calculate cost of loaded accounts size in the same way heap cost is charged at
-    // rate of 8cu per 32K. Citing `program_runtime\src\compute_budget.rs`: "(cost of
-    // heap is about) 0.5us per 32k at 15 units/us rounded up"
-    //
-    // Before feature `support_set_loaded_accounts_data_size_limit_ix` is enabled, or
-    // if user doesn't use compute budget ix `set_loaded_accounts_data_size_limit_ix`
-    // to set limit, `compute_budget.loaded_accounts_data_size_limit` is set to default
-    // limit of 64MB; which will convert to (64M/32K)*8CU = 16_000 CUs
-    //
-    pub fn calculate_loaded_accounts_data_size_cost(compute_budget: &ComputeBudget) -> u64 {
-        const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
-        (compute_budget.loaded_accounts_data_size_limit as u64)
-            .saturating_add(ACCOUNT_DATA_COST_PAGE_SIZE.saturating_sub(1))
-            .saturating_div(ACCOUNT_DATA_COST_PAGE_SIZE)
-            .saturating_mul(compute_budget.heap_cost)
     }
 
     fn filter_program_errors_and_collect_fee(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12482,28 +12482,28 @@ fn test_calculate_loaded_accounts_data_size_cost() {
     compute_budget.loaded_accounts_data_size_limit = 31_usize * 1024;
     assert_eq!(
         compute_budget.heap_cost,
-        Bank::calculate_loaded_accounts_data_size_cost(&compute_budget)
+        CostModel::calculate_loaded_accounts_data_size_cost(&compute_budget)
     );
 
     // ... requesting exact 32K should be charged as one block
     compute_budget.loaded_accounts_data_size_limit = 32_usize * 1024;
     assert_eq!(
         compute_budget.heap_cost,
-        Bank::calculate_loaded_accounts_data_size_cost(&compute_budget)
+        CostModel::calculate_loaded_accounts_data_size_cost(&compute_budget)
     );
 
     // ... requesting slightly above 32K should be charged as 2 block
     compute_budget.loaded_accounts_data_size_limit = 33_usize * 1024;
     assert_eq!(
         compute_budget.heap_cost * 2,
-        Bank::calculate_loaded_accounts_data_size_cost(&compute_budget)
+        CostModel::calculate_loaded_accounts_data_size_cost(&compute_budget)
     );
 
     // ... requesting exact 64K should be charged as 2 block
     compute_budget.loaded_accounts_data_size_limit = 64_usize * 1024;
     assert_eq!(
         compute_budget.heap_cost * 2,
-        Bank::calculate_loaded_accounts_data_size_cost(&compute_budget)
+        CostModel::calculate_loaded_accounts_data_size_cost(&compute_budget)
     );
 }
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -634,14 +634,8 @@ mod tests {
         let feature_set = FeatureSet::default();
         assert!(!feature_set.is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()));
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        let expected_execution_cost = BUILT_IN_INSTRUCTION_COSTS
-            .get(&system_program::id())
-            .unwrap()
-            + BUILT_IN_INSTRUCTION_COSTS
-                .get(&compute_budget::id())
-                .unwrap();
-        // feature `include_loaded_accounts_data_size_in_fee_calculation` is not enabled, accounts data
-        // size limit is set.
+        // with features all diabled, builtins and loaded account size don't cost CU
+        let expected_execution_cost = 0;
         let expected_loaded_accounts_data_size_cost = 0;
 
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -639,7 +639,7 @@ mod tests {
         let feature_set = FeatureSet::default();
         assert!(!feature_set.is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()));
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        // with features all diabled, builtins and loaded account size don't cost CU
+        // with features all disabled, builtins and loaded account size don't cost CU
         let expected_execution_cost = 0;
         let expected_loaded_accounts_data_size_cost = 0;
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -89,11 +89,11 @@ impl CostModel {
         // calculate bpf cost based on compute budget instructions
         let mut compute_budget = ComputeBudget::default();
 
-        // Starting from v1.15, cost model uses compute_compute_budget.set_compute_unit_limit to
+        // Starting from v1.15, cost model uses compute_budget.set_compute_unit_limit to
         // measure bpf_costs (code below), vs earlier versions that use estimated
         // bpf instruction costs. The calculated transaction costs are used by leaders
         // during block packing, different costs for same transaction due to different versions
-        // will not impact consensus. So for v1.15+, should call compute compute_budget with
+        // will not impact consensus. So for v1.15+, should call compute budget with
         // the feature gate `enable_request_heap_frame_ix` enabled.
         let enable_request_heap_frame_ix = true;
         let result = compute_budget.process_instructions(

--- a/runtime/src/transaction_cost.rs
+++ b/runtime/src/transaction_cost.rs
@@ -11,6 +11,7 @@ pub struct TransactionCost {
     pub data_bytes_cost: u64,
     pub builtins_execution_cost: u64,
     pub bpf_execution_cost: u64,
+    pub loaded_accounts_data_size_cost: u64,
     pub account_data_size: u64,
     pub is_simple_vote: bool,
 }
@@ -24,6 +25,7 @@ impl Default for TransactionCost {
             data_bytes_cost: 0u64,
             builtins_execution_cost: 0u64,
             bpf_execution_cost: 0u64,
+            loaded_accounts_data_size_cost: 0u64,
             account_data_size: 0u64,
             is_simple_vote: false,
         }
@@ -42,6 +44,7 @@ impl PartialEq for TransactionCost {
             && self.data_bytes_cost == other.data_bytes_cost
             && self.builtins_execution_cost == other.builtins_execution_cost
             && self.bpf_execution_cost == other.bpf_execution_cost
+            && self.loaded_accounts_data_size_cost == other.loaded_accounts_data_size_cost
             && self.account_data_size == other.account_data_size
             && self.is_simple_vote == other.is_simple_vote
             && to_hash_set(&self.writable_accounts) == to_hash_set(&other.writable_accounts)
@@ -69,5 +72,6 @@ impl TransactionCost {
             .saturating_add(self.data_bytes_cost)
             .saturating_add(self.builtins_execution_cost)
             .saturating_add(self.bpf_execution_cost)
+            .saturating_add(self.loaded_accounts_data_size_cost)
     }
 }


### PR DESCRIPTION
#### Problem

There is cost associated with amount memory space transactions request to load accounts into. #30659 formulated cost into CUs for base fee calculation. Can use same formula in cost model, also behind `include_loaded_accounts_data_size_in_fee_calculation` feature gate

#### Summary of Changes
- Add `loaded_accounts_data_size_cost` to cost_model. When feature gate `include_loaded_accounts_data_size_in_fee_calculation` is activated, additional CUs for loaded_accounts_data_size will be contributed to overall transaction cost;

Note: Behind feature Gate Issue #30657
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
