### PR TITLE
[zk-token-sdk] rename `TransferAmountEncryption` to `TransferAmountCiphertext` and define it as a wrapper around `GroupedElGamalCiphertext`

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -8,7 +8,7 @@ use crate::{
     zk_token_elgamal::pod,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C)]
 #[cfg(not(target_os = "solana"))]
 pub struct TransferAmountEncryption(pub(crate) GroupedElGamalCiphertext<3>);

--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -11,10 +11,10 @@ use crate::{
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C)]
 #[cfg(not(target_os = "solana"))]
-pub struct TransferAmountEncryption(pub(crate) GroupedElGamalCiphertext<3>);
+pub struct TransferAmountCiphertext(pub(crate) GroupedElGamalCiphertext<3>);
 
 #[cfg(not(target_os = "solana"))]
-impl TransferAmountEncryption {
+impl TransferAmountCiphertext {
     pub fn new(
         amount: u64,
         source_pubkey: &ElGamalPubkey,

--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Clone)]
 #[repr(C)]
 #[cfg(not(target_os = "solana"))]
-pub struct TransferAmountEncryption(GroupedElGamalCiphertext<3>);
+pub struct TransferAmountEncryption(pub(crate) GroupedElGamalCiphertext<3>);
 
 #[cfg(not(target_os = "solana"))]
 impl TransferAmountEncryption {
@@ -45,15 +45,6 @@ impl TransferAmountEncryption {
 
     pub fn get_auditor_handle(&self) -> &DecryptHandle {
         &self.0.handles.get(2).unwrap()
-    }
-
-    pub fn to_pod(&self) -> pod::TransferAmountEncryption {
-        pod::TransferAmountEncryption {
-            commitment: self.commitment.into(),
-            source_handle: self.source_handle.into(),
-            destination_handle: self.destination_handle.into(),
-            auditor_handle: self.auditor_handle.into(),
-        }
     }
 }
 

--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -36,15 +36,15 @@ impl TransferAmountCiphertext {
     }
 
     pub fn get_source_handle(&self) -> &DecryptHandle {
-        &self.0.handles.get(0).unwrap()
+        self.0.handles.get(0).unwrap()
     }
 
     pub fn get_destination_handle(&self) -> &DecryptHandle {
-        &self.0.handles.get(1).unwrap()
+        self.0.handles.get(1).unwrap()
     }
 
     pub fn get_auditor_handle(&self) -> &DecryptHandle {
-        &self.0.handles.get(2).unwrap()
+        self.0.handles.get(2).unwrap()
     }
 }
 

--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -36,14 +36,20 @@ impl TransferAmountCiphertext {
     }
 
     pub fn get_source_handle(&self) -> &DecryptHandle {
+        // `TransferAmountCiphertext` is a wrapper for `GroupedElGamalCiphertext<3>`, which
+        // holds exactly three decryption handles.
         self.0.handles.get(0).unwrap()
     }
 
     pub fn get_destination_handle(&self) -> &DecryptHandle {
+        // `TransferAmountCiphertext` is a wrapper for `GroupedElGamalCiphertext<3>`, which holds
+        // exactly three decryption handles.
         self.0.handles.get(1).unwrap()
     }
 
     pub fn get_auditor_handle(&self) -> &DecryptHandle {
+        // `TransferAmountCiphertext` is a wrapper for `GroupedElGamalCiphertext<3>`, which holds
+        // exactly three decryption handles.
         self.0.handles.get(2).unwrap()
     }
 }

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -13,7 +13,7 @@ use {
 };
 #[cfg(not(target_os = "solana"))]
 pub use {
-    encryption::{FeeEncryption, TransferAmountEncryption},
+    encryption::{FeeEncryption, TransferAmountCiphertext},
     with_fee::TransferWithFeePubkeys,
     without_fee::TransferPubkeys,
 };

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -182,8 +182,8 @@ impl TransferWithFeeData {
             auditor_pubkey: (*auditor_pubkey).into(),
             withdraw_withheld_authority_pubkey: (*withdraw_withheld_authority_pubkey).into(),
         };
