### PR TITLE
correct feature gate use_default_units_in_fee_calculation usage

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -252,7 +252,7 @@ impl Accounts {
                 ComputeBudget::new(compute_budget::MAX_COMPUTE_UNIT_LIMIT as u64);
             let _process_transaction_result = compute_budget.process_instructions(
                 tx.message().program_instructions_iter(),
-                feature_set.is_active(&use_default_units_in_fee_calculation::id()),
+                true, // default_units_per_instruction has enabled in MNB
                 !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                 true, // don't reject txs that use request heap size ix
                 feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -15,7 +15,7 @@ use {
         feature_set::{
             add_set_tx_loaded_accounts_data_size_instruction,
             include_loaded_accounts_data_size_in_fee_calculation,
-            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
+            remove_deprecated_request_unit_ix, FeatureSet,
         },
         instruction::CompiledInstruction,
         program_utils::limited_deserialize,
@@ -116,7 +116,7 @@ impl CostModel {
         let enable_request_heap_frame_ix = true;
         let result = compute_budget.process_instructions(
             transaction.message().program_instructions_iter(),
-            feature_set.is_active(&use_default_units_in_fee_calculation::id()),
+            true, // default_units_per_instruction has enabled in MNB
             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
             enable_request_heap_frame_ix,
             feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),


### PR DESCRIPTION
#### Problem
Noticed the misusage of feature gate `use_default_units_in_fee_calculation` when working on another issue. This feature gate (#26785) was introduced to fix a hard-coded bug in `bank::calculate_fee()`, should only be used when calling `calculate_fee()`. 

`default_units_per_instruction` was enabled in mnb in epoch 327, all calls to `ComputeBudget::process_instructions()` should pass `true` to this parameter. 

The misusage corrected in this PR most likely resulting from copy/paste. Correcting should not have functional impact.

#### Summary of Changes
- use `true` for default_units_per_instruction instead of using  wrong feature gate status.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
