### PR TITLE
Reset program cache stats after submit

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -170,6 +170,10 @@ impl Stats {
             );
         }
     }
+
+    pub fn reset(&mut self) {
+        *self = Stats::default();
+    }
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1681,6 +1681,7 @@ impl Bank {
             .stats
             .submit(parent.slot());
 
+        new.loaded_programs_cache.write().unwrap().stats.reset();
         new
     }
 


### PR DESCRIPTION
#### Problem
The cache stats are monotonically increasing, since the same cache object is being shared for all banks. This makes it hard to compare the stats with previous implementation. Also, the stats will eventually rollover.

#### Summary of Changes
Reset the stats when a new bank in created, after submitting to the database.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
