### PR TITLE
Removes unnecessary call to `purge_old_bank_snapshots()` in local-cluster test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1108,14 +1108,6 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     info!(
         "Restarting the validator with full snapshot {validator_full_snapshot_slot_at_startup}..."
     );
-    // To restart, it is not enough to remove the old bank snapshot directories under snapshot/.
-    // The old hardlinks under <account_path>/snapshot/<slot> should also be removed.
-    // The purge call covers all of them.
-    snapshot_utils::purge_old_bank_snapshots(
-        validator_snapshot_test_config.bank_snapshots_dir,
-        0,
-        None,
-    );
     cluster.restart_node(
         &validator_identity.pubkey(),
         validator_info,


### PR DESCRIPTION
#### Problem

#29496 added code to cleanup leftover files that may still be in `accounts/snapshots/` that caused this test to fail. Since then, we now perform the cleanup when the validator starts up, and this additional cleanup is no longer necessary.


#### Summary of Changes

Do not call `purge_old_bank_snapshots()` in local-cluster tests.


#### Additional Testing

I've been running `test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup` in a loop on my dev box since opening this PR. No failures seen so far (about 15 hours at the time of writing).