### PR TITLE
GeyserPluginService: Use common `exit` flag.

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -581,7 +581,6 @@ impl Validator {
             ));
         }
 
-        let exit = Arc::new(AtomicBool::new(false));
         {
             let exit = exit.clone();
             config

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -19,7 +19,10 @@ use {
     solana_runtime::accounts_update_notifier_interface::AccountsUpdateNotifier,
     std::{
         path::{Path, PathBuf},
-        sync::{atomic::AtomicBool, Arc, RwLock},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
         thread,
         time::Duration,
     },
@@ -231,7 +234,7 @@ impl GeyserPluginService {
                     }
                 }
 
-                if exit.load(std::sync::atomic::Ordering::Relaxed) {
+                if exit.load(Ordering::Relaxed) {
                     break;
                 }
             })


### PR DESCRIPTION
#### Problem
Geyser plugin thread would never shutdown correctly, as it is using an exit flag that is never set.

#### Summary of Changes
Use common exit flag.

And a minor refactoring in the `use` statement.