### PR TITLE
Adds `--boot-from-local-state` to validator

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -292,6 +292,19 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Use DIR as snapshot location [default: --ledger value]"),
         )
         .arg(
+            Arg::with_name("boot_from_local_state")
+                .long("boot-from-local-state")
+                .takes_value(false)
+                .hidden(hidden_unless_forced())
+                .help("Boot from state already on disk")
+                .long_help(
+                    "Boot from state already on disk, instead of \
+                    extracting it from a snapshot archive. \
+                    Note, this will use the latest state available, \
+                    which may be newer than the latest snapshot archive.",
+                )
+        )
+        .arg(
             Arg::with_name("incremental_snapshot_archive_path")
                 .long("incremental-snapshot-archive-path")
                 .conflicts_with("no-incremental-snapshots")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1374,6 +1374,7 @@ pub fn main() {
         },
         staked_nodes_overrides: staked_nodes_overrides.clone(),
         replay_slots_concurrently: matches.is_present("replay_slots_concurrently"),
+        boot_from_local_state: matches.is_present("boot_from_local_state"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

Fastboot is not supported with `solana-validator`.


#### Summary of Changes

Add `--boot-from-local-state` to the validator's CLI flags.


#### Additional Testing

I started a validator and let it run for a while to catch up and take new snapshots. I then restarted it with `--boot-from-local` state and ensured the validator did indeed start from the bank snapshot and *not* the snapshot archive.