### PR TITLE
Fix - `enable_alt_bn128_syscall`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7730,6 +7730,7 @@ impl Bank {
             feature_set::reject_callx_r10::id(),
             feature_set::switch_to_new_elf_parser::id(),
             feature_set::bpf_account_data_direct_mapping::id(),
+            feature_set::enable_alt_bn128_syscall::id(),
         ];
         if !only_apply_transitions_for_new_features
             || FEATURES_AFFECTING_RBPF


### PR DESCRIPTION
#### Problem
The feature affects RBPF as it changes the set of valid syscalls, so it must be included in `FEATURES_AFFECTING_RBPF` as well.

#### Summary of Changes
- Adds `enable_alt_bn128_syscall` to `FEATURES_AFFECTING_RBPF`.
- Fixes `test_runtime_feature_enable_with_program_cache`.