### PR TITLE
chore: Add name string for bank_serialize measure!

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1303,10 +1303,10 @@ pub fn add_bank_snapshot(
         )?;
         Ok(())
     };
-    let (bank_snapshot_consumed_size, bank_serialize) = measure!(serialize_snapshot_data_file(
-        &bank_snapshot_path,
-        bank_snapshot_serializer
-    )?);
+    let (bank_snapshot_consumed_size, bank_serialize) = measure!(
+        serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer)?,
+        "bank serialize"
+    );
     add_snapshot_time.stop();
 
     let status_cache_path = bank_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);


### PR DESCRIPTION
#### Problem
The measurement is later logged, so include a name to more clearly identify what the measurement was.

For example, the current pair of logs for creating this snapshot is as follows, noting that there is nothing before `took` in the second log.
```
[2023-06-01T03:04:10.287058361Z INFO  solana_runtime::snapshot_utils]
Creating bank snapshot for slot 197099927, path: /home/sol/ledger/snapshot/197099927/197099927.pre

[2023-06-01T03:04:26.324303651Z INFO  solana_runtime::snapshot_utils]  
took 7.5s for slot 197099927 at /home/sol/ledger/snapshot/197099927/197099927.pre
```