### PR TITLE
simplify clean_dead_slot, factor out root stats

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4621,8 +4621,7 @@ impl AccountsDb {
         let mut bank_hash_stats = self.bank_hash_stats.lock().unwrap();
 
         dropped_roots.for_each(|slot| {
-            self.accounts_index
-                .clean_dead_slot(slot, &mut AccountsIndexRootsStats::default());
+            self.accounts_index.clean_dead_slot(slot);
             accounts_delta_hashes.remove(&slot);
             bank_hash_stats.remove(&slot);
             // the storage has been removed from this slot and recycled or dropped
@@ -8210,10 +8209,7 @@ impl AccountsDb {
         let mut unrooted_cleaned_count = 0;
         let dead_slots: Vec<_> = dead_slots_iter
             .map(|slot| {
-                if self
-                    .accounts_index
-                    .clean_dead_slot(*slot, &mut accounts_index_root_stats)
-                {
+                if self.accounts_index.clean_dead_slot(*slot) {
                     rooted_cleaned_count += 1;
                 } else {
                     unrooted_cleaned_count += 1;
@@ -8230,7 +8226,8 @@ impl AccountsDb {
             );
             trace!("remove_dead_slots_metadata: dead_slots: {:?}", dead_slots);
         }
-
+        self.accounts_index
+            .update_roots_stats(&mut accounts_index_root_stats);
         accounts_index_root_stats.rooted_cleaned_count += rooted_cleaned_count;
         accounts_index_root_stats.unrooted_cleaned_count += unrooted_cleaned_count;
 


### PR DESCRIPTION
#### Problem
When we eliminate rewrites, we will not identify dead slots in the same way anymore. The ancient append vec code will squash these dead slots. This will change the pattern of how we update root stats (such as # of alive_roots). Furthermore, we are often removing multiple dead slots in serial. We only need the stats at the end.

Today, we end up with stats like this, which is not ideal. We would like to see a better sampling of the stats:
![image](https://github.com/solana-labs/solana/assets/75863576/217a7837-dda5-4c21-a8f6-620a5e9f035b)


#### Summary of Changes
Separate out removing root from updating stats.
Update the stats after each clean, whether we found dead slots or not.
As a nice side effect, we hold the write lock on `roots_tracker` for less time.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
