### PR TITLE
add compare_with_partitioned_rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3094,6 +3094,32 @@ impl Bank {
         );
     }
 
+    #[allow(dead_code)]
+    /// compare the vote and stake accounts between the normal rewards calculation code
+    /// and the partitioned rewards calculation code
+    /// `stake_rewards_expected` and `vote_rewards_expected` are the results of the normal rewards calculation code
+    /// This fn should have NO side effects.
+    fn compare_with_partitioned_rewards(
+        &self,
+        stake_rewards_expected: &[StakeReward],
+        vote_rewards_expected: &DashMap<Pubkey, VoteReward>,
+        rewarded_epoch: Epoch,
+        thread_pool: &ThreadPool,
+        reward_calc_tracer: Option<impl RewardCalcTracer>,
+    ) {
+        let partitioned_rewards = self.calculate_rewards_for_partitioning(
+            rewarded_epoch,
+            reward_calc_tracer,
+            thread_pool,
+            &mut RewardsMetrics::default(),
+        );
+        Self::compare_with_partitioned_rewards_results(
+            stake_rewards_expected,
+            vote_rewards_expected,
+            partitioned_rewards,
+        );
+    }
+
     fn load_vote_and_stake_accounts(
         &mut self,
         thread_pool: &ThreadPool,


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

#### Summary of Changes
add `compare_with_partitioned_rewards`
This fn will be called when a test cli arg is passed to a validator. (`--partitioned_epoch_rewards_force_enable_single_slot`)
Normal rewards code will run, then this code will be run to make sure that both methods produce the same set of stake and vote account changes.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
