### PR TITLE
Feature - Recompile loaded programs before epoch boundary

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -552,7 +552,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .clone(),
     );
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key, false));
+        loaded_programs.replenish(key, bank.load_program(&key, false, None));
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -440,6 +440,8 @@ pub struct LoadedPrograms {
     /// Pubkey is the address of a program, multiple versions can coexists simultaneously under the same address (in different slots).
     entries: HashMap<Pubkey, Vec<Arc<LoadedProgram>>>,
     pub environments: ProgramRuntimeEnvironments,
+    /// List of loaded programs which should be recompiled before the next epoch (but don't have to).
+    pub programs_to_recompile: Vec<(Pubkey, Arc<LoadedProgram>)>,
     latest_root: Slot,
     pub stats: Stats,
 }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -412,6 +412,10 @@ pub struct ProgramRuntimeEnvironments {
     pub program_runtime_v1: ProgramRuntimeEnvironment,
     /// Globally shared RBPF config and syscall registry for runtime V2
     pub program_runtime_v2: ProgramRuntimeEnvironment,
+    /// Anticipated replacement for `program_runtime_v1` at the next epoch
+    pub upcoming_program_runtime_v1: Option<ProgramRuntimeEnvironment>,
+    /// Anticipated replacement for `program_runtime_v2` at the next epoch
+    pub upcoming_program_runtime_v2: Option<ProgramRuntimeEnvironment>,
 }
 
 impl Default for ProgramRuntimeEnvironments {
@@ -422,7 +426,9 @@ impl Default for ProgramRuntimeEnvironments {
         ));
         Self {
             program_runtime_v1: empty_loader.clone(),
-            program_runtime_v2: empty_loader,
+            program_runtime_v2: empty_loader.clone(),
+            upcoming_program_runtime_v1: Some(empty_loader.clone()),
+            upcoming_program_runtime_v2: Some(empty_loader),
         }
     }
 }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -26,7 +26,8 @@ use {
     },
 };
 
-const MAX_LOADED_ENTRY_COUNT: usize = 256;
+pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static>>>;
+pub const MAX_LOADED_ENTRY_COUNT: usize = 256;
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
 /// Relationship between two fork IDs
@@ -62,17 +63,17 @@ pub trait WorkingSlot {
 #[derive(Default)]
 pub enum LoadedProgramType {
     /// Tombstone for undeployed, closed or unloadable programs
-    FailedVerification(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    FailedVerification(ProgramRuntimeEnvironment),
     #[default]
     Closed,
     DelayVisibility,
     /// Successfully verified but not currently compiled, used to track usage statistics when a compiled program is evicted from memory.
-    Unloaded(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    Unloaded(ProgramRuntimeEnvironment),
     LegacyV0(Executable<InvokeContext<'static>>),
     LegacyV1(Executable<InvokeContext<'static>>),
     Typed(Executable<InvokeContext<'static>>),
     #[cfg(test)]
-    TestLoaded(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    TestLoaded(ProgramRuntimeEnvironment),
     Builtin(BuiltinProgram<InvokeContext<'static>>),
 }
 
@@ -221,7 +222,7 @@ impl LoadedProgram {
     /// Creates a new user program
     pub fn new(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
         effective_slot: Slot,
         maybe_expiration_slot: Option<Slot>,
@@ -407,10 +408,10 @@ impl LoadedProgram {
 
 #[derive(Clone, Debug)]
 pub struct ProgramRuntimeEnvironments {
-    /// Globally shared RBPF config and syscall registry
-    pub program_runtime_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    /// Globally shared RBPF config and syscall registry for runtime V1
+    pub program_runtime_v1: ProgramRuntimeEnvironment,
     /// Globally shared RBPF config and syscall registry for runtime V2
-    pub program_runtime_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    pub program_runtime_v2: ProgramRuntimeEnvironment,
 }
 
 impl Default for ProgramRuntimeEnvironments {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7225,7 +7225,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1, false);
+    let program = bank.load_program(&key1, false, None);
     assert_matches!(program.program, LoadedProgramType::LegacyV1(_));
     assert_eq!(
         program.account_size,
@@ -7380,7 +7380,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(*elf.get(i).unwrap(), *byte);
     }
 
-    let loaded_program = bank.load_program(&program_keypair.pubkey(), false);
+    let loaded_program = bank.load_program(&program_keypair.pubkey(), false, None);
 
     // Invoke deployed program
     mock_process_instruction(


### PR DESCRIPTION
#### Problem
Continuation of #31945, to not only prune old programs which were verified and compiled against the feature set of the previous epoch, but also start recompiling them for the upcoming one before it hits.

#### Summary of Changes
- Adds type `ProgramRuntimeEnvironment`.
- Adds `LoadedPrograms::upcoming_program_runtime_environment_v1`.
- Adds parameter recompile to `Bank::load_program()`.
- Removes the manually managed list `FEATURES_AFFECTING_RBPF`.