-        let pod_ciphertext_lo: pod::TransferAmountEncryption = ciphertext_lo.to_pod();
-        let pod_ciphertext_hi: pod::TransferAmountEncryption = ciphertext_hi.to_pod();
+        let pod_ciphertext_lo: pod::TransferAmountEncryption = ciphertext_lo.into();
+        let pod_ciphertext_hi: pod::TransferAmountEncryption = ciphertext_hi.into();
         let pod_new_source_ciphertext: pod::ElGamalCiphertext = new_source_ciphertext.into();
         let pod_fee_ciphertext_lo: pod::FeeEncryption = fee_ciphertext_lo.to_pod();
         let pod_fee_ciphertext_hi: pod::FeeEncryption = fee_ciphertext_hi.to_pod();

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -133,13 +133,13 @@ impl TransferWithFeeData {
             .ok_or(ProofError::Generation)?;
 
         let transfer_amount_lo_source = ElGamalCiphertext {
-            commitment: ciphertext_lo.commitment,
-            handle: ciphertext_lo.source_handle,
+            commitment: *ciphertext_lo.get_commitment(),
+            handle: *ciphertext_lo.get_source_handle(),
         };
 
         let transfer_amount_hi_source = ElGamalCiphertext {
-            commitment: ciphertext_hi.commitment,
-            handle: ciphertext_hi.source_handle,
+            commitment: *ciphertext_hi.get_commitment(),
+            handle: *ciphertext_hi.get_source_handle(),
         };
 
         let new_source_ciphertext = old_source_ciphertext
@@ -222,16 +222,16 @@ impl TransferWithFeeData {
         let ciphertext_lo: TransferAmountEncryption = self.context.ciphertext_lo.try_into()?;
 
         let handle_lo = match role {
-            Role::Source => Some(ciphertext_lo.source_handle),
-            Role::Destination => Some(ciphertext_lo.destination_handle),
-            Role::Auditor => Some(ciphertext_lo.auditor_handle),
+            Role::Source => Some(ciphertext_lo.get_source_handle()),
+            Role::Destination => Some(ciphertext_lo.get_destination_handle()),
+            Role::Auditor => Some(ciphertext_lo.get_auditor_handle()),
             Role::WithdrawWithheldAuthority => None,
         };
 
         if let Some(handle) = handle_lo {
             Ok(ElGamalCiphertext {
-                commitment: ciphertext_lo.commitment,
-                handle,
+                commitment: *ciphertext_lo.get_commitment(),
+                handle: *handle,
             })
         } else {
             Err(ProofError::MissingCiphertext)
@@ -243,16 +243,16 @@ impl TransferWithFeeData {
         let ciphertext_hi: TransferAmountEncryption = self.context.ciphertext_hi.try_into()?;
 
         let handle_hi = match role {
-            Role::Source => Some(ciphertext_hi.source_handle),
-            Role::Destination => Some(ciphertext_hi.destination_handle),
-            Role::Auditor => Some(ciphertext_hi.auditor_handle),
+            Role::Source => Some(ciphertext_hi.get_source_handle()),
+            Role::Destination => Some(ciphertext_hi.get_destination_handle()),
+            Role::Auditor => Some(ciphertext_hi.get_auditor_handle()),
             Role::WithdrawWithheldAuthority => None,
         };
 
         if let Some(handle) = handle_hi {
             Ok(ElGamalCiphertext {
-                commitment: ciphertext_hi.commitment,
-                handle,
+                commitment: *ciphertext_hi.get_commitment(),
+                handle: *handle,
             })
         } else {
             Err(ProofError::MissingCiphertext)
@@ -456,8 +456,8 @@ impl TransferWithFeeProof {
         transcript.append_commitment(b"commitment-claimed", &pod_claimed_commitment);
 
         let combined_commitment = combine_lo_hi_commitments(
-            &ciphertext_lo.commitment,
-            &ciphertext_hi.commitment,
+            ciphertext_lo.get_commitment(),
+            ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
         );
         let combined_opening =
@@ -586,12 +586,18 @@ impl TransferWithFeeProof {
                 &transfer_with_fee_pubkeys.destination_pubkey,
                 &transfer_with_fee_pubkeys.auditor_pubkey,
             ),
-            (&ciphertext_lo.commitment, &ciphertext_hi.commitment),
             (
-                &ciphertext_lo.destination_handle,
-                &ciphertext_hi.destination_handle,
+                ciphertext_lo.get_commitment(),
+                ciphertext_hi.get_commitment(),
             ),
-            (&ciphertext_lo.auditor_handle, &ciphertext_hi.auditor_handle),
+            (
+                ciphertext_lo.get_destination_handle(),
+                ciphertext_hi.get_destination_handle(),
+            ),
+            (
+                ciphertext_lo.get_auditor_handle(),
+                ciphertext_hi.get_auditor_handle(),
+            ),
             transcript,
         )?;
 
@@ -599,8 +605,8 @@ impl TransferWithFeeProof {
         transcript.append_commitment(b"commitment-claimed", &self.claimed_commitment);
 
         let combined_commitment = combine_lo_hi_commitments(
-            &ciphertext_lo.commitment,
-            &ciphertext_hi.commitment,
+            ciphertext_lo.get_commitment(),
+            ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
         );
         let combined_fee_commitment = combine_lo_hi_commitments(
@@ -652,8 +658,8 @@ impl TransferWithFeeProof {
         range_proof.verify(
             vec![
                 &new_source_commitment,
-                &ciphertext_lo.commitment,
-                &ciphertext_hi.commitment,
+                ciphertext_lo.get_commitment(),
+                ciphertext_hi.get_commitment(),
                 &claimed_commitment,
                 &claimed_commitment_negated,
                 &fee_ciphertext_lo.commitment,

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -54,8 +54,7 @@ mod target_arch {
             curve25519::scalar::PodScalar,
             errors::ProofError,
             instruction::transfer::{
-                FeeEncryption, FeeParameters, TransferAmountEncryption, TransferPubkeys,
-                TransferWithFeePubkeys,
+                FeeEncryption, FeeParameters, TransferPubkeys, TransferWithFeePubkeys,
             },
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
@@ -132,30 +131,6 @@ mod target_arch {
                 withdraw_withheld_authority_pubkey: pod
                     .withdraw_withheld_authority_pubkey
                     .try_into()?,
-            })
-        }
-    }
-
-    impl From<TransferAmountEncryption> for pod::TransferAmountEncryption {
-        fn from(ciphertext: TransferAmountEncryption) -> Self {
-            Self {
-                commitment: ciphertext.commitment.into(),
-                source_handle: ciphertext.source_handle.into(),
-                destination_handle: ciphertext.destination_handle.into(),
-                auditor_handle: ciphertext.auditor_handle.into(),
-            }
-        }
-    }
-
-    impl TryFrom<pod::TransferAmountEncryption> for TransferAmountEncryption {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::TransferAmountEncryption) -> Result<Self, Self::Error> {
-            Ok(Self {
-                commitment: pod.commitment.try_into()?,
-                source_handle: pod.source_handle.try_into()?,
-                destination_handle: pod.destination_handle.try_into()?,
-                auditor_handle: pod.auditor_handle.try_into()?,
             })
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -57,7 +57,7 @@ impl Default for GroupedElGamalCiphertext3Handles {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl From<GroupedElGamalCiphertext<3>> for GroupedElGamalCiphertext2Handles {
+impl From<GroupedElGamalCiphertext<3>> for GroupedElGamalCiphertext3Handles {
     fn from(decoded_ciphertext: GroupedElGamalCiphertext<3>) -> Self {
         Self(decoded_ciphertext.to_bytes().try_into().unwrap())
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -26,12 +26,14 @@ pub struct TransferWithFeePubkeys {
 #[repr(C)]
 pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
+#[cfg(not(target_os = "solana"))]
 impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
     fn from(decoded_ciphertext: decoded::TransferAmountCiphertext) -> Self {
         Self(decoded_ciphertext.0.into())
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
     type Error = ProofError;
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -24,18 +24,18 @@ pub struct TransferWithFeePubkeys {
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct TransferAmountEncryption(pub GroupedElGamalCiphertext3Handles);
+pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
-impl From<decoded::TransferAmountEncryption> for TransferAmountEncryption {
-    fn from(decoded_ciphertext: decoded::TransferAmountEncryption) -> Self {
+impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
+    fn from(decoded_ciphertext: decoded::TransferAmountCiphertext) -> Self {
         Self(decoded_ciphertext.0.into())
     }
 }
 
-impl TryFrom<TransferAmountEncryption> for decoded::TransferAmountEncryption {
+impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
     type Error = ProofError;
 
-    fn try_from(pod_ciphertext: TransferAmountEncryption) -> Result<Self, Self::Error> {
+    fn try_from(pod_ciphertext: TransferAmountCiphertext) -> Result<Self, Self::Error> {
         Ok(Self(pod_ciphertext.0.try_into()?))
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -17,7 +17,7 @@ pub use {
     elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles},
     instruction::{
-        FeeEncryption, FeeParameters, TransferAmountEncryption, TransferPubkeys,
+        FeeEncryption, FeeParameters, TransferAmountCiphertext, TransferPubkeys,
         TransferWithFeePubkeys,
     },
     pedersen::PedersenCommitment,


### PR DESCRIPTION
#### Problem
The `TransferAmountEncryption` used in the transfer instructions is defined as a struct that contains a Pedersen commitment and three decryption handles associated with the source, destination, and auditor public keys. It can be defined as a thin wrapper around the type `GroupedElGamalCiphertext` (https://github.com/solana-labs/solana/pull/31849).

#### Summary of Changes
- `03b9f01`: Defined the `TransferAmountEncryption` as a thin wrapper around `GroupedElGamalCiphertext`
- `4f52343`: Previously, `GroupedElGamalCiphertext<3>` implemented the `From` trait for `GroupedElGamalCiphertext2Handles`, but it should be `GroupedElGamalCiphertext3Handles`. This was a miss from a previous PR (https://github.com/solana-labs/solana/pull/31849) :pray:. Fixed it here.
- `3447f6c`: Defined the `Pod` version of `TransferAmountEncryption` as a wrapper around the `Pod` verison of `GroupedElGamalCiphertext3Handles`
- 4023114`: Extended the derived traits for `TransferAmountEncryption` to include `Copy`, `Debug`, `Eq`, and `PartialEq`, which is derived for `GroupedElGamalCiphertext`
- 0f96df0`: Renamed `TransferAmountEncryption` to `TransferAmountCiphertext` as it is a more suitable name

I can also split the PR if requested. My guess is that the the last two commits above could be a separate PR...

Once this PR lands, I will create a follow-up PR for the `FeeEncryption` type.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
