### PR TITLE
Proof of Concept: Add `update_bank` to Geyser interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5720,6 +5720,7 @@ name = "solana-geyser-plugin-interface"
 version = "1.17.0"
 dependencies = [
  "log",
+ "solana-runtime",
  "solana-sdk",
  "solana-transaction-status",
  "thiserror",

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,13 +3,14 @@
 /// In addition, the dynamic library must export a "C" function _create_plugin which
 /// creates the implementation of the plugin.
 use {
+    solana_runtime::bank::Bank,
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         signature::Signature,
         transaction::SanitizedTransaction,
     },
     solana_transaction_status::{Reward, TransactionStatusMeta},
-    std::{any::Any, error, io},
+    std::{any::Any, error, io, sync::Arc},
     thiserror::Error,
 };
 
@@ -315,6 +316,12 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         parent: Option<u64>,
         status: SlotStatus,
     ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when a bank is updated
+    #[allow(unused_variables)]
+    fn update_bank(&self, bank: Option<Arc<Bank>>, status: SlotStatus) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -4,19 +4,20 @@ use {
     solana_geyser_plugin_interface::geyser_plugin_interface::SlotStatus,
     solana_measure::measure::Measure,
     solana_metrics::*,
+    solana_runtime::bank::Bank,
     solana_sdk::clock::Slot,
     std::sync::{Arc, RwLock},
 };
 
 pub trait SlotStatusNotifierInterface {
     /// Notified when a slot is optimistically confirmed
-    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_confirmed(&self, slot: Slot, bank: Option<Arc<Bank>>);
 
     /// Notified when a slot is marked frozen.
-    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_processed(&self, slot: Slot, bank: Option<Arc<Bank>>);
 
     /// Notified when a slot is rooted.
-    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_rooted(&self, slot: Slot, bank: Option<Arc<Bank>>);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;
@@ -26,16 +27,16 @@ pub struct SlotStatusNotifierImpl {
 }
 
 impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
-    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Confirmed);
+    fn notify_slot_confirmed(&self, slot: Slot, bank: Option<Arc<Bank>>) {
+        self.notify_slot_status(slot, bank, SlotStatus::Confirmed);
     }
 
-    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Processed);
+    fn notify_slot_processed(&self, slot: Slot, bank: Option<Arc<Bank>>) {
+        self.notify_slot_status(slot, bank, SlotStatus::Processed);
     }
 
-    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Rooted);
+    fn notify_slot_rooted(&self, slot: Slot, bank: Option<Arc<Bank>>) {
+        self.notify_slot_status(slot, bank, SlotStatus::Rooted);
     }
 }
 
@@ -44,12 +45,13 @@ impl SlotStatusNotifierImpl {
         Self { plugin_manager }
     }
 
