### PR TITLE
Removes file permission twiddling in snapshot test

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3432,7 +3432,6 @@ mod tests {
         std::{
             convert::TryFrom,
             mem::size_of,
-            os::unix::fs::PermissionsExt,
             sync::{atomic::Ordering, Arc},
         },
         tempfile::NamedTempFile,
@@ -5299,40 +5298,22 @@ mod tests {
             })
             .unzip();
 
-        // Set the parent directory of the first account path to be readonly, so that
-        // create_dir_all in create_all_accounts_run_and_snapshot_dirs fails.
-        let account_path_first = &account_paths[0];
-        let parent = account_path_first.parent().unwrap();
-        let mut parent_permissions = fs::metadata(parent).unwrap().permissions();
-        parent_permissions.set_readonly(true);
-        fs::set_permissions(parent, parent_permissions.clone()).unwrap();
-
-        // assert that create_all_accounts_run_and_snapshot_dirs returns error when the first account path
-        // is readonly.
-        assert!(create_all_accounts_run_and_snapshot_dirs(&account_paths).is_err());
-
-        // Set the parent directory of the first account path to be writable, so that
-        // create_all_accounts_run_and_snapshot_dirs returns Ok.
-        parent_permissions.set_mode(0o744);
-        fs::set_permissions(parent, parent_permissions.clone()).unwrap();
-        let result = create_all_accounts_run_and_snapshot_dirs(&account_paths);
-        assert!(result.is_ok());
-
-        let (account_run_paths, account_snapshot_paths) = result.unwrap();
+        // create the `run/` and `snapshot/` dirs, and ensure they're there
+        let (account_run_paths, account_snapshot_paths) =
+            create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap();
         account_run_paths.iter().all(|path| path.is_dir());
         account_snapshot_paths.iter().all(|path| path.is_dir());
 
+        // delete a `run/` and `snapshot/` dir, then re-create it
+        let account_path_first = account_paths.first().unwrap();
         delete_contents_of_path(account_path_first);
         assert!(account_path_first.exists());
-        let mut permissions = fs::metadata(account_path_first).unwrap().permissions();
-        permissions.set_readonly(true);
-        fs::set_permissions(account_path_first, permissions.clone()).unwrap();
-        parent_permissions.set_readonly(true);
-        fs::set_permissions(parent, parent_permissions.clone()).unwrap();
-        // assert that create_all_accounts_run_and_snapshot_dirs returns error when the first account path
-        // and its parent are readonly.  This exercises the case where the first account path is readonly,
-        // causing create_accounts_run_and_snapshot_dirs to fail.
-        assert!(create_all_accounts_run_and_snapshot_dirs(&account_paths).is_err());
+        assert!(!account_path_first.join("run").exists());
+        assert!(!account_path_first.join("snapshot").exists());
+
+        _ = create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap();
+        account_run_paths.iter().all(|path| path.is_dir());
+        account_snapshot_paths.iter().all(|path| path.is_dir());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

@yihau is working on moving CI test execution into docker. Since docker runs everything as root by default, the file permission twiddling in the snapshot_utils test, `test_create_all_accounts_run_and_snapshot_dirs`, is circumvented, causing the test to fail (when running as root).

Testing the filesystem should *not* be the goal of a unit test. Also, if the file permissions get messed up, that's not a recoverable error. So it seems reasonable to remove the file permission twiddling here.


#### Summary of Changes

Rework `test_create_all_accounts_run_and_snapshot_dirs` to remove file permission twiddling.

Note: This test runs as part of `partitions 1/3`