### PR TITLE
move StakeReward to stake_rewards.rs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -71,6 +71,7 @@ use {
         sorted_storages::SortedStorages,
         stake_account::{self, StakeAccount},
         stake_history::StakeHistory,
+        stake_rewards::StakeReward,
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -1128,19 +1129,6 @@ pub struct CommitTransactionCounts {
     pub committed_non_vote_transactions_count: u64,
     pub committed_with_failure_result_count: u64,
     pub signature_count: u64,
-}
-
-#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub(crate) struct StakeReward {
-    stake_pubkey: Pubkey,
-    stake_reward_info: RewardInfo,
-    stake_account: AccountSharedData,
-}
-
-impl StakeReward {
-    fn get_stake_reward(&self) -> i64 {
-        self.stake_reward_info.lamports
-    }
 }
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,6 +71,7 @@ pub mod snapshot_utils;
 pub mod sorted_storages;
 mod stake_account;
 pub mod stake_history;
+mod stake_rewards;
 pub mod stake_weighted_timestamp;
 pub mod stakes;
 pub mod static_ids;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -719,7 +719,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "9BucA5MtPMNNUjADyV27vNgzvDy1RqCLH2gRq5NEuDEF")]
+    #[frozen_abi(digest = "8LhKH71kTwmagxUGJA6Es58p8fejJsSAdgEmtL3xZdoY")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/stake_rewards.rs
+++ b/runtime/src/stake_rewards.rs
@@ -1,0 +1,19 @@
+//! Code for stake and vote rewards
+
+use {
+    crate::bank::RewardInfo,
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+};
+
+#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub(crate) struct StakeReward {
+    pub(crate) stake_pubkey: Pubkey,
+    pub(crate) stake_reward_info: RewardInfo,
+    pub(crate) stake_account: AccountSharedData,
+}
+
+impl StakeReward {
+    pub(crate) fn get_stake_reward(&self) -> i64 {
+        self.stake_reward_info.lamports
+    }
+}


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

#### Summary of Changes
Move `StakeReward` to its own file for later use and to simplify `bank.rs`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->