### PR TITLE
Make Blockstore::scan_and_fix_roots() take optional start/stop slots

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -386,7 +386,7 @@ impl Default for ValidatorStartProgress {
 }
 
 struct BlockstoreRootScan {
-    thread: Option<JoinHandle<Result<(), BlockstoreError>>>,
+    thread: Option<JoinHandle<Result<usize, BlockstoreError>>>,
 }
 
 impl BlockstoreRootScan {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -399,7 +399,7 @@ impl BlockstoreRootScan {
             Some(
                 Builder::new()
                     .name("solBStoreRtScan".to_string())
-                    .spawn(move || blockstore.scan_and_fix_roots(&exit))
+                    .spawn(move || blockstore.scan_and_fix_roots(None, None, &exit))
                     .unwrap(),
             )
         } else {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3964,7 +3964,6 @@ fn main() {
                     start_root.saturating_sub(max_slots)
                 };
                 assert!(start_root > end_root);
-                assert!(blockstore.is_root(start_root));
                 let num_slots = start_root - end_root - 1; // Adjust by one since start_root need not be checked
                 if arg_matches.is_present("end_root") && num_slots > max_slots {
                     eprintln!(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3974,12 +3974,13 @@ fn main() {
                     exit(1);
                 }
 
-                blockstore
+                let num_repaired_roots = blockstore
                     .scan_and_fix_roots(Some(start_root), Some(end_root), &AtomicBool::new(false))
                     .unwrap_or_else(|err| {
                         eprintln!("Unable to repair roots: {err}");
                         exit(1);
-                    })
+                    });
+                println!("Successfully repaired {num_repaired_roots} roots");
             }
             ("bounds", Some(arg_matches)) => {
                 let blockstore = open_blockstore(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3323,10 +3323,22 @@ impl Blockstore {
         self.db.is_primary_access()
     }
 
-    /// Search for any ancestors of the latest root that are not marked as
-    /// roots themselves. Then, mark these found slots as roots since the
-    /// ancestor of a root is also inherently a root.
-    pub fn scan_and_fix_roots(&self, exit: &AtomicBool) -> Result<()> {
+    /// Scan for any ancestors of the supplied `start_root` that are not
+    /// marked as roots themselves. Mark any found slots as roots since
+    /// the ancestor of a root is also inherently a root.
+    ///
+    /// Arguments:
+    ///  - `start_root`: The root to start scan from, or the highest root in
+    ///    the blockstore if this value is `None`. This slot must be a root.
+    ///  - `end_slot``: The slot to stop the scan at; the scan will continue to
+    ///    the earliest slot in the Blockstore if this value is `None`.
+    ///  - `exit`: Exit early if this flag is set to `true`.
+    pub fn scan_and_fix_roots(
+        &self,
+        start_root: Option<Slot>,
+        end_slot: Option<Slot>,
+        exit: &AtomicBool,
+    ) -> Result<()> {
         // Hold the lowest_cleanup_slot read lock to prevent any cleaning of
         // the blockstore from another thread. Doing so will prevent a
         // possible inconsistency across column families where a slot is:
@@ -3335,7 +3347,17 @@ impl Blockstore {
         //  - Marked as root via Self::set_root() by this this thread
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
 
-        let ancestor_iterator = AncestorIterator::new(self.last_root(), self);
+        let start_root = if let Some(slot) = start_root {
+            if !self.is_root(slot) {
+                return Err(BlockstoreError::SlotNotRooted);
+            }
+            slot
+        } else {
+            self.last_root()
+        };
+        let end_slot = end_slot.unwrap_or(*lowest_cleanup_slot);
+        let ancestor_iterator =
+            AncestorIterator::new(start_root, self).take_while(|&slot| slot >= end_slot);
 
         let mut find_missing_roots = Measure::start("find_missing_roots");
         let mut roots_to_fix = vec![];
@@ -3357,11 +3379,7 @@ impl Blockstore {
                 self.set_roots(chunk.iter())?;
             }
         } else {
-            debug!(
-                "No missing roots found in range {} to {}",
-                *lowest_cleanup_slot,
-                self.last_root()
-            );
+            debug!("No missing roots found in range {start_root} to {end_slot}");
         }
         fix_roots.stop();
         datapoint_info!(
@@ -5617,18 +5635,25 @@ pub mod tests {
 
     #[test]
     fn test_scan_and_fix_roots() {
+        fn blockstore_roots(blockstore: &Blockstore) -> Vec<Slot> {
+            blockstore
+                .rooted_slot_iterator(0)
+                .unwrap()
+                .collect::<Vec<_>>()
+        }
+
         solana_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let entries_per_slot = max_ticks_per_n_shreds(5, None);
         let start_slot: Slot = 0;
-        let num_slots = 10;
+        let num_slots = 18;
 
         // Produce the following chains and insert shreds into Blockstore
-        // 0 --> 2 --> 4 --> 6 --> 8 --> 10
+        // 0 -> 2 -> 4 -> 6 -> 8 -> 10 -> 12 -> 14 -> 16 -> 18
         //  \
-        //   --> 1 --> 3 --> 5 --> 7 --> 9
+        //   -> 1 -> 3 -> 5 -> 7 ->  9 -> 11 -> 13 -> 15 -> 17
         let shreds: Vec<_> = (start_slot..=num_slots)
             .flat_map(|slot| {
                 let parent_slot = if slot % 2 == 0 {
@@ -5647,41 +5672,61 @@ pub mod tests {
             .collect();
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        // Mark several roots
-        let roots = vec![6, 10];
-        blockstore.set_roots(roots.iter()).unwrap();
-        assert_eq!(
-            &roots,
-            &blockstore
-                .rooted_slot_iterator(0)
-                .unwrap()
-                .collect::<Vec<_>>(),
+        // Start slot must be a root
+        let (start, end) = (Some(16), None);
+        assert_matches!(
+            blockstore.scan_and_fix_roots(start, end, &AtomicBool::new(false)),
+            Err(BlockstoreError::SlotNotRooted)
         );
 
-        // Fix roots and ensure all even slots are now root
-        let roots = vec![0, 2, 4, 6, 8, 10];
+        // Mark several roots
+        let new_roots = vec![6, 12];
+        blockstore.set_roots(new_roots.iter()).unwrap();
+        assert_eq!(&new_roots, &blockstore_roots(&blockstore));
+
+        // Specify both a start root and end slot
+        let (start, end) = (Some(12), Some(8));
+        let roots = vec![6, 8, 10, 12];
         blockstore
-            .scan_and_fix_roots(&AtomicBool::new(false))
+            .scan_and_fix_roots(start, end, &AtomicBool::new(false))
             .unwrap();
-        assert_eq!(
-            &roots,
-            &blockstore
-                .rooted_slot_iterator(0)
-                .unwrap()
-                .collect::<Vec<_>>(),
-        );
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
+
+        // Specify only an end slot
+        let (start, end) = (None, Some(4));
+        let roots = vec![4, 6, 8, 10, 12];
+        blockstore
+            .scan_and_fix_roots(start, end, &AtomicBool::new(false))
+            .unwrap();
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
+
+        // Specify only a start slot
+        let (start, end) = (Some(12), None);
+        let roots = vec![0, 2, 4, 6, 8, 10, 12];
+        blockstore
+            .scan_and_fix_roots(start, end, &AtomicBool::new(false))
+            .unwrap();
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
+
+        // Mark additional root
+        let new_roots = vec![16];
+        let roots = vec![0, 2, 4, 6, 8, 10, 12, 16];
+        blockstore.set_roots(new_roots.iter()).unwrap();
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
+
+        // Leave both start and end unspecified
+        let (start, end) = (None, None);
+        let roots = vec![0, 2, 4, 6, 8, 10, 12, 14, 16];
+        blockstore
+            .scan_and_fix_roots(start, end, &AtomicBool::new(false))
+            .unwrap();
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
 
         // Subsequent calls should have no effect and return without error
         blockstore
-            .scan_and_fix_roots(&AtomicBool::new(false))
+            .scan_and_fix_roots(start, end, &AtomicBool::new(false))
             .unwrap();
-        assert_eq!(
-            &roots,
-            &blockstore
-                .rooted_slot_iterator(0)
-                .unwrap()
-                .collect::<Vec<_>>(),
-        );
+        assert_eq!(&roots, &blockstore_roots(&blockstore));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Several problems broken up by commits:
1. `LedgerCleanupService` cleaning while `Blockstore::scan_and_fix_roots()` is running could cause inconsistency between Blockstore columns. Namely, the root column could be out of sync with everything else is a slot is identified to have the root repaired, but `LedgerCleanupService` purges that slot before `Blockstore::set_roots()` gets called.
2. `solana-ledger-tool repair-roots` implements near identical logic as `Blockstore::scan_and_fix_roots()`

#### Summary of Changes
To address the numbered items above:
1. Hold lowest cleanup slot lock (reader) while function runs; will prevent cleanup but still allow other stuff (such as RPC reads)
2. Adjust `scan_and_fix_roots()` to work for both callers (`solana-validator` and `solana-ledger-tool`)

The broader goal here is to consolidate / de-duplicate root repair logic. Two more places where we run similar routine:
https://github.com/solana-labs/solana/blob/6f72258e3e5f271d52d9974892afa399d52a2290/ledger/src/blockstore_processor.rs#L1537-L1554
https://github.com/solana-labs/solana/blob/6f72258e3e5f271d52d9974892afa399d52a2290/core/src/consensus.rs#L1477-L1530

I don't think we can single source everything, but at the very least, leaving a paper-trail between these similar pieces should be beneficial for future readers.
