### PR TITLE
[zk-token-proof] Fix doc typo

### DIFF
--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -68,7 +68,7 @@ pub enum ProofInstruction {
 
     /// Verify a withdraw zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
+    /// This proof is a collection of smaller proofs that are required by the SPL Token 2022
     /// confidential extension `Withdraw` instruction.
     ///
     /// Accounts expected by this instruction:
@@ -106,7 +106,7 @@ pub enum ProofInstruction {
 
     /// Verify a transfer zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
+    /// This proof is a collection of smaller proofs that are required by the SPL Token 2022
     /// confidential extension `Transfer` instruction with transfer fees.
     ///
     /// Accounts expected by this instruction:
@@ -125,7 +125,7 @@ pub enum ProofInstruction {
 
     /// Verify a transfer with fee zero-knowledge proof.
     ///
-    /// This proof is a collection of smallers proofs that are required by the SPL Token 2022
+    /// This proof is a collection of smaller proofs that are required by the SPL Token 2022
     /// confidential extension `Transfer` instruction without transfer fees.
     ///
     /// Accounts expected by this instruction:


### PR DESCRIPTION
#### Problem
Oops, we missed a typo in the ZK Token proof program instruction docs.

#### Summary of Changes
Fix
