### PR TITLE
optionally compare with partitioned rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3034,6 +3034,21 @@ impl Bank {
                 metrics,
             );
 
+            // this checking of an unactivated feature can be enabled in tests or with a validator by passing `--partitioned-epoch-rewards-compare-calculation`
+            if self
+                .partitioned_epoch_rewards_config()
+                .test_compare_partitioned_epoch_rewards
+            {
+                // immutable `&self` to avoid side effects
+                (self as &Bank).compare_with_partitioned_rewards(
+                    &stake_rewards,
+                    &vote_account_rewards,
+                    rewarded_epoch,
+                    thread_pool,
+                    null_tracer(),
+                );
+            }
+
             self.store_stake_accounts(&stake_rewards, metrics);
             let vote_rewards = self.store_vote_accounts(vote_account_rewards, metrics);
             self.update_reward_history(stake_rewards, vote_rewards);


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

During normal beginning of epoch reward calculation and distribution, we can calculate rewards to stake and vote accounts using the partition code. We can then compare the partitioned reward expectations with what is about to be applied to stake and vote accounts.
This can be accomplished in tests by setting (which is on by default for all tests):
https://github.com/solana-labs/solana/blob/a44b080b7f5009150519b0228eb8b1ecbc69aed2/runtime/src/accounts_db.rs#L481

or by the validator cli argument:
`--partitioned-epoch-rewards-compare-calculation`
such that a running validator compares the results.

This costs time to the validator, but has no other side effects.

#### Summary of Changes
Check for testing condition to compare. If testing, then calculate the stake and vote account changes and compare with what the normal code path has calculated.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
