### PR TITLE
rename MAX_NUM_TRANSACTIONS_PER_BATCH

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -36,7 +36,8 @@ use {
     },
 };
 
-pub const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
+/// Consumer will create chunks of transactions from buffer with up to this size.
+pub const TARGET_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -288,7 +289,7 @@ impl Consumer {
         while chunk_start != transactions.len() {
             let chunk_end = std::cmp::min(
                 transactions.len(),
-                chunk_start + MAX_NUM_TRANSACTIONS_PER_BATCH,
+                chunk_start + TARGET_NUM_TRANSACTIONS_PER_BATCH,
             );
             let process_transaction_batch_output = self.process_and_record_transactions(
                 bank,
@@ -1354,7 +1355,7 @@ mod tests {
                 lamports + 1,
                 genesis_config.hash(),
             );
-            MAX_NUM_TRANSACTIONS_PER_BATCH
+            TARGET_NUM_TRANSACTIONS_PER_BATCH
         ];
 
         // Make one transaction that will succeed.
@@ -1412,7 +1413,7 @@ mod tests {
                 1,
                 genesis_config.hash()
             );
-            MAX_NUM_TRANSACTIONS_PER_BATCH
+            TARGET_NUM_TRANSACTIONS_PER_BATCH
         ];
 
         // Make one more in separate batch that also conflicts, but because it's in a separate batch, it


### PR DESCRIPTION
#### Problem
Naming kind of implies this is the maximum allowed for some functional reason. There's no protocol limitation on batch/entry size.

#### Summary of Changes
`TARGET_NUM_TRANSACTIONS_PER_BATCH` seems more appropriate, `BankingStage` will *try* to create batches of this size, if there's enough non-conflicting txs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
