### PR TITLE
[TieredStorage]  TieredAccountMeta (1/N)

### DIFF
--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -28,10 +28,6 @@ pub trait TieredAccountMeta: Sized {
     /// Constructs a TieredAcountMeta instance.
     fn new() -> Self;
 
-    /// Returns true if the TieredAccountMeta implementation supports multiple
-    /// accounts sharing one account block.
-    fn supports_shared_account_block() -> bool;
-
     /// A builder function that initializes lamports.
     fn with_lamports(self, lamports: u64) -> Self;
 
@@ -67,6 +63,10 @@ pub trait TieredAccountMeta: Sized {
 
     /// Returns the AccountMetaFlags of the current meta.
     fn flags(&self) -> &AccountMetaFlags;
+
+    /// Returns true if the TieredAccountMeta implementation supports multiple
+    /// accounts sharing one account block.
+    fn supports_shared_account_block() -> bool;
 }
 
 impl AccountMetaFlags {

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -25,25 +25,26 @@ pub struct AccountMetaFlags {
 /// A trait that allows different implementations of the account meta that
 /// support different tiers of the accounts storage.
 pub trait TieredAccountMeta {
-    /// Construct a TieredAcountMeta instance.
+    /// Constructs a TieredAcountMeta instance.
     fn new() -> Self;
 
     /// Returns true if the TieredAccountMeta implementation supports multiple
-    /// accounts sharing one byte block.
-    fn support_shared_byte_block() -> bool;
+    /// accounts sharing one account block.
+    fn supports_shared_account_block() -> bool;
 
     /// A builder function that initializes lamports.
     fn with_lamports(&mut self, lamports: u64) -> &mut Self;
 
     /// A builder function that initializes the number of padding bytes
     /// for the account data associated with the current meta.
-    fn with_account_data_padding(&mut self, paddings: u8) -> &mut Self;
+    fn with_account_data_padding(&mut self, padding: u8) -> &mut Self;
 
-    /// A builder function that initializes the owner's local id.
-    fn with_owner_local_id(&mut self, local_id: u32) -> &mut Self;
+    /// A builder function that initializes the owner's index.
+    fn with_owner_index(&mut self, index: u32) -> &mut Self;
 
-    /// A builder function that initializes the raw account data size.
-    fn with_raw_data_size(&mut self, data_size: u64) -> &mut Self;
+    /// A builder function that initializes the account data size.
+    /// The size here represents the logical data size without compression.
+    fn with_data_size(&mut self, data_size: u64) -> &mut Self;
 
     /// A builder function that initializes the AccountMetaFlags of the current
     /// meta.
@@ -55,14 +56,14 @@ pub trait TieredAccountMeta {
     /// Returns the number of padding bytes for the associated account data
     fn account_data_padding(&self) -> u8;
 
-    /// Returns the raw size of its account data if the current accout meta
-    /// shares its byte block with other account meta entries.
+    /// Returns the size of its account data if the current accout meta
+    /// shares its account block with other account meta entries.
     ///
     /// Otherwise, None will be returned.
-    fn raw_data_size_for_shared_block(&self) -> Option<usize>;
+    fn data_size_for_shared_block(&self) -> Option<usize>;
 
-    /// Returns the local id to the accounts' owner in the current AccountsFile.
-    fn owner_local_id(&self) -> u32;
+    /// Returns the index to the accounts' owner in the current AccountsFile.
+    fn owner_index(&self) -> u32;
 
     /// Returns the AccountMetaFlags of the current meta.
     fn flags(&self) -> &AccountMetaFlags;

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -24,7 +24,7 @@ pub struct AccountMetaFlags {
 
 /// A trait that allows different implementations of the account meta that
 /// support different tiers of the accounts storage.
-pub trait TieredAccountMeta {
+pub trait TieredAccountMeta : Sized {
     /// Constructs a TieredAcountMeta instance.
     fn new() -> Self;
 
@@ -33,22 +33,22 @@ pub trait TieredAccountMeta {
     fn supports_shared_account_block() -> bool;
 
     /// A builder function that initializes lamports.
-    fn with_lamports(&mut self, lamports: u64) -> &mut Self;
+    fn with_lamports(self, lamports: u64) -> Self;
 
     /// A builder function that initializes the number of padding bytes
     /// for the account data associated with the current meta.
-    fn with_account_data_padding(&mut self, padding: u8) -> &mut Self;
+    fn with_account_data_padding(self, padding: u8) -> Self;
 
     /// A builder function that initializes the owner's index.
-    fn with_owner_index(&mut self, index: u32) -> &mut Self;
+    fn with_owner_index(self, index: u32) -> Self;
 
     /// A builder function that initializes the account data size.
     /// The size here represents the logical data size without compression.
-    fn with_data_size(&mut self, data_size: u64) -> &mut Self;
+    fn with_data_size(self, data_size: u64) -> Self;
 
     /// A builder function that initializes the AccountMetaFlags of the current
     /// meta.
-    fn with_flags(&mut self, flags: &AccountMetaFlags) -> &mut Self;
+    fn with_flags(self, flags: &AccountMetaFlags) -> Self;
 
     /// Returns the balance of the lamports associated with the account.
     fn lamports(&self) -> u64;

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -22,6 +22,52 @@ pub struct AccountMetaFlags {
     reserved: B29,
 }
 
+/// A trait that allows different implementations of the account meta that
+/// support different tiers of the accounts storage.
+pub trait TieredAccountMeta {
+    /// Construct a TieredAcountMeta instance.
+    fn new() -> Self;
+
+    /// Returns true if the TieredAccountMeta implementation supports multiple
+    /// accounts sharing one byte block.
+    fn support_shared_byte_block() -> bool;
+
+    /// A builder function that initializes lamports.
+    fn with_lamports(&mut self, lamports: u64) -> &mut Self;
+
+    /// A builder function that initializes the number of padding bytes
+    /// for the account data associated with the current meta.
+    fn with_account_data_padding(&mut self, paddings: u8) -> &mut Self;
+
+    /// A builder function that initializes the owner's local id.
+    fn with_owner_local_id(&mut self, local_id: u32) -> &mut Self;
+
+    /// A builder function that initializes the raw account data size.
+    fn with_raw_data_size(&mut self, data_size: u64) -> &mut Self;
+
+    /// A builder function that initializes the AccountMetaFlags of the current
+    /// meta.
+    fn with_flags(&mut self, flags: &AccountMetaFlags) -> &mut Self;
+
+    /// Returns the balance of the lamports associated with the account.
+    fn lamports(&self) -> u64;
+
+    /// Returns the number of padding bytes for the associated account data
+    fn account_data_padding(&self) -> u8;
+
+    /// Returns the raw size of its account data if the current accout meta
+    /// shares its byte block with other account meta entries.
+    ///
+    /// Otherwise, None will be returned.
+    fn raw_data_size_for_shared_block(&self) -> Option<usize>;
+
+    /// Returns the local id to the accounts' owner in the current AccountsFile.
+    fn owner_local_id(&self) -> u32;
+
+    /// Returns the AccountMetaFlags of the current meta.
+    fn flags(&self) -> &AccountMetaFlags;
+}
+
 impl AccountMetaFlags {
     pub fn new_from(optional_fields: &AccountMetaOptionalFields) -> Self {
         let mut flags = AccountMetaFlags::default();

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -24,7 +24,7 @@ pub struct AccountMetaFlags {
 
 /// A trait that allows different implementations of the account meta that
 /// support different tiers of the accounts storage.
-pub trait TieredAccountMeta : Sized {
+pub trait TieredAccountMeta: Sized {
     /// Constructs a TieredAcountMeta instance.
     fn new() -> Self;
 


### PR DESCRIPTION
#### Summary of Changes
This PR introduces TieredAccountMeta, a trait that allows different implementations
of the account meta for different tiers of the accounts storage.

This PR includes the mutator and getter methods for the common TieredAccountMeta
fields.  Functions that also work with the account data block will be in separate PRs.