### PR TITLE
add store_stake_accounts_in_partition

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1105,7 +1105,7 @@ struct VoteReward {
 
 type VoteRewards = DashMap<Pubkey, VoteReward>;
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct VoteRewardsAccounts {
     /// reward info for each vote account pubkey.
     /// This type is used by `update_reward_history()`
@@ -3162,6 +3162,38 @@ impl Bank {
             .iter()
             .map(|stake_reward| stake_reward.stake_reward_info.lamports)
             .sum::<i64>() as u64
+    }
+
+    #[allow(dead_code)]
+    fn store_vote_accounts_partitioned(
+        &self,
+        vote_account_rewards: VoteRewardsAccounts,
+        metrics: &mut RewardsMetrics,
+    ) -> Vec<(Pubkey, RewardInfo)> {
+        let (_, measure_us) = measure_us!({
+            let to_store = vote_account_rewards
+                .accounts_to_store
+                .iter()
+                .enumerate()
+                .filter_map(|(i, account)| {
+                    if account.is_some() {
+                        Some((
+                            &vote_account_rewards.rewards[i].0,
+                            account.as_ref().unwrap(),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            self.store_accounts((self.slot(), &to_store[..], self.include_slot_in_hash()));
+        });
+
+        metrics
+            .store_vote_accounts_us
+            .fetch_add(measure_us, Relaxed);
+
+        vote_account_rewards.rewards
     }
 
     fn store_vote_accounts(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -159,6 +159,30 @@ impl StakeReward {
     }
 }
 
+impl VoteReward {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+
+        let validator_pubkey = solana_sdk::pubkey::new_rand();
+        let validator_stake_lamports = rng.gen_range(1, 200);
+        let validator_voting_keypair = Keypair::new();
+
+        let validator_vote_account = vote_state::create_account(
+            &validator_voting_keypair.pubkey(),
+            &validator_pubkey,
+            rng.gen_range(1, 20),
+            validator_stake_lamports,
+        );
+
+        Self {
+            vote_account: validator_vote_account,
+            commission: rng.gen_range(1, 20),
+            vote_rewards: rng.gen_range(1, 200),
+            vote_needs_store: rng.gen_range(1, 20) > 10,
+        }
+    }
+}
+
 #[test]
 fn test_race_register_tick_freeze() {
     solana_logger::setup();
@@ -12668,6 +12692,53 @@ fn test_update_reward_history_in_partition_empty() {
 
     let num_in_history = bank.update_reward_history_in_partition(&stake_rewards);
     assert_eq!(num_in_history, 0);
+}
+
+#[test]
+fn test_store_vote_accounts_partitioned() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    let expected_vote_rewards_num = 100;
+
+    let vote_rewards = (0..expected_vote_rewards_num)
+        .map(|_| Some((Pubkey::new_unique(), VoteReward::random())))
+        .collect::<Vec<_>>();
+
+    let mut vote_rewards_account = VoteRewardsAccounts::default();
+    vote_rewards.into_iter().for_each(|e| {
+        if let Some(p) = &e {
+            let info = RewardInfo {
+                reward_type: RewardType::Voting,
+                lamports: p.1.vote_rewards as i64,
+                post_balance: p.1.vote_rewards,
+                commission: Some(p.1.commission),
+            };
+            vote_rewards_account.rewards.push((p.0, info));
+            vote_rewards_account
+                .accounts_to_store
+                .push(e.as_ref().map(|p| p.1.vote_account.clone()));
+        }
+    });
+
+    let mut metrics = RewardsMetrics::default();
+
+    let stored_vote_accounts =
+        bank.store_vote_accounts_partitioned(vote_rewards_account, &mut metrics);
+    assert_eq!(expected_vote_rewards_num, stored_vote_accounts.len());
+}
+
+#[test]
+fn test_store_vote_accounts_partitioned_empty() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    let expected = 0;
+    let vote_rewards = VoteRewardsAccounts::default();
+    let mut metrics = RewardsMetrics::default();
+
+    let stored_vote_accounts = bank.store_vote_accounts_partitioned(vote_rewards, &mut metrics);
+    assert_eq!(expected, stored_vote_accounts.len());
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

#### Summary of Changes
add `store_stake_accounts_in_partition`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->