-    pub fn notify_slot_status(&self, slot: Slot, parent: Option<Slot>, slot_status: SlotStatus) {
+    pub fn notify_slot_status(&self, slot: Slot, bank: Option<Arc<Bank>>, slot_status: SlotStatus) {
         let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
+        let parent = bank.as_ref().map(|bank| bank.parent_slot());
         for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
             match plugin.update_slot_status(slot, parent, slot_status) {
@@ -72,6 +74,32 @@ impl SlotStatusNotifierImpl {
             measure.stop();
             inc_new_counter_debug!(
                 "geyser-plugin-update-slot-us",
+                measure.as_us() as usize,
+                1000,
+                1000
+            );
+
+            let mut measure = Measure::start("geyser-plugin-update-bank");
+            match plugin.update_bank(bank.clone(), slot_status) {
+                Err(err) => {
+                    error!(
+                        "Failed to update bank at slot {}, error: {} to plugin {}",
+                        slot,
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Successfully updated bank at slot {} to plugin {}",
+                        slot,
+                        plugin.name()
+                    );
+                }
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "geyser-plugin-update-bank-us",
                 measure.as_us() as usize,
                 1000,
                 1000

--- a/geyser-plugin-manager/src/slot_status_observer.rs
+++ b/geyser-plugin-manager/src/slot_status_observer.rs
@@ -55,16 +55,13 @@ impl SlotStatusObserver {
                         let notifier = slot_status_notifier.read().unwrap();
                         match slot {
                             SlotNotification::OptimisticallyConfirmed(bank) => {
-                                notifier
-                                    .notify_slot_confirmed(bank.slot(), Some(bank.parent_slot()));
+                                notifier.notify_slot_confirmed(bank.slot(), Some(bank));
                             }
                             SlotNotification::Frozen(bank) => {
-                                notifier
-                                    .notify_slot_processed(bank.slot(), Some(bank.parent_slot()));
+                                notifier.notify_slot_processed(bank.slot(), Some(bank));
                             }
                             SlotNotification::Root((slot, bank)) => {
-                                notifier
-                                    .notify_slot_rooted(slot, bank.map(|bank| bank.parent_slot()));
+                                notifier.notify_slot_rooted(slot, bank);
                             }
                         }
                     }

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -48,11 +48,9 @@ pub enum BankNotification {
 
 #[derive(Clone, Debug)]
 pub enum SlotNotification {
-    OptimisticallyConfirmed(Slot),
-    /// The (Slot, Parent Slot) pair for the slot frozen
-    Frozen((Slot, Slot)),
-    /// The (Slot, Parent Slot) pair for the root slot
-    Root((Slot, Slot)),
+    OptimisticallyConfirmed(Arc<Bank>),
+    Frozen(Arc<Bank>),
+    Root((Slot, Option<Arc<Bank>>)),
 }
 
 impl std::fmt::Debug for BankNotification {
@@ -185,7 +183,7 @@ impl OptimisticallyConfirmedBankTracker {
                 *last_notified_confirmed_slot = bank.slot();
                 Self::notify_slot_status(
                     slot_notification_subscribers,
-                    SlotNotification::OptimisticallyConfirmed(bank.slot()),
+                    SlotNotification::OptimisticallyConfirmed(bank.clone()),
                 );
             }
         } else if bank.slot() > bank_forks.read().unwrap().root_bank().slot() {
@@ -224,6 +222,7 @@ impl OptimisticallyConfirmedBankTracker {
     fn notify_new_root_slots(
         roots: &mut Vec<Slot>,
         newest_root_slot: &mut Slot,
+        bank_forks: &Arc<RwLock<BankForks>>,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
     ) {
         if slot_notification_subscribers.is_none() {
@@ -242,7 +241,7 @@ impl OptimisticallyConfirmedBankTracker {
                 );
                 Self::notify_slot_status(
                     slot_notification_subscribers,
-                    SlotNotification::Root((root, parent)),
+                    SlotNotification::Root((root, bank_forks.read().unwrap().get(root))),
                 );
                 *newest_root_slot = root;
             }
@@ -318,7 +317,7 @@ impl OptimisticallyConfirmedBankTracker {
 
                     Self::notify_slot_status(
                         slot_notification_subscribers,
-                        SlotNotification::Frozen((bank.slot(), bank.parent_slot())),
+                        SlotNotification::Frozen(bank.clone()),
                     );
                 }
 
@@ -361,6 +360,7 @@ impl OptimisticallyConfirmedBankTracker {
                 Self::notify_new_root_slots(
                     &mut roots,
                     newest_root_slot,
+                    bank_forks,
                     slot_notification_subscribers,
                 );
             }


### PR DESCRIPTION
#### Problem

If we don't catch the initial account state on startup we can not get it later, with `fn update_bank` we will able to get accounts states and clients will able to keep in the actual state with `fn update_account`. Should be really helpful for https://github.com/rpcpool/yellowstone-grpc

#### Summary of Changes

Add `fn update_bank(&self, bank: Option<Arc<Bank>>, status: SlotStatus)` to Geyser interface.

<!-- Fixes # -->
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
