### PR TITLE
pass get_reward_interval to load_accounts

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5051,7 +5051,7 @@ impl Bank {
             &self.feature_set,
             &self.fee_structure,
             account_overrides,
-            RewardInterval::OutsideInterval,
+            self.get_reward_interval(),
             &program_accounts_map,
             &programs_loaded_for_tx_batch.borrow(),
         );


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.




#### Summary of Changes
pass `bank.get_reward_interval()` to load_accounts. Prior to feature activation, `bank.get_reward_interval()` will only be `RewardInterval::OutsideInterval`, which is the default no-op behavior that exists today.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
