### PR TITLE
 add update_reward_history_in_partition

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3085,6 +3085,22 @@ impl Bank {
             .for_each(|x| rewards.push((x.stake_pubkey, x.stake_reward_info)));
     }
 
+    #[allow(dead_code)]
+    /// insert non-zero stake rewards to self.rewards
+    /// Return the number of rewards inserted
+    fn update_reward_history_in_partition(&self, stake_rewards: &[StakeReward]) -> usize {
+        let mut rewards: RwLockWriteGuard<Vec<(Pubkey, RewardInfo)>> =
+            self.rewards.write().unwrap();
+        rewards.reserve(stake_rewards.len());
+        let initial_len = rewards.len();
+        stake_rewards
+            .iter()
+            .filter(|x| x.get_stake_reward() > 0)
+            .for_each(|x| rewards.push((x.stake_pubkey, x.stake_reward_info)));
+        rewards.len().saturating_sub(initial_len)
+    }
+
+    /// Process reward credits for a partition of rewards
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
         #[allow(deprecated)]
         self.update_sysvar_account(&sysvar::recent_blockhashes::id(), |account| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3089,8 +3089,7 @@ impl Bank {
     /// insert non-zero stake rewards to self.rewards
     /// Return the number of rewards inserted
     fn update_reward_history_in_partition(&self, stake_rewards: &[StakeReward]) -> usize {
-        let mut rewards: RwLockWriteGuard<Vec<(Pubkey, RewardInfo)>> =
-            self.rewards.write().unwrap();
+        let mut rewards = self.rewards.write().unwrap();
         rewards.reserve(stake_rewards.len());
         let initial_len = rewards.len();
         stake_rewards

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3099,7 +3099,6 @@ impl Bank {
         rewards.len().saturating_sub(initial_len)
     }
 
-    /// Process reward credits for a partition of rewards
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
         #[allow(deprecated)]
         self.update_sysvar_account(&sysvar::recent_blockhashes::id(), |account| {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12491,6 +12491,63 @@ fn test_squash_timing_add_assign() {
 }
 
 #[test]
+fn test_update_reward_history_in_partition() {
+    for zero_reward in [false, true] {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        let mut expected_num = 100;
+
+        let mut stake_rewards = (0..expected_num)
+            .map(|_| StakeReward::new_random())
+            .collect::<Vec<_>>();
+
+        let mut rng = rand::thread_rng();
+        let i_zero = rng.gen_range(0, expected_num);
+        if zero_reward {
+            // pick one entry to have zero rewards so it gets ignored
+            stake_rewards[i_zero].stake_reward_info.lamports = 0;
+        }
+
+        let num_in_history = bank.update_reward_history_in_partition(&stake_rewards);
+
+        if zero_reward {
+            stake_rewards.remove(i_zero);
+            // -1 because one of them had zero rewards and was ignored
+            expected_num -= 1;
+        }
+
+        bank.rewards
+            .read()
+            .unwrap()
+            .iter()
+            .zip(stake_rewards.iter())
+            .for_each(|((k, reward_info), expected_stake_reward)| {
+                assert_eq!(
+                    (
+                        &expected_stake_reward.stake_pubkey,
+                        &expected_stake_reward.stake_reward_info
+                    ),
+                    (k, reward_info)
+                );
+            });
+
+        assert_eq!(num_in_history, expected_num);
+    }
+}
+
+#[test]
+fn test_update_reward_history_in_partition_empty() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    let stake_rewards = vec![];
+
+    let num_in_history = bank.update_reward_history_in_partition(&stake_rewards);
+    assert_eq!(num_in_history, 0);
+}
+
+#[test]
 fn test_system_instruction_allocate() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.0));
     let bank = Bank::new_for_tests(&genesis_config);


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.




#### Summary of Changes
Add `update_reward_history_in_partition`.
This is basically a copy of the existing fn right above this one: `update_reward_history`.
`update_reward_history` will be deleted once this feature is activated.
We cannot efficiently remove `StakeReward`s from a single partition, so we need to pass a ref to the current partition's rewards. Vote rewards would have been saved off earlier, so we'll never save vote rewards in the same code path.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
