### PR TITLE
Revert "EpochAccountsHash tests no longer ignore shutdown errors (#31883)"

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -237,16 +237,11 @@ impl Drop for BackgroundServices {
         info!("Stopping background services...");
         self.exit.store(true, Ordering::Relaxed);
 
+        // Join the background threads, and ignore any errors.
         // SAFETY: We do not use any of the `ManuallyDrop` fields again, so `.take()` is OK here.
-        unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }
-            .join()
-            .expect("stop AccountsBackgroundService");
-        unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }
-            .join()
-            .expect("stop AccountsHashVerifier");
-        unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }
-            .join()
-            .expect("stop SnapshotPackagerService");
+        _ = unsafe { ManuallyDrop::take(&mut self.accounts_background_service) }.join();
+        _ = unsafe { ManuallyDrop::take(&mut self.accounts_hash_verifier) }.join();
+        _ = unsafe { ManuallyDrop::take(&mut self.snapshot_packager_service) }.join();
 
         info!("Stopping background services... DONE");
     }


### PR DESCRIPTION
#### Problem

Welp, turns out I was wrong with #31883... CI just panicked while stopping the background services in the EpochAccountsHash tests. 

https://buildkite.com/solana-labs/solana/builds/97076#01889755-9fc8-44b6-9f27-9f4690a96566


#### Summary of Changes

This reverts commit 2fc1dc1bf6cfc8901fa521c453d9d9b7ab64db3d.