### PR TITLE
create and  canonicalize account_paths

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -422,6 +422,21 @@ pub enum VerifySlotDeltasError {
     BadSlotHistory,
 }
 
+/// Creates directories if they do not exist, and canonicalizes the paths.
+pub fn create_and_canonicalize_directories(directories: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    directories
+        .iter()
+        .map(|path| {
+            std::fs::create_dir_all(path).map_err(|err| {
+                SnapshotError::IoWithSourceAndFile(err, "create_dir_all", path.clone())
+            })?;
+            path.canonicalize().map_err(|err| {
+                SnapshotError::IoWithSourceAndFile(err, "canonicalize", path.clone())
+            })
+        })
+        .collect()
+}
+
 /// Delete the files and subdirectories in a directory.
 /// This is useful if the process does not have permission
 /// to delete the top level directory it might be able to

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -965,7 +965,7 @@ pub fn main() {
 
     // Canonicalize ledger path to avoid issues with symlink creation
     let ledger_path = create_and_canonicalize_directories(&[ledger_path]).unwrap_or_else(|err| {
-        eprintln!("Unable to access ledger path: {err:?}");
+        eprintln!("Unable to access ledger path: {err}");
         exit(1);
     });
 
@@ -1398,7 +1398,7 @@ pub fn main() {
         };
     let account_paths = snapshot_utils::create_and_canonicalize_directories(&account_paths)
         .unwrap_or_else(|err| {
-            eprintln!("Unable to access account path: {err:?}");
+            eprintln!("Unable to access account path: {err}");
             exit(1);
         });
 
@@ -1420,7 +1420,7 @@ pub fn main() {
 
     validator_config.account_shrink_paths = account_shrink_paths.map(|paths| {
         create_and_canonicalize_directories(&paths).unwrap_or_else(|err| {
-            eprintln!("Unable to access account shrink path: {err:?}");
+            eprintln!("Unable to access account shrink path: {err}");
             exit(1);
         })
     });

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1396,6 +1396,22 @@ pub fn main() {
         } else {
             vec![ledger_path.join("accounts")]
         };
+
+    let account_paths: Vec<PathBuf> = account_paths
+        .into_iter()
+        .map(|account_path| {
+            match std::fs::create_dir_all(&account_path)
+                .and_then(|_| std::fs::canonicalize(&account_path))
+            {
+                Ok(account_path) => account_path,
+                Err(err) => {
+                    eprintln!("Unable to access account path: {account_path:?}, err: {err:?}");
+                    exit(1);
+                }
+            }
+        })
+        .collect();
+
     let account_shrink_paths: Option<Vec<PathBuf>> =
         values_t!(matches, "account_shrink_path", String)
             .map(|shrink_paths| shrink_paths.into_iter().map(PathBuf::from).collect())

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1393,7 +1393,7 @@ pub fn main() {
                 .join(",")
                 .split(',')
                 .map(PathBuf::from)
-                .collect::<Vec<_>>()
+                .collect()
         } else {
             vec![ledger_path.join("accounts")]
         };

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -964,10 +964,13 @@ pub fn main() {
         .map(BlockstoreRecoveryMode::from);
 
     // Canonicalize ledger path to avoid issues with symlink creation
-    let ledger_path = create_and_canonicalize_directories(&[ledger_path]).unwrap_or_else(|err| {
-        eprintln!("Unable to access ledger path: {err}");
-        exit(1);
-    });
+    let ledger_path = create_and_canonicalize_directories(&[ledger_path])
+        .unwrap_or_else(|err| {
+            eprintln!("Unable to access ledger path: {err}");
+            exit(1);
+        })
+        .pop()
+        .unwrap();
 
     let debug_keys: Option<Arc<HashSet<_>>> = if matches.is_present("debug_key") {
         Some(Arc::new(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -964,8 +964,7 @@ pub fn main() {
         .map(BlockstoreRecoveryMode::from);
 
     // Canonicalize ledger path to avoid issues with symlink creation
-    let _ = fs::create_dir_all(&ledger_path);
-    let ledger_path = fs::canonicalize(&ledger_path).unwrap_or_else(|err| {
+    let ledger_path = create_and_canonicalize_directories(&[ledger_path]).unwrap_or_else(|err| {
         eprintln!("Unable to access ledger path: {err:?}");
         exit(1);
     });


### PR DESCRIPTION
#### Problem
We stopped canonicalizing validator `account_paths` in #30645.
This causes [issues](https://discord.com/channels/428295358100013066/670512312339398668/1116426454041907321) if users specify `account_paths` which are symlinks, when we start to clean our account directories. The directory that the cleanup process deletes & recreates should be at the followed path, not the location of the link.

#### Summary of Changes
canonicalize the `account_paths` like we've always done.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
