### PR TITLE
Sets default snapshot archive format to Zstd

### DIFF
--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -56,7 +56,7 @@ impl Default for SnapshotConfig {
             full_snapshot_archives_dir: PathBuf::default(),
             incremental_snapshot_archives_dir: PathBuf::default(),
             bank_snapshots_dir: PathBuf::default(),
-            archive_format: ArchiveFormat::TarBzip2,
+            archive_format: ArchiveFormat::TarZstd,
             snapshot_version: SnapshotVersion::default(),
             maximum_full_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,


### PR DESCRIPTION
#### Problem

`SnapshotConfig`'s default archive format is bzip2, which is slow.

When manually testing the archive formats on an mnb snapshot, I ran the various archival commands with all (see update below) our currently supported archival formats. Here's the runtimes:

input | input size | archival format | archival time (real) | user | sys | archive size
-- | -- | -- | -- | -- | -- | --
mnb snapshot from 2023-05-11 |   |   |   |   |   |  
  | 134 GB | tar | 3m59.468s | 0m4.040s | 1m56.291s | 134 GB
  | 134 GB | tar + gzip | 50m26.798s | 49m49.511s | 1m35.082s | 48 GB
  | 134 GB | tar + bzip2 | 136m58.677s | 136m2.313s | 2m31.762s | 45 GB
  | 134 GB | tar + zstd | 8m9.644s | 8m43.331s | 1m53.949s | 43 GB



Clearly `zstd` is the winner here (not counting no-compression), but `SnapshotConfig` defaults to `bzip2`.

(Note that both the validator and ledger-tool's CLI parameters/parsing default to zstd, so those primary usages are OK.)

Update: Looks like I overlooked testing lz4 here (sorry @apfitzge!)... I think that testing lz4 too would've been useful, but thinking a bit more, I feel that the SnapshotConfig's default should match the default in `validator` and `ledger-tool`. So ultimately this really only needs to compare bzip2 and zstd. I think if we want to revisit this later and change the defaults everywhere, then testing all the archive formats would be necessary.


#### Summary of Changes

Change the default SnapshotConfig archive format to zstd.