### PR TITLE
set Transfer transaction loaded_accounts_data_size in bench-tps

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -62,6 +62,10 @@ pub fn max_lamports_for_prioritization(use_randomized_compute_unit_price: bool) 
     }
 }
 
+// set transfer transaction's loaded account data size to 30K - large enough yet smaller than
+// 32K page size, so it'd cost 0 extra CU.
+const TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE: u32 = 30 * 1024;
+
 pub type TimestampedTransaction = (Transaction, Option<u64>);
 pub type SharedTransactions = Arc<RwLock<VecDeque<Vec<TimestampedTransaction>>>>;
 
@@ -592,6 +596,11 @@ fn transfer_with_compute_unit_price_and_padding(
             ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
         ])
     }
+    instructions.extend_from_slice(&[
+        ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+            TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE,
+        ),
+    ]);
     let message = Message::new(&instructions, Some(&from_pubkey));
     Transaction::new(&[from_keypair], message, recent_blockhash)
 }
@@ -678,8 +687,14 @@ fn nonced_transfer_with_padding(
     } else {
         transfer_instruction
     };
+    let mut instructions = vec![instruction];
+    instructions.extend_from_slice(&[
+        ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+            TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE,
+        ),
+    ]);
     let message = Message::new_with_nonce(
-        vec![instruction],
+        instructions,
         Some(&from_pubkey),
         nonce_account,
         &nonce_authority.pubkey(),

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -45,7 +45,7 @@ const MAX_TX_QUEUE_AGE: u64 = (MAX_PROCESSING_AGE as f64 * DEFAULT_S_PER_SLOT) a
 // It also sets transaction's compute-unit to TRANSFER_TRANSACTION_COMPUTE_UNIT. Therefore the
 // max additional cost is `TRANSFER_TRANSACTION_COMPUTE_UNIT * MAX_COMPUTE_UNIT_PRICE / 1_000_000`
 const MAX_COMPUTE_UNIT_PRICE: u64 = 50;
-const TRANSFER_TRANSACTION_COMPUTE_UNIT: u32 = 450;
+const TRANSFER_TRANSACTION_COMPUTE_UNIT: u32 = 600; // 1 transfer is plus 3 compute_budget ixs
 /// calculate maximum possible prioritization fee, if `use-randomized-compute-unit-price` is
 /// enabled, round to nearest lamports.
 pub fn max_lamports_for_prioritization(use_randomized_compute_unit_price: bool) -> u64 {


### PR DESCRIPTION
#### Problem
#31905 includes CU cost of transaction's loaded_accounts_data_size to cost model. Mentioned [here](https://discord.com/channels/428295358100013066/1031929516383281154/1116747787070079026), if transaction does not explicitly use `ComputeBudgetInstruction::set_loaded_accounts_data_size_limit()` to set accounts data limit, the default 64M (chosen to not to break any existing mainnet-beta programs) will be used. Applying same heap cost (eg 8cu per 32K), that'd add 16K CU to each Transfer transaction, quickly fill up block CU limit, reduce tps.

#### Summary of Changes
- Add `ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(30 * 1024)` to Transfer transaction.

tested and confirmed on single node cluster.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
