### PR TITLE
Send messages to EntryNotifierService in Tpu, simpler

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,6 +74,7 @@ mod tower1_14_11;
 mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;
+mod tpu_entry_notifier;
 pub mod tracer_packet_stats;
 pub mod tree_diff;
 pub mod tvu;

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -58,7 +58,7 @@ impl TpuEntryNotifier {
     ) -> Result<(), RecvTimeoutError> {
         let (bank, (entry, tick_height)) = entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
-        let index = if slot > *current_slot {
+        let index = if slot != *current_slot {
             *current_index = 0;
             *current_slot = slot;
             0

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,0 +1,82 @@
+use {
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    solana_entry::entry::EntrySummary,
+    solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
+    solana_poh::poh_recorder::WorkingBankEntry,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::Duration,
+    },
+};
+
+pub(crate) struct TpuEntryNotifier {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl TpuEntryNotifier {
+    pub(crate) fn new(
+        receiver: Receiver<WorkingBankEntry>,
+        entry_notification_sender: EntryNotifierSender,
+        broadcast_entry_sender: Sender<WorkingBankEntry>,
+        exit: Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let thread_hdl = Builder::new()
+            .name("solTpuEntry".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if let Err(RecvTimeoutError::Disconnected) = Self::send_entry_notification(
+                    &receiver,
+                    &entry_notification_sender,
+                    &broadcast_entry_sender,
+                ) {
+                    break;
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    pub(crate) fn send_entry_notification(
+        receiver: &Receiver<WorkingBankEntry>,
+        entry_notification_sender: &EntryNotifierSender,
+        broadcast_entry_sender: &Sender<WorkingBankEntry>,
+    ) -> Result<(), RecvTimeoutError> {
+        let (bank, (entry, tick_height)) = receiver.recv_timeout(Duration::from_secs(1))?;
+        let slot = bank.slot();
+        let index = 0;
+
+        let entry_summary = EntrySummary {
+            num_hashes: entry.num_hashes,
+            hash: entry.hash,
+            num_transactions: entry.transactions.len() as u64,
+        };
+        if let Err(err) = entry_notification_sender.send(EntryNotification {
+            slot,
+            index,
+            entry: entry_summary,
+        }) {
+            warn!(
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to EntryNotifierService, error {err:?}",
+            );
+        }
+
+        if let Err(err) = broadcast_entry_sender.send((bank, (entry, tick_height))) {
+            warn!(
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to BroadcastStage, error {err:?}",
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -19,12 +19,11 @@ pub(crate) struct TpuEntryNotifier {
 
 impl TpuEntryNotifier {
     pub(crate) fn new(
-        receiver: Receiver<WorkingBankEntry>,
+        entry_receiver: Receiver<WorkingBankEntry>,
         entry_notification_sender: EntryNotifierSender,
         broadcast_entry_sender: Sender<WorkingBankEntry>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let exit = exit.clone();
         let thread_hdl = Builder::new()
             .name("solTpuEntry".to_string())
             .spawn(move || loop {
@@ -33,7 +32,7 @@ impl TpuEntryNotifier {
                 }
 
                 if let Err(RecvTimeoutError::Disconnected) = Self::send_entry_notification(
-                    &receiver,
+                    &entry_receiver,
                     &entry_notification_sender,
                     &broadcast_entry_sender,
                 ) {
@@ -45,11 +44,11 @@ impl TpuEntryNotifier {
     }
 
     pub(crate) fn send_entry_notification(
-        receiver: &Receiver<WorkingBankEntry>,
+        entry_receiver: &Receiver<WorkingBankEntry>,
         entry_notification_sender: &EntryNotifierSender,
         broadcast_entry_sender: &Sender<WorkingBankEntry>,
     ) -> Result<(), RecvTimeoutError> {
-        let (bank, (entry, tick_height)) = receiver.recv_timeout(Duration::from_secs(1))?;
+        let (bank, (entry, tick_height)) = entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
         let index = 0;
 


### PR DESCRIPTION
#### Problem
An alternative to #31889

https://github.com/solana-labs/solana/pull/31290 adds an entry notification service, which is currently only fed from the Tvu pipeline. But leaders should also support geyser entry notifications -- this is especially useful for testing plugins on solana-test-validator, since the TestValidator is the leader for every slot.

#### Summary of Changes
Adds a little service to sit between PohRecorder and BroadcastStage in the Tpu pipeline. If geyser entry notifications are supported, the entry summary information is copied from the message and sent to the entry notification service. All entries are passed through unchanged to the BroadcastStage receiver.

Differs from #31889 in that entry indexes are tracked in the TpuEntryNotifier instead of PohRecorder.

Closes #31889
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
