### PR TITLE
impl Eq for dyn Signer

### DIFF
--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -99,6 +99,8 @@ impl PartialEq for dyn Signer {
     }
 }
 
+impl Eq for dyn Signer {}
+
 impl std::fmt::Debug for dyn Signer {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(fmt, "Signer: {:?}", self.pubkey())


### PR DESCRIPTION
#### Problem
signers are equal when pubkeys are equal, and pubkey equality is total, but signer is only partial. total equality is required for iterator sort, which would be useful for deduplicating vectors of signers

#### Summary of Changes
this uses the default impl of Eq for dyn Signer