### PR TITLE
Remove a unnecessary sleep in run server

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -36,10 +36,7 @@ use {
         },
         time::{Duration, Instant},
     },
-    tokio::{
-        task::JoinHandle,
-        time::{sleep, timeout},
-    },
+    tokio::{task::JoinHandle, time::timeout},
 };
 
 const WAIT_FOR_STREAM_TIMEOUT: Duration = Duration::from_millis(100);
@@ -135,7 +132,6 @@ async fn run_server(
     coalesce: Duration,
 ) {
     const WAIT_FOR_CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
-    const WAIT_BETWEEN_NEW_CONNECTIONS: Duration = Duration::from_millis(1);
     debug!("spawn quic server");
     let mut last_datapoint = Instant::now();
     let unstaked_connection_table: Arc<Mutex<ConnectionTable>> = Arc::new(Mutex::new(
@@ -173,7 +169,6 @@ async fn run_server(
                 stats.clone(),
                 wait_for_chunk_timeout,
             ));
-            sleep(WAIT_BETWEEN_NEW_CONNECTIONS).await;
         } else {
             debug!("accept(): Timed out waiting for connection");
         }


### PR DESCRIPTION
#### Problem
The quic streamer run_server unnecessarily sleep. This can slow down processing connection in initializing state and build up memory pressure. We do not need it as we have already used timeout when doing

        let timeout_connection = timeout(WAIT_FOR_CONNECTION_TIMEOUT, incoming.accept()).await;


#### Summary of Changes
Remove the unnecessary sleep.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
