### PR TITLE
Fixed link to Plum Tree doc.

### DIFF
--- a/docs/src/validator/gossip.md
+++ b/docs/src/validator/gossip.md
@@ -84,7 +84,7 @@ Just like _pull message_, nodes are selected into the active set based on weight
 ## Notable differences from PlumTree
 
 The active push protocol described here is based on
-[Plum Tree](https://haslab.uminho.pt/sites/default/files/jop/files/lpr07a.pdf).
+[Plum Tree](https://www.dpss.inesc-id.pt/~ler/reports/srds07.pdf).
 The main differences are:
 
 - Push messages have a wallclock that is signed by the originator. Once the wallclock expires the message is dropped. A hop limit is difficult to implement in an adversarial setting.


### PR DESCRIPTION
#### Problem

The link to the document describing the Plum Tree algorithm was no longer valid.

#### Summary of Changes

Searched for "Plum Tree Protocol" in google, found first document that looked like it was likely the one (don't have the old document for comparison, so I hope this is the right one), and updated the link to point to it.

Probably would be better to store a copy of the PDF in the solana repo rather than relying on links that can break; but as this doesn't seem to be the policy, I did not do this.
