### PR TITLE
chore: bump zeroize_derive to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8688,14 +8688,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7715,14 +7715,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.18",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

zeroize_derive 1.2.0 has been yanked. (https://crates.io/crates/zeroize_derive/versions)

#### Summary of Changes

bump it to 1.4.2

---

perf test

```
mean_tps: 28137
max_tps: 97743
mean_confirmation_ms: 979
max_confirmation_ms: 7805
99th_percentile_confirmation_ms: 4732
max_tower_distance: 47
last_tower_distance: 31
slots_per_second: 2.699
```

