### PR TITLE
[zk-token-sdk] Update transcript functions to use full names

### DIFF
--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -68,7 +68,7 @@ impl InnerProductProof {
         // All of the input vectors must have a length that is a power of two.
         assert!(n.is_power_of_two());
 
-        transcript.innerproduct_domain_sep(n as u64);
+        transcript.innerproduct_domain_separator(n as u64);
 
         let lg_n = n.next_power_of_two().trailing_zeros() as usize;
         let mut L_vec = Vec::with_capacity(lg_n);
@@ -215,7 +215,7 @@ impl InnerProductProof {
             return Err(ProofVerificationError::InvalidBitSize.into());
         }
 
-        transcript.innerproduct_domain_sep(n as u64);
+        transcript.innerproduct_domain_separator(n as u64);
 
         // 1. Recompute x_k,...,x_1 based on the proof transcript
 

--- a/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
@@ -51,7 +51,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         (opening_lo, opening_hi): (&PedersenOpening, &PedersenOpening),
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_sep();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
 
         let t = transcript.challenge_scalar(b"t");
 
@@ -81,7 +81,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         (auditor_handle_lo, auditor_handle_hi): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofError> {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_sep();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
 
         let t = transcript.challenge_scalar(b"t");
 

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
@@ -68,7 +68,7 @@ impl CiphertextCiphertextEqualityProof {
         amount: u64,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.equality_proof_domain_sep();
+        transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_keypair.public.get_point();
@@ -136,7 +136,7 @@ impl CiphertextCiphertextEqualityProof {
         destination_ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
-        transcript.equality_proof_domain_sep();
+        transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.get_point();

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -72,7 +72,7 @@ impl CiphertextCommitmentEqualityProof {
         amount: u64,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.equality_proof_domain_sep();
+        transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_keypair.public.get_point();
@@ -133,7 +133,7 @@ impl CiphertextCommitmentEqualityProof {
         destination_commitment: &PedersenCommitment,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
-        transcript.equality_proof_domain_sep();
+        transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.get_point();

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -70,7 +70,7 @@ impl GroupedCiphertext2HandlesValidityProof {
         opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.grouped_ciphertext_validity_proof_domain_sep();
+        transcript.grouped_ciphertext_validity_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_dest = destination_pubkey.get_point();
@@ -125,7 +125,7 @@ impl GroupedCiphertext2HandlesValidityProof {
         (destination_handle, auditor_handle): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofError> {
-        transcript.grouped_ciphertext_validity_proof_domain_sep();
+        transcript.grouped_ciphertext_validity_proof_domain_separator();
 
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -54,7 +54,7 @@ impl PubkeyValidityProof {
     /// proved
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn new(elgamal_keypair: &ElGamalKeypair, transcript: &mut Transcript) -> Self {
-        transcript.pubkey_proof_domain_sep();
+        transcript.pubkey_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
         let s = elgamal_keypair.secret.get_scalar();
@@ -87,7 +87,7 @@ impl PubkeyValidityProof {
         elgamal_pubkey: &ElGamalPubkey,
         transcript: &mut Transcript,
     ) -> Result<(), PubkeyValidityProofError> {
-        transcript.pubkey_proof_domain_sep();
+        transcript.pubkey_proof_domain_separator();
 
         // extract the relvant scalar and Ristretto points from the input
         let P = elgamal_pubkey.get_point();

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -60,7 +60,7 @@ impl ZeroBalanceProof {
         ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.zero_balance_proof_domain_sep();
+        transcript.zero_balance_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
         let P = elgamal_keypair.public.get_point();
@@ -99,7 +99,7 @@ impl ZeroBalanceProof {
         ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ZeroBalanceProofError> {
-        transcript.zero_balance_proof_domain_sep();
+        transcript.zero_balance_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
         let P = elgamal_pubkey.get_point();

--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -169,6 +169,8 @@ impl TranscriptProtocol for Transcript {
     }
 
     fn grouped_ciphertext_validity_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"validity-proof")
+    }
 
     fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"batched-validity-proof")

--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -7,23 +7,23 @@ use {
 pub trait TranscriptProtocol {
     /// Append a domain separator for an `n`-bit rangeproof for ElGamalKeypair
     /// ciphertext using a decryption key
-    fn rangeproof_from_key_domain_sep(&mut self, n: u64);
+    fn rangeproof_from_key_domain_separator(&mut self, n: u64);
 
     /// Append a domain separator for an `n`-bit rangeproof for ElGamalKeypair
     /// ciphertext using an opening
-    fn rangeproof_from_opening_domain_sep(&mut self, n: u64);
+    fn rangeproof_from_opening_domain_separator(&mut self, n: u64);
 
     /// Append a domain separator for a length-`n` inner product proof.
-    fn innerproduct_domain_sep(&mut self, n: u64);
+    fn innerproduct_domain_separator(&mut self, n: u64);
 
     /// Append a domain separator for close account proof.
-    fn close_account_proof_domain_sep(&mut self);
+    fn close_account_proof_domain_separator(&mut self);
 
     /// Append a domain separator for withdraw proof.
-    fn withdraw_proof_domain_sep(&mut self);
+    fn withdraw_proof_domain_separator(&mut self);
 
     /// Append a domain separator for transfer proof.
-    fn transfer_proof_domain_sep(&mut self);
+    fn transfer_proof_domain_separator(&mut self);
 
     /// Append a `scalar` with the given `label`.
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
@@ -51,22 +51,22 @@ pub trait TranscriptProtocol {
     fn append_handle(&mut self, label: &'static [u8], point: &pod::DecryptHandle);
 
     /// Append a domain separator for equality proof.
-    fn equality_proof_domain_sep(&mut self);
+    fn equality_proof_domain_separator(&mut self);
 
     /// Append a domain separator for zero-balance proof.
-    fn zero_balance_proof_domain_sep(&mut self);
+    fn zero_balance_proof_domain_separator(&mut self);
 
     /// Append a domain separator for grouped ciphertext validity proof.
-    fn grouped_ciphertext_validity_proof_domain_sep(&mut self);
+    fn grouped_ciphertext_validity_proof_domain_separator(&mut self);
 
     /// Append a domain separator for batched grouped ciphertext validity proof.
-    fn batched_grouped_ciphertext_validity_proof_domain_sep(&mut self);
+    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self);
 
     /// Append a domain separator for fee sigma proof.
-    fn fee_sigma_proof_domain_sep(&mut self);
+    fn fee_sigma_proof_domain_separator(&mut self);
 
     /// Append a domain separator for public-key proof.
-    fn pubkey_proof_domain_sep(&mut self);
+    fn pubkey_proof_domain_separator(&mut self);
 
     /// Check that a point is not the identity, then append it to the
     /// transcript.  Otherwise, return an error.
@@ -81,30 +81,30 @@ pub trait TranscriptProtocol {
 }
 
 impl TranscriptProtocol for Transcript {
-    fn rangeproof_from_key_domain_sep(&mut self, n: u64) {
+    fn rangeproof_from_key_domain_separator(&mut self, n: u64) {
         self.append_message(b"dom-sep", b"rangeproof from opening v1");
         self.append_u64(b"n", n);
     }
 
-    fn rangeproof_from_opening_domain_sep(&mut self, n: u64) {
+    fn rangeproof_from_opening_domain_separator(&mut self, n: u64) {
         self.append_message(b"dom-sep", b"rangeproof from opening v1");
         self.append_u64(b"n", n);
     }
 
-    fn innerproduct_domain_sep(&mut self, n: u64) {
+    fn innerproduct_domain_separator(&mut self, n: u64) {
         self.append_message(b"dom-sep", b"ipp v1");
         self.append_u64(b"n", n);
     }
 
-    fn close_account_proof_domain_sep(&mut self) {
+    fn close_account_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"CloseAccountProof");
     }
 
-    fn withdraw_proof_domain_sep(&mut self) {
+    fn withdraw_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"WithdrawProof");
     }
 
-    fn transfer_proof_domain_sep(&mut self) {
+    fn transfer_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"TransferProof");
     }
 
@@ -160,27 +160,25 @@ impl TranscriptProtocol for Transcript {
         self.append_message(label, &handle.0);
     }
 
-    fn equality_proof_domain_sep(&mut self) {
+    fn equality_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"equality-proof")
     }
 
-    fn zero_balance_proof_domain_sep(&mut self) {
+    fn zero_balance_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"zero-balance-proof")
     }
 
-    fn grouped_ciphertext_validity_proof_domain_sep(&mut self) {
-        self.append_message(b"dom-sep", b"validity-proof")
-    }
+    fn grouped_ciphertext_validity_proof_domain_separator(&mut self) {
 
-    fn batched_grouped_ciphertext_validity_proof_domain_sep(&mut self) {
+    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"batched-validity-proof")
     }
 
-    fn fee_sigma_proof_domain_sep(&mut self) {
+    fn fee_sigma_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"fee-sigma-proof")
     }
 
-    fn pubkey_proof_domain_sep(&mut self) {
+    fn pubkey_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"pubkey-proof")
     }
 }


### PR DESCRIPTION
#### Problem
The (private) function names in the `transcript` module use shortened names. For example, `pubkey_proof_domain_sep`.

#### Summary of Changes
Update function names to use `separator` instead of `sep`. For example `pubkey_proof_domain_sep` --> `pubkey_proof_domain_separator`.

This is a follow-up to https://github.com/solana-labs/solana/pull/32040#discussion_r1227357628.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
