### PR TITLE
[TieredStorage] AccountMetaOptionalFields::size_from_flags()

### DIFF
--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -56,6 +56,23 @@ impl AccountMetaOptionalFields {
                 .write_version
                 .map_or(0, |_| std::mem::size_of::<StoredMetaWriteVersion>())
     }
+
+    /// Given the specified AccountMetaFlags, returns the size of its
+    /// associated AccountMetaOptionalFields.
+    pub fn size_from_flags(flags: &AccountMetaFlags) -> usize {
+        let mut fields_size = 0;
+        if flags.has_rent_epoch() {
+            fields_size += std::mem::size_of::<Epoch>();
+        }
+        if flags.has_account_hash() {
+            fields_size += std::mem::size_of::<Hash>();
+        }
+        if flags.has_write_version() {
+            fields_size += std::mem::size_of::<StoredMetaWriteVersion>();
+        }
+
+        fields_size
+    }
 }
 
 #[cfg(test)]
@@ -158,6 +175,12 @@ pub mod tests {
                             + account_hash.map_or(0, |_| std::mem::size_of::<Hash>())
                             + write_version
                                 .map_or(0, |_| std::mem::size_of::<StoredMetaWriteVersion>())
+                    );
+                    assert_eq!(
+                        opt_fields.size(),
+                        AccountMetaOptionalFields::size_from_flags(&AccountMetaFlags::new_from(
+                            &opt_fields
+                        ))
                     );
                 }
             }


### PR DESCRIPTION
#### Summary of Changes
This PR adds AccountMetaOptionalFields::size_from_flags that takes
`&AccountMegaFlags` and returns the size of the AccountMetaOptionalFields
based on the input AccountMegaFlags.

This function is needed because the reader of the TieredAccountMeta
directly extract all the Some fields of AccountMetaOptionalFields
from its account block without constructing the AccountMetaOptionalFields
instance.

#### Test plan
Improve existing unit tests that further verify the correctness of the function.