### PR TITLE
Allow maximum connection in quic server config no more than combined …

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -99,8 +99,8 @@ pub fn spawn_server(
     coalesce: Duration,
 ) -> Result<(Endpoint, Arc<StreamStats>, JoinHandle<()>), QuicServerError> {
     info!("Start {name} quic server on {sock:?}");
-    let (config, _cert) = configure_server(keypair, gossip_host)?;
-
+    let (mut config, _cert) = configure_server(keypair, gossip_host)?;
+    config.concurrent_connections(max_staked_connections.saturating_add(max_unstaked_connections) as u32);
     let endpoint = Endpoint::new(EndpointConfig::default(), Some(config), sock, TokioRuntime)
         .map_err(QuicServerError::EndpointFailed)?;
     let stats = Arc::<StreamStats>::default();

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -100,7 +100,9 @@ pub fn spawn_server(
 ) -> Result<(Endpoint, Arc<StreamStats>, JoinHandle<()>), QuicServerError> {
     info!("Start {name} quic server on {sock:?}");
     let (mut config, _cert) = configure_server(keypair, gossip_host)?;
-    config.concurrent_connections(max_staked_connections.saturating_add(max_unstaked_connections) as u32);
+    config.concurrent_connections(
+        max_staked_connections.saturating_add(max_unstaked_connections) as u32,
+    );
     let endpoint = Endpoint::new(EndpointConfig::default(), Some(config), sock, TokioRuntime)
         .map_err(QuicServerError::EndpointFailed)?;
     let stats = Arc::<StreamStats>::default();

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -99,10 +99,11 @@ pub fn spawn_server(
     coalesce: Duration,
 ) -> Result<(Endpoint, Arc<StreamStats>, JoinHandle<()>), QuicServerError> {
     info!("Start {name} quic server on {sock:?}");
-    let (mut config, _cert) = configure_server(keypair, gossip_host)?;
-    config.concurrent_connections(
+    let (config, _cert) = configure_server(
+        keypair,
+        gossip_host,
         max_staked_connections.saturating_add(max_unstaked_connections) as u32,
-    );
+    )?;
     let endpoint = Endpoint::new(EndpointConfig::default(), Some(config), sock, TokioRuntime)
         .map_err(QuicServerError::EndpointFailed)?;
     let stats = Arc::<StreamStats>::default();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -56,6 +56,7 @@ impl rustls::server::ClientCertVerifier for SkipClientVerification {
 pub(crate) fn configure_server(
     identity_keypair: &Keypair,
     gossip_host: IpAddr,
+    max_concurrent_connections: u32,
 ) -> Result<(ServerConfig, String), QuicServerError> {
     let (cert, priv_key) = new_self_signed_tls_certificate(identity_keypair, gossip_host)?;
     let cert_chain_pem_parts = vec![Pem {
@@ -72,6 +73,7 @@ pub(crate) fn configure_server(
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(server_tls_config));
     server_config.use_retry(true);
+    server_config.concurrent_connections(max_concurrent_connections);
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
     // QUIC_MAX_CONCURRENT_STREAMS doubled, which was found to improve reliability


### PR DESCRIPTION
Allow maximum connection in quic server config no more than combined staked and non-staked connections.

#### Problem
The maximum Quic connection limit can be enforced earlier.

#### Summary of Changes

Quic server config allows one to configure the maximum concurrent number of connections connecting to the Endpoint. This is also effective against connections still in "Connecting" mode. Use the concurrent_connections option.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
