### PR TITLE
[TieredStorage] Make AccountMetaFlags::new_from pub(crate)

### DIFF
--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -23,7 +23,7 @@ pub struct AccountMetaFlags {
 }
 
 impl AccountMetaFlags {
-    fn new_from(optional_fields: &AccountMetaOptionalFields) -> Self {
+    pub(crate) fn new_from(optional_fields: &AccountMetaOptionalFields) -> Self {
         let mut flags = AccountMetaFlags::default();
         flags.set_has_rent_epoch(optional_fields.rent_epoch.is_some());
         flags.set_has_account_hash(optional_fields.account_hash.is_some());


### PR DESCRIPTION
#### Summary of Changes
The newly introduced AccountMetaFlags::new_from must be `pub(crate)`
in order to make the tiered storage writer able to use it.
