### PR TITLE
[zk-token-sdk] Refactor pod `FeeParameters` conversion and remove manual byte conversion for the type

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -8,7 +8,6 @@ use {
         elgamal::ElGamalCiphertext,
         pedersen::{PedersenCommitment, PedersenOpening},
     },
-    arrayref::{array_ref, array_refs},
     curve25519_dalek::scalar::Scalar,
 };
 #[cfg(not(target_os = "solana"))]
@@ -91,25 +90,4 @@ pub struct FeeParameters {
     pub fee_rate_basis_points: u16,
     /// Maximum fee assessed on transfers, expressed as an amount of tokens
     pub maximum_fee: u64,
-}
-
-#[cfg(not(target_os = "solana"))]
-impl FeeParameters {
-    pub fn to_bytes(&self) -> [u8; 10] {
-        let mut bytes = [0u8; 10];
-        bytes[..2].copy_from_slice(&self.fee_rate_basis_points.to_le_bytes());
-        bytes[2..10].copy_from_slice(&self.maximum_fee.to_le_bytes());
-
-        bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Self {
-        let bytes = array_ref![bytes, 0, 10];
-        let (fee_rate_basis_points, maximum_fee) = array_refs![bytes, 2, 8];
-
-        Self {
-            fee_rate_basis_points: u16::from_le_bytes(*fee_rate_basis_points),
-            maximum_fee: u64::from_le_bytes(*maximum_fee),
-        }
-    }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -53,7 +53,7 @@ mod target_arch {
         crate::{
             curve25519::scalar::PodScalar,
             errors::ProofError,
-            instruction::transfer::{FeeParameters, TransferPubkeys, TransferWithFeePubkeys},
+            instruction::transfer::{TransferPubkeys, TransferWithFeePubkeys},
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -130,24 +130,6 @@ mod target_arch {
                     .withdraw_withheld_authority_pubkey
                     .try_into()?,
             })
-        }
-    }
-
-    impl From<FeeParameters> for pod::FeeParameters {
-        fn from(parameters: FeeParameters) -> Self {
-            Self {
-                fee_rate_basis_points: parameters.fee_rate_basis_points.into(),
-                maximum_fee: parameters.maximum_fee.into(),
-            }
-        }
-    }
-
-    impl From<pod::FeeParameters> for FeeParameters {
-        fn from(pod: pod::FeeParameters) -> Self {
-            Self {
-                fee_rate_basis_points: pod.fee_rate_basis_points.into(),
-                maximum_fee: pod.maximum_fee.into(),
-            }
         }
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -3,13 +3,7 @@ use crate::zk_token_elgamal::pod::{
     PodU64, Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
-use crate::{
-    errors::ProofError,
-    instruction::transfer::{
-        FeeParameters as DecodedFeeParameters,
-        TransferAmountCiphertext as DecodedTransferAmountCiphertext,
-    },
-};
+use crate::{errors::ProofError, instruction::transfer as decoded};
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
@@ -33,14 +27,14 @@ pub struct TransferWithFeePubkeys {
 pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedTransferAmountCiphertext> for TransferAmountCiphertext {
-    fn from(decoded_ciphertext: DecodedTransferAmountCiphertext) -> Self {
+impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
+    fn from(decoded_ciphertext: decoded::TransferAmountCiphertext) -> Self {
         Self(decoded_ciphertext.0.into())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<TransferAmountCiphertext> for DecodedTransferAmountCiphertext {
+impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
     type Error = ProofError;
 
     fn try_from(pod_ciphertext: TransferAmountCiphertext) -> Result<Self, Self::Error> {
@@ -78,8 +72,8 @@ pub struct FeeParameters {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedFeeParameters> for FeeParameters {
-    fn from(decoded_fee_parameters: DecodedFeeParameters) -> Self {
+impl From<decoded::FeeParameters> for FeeParameters {
+    fn from(decoded_fee_parameters: decoded::FeeParameters) -> Self {
         FeeParameters {
             fee_rate_basis_points: decoded_fee_parameters.fee_rate_basis_points.into(),
             maximum_fee: decoded_fee_parameters.maximum_fee.into(),
@@ -88,9 +82,9 @@ impl From<DecodedFeeParameters> for FeeParameters {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl From<FeeParameters> for DecodedFeeParameters {
+impl From<FeeParameters> for decoded::FeeParameters {
     fn from(pod_fee_parameters: FeeParameters) -> Self {
-        DecodedFeeParameters {
+        decoded::FeeParameters {
             fee_rate_basis_points: pod_fee_parameters.fee_rate_basis_points.into(),
             maximum_fee: pod_fee_parameters.maximum_fee.into(),
         }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -3,7 +3,10 @@ use crate::zk_token_elgamal::pod::{
     PodU64, Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
-use crate::{errors::ProofError, instruction::transfer as decoded};
+use crate::{
+    errors::ProofError,
+    instruction::transfer::TransferAmountCiphertext as DecodedTransferAmountCiphertext,
+};
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
@@ -27,14 +30,14 @@ pub struct TransferWithFeePubkeys {
 pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
 #[cfg(not(target_os = "solana"))]
-impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
-    fn from(decoded_ciphertext: decoded::TransferAmountCiphertext) -> Self {
+impl From<DecodedTransferAmountCiphertext> for TransferAmountCiphertext {
+    fn from(decoded_ciphertext: DecodedTransferAmountCiphertext) -> Self {
         Self(decoded_ciphertext.0.into())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
+impl TryFrom<TransferAmountCiphertext> for DecodedTransferAmountCiphertext {
     type Error = ProofError;
 
     fn try_from(pod_ciphertext: TransferAmountCiphertext) -> Result<Self, Self::Error> {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -5,7 +5,10 @@ use crate::zk_token_elgamal::pod::{
 #[cfg(not(target_os = "solana"))]
 use crate::{
     errors::ProofError,
-    instruction::transfer::TransferAmountCiphertext as DecodedTransferAmountCiphertext,
+    instruction::transfer::{
+        FeeParameters as DecodedFeeParameters,
+        TransferAmountCiphertext as DecodedTransferAmountCiphertext,
+    },
 };
 
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -72,4 +75,24 @@ pub struct FeeParameters {
     pub fee_rate_basis_points: PodU16,
     /// Maximum fee assessed on transfers, expressed as an amount of tokens
     pub maximum_fee: PodU64,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedFeeParameters> for FeeParameters {
+    fn from(decoded_fee_parameters: DecodedFeeParameters) -> Self {
+        FeeParameters {
+            fee_rate_basis_points: decoded_fee_parameters.fee_rate_basis_points.into(),
+            maximum_fee: decoded_fee_parameters.maximum_fee.into(),
+        }
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl From<FeeParameters> for DecodedFeeParameters {
+    fn from(pod_fee_parameters: FeeParameters) -> Self {
+        DecodedFeeParameters {
+            fee_rate_basis_points: pod_fee_parameters.fee_rate_basis_points.into(),
+            maximum_fee: pod_fee_parameters.maximum_fee.into(),
+        }
+    }
 }


### PR DESCRIPTION
#### Problem
Currently, the `FeeParameters` type in the zk-token-sdk instruction module contains manual byte conversion `to_bytes` and `from_bytes`. There already exists `Pod` conversions between decoded and pod `FeeParameters` in `zk-token-elgamal` and hence these manual conversions can be removed for simplicity.

#### Summary of Changes
- Removed manual byte conversions `to_bytes` and `from_bytes` for the `FeeParameters` type
- Refactored `Pod` conversions betweenn the decoded and non-decoded `FeeParameters` types that existed in the `convert` submodule to the `instruction` submodule where the pod `FeeParameters` type is defined. This is now in-line with how the other the pod types and conversion logic are structured in `zk-token-elgamal`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
