### PR TITLE
split TransactionCost to its own module

### DIFF
--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -7,10 +7,7 @@ use {
     crate::banking_stage::{committer::CommitTransactionDetails, BatchedTransactionDetails},
     crossbeam_channel::{unbounded, Receiver, Sender},
     solana_measure::measure::Measure,
-    solana_runtime::{
-        bank::Bank,
-        cost_model::{CostModel, TransactionCost},
-    },
+    solana_runtime::{bank::Bank, cost_model::CostModel, transaction_cost::TransactionCost},
     solana_sdk::{
         clock::Slot,
         feature_set::FeatureSet,

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -6,7 +6,7 @@
 //!
 
 use {
-    crate::block_cost_limits::*,
+    crate::{block_cost_limits::*, transaction_cost::TransactionCost},
     log::*,
     solana_program_runtime::compute_budget::{
         ComputeBudget, DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
@@ -25,84 +25,6 @@ use {
     },
 };
 
-const MAX_WRITABLE_ACCOUNTS: usize = 256;
-
-// costs are stored in number of 'compute unit's
-#[derive(Debug)]
-pub struct TransactionCost {
-    pub writable_accounts: Vec<Pubkey>,
-    pub signature_cost: u64,
-    pub write_lock_cost: u64,
-    pub data_bytes_cost: u64,
-    pub builtins_execution_cost: u64,
-    pub bpf_execution_cost: u64,
-    pub account_data_size: u64,
-    pub is_simple_vote: bool,
-}
-
-impl Default for TransactionCost {
-    fn default() -> Self {
-        Self {
-            writable_accounts: Vec::with_capacity(MAX_WRITABLE_ACCOUNTS),
-            signature_cost: 0u64,
-            write_lock_cost: 0u64,
-            data_bytes_cost: 0u64,
-            builtins_execution_cost: 0u64,
-            bpf_execution_cost: 0u64,
-            account_data_size: 0u64,
-            is_simple_vote: false,
-        }
-    }
-}
-
-#[cfg(test)]
-impl PartialEq for TransactionCost {
-    fn eq(&self, other: &Self) -> bool {
-        fn to_hash_set(v: &[Pubkey]) -> std::collections::HashSet<&Pubkey> {
-            v.iter().collect()
-        }
-
-        self.signature_cost == other.signature_cost
-            && self.write_lock_cost == other.write_lock_cost
-            && self.data_bytes_cost == other.data_bytes_cost
-            && self.builtins_execution_cost == other.builtins_execution_cost
-            && self.bpf_execution_cost == other.bpf_execution_cost
-            && self.account_data_size == other.account_data_size
-            && self.is_simple_vote == other.is_simple_vote
-            && to_hash_set(&self.writable_accounts) == to_hash_set(&other.writable_accounts)
-    }
-}
-
-#[cfg(test)]
-impl Eq for TransactionCost {}
-
-impl TransactionCost {
-    pub fn new_with_capacity(capacity: usize) -> Self {
-        Self {
-            writable_accounts: Vec::with_capacity(capacity),
-            ..Self::default()
-        }
-    }
-
-    pub fn reset(&mut self) {
-        self.writable_accounts.clear();
-        self.signature_cost = 0;
-        self.write_lock_cost = 0;
-        self.data_bytes_cost = 0;
-        self.builtins_execution_cost = 0;
-        self.bpf_execution_cost = 0;
-        self.is_simple_vote = false;
-    }
-
-    pub fn sum(&self) -> u64 {
-        self.signature_cost
-            .saturating_add(self.write_lock_cost)
-            .saturating_add(self.data_bytes_cost)
-            .saturating_add(self.builtins_execution_cost)
-            .saturating_add(self.bpf_execution_cost)
-    }
-}
-
 pub struct CostModel;
 
 impl CostModel {
@@ -110,7 +32,7 @@ impl CostModel {
         transaction: &SanitizedTransaction,
         feature_set: &FeatureSet,
     ) -> TransactionCost {
-        let mut tx_cost = TransactionCost::new_with_capacity(MAX_WRITABLE_ACCOUNTS);
+        let mut tx_cost = TransactionCost::default();
 
         tx_cost.signature_cost = Self::get_signature_cost(transaction);
         Self::get_write_lock_cost(&mut tx_cost, transaction);

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -4,7 +4,7 @@
 //! - add_transaction_cost(&tx_cost), mutable function to accumulate tx_cost to tracker.
 //!
 use {
-    crate::{block_cost_limits::*, cost_model::TransactionCost},
+    crate::{block_cost_limits::*, transaction_cost::TransactionCost},
     solana_sdk::{
         clock::Slot, pubkey::Pubkey, saturating_add_assign, transaction::TransactionError,
     },

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -78,6 +78,7 @@ pub mod status_cache;
 mod storable_accounts;
 pub mod tiered_storage;
 pub mod transaction_batch;
+pub mod transaction_cost;
 pub mod transaction_error_metrics;
 pub mod transaction_priority_details;
 mod verify_accounts_hash_in_background;

--- a/runtime/src/transaction_cost.rs
+++ b/runtime/src/transaction_cost.rs
@@ -1,0 +1,79 @@
+use solana_sdk::pubkey::Pubkey;
+
+const MAX_WRITABLE_ACCOUNTS: usize = 256;
+
+// costs are stored in number of 'compute unit's
+#[derive(Debug)]
+pub struct TransactionCost {
+    pub writable_accounts: Vec<Pubkey>,
+    pub signature_cost: u64,
+    pub write_lock_cost: u64,
+    pub data_bytes_cost: u64,
+    pub builtins_execution_cost: u64,
+    pub bpf_execution_cost: u64,
+    pub account_data_size: u64,
+    pub is_simple_vote: bool,
+}
+
+impl Default for TransactionCost {
+    fn default() -> Self {
+        Self {
+            writable_accounts: Vec::with_capacity(MAX_WRITABLE_ACCOUNTS),
+            signature_cost: 0u64,
+            write_lock_cost: 0u64,
+            data_bytes_cost: 0u64,
+            builtins_execution_cost: 0u64,
+            bpf_execution_cost: 0u64,
+            account_data_size: 0u64,
+            is_simple_vote: false,
+        }
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for TransactionCost {
+    fn eq(&self, other: &Self) -> bool {
+        fn to_hash_set(v: &[Pubkey]) -> std::collections::HashSet<&Pubkey> {
+            v.iter().collect()
+        }
+
+        self.signature_cost == other.signature_cost
+            && self.write_lock_cost == other.write_lock_cost
+            && self.data_bytes_cost == other.data_bytes_cost
+            && self.builtins_execution_cost == other.builtins_execution_cost
+            && self.bpf_execution_cost == other.bpf_execution_cost
+            && self.account_data_size == other.account_data_size
+            && self.is_simple_vote == other.is_simple_vote
+            && to_hash_set(&self.writable_accounts) == to_hash_set(&other.writable_accounts)
+    }
+}
+
+#[cfg(test)]
+impl Eq for TransactionCost {}
+
+impl TransactionCost {
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        Self {
+            writable_accounts: Vec::with_capacity(capacity),
+            ..Self::default()
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.writable_accounts.clear();
+        self.signature_cost = 0;
+        self.write_lock_cost = 0;
+        self.data_bytes_cost = 0;
+        self.builtins_execution_cost = 0;
+        self.bpf_execution_cost = 0;
+        self.is_simple_vote = false;
+    }
+
+    pub fn sum(&self) -> u64 {
+        self.signature_cost
+            .saturating_add(self.write_lock_cost)
+            .saturating_add(self.data_bytes_cost)
+            .saturating_add(self.builtins_execution_cost)
+            .saturating_add(self.bpf_execution_cost)
+    }
+}


### PR DESCRIPTION
#### Problem
`CostTracker` depends on `CostModel` only to access `TransactionCost`, this dependency is unnecessary cause `CostTracker` is entirely independent from `CostModel`. 

#### Summary of Changes
- split `TransactionCost` to its own module

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
