### PR TITLE
[zk-token-sdk] Define `FeeEncryption` as a wrapper around `GroupedElGamalCiphertext`

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -78,10 +78,14 @@ impl FeeEncryption {
     }
 
     pub fn get_destination_handle(&self) -> &DecryptHandle {
+        // `FeeEncryption` is a wrapper for `GroupedElGamalCiphertext<2>`, which holds
+        // exactly two decryption handles.
         self.0.handles.get(0).unwrap()
     }
 
     pub fn get_withdraw_withheld_authority_handle(&self) -> &DecryptHandle {
+        // `FeeEncryption` is a wrapper for `GroupedElGamalCiphertext<2>`, which holds
+        // exactly two decryption handles.
         self.0.handles.get(1).unwrap()
     }
 }

--- a/zk-token-sdk/src/instruction/transfer/encryption.rs
+++ b/zk-token-sdk/src/instruction/transfer/encryption.rs
@@ -1,11 +1,8 @@
 #[cfg(not(target_os = "solana"))]
-use crate::{
-    encryption::{
-        elgamal::{DecryptHandle, ElGamalPubkey},
-        grouped_elgamal::{GroupedElGamal, GroupedElGamalCiphertext},
-        pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
-    },
-    zk_token_elgamal::pod,
+use crate::encryption::{
+    elgamal::{DecryptHandle, ElGamalPubkey},
+    grouped_elgamal::{GroupedElGamal, GroupedElGamalCiphertext},
+    pedersen::{PedersenCommitment, PedersenOpening},
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -54,15 +51,10 @@ impl TransferAmountCiphertext {
     }
 }
 
-// FeeEncryption
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C)]
 #[cfg(not(target_os = "solana"))]
-pub struct FeeEncryption {
-    pub commitment: PedersenCommitment,
-    pub destination_handle: DecryptHandle,
-    pub withdraw_withheld_authority_handle: DecryptHandle,
-}
+pub struct FeeEncryption(pub(crate) GroupedElGamalCiphertext<2>);
 
 #[cfg(not(target_os = "solana"))]
 impl FeeEncryption {
@@ -71,22 +63,25 @@ impl FeeEncryption {
         destination_pubkey: &ElGamalPubkey,
         withdraw_withheld_authority_pubkey: &ElGamalPubkey,
     ) -> (Self, PedersenOpening) {
-        let (commitment, opening) = Pedersen::new(amount);
-        let fee_encryption = Self {
-            commitment,
-            destination_handle: destination_pubkey.decrypt_handle(&opening),
-            withdraw_withheld_authority_handle: withdraw_withheld_authority_pubkey
-                .decrypt_handle(&opening),
-        };
+        let opening = PedersenOpening::new_rand();
+        let grouped_ciphertext = GroupedElGamal::<2>::encrypt_with(
+            [destination_pubkey, withdraw_withheld_authority_pubkey],
+            amount,
+            &opening,
+        );
 
-        (fee_encryption, opening)
+        (Self(grouped_ciphertext), opening)
     }
 
-    pub fn to_pod(&self) -> pod::FeeEncryption {
-        pod::FeeEncryption {
-            commitment: self.commitment.into(),
-            destination_handle: self.destination_handle.into(),
-            withdraw_withheld_authority_handle: self.withdraw_withheld_authority_handle.into(),
-        }
+    pub fn get_commitment(&self) -> &PedersenCommitment {
+        &self.0.commitment
+    }
+
+    pub fn get_destination_handle(&self) -> &DecryptHandle {
+        self.0.handles.get(0).unwrap()
+    }
+
+    pub fn get_withdraw_withheld_authority_handle(&self) -> &DecryptHandle {
+        self.0.handles.get(1).unwrap()
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -53,9 +53,7 @@ mod target_arch {
         crate::{
             curve25519::scalar::PodScalar,
             errors::ProofError,
-            instruction::transfer::{
-                FeeEncryption, FeeParameters, TransferPubkeys, TransferWithFeePubkeys,
-            },
+            instruction::transfer::{FeeParameters, TransferPubkeys, TransferWithFeePubkeys},
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -130,32 +128,6 @@ mod target_arch {
                 auditor_pubkey: pod.auditor_pubkey.try_into()?,
                 withdraw_withheld_authority_pubkey: pod
                     .withdraw_withheld_authority_pubkey
-                    .try_into()?,
-            })
-        }
-    }
-
-    impl From<FeeEncryption> for pod::FeeEncryption {
-        fn from(ciphertext: FeeEncryption) -> Self {
-            Self {
-                commitment: ciphertext.commitment.into(),
-                destination_handle: ciphertext.destination_handle.into(),
-                withdraw_withheld_authority_handle: ciphertext
-                    .withdraw_withheld_authority_handle
-                    .into(),
-            }
-        }
-    }
-
-    impl TryFrom<pod::FeeEncryption> for FeeEncryption {
-        type Error = ProofError;
-
-        fn try_from(pod: pod::FeeEncryption) -> Result<Self, Self::Error> {
-            Ok(Self {
-                commitment: pod.commitment.try_into()?,
-                destination_handle: pod.destination_handle.try_into()?,
-                withdraw_withheld_authority_handle: pod
-                    .withdraw_withheld_authority_handle
                     .try_into()?,
             })
         }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -1,6 +1,6 @@
 use crate::zk_token_elgamal::pod::{
-    DecryptHandle, ElGamalPubkey, GroupedElGamalCiphertext3Handles, PedersenCommitment, Pod,
-    PodU16, PodU64, Zeroable,
+    ElGamalPubkey, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles, Pod, PodU16,
+    PodU64, Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
 use crate::{errors::ProofError, instruction::transfer as decoded};
@@ -44,10 +44,22 @@ impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct FeeEncryption {
-    pub commitment: PedersenCommitment,
-    pub destination_handle: DecryptHandle,
-    pub withdraw_withheld_authority_handle: DecryptHandle,
+pub struct FeeEncryption(pub GroupedElGamalCiphertext2Handles);
+
+#[cfg(not(target_os = "solana"))]
+impl From<decoded::FeeEncryption> for FeeEncryption {
+    fn from(decoded_ciphertext: decoded::FeeEncryption) -> Self {
+        Self(decoded_ciphertext.0.into())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<FeeEncryption> for decoded::FeeEncryption {
+    type Error = ProofError;
+
+    fn try_from(pod_ciphertext: FeeEncryption) -> Result<Self, Self::Error> {
+        Ok(Self(pod_ciphertext.0.try_into()?))
+    }
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]


### PR DESCRIPTION
#### Problem
The `FeeEncryption` used in the transfer with fee instruction is defined as a struct that contains a Pedersen commitment and two decryption handles associated with the destination and withdraw withheld authority public keys. Instead, it can be simplified to be a thin wrapper around the type `GroupedElGamalCiphertext`.

#### Summary of Changes
Define the `FeeEncryption` to be a thin wrapper around the type `GroupedElGamalCiphertext`.

This is a follow-up to https://github.com/solana-labs/solana/pull/32026. It would be nice to rename `FeeEncryption` to `FeeCiphertext` as was done in https://github.com/solana-labs/solana/pull/32026 for `TransferAmountEncryption`, but unfortunately, this breaks downstream. We can perhaps update it in a future PR.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
