### PR TITLE
Clean up credits_auto_rewind feature

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -248,49 +248,43 @@ fn calculate_stake_points_and_credits(
     let credits_in_stake = stake.credits_observed;
     let credits_in_vote = new_vote_state.credits();
     // if there is no newer credits since observed, return no point
-    if credits_in_vote <= credits_in_stake {
-        if credits_in_vote < credits_in_stake {
-            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
-            }
-            // Don't adjust stake.activation_epoch for simplicity:
-            //  - generally fast-forwarding stake.activation_epoch forcibly (for
-            //    artificial re-activation with re-warm-up) skews the stake
-            //    history sysvar. And properly handling all the cases
-            //    regarding deactivation epoch/warm-up/cool-down without
-            //    introducing incentive skew is hard.
-            //  - Conceptually, it should be acceptable for the staked SOLs at
-            //    the recreated vote to receive rewards again immediately after
-            //    rewind even if it looks like instant activation. That's
-            //    because it must have passed the required warmed-up at least
-            //    once in the past already
-            //  - Also such a stake account remains to be a part of overall
-            //    effective stake calculation even while the vote account is
-            //    missing for (indefinite) time or remains to be pre-remove
-            //    credits score. It should be treated equally to staking with
-            //    delinquent validator with no differentiation.
+    if credits_in_vote < credits_in_stake {
+        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
+        }
+        // Don't adjust stake.activation_epoch for simplicity:
+        //  - generally fast-forwarding stake.activation_epoch forcibly (for
+        //    artificial re-activation with re-warm-up) skews the stake
+        //    history sysvar. And properly handling all the cases
+        //    regarding deactivation epoch/warm-up/cool-down without
+        //    introducing incentive skew is hard.
+        //  - Conceptually, it should be acceptable for the staked SOLs at
+        //    the recreated vote to receive rewards again immediately after
+        //    rewind even if it looks like instant activation. That's
+        //    because it must have passed the required warmed-up at least
+        //    once in the past already
+        //  - Also such a stake account remains to be a part of overall
+        //    effective stake calculation even while the vote account is
+        //    missing for (indefinite) time or remains to be pre-remove
+        //    credits score. It should be treated equally to staking with
+        //    delinquent validator with no differentiation.
 
-            // hint with true to indicate some exceptional credits handling is needed
-            return CalculatedStakePoints {
-                points: 0,
-                new_credits_observed: credits_in_vote,
-                force_credits_update_with_skipped_reward: true,
-            };
-        } else {
-            // change the above `else` to `else if credits_in_vote == credits_in_stake`
-            // (and remove the outermost enclosing `if`) when cleaning credits_auto_rewind
-            // after activation
-
-            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
-            }
-            // don't hint the caller and return current value if credits remain to be unchanged (=
-            // delinquent)
-            return CalculatedStakePoints {
-                points: 0,
-                new_credits_observed: credits_in_stake,
-                force_credits_update_with_skipped_reward: false,
-            };
+        // hint with true to indicate some exceptional credits handling is needed
+        return CalculatedStakePoints {
+            points: 0,
+            new_credits_observed: credits_in_vote,
+            force_credits_update_with_skipped_reward: true,
+        };
+    } else if credits_in_vote == credits_in_stake {
+        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
+        }
+        // don't hint the caller and return current value if credits remain to be unchanged (=
+        // delinquent)
+        return CalculatedStakePoints {
+            points: 0,
+            new_credits_observed: credits_in_stake,
+            force_credits_update_with_skipped_reward: false,
         };
     }
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -281,8 +281,7 @@ fn calculate_stake_points_and_credits(
             if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
                 inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
             }
-            // don't hint the caller and return current value if credits remain to be unchanged (=
-            // delinquent)
+            // don't hint caller and return current value if credits remain unchanged (= delinquent)
             return CalculatedStakePoints {
                 points: 0,
                 new_credits_observed: credits_in_stake,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -33,7 +33,7 @@ use {
         },
     },
     solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
-    std::{collections::HashSet, convert::TryFrom},
+    std::{cmp::Ordering, collections::HashSet, convert::TryFrom},
 };
 
 #[derive(Debug)]
