### PR TITLE
in testing, hash_internal_state ignores epoch_rewards_sysvar

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7157,11 +7157,18 @@ impl Bank {
     ///  of the delta of the ledger since the last vote and up to now
     fn hash_internal_state(&self) -> Hash {
         let slot = self.slot();
+        let ignore = (!self.partitioned_rewards_feature_enabled()
+            && (self
+                .partitioned_epoch_rewards_config()
+                .test_enable_partitioned_rewards
+                && self.get_reward_calculation_num_blocks() == 0
+                && self.partitioned_rewards_stake_account_stores_per_block() == u64::MAX))
+            .then_some(sysvar::epoch_rewards::id());
         let accounts_delta_hash = self
             .rc
             .accounts
             .accounts_db
-            .calculate_accounts_delta_hash(slot);
+            .calculate_accounts_delta_hash_internal(slot, ignore);
 
         let mut signature_count_buf = [0u8; 8];
         LittleEndian::write_u64(&mut signature_count_buf[..], self.signature_count());


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

When running a validator with the debug cli argument `--partitioned-epoch-rewards-force-enable-single-slot`,
we need to not include the zero-ed out epoch reward sysvar in the delta hash of the bank. If we include it, the bank hash will never match the non-activated feature bank hash.

#### Summary of Changes
optionally ignore the sysvar account in delta hash if we're testing the new rewards calculation against a cluster where the feature is not activated.
This code will have no effect unless the cli arg is passed.
Note the sysvar account will have zero lamports if the functionality works correctly, but even having the zero lamport sysvar account in the delta hash will cause a delta hash mismatch. It would not cause an accounts hash mismatch (because zero lamport account are ignored).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
