### PR TITLE
Use workspace serde dependency in program-runtime

### DIFF
--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -21,7 +21,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 percentage = { workspace = true }
 rand = { workspace = true }
-serde = { version = "1.0.163", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-measure = { workspace = true }


### PR DESCRIPTION
#### Problem
I noticed in https://github.com/solana-labs/solana/pull/32028/files that the `solana-program-runtime` crate is using a specific version of serde for no reason I can intuit (it is the same version as specified in the workspace).

#### Summary of Changes
Use workspace serde
