### PR TITLE
add distribute_partitioned_epoch_rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1895,10 +1895,10 @@ impl Bank {
         self.set_epoch_reward_status_active(stake_rewards_by_partition);
 
         datapoint_info!(
-            "epoch-reward-status-update",
+            "epoch-rewards-status-update",
             ("start_slot", slot, i64),
             ("start_block_height", self.block_height(), i64),
-            ("activate", 1, i64),
+            ("active", 1, i64),
             ("parent_slot", parent_slot, i64),
             ("parent_block_height", parent_block_height, i64),
         );
@@ -1931,10 +1931,10 @@ impl Bank {
 
         if height.saturating_add(1) >= credit_end_exclusive {
             datapoint_info!(
-                "epoch-reward-status-update",
+                "epoch-rewards-status-update",
                 ("slot", self.slot(), i64),
                 ("block_height", height, i64),
-                ("activate", 0, i64),
+                ("active", 0, i64),
                 ("start_block_height", start_block_height, i64),
             );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12622,8 +12622,36 @@ fn test_deactivate_epoch_reward_status() {
     assert!(bank.get_reward_interval() == RewardInterval::OutsideInterval);
 }
 
-/// Test rewards compuation and partitioned rewards distribution at the epoch boundary
 #[test]
+fn test_distribute_partitioned_epoch_rewards() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+
+    let expected_num = 100;
+
+    let stake_rewards = (0..expected_num)
+        .map(|_| StakeReward::new_random())
+        .collect::<Vec<_>>();
+
+    let stake_rewards = hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 100);
+
+    bank.set_epoch_reward_status_active(stake_rewards);
+
+    bank.distribute_partitioned_epoch_rewards();
+}
+
+#[test]
+fn test_distribute_partitioned_epoch_rewards_empty() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+
+    bank.set_epoch_reward_status_active(vec![]);
+
+    bank.distribute_partitioned_epoch_rewards();
+}
+
+#[test]
+/// Test rewards compuation and partitioned rewards distribution at the epoch boundary
 fn test_rewards_computation() {
     solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

When partitioned epoch rewards are enabled, each block may need to store some stake account rewards.

#### Summary of Changes
add `distribute_partitioned_epoch_rewards`
to distribute the epoch rewards to this block/partition

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
