### PR TITLE
unnecessary error conversions in core

### DIFF
--- a/core/src/tower1_7_14.rs
+++ b/core/src/tower1_7_14.rs
@@ -1,5 +1,5 @@
 use {
-    crate::consensus::{SwitchForkDecision, TowerError},
+    crate::consensus::{Result, SwitchForkDecision, TowerError},
     solana_sdk::{
         clock::Slot,
         hash::Hash,
@@ -46,7 +46,7 @@ pub struct SavedTower1_7_14 {
 }
 
 impl SavedTower1_7_14 {
-    pub fn new<T: Signer>(tower: &Tower1_7_14, keypair: &T) -> Result<Self, TowerError> {
+    pub fn new<T: Signer>(tower: &Tower1_7_14, keypair: &T) -> Result<Self> {
         let node_pubkey = keypair.pubkey();
         if tower.node_pubkey != node_pubkey {
             return Err(TowerError::WrongTower(format!(


### PR DESCRIPTION
#### Problem
- Unnecessary error conversions in core take dependencies on `core::result::Result`.
- Instances of crossbeam channel error handling not distinguishing between `RecvTimeoutError::Timeout` and `RecvTimeoutError::Disconnected`.

#### Summary of Changes
- Remove unnecessary error conversions.
- update crossbeam channel error handling.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
