### PR TITLE
add is_partitioned_rewards_code_enabled

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1491,7 +1491,7 @@ impl Bank {
     }
 
     #[allow(dead_code)]
-    fn partitioned_rewards_feature_enabled(&self) -> bool {
+    fn is_partitioned_rewards_feature_enabled(&self) -> bool {
         false // Will be feature later. It is convenient to have a constant fn at the moment.
     }
 
@@ -3892,8 +3892,8 @@ impl Bank {
     #[allow(dead_code)]
     /// true if it is ok to run partitioned rewards code.
     /// This means the feature is activated or certain testing situations.
-    fn partitioned_rewards_code_enabled(&self) -> bool {
-        self.partitioned_rewards_feature_enabled()
+    fn is_partitioned_rewards_code_enabled(&self) -> bool {
+        self.is_partitioned_rewards_feature_enabled()
             || self
                 .partitioned_epoch_rewards_config()
                 .test_enable_partitioned_rewards
@@ -7340,7 +7340,7 @@ impl Bank {
     ///  of the delta of the ledger since the last vote and up to now
     fn hash_internal_state(&self) -> Hash {
         let slot = self.slot();
-        let ignore = (!self.partitioned_rewards_feature_enabled()
+        let ignore = (!self.is_partitioned_rewards_feature_enabled()
             && (self
                 .partitioned_epoch_rewards_config()
                 .test_enable_partitioned_rewards

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3889,6 +3889,16 @@ impl Bank {
         report_partitioned_reward_metrics(self, metrics);
     }
 
+    #[allow(dead_code)]
+    /// true if it is ok to run partitioned rewards code.
+    /// This means the feature is activated or certain testing situations.
+    fn partitioned_rewards_code_enabled(&self) -> bool {
+        self.partitioned_rewards_feature_enabled()
+            || self
+                .partitioned_epoch_rewards_config()
+                .test_enable_partitioned_rewards
+    }
+
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
         #[allow(deprecated)]
         self.update_sysvar_account(&sysvar::recent_blockhashes::id(), |account| {


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

When running a validator with the debug cli argument `--partitioned-epoch-rewards-force-enable-single-slot`,
we need to run some partitioned rewards code even though the feature is not enabled.

#### Summary of Changes
add `partitioned_rewards_code_enabled`
which returns: true if the feature is activated or `--partitioned-epoch-rewards-force-enable-single-slot`
This code will have no effect unless the cli arg is passed (or feature is activated).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
