### PR TITLE
[zk-token-sdk] remove non-pod structs `TransferPubkeys` and `TransferWithFeePubkeys`

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -381,12 +381,12 @@ impl ZkProofData<TransferWithFeeProofContext> for TransferWithFeeData {
         let fee_parameters = self.context.fee_parameters.into();
 
         self.proof.verify(
-            &ciphertext_lo,
-            &ciphertext_hi,
             &source_pubkey,
             &destination_pubkey,
             &auditor_pubkey,
             &withdraw_withheld_authority_pubkey,
+            &ciphertext_lo,
+            &ciphertext_hi,
             &new_source_ciphertext,
             &fee_ciphertext_lo,
             &fee_ciphertext_hi,
@@ -574,12 +574,12 @@ impl TransferWithFeeProof {
 
     pub fn verify(
         &self,
-        ciphertext_lo: &TransferAmountCiphertext,
-        ciphertext_hi: &TransferAmountCiphertext,
         source_pubkey: &ElGamalPubkey,
         destination_pubkey: &ElGamalPubkey,
         auditor_pubkey: &ElGamalPubkey,
         withdraw_withheld_authority_pubkey: &ElGamalPubkey,
+        ciphertext_lo: &TransferAmountCiphertext,
+        ciphertext_hi: &TransferAmountCiphertext,
         new_spendable_ciphertext: &ElGamalCiphertext,
         // fee parameters
         fee_ciphertext_lo: &FeeEncryption,

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -101,6 +101,16 @@ pub struct TransferWithFeeProofContext {
     pub fee_parameters: pod::FeeParameters, // 10 bytes
 }
 
+/// The ElGamal public keys needed for a transfer with fee
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct TransferWithFeePubkeys {
+    pub source: pod::ElGamalPubkey,
+    pub destination: pod::ElGamalPubkey,
+    pub auditor: pod::ElGamalPubkey,
+    pub withdraw_withheld_authority: pod::ElGamalPubkey,
+}
+
 #[cfg(not(target_os = "solana"))]
 impl TransferWithFeeData {
     pub fn new(
@@ -694,16 +704,6 @@ impl TransferWithFeeProof {
 
         Ok(())
     }
-}
-
-/// The ElGamal public keys needed for a transfer with fee
-#[derive(Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
-pub struct TransferWithFeePubkeys {
-    pub source: pod::ElGamalPubkey,
-    pub destination: pod::ElGamalPubkey,
-    pub auditor: pod::ElGamalPubkey,
-    pub withdraw_withheld_authority: pod::ElGamalPubkey,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -177,10 +177,10 @@ impl TransferWithFeeData {
 
         // generate transcript and append all public inputs
         let pod_transfer_with_fee_pubkeys = TransferWithFeePubkeys {
-            source_pubkey: source_keypair.public.into(),
-            destination_pubkey: (*destination_pubkey).into(),
-            auditor_pubkey: (*auditor_pubkey).into(),
-            withdraw_withheld_authority_pubkey: (*withdraw_withheld_authority_pubkey).into(),
+            source: source_keypair.public.into(),
+            destination: (*destination_pubkey).into(),
+            auditor: (*auditor_pubkey).into(),
+            withdraw_withheld_authority: (*withdraw_withheld_authority_pubkey).into(),
         };
         let pod_ciphertext_lo: pod::TransferAmountCiphertext = ciphertext_lo.into();
         let pod_ciphertext_hi: pod::TransferAmountCiphertext = ciphertext_hi.into();
@@ -349,25 +349,17 @@ impl ZkProofData<TransferWithFeeProofContext> for TransferWithFeeData {
     fn verify_proof(&self) -> Result<(), ProofError> {
         let mut transcript = self.context.new_transcript();
 
-        let source_pubkey = self
-            .context
-            .transfer_with_fee_pubkeys
-            .source_pubkey
-            .try_into()?;
+        let source_pubkey = self.context.transfer_with_fee_pubkeys.source.try_into()?;
         let destination_pubkey = self
             .context
             .transfer_with_fee_pubkeys
-            .destination_pubkey
+            .destination
             .try_into()?;
-        let auditor_pubkey = self
-            .context
-            .transfer_with_fee_pubkeys
-            .auditor_pubkey
-            .try_into()?;
+        let auditor_pubkey = self.context.transfer_with_fee_pubkeys.auditor.try_into()?;
         let withdraw_withheld_authority_pubkey = self
             .context
             .transfer_with_fee_pubkeys
-            .withdraw_withheld_authority_pubkey
+            .withdraw_withheld_authority
             .try_into()?;
 
         let ciphertext_lo = self.context.ciphertext_lo.try_into()?;
@@ -708,10 +700,10 @@ impl TransferWithFeeProof {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferWithFeePubkeys {
-    pub source_pubkey: pod::ElGamalPubkey,
-    pub destination_pubkey: pod::ElGamalPubkey,
-    pub auditor_pubkey: pod::ElGamalPubkey,
-    pub withdraw_withheld_authority_pubkey: pod::ElGamalPubkey,
+    pub source: pod::ElGamalPubkey,
+    pub destination: pod::ElGamalPubkey,
+    pub auditor: pod::ElGamalPubkey,
+    pub withdraw_withheld_authority: pod::ElGamalPubkey,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -572,6 +572,7 @@ impl TransferWithFeeProof {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn verify(
         &self,
         source_pubkey: &ElGamalPubkey,

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -16,7 +16,6 @@ use {
         },
         transcript::TranscriptProtocol,
     },
-    arrayref::{array_ref, array_refs},
     bytemuck::bytes_of,
     merlin::Transcript,
     std::convert::TryInto,
@@ -69,7 +68,7 @@ pub struct TransferProofContext {
     pub ciphertext_hi: pod::TransferAmountCiphertext, // 128 bytes
 
     /// The public encryption keys associated with the transfer: source, dest, and auditor
-    pub transfer_pubkeys: pod::TransferPubkeys, // 96 bytes
+    pub transfer_pubkeys: TransferPubkeys, // 96 bytes
 
     /// The final spendable ciphertext after the transfer
     pub new_source_ciphertext: pod::ElGamalCiphertext, // 64 bytes
@@ -124,7 +123,7 @@ impl TransferData {
             );
 
         // generate transcript and append all public inputs
-        let pod_transfer_pubkeys = pod::TransferPubkeys {
+        let pod_transfer_pubkeys = TransferPubkeys {
             source_pubkey: source_keypair.public.into(),
             destination_pubkey: (*destination_pubkey).into(),
             auditor_pubkey: (*auditor_pubkey).into(),
@@ -225,15 +224,24 @@ impl ZkProofData<TransferProofContext> for TransferData {
         // generate transcript and append all public inputs
         let mut transcript = self.context.new_transcript();
 
+        let source_pubkey = self.context.transfer_pubkeys.source_pubkey.try_into()?;
+        let destination_pubkey = self
+            .context
+            .transfer_pubkeys
+            .destination_pubkey
+            .try_into()?;
+        let auditor_pubkey = self.context.transfer_pubkeys.auditor_pubkey.try_into()?;
+
         let ciphertext_lo = self.context.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.context.ciphertext_hi.try_into()?;
-        let transfer_pubkeys = self.context.transfer_pubkeys.try_into()?;
         let new_spendable_ciphertext = self.context.new_source_ciphertext.try_into()?;
 
         self.proof.verify(
             &ciphertext_lo,
             &ciphertext_hi,
-            &transfer_pubkeys,
+            &source_pubkey,
+            &destination_pubkey,
+            &auditor_pubkey,
             &new_spendable_ciphertext,
             &mut transcript,
         )
@@ -355,7 +363,9 @@ impl TransferProof {
         &self,
         ciphertext_lo: &TransferAmountCiphertext,
         ciphertext_hi: &TransferAmountCiphertext,
-        transfer_pubkeys: &TransferPubkeys,
+        source_pubkey: &ElGamalPubkey,
+        destination_pubkey: &ElGamalPubkey,
+        auditor_pubkey: &ElGamalPubkey,
         ciphertext_new_spendable: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
@@ -369,7 +379,7 @@ impl TransferProof {
 
         // verify equality proof
         equality_proof.verify(
-            &transfer_pubkeys.source_pubkey,
+            source_pubkey,
             ciphertext_new_spendable,
             &commitment,
             transcript,
@@ -377,10 +387,7 @@ impl TransferProof {
 
         // verify validity proof
         aggregated_validity_proof.verify(
-            (
-                &transfer_pubkeys.destination_pubkey,
-                &transfer_pubkeys.auditor_pubkey,
-            ),
+            (destination_pubkey, auditor_pubkey),
             (
                 ciphertext_lo.get_commitment(),
                 ciphertext_hi.get_commitment(),
@@ -437,43 +444,12 @@ impl TransferProof {
 }
 
 /// The ElGamal public keys needed for a transfer
-#[derive(Clone)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-#[cfg(not(target_os = "solana"))]
 pub struct TransferPubkeys {
-    pub source_pubkey: ElGamalPubkey,
-    pub destination_pubkey: ElGamalPubkey,
-    pub auditor_pubkey: ElGamalPubkey,
-}
-
-#[cfg(not(target_os = "solana"))]
-impl TransferPubkeys {
-    // TODO: use constructor instead
-    pub fn to_bytes(&self) -> [u8; 96] {
-        let mut bytes = [0u8; 96];
-        bytes[..32].copy_from_slice(&self.source_pubkey.to_bytes());
-        bytes[32..64].copy_from_slice(&self.destination_pubkey.to_bytes());
-        bytes[64..96].copy_from_slice(&self.auditor_pubkey.to_bytes());
-        bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
-        let bytes = array_ref![bytes, 0, 96];
-        let (source_pubkey, destination_pubkey, auditor_pubkey) = array_refs![bytes, 32, 32, 32];
-
-        let source_pubkey =
-            ElGamalPubkey::from_bytes(source_pubkey).ok_or(ProofError::PubkeyDeserialization)?;
-        let destination_pubkey = ElGamalPubkey::from_bytes(destination_pubkey)
-            .ok_or(ProofError::PubkeyDeserialization)?;
-        let auditor_pubkey =
-            ElGamalPubkey::from_bytes(auditor_pubkey).ok_or(ProofError::PubkeyDeserialization)?;
-
-        Ok(Self {
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
-        })
-    }
+    pub source_pubkey: pod::ElGamalPubkey,
+    pub destination_pubkey: pod::ElGamalPubkey,
+    pub auditor_pubkey: pod::ElGamalPubkey,
 }
 
 #[cfg(test)]

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -74,6 +74,15 @@ pub struct TransferProofContext {
     pub new_source_ciphertext: pod::ElGamalCiphertext, // 64 bytes
 }
 
+/// The ElGamal public keys needed for a transfer
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct TransferPubkeys {
+    pub source: pod::ElGamalPubkey,
+    pub destination: pod::ElGamalPubkey,
+    pub auditor: pod::ElGamalPubkey,
+}
+
 #[cfg(not(target_os = "solana"))]
 impl TransferData {
     #[allow(clippy::too_many_arguments)]
@@ -437,15 +446,6 @@ impl TransferProof {
 
         Ok(())
     }
-}
-
-/// The ElGamal public keys needed for a transfer
-#[derive(Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
-pub struct TransferPubkeys {
-    pub source: pod::ElGamalPubkey,
-    pub destination: pod::ElGamalPubkey,
-    pub auditor: pod::ElGamalPubkey,
 }
 
 #[cfg(test)]

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -124,9 +124,9 @@ impl TransferData {
 
         // generate transcript and append all public inputs
         let pod_transfer_pubkeys = TransferPubkeys {
-            source_pubkey: source_keypair.public.into(),
-            destination_pubkey: (*destination_pubkey).into(),
-            auditor_pubkey: (*auditor_pubkey).into(),
+            source: source_keypair.public.into(),
+            destination: (*destination_pubkey).into(),
+            auditor: (*auditor_pubkey).into(),
         };
         let pod_ciphertext_lo: pod::TransferAmountCiphertext = ciphertext_lo.into();
         let pod_ciphertext_hi: pod::TransferAmountCiphertext = ciphertext_hi.into();
@@ -224,13 +224,9 @@ impl ZkProofData<TransferProofContext> for TransferData {
         // generate transcript and append all public inputs
         let mut transcript = self.context.new_transcript();
 
-        let source_pubkey = self.context.transfer_pubkeys.source_pubkey.try_into()?;
-        let destination_pubkey = self
-            .context
-            .transfer_pubkeys
-            .destination_pubkey
-            .try_into()?;
-        let auditor_pubkey = self.context.transfer_pubkeys.auditor_pubkey.try_into()?;
+        let source_pubkey = self.context.transfer_pubkeys.source.try_into()?;
+        let destination_pubkey = self.context.transfer_pubkeys.destination.try_into()?;
+        let auditor_pubkey = self.context.transfer_pubkeys.auditor.try_into()?;
 
         let ciphertext_lo = self.context.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.context.ciphertext_hi.try_into()?;
@@ -447,9 +443,9 @@ impl TransferProof {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferPubkeys {
-    pub source_pubkey: pod::ElGamalPubkey,
-    pub destination_pubkey: pod::ElGamalPubkey,
-    pub auditor_pubkey: pod::ElGamalPubkey,
+    pub source: pod::ElGamalPubkey,
+    pub destination: pod::ElGamalPubkey,
+    pub auditor: pod::ElGamalPubkey,
 }
 
 #[cfg(test)]

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -242,11 +242,11 @@ impl ZkProofData<TransferProofContext> for TransferData {
         let new_spendable_ciphertext = self.context.new_source_ciphertext.try_into()?;
 
         self.proof.verify(
-            &ciphertext_lo,
-            &ciphertext_hi,
             &source_pubkey,
             &destination_pubkey,
             &auditor_pubkey,
+            &ciphertext_lo,
+            &ciphertext_hi,
             &new_spendable_ciphertext,
             &mut transcript,
         )
@@ -366,11 +366,11 @@ impl TransferProof {
 
     pub fn verify(
         &self,
-        ciphertext_lo: &TransferAmountCiphertext,
-        ciphertext_hi: &TransferAmountCiphertext,
         source_pubkey: &ElGamalPubkey,
         destination_pubkey: &ElGamalPubkey,
         auditor_pubkey: &ElGamalPubkey,
+        ciphertext_lo: &TransferAmountCiphertext,
+        ciphertext_hi: &TransferAmountCiphertext,
         ciphertext_new_spendable: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -50,10 +50,7 @@ impl From<PodRistrettoPoint> for pod::DecryptHandle {
 mod target_arch {
     use {
         super::pod,
-        crate::{
-            curve25519::scalar::PodScalar, errors::ProofError,
-            instruction::transfer::TransferPubkeys,
-        },
+        crate::{curve25519::scalar::PodScalar, errors::ProofError},
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
     };
@@ -81,28 +78,6 @@ mod target_arch {
     impl From<pod::CompressedRistretto> for CompressedRistretto {
         fn from(pod: pod::CompressedRistretto) -> Self {
             Self(pod.0)
-        }
-    }
-
-    impl From<TransferPubkeys> for pod::TransferPubkeys {
-        fn from(keys: TransferPubkeys) -> Self {
-            Self {
-                source_pubkey: keys.source_pubkey.into(),
-                destination_pubkey: keys.destination_pubkey.into(),
-                auditor_pubkey: keys.auditor_pubkey.into(),
-            }
-        }
-    }
-
-    impl TryFrom<pod::TransferPubkeys> for TransferPubkeys {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::TransferPubkeys) -> Result<Self, Self::Error> {
-            Ok(Self {
-                source_pubkey: pod.source_pubkey.try_into()?,
-                destination_pubkey: pod.destination_pubkey.try_into()?,
-                auditor_pubkey: pod.auditor_pubkey.try_into()?,
-            })
         }
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -51,9 +51,8 @@ mod target_arch {
     use {
         super::pod,
         crate::{
-            curve25519::scalar::PodScalar,
-            errors::ProofError,
-            instruction::transfer::{TransferPubkeys, TransferWithFeePubkeys},
+            curve25519::scalar::PodScalar, errors::ProofError,
+            instruction::transfer::TransferPubkeys,
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -103,32 +102,6 @@ mod target_arch {
                 source_pubkey: pod.source_pubkey.try_into()?,
                 destination_pubkey: pod.destination_pubkey.try_into()?,
                 auditor_pubkey: pod.auditor_pubkey.try_into()?,
-            })
-        }
-    }
-
-    impl From<TransferWithFeePubkeys> for pod::TransferWithFeePubkeys {
-        fn from(keys: TransferWithFeePubkeys) -> Self {
-            Self {
-                source_pubkey: keys.source_pubkey.into(),
-                destination_pubkey: keys.destination_pubkey.into(),
-                auditor_pubkey: keys.auditor_pubkey.into(),
-                withdraw_withheld_authority_pubkey: keys.withdraw_withheld_authority_pubkey.into(),
-            }
-        }
-    }
-
-    impl TryFrom<pod::TransferWithFeePubkeys> for TransferWithFeePubkeys {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::TransferWithFeePubkeys) -> Result<Self, Self::Error> {
-            Ok(Self {
-                source_pubkey: pod.source_pubkey.try_into()?,
-                destination_pubkey: pod.destination_pubkey.try_into()?,
-                auditor_pubkey: pod.auditor_pubkey.try_into()?,
-                withdraw_withheld_authority_pubkey: pod
-                    .withdraw_withheld_authority_pubkey
-                    .try_into()?,
             })
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -1,17 +1,9 @@
 use crate::zk_token_elgamal::pod::{
-    ElGamalPubkey, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles, Pod, PodU16,
-    PodU64, Zeroable,
+    GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles, Pod, PodU16, PodU64,
+    Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
 use crate::{errors::ProofError, instruction::transfer as decoded};
-
-#[derive(Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
-pub struct TransferPubkeys {
-    pub source_pubkey: ElGamalPubkey,
-    pub destination_pubkey: ElGamalPubkey,
-    pub auditor_pubkey: ElGamalPubkey,
-}
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -15,15 +15,6 @@ pub struct TransferPubkeys {
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct TransferWithFeePubkeys {
-    pub source_pubkey: ElGamalPubkey,
-    pub destination_pubkey: ElGamalPubkey,
-    pub auditor_pubkey: ElGamalPubkey,
-    pub withdraw_withheld_authority_pubkey: ElGamalPubkey,
-}
-
-#[derive(Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
 pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -16,10 +16,7 @@ pub use {
     bytemuck::{Pod, Zeroable},
     elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles},
-    instruction::{
-        FeeEncryption, FeeParameters, TransferAmountCiphertext, TransferPubkeys,
-        TransferWithFeePubkeys,
-    },
+    instruction::{FeeEncryption, FeeParameters, TransferAmountCiphertext, TransferPubkeys},
     pedersen::PedersenCommitment,
     range_proof::{RangeProofU128, RangeProofU256, RangeProofU64},
     sigma_proofs::{

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -16,7 +16,7 @@ pub use {
     bytemuck::{Pod, Zeroable},
     elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles},
-    instruction::{FeeEncryption, FeeParameters, TransferAmountCiphertext, TransferPubkeys},
+    instruction::{FeeEncryption, FeeParameters, TransferAmountCiphertext},
     pedersen::PedersenCommitment,
     range_proof::{RangeProofU128, RangeProofU256, RangeProofU64},
     sigma_proofs::{


### PR DESCRIPTION
#### Problem
The struct `TransferPubkeys` and `TransferWithFeePubkeys` in the `instruction::transfer` module exist to group the ElGamal public keys needed in a transfer instruction (`source_pubkey`, `destination_pubkey`, ...). However, this struct is not very useful:

The constructors for `TransferData` and `TransferWithFeeData` take in the individual ElGamal public keys as input, groups them into a `TransferPubkeys` and `TransferWithFeePubkeys`, and then immediately converts them to their `Pod` variants.

The verification functions does take in the types `TransferPubkeys` and `TransferWithFeePubkeys` as input, but they invoke the sigma or range proof verification functions with the individual public keys.

The code can be quite simplified by just removing the non-`Pod` types `TransferPubkeys` and `TransferWithFeePubkeys` altogether and just solely work with the `Pod` variants of `TransferPubkeys` and `TransferWithFeePubkeys` from `zk-token-elgamal`.

#### Summary of Changes
Replaced the `TransferPubkeys` and `TransferWithFeePubkeys` from the `instruction::transfer` module and replaced them with their `Pod` versions of these structs from the `zk_token_elgamal` module.

We can perhaps also remove the `Pod` versions of `TransferPubkeys` and `TransferWithFeePubkeys` as well and just work with the individual public keys, but I think these types do simplify the structure of `TransferProofContext` and `TransferWithFeeProofContext` a little bit.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
