### PR TITLE
[zk-token-sdk] Rename `RangeProof{64,128,256}` to `RangeProofU{64,128,256}`

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
@@ -18,7 +18,7 @@ use {
 };
 
 /// The instruction data that is needed for the
-/// `ProofInstruction::VerifyBatchedRangeProof128` instruction.
+/// `ProofInstruction::VerifyBatchedRangeProofU128` instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
@@ -29,7 +29,7 @@ pub struct BatchedRangeProofU128Data {
     pub context: BatchedRangeProofContext,
 
     /// The batched range proof
-    pub proof: pod::RangeProof128,
+    pub proof: pod::RangeProofU128,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -32,7 +32,7 @@ pub struct BatchedRangeProofU256Data {
     pub context: BatchedRangeProofContext,
 
     /// The batched range proof
-    pub proof: pod::RangeProof256,
+    pub proof: pod::RangeProofU256,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
@@ -18,7 +18,7 @@ use {
 };
 
 /// The instruction data that is needed for the
-/// `ProofInstruction::VerifyBatchedRangeProof64` instruction.
+/// `ProofInstruction::VerifyBatchedRangeProofU64` instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
@@ -29,7 +29,7 @@ pub struct BatchedRangeProofU64Data {
     pub context: BatchedRangeProofContext,
 
     /// The batched range proof
-    pub proof: pod::RangeProof64,
+    pub proof: pod::RangeProofU64,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -41,7 +41,7 @@ pub struct RangeProofU64Data {
     pub context: RangeProofContext,
 
     /// The proof that a committed value in a Pedersen commitment is a 64-bit value
-    pub proof: pod::RangeProof64,
+    pub proof: pod::RangeProofU64,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -402,7 +402,7 @@ pub struct TransferWithFeeProof {
     pub ciphertext_amount_validity_proof: pod::AggregatedValidityProof,
     pub fee_sigma_proof: pod::FeeSigmaProof,
     pub fee_ciphertext_validity_proof: pod::AggregatedValidityProof,
-    pub range_proof: pod::RangeProof256,
+    pub range_proof: pod::RangeProofU256,
 }
 
 #[allow(non_snake_case)]

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -270,7 +270,7 @@ pub struct TransferProof {
     pub validity_proof: pod::AggregatedValidityProof,
 
     // Associated range proof
-    pub range_proof: pod::RangeProof128,
+    pub range_proof: pod::RangeProofU128,
 }
 
 #[allow(non_snake_case)]

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -129,7 +129,7 @@ pub struct WithdrawProof {
     pub equality_proof: pod::CiphertextCommitmentEqualityProof,
 
     /// Associated range proof
-    pub range_proof: pod::RangeProof64, // 672 bytes
+    pub range_proof: pod::RangeProofU64, // 672 bytes
 }
 
 #[allow(non_snake_case)]

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -227,7 +227,7 @@ mod tests {
 
         let proof = RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create);
 
-        let proof_serialized: pod::RangeProof64 = proof.try_into().unwrap();
+        let proof_serialized: pod::RangeProofU64 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
 
         assert!(proof_deserialized
@@ -237,7 +237,7 @@ mod tests {
         // should fail to serialize to pod::RangeProof128
         let proof = RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create);
 
-        assert!(TryInto::<pod::RangeProof128>::try_into(proof).is_err());
+        assert!(TryInto::<pod::RangeProofU128>::try_into(proof).is_err());
     }
 
     #[test]
@@ -256,7 +256,7 @@ mod tests {
             &mut transcript_create,
         );
 
-        let proof_serialized: pod::RangeProof128 = proof.try_into().unwrap();
+        let proof_serialized: pod::RangeProofU128 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
 
         assert!(proof_deserialized
@@ -275,6 +275,6 @@ mod tests {
             &mut transcript_create,
         );
 
-        assert!(TryInto::<pod::RangeProof64>::try_into(proof).is_err());
+        assert!(TryInto::<pod::RangeProofU64>::try_into(proof).is_err());
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -21,7 +21,7 @@ pub use {
         TransferWithFeePubkeys,
     },
     pedersen::PedersenCommitment,
-    range_proof::{RangeProof128, RangeProof256, RangeProof64},
+    range_proof::{RangeProofU128, RangeProofU256, RangeProofU64},
     sigma_proofs::{
         AggregatedValidityProof, CiphertextCiphertextEqualityProof,
         CiphertextCommitmentEqualityProof, FeeSigmaProof, PubkeyValidityProof, ValidityProof,

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -10,10 +10,10 @@ use crate::{
 /// The `RangeProof` type as a `Pod` restricted to proofs on 64-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProof64(pub [u8; 672]);
+pub struct RangeProofU64(pub [u8; 672]);
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<decoded::RangeProof> for RangeProof64 {
+impl TryFrom<decoded::RangeProof> for RangeProofU64 {
     type Error = RangeProofError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
@@ -30,15 +30,15 @@ impl TryFrom<decoded::RangeProof> for RangeProof64 {
         buf[160..192].copy_from_slice(decoded_proof.t_x_blinding.as_bytes());
         buf[192..224].copy_from_slice(decoded_proof.e_blinding.as_bytes());
         buf[224..672].copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
-        Ok(RangeProof64(buf))
+        Ok(RangeProofU64(buf))
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<RangeProof64> for decoded::RangeProof {
+impl TryFrom<RangeProofU64> for decoded::RangeProof {
     type Error = RangeProofError;
 
-    fn try_from(pod_proof: RangeProof64) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: RangeProofU64) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -46,10 +46,10 @@ impl TryFrom<RangeProof64> for decoded::RangeProof {
 /// The `RangeProof` type as a `Pod` restricted to proofs on 128-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProof128(pub [u8; 736]);
+pub struct RangeProofU128(pub [u8; 736]);
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<decoded::RangeProof> for RangeProof128 {
+impl TryFrom<decoded::RangeProof> for RangeProofU128 {
     type Error = RangeProofError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
@@ -66,15 +66,15 @@ impl TryFrom<decoded::RangeProof> for RangeProof128 {
         buf[160..192].copy_from_slice(decoded_proof.t_x_blinding.as_bytes());
         buf[192..224].copy_from_slice(decoded_proof.e_blinding.as_bytes());
         buf[224..736].copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
-        Ok(RangeProof128(buf))
+        Ok(RangeProofU128(buf))
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<RangeProof128> for decoded::RangeProof {
+impl TryFrom<RangeProofU128> for decoded::RangeProof {
     type Error = RangeProofError;
 
-    fn try_from(pod_proof: RangeProof128) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: RangeProofU128) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -82,10 +82,10 @@ impl TryFrom<RangeProof128> for decoded::RangeProof {
 /// The `RangeProof` type as a `Pod` restricted to proofs on 256-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProof256(pub [u8; 800]);
+pub struct RangeProofU256(pub [u8; 800]);
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<decoded::RangeProof> for RangeProof256 {
+impl TryFrom<decoded::RangeProof> for RangeProofU256 {
     type Error = RangeProofError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
@@ -102,15 +102,15 @@ impl TryFrom<decoded::RangeProof> for RangeProof256 {
         buf[160..192].copy_from_slice(decoded_proof.t_x_blinding.as_bytes());
         buf[192..224].copy_from_slice(decoded_proof.e_blinding.as_bytes());
         buf[224..800].copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
-        Ok(RangeProof256(buf))
+        Ok(RangeProofU256(buf))
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<RangeProof256> for decoded::RangeProof {
+impl TryFrom<RangeProofU256> for decoded::RangeProof {
     type Error = RangeProofError;
 
-    fn try_from(pod_proof: RangeProof256) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: RangeProofU256) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -118,11 +118,11 @@ impl TryFrom<RangeProof256> for decoded::RangeProof {
 // The range proof pod types are wrappers for byte arrays, which are both `Pod` and `Zeroable`. However,
 // the marker traits `bytemuck::Pod` and `bytemuck::Zeroable` can only be derived for power-of-two
 // length byte arrays. Directly implement these traits for the range proof pod types.
-unsafe impl Zeroable for RangeProof64 {}
-unsafe impl Pod for RangeProof64 {}
+unsafe impl Zeroable for RangeProofU64 {}
+unsafe impl Pod for RangeProofU64 {}
 
-unsafe impl Zeroable for RangeProof128 {}
-unsafe impl Pod for RangeProof128 {}
+unsafe impl Zeroable for RangeProofU128 {}
+unsafe impl Pod for RangeProofU128 {}
 
-unsafe impl Zeroable for RangeProof256 {}
-unsafe impl Pod for RangeProof256 {}
+unsafe impl Zeroable for RangeProofU256 {}
+unsafe impl Pod for RangeProofU256 {}


### PR DESCRIPTION
#### Problem
The zk-token-proof instruction name for 64-bit range proof has bee updated to `VerifyRangeProofU64`, but the zk-token-elgamal pod types for range proof is still `RangeProof64`.

#### Summary of Changes
Change type names `RangeProof{64, 128, 256}` to `RangeProofU{64, 128, 256}`.

This is a follow-up to https://github.com/solana-labs/solana/pull/31855#discussion_r1210449561.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
