### PR TITLE
ci: update zk-token-sdk Cargo.toml

### DIFF
--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "solana-zk-token-sdk"
+description = "Solana Zk Token SDK"
+documentation = "https://docs.rs/solana-zk-token-sdk"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem

I accidentally deleted `description` for zk-token-sdk when I was trying to introduce workspace inheritance to our repo.

(btw, a peek view for `zk-token-sdk/Cargo.toml` on v1.14)
https://github.com/solana-labs/solana/blob/de5faf8f7811a89a913a91db1af3f1c4fba00748/zk-token-sdk/Cargo.toml#L1-L8

#### Summary of Changes

- add `description` back to `zk-token-sdk/Cargo.toml`
- add `documentation` for `zk-token-sdk/Cargo.toml`