### PR TITLE
Nonzero snap intervals

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -412,29 +412,34 @@ where
     }
 }
 
+pub fn validate_full_snapshot_interval_slots<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    validate_nonzero_arg(value, "full-snapshot-interval-slots")
+}
+
 pub fn validate_maximum_full_snapshot_archives_to_retain<T>(value: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    let value = value.as_ref();
-    if value.eq("0") {
-        Err(String::from(
-            "--maximum-full-snapshot-archives-to-retain cannot be zero",
-        ))
-    } else {
-        Ok(())
-    }
+    validate_nonzero_arg(value, "maximum-full-snapshot-archives-to-retain")
 }
 
 pub fn validate_maximum_incremental_snapshot_archives_to_retain<T>(value: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    validate_nonzero_arg(value, "maximum-incremental-snapshot-archives-to-retain")
+}
+
+fn validate_nonzero_arg<T>(value: T, arg_name: &str) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
     let value = value.as_ref();
     if value.eq("0") {
-        Err(String::from(
-            "--maximum-incremental-snapshot-archives-to-retain cannot be zero",
-        ))
+        Err(format!("--{} cannot be zero", arg_name))
     } else {
         Ok(())
     }

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -587,7 +587,9 @@ mod tests {
         super::*,
         rand::seq::SliceRandom,
         solana_gossip::contact_info::ContactInfo,
-        solana_runtime::snapshot_package::SnapshotType,
+        solana_runtime::{
+            snapshot_package::SnapshotType, snapshot_utils::SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        },
         solana_sdk::{
             signature::{Keypair, Signer},
             timing::timestamp,
@@ -613,7 +615,7 @@ mod tests {
         let full_snapshot_archive_interval_slots = 100;
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots,
-            incremental_snapshot_archive_interval_slots: Slot::MAX,
+            incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
             ..SnapshotConfig::default()
         };
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -595,7 +595,7 @@ mod tests {
             timing::timestamp,
         },
         solana_streamer::socket::SocketAddrSpace,
-        std::str::FromStr,
+        std::{num::NonZeroU64, str::FromStr},
     };
 
     fn new_test_cluster_info() -> ClusterInfo {
@@ -614,7 +614,7 @@ mod tests {
         let mut hashes = vec![];
         let full_snapshot_archive_interval_slots = 100;
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots,
+            full_snapshot_archive_interval_slots: NonZeroU64::new(100).unwrap(),
             incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
             ..SnapshotConfig::default()
         };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -95,6 +95,7 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
             self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
     },
     solana_sdk::{
@@ -2267,13 +2268,14 @@ pub fn is_snapshot_config_valid(
     let incremental_snapshot_interval_slots =
         snapshot_config.incremental_snapshot_archive_interval_slots;
 
-    let is_incremental_config_valid = if incremental_snapshot_interval_slots == Slot::MAX {
-        true
-    } else {
-        incremental_snapshot_interval_slots >= accounts_hash_interval_slots
-            && incremental_snapshot_interval_slots % accounts_hash_interval_slots == 0
-            && full_snapshot_interval_slots > incremental_snapshot_interval_slots
-    };
+    let is_incremental_config_valid =
+        if incremental_snapshot_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
+            true
+        } else {
+            incremental_snapshot_interval_slots >= accounts_hash_interval_slots
+                && incremental_snapshot_interval_slots % accounts_hash_interval_slots == 0
+                && full_snapshot_interval_slots > incremental_snapshot_interval_slots
+        };
 
     full_snapshot_interval_slots >= accounts_hash_interval_slots
         && full_snapshot_interval_slots % accounts_hash_interval_slots == 0
@@ -2562,19 +2564,22 @@ mod tests {
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                Slot::MAX
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
             &new_snapshot_config(
                 snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                Slot::MAX
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
             ),
             default_accounts_hash_interval
         ));
         assert!(is_snapshot_config_valid(
-            &new_snapshot_config(Slot::MAX, Slot::MAX),
+            &new_snapshot_config(
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL
+            ),
             Slot::MAX
         ));
 
@@ -2619,8 +2624,8 @@ mod tests {
         ));
         assert!(is_snapshot_config_valid(
             &SnapshotConfig {
-                full_snapshot_archive_interval_slots: Slot::MAX,
-                incremental_snapshot_archive_interval_slots: Slot::MAX,
+                full_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                incremental_snapshot_archive_interval_slots: SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
                 ..SnapshotConfig::new_load_only()
             },
             100

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -39,6 +39,7 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     std::{
         mem::ManuallyDrop,
+        num::NonZeroU64,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
@@ -81,8 +82,14 @@ impl TestEnvironment {
         incremental_snapshot_archive_interval_slots: Slot,
     ) -> TestEnvironment {
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots,
-            incremental_snapshot_archive_interval_slots,
+            full_snapshot_archive_interval_slots: NonZeroU64::new(
+                full_snapshot_archive_interval_slots,
+            )
+            .unwrap(),
+            incremental_snapshot_archive_interval_slots: NonZeroU64::new(
+                incremental_snapshot_archive_interval_slots,
+            )
+            .unwrap(),
             ..SnapshotConfig::default()
         };
         Self::_new(snapshot_config)
@@ -114,7 +121,9 @@ impl TestEnvironment {
             BankTestConfig::default(),
         ));
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
-        bank_forks.set_accounts_hash_interval_slots(Self::ACCOUNTS_HASH_INTERVAL);
+        bank_forks.set_accounts_hash_interval_slots(
+            NonZeroU64::new(Self::ACCOUNTS_HASH_INTERVAL).unwrap(),
+        );
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         let exit = Arc::new(AtomicBool::new(false));

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -31,6 +31,7 @@ use {
         snapshot_utils::{
             self,
             SnapshotVersion::{self, V1_2_0},
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
         status_cache::MAX_CACHE_ENTRIES,
     },
@@ -199,7 +200,7 @@ fn run_bank_forks_snapshot_n<F>(
         cluster_type,
         set_root_interval,
         set_root_interval,
-        Slot::MAX,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
     );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
@@ -327,8 +328,13 @@ fn test_concurrent_snapshot_packaging(
     const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8;
 
     // Set up snapshotting config
-    let mut snapshot_test_config =
-        SnapshotTestConfig::new(snapshot_version, cluster_type, 1, 1, Slot::MAX);
+    let mut snapshot_test_config = SnapshotTestConfig::new(
+        snapshot_version,
+        cluster_type,
+        1,
+        1,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+    );
 
     let bank_forks = &mut snapshot_test_config.bank_forks;
     let snapshot_config = &snapshot_test_config.snapshot_config;
@@ -582,7 +588,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
             cluster_type,
             (*add_root_interval * num_set_roots * 2) as Slot,
             (*add_root_interval * num_set_roots * 2) as Slot,
-            Slot::MAX,
+            SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         );
         let mut current_bank = snapshot_test_config.bank_forks[0].clone();
         let request_sender = AbsRequestSender::new(snapshot_sender);

--- a/local-cluster/tests/common/mod.rs
+++ b/local-cluster/tests/common/mod.rs
@@ -22,7 +22,10 @@ use {
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::{
-        snapshot_config::SnapshotConfig, snapshot_utils::create_accounts_run_and_snapshot_dirs,
+        snapshot_config::SnapshotConfig,
+        snapshot_utils::{
+            create_accounts_run_and_snapshot_dirs, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+        },
     },
     solana_sdk::{
         account::AccountSharedData,
@@ -477,9 +480,9 @@ impl SnapshotValidatorConfig {
     ) -> SnapshotValidatorConfig {
         assert!(accounts_hash_interval_slots > 0);
         assert!(full_snapshot_archive_interval_slots > 0);
-        assert!(full_snapshot_archive_interval_slots != Slot::MAX);
+        assert!(full_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL);
         assert!(full_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0);
-        if incremental_snapshot_archive_interval_slots != Slot::MAX {
+        if incremental_snapshot_archive_interval_slots != SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
             assert!(incremental_snapshot_archive_interval_slots > 0);
             assert!(
                 incremental_snapshot_archive_interval_slots % accounts_hash_interval_slots == 0
@@ -536,7 +539,7 @@ pub fn setup_snapshot_validator_config(
 ) -> SnapshotValidatorConfig {
     SnapshotValidatorConfig::new(
         snapshot_interval_slots,
-        Slot::MAX,
+        SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         snapshot_interval_slots,
         num_account_paths,
     )

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -778,6 +778,7 @@ mod test {
         solana_sdk::{
             account::AccountSharedData, epoch_schedule::EpochSchedule, hash::Hash, pubkey::Pubkey,
         },
+        std::num::NonZeroU64,
     };
 
     #[test]
@@ -820,12 +821,12 @@ mod test {
         // other requests before this slot, and then 2+ requests of each type afterwards (to
         // further test the prioritization logic).
         const SLOTS_PER_EPOCH: Slot = 400;
-        const FULL_SNAPSHOT_INTERVAL: Slot = 80;
-        const INCREMENTAL_SNAPSHOT_INTERVAL: Slot = 30;
+        let full_snapshot_interval = NonZeroU64::new(80).unwrap();
+        let incremental_snapshot_interval = NonZeroU64::new(30).unwrap();
 
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots: FULL_SNAPSHOT_INTERVAL,
-            incremental_snapshot_archive_interval_slots: INCREMENTAL_SNAPSHOT_INTERVAL,
+            full_snapshot_archive_interval_slots: full_snapshot_interval,
+            incremental_snapshot_archive_interval_slots: incremental_snapshot_interval,
             ..SnapshotConfig::default()
         };
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -13,6 +13,7 @@ use {
     solana_sdk::{clock::Slot, feature_set, hash::Hash, timing},
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
+        num::NonZeroU64,
         ops::Index,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -63,7 +64,7 @@ pub struct BankForks {
 
     pub snapshot_config: Option<SnapshotConfig>,
 
-    pub accounts_hash_interval_slots: Slot,
+    pub accounts_hash_interval_slots: NonZeroU64,
     last_accounts_hash_slot: Slot,
     in_vote_only_mode: Arc<AtomicBool>,
     highest_slot_at_startup: Slot,
@@ -180,7 +181,7 @@ impl BankForks {
             banks,
             descendants,
             snapshot_config: None,
-            accounts_hash_interval_slots: std::u64::MAX,
+            accounts_hash_interval_slots: NonZeroU64::new(std::u64::MAX).unwrap(),
             last_accounts_hash_slot: root,
             in_vote_only_mode: Arc::new(AtomicBool::new(false)),
             highest_slot_at_startup: 0,
@@ -335,7 +336,7 @@ impl BankForks {
         // intervals), it *is* possible, and there are tests to exercise this possibility.
         if let Some(bank) = banks.iter().find(|bank| {
             bank.slot() > self.last_accounts_hash_slot
-                && bank.block_height() % self.accounts_hash_interval_slots == 0
+                && bank.block_height() % self.accounts_hash_interval_slots.get() == 0
         }) {
             let bank_slot = bank.slot();
             self.last_accounts_hash_slot = bank_slot;
@@ -622,7 +623,7 @@ impl BankForks {
         self.snapshot_config = snapshot_config;
     }
 
-    pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: u64) {
+    pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: NonZeroU64) {
         self.accounts_hash_interval_slots = accounts_interval_slots;
     }
 

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,7 +1,9 @@
 use {
     crate::snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
-    solana_sdk::clock::Slot,
-    std::{num::NonZeroUsize, path::PathBuf},
+    std::{
+        num::{NonZeroU64, NonZeroUsize},
+        path::PathBuf,
+    },
 };
 
 /// Snapshot configuration and runtime information
@@ -11,10 +13,10 @@ pub struct SnapshotConfig {
     pub usage: SnapshotUsage,
 
     /// Generate a new full snapshot archive every this many slots
-    pub full_snapshot_archive_interval_slots: Slot,
+    pub full_snapshot_archive_interval_slots: NonZeroU64,
 
     /// Generate a new incremental snapshot archive every this many slots
-    pub incremental_snapshot_archive_interval_slots: Slot,
+    pub incremental_snapshot_archive_interval_slots: NonZeroU64,
 
     /// Path to the directory where full snapshot archives are stored
     pub full_snapshot_archives_dir: PathBuf,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -95,6 +95,7 @@ pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(2) };
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(4) };
+pub const SNAPSHOT_ARCHIVE_DISABLED_INTERVAL: Slot = Slot::MAX;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -61,6 +61,7 @@ use {
         fs::{self, remove_dir_all, File},
         io::Read,
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroU64,
         path::{Path, PathBuf},
         str::FromStr,
         sync::{Arc, RwLock},
@@ -930,7 +931,7 @@ impl TestValidator {
             )),
             rpc_config: config.rpc_config.clone(),
             pubsub_config: config.pubsub_config.clone(),
-            accounts_hash_interval_slots: 100,
+            accounts_hash_interval_slots: NonZeroU64::new(100).unwrap(),
             account_paths: vec![
                 create_accounts_run_and_snapshot_dirs(ledger_path.join("accounts"))
                     .unwrap()
@@ -938,8 +939,9 @@ impl TestValidator {
             ],
             run_verification: false, // Skip PoH verification of ledger on startup for speed
             snapshot_config: SnapshotConfig {
-                full_snapshot_archive_interval_slots: 100,
-                incremental_snapshot_archive_interval_slots: Slot::MAX,
+                full_snapshot_archive_interval_slots: NonZeroU64::new(100).unwrap(),
+                incremental_snapshot_archive_interval_slots: NonZeroU64::new(std::u64::MAX)
+                    .unwrap(),
                 bank_snapshots_dir: ledger_path.join("snapshot"),
                 full_snapshot_archives_dir: ledger_path.to_path_buf(),
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -8,7 +8,7 @@ use {
         input_validators::{
             is_keypair, is_keypair_or_ask_keyword, is_niceness_adjustment_valid, is_parsable,
             is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
-            is_valid_percentage, is_within_range,
+            is_valid_percentage, is_within_range, validate_full_snapshot_interval_slots,
             validate_maximum_full_snapshot_archives_to_retain,
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
@@ -461,6 +461,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.full_snapshot_archive_interval_slots)
+                .validator(validate_full_snapshot_interval_slots)
                 .help("Number of slots between generating full snapshots")
         )
         .arg(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -72,7 +72,7 @@ use {
         env,
         fs::{self, File},
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        num::NonZeroUsize,
+        num::{NonZeroU64, NonZeroUsize},
         path::{Path, PathBuf},
         process::exit,
         str::FromStr,
@@ -1515,10 +1515,12 @@ pub fn main() {
     let incremental_snapshot_interval_slots =
         value_t_or_exit!(matches, "incremental_snapshot_interval_slots", u64);
     let (full_snapshot_archive_interval_slots, incremental_snapshot_archive_interval_slots) =
-        if incremental_snapshot_interval_slots > 0 {
+        if let Some(incremental_snapshot_interval_slots) =
+            NonZeroU64::new(incremental_snapshot_interval_slots)
+        {
             if !matches.is_present("no_incremental_snapshots") {
                 (
-                    value_t_or_exit!(matches, "full_snapshot_interval_slots", u64),
+                    value_t_or_exit!(matches, "full_snapshot_interval_slots", NonZeroU64),
                     incremental_snapshot_interval_slots,
                 )
             } else {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -45,7 +45,7 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
             self, create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
-            ArchiveFormat, SnapshotVersion,
+            ArchiveFormat, SnapshotVersion, SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
         },
     },
     solana_sdk::{
@@ -1522,14 +1522,20 @@ pub fn main() {
                     incremental_snapshot_interval_slots,
                 )
             } else {
-                (incremental_snapshot_interval_slots, Slot::MAX)
+                (
+                    incremental_snapshot_interval_slots,
+                    SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                )
             }
         } else {
-            (Slot::MAX, Slot::MAX)
+            (
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+                SNAPSHOT_ARCHIVE_DISABLED_INTERVAL,
+            )
         };
 
     validator_config.snapshot_config = SnapshotConfig {
-        usage: if full_snapshot_archive_interval_slots == Slot::MAX {
+        usage: if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL {
             SnapshotUsage::LoadOnly
         } else {
             SnapshotUsage::LoadAndGenerate
@@ -1565,8 +1571,8 @@ pub fn main() {
             \n\tfull snapshot interval: {} \
             \n\tincremental snapshot interval: {} \
             \n\taccounts hash interval: {}",
-            if full_snapshot_archive_interval_slots == Slot::MAX { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
-            if incremental_snapshot_archive_interval_slots == Slot::MAX { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
+            if full_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
+            if incremental_snapshot_archive_interval_slots == SNAPSHOT_ARCHIVE_DISABLED_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
             validator_config.accounts_hash_interval_slots);
 
         exit(1);


### PR DESCRIPTION
#### Problem
The snapshot interval fields (full and incremental) cannot be zero. This is enforced with some checks at the level of parsing in `validator/src/main.rs`, and also assumed given that these values are used as a divisor in other areas of the codebase. So, enforce the values being nonzero with the compiler by changing to NonZeroU64.

I was initially touching local-cluster tests, saw some duplicated logic that I wanted to clean up and ended up with this PR 😅 .

#### Summary of Changes
Switch `full_snapshot_archive_interval_slots`, `incremental_snapshot_archive_interval_slots`, and `accounts_hash_interval_slots` to all be `NonZeroU64`'s.

This PR is currently on top of https://github.com/solana-labs/solana/pull/32236.

Also, I think someone could technically get a divde-by-zero by passing;
```
--incremental-snapshot-interval-slots X
--full-snapshot-interval-slots 0
```
With these values, `accounts_hash_interval_slots` would be set to 0:
https://github.com/solana-labs/solana/blob/1452ed7044f148865e6674245b79e54f852d39ff/validator/src/main.rs#L1551-L1554
This line would then attempt to do a `0 % 0`:
https://github.com/solana-labs/solana/blob/1452ed7044f148865e6674245b79e54f852d39ff/core/src/validator.rs#L2279

Granted that is early on and that function could be reworked, but I think it is indicative of the type of error that using the NonZero type eliminates.