### PR TITLE
Removes #![allow(dead_code)] from local-cluster/tests/common.rs

### DIFF
--- a/local-cluster/tests/common/mod.rs
+++ b/local-cluster/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic, dead_code)]
+#![allow(clippy::integer_arithmetic)]
 use {
     log::*,
     solana_core::{


### PR DESCRIPTION
#### Problem

`local-cluster/tests/common.rs` has `#![allow(dead_code)]`, but doesn't need to.

Also, because of how rust handles integration tests, we see
```
Running tests/common.rs (/Users/brooks/work/solana/target/debug/deps/common-26a26a7b1a7f2b06)
0 tests, 0 benchmarks
```
when running the tests.


#### Summary of Changes

* Remove `#![allow(dead_code)]`
* Follow [the recommendations in the Rust book](https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests): move `local-cluster/tests/common.rs` to `local-cluster/tests/common/mod.rs`.