### PR TITLE
Fix minimum balance when deploying program

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -994,7 +994,7 @@ fn process_program_deploy(
         program_len * 2
     };
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
-        UpgradeableLoaderState::size_of_programdata(program_len),
+        UpgradeableLoaderState::size_of_programdata(programdata_len),
     )?;
 
     let result = if do_deploy {


### PR DESCRIPTION
#### Problem
I think there is an issue with the deploy command. It does not compute correctly the minimum balance required for deploying the program.

#### Reproduce

1. Try and deploy a program with an empty account.
```
Error: Account D7GiatJ4KwZ6WmuBLkACyyY9FNs4txdPZWMnAnpbRzYU has insufficient funds for spend (1.41881688 SOL) + fee (0.00103 SOL)
```

2. Airdrop the necessary amount
```solana airdrop 1.42```

3. Redeploy the program
```
Error: Deploying program failed: Error processing Instruction 1: custom program error: 0x1
```
