### PR TITLE
ci: make loader v4 program publish = true

### DIFF
--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "solana-loader-v4-program"
 description = "Solana Loader v4"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-loader-v4-program"
-description = "Solana Loader v3"
+description = "Solana Loader v4"
 publish = false
 version = { workspace = true }
 authors = { workspace = true }


### PR DESCRIPTION
#### Problem

solana-runtime needs solana-loader-v4-program for crates publishing

https://github.com/solana-labs/solana/blob/4353ac67975d917d57392ffe9c1580e00567801b/runtime/Cargo.toml#L53

#### Summary of Changes

publish loader v4 program