### PR TITLE
patches QuicConnectionManager::new_connection_config

### DIFF
--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -79,6 +79,7 @@ impl ConnectionPool for QuicPool {
     }
 }
 
+#[derive(Clone)]
 pub struct QuicConfig {
     client_certificate: Arc<QuicClientCertificate>,
     maybe_staked_nodes: Option<Arc<RwLock<StakedNodes>>>,
@@ -204,7 +205,7 @@ impl ConnectionManager for QuicConnectionManager {
     }
 
     fn new_connection_config(&self) -> QuicConfig {
-        QuicConfig::new().unwrap()
+        self.connection_config.clone()
     }
 }
 


### PR DESCRIPTION

#### Problem
`QuicConnectionManager::new_connection_config` is returning an invalid new `QuicConfig` instead of the value it is initialized with.


#### Summary of Changes
Return `self.connection_config` instead of a new `QuicConfig`.