### PR TITLE
Remove --locked for cli-arg based patch...

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -142,12 +142,12 @@ mkdir -p "$installDir/bin"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
-    # the config is work around until we ship newer spl-token-cli...
+    # the config is work around and --locked is removed until we ship newer spl-token-cli...
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
     "$cargo" $maybeRustVersion \
       --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
       --config 'patch.crates-io.ntapi.rev="5980bbab2e0501a8100eb88c12222d664ccb3a0a"' \
-      install --locked spl-token-cli --root "$installDir"
+      install spl-token-cli --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
#### Problem

I'm a bad guy who is testing in the production environment (of ci).

https://github.com/solana-labs/solana/actions/runs/5177053842/jobs/9326670925#step:6:2691

T_T

```
Updating git repository `https://github.com/solana-labs/ntapi`
warning: Patch `ntapi v0.3.6 (https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
warning: package `h2 v0.3.17` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
    Updating git repository `[https://github.com/solana-labs/ntapi`](https://github.com/solana-labs/ntapi%60)
warning: Patch `ntapi v0.3.6 (https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
 Downloading crates ...
  Downloaded alloc-no-stdlib v2.0.4
  Downloaded libc v0.2.141
```

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
