### PR TITLE
removes hard-coded ALPN protocol id in QUIC streamer

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -249,6 +249,7 @@ mod tests {
             response_recv_socket,
             &keypair2,
             response_recv_ip,
+            vec![], // alpn_protocols
             sender2,
             response_recv_exit.clone(),
             1,

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -23,6 +23,7 @@ use {
     },
 };
 
+const ALPN_TVU_PROTOCOL_ID: &[u8] = b"solana-tvu";
 const MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 const MAX_STAKED_QUIC_CONNECTIONS: usize = 2000;
 const MAX_UNSTAKED_QUIC_CONNECTIONS: usize = 1000;
@@ -240,6 +241,7 @@ impl ShredFetchStage {
             quic_socket,
             &keypair,
             ip_addr,
+            vec![Vec::from(ALPN_TVU_PROTOCOL_ID)],
             packet_sender,
             exit,
             MAX_QUIC_CONNECTIONS_PER_PEER,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -37,7 +37,7 @@ use {
     },
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
     solana_streamer::{
-        nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+        nonblocking::quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
         quic::{spawn_server, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
         streamer::StakedNodes,
     },
@@ -156,6 +156,7 @@ impl Tpu {
                 .tpu(Protocol::QUIC)
                 .expect("Operator must spin up node with valid (QUIC) TPU address")
                 .ip(),
+            vec![Vec::from(ALPN_TPU_PROTOCOL_ID)],
             packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -176,6 +177,7 @@ impl Tpu {
                 .tpu_forwards(Protocol::QUIC)
                 .expect("Operator must spin up node with valid (QUIC) TPU-forwards address")
                 .ip(),
+            vec![Vec::from(ALPN_TPU_PROTOCOL_ID)],
             forwarded_packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -73,6 +73,7 @@ mod tests {
             s.try_clone().unwrap(),
             &keypair,
             ip,
+            vec![], // alpn_protocols
             sender,
             exit.clone(),
             1,
@@ -153,6 +154,7 @@ mod tests {
             s.try_clone().unwrap(),
             &keypair,
             ip,
+            vec![], // alpn_protocols
             sender,
             exit.clone(),
             1,
@@ -209,6 +211,7 @@ mod tests {
             request_recv_socket.try_clone().unwrap(),
             &keypair,
             request_recv_ip,
+            vec![], // alpn_protocols
             sender,
             request_recv_exit.clone(),
             1,
@@ -233,6 +236,7 @@ mod tests {
             response_recv_socket,
             &keypair2,
             response_recv_ip,
+            vec![], // alpn_protocols
             sender2,
             response_recv_exit.clone(),
             1,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -89,6 +89,7 @@ pub fn spawn_server(
     sock: UdpSocket,
     keypair: &Keypair,
     gossip_host: IpAddr,
+    alpn_protocols: Vec<Vec<u8>>,
     packet_sender: Sender<PacketBatch>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
@@ -99,7 +100,7 @@ pub fn spawn_server(
     coalesce: Duration,
 ) -> Result<(Endpoint, Arc<StreamStats>, JoinHandle<()>), QuicServerError> {
     info!("Start {name} quic server on {sock:?}");
-    let (config, _cert) = configure_server(keypair, gossip_host)?;
+    let (config, _cert) = configure_server(keypair, gossip_host, alpn_protocols)?;
 
     let endpoint = Endpoint::new(EndpointConfig::default(), Some(config), sock, TokioRuntime)
         .map_err(QuicServerError::EndpointFailed)?;
@@ -1139,7 +1140,6 @@ pub mod test {
             .expect("Failed to use client certificate");
 
         crypto.enable_early_data = true;
-        crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
         let mut config = ClientConfig::new(Arc::new(crypto));
 
@@ -1174,6 +1174,7 @@ pub mod test {
             s,
             &keypair,
             ip,
+            vec![], // alpn_protocols
             sender,
             exit.clone(),
             max_connections_per_peer,
@@ -1604,6 +1605,7 @@ pub mod test {
             s,
             &keypair,
             ip,
+            vec![], // alpn_protocols
             sender,
             exit.clone(),
             1,
@@ -1635,6 +1637,7 @@ pub mod test {
             s,
             &keypair,
             ip,
+            vec![], // alpn_protocols
             sender,
             exit.clone(),
             2,


### PR DESCRIPTION
#### Problem
Not everything is TPU.

#### Summary of Changes
Removed hard-coded ALPN protocol id in QUIC streamer