### PR TITLE
ci: discard misleading `cargo uninstall` errors in bk post-checkout hook

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -39,6 +39,6 @@ source ci/env.sh
 # HACK: These are in our docker images, need to be removed from CARGO_HOME
 #  because we try to cache downloads across builds with CARGO_HOME
 # cargo lacks a facility for "system" tooling, always tries CARGO_HOME first
-cargo uninstall cargo-audit || true
-cargo uninstall svgbob_cli || true
-cargo uninstall mdbook || true
+cargo uninstall cargo-audit &>/dev/null || true
+cargo uninstall svgbob_cli &>/dev/null || true
+cargo uninstall mdbook &>/dev/null || true


### PR DESCRIPTION
#### Problem

there's a hack in our buildkite post-checkout hook that blindly attempts to `cargo uninstall` some bin crates that may not actually be installed.  when they aren't, a misleading error is printed prominently, which frequently distracts from the true cause of a failed ci job.

#### Summary of Changes

swallow all `cargo uninstall` output in the buildkite post-checkout hook