### PR TITLE
Feature - Prune on feature set transition

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -148,6 +148,8 @@ pub fn create_program_runtime_environment<'a>(
     debugging_features: bool,
 ) -> Result<BuiltinProgram<InvokeContext<'a>>, Error> {
     use rand::Rng;
+    // When adding new features for RBPF,
+    // also add them to `Bank::apply_builtin_program_feature_transitions()`.
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6286,17 +6286,6 @@ impl Bank {
         );
 
         if !debug_do_not_add_builtins {
-            let program_runtime_environment_v1 = create_program_runtime_environment(
-                &self.feature_set,
-                &self.runtime_config.compute_budget.unwrap_or_default(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap();
-            self.loaded_programs_cache
-                .write()
-                .unwrap()
-                .program_runtime_environment_v1 = Arc::new(program_runtime_environment_v1);
             for builtin in BUILTINS
                 .iter()
                 .chain(additional_builtins.unwrap_or(&[]).iter())
@@ -7577,6 +7566,32 @@ impl Bank {
         only_apply_transitions_for_new_features: bool,
         new_feature_activations: &HashSet<Pubkey>,
     ) {
+        const FEATURES_AFFECTING_RBPF: &[Pubkey] = &[
+            feature_set::error_on_syscall_bpf_function_hash_collisions::id(),
+            feature_set::reject_callx_r10::id(),
+            feature_set::switch_to_new_elf_parser::id(),
+            feature_set::bpf_account_data_direct_mapping::id(),
+        ];
+        if !only_apply_transitions_for_new_features
+            || FEATURES_AFFECTING_RBPF
+                .iter()
+                .any(|key| new_feature_activations.contains(key))
+        {
+            let program_runtime_environment_v1 = create_program_runtime_environment(
+                &self.feature_set,
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap();
+            let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
+            if *loaded_programs_cache.program_runtime_environment_v1
+                != program_runtime_environment_v1
+            {
+                loaded_programs_cache.program_runtime_environment_v1 =
+                    Arc::new(program_runtime_environment_v1);
+            }
+        }
         for builtin in BUILTINS.iter() {
             if let Some(feature_id) = builtin.feature_id {
                 let should_apply_action_for_feature_transition =
@@ -7598,7 +7613,6 @@ impl Bank {
                 }
             }
         }
-
         for precompile in get_precompiles() {
             #[allow(clippy::blocks_in_if_conditions)]
             if precompile.feature.map_or(false, |ref feature_id| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7591,6 +7591,7 @@ impl Bank {
                 loaded_programs_cache.program_runtime_environment_v1 =
                     Arc::new(program_runtime_environment_v1);
             }
+            loaded_programs_cache.prune_feature_set_transition();
         }
         for builtin in BUILTINS.iter() {
             if let Some(feature_id) = builtin.feature_id {


### PR DESCRIPTION
#### Problem
The cached `program_runtime_environment` and all programs compiled against it can become outdated when a feature which involves the RBPF config is activated.

#### Summary of Changes
- Call `create_program_runtime_environment()` in `Bank::apply_builtin_program_feature_transitions()`.
- Adds `LoadedPrograms::prune_feature_set_transition()`.

This PR does only ensures that the cache does not contain any outdated entries after the feature transition, it does not recompile them before the epoch boundary hits.