### PR TITLE
Move message_processor to program-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6348,6 +6348,7 @@ dependencies = [
  "enum-iterator",
  "itertools",
  "libc",
+ "libsecp256k1",
  "log",
  "num-derive",
  "num-traits",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -31,6 +31,7 @@ solana_rbpf = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+libsecp256k1 = { workspace = true }
 solana-logger = { workspace = true }
 
 [lib]

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod compute_budget;
 pub mod invoke_context;
 pub mod loaded_programs;
 pub mod log_collector;
+pub mod message_processor;
 pub mod pre_account;
 pub mod prioritization_fee;
 pub mod stable_log;

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -187,10 +187,12 @@ impl MessageProcessor {
 
 #[cfg(test)]
 mod tests {
-    use crate::message_processor::MessageProcessor;
     use {
         super::*,
-        crate::{declare_process_instruction, loaded_programs::LoadedProgram},
+        crate::{
+            declare_process_instruction, loaded_programs::LoadedProgram,
+            message_processor::MessageProcessor,
+        },
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             instruction::{AccountMeta, Instruction, InstructionError},

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -1,7 +1,5 @@
 use {
-    serde::{Deserialize, Serialize},
-    solana_measure::measure::Measure,
-    solana_program_runtime::{
+    crate::{
         compute_budget::ComputeBudget,
         invoke_context::InvokeContext,
         loaded_programs::LoadedProgramsForTxBatch,
@@ -9,6 +7,8 @@ use {
         sysvar_cache::SysvarCache,
         timings::{ExecuteDetailsTimings, ExecuteTimings},
     },
+    serde::{Deserialize, Serialize},
+    solana_measure::measure::Measure,
     solana_sdk::{
         account::WritableAccount,
         feature_set::FeatureSet,
@@ -187,9 +187,10 @@ impl MessageProcessor {
 
 #[cfg(test)]
 mod tests {
+    use crate::message_processor::MessageProcessor;
     use {
         super::*,
-        solana_program_runtime::{declare_process_instruction, loaded_programs::LoadedProgram},
+        crate::{declare_process_instruction, loaded_programs::LoadedProgram},
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             instruction::{AccountMeta, Instruction, InstructionError},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -62,7 +62,6 @@ use {
         epoch_accounts_hash::{self, EpochAccountsHash},
         epoch_rewards_hasher::hash_rewards_into_partitions,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
-        message_processor::MessageProcessor,
         partitioned_rewards::PartitionedEpochRewardsConfig,
         rent_collector::{CollectedInfo, RentCollector},
         rent_debits::RentDebits,
@@ -263,6 +262,7 @@ pub struct BankRc {
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 use solana_frozen_abi::abi_example::AbiExample;
+use solana_program_runtime::message_processor::MessageProcessor;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl AbiExample for BankRc {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -103,6 +103,7 @@ use {
             LoadedProgramsForTxBatch, WorkingSlot,
         },
         log_collector::LogCollector,
+        message_processor::MessageProcessor,
         sysvar_cache::SysvarCache,
         timings::{ExecuteDetailsTimings, ExecuteTimingType, ExecuteTimings},
     },
@@ -262,7 +263,6 @@ pub struct BankRc {
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 use solana_frozen_abi::abi_example::AbiExample;
-use solana_program_runtime::message_processor::MessageProcessor;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl AbiExample for BankRc {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -48,7 +48,6 @@ pub mod inline_spl_associated_token_account;
 pub mod inline_spl_token;
 pub mod inline_spl_token_2022;
 pub mod loader_utils;
-pub mod message_processor;
 pub mod non_circulating_supply;
 pub mod partitioned_rewards;
 pub mod prioritization_fee;


### PR DESCRIPTION
#### Problem
`MessageProcessor` could be moved down to `program-runtime` as it has no dependencies on runtime. 

#### Summary of Changes
Moved the code and updated imports and Cargo.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
