### PR TITLE
Reduce reliance on `getHealth`

### DIFF
--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -58,72 +58,7 @@ impl RpcHealth {
             return RpcHealthStatus::Unknown;
         }
 
-        if self.override_health_check.load(Ordering::Relaxed) {
-            RpcHealthStatus::Ok
-        } else if let Some(known_validators) = &self.known_validators {
-            match (
-                self.cluster_info
-                    .get_accounts_hash_for_node(&self.cluster_info.id(), |hashes| {
-                        hashes
-                            .iter()
-                            .max_by(|a, b| a.0.cmp(&b.0))
-                            .map(|slot_hash| slot_hash.0)
-                    })
-                    .flatten(),
-                known_validators
-                    .iter()
-                    .filter_map(|known_validator| {
-                        self.cluster_info
-                            .get_accounts_hash_for_node(known_validator, |hashes| {
-                                hashes
-                                    .iter()
-                                    .max_by(|a, b| a.0.cmp(&b.0))
-                                    .map(|slot_hash| slot_hash.0)
-                            })
-                            .flatten()
-                    })
-                    .max(),
-            ) {
-                (
-                    Some(latest_account_hash_slot),
-                    Some(latest_known_validator_account_hash_slot),
-                ) => {
-                    // The validator is considered healthy if its latest account hash slot is within
-                    // `health_check_slot_distance` of the latest known validator's account hash slot
-                    if latest_account_hash_slot
-                        > latest_known_validator_account_hash_slot
-                            .saturating_sub(self.health_check_slot_distance)
-                    {
-                        RpcHealthStatus::Ok
-                    } else {
-                        let num_slots = latest_known_validator_account_hash_slot
-                            .saturating_sub(latest_account_hash_slot);
-                        warn!(
-                            "health check: behind by {} slots: me={}, latest known_validator={}",
-                            num_slots,
-                            latest_account_hash_slot,
-                            latest_known_validator_account_hash_slot
-                        );
-                        RpcHealthStatus::Behind { num_slots }
-                    }
-                }
-                (latest_account_hash_slot, latest_known_validator_account_hash_slot) => {
-                    if latest_account_hash_slot.is_none() {
-                        warn!("health check: latest_account_hash_slot not available");
-                    }
-                    if latest_known_validator_account_hash_slot.is_none() {
-                        warn!(
-                            "health check: latest_known_validator_account_hash_slot not available"
-                        );
-                    }
-                    RpcHealthStatus::Unknown
-                }
-            }
-        } else {
-            // No known validator point of reference available, so this validator is healthy
-            // because it's running
-            RpcHealthStatus::Ok
-        }
+        RpcHealthStatus::Ok
     }
 
     #[cfg(test)]


### PR DESCRIPTION
The RPC `getHealth` method is quite arbitrary, and doesn't do a good job reflecting the health of a node. Its use should be discouraged.

* If a node has no known validators, it'll always report healthy
* If a node's accounts hash interval is larger than `health_check_slot_distance`, it'll mostly report unhealthy
* If the known validators accounts hash interval is larger than `health_check_slot_distance`, it'll mostly report unhealthy
* If a node is keeping up with transaction processing but the background AccountsHashVerifier is dropped some accounts hash verifier request, the node may report unhealthy