### PR TITLE
Patch ntapi to restore windows build

### DIFF
--- a/.github/workflows/release-artifacts-auto.yml
+++ b/.github/workflows/release-artifacts-auto.yml
@@ -3,7 +3,7 @@ name: release-artifacts-auto
 on:
   push:
     branches:
-      # - master
+      - master
       - v[0-9]+.[0-9]+
     tags:
       - v[0-9]+.[0-9]+.[0-9]+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,8 +3082,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 [[package]]
 name = "ntapi"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+source = "git+https://github.com/ryoqun/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,7 +3082,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 [[package]]
 name = "ntapi"
 version = "0.3.6"
-source = "git+https://github.com/ryoqun/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
+source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,7 +405,7 @@ zstd = "0.11.2"
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12
-ntapi = { git = "https://github.com/ryoqun/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,7 @@ zstd = "0.11.2"
 [patch.crates-io]
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+ntapi = { git = "https://github.com/ryoqun/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,8 @@ zstd = "0.11.2"
 [patch.crates-io]
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+# Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
+#   https://github.com/MSxDOS/ntapi/pull/12
 ntapi = { git = "https://github.com/ryoqun/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
 
 # We include the following crates as our dependencies above from crates.io:


### PR DESCRIPTION
#### Problem

It's been awhile we _temporarily_ stopped Windows build due to incompatibility between one of transitive deps (`ntapi`) and the solana monorepo's rust toolchain version (v1.69)....:

https://github.com/solana-labs/solana/pull/31353
https://github.com/solana-labs/solana/pull/31893

Unfortunately, it's not easy to update to `ntapi v0.4.x` (which contains a fix for the incompatibility), due to its being middle of our gigantic dep. graph (beneath our somewhat outdated `tokio`...). On top of ti, the crate maintainer hasn't been responsive with regard to backporting the fix into `v0.3.x`.

#### Summary of Changes

Patch `ntapi`: https://github.com/solana-labs/ntapi/commit/5980bbab2e0501a8100eb88c12222d664ccb3a0a : 

```
~/work/ntapi$ git diff --no-index /home/ryoqun/.cargo/registry/src/github.com-1ecc6299db9ec823/ntapi-0.3.6/src/ ./src/
diff --git a/home/ryoqun/.cargo/registry/src/github.com-1ecc6299db9ec823/ntapi-0.3.6/src/ntexapi.rs b/./src/ntexapi.rs
index 7d34220..72184bd 100644
--- a/home/ryoqun/.cargo/registry/src/github.com-1ecc6299db9ec823/ntapi-0.3.6/src/ntexapi.rs
+++ b/./src/ntexapi.rs
@@ -1,5 +1,7 @@
 #[allow(deprecated)] //fixme
 use core::mem::uninitialized;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use core::ptr::addr_of;
 use core::ptr::read_volatile;
 #[cfg(target_arch = "x86")]
 use core::sync::atomic::spin_loop_hint;
@@ -2782,7 +2784,7 @@ pub unsafe fn NtGetTickCount64() -> ULONGLONG {
     #[allow(deprecated)] //fixme
     let mut tick_count: ULARGE_INTEGER = uninitialized();
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        *tick_count.QuadPart_mut() = read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad);
+        *tick_count.QuadPart_mut() = read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad));
     }
     #[cfg(target_arch = "x86")] {
         loop {
@@ -2806,7 +2808,7 @@ pub unsafe fn NtGetTickCount64() -> ULONGLONG {
 #[inline]
 pub unsafe fn NtGetTickCount() -> ULONG {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        ((read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad)
+        ((read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad))
             * (*USER_SHARED_DATA).TickCountMultiplier as u64) >> 24) as u32
     }
     #[cfg(target_arch = "x86")] {



~/work/ntapi$ git log -n 2
commit 5980bbab2e0501a8100eb88c12222d664ccb3a0a (HEAD -> master, solana-labs/v0.3.6-for-rust-1.69, ryoqun/v0.3.6-for-rust-1.69)
Author: 包布丁 <htbai1998m@hotmail.com>
Date:   Sat Sep 24 04:26:08 2022 +0800

    Fix temporary references for volatile read (#12)

    * Bump Rust toolchain version for CI to 1.64

    * Fix temporary references for volatile read

commit cbea31ea9d624169f01ae0997e6698baceb51867
Author: MSxDOS <15524350+MSxDOS@users.noreply.github.com>
Date:   Fri Oct 23 17:08:17 2020 +0300

    Release 0.3.6



~/work/ntapi$ cat /home/ryoqun/.cargo/registry/src/github.com-1ecc6299db9ec823/ntapi-0.3.6/.cargo_vcs_info.json
{ 
  "git": {
    "sha1": "cbea31ea9d624169f01ae0997e6698baceb51867"
  }
}
```

the cherry-picked commit is quite small; so it's low risk. also, carrying the patch won't cause much trouble because the upstream crate is itself kind of being unmaintained...

all in all, i think this is win for restoring window build to detect any build issue on Windows as soon as possible. Also, Windows' solana v1.16.x binaries will be again available.

the build fix is confirmed at my fork:

https://github.com/ryoqun/solana/actions/runs/5172165189/jobs/9316255905#step:4:655 :

```
    Checking tinyvec_macros v0.1.0
    Checking tinyvec v1.5.0
    Checking zeroize v1.3.0
   Compiling ntapi v0.3.6 (https://github.com/ryoqun/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab)
    Checking parking_lot v0.11.2
    Checking aho-corasick v0.7.18
    Checking regex-syntax v0.6.27
```