### PR TITLE
Add rust-version field to solana-program to prevent the accidental use of unsupported platform-tools versions

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.68.0" # solana platform-tools rust version
 
 [dependencies]
 bincode = { workspace = true }


### PR DESCRIPTION
People are accidentally using unsupported versions of rust when building solana programs.

A recent notable occurrence of this is #32133, where people are trying to build solana-program 1.16.1 without installing the 1.16-version of the platform-tools. The resulting error is not obvious and hard to debug. With this patch instead they'll get an immediate error from `cargo` indicating they're using an unsupported rustc version

Fixes #32133