### PR TITLE
[zk-token-sdk] Make inner scalar and ristretto point of `PedersenOpening` and `PedersenCommitment` private

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -133,7 +133,7 @@ impl ElGamal {
     fn decrypt(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> DiscreteLog {
         DiscreteLog::new(
             *G,
-            &ciphertext.commitment.0 - &(&secret.0 * &ciphertext.handle.0),
+            ciphertext.commitment.get_point() - &(&secret.0 * &ciphertext.handle.0),
         )
     }
 
@@ -520,7 +520,8 @@ pub struct ElGamalCiphertext {
 }
 impl ElGamalCiphertext {
     pub fn add_amount<T: Into<Scalar>>(&self, amount: T) -> Self {
-        let commitment_to_add = PedersenCommitment(amount.into() * &(*G));
+        let point = amount.into() * &(*G);
+        let commitment_to_add = PedersenCommitment::new(point);
         ElGamalCiphertext {
             commitment: &self.commitment + &commitment_to_add,
             handle: self.handle,
@@ -528,7 +529,8 @@ impl ElGamalCiphertext {
     }
 
     pub fn subtract_amount<T: Into<Scalar>>(&self, amount: T) -> Self {
-        let commitment_to_subtract = PedersenCommitment(amount.into() * &(*G));
+        let point = amount.into() * &(*G);
+        let commitment_to_subtract = PedersenCommitment::new(point);
         ElGamalCiphertext {
             commitment: &self.commitment - &commitment_to_subtract,
             handle: self.handle,

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -650,7 +650,7 @@ define_mul_variants!(
 pub struct DecryptHandle(RistrettoPoint);
 impl DecryptHandle {
     pub fn new(public: &ElGamalPubkey, opening: &PedersenOpening) -> Self {
-        Self(&public.0 * &opening.0)
+        Self(&public.0 * opening.get_scalar())
     }
 
     pub fn get_point(&self) -> &RistrettoPoint {

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -167,8 +167,12 @@ define_mul_variants!(
 
 /// Pedersen commitment type.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct PedersenCommitment(pub(crate) RistrettoPoint);
+pub struct PedersenCommitment(RistrettoPoint);
 impl PedersenCommitment {
+    pub fn new(point: RistrettoPoint) -> Self {
+        Self(point)
+    }
+
     pub fn get_point(&self) -> &RistrettoPoint {
         &self.0
     }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -67,8 +67,12 @@ impl Pedersen {
 /// Instances of Pedersen openings are zeroized on drop.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
-pub struct PedersenOpening(pub(crate) Scalar);
+pub struct PedersenOpening(Scalar);
 impl PedersenOpening {
+    pub fn new(scalar: Scalar) -> Self {
+        Self(scalar)
+    }
+
     pub fn get_scalar(&self) -> &Scalar {
         &self.0
     }


### PR DESCRIPTION
#### Problem
Currently, the `Scalar` and `RistrettoPoint` components of the `PedersenOpening` and `PedersenCommitment` types have visibility `pub(crate)` while each of these types have getters to access the inner types.

#### Summary of Changes
- Make the inenr `Scalar` and `RistrettoPoint` components in these structs be fully private
- For places that accesses these inner components directly, update them so that they use the specific getter function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
