### PR TITLE
[zk-token-sdk] Make `ElGamalKeypair` fields private

### DIFF
--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -650,16 +650,10 @@ async fn test_batched_grouped_ciphertext_2_handles_validity() {
     let opening_lo = PedersenOpening::new_rand();
     let opening_hi = PedersenOpening::new_rand();
 
-    let grouped_ciphertext_lo = GroupedElGamal::encrypt_with(
-        [destination_pubkey, auditor_pubkey],
-        amount_lo,
-        &opening_lo,
-    );
-    let grouped_ciphertext_hi = GroupedElGamal::encrypt_with(
-        [destination_pubkey, auditor_pubkey],
-        amount_hi,
-        &opening_hi,
-    );
+    let grouped_ciphertext_lo =
+        GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount_lo, &opening_lo);
+    let grouped_ciphertext_hi =
+        GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount_hi, &opening_hi);
 
     let success_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
         destination_pubkey,

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -10,7 +10,7 @@ use {
     },
     solana_zk_token_sdk::{
         encryption::{
-            elgamal::ElGamalKeypair,
+            elgamal::{ElGamalKeypair, ElGamalSecretKey},
             grouped_elgamal::GroupedElGamal,
             pedersen::{Pedersen, PedersenOpening},
         },
@@ -42,13 +42,13 @@ const VERIFY_INSTRUCTION_TYPES: [ProofInstruction; 13] = [
 async fn test_zero_balance() {
     let elgamal_keypair = ElGamalKeypair::new_rand();
 
-    let zero_ciphertext = elgamal_keypair.public.encrypt(0_u64);
+    let zero_ciphertext = elgamal_keypair.pubkey().encrypt(0_u64);
     let success_proof_data = ZeroBalanceProofData::new(&elgamal_keypair, &zero_ciphertext).unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = elgamal_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+
     let fail_proof_data = ZeroBalanceProofData::new(&incorrect_keypair, &zero_ciphertext).unwrap();
 
     test_verify_proof_without_context(
@@ -80,16 +80,16 @@ async fn test_ciphertext_ciphertext_equality() {
     let destination_keypair = ElGamalKeypair::new_rand();
 
     let amount: u64 = 0;
-    let source_ciphertext = source_keypair.public.encrypt(amount);
+    let source_ciphertext = source_keypair.pubkey().encrypt(amount);
 
     let destination_opening = PedersenOpening::new_rand();
     let destination_ciphertext = destination_keypair
-        .public
+        .pubkey()
         .encrypt_with(amount, &destination_opening);
 
     let success_proof_data = CiphertextCiphertextEqualityProofData::new(
         &source_keypair,
-        &destination_keypair.public,
+        destination_keypair.pubkey(),
         &source_ciphertext,
         &destination_ciphertext,
         &destination_opening,
@@ -97,13 +97,13 @@ async fn test_ciphertext_ciphertext_equality() {
     )
     .unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = source_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+
     let fail_proof_data = CiphertextCiphertextEqualityProofData::new(
         &incorrect_keypair,
-        &destination_keypair.public,
+        destination_keypair.pubkey(),
         &source_ciphertext,
         &destination_ciphertext,
         &destination_opening,
@@ -137,11 +137,15 @@ async fn test_ciphertext_ciphertext_equality() {
 #[tokio::test]
 async fn test_transfer() {
     let source_keypair = ElGamalKeypair::new_rand();
-    let dest_pubkey = ElGamalKeypair::new_rand().public;
-    let auditor_pubkey = ElGamalKeypair::new_rand().public;
+
+    let destination_keypair = ElGamalKeypair::new_rand();
+    let destination_pubkey = destination_keypair.pubkey();
+
+    let auditor_keypair = ElGamalKeypair::new_rand();
+    let auditor_pubkey = auditor_keypair.pubkey();
 
     let spendable_balance: u64 = 0;
-    let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
+    let spendable_ciphertext = source_keypair.pubkey().encrypt(spendable_balance);
 
     let transfer_amount: u64 = 0;
 
@@ -149,20 +153,19 @@ async fn test_transfer() {
         transfer_amount,
         (spendable_balance, &spendable_ciphertext),
         &source_keypair,
-        (&dest_pubkey, &auditor_pubkey),
+        (destination_pubkey, auditor_pubkey),
     )
     .unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = source_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = TransferData::new(
         transfer_amount,
         (spendable_balance, &spendable_ciphertext),
         &incorrect_keypair,
-        (&dest_pubkey, &auditor_pubkey),
+        (destination_pubkey, auditor_pubkey),
     )
     .unwrap();
 
@@ -192,12 +195,18 @@ async fn test_transfer() {
 #[tokio::test]
 async fn test_transfer_with_fee() {
     let source_keypair = ElGamalKeypair::new_rand();
-    let destination_pubkey = ElGamalKeypair::new_rand().public;
-    let auditor_pubkey = ElGamalKeypair::new_rand().public;
-    let withdraw_withheld_authority_pubkey = ElGamalKeypair::new_rand().public;
+
+    let destination_keypair = ElGamalKeypair::new_rand();
+    let destination_pubkey = destination_keypair.pubkey();
+
+    let auditor_keypair = ElGamalKeypair::new_rand();
+    let auditor_pubkey = auditor_keypair.pubkey();
+
+    let withdraw_withheld_authority_keypair = ElGamalKeypair::new_rand();
+    let withdraw_withheld_authority_pubkey = withdraw_withheld_authority_keypair.pubkey();
 
     let spendable_balance: u64 = 120;
-    let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
+    let spendable_ciphertext = source_keypair.pubkey().encrypt(spendable_balance);
 
     let transfer_amount: u64 = 0;
 
@@ -210,24 +219,23 @@ async fn test_transfer_with_fee() {
         transfer_amount,
         (spendable_balance, &spendable_ciphertext),
         &source_keypair,
-        (&destination_pubkey, &auditor_pubkey),
+        (destination_pubkey, auditor_pubkey),
         fee_parameters,
-        &withdraw_withheld_authority_pubkey,
+        withdraw_withheld_authority_pubkey,
     )
     .unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = source_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = TransferWithFeeData::new(
         transfer_amount,
         (spendable_balance, &spendable_ciphertext),
         &incorrect_keypair,
-        (&destination_pubkey, &auditor_pubkey),
+        (destination_pubkey, auditor_pubkey),
         fee_parameters,
-        &withdraw_withheld_authority_pubkey,
+        withdraw_withheld_authority_pubkey,
     )
     .unwrap();
 
@@ -259,7 +267,7 @@ async fn test_withdraw() {
     let elgamal_keypair = ElGamalKeypair::new_rand();
 
     let current_balance: u64 = 77;
-    let current_ciphertext = elgamal_keypair.public.encrypt(current_balance);
+    let current_ciphertext = elgamal_keypair.pubkey().encrypt(current_balance);
     let withdraw_amount: u64 = 55;
 
     let success_proof_data = WithdrawData::new(
@@ -270,10 +278,10 @@ async fn test_withdraw() {
     )
     .unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = elgamal_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+
     let fail_proof_data = WithdrawData::new(
         withdraw_amount,
         &incorrect_keypair,
@@ -311,10 +319,9 @@ async fn test_pubkey_validity() {
 
     let success_proof_data = PubkeyValidityData::new(&elgamal_keypair).unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = elgamal_keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = PubkeyValidityData::new(&incorrect_keypair).unwrap();
 
@@ -526,7 +533,7 @@ async fn test_batched_range_proof_u256() {
 async fn test_ciphertext_commitment_equality() {
     let keypair = ElGamalKeypair::new_rand();
     let amount: u64 = 55;
-    let ciphertext = keypair.public.encrypt(amount);
+    let ciphertext = keypair.pubkey().encrypt(amount);
     let (commitment, opening) = Pedersen::new(amount);
 
     let success_proof_data = CiphertextCommitmentEqualityProofData::new(
@@ -538,10 +545,9 @@ async fn test_ciphertext_commitment_equality() {
     )
     .unwrap();
 
-    let incorrect_keypair = ElGamalKeypair {
-        public: ElGamalKeypair::new_rand().public,
-        secret: ElGamalKeypair::new_rand().secret,
-    };
+    let incorrect_pubkey = keypair.pubkey();
+    let incorrect_secret = ElGamalSecretKey::new_rand();
+    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = CiphertextCommitmentEqualityProofData::new(
         &incorrect_keypair,
@@ -577,17 +583,20 @@ async fn test_ciphertext_commitment_equality() {
 
 #[tokio::test]
 async fn test_grouped_ciphertext_2_handles_validity() {
-    let destination_pubkey = ElGamalKeypair::new_rand().public;
-    let auditor_pubkey = ElGamalKeypair::new_rand().public;
+    let destination_keypair = ElGamalKeypair::new_rand();
+    let destination_pubkey = destination_keypair.pubkey();
+
+    let auditor_keypair = ElGamalKeypair::new_rand();
+    let auditor_pubkey = auditor_keypair.pubkey();
 
     let amount: u64 = 55;
     let opening = PedersenOpening::new_rand();
     let grouped_ciphertext =
-        GroupedElGamal::encrypt_with([&destination_pubkey, &auditor_pubkey], amount, &opening);
+        GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount, &opening);
 
     let success_proof_data = GroupedCiphertext2HandlesValidityProofData::new(
-        &destination_pubkey,
-        &auditor_pubkey,
+        destination_pubkey,
+        auditor_pubkey,
         &grouped_ciphertext,
         amount,
         &opening,
@@ -596,8 +605,8 @@ async fn test_grouped_ciphertext_2_handles_validity() {
 
     let incorrect_opening = PedersenOpening::new_rand();
     let fail_proof_data = GroupedCiphertext2HandlesValidityProofData::new(
-        &destination_pubkey,
-        &auditor_pubkey,
+        destination_pubkey,
+        auditor_pubkey,
         &grouped_ciphertext,
         amount,
         &incorrect_opening,
@@ -629,8 +638,11 @@ async fn test_grouped_ciphertext_2_handles_validity() {
 
 #[tokio::test]
 async fn test_batched_grouped_ciphertext_2_handles_validity() {
-    let destination_pubkey = ElGamalKeypair::new_rand().public;
-    let auditor_pubkey = ElGamalKeypair::new_rand().public;
+    let destination_keypair = ElGamalKeypair::new_rand();
+    let destination_pubkey = destination_keypair.pubkey();
+
+    let auditor_keypair = ElGamalKeypair::new_rand();
+    let auditor_pubkey = auditor_keypair.pubkey();
 
     let amount_lo: u64 = 55;
     let amount_hi: u64 = 22;
@@ -639,19 +651,19 @@ async fn test_batched_grouped_ciphertext_2_handles_validity() {
     let opening_hi = PedersenOpening::new_rand();
 
     let grouped_ciphertext_lo = GroupedElGamal::encrypt_with(
-        [&destination_pubkey, &auditor_pubkey],
+        [destination_pubkey, auditor_pubkey],
         amount_lo,
         &opening_lo,
     );
     let grouped_ciphertext_hi = GroupedElGamal::encrypt_with(
-        [&destination_pubkey, &auditor_pubkey],
+        [destination_pubkey, auditor_pubkey],
         amount_hi,
         &opening_hi,
     );
 
     let success_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
-        &destination_pubkey,
-        &auditor_pubkey,
+        destination_pubkey,
+        auditor_pubkey,
         &grouped_ciphertext_lo,
         &grouped_ciphertext_hi,
         amount_lo,
@@ -663,8 +675,8 @@ async fn test_batched_grouped_ciphertext_2_handles_validity() {
 
     let incorrect_opening = PedersenOpening::new_rand();
     let fail_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
-        &destination_pubkey,
-        &auditor_pubkey,
+        destination_pubkey,
+        auditor_pubkey,
         &grouped_ciphertext_lo,
         &grouped_ciphertext_hi,
         amount_lo,

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -47,7 +47,7 @@ async fn test_zero_balance() {
 
     let incorrect_pubkey = elgamal_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = ZeroBalanceProofData::new(&incorrect_keypair, &zero_ciphertext).unwrap();
 
@@ -99,7 +99,7 @@ async fn test_ciphertext_ciphertext_equality() {
 
     let incorrect_pubkey = source_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = CiphertextCiphertextEqualityProofData::new(
         &incorrect_keypair,
@@ -159,7 +159,7 @@ async fn test_transfer() {
 
     let incorrect_pubkey = source_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = TransferData::new(
         transfer_amount,
@@ -227,7 +227,7 @@ async fn test_transfer_with_fee() {
 
     let incorrect_pubkey = source_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = TransferWithFeeData::new(
         transfer_amount,
@@ -280,7 +280,7 @@ async fn test_withdraw() {
 
     let incorrect_pubkey = elgamal_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = WithdrawData::new(
         withdraw_amount,
@@ -321,7 +321,7 @@ async fn test_pubkey_validity() {
 
     let incorrect_pubkey = elgamal_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = PubkeyValidityData::new(&incorrect_keypair).unwrap();
 
@@ -547,7 +547,7 @@ async fn test_ciphertext_commitment_equality() {
 
     let incorrect_pubkey = keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new(*incorrect_pubkey, incorrect_secret);
+    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
     let fail_proof_data = CiphertextCommitmentEqualityProofData::new(
         &incorrect_keypair,

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -200,7 +200,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                         println!(
                             "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new ElGamal keypair:\n{}\n{}",
-                            &divider, elgamal_keypair.public, &divider, passphrase_message, phrase, &divider
+                            &divider, elgamal_keypair.pubkey(), &divider, passphrase_message, phrase, &divider
                         );
                     }
                 }
@@ -241,8 +241,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             // future
             match key_type {
                 KeyType::ElGamal => {
-                    let elgamal_pubkey =
-                        elgamal_keypair_from_path(matches, path, "pubkey recovery", false)?.public;
+                    let elgamal_keypair =
+                        elgamal_keypair_from_path(matches, path, "pubkey recovery", false)?;
+                    let elgamal_pubkey = elgamal_keypair.pubkey();
                     println!("{elgamal_pubkey}");
                 }
                 _ => unreachable!(),

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -161,11 +161,16 @@ pub struct ElGamalKeypair {
 }
 
 impl ElGamalKeypair {
-    pub fn new(public: ElGamalPubkey, secret: ElGamalSecretKey) -> Self {
+    /// Create an ElGamal keypair from an ElGamal public key and an ElGamal secret key.
+    ///
+    /// An ElGamal keypair should never be instantiated manually; `ElGamalKeypair::new_rand` or
+    /// `ElGamalKeypair::new_from_signer` should be used instead. This function exists to create
+    /// custom ElGamal keypairs for tests.
+    pub fn new_for_tests(public: ElGamalPubkey, secret: ElGamalSecretKey) -> Self {
         Self { public, secret }
     }
 
-    /// Deterministically derives an ElGamal keypair from a Solana signer and a public seed..
+    /// Deterministically derives an ElGamal keypair from a Solana signer and a public seed.
     ///
     /// This function exists for applications where a user may not wish to maintain a Solana signer
     /// and an ElGamal keypair separately. Instead, a user can derive the ElGamal keypair

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -155,12 +155,16 @@ impl ElGamal {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Zeroize)]
 pub struct ElGamalKeypair {
     /// The public half of this keypair.
-    pub public: ElGamalPubkey,
+    public: ElGamalPubkey,
     /// The secret half of this keypair.
-    pub secret: ElGamalSecretKey,
+    secret: ElGamalSecretKey,
 }
 
 impl ElGamalKeypair {
+    pub fn new(public: ElGamalPubkey, secret: ElGamalSecretKey) -> Self {
+        Self { public, secret }
+    }
+
     /// Deterministically derives an ElGamal keypair from a Solana signer and a public seed..
     ///
     /// This function exists for applications where a user may not wish to maintain a Solana signer
@@ -190,6 +194,14 @@ impl ElGamalKeypair {
     #[cfg(not(target_os = "solana"))]
     pub fn new_rand() -> Self {
         ElGamal::keygen()
+    }
+
+    pub fn pubkey(&self) -> &ElGamalPubkey {
+        &self.public
+    }
+
+    pub fn secret(&self) -> &ElGamalSecretKey {
+        &self.secret
     }
 
     pub fn to_bytes(&self) -> [u8; 64] {

--- a/zk-token-sdk/src/encryption/grouped_elgamal.rs
+++ b/zk-token-sdk/src/encryption/grouped_elgamal.rs
@@ -209,9 +209,9 @@ mod tests {
         let amount: u64 = 10;
         let grouped_ciphertext = GroupedElGamal::encrypt(
             [
-                &elgamal_keypair_0.public,
-                &elgamal_keypair_1.public,
-                &elgamal_keypair_2.public,
+                elgamal_keypair_0.pubkey(),
+                elgamal_keypair_1.pubkey(),
+                elgamal_keypair_2.pubkey(),
             ],
             amount,
         );
@@ -219,28 +219,28 @@ mod tests {
         assert_eq!(
             Some(amount),
             grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_0.secret, 0)
+                .decrypt_u32(elgamal_keypair_0.secret(), 0)
                 .unwrap()
         );
 
         assert_eq!(
             Some(amount),
             grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_1.secret, 1)
+                .decrypt_u32(elgamal_keypair_1.secret(), 1)
                 .unwrap()
         );
 
         assert_eq!(
             Some(amount),
             grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_2.secret, 2)
+                .decrypt_u32(elgamal_keypair_2.secret(), 2)
                 .unwrap()
         );
 
         assert_eq!(
             GroupedElGamalError::IndexOutOfBounds,
             grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_0.secret, 3)
+                .decrypt_u32(elgamal_keypair_0.secret(), 3)
                 .unwrap_err()
         );
     }
@@ -254,9 +254,9 @@ mod tests {
         let amount: u64 = 10;
         let grouped_ciphertext = GroupedElGamal::encrypt(
             [
-                &elgamal_keypair_0.public,
-                &elgamal_keypair_1.public,
-                &elgamal_keypair_2.public,
+                elgamal_keypair_0.pubkey(),
+                elgamal_keypair_1.pubkey(),
+                elgamal_keypair_2.pubkey(),
             ],
             amount,
         );
@@ -269,21 +269,21 @@ mod tests {
         assert_eq!(
             Some(amount),
             decoded_grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_0.secret, 0)
+                .decrypt_u32(elgamal_keypair_0.secret(), 0)
                 .unwrap()
         );
 
         assert_eq!(
             Some(amount),
             decoded_grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_1.secret, 1)
+                .decrypt_u32(elgamal_keypair_1.secret(), 1)
                 .unwrap()
         );
 
         assert_eq!(
             Some(amount),
             decoded_grouped_ciphertext
-                .decrypt_u32(&elgamal_keypair_2.secret, 2)
+                .decrypt_u32(elgamal_keypair_2.secret(), 2)
                 .unwrap()
         );
     }

--- a/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity.rs
+++ b/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity.rs
@@ -168,8 +168,11 @@ mod test {
 
     #[test]
     fn test_ciphertext_validity_proof_instruction_correctness() {
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
@@ -178,20 +181,20 @@ mod test {
         let opening_hi = PedersenOpening::new_rand();
 
         let grouped_ciphertext_lo = GroupedElGamal::encrypt_with(
-            [&destination_pubkey, &auditor_pubkey],
+            [destination_pubkey, auditor_pubkey],
             amount_lo,
             &opening_lo,
         );
 
         let grouped_ciphertext_hi = GroupedElGamal::encrypt_with(
-            [&destination_pubkey, &auditor_pubkey],
+            [destination_pubkey, auditor_pubkey],
             amount_hi,
             &opening_hi,
         );
 
         let proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
-            &destination_pubkey,
-            &auditor_pubkey,
+            destination_pubkey,
+            auditor_pubkey,
             &grouped_ciphertext_lo,
             &grouped_ciphertext_hi,
             amount_lo,

--- a/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
@@ -66,7 +66,7 @@ impl CiphertextCiphertextEqualityProofData {
         destination_opening: &PedersenOpening,
         amount: u64,
     ) -> Result<Self, ProofError> {
-        let pod_source_pubkey = pod::ElGamalPubkey(source_keypair.public.to_bytes());
+        let pod_source_pubkey = pod::ElGamalPubkey(source_keypair.pubkey().to_bytes());
         let pod_destination_pubkey = pod::ElGamalPubkey(destination_pubkey.to_bytes());
         let pod_source_ciphertext = pod::ElGamalCiphertext(source_ciphertext.to_bytes());
         let pod_destination_ciphertext = pod::ElGamalCiphertext(destination_ciphertext.to_bytes());
@@ -151,16 +151,16 @@ mod test {
         let destination_keypair = ElGamalKeypair::new_rand();
 
         let amount: u64 = 0;
-        let source_ciphertext = source_keypair.public.encrypt(amount);
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
 
         let destination_opening = PedersenOpening::new_rand();
         let destination_ciphertext = destination_keypair
-            .public
+            .pubkey()
             .encrypt_with(amount, &destination_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
             &source_keypair,
-            &destination_keypair.public,
+            destination_keypair.pubkey(),
             &source_ciphertext,
             &destination_ciphertext,
             &destination_opening,
@@ -171,16 +171,16 @@ mod test {
         assert!(proof_data.verify_proof().is_ok());
 
         let amount: u64 = 55;
-        let source_ciphertext = source_keypair.public.encrypt(amount);
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
 
         let destination_opening = PedersenOpening::new_rand();
         let destination_ciphertext = destination_keypair
-            .public
+            .pubkey()
             .encrypt_with(amount, &destination_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
             &source_keypair,
-            &destination_keypair.public,
+            destination_keypair.pubkey(),
             &source_ciphertext,
             &destination_ciphertext,
             &destination_opening,
@@ -191,16 +191,16 @@ mod test {
         assert!(proof_data.verify_proof().is_ok());
 
         let amount = u64::max_value();
-        let source_ciphertext = source_keypair.public.encrypt(amount);
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
 
         let destination_opening = PedersenOpening::new_rand();
         let destination_ciphertext = destination_keypair
-            .public
+            .pubkey()
             .encrypt_with(amount, &destination_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
             &source_keypair,
-            &destination_keypair.public,
+            destination_keypair.pubkey(),
             &source_ciphertext,
             &destination_ciphertext,
             &destination_opening,

--- a/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
@@ -62,7 +62,7 @@ impl CiphertextCommitmentEqualityProofData {
         amount: u64,
     ) -> Result<Self, ProofError> {
         let context = CiphertextCommitmentEqualityProofContext {
-            pubkey: pod::ElGamalPubkey(keypair.public.to_bytes()),
+            pubkey: pod::ElGamalPubkey(keypair.pubkey().to_bytes()),
             ciphertext: pod::ElGamalCiphertext(ciphertext.to_bytes()),
             commitment: pod::PedersenCommitment(commitment.to_bytes()),
         };
@@ -128,7 +128,7 @@ mod test {
     fn test_ctxt_comm_equality_proof_correctness() {
         let keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
-        let ciphertext = keypair.public.encrypt(amount);
+        let ciphertext = keypair.pubkey().encrypt(amount);
         let (commitment, opening) = Pedersen::new(amount);
 
         let proof_data = CiphertextCommitmentEqualityProofData::new(

--- a/zk-token-sdk/src/instruction/grouped_ciphertext_validity.rs
+++ b/zk-token-sdk/src/instruction/grouped_ciphertext_validity.rs
@@ -144,17 +144,20 @@ mod test {
 
     #[test]
     fn test_ciphertext_validity_proof_instruction_correctness() {
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount: u64 = 55;
         let opening = PedersenOpening::new_rand();
         let grouped_ciphertext =
-            GroupedElGamal::encrypt_with([&destination_pubkey, &auditor_pubkey], amount, &opening);
+            GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount, &opening);
 
         let proof_data = GroupedCiphertext2HandlesValidityProofData::new(
-            &destination_pubkey,
-            &auditor_pubkey,
+            destination_pubkey,
+            auditor_pubkey,
             &grouped_ciphertext,
             amount,
             &opening,

--- a/zk-token-sdk/src/instruction/pubkey_validity.rs
+++ b/zk-token-sdk/src/instruction/pubkey_validity.rs
@@ -48,7 +48,7 @@ pub struct PubkeyValidityProofContext {
 #[cfg(not(target_os = "solana"))]
 impl PubkeyValidityData {
     pub fn new(keypair: &ElGamalKeypair) -> Result<Self, ProofError> {
-        let pod_pubkey = pod::ElGamalPubkey(keypair.public.to_bytes());
+        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().to_bytes());
 
         let context = PubkeyValidityProofContext { pubkey: pod_pubkey };
 

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -69,7 +69,7 @@ impl WithdrawData {
         // current source balance
         let final_ciphertext = current_ciphertext - &ElGamal::encode(amount);
 
-        let pod_pubkey = pod::ElGamalPubkey(keypair.public.to_bytes());
+        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().to_bytes());
         let pod_final_ciphertext: pod::ElGamalCiphertext = final_ciphertext.into();
 
         let context = WithdrawProofContext {
@@ -202,7 +202,7 @@ mod test {
         let keypair = ElGamalKeypair::new_rand();
 
         let current_balance: u64 = 77;
-        let current_ciphertext = keypair.public.encrypt(current_balance);
+        let current_ciphertext = keypair.pubkey().encrypt(current_balance);
 
         let withdraw_amount: u64 = 55;
 

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -54,7 +54,7 @@ impl ZeroBalanceProofData {
         keypair: &ElGamalKeypair,
         ciphertext: &ElGamalCiphertext,
     ) -> Result<Self, ProofError> {
-        let pod_pubkey = pod::ElGamalPubkey(keypair.public.to_bytes());
+        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().to_bytes());
         let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
 
         let context = ZeroBalanceProofContext {
@@ -110,12 +110,12 @@ mod test {
         let keypair = ElGamalKeypair::new_rand();
 
         // general case: encryption of 0
-        let ciphertext = keypair.public.encrypt(0_u64);
+        let ciphertext = keypair.pubkey().encrypt(0_u64);
         let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
         assert!(zero_balance_proof_data.verify_proof().is_ok());
 
         // general case: encryption of > 0
-        let ciphertext = keypair.public.encrypt(1_u64);
+        let ciphertext = keypair.pubkey().encrypt(1_u64);
         let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
         assert!(zero_balance_proof_data.verify_proof().is_err());
     }

--- a/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
@@ -117,8 +117,11 @@ mod test {
 
     #[test]
     fn test_batched_grouped_ciphertext_validity_proof() {
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount_lo: u64 = 55;
         let amount_hi: u64 = 77;
@@ -136,7 +139,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = BatchedGroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (destination_pubkey, auditor_pubkey),
             (amount_lo, amount_hi),
             (&open_lo, &open_hi),
             &mut prover_transcript,
@@ -144,7 +147,7 @@ mod test {
 
         assert!(proof
             .verify(
-                (&destination_pubkey, &auditor_pubkey),
+                (destination_pubkey, auditor_pubkey),
                 (&commitment_lo, &commitment_hi),
                 (&destination_handle_lo, &destination_handle_hi),
                 (&auditor_handle_lo, &auditor_handle_hi),

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
@@ -71,11 +71,11 @@ impl CiphertextCiphertextEqualityProof {
         transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = source_keypair.public.get_point();
+        let P_source = source_keypair.pubkey().get_point();
         let D_source = source_ciphertext.handle.get_point();
         let P_destination = destination_pubkey.get_point();
 
-        let s = source_keypair.secret.get_scalar();
+        let s = source_keypair.secret().get_scalar();
         let x = Scalar::from(amount);
         let r = destination_opening.get_scalar();
 
@@ -270,11 +270,11 @@ mod test {
         let destination_keypair = ElGamalKeypair::new_rand();
         let message: u64 = 55;
 
-        let source_ciphertext = source_keypair.public.encrypt(message);
+        let source_ciphertext = source_keypair.pubkey().encrypt(message);
 
         let destination_opening = PedersenOpening::new_rand();
         let destination_ciphertext = destination_keypair
-            .public
+            .pubkey()
             .encrypt_with(message, &destination_opening);
 
         let mut prover_transcript = Transcript::new(b"Test");
@@ -282,7 +282,7 @@ mod test {
 
         let proof = CiphertextCiphertextEqualityProof::new(
             &source_keypair,
-            &destination_keypair.public,
+            destination_keypair.pubkey(),
             &source_ciphertext,
             &destination_opening,
             message,
@@ -291,8 +291,8 @@ mod test {
 
         assert!(proof
             .verify(
-                &source_keypair.public,
-                &destination_keypair.public,
+                source_keypair.pubkey(),
+                destination_keypair.pubkey(),
                 &source_ciphertext,
                 &destination_ciphertext,
                 &mut verifier_transcript
@@ -303,11 +303,11 @@ mod test {
         let source_message: u64 = 55;
         let destination_message: u64 = 77;
 
-        let source_ciphertext = source_keypair.public.encrypt(source_message);
+        let source_ciphertext = source_keypair.pubkey().encrypt(source_message);
 
         let destination_opening = PedersenOpening::new_rand();
         let destination_ciphertext = destination_keypair
-            .public
+            .pubkey()
             .encrypt_with(destination_message, &destination_opening);
 
         let mut prover_transcript = Transcript::new(b"Test");
@@ -315,7 +315,7 @@ mod test {
 
         let proof = CiphertextCiphertextEqualityProof::new(
             &source_keypair,
-            &destination_keypair.public,
+            destination_keypair.pubkey(),
             &source_ciphertext,
             &destination_opening,
             message,
@@ -324,8 +324,8 @@ mod test {
 
         assert!(proof
             .verify(
-                &source_keypair.public,
-                &destination_keypair.public,
+                source_keypair.pubkey(),
+                destination_keypair.pubkey(),
                 &source_ciphertext,
                 &destination_ciphertext,
                 &mut verifier_transcript

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -75,10 +75,10 @@ impl CiphertextCommitmentEqualityProof {
         transcript.equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = source_keypair.public.get_point();
+        let P_source = source_keypair.pubkey().get_point();
         let D_source = source_ciphertext.handle.get_point();
 
-        let s = source_keypair.secret.get_scalar();
+        let s = source_keypair.secret().get_scalar();
         let x = Scalar::from(amount);
         let r = opening.get_scalar();
 
@@ -250,7 +250,7 @@ mod test {
         let source_keypair = ElGamalKeypair::new_rand();
         let message: u64 = 55;
 
-        let source_ciphertext = source_keypair.public.encrypt(message);
+        let source_ciphertext = source_keypair.pubkey().encrypt(message);
         let (destination_commitment, destination_opening) = Pedersen::new(message);
 
         let mut prover_transcript = Transcript::new(b"Test");
@@ -266,7 +266,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &source_keypair.public,
+                source_keypair.pubkey(),
                 &source_ciphertext,
                 &destination_commitment,
                 &mut verifier_transcript
@@ -278,7 +278,7 @@ mod test {
         let encrypted_message: u64 = 55;
         let committed_message: u64 = 77;
 
-        let source_ciphertext = source_keypair.public.encrypt(encrypted_message);
+        let source_ciphertext = source_keypair.pubkey().encrypt(encrypted_message);
         let (destination_commitment, destination_opening) = Pedersen::new(committed_message);
 
         let mut prover_transcript = Transcript::new(b"Test");
@@ -294,7 +294,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &source_keypair.public,
+                source_keypair.pubkey(),
                 &source_ciphertext,
                 &destination_commitment,
                 &mut verifier_transcript
@@ -308,10 +308,10 @@ mod test {
         let public = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
         let secret = ElGamalSecretKey::new_rand();
 
-        let elgamal_keypair = ElGamalKeypair { public, secret };
+        let elgamal_keypair = ElGamalKeypair::new(public, secret);
 
         let message: u64 = 55;
-        let ciphertext = elgamal_keypair.public.encrypt(message);
+        let ciphertext = elgamal_keypair.pubkey().encrypt(message);
         let (commitment, opening) = Pedersen::new(message);
 
         let mut prover_transcript = Transcript::new(b"Test");
@@ -327,7 +327,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &elgamal_keypair.public,
+                elgamal_keypair.pubkey(),
                 &ciphertext,
                 &commitment,
                 &mut verifier_transcript
@@ -356,7 +356,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &elgamal_keypair.public,
+                elgamal_keypair.pubkey(),
                 &ciphertext,
                 &commitment,
                 &mut verifier_transcript
@@ -368,7 +368,7 @@ mod test {
         let elgamal_keypair = ElGamalKeypair::new_rand();
 
         let message: u64 = 0;
-        let ciphertext = elgamal_keypair.public.encrypt(message);
+        let ciphertext = elgamal_keypair.pubkey().encrypt(message);
         let commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
         let opening = PedersenOpening::from_bytes(&[0u8; 32]).unwrap();
 
@@ -385,7 +385,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &elgamal_keypair.public,
+                elgamal_keypair.pubkey(),
                 &ciphertext,
                 &commitment,
                 &mut verifier_transcript
@@ -413,7 +413,7 @@ mod test {
 
         assert!(proof
             .verify(
-                &elgamal_keypair.public,
+                elgamal_keypair.pubkey(),
                 &ciphertext,
                 &commitment,
                 &mut verifier_transcript

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -308,7 +308,7 @@ mod test {
         let public = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
         let secret = ElGamalSecretKey::new_rand();
 
-        let elgamal_keypair = ElGamalKeypair::new(public, secret);
+        let elgamal_keypair = ElGamalKeypair::new_for_tests(public, secret);
 
         let message: u64 = 55;
         let ciphertext = elgamal_keypair.pubkey().encrypt(message);

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -234,8 +234,11 @@ mod test {
 
     #[test]
     fn test_grouped_ciphertext_validity_proof_correctness() {
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount: u64 = 55;
         let (commitment, opening) = Pedersen::new(amount);
@@ -247,7 +250,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (destination_pubkey, auditor_pubkey),
             amount,
             &opening,
             &mut prover_transcript,
@@ -256,7 +259,7 @@ mod test {
         assert!(proof
             .verify(
                 &commitment,
-                (&destination_pubkey, &auditor_pubkey),
+                (destination_pubkey, auditor_pubkey),
                 (&destination_handle, &auditor_handle),
                 &mut verifier_transcript,
             )
@@ -267,7 +270,9 @@ mod test {
     fn test_grouped_ciphertext_validity_proof_edge_cases() {
         // if destination public key zeroed, then the proof should always reject
         let destination_pubkey = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount: u64 = 55;
         let (commitment, opening) = Pedersen::new(amount);
@@ -279,7 +284,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (&destination_pubkey, auditor_pubkey),
             amount,
             &opening,
             &mut prover_transcript,
@@ -288,14 +293,16 @@ mod test {
         assert!(proof
             .verify(
                 &commitment,
-                (&destination_pubkey, &auditor_pubkey),
+                (&destination_pubkey, auditor_pubkey),
                 (&destination_handle, &auditor_handle),
                 &mut verifier_transcript,
             )
             .is_err());
 
         // if auditor public key zeroed, then the proof should always reject
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
         let auditor_pubkey = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
 
         let amount: u64 = 55;
@@ -308,7 +315,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (destination_pubkey, &auditor_pubkey),
             amount,
             &opening,
             &mut prover_transcript,
@@ -317,15 +324,18 @@ mod test {
         assert!(proof
             .verify(
                 &commitment,
-                (&destination_pubkey, &auditor_pubkey),
+                (destination_pubkey, &auditor_pubkey),
                 (&destination_handle, &auditor_handle),
                 &mut verifier_transcript,
             )
             .is_err());
 
         // all zeroed ciphertext should still be valid
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount: u64 = 0;
         let commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
@@ -338,7 +348,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (destination_pubkey, auditor_pubkey),
             amount,
             &opening,
             &mut prover_transcript,
@@ -347,15 +357,18 @@ mod test {
         assert!(proof
             .verify(
                 &commitment,
-                (&destination_pubkey, &auditor_pubkey),
+                (destination_pubkey, auditor_pubkey),
                 (&destination_handle, &auditor_handle),
                 &mut verifier_transcript,
             )
             .is_ok());
 
         // decryption handles can be zero as long as the Pedersen commitment is valid
-        let destination_pubkey = ElGamalKeypair::new_rand().public;
-        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let destination_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = destination_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pubkey = auditor_keypair.pubkey();
 
         let amount: u64 = 55;
         let (commitment, opening) = Pedersen::new(amount);
@@ -367,7 +380,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (&destination_pubkey, &auditor_pubkey),
+            (destination_pubkey, auditor_pubkey),
             amount,
             &opening,
             &mut prover_transcript,
@@ -376,7 +389,7 @@ mod test {
         assert!(proof
             .verify(
                 &commitment,
-                (&destination_pubkey, &auditor_pubkey),
+                (destination_pubkey, auditor_pubkey),
                 (&destination_handle, &auditor_handle),
                 &mut verifier_transcript,
             )

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -59,7 +59,7 @@ impl PubkeyValidityProof {
         transcript.pubkey_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
-        let s = elgamal_keypair.secret.get_scalar();
+        let s = elgamal_keypair.secret().get_scalar();
 
         assert!(s != &Scalar::zero());
         let s_inv = s.invert();
@@ -152,7 +152,7 @@ mod test {
 
         let proof = PubkeyValidityProof::new(&keypair, &mut prover_transcript);
         assert!(proof
-            .verify(&keypair.public, &mut verifier_transcript)
+            .verify(keypair.pubkey(), &mut verifier_transcript)
             .is_ok());
 
         // derived ElGamal keypair
@@ -164,7 +164,7 @@ mod test {
 
         let proof = PubkeyValidityProof::new(&keypair, &mut prover_transcript);
         assert!(proof
-            .verify(&keypair.public, &mut verifier_transcript)
+            .verify(keypair.pubkey(), &mut verifier_transcript)
             .is_ok());
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/decryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/decryption.rs
@@ -25,11 +25,11 @@ mod tests {
         let keypair = ElGamalKeypair::new_rand();
 
         let pod_ciphertext = pod::ElGamalCiphertext([0u8; 64]);
-        assert_eq!(pod_ciphertext.decrypt(&keypair.secret).unwrap(), 0);
+        assert_eq!(pod_ciphertext.decrypt(keypair.secret()).unwrap(), 0);
 
         let amount = 55_u64;
-        let ciphertext = keypair.public.encrypt(amount);
+        let ciphertext = keypair.pubkey().encrypt(amount);
         let pod_ciphertext: pod::ElGamalCiphertext = ciphertext.into();
-        assert_eq!(pod_ciphertext.decrypt(&keypair.secret).unwrap(), 55);
+        assert_eq!(pod_ciphertext.decrypt(keypair.secret()).unwrap(), 55);
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -151,7 +151,8 @@ mod tests {
 
         // spendable_ct should be an encryption of 0 for any public key when
         // `PedersenOpen::default()` is used
-        let public = ElGamalKeypair::new_rand().public;
+        let keypair = ElGamalKeypair::new_rand();
+        let public = keypair.pubkey();
         let balance: u64 = 0;
         assert_eq!(
             spendable_ct,
@@ -175,7 +176,8 @@ mod tests {
 
         let added_ct = ops::add_to(&spendable_balance, 55).unwrap();
 
-        let public = ElGamalKeypair::new_rand().public;
+        let keypair = ElGamalKeypair::new_rand();
+        let public = keypair.pubkey();
         let expected: pod::ElGamalCiphertext = public
             .encrypt_with(55_u64, &PedersenOpening::default())
             .into();
@@ -186,7 +188,8 @@ mod tests {
     #[test]
     fn test_subtract_from() {
         let amount = 77_u64;
-        let public = ElGamalKeypair::new_rand().public;
+        let keypair = ElGamalKeypair::new_rand();
+        let public = keypair.pubkey();
         let open = PedersenOpening::new_rand();
         let encrypted_amount: pod::ElGamalCiphertext = public.encrypt_with(amount, &open).into();
 
@@ -204,9 +207,14 @@ mod tests {
         let (amount_lo, amount_hi) = split_u64(transfer_amount, 16);
 
         // generate public keys
-        let source_pk = ElGamalKeypair::new_rand().public;
-        let dest_pk = ElGamalKeypair::new_rand().public;
-        let auditor_pk = ElGamalKeypair::new_rand().public;
+        let source_keypair = ElGamalKeypair::new_rand();
+        let source_pk = source_keypair.pubkey();
+
+        let dest_keypair = ElGamalKeypair::new_rand();
+        let dest_pk = dest_keypair.pubkey();
+
+        let auditor_keypair = ElGamalKeypair::new_rand();
+        let auditor_pk = auditor_keypair.pubkey();
 
         // commitments associated with TransferRangeProof
         let (comm_lo, open_lo) = Pedersen::new(amount_lo);


### PR DESCRIPTION
#### Problem
Currently, the fields `public` and `secret` in the type `ElGamalKeypair` are all public. This is somewhat unnatural and could also cause security issues since the `secret` component implements `Copy` allowing downstream to copy/clone the secret key in memory under the hood.

#### Summary of Changes
- Changed the `public` and `secret` fields in `ElGamalKeypair` to be private
- Added constructor for `ElGamalKeypair` and getters for its private fields
- Updated the rest of the repo for the new visibility

I referenced the interface for `Keypair` in the sdk. There, we have the interface
```
pub fn secret(&self) -> &SecretKey { ... } // returns reference to `SecretKey`
```
and
```
pub fn pubkey(&self) -> Pubkey { ...} // returns a copy of `Pubkey`
```

In this PR, I made both getters to return references to `ElGamalSecretKey` and `ElGamalPubkey`. For secret key, it obviously makes sense to return a reference. For the pubkey part, I thought returning a refernce is more flexible than returning a fully owned `ElGamalPubkey` since `ElGamalPubkey` implements `Copy` and hence, the returned variable from the getter can always be dereferenced immediately.

But when I was updating the rest of the crates, encountered some occurrences in tests like
```
let random_elgamal_pubkey = ElGamalKeypair::new_rand().pubkey();
```
which does not compile because the output of `ElGamalKeypair::new_rand()` is freed immediately after its call and `random_elgamal_pubkey` becomes a dangling pointer. The snippet would work if the getter returned a fully-owned `ElGamalPubkey`.

With returning a reference, the snippet above has to become
```
let random_elgamal_keypair = ElGamalKeypair::new_rand(); // must save keypair in a variable
let random_elgamal_pubkey = random_elgamal_keypair::pubkey();
```
I think generating a random `ElGamalPubkey` without generating a corresponding `ElGamalSecretKey` will be very rare in practice other than in tests, so I think this is more minor for downstream.

But one other example is
```
let keypair = ElGamalKeypair::new_rand();

let pod_elgamal_pubkey: PodElGamalPubkey = keypair.pubkey().into(); // does not work
let pod_elgamal_pubkey: PodElGamalPubkey = (*keypair.pubkey()).into(); // must be dereferenced first
```

There are some issues like these that make the code slightly less ergonomic. I thought about this a bit and I thought going with returning `&ElGamalPubkey` is still the way to go, but I'd be happy to discuss.

This is a follow-up to https://github.com/solana-labs/solana/pull/31468#discussion_r1185381664.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
