### PR TITLE
print a useful error message if we fail to async remove path

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -512,7 +512,9 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path>) {
     Builder::new()
         .name("solDeletePath".to_string())
         .spawn(move || {
-            std::fs::remove_dir_all(path_delete).unwrap();
+            if let Err(err) = std::fs::remove_dir_all(&path_delete) {
+                panic!("Failed to remove path {}: {}", path_delete.display(), err);
+            }
         })
         .unwrap();
 }


### PR DESCRIPTION
#### Problem
We've seen several panics at this spot, but the error message via unwrap gives no useful information.

#### Summary of Changes
Panic with the path and error

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
