### PR TITLE
rolls out merkle shreds to ~50% of testnet

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -498,8 +498,8 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_use_merkle_variant(_slot: Slot, _cluster_type: ClusterType, _shred_version: u16) -> bool {
-    false
+fn should_use_merkle_variant(slot: Slot, cluster_type: ClusterType, shred_version: u16) -> bool {
+    cluster_type == ClusterType::Testnet && shred_version == 28353 && (slot % 19 < 10)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Continue Merkle shreds rollout off last one: https://github.com/solana-labs/solana/pull/28905

#### Summary of Changes
Roll out merkle shreds to ~50% of testnet