@@ -248,44 +248,48 @@ fn calculate_stake_points_and_credits(
     let credits_in_stake = stake.credits_observed;
     let credits_in_vote = new_vote_state.credits();
     // if there is no newer credits since observed, return no point
-    if credits_in_vote < credits_in_stake {
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
-        }
-        // Don't adjust stake.activation_epoch for simplicity:
-        //  - generally fast-forwarding stake.activation_epoch forcibly (for
-        //    artificial re-activation with re-warm-up) skews the stake
-        //    history sysvar. And properly handling all the cases
-        //    regarding deactivation epoch/warm-up/cool-down without
-        //    introducing incentive skew is hard.
-        //  - Conceptually, it should be acceptable for the staked SOLs at
-        //    the recreated vote to receive rewards again immediately after
-        //    rewind even if it looks like instant activation. That's
-        //    because it must have passed the required warmed-up at least
-        //    once in the past already
-        //  - Also such a stake account remains to be a part of overall
-        //    effective stake calculation even while the vote account is
-        //    missing for (indefinite) time or remains to be pre-remove
-        //    credits score. It should be treated equally to staking with
-        //    delinquent validator with no differentiation.
+    match credits_in_vote.cmp(&credits_in_stake) {
+        Ordering::Less => {
+            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
+            }
+            // Don't adjust stake.activation_epoch for simplicity:
+            //  - generally fast-forwarding stake.activation_epoch forcibly (for
+            //    artificial re-activation with re-warm-up) skews the stake
+            //    history sysvar. And properly handling all the cases
+            //    regarding deactivation epoch/warm-up/cool-down without
+            //    introducing incentive skew is hard.
+            //  - Conceptually, it should be acceptable for the staked SOLs at
+            //    the recreated vote to receive rewards again immediately after
+            //    rewind even if it looks like instant activation. That's
+            //    because it must have passed the required warmed-up at least
+            //    once in the past already
+            //  - Also such a stake account remains to be a part of overall
+            //    effective stake calculation even while the vote account is
+            //    missing for (indefinite) time or remains to be pre-remove
+            //    credits score. It should be treated equally to staking with
+            //    delinquent validator with no differentiation.
 
-        // hint with true to indicate some exceptional credits handling is needed
-        return CalculatedStakePoints {
-            points: 0,
-            new_credits_observed: credits_in_vote,
-            force_credits_update_with_skipped_reward: true,
-        };
-    } else if credits_in_vote == credits_in_stake {
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
+            // hint with true to indicate some exceptional credits handling is needed
+            return CalculatedStakePoints {
+                points: 0,
+                new_credits_observed: credits_in_vote,
+                force_credits_update_with_skipped_reward: true,
+            };
         }
-        // don't hint the caller and return current value if credits remain to be unchanged (=
-        // delinquent)
-        return CalculatedStakePoints {
-            points: 0,
-            new_credits_observed: credits_in_stake,
-            force_credits_update_with_skipped_reward: false,
-        };
+        Ordering::Equal => {
+            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
+            }
+            // don't hint the caller and return current value if credits remain to be unchanged (=
+            // delinquent)
+            return CalculatedStakePoints {
+                points: 0,
+                new_credits_observed: credits_in_stake,
+                force_credits_update_with_skipped_reward: false,
+            };
+        }
+        Ordering::Greater => {}
     }
 
     let mut points = 0;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2834,7 +2834,6 @@ impl Bank {
             prev_epoch,
             validator_rewards,
             reward_calc_tracer,
-            self.credits_auto_rewind(),
             thread_pool,
             metrics,
             update_rewards_from_cached_accounts,
@@ -3271,7 +3270,6 @@ impl Bank {
         rewarded_epoch: Epoch,
         rewards: u64,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
-        credits_auto_rewind: bool,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
         update_rewards_from_cached_accounts: bool,
@@ -3297,7 +3295,6 @@ impl Bank {
                 vote_with_stake_delegations_map,
                 rewarded_epoch,
                 point_value,
-                credits_auto_rewind,
                 &stake_history,
                 thread_pool,
                 reward_calc_tracer.as_ref(),
@@ -3579,7 +3576,6 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
     ) -> (VoteRewardsAccounts, StakeRewardCalculation) {
-        let credits_auto_rewind = self.credits_auto_rewind();
         let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
@@ -3713,7 +3709,6 @@ impl Bank {
         vote_with_stake_delegations_map: DashMap<Pubkey, VoteWithStakeDelegations>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
-        credits_auto_rewind: bool,
         stake_history: &StakeHistory,
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
@@ -8392,11 +8387,6 @@ impl Bank {
     pub fn prevent_rent_paying_rent_recipients(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::prevent_rent_paying_rent_recipients::id())
-    }
-
-    pub fn credits_auto_rewind(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::credits_auto_rewind::id())
     }
 
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3647,7 +3647,6 @@ impl Bank {
                         &point_value,
                         Some(stake_history),
                         reward_calc_tracer.as_ref(),
-                        credits_auto_rewind,
                     );
 
                     let post_lamport = stake_account.lamports();
@@ -3766,7 +3765,6 @@ impl Bank {
                         &point_value,
                         Some(stake_history),
                         reward_calc_tracer.as_ref(),
-                        credits_auto_rewind,
                     );
                     if let Ok((stakers_reward, voters_reward)) = redeemed {
                         // track voter rewards


### PR DESCRIPTION
#### Problem
The [credits_auto_rewind feature](https://github.com/solana-labs/solana/issues/24674) is active on all public clusters, but the gating logic is still present.

#### Summary of Changes
Remove it. Also follow cleaning orders for if-else

Closes #24674
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
