### PR TITLE
Bump patched ntapi from v0.3.6 to v0.3.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,8 +3081,8 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
-source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
+version = "0.3.7"
+source = "git+https://github.com/solana-labs/ntapi?rev=97ede981a1777883ff86d142b75024b023f04fad#97ede981a1777883ff86d142b75024b023f04fad"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,7 @@ crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd2
 
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12
-ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "97ede981a1777883ff86d142b75024b023f04fad" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2825,8 +2825,8 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
-source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
+version = "0.3.7"
+source = "git+https://github.com/solana-labs/ntapi?rev=97ede981a1777883ff86d142b75024b023f04fad#97ede981a1777883ff86d142b75024b023f04fad"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -162,7 +162,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [patch.crates-io]
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12
-ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "97ede981a1777883ff86d142b75024b023f04fad" }
 
 # We include the following crates as our dependencies from crates.io:
 #

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -142,12 +142,12 @@ mkdir -p "$installDir/bin"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
-    # the config is work around and --locked is removed until we ship newer spl-token-cli...
+    # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
     "$cargo" $maybeRustVersion \
       --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
-      --config 'patch.crates-io.ntapi.rev="5980bbab2e0501a8100eb88c12222d664ccb3a0a"' \
-      install spl-token-cli --root "$installDir"
+      --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
+      install --locked spl-token-cli --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
#### Problem

the solana git _repo_ and published spl _crate_ are using different versions of `ntapi`, which is troubling consistent `[patch]`-ing. the repo had been pinning to v0.3.6 via Cargo.locked. but the published spl _crate_ is specifying `v0.3.x` and resolved to latest one: `v0.3.7`

#### Summary of Changes

Just use same version, restoring `--locked`.

so, this effectively bumps monorepo's ntapi from v0.3.6 to v0.3.7, which seems to contain only small changes:

https://github.com/MSxDOS/ntapi/compare/cbea31ea9d624169f01ae0997e6698baceb51867...3a0063ad916e5f0c6972ab53e025689b9f0f92ad according to:

```
$ git diff --no-index ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.{6,7}/.cargo_vcs_info.json
diff --git a/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.6/.cargo_vcs_info.json b/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.7/.cargo_vcs_info.json
index 8ae34a3dff4..d974c8a1461 100644
--- a/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.6/.cargo_vcs_info.json
+++ b/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.7/.cargo_vcs_info.json
@@ -1,5 +1,6 @@
 {
   "git": {
-    "sha1": "cbea31ea9d624169f01ae0997e6698baceb51867"
-  }
-}
+    "sha1": "3a0063ad916e5f0c6972ab53e025689b9f0f92ad"
+  },
+  "path_in_vcs": ""
+}
\ No newline at end of file

```

new patch commit: https://github.com/solana-labs/ntapi/commit/97ede981a1777883ff86d142b75024b023f04fad :

```
$ git diff --no-index ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.7/src/ ./src/
diff --git a/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.7/src/ntexapi.rs b/./src/ntexapi.rs
index 5fa47c9..d48749d 100644
--- a/home/ryoqun/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntapi-0.3.7/src/ntexapi.rs
+++ b/./src/ntexapi.rs
@@ -1,4 +1,6 @@
 use core::mem::uninitialized;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use core::ptr::addr_of;
 use core::ptr::read_volatile;
 #[cfg(target_arch = "x86")]
 use core::sync::atomic::spin_loop_hint;
@@ -2780,7 +2782,7 @@ pub const USER_SHARED_DATA: *const KUSER_SHARED_DATA = 0x7ffe0000 as *const _;
 pub unsafe fn NtGetTickCount64() -> ULONGLONG {
     let mut tick_count: ULARGE_INTEGER = uninitialized();
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        *tick_count.QuadPart_mut() = read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad);
+        *tick_count.QuadPart_mut() = read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad));
     }
     #[cfg(target_arch = "x86")] {
         loop {
@@ -2804,7 +2806,7 @@ pub unsafe fn NtGetTickCount64() -> ULONGLONG {
 #[inline]
 pub unsafe fn NtGetTickCount() -> ULONG {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        ((read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad)
+        ((read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad))
             * (*USER_SHARED_DATA).TickCountMultiplier as u64) >> 24) as u32
     }
     #[cfg(target_arch = "x86")] {

```

so, hopefully, this marks the end of window build restoration journey... this and all previous prs will be backported as-is.