### PR TITLE
[zk-token-sdk] Replace range hard-coded constants with constant variables in `rangeproof` module

### DIFF
--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -388,16 +388,16 @@ impl InnerProductProof {
         let mut R_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);
         for i in 0..lg_n {
             let pos = 2 * i * RISTRETTO_LEN;
-            L_vec.push(CompressedRistretto(util::read32(&slice[pos..])));
-            R_vec.push(CompressedRistretto(util::read32(
+            L_vec.push(CompressedRistretto(util::read_unit(&slice[pos..])));
+            R_vec.push(CompressedRistretto(util::read_unit(
                 &slice[pos + RISTRETTO_LEN..],
             )));
         }
 
-        let pos = 2 * lg_n * 32;
-        let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
+        let pos = 2 * lg_n * UNIT_LEN;
+        let a = Scalar::from_canonical_bytes(util::read_unit(&slice[pos..]))
             .ok_or(ProofVerificationError::Deserialization)?;
-        let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + SCALAR_LEN..]))
+        let b = Scalar::from_canonical_bytes(util::read_unit(&slice[pos + SCALAR_LEN..]))
             .ok_or(ProofVerificationError::Deserialization)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -360,16 +360,16 @@ impl RangeProof {
             return Err(ProofVerificationError::Deserialization.into());
         }
 
-        let A = CompressedRistretto(util::read32(&slice[0..]));
-        let S = CompressedRistretto(util::read32(&slice[RISTRETTO_LEN..]));
-        let T_1 = CompressedRistretto(util::read32(&slice[2 * RISTRETTO_LEN..]));
-        let T_2 = CompressedRistretto(util::read32(&slice[3 * RISTRETTO_LEN..]));
+        let A = CompressedRistretto(util::read_unit(&slice[0..]));
+        let S = CompressedRistretto(util::read_unit(&slice[RISTRETTO_LEN..]));
+        let T_1 = CompressedRistretto(util::read_unit(&slice[2 * RISTRETTO_LEN..]));
+        let T_2 = CompressedRistretto(util::read_unit(&slice[3 * RISTRETTO_LEN..]));
 
-        let t_x = Scalar::from_canonical_bytes(util::read32(&slice[4 * SCALAR_LEN..]))
+        let t_x = Scalar::from_canonical_bytes(util::read_unit(&slice[4 * SCALAR_LEN..]))
             .ok_or(ProofVerificationError::Deserialization)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(util::read32(&slice[5 * SCALAR_LEN..]))
+        let t_x_blinding = Scalar::from_canonical_bytes(util::read_unit(&slice[5 * SCALAR_LEN..]))
             .ok_or(ProofVerificationError::Deserialization)?;
-        let e_blinding = Scalar::from_canonical_bytes(util::read32(&slice[6 * SCALAR_LEN..]))
+        let e_blinding = Scalar::from_canonical_bytes(util::read_unit(&slice[6 * SCALAR_LEN..]))
             .ok_or(ProofVerificationError::Deserialization)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * SCALAR_LEN..])?;

--- a/zk-token-sdk/src/range_proof/util.rs
+++ b/zk-token-sdk/src/range_proof/util.rs
@@ -1,7 +1,7 @@
 /// Utility functions for Bulletproofs.
 ///
 /// The code is copied from https://github.com/dalek-cryptography/bulletproofs for now...
-use curve25519_dalek::scalar::Scalar;
+use {crate::range_proof::UNIT_LEN, curve25519_dalek::scalar::Scalar};
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
 pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
@@ -88,10 +88,10 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
 }
 
 /// Given `data` with `len >= 32`, return the first 32 bytes.
-pub fn read32(data: &[u8]) -> [u8; 32] {
-    let mut buf32 = [0u8; 32];
-    buf32[..].copy_from_slice(&data[..32]);
-    buf32
+pub fn read_unit(data: &[u8]) -> [u8; UNIT_LEN] {
+    let mut buf_unit = [0u8; UNIT_LEN];
+    buf_unit[..].copy_from_slice(&data[..UNIT_LEN]);
+    buf_unit
 }
 
 /// Computes an inner product of two vectors


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
