### PR TITLE
fix error `let...else` statements are unstable

### DIFF
--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_else)]
+
 extern crate proc_macro;
 
 // This file littered with these essential cfgs so ensure them.


### PR DESCRIPTION
#### Problem
![Screenshot 2023-06-13 004709](https://github.com/solana-labs/solana/assets/62652273/92e3bda5-36cb-4208-9722-4eaa39bf8544)


#### Summary of Changes

Added `#![feature(let_else)]` to the lib.rs file in order to enable the `let_else` feature.
