### PR TITLE
Fix panic in record()

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -183,10 +183,10 @@ impl TransactionRecorder {
                         starting_transaction_index: None,
                     };
                 }
-                Err(PohRecorderError::SendError(_)) => {
+                Err(PohRecorderError::SendError(e)) => {
                     return RecordTransactionsSummary {
                         record_transactions_timings,
-                        result: Err(PohRecorderError::MaxHeightReached),
+                        result: Err(PohRecorderError::SendError(e)),
                         starting_transaction_index: None,
                     };
                 }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -183,6 +183,13 @@ impl TransactionRecorder {
                         starting_transaction_index: None,
                     };
                 }
+                Err(PohRecorderError::SendError(_)) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecorderError::MaxHeightReached),
+                        starting_transaction_index: None,
+                    };
+                }
                 Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
             }
         }


### PR DESCRIPTION
#### Problem
`record()` called from BankingStage panics on potential `SendError`'s bubbled up on send in `PohRecorder::record()` between `PohService` and `BankingStage`

#### Summary of Changes
Return `MaxHeightReached` instead of panicking because `BroadcastStage` has exited and all further record will fail. BankingStage will then exit on the next iteration of fetch from `Sigverify` because that channel will be disconnected as well because the `exit` flag is set

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
