### PR TITLE
Bugfix: Account Shrink Paths must conform to account directory structure 

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1410,7 +1410,7 @@ pub fn main() {
             .map(|shrink_paths| shrink_paths.into_iter().map(PathBuf::from).collect())
             .ok();
     let account_shrink_paths = account_shrink_paths.as_ref().map(|paths| {
-        create_and_canonicalize_directories(&paths).unwrap_or_else(|err| {
+        create_and_canonicalize_directories(paths).unwrap_or_else(|err| {
             eprintln!("Unable to access account shrink path: {err}");
             exit(1);
         })

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1418,14 +1418,14 @@ pub fn main() {
 
     let (account_run_paths, account_snapshot_paths) =
         create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap_or_else(|err| {
-            eprintln!("Error: {err:?}");
+            eprintln!("Error: {err}");
             exit(1);
         });
 
     let (account_shrink_run_paths, account_shrink_snapshot_paths) =
         match account_shrink_paths.map(|paths| {
             create_all_accounts_run_and_snapshot_dirs(&paths).unwrap_or_else(|err| {
-                eprintln!("Error: {err:?}");
+                eprintln!("Error: {err}");
                 exit(1);
             })
         }) {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1422,16 +1422,14 @@ pub fn main() {
             exit(1);
         });
 
-    let (account_shrink_run_paths, account_shrink_snapshot_paths) =
-        match account_shrink_paths.map(|paths| {
+    let (account_shrink_run_paths, account_shrink_snapshot_paths) = account_shrink_paths
+        .map(|paths| {
             create_all_accounts_run_and_snapshot_dirs(&paths).unwrap_or_else(|err| {
                 eprintln!("Error: {err}");
                 exit(1);
             })
-        }) {
-            Some((run_paths, snapshot_paths)) => (Some(run_paths), Some(snapshot_paths)),
-            None => (None, None),
-        };
+        })
+        .unzip();
 
     // From now on, use run/ paths in the same way as the previous account_paths.
     validator_config.account_paths = account_run_paths;


### PR DESCRIPTION
#### Problem
Validator crashes if you specify account shrink paths. Discord context: https://discord.com/channels/428295358100013066/670512312339398668/1117869012576129074

#29496 introduced hardlinking for account storages, which created an expected account directory structure. Account directories are expected to have a structure:
```
account_path
   |
    -----run/
   |
    -----snapshot/
```
appendvecs in directories that do not follow this structure will cause `get_account_path_from_appendvec_path` to return an `InvalidAppendVecPath`.

The validator ensures account paths follow this structure, but does not do so for account shrink paths.

#### Summary of Changes
Ensure correct account directory structure for account shrink paths.

#### Testing
I was able to replicate the bug by running a local node w/ account shrink paths. On the snapshot after initial shrinking you see an panic:
```
thread 'solBgAccounts' panicked at 'snapshot bank: InvalidAppendVecPath("/home/apfitzge/dev/solana.worktrees/one-offs/config/bootstrap-validator/fking-shrink/82.128")', runtime/src/accounts_background_service.rs:396:18
```

Re-ran with the changes in this PR, and saw the snapshot generated w/o crashing and accounts in the `<account-shrink-path>/run/` and `<account-shrink-path>/snapshot/X/` paths.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
