### PR TITLE
Adds "archive" to log when loading snapshot archives

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1523,7 +1523,7 @@ pub fn bank_from_snapshot_archives(
     exit: Arc<AtomicBool>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     info!(
-        "Loading bank from full snapshot: {}, and incremental snapshot: {:?}",
+        "Loading bank from full snapshot archive: {}, and incremental snapshot archive: {:?}",
         full_snapshot_archive_info.path().display(),
         incremental_snapshot_archive_info
             .as_ref()


### PR DESCRIPTION
#### Problem

Originally brought up here, https://github.com/solana-labs/solana/pull/32255#discussion_r1242354490, the log when loading from snapshot archives is missing the word "archive".


#### Summary of Changes

Add "archive" to the log.