### PR TITLE
add begin_partitioned_rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1858,7 +1858,7 @@ impl Bank {
         thread_pool: &ThreadPool,
         parent_epoch: Epoch,
         parent_slot: Slot,
-        parent_height: u64,
+        parent_block_height: u64,
         rewards_metrics: &mut RewardsMetrics,
     ) {
         let CalculateRewardsAndDistributeVoteRewardsResult {
@@ -1875,12 +1875,12 @@ impl Bank {
         self.set_epoch_reward_status_active(stake_rewards_by_partition);
 
         datapoint_info!(
-            "reward-status-update",
-            ("slot", slot, i64),
-            ("block_height", self.block_height(), i64),
+            "epoch-reward-status-update",
+            ("start_slot", slot, i64),
+            ("start_block_height", self.block_height(), i64),
             ("activate", 1, i64),
-            ("parent_start_slot", parent_slot, i64),
-            ("parent_start_height", parent_height, i64),
+            ("parent_slot", parent_slot, i64),
+            ("parent_block_height", parent_block_height, i64),
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1849,6 +1849,41 @@ impl Bank {
         self.epoch_reward_status = EpochRewardStatus::Inactive;
     }
 
+    #[allow(dead_code)]
+    /// Begin the process of calculating and distributing rewards.
+    /// This process can take multiple slots.
+    fn begin_partitioned_rewards(
+        &mut self,
+        parent_epoch: Epoch,
+        reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
+        thread_pool: &ThreadPool,
+        parent_slot: Slot,
+        parent_height: u64,
+        rewards_metrics: &mut RewardsMetrics,
+    ) {
+        let CalculateRewardsAndDistributeVoteRewardsResult {
+            stake_rewards_by_partition,
+            ..
+        } = self.calculate_rewards_and_distribute_vote_rewards(
+            parent_epoch,
+            reward_calc_tracer,
+            thread_pool,
+            rewards_metrics,
+        );
+
+        let slot = self.slot();
+        self.set_epoch_reward_status_active(stake_rewards_by_partition);
+
+        datapoint_info!(
+            "reward-status-update",
+            ("slot", slot, i64),
+            ("height", self.block_height(), i64),
+            ("activate", 1, i64),
+            ("parent_start_slot", parent_slot, i64),
+            ("parent_start_height", parent_height, i64),
+        );
+    }
+
     pub fn byte_limit_for_scans(&self) -> Option<usize> {
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1854,9 +1854,9 @@ impl Bank {
     /// This process can take multiple slots.
     fn begin_partitioned_rewards(
         &mut self,
-        parent_epoch: Epoch,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
         thread_pool: &ThreadPool,
+        parent_epoch: Epoch,
         parent_slot: Slot,
         parent_height: u64,
         rewards_metrics: &mut RewardsMetrics,
@@ -1877,7 +1877,7 @@ impl Bank {
         datapoint_info!(
             "reward-status-update",
             ("slot", slot, i64),
-            ("height", self.block_height(), i64),
+            ("block_height", self.block_height(), i64),
             ("activate", 1, i64),
             ("parent_start_slot", parent_slot, i64),
             ("parent_start_height", parent_height, i64),


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

see #32114 or the other end of this pr.
The partitioned reward status goes from inactive to active and back to inactive.
Active is the state while we are distributing rewards to stake accounts, some per block.

We need a method to begin the period when are actively distributing rewards.
This will be called on the first block of a new epoch.
Later, this will also create the sysvar.

#### Summary of Changes
add `begin_partitioned_rewards`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
