### PR TITLE
Funding transactions must specify data limit

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1100,6 +1100,7 @@ pub fn fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
             total,
             max_fee,
             lamports_per_account,
+            TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE,
         );
     }
     Ok(())


### PR DESCRIPTION
#### Problem
We must specify the data limit on the funding transactions otherwise funding takes longer.

#### Summary of Changes
Add data limit on funding transactions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
