### PR TITLE
Revert "add test for is_partitioned_rewards_feature_enabled (#32158)"

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1492,8 +1492,7 @@ impl Bank {
 
     #[allow(dead_code)]
     fn is_partitioned_rewards_feature_enabled(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::enable_partitioned_epoch_reward::id())
+        false // Will be feature later. It is convenient to have a constant fn at the moment.
     }
 
     #[allow(dead_code)]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12604,17 +12604,6 @@ fn test_rewards_point_calculation_empty() {
     assert!(point_value.is_none());
 }
 
-/// Test partitioned_reward feature enable/disable
-#[test]
-fn test_is_partitioned_reward_enable() {
-    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    assert!(!bank.is_partitioned_rewards_feature_enabled());
-    bank.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
-    assert!(bank.is_partitioned_rewards_feature_enabled());
-}
-
 #[test]
 fn test_deactivate_epoch_reward_status() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/32158 will enable epoch reward feature for stake tests. Therefore, the stake tests update for epoch reward features should go in together with 32158. 


#### Summary of Changes

This reverts commit d06b099ecb40e22cdfc65946dd2a4ad0054ff0ce.

We will do #32158 again with update of stake tests together.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
