### PR TITLE
Don't look up snapshot archives twice in load_bank_forks()

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -105,8 +105,7 @@ pub fn load_bank_forks(
         FullSnapshotArchiveInfo,
         Option<IncrementalSnapshotArchiveInfo>,
     )> {
-        let Some(snapshot_config) = snapshot_config
-        else {
+        let Some(snapshot_config) = snapshot_config else {
             info!("Snapshots disabled; will load from genesis");
             return None;
         };


### PR DESCRIPTION
#### Problem

In `load_bank_forks()`, we check if there are snapshot archives to load from. Then if yes, we *re-check* for snapshot archives again. 

1. We don't need to do this redundant work
2. In order to support `UseSnapshotArchivesAtStartup::WhenNewer`, the function will need to know about the snapshot archives *before*, in order to decide if they should be loaded from or not. 

We can pass the discovered snapshot archives from `load_bank_forks()` down into `bank_forks_from_snapshot()`.


#### Summary of Changes

Discover both full and incremental snapshot archives in `load_bank_forks()`, and then pass those into `bank_forks_from_snapshot()`.