### PR TITLE
Downgrades log to debug if reading bank snapshot from dir fails

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -861,7 +861,7 @@ pub fn get_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) -> Vec<BankSnaps
             .for_each(
                 |slot| match BankSnapshotInfo::new_from_dir(&bank_snapshots_dir, slot) {
                     Ok(snapshot_info) => bank_snapshots.push(snapshot_info),
-                    Err(err) => warn!("Unable to read bank snapshot for slot {slot}: {err}"),
+                    Err(err) => debug!("Unable to read bank snapshot for slot {slot}: {err}"),
                 },
             ),
     }


### PR DESCRIPTION
#### Problem

Bank snapshots are purged in a different thread than where they are created, so there's a possibility for erroneous log messages to be emitted. (Testnet validators [reported in Discord](https://discord.com/channels/428295358100013066/670512312339398668/1113934201759211541).)

Specifically on v1.16.0, in SnapshotPackagerService after is creates a snapshot archive, it purges old bank snapshots. The code to purge old bank snapshots will read the existing bank snapshots to populate a list to purge. Simultaneously, AccountsBackgroundService may be creating a bank snapshot. If the times are just right, SPS will see the partial new bank snapshot and log an error saying that the bank snapshot could not be read. This is totally fine and not an issue.

Ultimately, I don't think we should surface any visible log to the user. This is how `get_bank_snapshot()` used to work before v1.16 too. We've added cleanup logic at boot that will purge incomplete/old snapshots, so that will not be an issue here during normal steady state runtime.

In master, I previously downgraded the `error!` to a `warn!` (https://github.com/solana-labs/solana/pull/31885) so that tests were less noisy. I think we need to fix this for v1.16, thus we should either remove the log entirely or lower its level so its not seen by default.


#### Summary of Changes

Downgrade log to `debug!`.