### PR TITLE
Docs/fix/transaction confirmation

### DIFF
--- a/docs/src/developing/transaction_confirmation.md
+++ b/docs/src/developing/transaction_confirmation.md
@@ -2,7 +2,7 @@
 title: "Transaction Confirmation"
 ---
 
-Problems relating to [transaction confirmation](./transaction_confirmation.md) are common with many newer developers while building applications. This article aims to boost the overall understanding of the confirmation mechanism used on the Solana blockchain, including some recommended best practices.
+Problems relating to [transaction confirmation](./../terminology.md#transaction-confirmations) are common with many newer developers while building applications. This article aims to boost the overall understanding of the confirmation mechanism used on the Solana blockchain, including some recommended best practices.
 
 ## Brief background on transactions
 

--- a/docs/src/developing/transaction_confirmation.md
+++ b/docs/src/developing/transaction_confirmation.md
@@ -2,8 +2,6 @@
 title: "Transaction Confirmation"
 ---
 
-into to transaction confirmation?
-
 Problems relating to [transaction confirmation](./transaction_confirmation.md) are common with many newer developers while building applications. This article aims to boost the overall understanding of the confirmation mechanism used on the Solana blockchain, including some recommended best practices.
 
 ## Brief background on transactions


### PR DESCRIPTION
#### Problem
1) First sentence of Transaction Confirmation page makes no sense.
2) Transaction confirmation link is linking to same page the docs are on.

#### Summary of Changes
1) Removes sentence that makes no sense (not sure the original intent, but happy to fix it if I can get some direction)
2) Fix link to link to transaction confirmations terminology page.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
