### PR TITLE
Add runtime environment to FailedVerification tombstones

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -545,7 +545,13 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             debug!("Failed to load program {}, error {:?}", key, err);
             Arc::new(LoadedProgram::new_tombstone(
                 0,
-                LoadedProgramType::FailedVerification,
+                LoadedProgramType::FailedVerification(
+                    bank.loaded_programs_cache
+                        .read()
+                        .unwrap()
+                        .program_runtime_environment_v1
+                        .clone(),
+                ),
             ))
         });
         debug!("Loaded program {}", key);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -57,9 +57,11 @@ pub trait WorkingSlot {
     fn is_ancestor(&self, other: Slot) -> bool;
 }
 
+#[derive(Default)]
 pub enum LoadedProgramType {
     /// Tombstone for undeployed, closed or unloadable programs
     FailedVerification(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    #[default]
     Closed,
     DelayVisibility,
     /// Successfully verified but not currently compiled, used to track usage statistics when a compiled program is evicted from memory.
@@ -91,7 +93,7 @@ impl Debug for LoadedProgramType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LoadedProgram {
     /// The program of this entry
     pub program: LoadedProgramType,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -498,6 +498,7 @@ impl LoadedPrograms {
                         true
                     }
                     LoadedProgramType::Unloaded(environment)
+                    | LoadedProgramType::FailedVerification(environment)
                         if Arc::ptr_eq(environment, &self.program_runtime_environment_v1) =>
                     {
                         true

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -488,7 +488,9 @@ impl LoadedPrograms {
         for second_level in self.entries.values_mut() {
             second_level.retain(|entry| {
                 let retain = match &entry.program {
-                    LoadedProgramType::Builtin(_) | LoadedProgramType::Closed => true,
+                    LoadedProgramType::Builtin(_)
+                    | LoadedProgramType::DelayVisibility
+                    | LoadedProgramType::Closed => true,
                     LoadedProgramType::LegacyV0(program) | LoadedProgramType::LegacyV1(program)
                         if Arc::ptr_eq(
                             program.get_loader(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -570,7 +570,7 @@ fn process_instruction_inner(
 
     executor.ix_usage_counter.fetch_add(1, Ordering::Relaxed);
     match &executor.program {
-        LoadedProgramType::FailedVerification
+        LoadedProgramType::FailedVerification(_)
         | LoadedProgramType::Closed
         | LoadedProgramType::DelayVisibility => {
             Err(Box::new(InstructionError::InvalidAccountData) as Box<dyn std::error::Error>)

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -612,7 +612,7 @@ pub fn process_instruction_inner(
             .ix_usage_counter
             .fetch_add(1, Ordering::Relaxed);
         match &loaded_program.program {
-            LoadedProgramType::FailedVerification
+            LoadedProgramType::FailedVerification(_)
             | LoadedProgramType::Closed
             | LoadedProgramType::DelayVisibility => {
                 Err(Box::new(InstructionError::InvalidAccountData) as Box<dyn std::error::Error>)

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -298,7 +298,7 @@ impl Accounts {
     ) -> Result<AccountSharedData> {
         // Check for tombstone
         let result = match &program.program {
-            LoadedProgramType::FailedVerification | LoadedProgramType::Closed => {
+            LoadedProgramType::FailedVerification(_) | LoadedProgramType::Closed => {
                 Err(TransactionError::InvalidProgramForExecution)
             }
             LoadedProgramType::DelayVisibility => {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4450,7 +4450,13 @@ impl Bank {
                     debug!("Failed to load program {}, error {:?}", key, err);
                     Arc::new(LoadedProgram::new_tombstone(
                         self.slot,
-                        LoadedProgramType::FailedVerification,
+                        LoadedProgramType::FailedVerification(
+                            self.loaded_programs_cache
+                                .read()
+                                .unwrap()
+                                .program_runtime_environment_v1
+                                .clone(),
+                        ),
                     ))
                 });
                 program.tx_usage_counter.store(*count, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
The programs that failed verification could succeed after a certain runtime feature has been activated. Currently, cache does not store the runtime environment that was used when the program failed to verify/compile. It's needed to check if the re-verification should be triggered for the failed program. 

#### Summary of Changes
Retain environment for FailedVerification tombstones.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
