### PR TITLE
Fix wasm-pack

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -2,6 +2,7 @@
 # ci/rust-version.sh to pick up the new image tag
 FROM rust:1.69.0
 
+# we need to pin wasm-pack due to https://github.com/rustwasm/wasm-pack/issues/1308
 RUN set -x \
  && apt update \
  && apt-get install apt-transport-https \
@@ -37,7 +38,7 @@ RUN set -x \
  && cargo install mdbook \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \
- && cargo install wasm-pack \
+ && cargo install --version 0.11.1 wasm-pack \
  && cargo install sccache \
  && rustc --version \
  && cargo --version


### PR DESCRIPTION
#### Problem

docker image update at #32234 updated various other commands and `wasm-pack` introduced some compatibility issue:

```
+ wasm-pack --version
error: unexpected argument '--version' found
 
  tip: a similar argument exists: '--verbose'
 
Usage: wasm-pack <--verbose...|--quiet|--log-level <LOG_LEVEL>> <COMMAND>
```

already reported to upstream: https://github.com/rustwasm/wasm-pack/issues/1308

#### Summary of Changes

Pin it for now.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
