### PR TITLE
add partitioned_rewards_feature_enabled

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1480,6 +1480,11 @@ impl Bank {
     }
 
     #[allow(dead_code)]
+    fn partitioned_rewards_feature_enabled(&self) -> bool {
+        false // Will be feature later. It is convenient to have a constant fn at the moment.
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn set_epoch_reward_status_active(&mut self, stake_rewards: Vec<StakeRewards>) {
         self.epoch_reward_status = EpochRewardStatus::Active(StartBlockHeightAndRewards {
             start_block_height: self.block_height,


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

partitioned epoch rewards will be a feature at some point. It is unwise to create a feature id until the feature is ready to be activated. In the meantime, it is convenient to have a constant fn which can be called to determine if the feature has been activated. Returning a constant `false` allows existing code to run as-is. When the feature is added, the impl of this fn can be filled out.

#### Summary of Changes
add `partitioned_rewards_feature_enabled`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
