### PR TITLE
derive Clone for OutputFormat in cli-output

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -59,7 +59,7 @@ static CHECK_MARK: Emoji = Emoji("✅ ", "");
 static CROSS_MARK: Emoji = Emoji("❌ ", "");
 static WARNING: Emoji = Emoji("⚠️", "!");
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OutputFormat {
     Display,
     Json,


### PR DESCRIPTION
#### Problem
id like to use `OutputFormat` as a cli arg for a clap v3 cli like so:
```
    /// Return information in specified output format
    #[clap( 
        global(true),
        long = "output",
        id = "FORMAT",
        value_parser = PossibleValuesParser::new(["json", "json-compact"]).map(|o| parse_output_format(&o)),
    )]
    pub output_format: Option<OutputFormat>,
```

but this requires `Clone`

#### Summary of Changes
derive `Clone`