### PR TITLE
Add constant for disabled snapshot interval

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -587,7 +587,9 @@ mod tests {
         super::*,
         rand::seq::SliceRandom,
         solana_gossip::contact_info::ContactInfo,
-        solana_runtime::snapshot_package::SnapshotType,
+        solana_runtime::{
+            snapshot_package::SnapshotType, snapshot_utils::SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        },
         solana_sdk::{
             signature::{Keypair, Signer},
             timing::timestamp,
@@ -613,7 +615,7 @@ mod tests {
         let full_snapshot_archive_interval_slots = 100;
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots,
-            incremental_snapshot_archive_interval_slots: Slot::MAX,
+            incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
             ..SnapshotConfig::default()
         };
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -588,7 +588,7 @@ mod tests {
         rand::seq::SliceRandom,
         solana_gossip::contact_info::ContactInfo,
         solana_runtime::{
-            snapshot_package::SnapshotType, snapshot_utils::SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            snapshot_package::SnapshotType, snapshot_utils::DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         },
         solana_sdk::{
             signature::{Keypair, Signer},
@@ -615,7 +615,7 @@ mod tests {
         let full_snapshot_archive_interval_slots = 100;
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots,
-            incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            incremental_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
             ..SnapshotConfig::default()
         };
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -94,7 +94,7 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
             self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
-            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         },
     },
     solana_sdk::{
@@ -2269,7 +2269,7 @@ pub fn is_snapshot_config_valid(
         snapshot_config.incremental_snapshot_archive_interval_slots;
 
     let is_incremental_config_valid =
-        if incremental_snapshot_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
+        if incremental_snapshot_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
             true
         } else {
             incremental_snapshot_interval_slots >= accounts_hash_interval_slots
@@ -2564,21 +2564,21 @@ mod tests {
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
             ),
             Slot::MAX
         ));
@@ -2624,8 +2624,8 @@ mod tests {
         ));
         assert!(is_snapshot_config_valid(
             &SnapshotConfig {
-                full_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
-                incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                full_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                incremental_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
                 ..SnapshotConfig::new_load_only()
             },
             100

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -94,6 +94,7 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
             self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
     },
     solana_sdk::{
@@ -2267,13 +2268,14 @@ pub fn is_snapshot_config_valid(
     let incremental_snapshot_interval_slots =
         snapshot_config.incremental_snapshot_archive_interval_slots;
 
-    let is_incremental_config_valid = if incremental_snapshot_interval_slots == Slot::MAX {
-        true
-    } else {
-        incremental_snapshot_interval_slots >= accounts_hash_interval_slots
-            && incremental_snapshot_interval_slots % accounts_hash_interval_slots == 0
-            && full_snapshot_interval_slots > incremental_snapshot_interval_slots
-    };
+    let is_incremental_config_valid =
+        if incremental_snapshot_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
+            true
+        } else {
+            incremental_snapshot_interval_slots >= accounts_hash_interval_slots
+                && incremental_snapshot_interval_slots % accounts_hash_interval_slots == 0
+                && full_snapshot_interval_slots > incremental_snapshot_interval_slots
+        };
 
     full_snapshot_interval_slots >= accounts_hash_interval_slots
         && full_snapshot_interval_slots % accounts_hash_interval_slots == 0
@@ -2562,19 +2564,22 @@ mod tests {
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                Slot::MAX
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                Slot::MAX
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
-            &new_snapshot_config(Slot::MAX, Slot::MAX),
+            &new_snapshot_config(
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
+            ),
             Slot::MAX
         ));
 
@@ -2619,8 +2624,8 @@ mod tests {
         ));
         assert!(is_snapshot_config_valid(
             &SnapshotConfig {
-                full_snapshot_archive_interval_slots: Slot::MAX,
-                incremental_snapshot_archive_interval_slots: Slot::MAX,
+                full_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
                 ..SnapshotConfig::new_load_only()
             },
             100

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -31,6 +31,7 @@ use {
         snapshot_utils::{
             self,
             SnapshotVersion::{self, V1_2_0},
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
         status_cache::MAX_CACHE_ENTRIES,
     },
@@ -199,7 +200,7 @@ fn run_bank_forks_snapshot_n<F>(
         cluster_type,
         set_root_interval,
         set_root_interval,
-        Slot::MAX,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
     );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
@@ -327,8 +328,13 @@ fn test_concurrent_snapshot_packaging(
     const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8;
 
     // Set up snapshotting config
-    let mut snapshot_test_config =
-        SnapshotTestConfig::new(snapshot_version, cluster_type, 1, 1, Slot::MAX);
+    let mut snapshot_test_config = SnapshotTestConfig::new(
+        snapshot_version,
+        cluster_type,
+        1,
+        1,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+    );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
     let snapshot_config = &snapshot_test_config.snapshot_config;
@@ -582,7 +588,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
             cluster_type,
             (*add_root_interval * num_set_roots * 2) as Slot,
             (*add_root_interval * num_set_roots * 2) as Slot,
-            Slot::MAX,
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         );
         let mut current_bank = snapshot_test_config.bank_forks[0].clone();
         let request_sender = AbsRequestSender::new(snapshot_sender);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -31,7 +31,7 @@ use {
         snapshot_utils::{
             self,
             SnapshotVersion::{self, V1_2_0},
-            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         },
         status_cache::MAX_CACHE_ENTRIES,
     },
@@ -200,7 +200,7 @@ fn run_bank_forks_snapshot_n<F>(
         cluster_type,
         set_root_interval,
         set_root_interval,
-        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
     );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
@@ -333,7 +333,7 @@ fn test_concurrent_snapshot_packaging(
         cluster_type,
         1,
         1,
-        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
     );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
@@ -588,7 +588,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
             cluster_type,
             (*add_root_interval * num_set_roots * 2) as Slot,
             (*add_root_interval * num_set_roots * 2) as Slot,
-            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         );
         let mut current_bank = snapshot_test_config.bank_forks[0].clone();
         let request_sender = AbsRequestSender::new(snapshot_sender);

--- a/local-cluster/tests/common/mod.rs
+++ b/local-cluster/tests/common/mod.rs
@@ -21,7 +21,10 @@ use {
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::{
-        snapshot_config::SnapshotConfig, snapshot_utils::create_accounts_run_and_snapshot_dirs,
+        snapshot_config::SnapshotConfig,
+        snapshot_utils::{
+            create_accounts_run_and_snapshot_dirs, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        },
     },
     solana_sdk::{
         account::AccountSharedData,
@@ -477,9 +480,9 @@ impl SnapshotValidatorConfig {
     ) -> SnapshotValidatorConfig {
         assert!(accounts_hash_interval_slots > 0);
         assert!(full_snapshot_archive_interval_slots > 0);
-        assert!(full_snapshot_archive_interval_slots != Slot::MAX);
+        assert!(full_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL);
         assert!(full_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0);
-        if incremental_snapshot_archive_interval_slots != Slot::MAX {
+        if incremental_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
             assert!(incremental_snapshot_archive_interval_slots > 0);
             assert!(
                 incremental_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0
@@ -536,7 +539,7 @@ pub fn setup_snapshot_validator_config(
 ) -> SnapshotValidatorConfig {
     SnapshotValidatorConfig::new(
         snapshot_interval_slots,
-        Slot::MAX,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         snapshot_interval_slots,
         num_account_paths,
     )

--- a/local-cluster/tests/common/mod.rs
+++ b/local-cluster/tests/common/mod.rs
@@ -23,7 +23,7 @@ use {
     solana_runtime::{
         snapshot_config::SnapshotConfig,
         snapshot_utils::{
-            create_accounts_run_and_snapshot_dirs, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            create_accounts_run_and_snapshot_dirs, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         },
     },
     solana_sdk::{
@@ -480,9 +480,9 @@ impl SnapshotValidatorConfig {
     ) -> SnapshotValidatorConfig {
         assert!(accounts_hash_interval_slots > 0);
         assert!(full_snapshot_archive_interval_slots > 0);
-        assert!(full_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL);
+        assert!(full_snapshot_archive_interval_slots != DISABLED_SNAPSHOT_ARCHIVE_INTERVAL);
         assert!(full_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0);
-        if incremental_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
+        if incremental_snapshot_archive_interval_slots != DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
             assert!(incremental_snapshot_archive_interval_slots > 0);
             assert!(
                 incremental_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0
@@ -539,7 +539,7 @@ pub fn setup_snapshot_validator_config(
 ) -> SnapshotValidatorConfig {
     SnapshotValidatorConfig::new(
         snapshot_interval_slots,
-        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         snapshot_interval_slots,
         num_account_paths,
     )

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -95,6 +95,7 @@ pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(2) };
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(4) };
+pub const SNAPSHOT_ARCHIVE_DISABLED_INTERVAL: Slot = Slot::MAX;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -95,7 +95,7 @@ pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(2) };
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(4) };
-pub const SNAPSHOT_ARCHIVE_DISABLED_INTERVAL: Slot = Slot::MAX;
+pub const DISABLED_SNAPSHOT_ARCHIVE_INTERVAL: Slot = Slot::MAX;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,7 +49,7 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
             self, create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
-            ArchiveFormat, SnapshotVersion, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            ArchiveFormat, SnapshotVersion, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         },
     },
     solana_sdk::{
@@ -1532,18 +1532,18 @@ pub fn main() {
             } else {
                 (
                     incremental_snapshot_interval_slots,
-                    SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                    DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
                 )
             }
         } else {
             (
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
-                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
             )
         };
 
     validator_config.snapshot_config = SnapshotConfig {
-        usage: if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
+        usage: if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
             SnapshotUsage::LoadOnly
         } else {
             SnapshotUsage::LoadAndGenerate
@@ -1579,8 +1579,8 @@ pub fn main() {
             \n\tfull snapshot interval: {} \
             \n\tincremental snapshot interval: {} \
             \n\taccounts hash interval: {}",
-            if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
-            if incremental_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
+            if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
+            if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
             validator_config.accounts_hash_interval_slots);
 
         exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,7 +49,7 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
             self, create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
-            ArchiveFormat, SnapshotVersion,
+            ArchiveFormat, SnapshotVersion, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
     },
     solana_sdk::{
@@ -1530,14 +1530,20 @@ pub fn main() {
                     incremental_snapshot_interval_slots,
                 )
             } else {
-                (incremental_snapshot_interval_slots, Slot::MAX)
+                (
+                    incremental_snapshot_interval_slots,
+                    SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                )
             }
         } else {
-            (Slot::MAX, Slot::MAX)
+            (
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            )
         };
 
     validator_config.snapshot_config = SnapshotConfig {
-        usage: if full_snapshot_archive_interval_slots == Slot::MAX {
+        usage: if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
             SnapshotUsage::LoadOnly
         } else {
             SnapshotUsage::LoadAndGenerate
@@ -1573,8 +1579,8 @@ pub fn main() {
             \n\tfull snapshot interval: {} \
             \n\tincremental snapshot interval: {} \
             \n\taccounts hash interval: {}",
-            if full_snapshot_archive_interval_slots == Slot::MAX { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
-            if incremental_snapshot_archive_interval_slots == Slot::MAX { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
+            if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
+            if incremental_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
             validator_config.accounts_hash_interval_slots);
 
         exit(1);


### PR DESCRIPTION
#### Summary of Changes
Slot::MAX was used to specify that a type of snapshots should not be created; define a constant to be that value and reference the constant to have a single point of edit.

The naming felt a little awkward for this; I think what I came up with is passable but open to suggestions as well