### PR TITLE
[zk-token-proof] Update docs for the ZK Token proof program in `zk-token-sdk`

### DIFF
--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -1,3 +1,7 @@
+//! The instruction data types for the [`ZK Token proof`] instruction.
+//!
+//! [`ZK Token proof`]: https://edge.docs.solana.com/developing/runtime-facilities/zk-token-proof
+
 pub mod batched_grouped_ciphertext_validity;
 pub mod batched_range_proof;
 pub mod ciphertext_ciphertext_equality;

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -142,9 +142,9 @@ pub enum ProofInstruction {
     ///
     VerifyTransferWithFee,
 
-    /// Verify a public-key validity zero-knowledge proof.
+    /// Verify a public key validity zero-knowledge proof.
     ///
-    /// A public-key validity proof certifies that an ElGamal public key is well-formed and the
+    /// A public key validity proof certifies that an ElGamal public key is well-formed and the
     /// prover knows the corresponding secret key.
     ///
     /// Accounts expected by this instruction:

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -1,12 +1,12 @@
 //! Instructions provided by the [`ZK Token proof`] program.
 //!
-//! There are two types of instructions in the proof program: the proof verification instructions
+//! There are two types of instructions in the proof program: proof verification instructions
 //! and the `CloseContextState` instruction.
 //!
 //! Each proof verification instruction verifies a certain type of zero-knowledge proof. These
 //! instructions are processed by the program in two steps:
 //!   1. The program verifies the zero-knowledge proof.
-//!   2. The program optionally stores the context data component of the instruction data to a
+//!   2. The program optionally stores the context component of the instruction data to a
 //!      dedicated [`context-state`] account.
 //! If no accounts are provided with the instruction, the program simply verifies the proofs. If
 //! accounts are provided with the instruction, then the program writes the context data to the
@@ -68,7 +68,7 @@ pub enum ProofInstruction {
 
     /// Verify a withdraw zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
     /// confidential extension `Withdraw` instruction.
     ///
     /// Accounts expected by this instruction:
@@ -106,7 +106,7 @@ pub enum ProofInstruction {
 
     /// Verify a transfer zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
     /// confidential extension `Transfer` instruction with transfer fees.
     ///
     /// Accounts expected by this instruction:
@@ -125,7 +125,7 @@ pub enum ProofInstruction {
 
     /// Verify a transfer with fee zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
     /// confidential extension `Transfer` instruction without transfer fees.
     ///
     /// Accounts expected by this instruction:
@@ -249,7 +249,7 @@ pub enum ProofInstruction {
     /// Verify a ciphertext-commitment equality proof.
     ///
     /// A ciphertext-commitment equality proof certifies that an ElGamal ciphertext and a Pedersen
-    /// commitment encrypts/encodes the same message.
+    /// commitment encrypt/encode the same message.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -1,4 +1,27 @@
-//! Instructions provided by the ZkToken Proof program
+//! Instructions provided by the [`ZK Token proof`] program.
+//!
+//! There are two types of instructions in the proof program: the proof verification instructions
+//! and the `CloseContextState` instruction.
+//!
+//! Each proof verification instruction verifies a certain type of zero-knowledge proof. These
+//! instructions are processed by the program in two steps:
+//!   1. The program verifies the zero-knowledge proof.
+//!   2. The program optionally stores the context data component of the instruction data to a
+//!      dedicated [`context-state`] account.
+//! If no accounts are provided with the instruction, the program simply verifies the proofs. If
+//! accounts are provided with the instruction, then the program writes the context data to the
+//! specified context-state account.
+//!
+//! NOTE: A context-state account must be pre-allocated to the exact size of the context data that
+//! is expected for a proof type before it is included in a proof verification instruction.
+//!
+//! The `CloseContextState` instruction closes a context state account. A transaction containing
+//! this instruction must be signed by the context account's owner. This instruction can be used by
+//! the account owner to reclaim lamports for storage.
+//!
+//! [`ZK Token proof`]: https://edge.docs.solana.com/developing/runtime-facilities/zk-token-proof
+//! [`context-state`]: https://edge.docs.solana.com/developing/runtime-facilities/zk-token-proof#context-data
+
 pub use crate::instruction::*;
 use {
     bytemuck::bytes_of,
@@ -27,11 +50,6 @@ pub enum ProofInstruction {
 
     /// Verify a zero-balance proof.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<ZeroBalanceProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -47,11 +65,6 @@ pub enum ProofInstruction {
     VerifyZeroBalance,
 
     /// Verify a withdraw zero-knowledge proof.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<WithdrawProofContext>` and assigned to the ZkToken proof program prior
-    /// to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -69,11 +82,6 @@ pub enum ProofInstruction {
 
     /// Verify a ciphertext-ciphertext equality proof.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<CiphertextCiphertextEqualityProofContext>` and assigned to the ZkToken
-    /// proof program prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -89,11 +97,6 @@ pub enum ProofInstruction {
     VerifyCiphertextCiphertextEquality,
 
     /// Verify a transfer zero-knowledge proof.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<TransferProofContext>` and assigned to the ZkToken proof program prior
-    /// to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -111,11 +114,6 @@ pub enum ProofInstruction {
 
     /// Verify a transfer with fee zero-knowledge proof.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<TransferWithFeeProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -131,11 +129,6 @@ pub enum ProofInstruction {
     VerifyTransferWithFee,
 
     /// Verify a pubkey validity zero-knowledge proof.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<PubkeyValidityProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -155,11 +148,6 @@ pub enum ProofInstruction {
     ///
     /// A range proof is defined with respect to a Pedersen commitment. The 64-bit range proof
     /// certifies that a Pedersen commitment holds an unsigned 64-bit number.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<RangeProofContext>` and assigned to the ZkToken proof program prior to
-    /// the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -187,11 +175,6 @@ pub enum ProofInstruction {
     /// `n_1, ..., n_N`. For example, this instruction can be used to certify that two commitments
     /// `C_1` and `C_2` each hold positive 32-bit numbers.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<BatchedRangeProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -211,11 +194,6 @@ pub enum ProofInstruction {
     /// The bit-length of a batched range proof specifies the sum of the individual bit-lengths
     /// `n_1, ..., n_N`. For example, this instruction can be used to certify that two commitments
     /// `C_1` and `C_2` each hold positive 64-bit numbers.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<BatchedRangeProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -237,11 +215,6 @@ pub enum ProofInstruction {
     /// `n_1, ..., n_N`. For example, this instruction can be used to certify that four commitments
     /// `[C_1, C_2, C_3, C_4]` each hold positive 64-bit numbers.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<BatchedRangeProofContext>` and assigned to the ZkToken proof program
-    /// prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -257,11 +230,6 @@ pub enum ProofInstruction {
     VerifyBatchedRangeProofU256,
 
     /// Verify a ciphertext-commitment equality proof.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<CiphertextCommitmentEqualityProofContext>` and assigned to the ZkToken
-    /// proof program prior to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -283,11 +251,6 @@ pub enum ProofInstruction {
     /// well-defined, i.e. the ciphertext can be decrypted by private keys associated with its
     /// decryption handles.
     ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<GroupedCiphertextValidityProofContext>` and assigned to the ZkToken
-    /// proof program prior to the execution of this instruction.
-    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -308,11 +271,6 @@ pub enum ProofInstruction {
     /// ciphertext that are encrypted using the same set of ElGamal public keys. A batched
     /// grouped-ciphertext validity proof is shorter and more efficient than two individual
     /// grouped-ciphertext validity proofs.
-    ///
-    /// This instruction can be configured to optionally initialize a proof context state account.
-    /// If creating a context state account, an account must be pre-allocated to the exact size of
-    /// `ProofContextState<BatchedGroupedCiphertextValidityProofContext>` and assigned to the
-    /// ZkToken proof program prior to the execution of this instruction.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -50,6 +50,8 @@ pub enum ProofInstruction {
 
     /// Verify a zero-balance proof.
     ///
+    /// A zero-balance proof certifies that an ElGamal ciphertext encrypts the value zero.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -65,6 +67,9 @@ pub enum ProofInstruction {
     VerifyZeroBalance,
 
     /// Verify a withdraw zero-knowledge proof.
+    ///
+    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// confidential extension `Withdraw` instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -82,6 +87,9 @@ pub enum ProofInstruction {
 
     /// Verify a ciphertext-ciphertext equality proof.
     ///
+    /// A ciphertext-ciphertext equality proof certifies that two ElGamal ciphertexts encrypt the
+    /// same message.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -97,6 +105,9 @@ pub enum ProofInstruction {
     VerifyCiphertextCiphertextEquality,
 
     /// Verify a transfer zero-knowledge proof.
+    ///
+    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// confidential extension `Transfer` instruction with transfer fees.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -114,6 +125,9 @@ pub enum ProofInstruction {
 
     /// Verify a transfer with fee zero-knowledge proof.
     ///
+    /// This proof is a collection of smallers proofs that are required the SPL Token 2022
+    /// confidential extension `Transfer` instruction without transfer fees.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Creating a proof context account
@@ -128,7 +142,10 @@ pub enum ProofInstruction {
     ///
     VerifyTransferWithFee,
 
-    /// Verify a pubkey validity zero-knowledge proof.
+    /// Verify a public-key validity zero-knowledge proof.
+    ///
+    /// A public-key validity proof certifies that an ElGamal public key is well-formed and the
+    /// prover knows the corresponding secret key.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -230,6 +247,9 @@ pub enum ProofInstruction {
     VerifyBatchedRangeProofU256,
 
     /// Verify a ciphertext-commitment equality proof.
+    ///
+    /// A ciphertext-commitment equality proof certifies that an ElGamal ciphertext and a Pedersen
+    /// commitment encrypts/encodes the same message.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/zk-token-sdk/src/zk_token_proof_program.rs
+++ b/zk-token-sdk/src/zk_token_proof_program.rs
@@ -1,2 +1,11 @@
+//! The native ZK Token proof program.
+//!
+//! The program verifies a number of zero-knowledge proofs that are tailored to work with Pedersen
+//! commitments and ElGamal encryption over the elliptic curve curve25519. A general overview of
+//! the program as well as the technical details of some of the proof instructions can be found in
+//! the [`ZK Token proof`] documentation.
+//!
+//! [`ZK Token proof`]: https://edge.docs.solana.com/developing/runtime-facilities/zk-token-proof
+
 // Program Id of the ZkToken Proof program
 solana_program::declare_id!("ZkTokenProof1111111111111111111111111111111");


### PR DESCRIPTION
#### Problem
There are not much docs for the ZK Token proof program in the repo.

#### Summary of Changes
- Added docs to reference https://edge.docs.solana.com/developing/runtime-facilities/zk-token-proof
- Added note about requiring contexts state account to be pre-allocated
- For those that were missing, brief descriptions of the proofs were added

I think it would be nice to refactor/organized the modules `zk_token_proof_program.rs`, `zk_token_proof_instruction.rs`, `zk_token_proof_state.rs`, and `instructions` into a separate `proof_program` submodule that contains code relating to the proof program. There are some outstanding PRs that touch the `instruction` module, so I will do the refactor on a follow-up once these PRs are merged.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
