### PR TITLE
removes outdated tvu_forward socket

### DIFF
--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -62,9 +62,6 @@ fn bench_retransmitter(bencher: &mut Bencher) {
         let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
         let port = socket.local_addr().unwrap().port();
         contact_info.set_tvu((Ipv4Addr::LOCALHOST, port)).unwrap();
-        contact_info
-            .set_tvu_forwards(contact_info.tvu(Protocol::UDP).unwrap())
-            .unwrap();
         info!("local: {:?}", contact_info.tvu(Protocol::UDP).unwrap());
         cluster_info.insert_info(contact_info);
         socket.set_nonblocking(true).unwrap();

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -139,7 +139,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             peers.iter().enumerate().for_each(|(i, peer)| {
                 if fake == (i <= self.partition) {
                     // Send fake shreds to the first N peers
-                    if let Ok(addr) = peer.tvu_forwards() {
+                    if let Ok(addr) = peer.tvu(Protocol::UDP) {
                         data_shreds.iter().for_each(|b| {
                             sock.send_to(b.payload(), addr).unwrap();
                         });

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -1929,7 +1929,6 @@ mod tests {
         );
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
         nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
-        nxt.set_tvu_forwards((Ipv4Addr::LOCALHOST, 1236)).unwrap();
         nxt.set_repair((Ipv4Addr::LOCALHOST, 1237)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
@@ -1960,7 +1959,6 @@ mod tests {
         );
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
         nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
-        nxt.set_tvu_forwards((Ipv4Addr::LOCALHOST, 1236)).unwrap();
         nxt.set_repair((Ipv4Addr::LOCALHOST, 1237)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -80,7 +80,6 @@ pub struct TvuSockets {
     pub(crate) fetch_quic: UdpSocket,
     pub repair: UdpSocket,
     pub retransmit: Vec<UdpSocket>,
-    pub forwards: Vec<UdpSocket>,
     pub ancestor_hashes_requests: UdpSocket,
 }
 
@@ -149,7 +148,6 @@ impl Tvu {
             fetch: fetch_sockets,
             fetch_quic: fetch_quic_socket,
             retransmit: retransmit_sockets,
-            forwards: tvu_forward_sockets,
             ancestor_hashes_requests: ancestor_hashes_socket,
         } = sockets;
 
@@ -158,12 +156,9 @@ impl Tvu {
         let repair_socket = Arc::new(repair_socket);
         let ancestor_hashes_socket = Arc::new(ancestor_hashes_socket);
         let fetch_sockets: Vec<Arc<UdpSocket>> = fetch_sockets.into_iter().map(Arc::new).collect();
-        let forward_sockets: Vec<Arc<UdpSocket>> =
-            tvu_forward_sockets.into_iter().map(Arc::new).collect();
         let fetch_stage = ShredFetchStage::new(
             fetch_sockets,
             fetch_quic_socket,
-            forward_sockets,
             repair_socket.clone(),
             fetch_sender,
             tvu_config.shred_version,
@@ -463,7 +458,6 @@ pub mod tests {
                     retransmit: target1.sockets.retransmit_sockets,
                     fetch: target1.sockets.tvu,
                     fetch_quic: target1.sockets.tvu_quic,
-                    forwards: target1.sockets.tvu_forwards,
                     ancestor_hashes_requests: target1.sockets.ancestor_hashes_requests,
                 }
             },

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1135,7 +1135,6 @@ impl Validator {
                 retransmit: node.sockets.retransmit_sockets,
                 fetch: node.sockets.tvu,
                 fetch_quic: node.sockets.tvu_quic,
-                forwards: node.sockets.tvu_forwards,
                 ancestor_hashes_requests: node.sockets.ancestor_hashes_requests,
             },
             blockstore.clone(),

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -117,7 +117,6 @@ pub struct TransactionParams {
 pub enum Mode {
     Gossip,
     Tvu,
-    TvuForwards,
     Tpu,
     TpuForwards,
     Repair,

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -444,7 +444,6 @@ fn get_target(
                 target = match mode {
                     Mode::Gossip => Some((*node.pubkey(), node.gossip().unwrap())),
                     Mode::Tvu => Some((*node.pubkey(), node.tvu(Protocol::UDP).unwrap())),
-                    Mode::TvuForwards => Some((*node.pubkey(), node.tvu_forwards().unwrap())),
                     Mode::Tpu => Some((*node.pubkey(), node.tpu(protocol).unwrap())),
                     Mode::TpuForwards => {
                         Some((*node.pubkey(), node.tpu_forwards(protocol).unwrap()))

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -36,7 +36,6 @@ const SOCKET_TAG_TPU_FORWARDS_QUIC: u8 = 7;
 const SOCKET_TAG_TPU_QUIC: u8 = 8;
 const SOCKET_TAG_TPU_VOTE: u8 = 9;
 const SOCKET_TAG_TVU: u8 = 10;
-const SOCKET_TAG_TVU_FORWARDS: u8 = 11;
 const SOCKET_TAG_TVU_QUIC: u8 = 12;
 const_assert_eq!(SOCKET_CACHE_SIZE, 13);
 const SOCKET_CACHE_SIZE: usize = SOCKET_TAG_TVU_QUIC as usize + 1usize;
@@ -228,7 +227,6 @@ impl ContactInfo {
     );
     get_socket!(tpu_vote, SOCKET_TAG_TPU_VOTE);
     get_socket!(tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
-    get_socket!(tvu_forwards, SOCKET_TAG_TVU_FORWARDS);
 
     set_socket!(set_gossip, SOCKET_TAG_GOSSIP);
     set_socket!(set_repair, SOCKET_TAG_REPAIR);
@@ -243,7 +241,6 @@ impl ContactInfo {
     );
     set_socket!(set_tpu_vote, SOCKET_TAG_TPU_VOTE);
     set_socket!(set_tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
-    set_socket!(set_tvu_forwards, SOCKET_TAG_TVU_FORWARDS);
 
     remove_socket!(remove_serve_repair, SOCKET_TAG_SERVE_REPAIR);
     remove_socket!(remove_tpu, SOCKET_TAG_TPU, SOCKET_TAG_TPU_QUIC);
@@ -253,7 +250,6 @@ impl ContactInfo {
         SOCKET_TAG_TPU_FORWARDS_QUIC
     );
     remove_socket!(remove_tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
-    remove_socket!(remove_tvu_forwards, SOCKET_TAG_TVU_FORWARDS);
 
     #[cfg(test)]
     fn get_socket(&self, key: u8) -> Result<SocketAddr, Error> {
@@ -359,7 +355,6 @@ impl ContactInfo {
         let mut node = Self::new(*pubkey, wallclock, /*shred_version:*/ 0u16);
         node.set_gossip((Ipv4Addr::LOCALHOST, 8000)).unwrap();
         node.set_tvu((Ipv4Addr::LOCALHOST, 8001)).unwrap();
-        node.set_tvu_forwards((Ipv4Addr::LOCALHOST, 8002)).unwrap();
         node.set_repair((Ipv4Addr::LOCALHOST, 8007)).unwrap();
         node.set_tpu((Ipv4Addr::LOCALHOST, 8003)).unwrap(); // quic: 8009
         node.set_tpu_forwards((Ipv4Addr::LOCALHOST, 8004)).unwrap(); // quic: 8010
@@ -383,7 +378,6 @@ impl ContactInfo {
         let (addr, port) = (socket.ip(), socket.port());
         node.set_gossip((addr, port + 1)).unwrap();
         node.set_tvu((addr, port + 2)).unwrap();
-        node.set_tvu_forwards((addr, port + 3)).unwrap();
         node.set_repair((addr, port + 4)).unwrap();
         node.set_tpu((addr, port)).unwrap(); // quic: port + 6
         node.set_tpu_forwards((addr, port + 5)).unwrap(); // quic: port + 11
@@ -747,10 +741,6 @@ mod tests {
                 node.tvu(Protocol::QUIC).ok().as_ref(),
                 sockets.get(&SOCKET_TAG_TVU_QUIC)
             );
-            assert_eq!(
-                node.tvu_forwards().ok().as_ref(),
-                sockets.get(&SOCKET_TAG_TVU_FORWARDS)
-            );
             // Assert that all IP addresses are unique.
             assert_eq!(
                 node.addrs.len(),
@@ -841,7 +831,6 @@ mod tests {
             old.tvu(Protocol::UDP).unwrap(),
             node.tvu(Protocol::UDP).unwrap()
         );
-        assert_eq!(old.tvu_forwards().unwrap(), node.tvu_forwards().unwrap());
     }
 
     #[test]

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -196,7 +196,6 @@ impl LegacyContactInfo {
 
     get_socket!(gossip);
     get_socket!(@quic tvu);
-    get_socket!(tvu_forwards);
     get_socket!(repair);
     get_socket!(@quic tpu);
     get_socket!(@quic tpu_forwards);
@@ -264,7 +263,7 @@ impl TryFrom<&ContactInfo> for LegacyContactInfo {
             id: *node.pubkey(),
             gossip: unwrap_socket!(gossip),
             tvu: unwrap_socket!(tvu, Protocol::UDP),
-            tvu_forwards: unwrap_socket!(tvu_forwards),
+            tvu_forwards: SOCKET_ADDR_UNSPECIFIED,
             repair: unwrap_socket!(repair),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -130,7 +130,7 @@ fn retransmit_to(
     let dests: Vec<_> = if forwarded {
         peers
             .iter()
-            .filter_map(|peer| peer.tvu_forwards().ok())
+            .filter_map(|peer| peer.tvu(Protocol::UDP).ok())
             .filter(|addr| socket_addr_space.check(addr))
             .collect()
     } else {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -102,7 +102,7 @@ impl From<ContactInfo> for AdminRpcContactInfo {
             last_updated_timestamp: node.wallclock(),
             gossip: unwrap_socket!(gossip),
             tvu: unwrap_socket!(tvu, Protocol::UDP),
-            tvu_forwards: unwrap_socket!(tvu_forwards),
+            tvu_forwards: SOCKET_ADDR_UNSPECIFIED,
             repair: unwrap_socket!(repair),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -100,9 +100,6 @@ fn verify_reachable_ports(
         udp_sockets.extend(node.sockets.broadcast.iter());
         udp_sockets.extend(node.sockets.retransmit_sockets.iter());
     }
-    if verify_address(&node.info.tvu_forwards().ok()) {
-        udp_sockets.extend(node.sockets.tvu_forwards.iter());
-    }
 
     let mut tcp_listeners = vec![];
     if let Some((rpc_addr, rpc_pubsub_addr)) = validator_config.rpc_addrs {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1763,7 +1763,6 @@ pub fn main() {
         node.info.remove_tpu();
         node.info.remove_tpu_forwards();
         node.info.remove_tvu();
-        node.info.remove_tvu_forwards();
         node.info.remove_serve_repair();
 
         // A node in this configuration shouldn't be an entrypoint to other nodes


### PR DESCRIPTION
#### Problem
Shreds are no longer sent to `tvu_forward`.

#### Summary of Changes
Removed outdated `tvu_forward` socket.