### PR TITLE
Bump solana_rbpf to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7176,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0820fa96c8e644159a308b338465d2a6314b0a71abc92ed3ecf9ad61c906e3"
+checksum = "5ae90c406f0a2d4a15f08d16c8b64f37997a57611fec0a89f1277854166996e8"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ signal-hook = "0.3.15"
 smpl_jwt = "0.7.1"
 socket2 = "0.4.9"
 soketto = "0.7"
-solana_rbpf = "=0.4.0"
+solana_rbpf = "=0.5.0"
 solana-account-decoder = { path = "account-decoder", version = "=1.17.0" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.17.0" }
 solana-banks-client = { path = "banks-client", version = "=1.17.0" }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -14,7 +14,7 @@ use {
     solana_rbpf::{
         ebpf::MM_HEAP_START,
         memory_region::MemoryMapping,
-        vm::{BuiltInFunction, Config, ContextObject, ProgramResult},
+        vm::{BuiltinFunction, Config, ContextObject, ProgramResult},
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -43,7 +43,7 @@ use {
     },
 };
 
-pub type ProcessInstructionWithContext = BuiltInFunction<InvokeContext<'static>>;
+pub type ProcessInstructionWithContext = BuiltinFunction<InvokeContext<'static>>;
 
 /// Adapter so we can unify the interfaces of built-in programs and syscalls
 #[macro_export]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -9,7 +9,7 @@ use {
     log::{debug, log_enabled, trace},
     percentage::PercentageInteger,
     solana_measure::measure::Measure,
-    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::BuiltInProgram},
+    solana_rbpf::{elf::Executable, verifier::RequisiteVerifier, vm::BuiltinProgram},
     solana_sdk::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock::Slot, loader_v4,
         pubkey::Pubkey, saturating_add_assign,
@@ -71,7 +71,7 @@ pub enum LoadedProgramType {
     Typed(Executable<RequisiteVerifier, InvokeContext<'static>>),
     #[cfg(test)]
     TestLoaded,
-    Builtin(BuiltInProgram<InvokeContext<'static>>),
+    Builtin(BuiltinProgram<InvokeContext<'static>>),
 }
 
 impl Debug for LoadedProgramType {
@@ -217,7 +217,7 @@ impl LoadedProgram {
     /// Creates a new user program
     pub fn new(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltInProgram<InvokeContext<'static>>>,
+        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
         deployment_slot: Slot,
         effective_slot: Slot,
         maybe_expiration_slot: Option<Slot>,
@@ -286,7 +286,7 @@ impl LoadedProgram {
         account_size: usize,
         entrypoint: ProcessInstructionWithContext,
     ) -> Self {
-        let mut program = BuiltInProgram::default();
+        let mut program = BuiltinProgram::default();
         program
             .register_function(b"entrypoint", entrypoint)
             .unwrap();
@@ -351,7 +351,7 @@ pub struct LoadedPrograms {
     /// Pubkey is the address of a program, multiple versions can coexists simultaneously under the same address (in different slots).
     entries: HashMap<Pubkey, Vec<Arc<LoadedProgram>>>,
     /// Globally shared RBPF config and syscall registry
-    pub program_runtime_environment_v1: Arc<BuiltInProgram<InvokeContext<'static>>>,
+    pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
     latest_root: Slot,
     pub stats: Stats,
 }
@@ -740,7 +740,7 @@ mod tests {
             LoadedPrograms, LoadedProgramsForTxBatch, WorkingSlot, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         percentage::Percentage,
-        solana_rbpf::vm::BuiltInProgram,
+        solana_rbpf::vm::BuiltinProgram,
         solana_sdk::{clock::Slot, pubkey::Pubkey},
         std::{
             ops::ControlFlow,
@@ -753,7 +753,7 @@ mod tests {
 
     fn new_test_builtin_program(deployment_slot: Slot, effective_slot: Slot) -> Arc<LoadedProgram> {
         Arc::new(LoadedProgram {
-            program: LoadedProgramType::Builtin(BuiltInProgram::default()),
+            program: LoadedProgramType::Builtin(BuiltinProgram::default()),
             account_size: 0,
             deployment_slot,
             effective_slot,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -23,7 +23,7 @@ use {
         error::EbpfError,
         memory_region::{AccessType, MemoryCowCallback, MemoryMapping, MemoryRegion},
         verifier::RequisiteVerifier,
-        vm::{BuiltInProgram, ContextObject, EbpfVm, ProgramResult},
+        vm::{BuiltinProgram, ContextObject, EbpfVm, ProgramResult},
     },
     solana_sdk::{
         account::WritableAccount,
@@ -71,7 +71,7 @@ pub fn load_program_from_bytes(
     loader_key: &Pubkey,
     account_size: usize,
     deployment_slot: Slot,
-    program_runtime_environment: Arc<BuiltInProgram<InvokeContext<'static>>>,
+    program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
 ) -> Result<LoadedProgram, InstructionError> {
     let effective_slot = if feature_set.is_active(&delay_visibility_of_program_deployment::id()) {
         deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET)
@@ -100,7 +100,7 @@ pub fn load_program_from_account(
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     program: &BorrowedAccount,
     programdata: &BorrowedAccount,
-    program_runtime_environment: Arc<BuiltInProgram<InvokeContext<'static>>>,
+    program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
 ) -> Result<(Arc<LoadedProgram>, LoadProgramMetrics), InstructionError> {
     if !check_loader_id(program.get_owner()) {
         ic_logger_msg!(
@@ -352,7 +352,7 @@ macro_rules! create_vm {
 #[macro_export]
 macro_rules! mock_create_vm {
     ($vm:ident, $additional_regions:expr, $orig_account_lengths:expr, $invoke_context:expr $(,)?) => {
-        let loader = std::sync::Arc::new(BuiltInProgram::new_loader(
+        let loader = std::sync::Arc::new(BuiltinProgram::new_loader(
             solana_rbpf::vm::Config::default(),
         ));
         let function_registry = solana_rbpf::vm::FunctionRegistry::default();

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_rbpf::{
         memory_region::{AccessType, MemoryMapping},
-        vm::{BuiltInProgram, Config, ProgramResult, PROGRAM_ENVIRONMENT_KEY_SHIFT},
+        vm::{BuiltinProgram, Config, ProgramResult, PROGRAM_ENVIRONMENT_KEY_SHIFT},
     },
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
@@ -146,7 +146,7 @@ pub fn create_program_runtime_environment<'a>(
     compute_budget: &ComputeBudget,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
-) -> Result<BuiltInProgram<InvokeContext<'a>>, Error> {
+) -> Result<BuiltinProgram<InvokeContext<'a>>, Error> {
     use rand::Rng;
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
@@ -186,7 +186,7 @@ pub fn create_program_runtime_environment<'a>(
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
 
-    let mut result = BuiltInProgram::new_loader(config);
+    let mut result = BuiltinProgram::new_loader(config);
 
     // Abort
     result.register_function(b"abort", SyscallAbort::call)?;
@@ -1786,7 +1786,7 @@ mod tests {
         solana_rbpf::{
             error::EbpfError,
             memory_region::MemoryRegion,
-            vm::{BuiltInFunction, Config},
+            vm::{BuiltinFunction, Config},
         },
         solana_sdk::{
             account::{create_account_shared_data_for_test, AccountSharedData},
@@ -3341,7 +3341,7 @@ mod tests {
         seeds: &[&[u8]],
         program_id: &Pubkey,
         overlap_outputs: bool,
-        syscall: BuiltInFunction<InvokeContext<'b>>,
+        syscall: BuiltinFunction<InvokeContext<'b>>,
     ) -> Result<(Pubkey, u8), Error> {
         const SEEDS_VA: u64 = 0x100000000;
         const PROGRAM_ID_VA: u64 = 0x200000000;

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -16,7 +16,7 @@ use {
         memory_region::{MemoryMapping, MemoryRegion},
         verifier::RequisiteVerifier,
         vm::{
-            BuiltInProgram, Config, ContextObject, EbpfVm, ProgramResult,
+            BuiltinProgram, Config, ContextObject, EbpfVm, ProgramResult,
             PROGRAM_ENVIRONMENT_KEY_SHIFT,
         },
     },
@@ -105,7 +105,7 @@ pub fn load_program_from_account(
         aligned_memory_mapping: true,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
-    let loader = BuiltInProgram::new_loader(config);
+    let loader = BuiltinProgram::new_loader(config);
     let state = get_state(program.get_data())?;
     let programdata = program
         .get_data()

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6282,9 +6282,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0820fa96c8e644159a308b338465d2a6314b0a71abc92ed3ecf9ad61c906e3"
+checksum = "5ae90c406f0a2d4a15f08d16c8b64f37997a57611fec0a89f1277854166996e8"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 rand = "0.7"
 serde = "1.0.112"
 serde_json = "1.0.56"
-solana_rbpf = "=0.4.0"
+solana_rbpf = "=0.5.0"
 solana-account-decoder = { path = "../../account-decoder", version = "=1.17.0" }
 solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.17.0" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.17.0" }


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.5.0](https://github.com/solana-labs/rbpf/releases/tag/v0.5.0) was released.

#### Summary of Changes
- Some bug fixes for the new ELF parser.
- Renames `BuiltIn` to `Builtin` for consistency.