### PR TITLE
Make `ci/_` to print to stderr instead of stdout

### DIFF
--- a/ci/_
+++ b/ci/_
@@ -9,9 +9,9 @@ base_dir=$(realpath --strip "$(dirname "$0")/..")
 
 _() {
   if [[ $(pwd) = $base_dir ]]; then
-    echo "--- $*"
+    echo "--- $*" > /dev/stderr
   else
-    echo "--- $* (wd: $(pwd))"
+    echo "--- $* (wd: $(pwd))" > /dev/stderr
   fi
   "$@"
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8439,7 +8439,7 @@ impl Bank {
         bank_creation_time: &Instant,
         max_tx_ingestion_nanos: u128,
     ) -> bool {
-        // Do this check outside of the poh lock, hence not a method on PohRecorder
+        // Do this check outside of the PoH lock, hence not a method on PohRecorder
         bank_creation_time.elapsed().as_nanos() <= max_tx_ingestion_nanos
     }
 


### PR DESCRIPTION
#### Problem

echo-ing to stdout by `_` isn't desirable sometimes

#### Summary of Changes

Print to stderr. it seems this works.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
