### PR TITLE
adds const SOCKET_ADDR_UNSPECIFIED

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -22,6 +22,9 @@ pub use {
     crate::legacy_contact_info::LegacyContactInfo, solana_client::connection_cache::Protocol,
 };
 
+pub const SOCKET_ADDR_UNSPECIFIED: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0u16);
+
 const SOCKET_TAG_GOSSIP: u8 = 0;
 const SOCKET_TAG_REPAIR: u8 = 1;
 const SOCKET_TAG_RPC: u8 = 2;
@@ -181,7 +184,7 @@ impl ContactInfo {
             version: solana_version::Version::default(),
             addrs: Vec::<IpAddr>::default(),
             sockets: Vec::<SocketEntry>::default(),
-            cache: [socket_addr_unspecified(); SOCKET_CACHE_SIZE],
+            cache: [SOCKET_ADDR_UNSPECIFIED; SOCKET_CACHE_SIZE],
         }
     }
 
@@ -329,7 +332,7 @@ impl ContactInfo {
             }
             self.maybe_remove_addr(entry.index);
             if let Some(entry) = self.cache.get_mut(usize::from(key)) {
-                *entry = socket_addr_unspecified();
+                *entry = SOCKET_ADDR_UNSPECIFIED;
             }
         }
     }
@@ -425,7 +428,7 @@ impl TryFrom<ContactInfoLite> for ContactInfo {
             version,
             addrs,
             sockets,
-            cache: [socket_addr_unspecified(); SOCKET_CACHE_SIZE],
+            cache: [SOCKET_ADDR_UNSPECIFIED; SOCKET_CACHE_SIZE],
         };
         // Populate node.cache.
         let mut port = 0u16;
@@ -455,11 +458,6 @@ impl Sanitize for ContactInfo {
         }
         Ok(())
     }
-}
-
-// Workaround until feature(const_socketaddr) is stable.
-pub(crate) fn socket_addr_unspecified() -> SocketAddr {
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0u16)
 }
 
 pub(crate) fn sanitize_socket(socket: &SocketAddr) -> Result<(), Error> {
@@ -686,7 +684,7 @@ mod tests {
             version: solana_version::Version::default(),
             addrs: Vec::default(),
             sockets: Vec::default(),
-            cache: [socket_addr_unspecified(); SOCKET_CACHE_SIZE],
+            cache: [SOCKET_ADDR_UNSPECIFIED; SOCKET_CACHE_SIZE],
         };
         let mut sockets = HashMap::<u8, SocketAddr>::new();
         for _ in 0..1 << 14 {
@@ -706,7 +704,7 @@ mod tests {
                 if usize::from(key) < SOCKET_CACHE_SIZE {
                     assert_eq!(
                         &node.cache[usize::from(key)],
-                        socket.unwrap_or(&socket_addr_unspecified())
+                        socket.unwrap_or(&SOCKET_ADDR_UNSPECIFIED)
                     )
                 }
             }

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
         contact_info::{
-            get_quic_socket, sanitize_quic_offset, sanitize_socket, socket_addr_unspecified,
-            ContactInfo, Error, Protocol,
+            get_quic_socket, sanitize_quic_offset, sanitize_socket, ContactInfo, Error, Protocol,
+            SOCKET_ADDR_UNSPECIFIED,
         },
         crds_value::MAX_WALLCLOCK,
     },
@@ -244,12 +244,12 @@ impl TryFrom<&ContactInfo> for LegacyContactInfo {
     fn try_from(node: &ContactInfo) -> Result<Self, Self::Error> {
         macro_rules! unwrap_socket {
             ($name:ident) => {
-                node.$name().ok().unwrap_or_else(socket_addr_unspecified)
+                node.$name().ok().unwrap_or(SOCKET_ADDR_UNSPECIFIED)
             };
             ($name:ident, $protocol:expr) => {
                 node.$name($protocol)
                     .ok()
-                    .unwrap_or_else(socket_addr_unspecified)
+                    .unwrap_or(SOCKET_ADDR_UNSPECIFIED)
             };
         }
         sanitize_quic_offset(

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -14,7 +14,7 @@ use {
         tower_storage::TowerStorage, validator::ValidatorStartProgress,
     },
     solana_geyser_plugin_manager::GeyserPluginManagerRequest,
-    solana_gossip::contact_info::{ContactInfo, Protocol},
+    solana_gossip::contact_info::{ContactInfo, Protocol, SOCKET_ADDR_UNSPECIFIED},
     solana_rpc::rpc::verify_pubkey,
     solana_rpc_client_api::{config::RpcAccountIndex, custom_error::RpcCustomError},
     solana_runtime::accounts_index::AccountIndex,
@@ -27,7 +27,7 @@ use {
         collections::{HashMap, HashSet},
         error,
         fmt::{self, Display},
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::SocketAddr,
         path::{Path, PathBuf},
         sync::{Arc, RwLock},
         thread::{self, Builder},
@@ -91,14 +91,10 @@ impl From<ContactInfo> for AdminRpcContactInfo {
     fn from(node: ContactInfo) -> Self {
         macro_rules! unwrap_socket {
             ($name:ident) => {
-                node.$name().unwrap_or_else(|_| {
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0u16)
-                })
+                node.$name().unwrap_or(SOCKET_ADDR_UNSPECIFIED)
             };
             ($name:ident, $protocol:expr) => {
-                node.$name($protocol).unwrap_or_else(|_| {
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0u16)
-                })
+                node.$name($protocol).unwrap_or(SOCKET_ADDR_UNSPECIFIED)
             };
         }
         Self {


### PR DESCRIPTION
#### Problem
`const` socket-addr is stable since rust 1.69.0:
https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html

#### Summary of Changes
added `const SOCKET_ADDR_UNSPECIFIED`.