### PR TITLE
Removes init-time cleanup in add_bank_snapshot()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1246,32 +1246,12 @@ pub fn add_bank_snapshot(
 ) -> Result<BankSnapshotInfo> {
     let mut add_snapshot_time = Measure::start("add-snapshot-ms");
     let slot = bank.slot();
-    // bank_snapshots_dir/slot
     let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
-    if bank_snapshot_dir.is_dir() {
-        // There is a time window from when a snapshot directory is created to when its content
-        // is fully filled to become a full state good to construct a bank from.  At the init time,
-        // the system may not be booted from the latest snapshot directory, but an older and complete
-        // directory.  Then, when adding new snapshots, the newer incomplete snapshot directory could
-        // be found.  If so, it should be removed.
-        purge_bank_snapshot(&bank_snapshot_dir)?;
-    } else {
-        // Even the snapshot directory is not found, still ensure the account snapshot directory
-        // is also clean.  hardlink failure will happen if an old file exists.
-        let account_paths = &bank.accounts().accounts_db.paths;
-        let slot_str = slot.to_string();
-        for account_path in account_paths {
-            let account_snapshot_path = account_path
-                .parent()
-                .ok_or(SnapshotError::InvalidAccountPath(account_path.clone()))?
-                .join("snapshot")
-                .join(&slot_str);
-            if account_snapshot_path.is_dir() {
-                // remove the account snapshot directory
-                move_and_async_delete_path(&account_snapshot_path);
-            }
-        }
-    }
+    assert!(
+        !bank_snapshot_dir.exists(),
+        "A bank snapshot already exists for slot {slot}!? Path: {}",
+        bank_snapshot_dir.display()
+    );
     fs::create_dir_all(&bank_snapshot_dir)?;
 
     // the bank snapshot is stored as bank_snapshots_dir/slot/slot.BANK_SNAPSHOT_PRE_FILENAME_EXTENSION
@@ -1287,7 +1267,7 @@ pub fn add_bank_snapshot(
 
     // We are constructing the snapshot directory to contain the full snapshot state information to allow
     // constructing a bank from this directory.  It acts like an archive to include the full state.
-    // The set of the account appendvec files is the necessary part of this snapshot state.  Hard-link them
+    // The set of the account storages files is the necessary part of this snapshot state.  Hard-link them
     // from the operational accounts/ directory to here.
     hard_link_storages_to_snapshot(&bank_snapshot_dir, slot, snapshot_storages)?;
 


### PR DESCRIPTION
#### Problem

`add_bank_snapshot()` is performing cleanup tasks that should only happen once at initialization time. This masks real problems if we fail to cleanup at startup. (It also makes the `add_bank_snapshot()` code a bit slower and more cumbersome to deal with.)

Since we call `purge_incomplete_bank_snapshots()`, `purge_old_bank_snapshots_at_startup()`, and `clean_orphaned_account_snapshot_dirs()` at boot, there will not be any leftover bad bank snapshots nor orphaned accounts/snapshot/ dirs. And if there are, it's a bug to be fixed at boot, not here.


#### Summary of Changes

Removes cleanup within `add_bank_snapshot()`.