### PR TITLE
deactivate_epoch_rewards_status burns sysvar

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1846,12 +1846,24 @@ impl Bank {
 
     #[allow(dead_code)]
     /// partitioned reward distribution is complete.
+    /// So, deactivate the epoch rewards sysvar.
     fn deactivate_epoch_reward_status(&mut self) {
         assert!(matches!(
             self.epoch_reward_status,
             EpochRewardStatus::Active(_)
         ));
         self.epoch_reward_status = EpochRewardStatus::Inactive;
+        if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
+            if account.lamports() > 0 {
+                warn!(
+                    "burning {} extra lamports in EpochRewards sysvar account at slot {}",
+                    account.lamports(),
+                    self.slot()
+                );
+                self.log_epoch_rewards_sysvar("burn");
+                self.burn_and_purge_account(&sysvar::epoch_rewards::id(), account);
+            }
+        }
     }
 
     #[allow(dead_code)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1855,7 +1855,7 @@ impl Bank {
         self.epoch_reward_status = EpochRewardStatus::Inactive;
         if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
             if account.lamports() > 0 {
-                warn!(
+                info!(
                     "burning {} extra lamports in EpochRewards sysvar account at slot {}",
                     account.lamports(),
                     self.slot()


### PR DESCRIPTION
#### Problem
Implementing [partitioned rewards](https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1545187348) in pieces.

sysvar changes were happening in parallel to accounts work.
sysvar changes are now in.

#### Summary of Changes
When deactivating the reward interval, burn the sysvar correctly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
