### PR TITLE
impl Signers for Arc<dyn Signer> arrays

### DIFF
--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -67,6 +67,26 @@ impl Signers for [Arc<dyn Signer>] {
     default_keypairs_impl!();
 }
 
+impl Signers for [Arc<dyn Signer>; 0] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [Arc<dyn Signer>; 1] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [Arc<dyn Signer>; 2] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [Arc<dyn Signer>; 3] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [Arc<dyn Signer>; 4] {
+    default_keypairs_impl!();
+}
+
 impl Signers for Vec<Arc<dyn Signer>> {
     default_keypairs_impl!();
 }


### PR DESCRIPTION
#### Problem
we routinely use `Arc<dyn Signer>` in spl command line utilities, but without fixed-length impls for the `Signers` trait we have to do silly things like `&vec![payer]` or `&[&*payer]` to find a trait impl when passing signers to `Transaction` signing functions

#### Summary of Changes
impl for arrays, letting us do `&[payer]`