### PR TITLE
[zk-token-sdk] Use `TryFrom<&[T]>` for `&[T]` instead of `arrayref`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7250,7 +7250,6 @@ name = "solana-zk-token-sdk"
 version = "1.17.0"
 dependencies = [
  "aes-gcm-siv",
- "arrayref",
  "base64 0.21.2",
  "bincode",
  "bytemuck",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6264,7 +6264,6 @@ name = "solana-zk-token-sdk"
 version = "1.17.0"
 dependencies = [
  "aes-gcm-siv",
- "arrayref",
  "base64 0.21.2",
  "bincode",
  "bytemuck",

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -21,7 +21,6 @@ tiny-bip39 = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
-arrayref = { workspace = true }
 bincode = { workspace = true }
 byteorder = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -12,7 +12,6 @@ use {
     thiserror::Error,
 };
 use {
-    arrayref::{array_ref, array_refs},
     base64::{prelude::BASE64_STANDARD, Engine},
     sha3::{Digest, Sha3_512},
     solana_sdk::{
@@ -218,13 +217,10 @@ impl AeCiphertext {
             return None;
         }
 
-        let bytes = array_ref![bytes, 0, 36];
-        let (nonce, ciphertext) = array_refs![bytes, 12, 24];
+        let nonce = bytes[..32].try_into().ok()?;
+        let ciphertext = bytes[32..].try_into().ok()?;
 
-        Some(AeCiphertext {
-            nonce: *nonce,
-            ciphertext: *ciphertext,
-        })
+        Some(AeCiphertext { nonce, ciphertext })
     }
 }
 

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
@@ -11,6 +11,7 @@ use {
             pedersen::{PedersenOpening, G, H},
         },
         errors::ProofVerificationError,
+        sigma_proofs::canonical_scalar_from_slice,
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -242,24 +243,9 @@ impl CiphertextCiphertextEqualityProof {
         let Y_1 = CompressedRistretto::from_slice(&bytes[32..64]);
         let Y_2 = CompressedRistretto::from_slice(&bytes[64..96]);
         let Y_3 = CompressedRistretto::from_slice(&bytes[96..128]);
-
-        let z_s_bytes = bytes[128..160]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_s = Scalar::from_canonical_bytes(z_s_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_x_bytes = bytes[160..192]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_x = Scalar::from_canonical_bytes(z_x_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_r_bytes = bytes[192..224]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_r = Scalar::from_canonical_bytes(z_r_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
+        let z_s = canonical_scalar_from_slice(&bytes[128..160])?;
+        let z_x = canonical_scalar_from_slice(&bytes[160..192])?;
+        let z_r = canonical_scalar_from_slice(&bytes[192..224])?;
 
         Ok(CiphertextCiphertextEqualityProof {
             Y_0,

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -16,6 +16,7 @@ use {
             pedersen::{PedersenCommitment, PedersenOpening, G, H},
         },
         errors::ProofVerificationError,
+        sigma_proofs::canonical_scalar_from_slice,
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -221,24 +222,9 @@ impl CiphertextCommitmentEqualityProof {
         let Y_0 = CompressedRistretto::from_slice(&bytes[..32]);
         let Y_1 = CompressedRistretto::from_slice(&bytes[32..64]);
         let Y_2 = CompressedRistretto::from_slice(&bytes[64..96]);
-
-        let z_s_bytes = bytes[96..128]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_s = Scalar::from_canonical_bytes(z_s_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_x_bytes = bytes[128..160]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_x = Scalar::from_canonical_bytes(z_x_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_r_bytes = bytes[160..192]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_r = Scalar::from_canonical_bytes(z_r_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
+        let z_s = canonical_scalar_from_slice(&bytes[96..128])?;
+        let z_x = canonical_scalar_from_slice(&bytes[128..160])?;
+        let z_r = canonical_scalar_from_slice(&bytes[160..192])?;
 
         Ok(CiphertextCommitmentEqualityProof {
             Y_0,

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -23,7 +23,6 @@ use {
 };
 use {
     crate::{sigma_proofs::errors::EqualityProofError, transcript::TranscriptProtocol},
-    arrayref::{array_ref, array_refs},
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
@@ -219,19 +218,27 @@ impl CiphertextCommitmentEqualityProof {
             return Err(ProofVerificationError::Deserialization.into());
         }
 
-        let bytes = array_ref![bytes, 0, 192];
-        let (Y_0, Y_1, Y_2, z_s, z_x, z_r) = array_refs![bytes, 32, 32, 32, 32, 32, 32];
+        let Y_0 = CompressedRistretto::from_slice(&bytes[..32]);
+        let Y_1 = CompressedRistretto::from_slice(&bytes[32..64]);
+        let Y_2 = CompressedRistretto::from_slice(&bytes[64..96]);
 
-        let Y_0 = CompressedRistretto::from_slice(Y_0);
-        let Y_1 = CompressedRistretto::from_slice(Y_1);
-        let Y_2 = CompressedRistretto::from_slice(Y_2);
+        let z_s_bytes = bytes[96..128]
+            .try_into()
+            .map_err(|_| ProofVerificationError::Deserialization)?;
+        let z_s = Scalar::from_canonical_bytes(z_s_bytes)
+            .ok_or(ProofVerificationError::Deserialization)?;
 
-        let z_s =
-            Scalar::from_canonical_bytes(*z_s).ok_or(ProofVerificationError::Deserialization)?;
-        let z_x =
-            Scalar::from_canonical_bytes(*z_x).ok_or(ProofVerificationError::Deserialization)?;
-        let z_r =
-            Scalar::from_canonical_bytes(*z_r).ok_or(ProofVerificationError::Deserialization)?;
+        let z_x_bytes = bytes[128..160]
+            .try_into()
+            .map_err(|_| ProofVerificationError::Deserialization)?;
+        let z_x = Scalar::from_canonical_bytes(z_x_bytes)
+            .ok_or(ProofVerificationError::Deserialization)?;
+
+        let z_r_bytes = bytes[160..192]
+            .try_into()
+            .map_err(|_| ProofVerificationError::Deserialization)?;
+        let z_r = Scalar::from_canonical_bytes(z_r_bytes)
+            .ok_or(ProofVerificationError::Deserialization)?;
 
         Ok(CiphertextCommitmentEqualityProof {
             Y_0,

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -4,7 +4,10 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::pedersen::{PedersenCommitment, PedersenOpening, G, H},
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening, G, H},
+        sigma_proofs::canonical_scalar_from_slice,
+    },
     rand::rngs::OsRng,
 };
 use {
@@ -367,39 +370,14 @@ impl FeeSigmaProof {
         }
 
         let Y_max_proof = CompressedRistretto::from_slice(&bytes[..32]);
-
-        let z_max_bytes = bytes[32..64]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_max_proof = Scalar::from_canonical_bytes(z_max_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let c_max_proof = bytes[64..96]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let c_max_proof = Scalar::from_canonical_bytes(c_max_proof)
-            .ok_or(ProofVerificationError::Deserialization)?;
+        let z_max_proof = canonical_scalar_from_slice(&bytes[32..64])?;
+        let c_max_proof = canonical_scalar_from_slice(&bytes[64..96])?;
 
         let Y_delta = CompressedRistretto::from_slice(&bytes[96..128]);
         let Y_claimed = CompressedRistretto::from_slice(&bytes[128..160]);
-
-        let z_x_bytes = bytes[160..192]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_x = Scalar::from_canonical_bytes(z_x_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_delta_bytes = bytes[192..224]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_delta = Scalar::from_canonical_bytes(z_delta_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
-
-        let z_claimed_bytes = bytes[224..256]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_claimed = Scalar::from_canonical_bytes(z_claimed_bytes)
-            .ok_or(ProofVerificationError::Deserialization)?;
+        let z_x = canonical_scalar_from_slice(&bytes[160..192])?;
+        let z_delta = canonical_scalar_from_slice(&bytes[192..224])?;
+        let z_claimed = canonical_scalar_from_slice(&bytes[224..256])?;
 
         Ok(Self {
             fee_max_proof: FeeMaxProof {

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -16,6 +16,7 @@ use {
             pedersen::{PedersenCommitment, PedersenOpening, G, H},
         },
         errors::ProofVerificationError,
+        sigma_proofs::canonical_scalar_from_slice,
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -211,18 +212,8 @@ impl GroupedCiphertext2HandlesValidityProof {
         let Y_0 = CompressedRistretto::from_slice(&bytes[..32]);
         let Y_1 = CompressedRistretto::from_slice(&bytes[32..64]);
         let Y_2 = CompressedRistretto::from_slice(&bytes[64..96]);
-
-        let z_r = bytes[96..128]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z_x = bytes[128..160]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-
-        let z_r =
-            Scalar::from_canonical_bytes(z_r).ok_or(ProofVerificationError::Deserialization)?;
-        let z_x =
-            Scalar::from_canonical_bytes(z_x).ok_or(ProofVerificationError::Deserialization)?;
+        let z_r = canonical_scalar_from_slice(&bytes[96..128])?;
+        let z_x = canonical_scalar_from_slice(&bytes[128..160])?;
 
         Ok(GroupedCiphertext2HandlesValidityProof {
             Y_0,

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -23,7 +23,6 @@ use {
 };
 use {
     crate::{sigma_proofs::errors::ValidityProofError, transcript::TranscriptProtocol},
-    arrayref::{array_ref, array_refs},
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
@@ -209,17 +208,21 @@ impl GroupedCiphertext2HandlesValidityProof {
             return Err(ProofVerificationError::Deserialization.into());
         }
 
-        let bytes = array_ref![bytes, 0, 160];
-        let (Y_0, Y_1, Y_2, z_r, z_x) = array_refs![bytes, 32, 32, 32, 32, 32];
+        let Y_0 = CompressedRistretto::from_slice(&bytes[..32]);
+        let Y_1 = CompressedRistretto::from_slice(&bytes[32..64]);
+        let Y_2 = CompressedRistretto::from_slice(&bytes[64..96]);
 
-        let Y_0 = CompressedRistretto::from_slice(Y_0);
-        let Y_1 = CompressedRistretto::from_slice(Y_1);
-        let Y_2 = CompressedRistretto::from_slice(Y_2);
+        let z_r = bytes[96..128]
+            .try_into()
+            .map_err(|_| ProofVerificationError::Deserialization)?;
+        let z_x = bytes[128..160]
+            .try_into()
+            .map_err(|_| ProofVerificationError::Deserialization)?;
 
         let z_r =
-            Scalar::from_canonical_bytes(*z_r).ok_or(ProofVerificationError::Deserialization)?;
+            Scalar::from_canonical_bytes(z_r).ok_or(ProofVerificationError::Deserialization)?;
         let z_x =
-            Scalar::from_canonical_bytes(*z_x).ok_or(ProofVerificationError::Deserialization)?;
+            Scalar::from_canonical_bytes(z_x).ok_or(ProofVerificationError::Deserialization)?;
 
         Ok(GroupedCiphertext2HandlesValidityProof {
             Y_0,

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -23,3 +23,21 @@ pub mod fee_proof;
 pub mod grouped_ciphertext_validity_proof;
 pub mod pubkey_proof;
 pub mod zero_balance_proof;
+
+#[cfg(not(target_os = "solana"))]
+use {crate::errors::ProofVerificationError, curve25519_dalek::scalar::Scalar};
+
+#[cfg(not(target_os = "solana"))]
+fn canonical_scalar_from_slice(bytes: &[u8]) -> Result<Scalar, ProofVerificationError> {
+    if bytes.len() != 32 {
+        return Err(ProofVerificationError::Deserialization);
+    }
+
+    let scalar_bytes = bytes[..32]
+        .try_into()
+        .map_err(|_| ProofVerificationError::Deserialization)?;
+
+    let scalar = Scalar::from_canonical_bytes(scalar_bytes)
+        .ok_or(ProofVerificationError::Deserialization)?;
+    Ok(scalar)
+}

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -5,9 +5,12 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::{
-        elgamal::{ElGamalKeypair, ElGamalPubkey},
-        pedersen::H,
+    crate::{
+        encryption::{
+            elgamal::{ElGamalKeypair, ElGamalPubkey},
+            pedersen::H,
+        },
+        sigma_proofs::canonical_scalar_from_slice,
     },
     rand::rngs::OsRng,
     zeroize::Zeroize,
@@ -126,12 +129,7 @@ impl PubkeyValidityProof {
         }
 
         let Y = CompressedRistretto::from_slice(&bytes[..32]);
-
-        let z_bytes = bytes[32..64]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z =
-            Scalar::from_canonical_bytes(z_bytes).ok_or(ProofVerificationError::Deserialization)?;
+        let z = canonical_scalar_from_slice(&bytes[32..64])?;
 
         Ok(PubkeyValidityProof { Y, z })
     }

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -11,6 +11,7 @@ use {
             pedersen::H,
         },
         errors::ProofVerificationError,
+        sigma_proofs::canonical_scalar_from_slice,
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -166,12 +167,7 @@ impl ZeroBalanceProof {
 
         let Y_P = CompressedRistretto::from_slice(&bytes[..32]);
         let Y_D = CompressedRistretto::from_slice(&bytes[32..64]);
-
-        let z_bytes = bytes[64..96]
-            .try_into()
-            .map_err(|_| ProofVerificationError::Deserialization)?;
-        let z =
-            Scalar::from_canonical_bytes(z_bytes).ok_or(ProofVerificationError::Deserialization)?;
+        let z = canonical_scalar_from_slice(&bytes[64..96])?;
 
         Ok(ZeroBalanceProof { Y_P, Y_D, z })
     }


### PR DESCRIPTION
#### Problem
`arrayref` is used throughout the `zk-token-sdk`. However, the need for `arrayref` should be largely obviated by `TryFrom<&[T]>` for `&[T; N]`.

Removing `arrayref` from `zk-token-sdk` has the following benefits:
- `arrayref` requires that we suppress `clippy::integer_arithmetic`. Unchecked Integer arithmetic should really be removed from `zk-token-sdk`, so removing `arrayref` is a necessary step.
- `arrayref` does not play nicely with constant variables and requires hard-coded constants. Hard-coded constants should be remioved from `zk-token-sdk`, so removing `arrayref` is a necessary step.
- We want to minimize dependencies in general

#### Summary of Changes
Removed `arrayref` from `zk-token-sdk` and replaced it with using `TryFrom<&[T]>` for `&[T; N]`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
