### PR TITLE
Patch ntapi more thoroughly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,7 @@ zstd = "0.11.2"
 [patch.crates-io]
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12
 ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2825,9 +2825,8 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+version = "0.3.6"
+source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -160,6 +160,10 @@ members = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [patch.crates-io]
+# Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
+#   https://github.com/MSxDOS/ntapi/pull/12
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
+
 # We include the following crates as our dependencies from crates.io:
 #
 #  * spl-associated-token-account

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -142,8 +142,12 @@ mkdir -p "$installDir/bin"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
+    # the config is work around until we ship newer spl-token-cli...
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
+    "$cargo" $maybeRustVersion \
+      --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
+      --config 'patch.crates-io.ntapi.rev="5980bbab2e0501a8100eb88c12222d664ccb3a0a"' \
+      install --locked spl-token-cli --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
#### Problem

We needed more tender and loving care for patching `ntapi`, still breaking windows build after #31961 

#### Summary of Changes

patch moar!

(i'll create a proper pr at the spl-token repo...)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
