### PR TITLE
[TieredAccountStorage] getter functions for HotAccountMeta

### DIFF
--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         account_storage::meta::StoredMetaWriteVersion,
         tiered_storage::{
-            byte_block::ByteBlockReader,
+            byte_block,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
         },
     },
@@ -139,7 +139,7 @@ impl TieredAccountMeta for HotAccountMeta {
         let offset = self.optional_fields_offset(data_block);
         self.flags()
             .has_rent_epoch()
-            .then(|| ByteBlockReader::read_type::<Epoch>(data_block, offset).copied())
+            .then(|| byte_block::read_type::<Epoch>(data_block, offset).copied())
             .flatten()
     }
 
@@ -152,7 +152,7 @@ impl TieredAccountMeta for HotAccountMeta {
         }
         self.flags()
             .has_account_hash()
-            .then(|| ByteBlockReader::read_type::<Hash>(data_block, offset))
+            .then(|| byte_block::read_type::<Hash>(data_block, offset))
             .flatten()
     }
 
@@ -169,7 +169,7 @@ impl TieredAccountMeta for HotAccountMeta {
         self.flags
             .has_write_version()
             .then(|| {
-                ByteBlockReader::read_type::<StoredMetaWriteVersion>(data_block, offset).copied()
+                byte_block::read_type::<StoredMetaWriteVersion>(data_block, offset).copied()
             })
             .flatten()
     }
@@ -203,7 +203,7 @@ pub mod tests {
         crate::{
             account_storage::meta::StoredMetaWriteVersion,
             tiered_storage::{
-                byte_block::{ByteBlockReader, ByteBlockWriter},
+                byte_block::ByteBlockWriter,
                 footer::AccountBlockFormat,
                 meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
             },
@@ -319,7 +319,7 @@ pub mod tests {
         writer.write_optional_fields(&optional_fields).unwrap();
         let buffer = writer.finish().unwrap();
 
-        let meta = ByteBlockReader::read_type::<HotAccountMeta>(&buffer, 0).unwrap();
+        let meta = byte_block::read_type::<HotAccountMeta>(&buffer, 0).unwrap();
         assert_eq!(expected_meta, *meta);
         assert!(meta.flags().has_rent_epoch());
         assert!(meta.flags().has_account_hash());

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -136,7 +136,8 @@ impl TieredAccountMeta for HotAccountMeta {
     /// the specified account block.  None will be returned if this account
     /// does not persist this optional field.
     fn rent_epoch(&self, data_block: &[u8]) -> Option<Epoch> {
-        let offset = self.optional_fields_offset(data_block);
+        let offset = self.optional_fields_offset(data_block)
+            + AccountMetaOptionalFields::rent_epoch_offset(self.flags());
         self.flags()
             .has_rent_epoch()
             .then(|| byte_block::read_type::<Epoch>(data_block, offset).copied())
@@ -146,10 +147,8 @@ impl TieredAccountMeta for HotAccountMeta {
     /// Returns the account hash by parsing the specified account block.  None
     /// will be returned if this account does not persist this optional field.
     fn account_hash<'a>(&self, data_block: &'a [u8]) -> Option<&'a Hash> {
-        let mut offset = self.optional_fields_offset(data_block);
-        if self.flags.has_rent_epoch() {
-            offset += std::mem::size_of::<Epoch>();
-        }
+        let offset = self.optional_fields_offset(data_block)
+            + AccountMetaOptionalFields::account_hash_offset(self.flags());
         self.flags()
             .has_account_hash()
             .then(|| byte_block::read_type::<Hash>(data_block, offset))
@@ -159,13 +158,8 @@ impl TieredAccountMeta for HotAccountMeta {
     /// Returns the write version by parsing the specified account block.  None
     /// will be returned if this account does not persist this optional field.
     fn write_version(&self, data_block: &[u8]) -> Option<StoredMetaWriteVersion> {
-        let mut offset = self.optional_fields_offset(data_block);
-        if self.flags.has_rent_epoch() {
-            offset += std::mem::size_of::<Epoch>();
-        }
-        if self.flags.has_account_hash() {
-            offset += std::mem::size_of::<Hash>();
-        }
+        let offset = self.optional_fields_offset(data_block)
+            + AccountMetaOptionalFields::write_version_offset(self.flags());
         self.flags
             .has_write_version()
             .then(|| byte_block::read_type::<StoredMetaWriteVersion>(data_block, offset).copied())

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -135,56 +135,62 @@ impl TieredAccountMeta for HotAccountMeta {
     /// Returns the epoch that this account will next owe rent by parsing
     /// the specified account block.  None will be returned if this account
     /// does not persist this optional field.
-    fn rent_epoch(&self, data_block: &[u8]) -> Option<Epoch> {
-        let offset = self.optional_fields_offset(data_block)
-            + AccountMetaOptionalFields::rent_epoch_offset(self.flags());
+    fn rent_epoch(&self, account_block: &[u8]) -> Option<Epoch> {
         self.flags()
             .has_rent_epoch()
-            .then(|| byte_block::read_type::<Epoch>(data_block, offset).copied())
+            .then(|| {
+                let offset = self.optional_fields_offset(account_block)
+                    + AccountMetaOptionalFields::rent_epoch_offset(self.flags());
+                byte_block::read_type::<Epoch>(account_block, offset).copied()
+            })
             .flatten()
     }
 
     /// Returns the account hash by parsing the specified account block.  None
     /// will be returned if this account does not persist this optional field.
-    fn account_hash<'a>(&self, data_block: &'a [u8]) -> Option<&'a Hash> {
-        let offset = self.optional_fields_offset(data_block)
-            + AccountMetaOptionalFields::account_hash_offset(self.flags());
+    fn account_hash<'a>(&self, account_block: &'a [u8]) -> Option<&'a Hash> {
         self.flags()
             .has_account_hash()
-            .then(|| byte_block::read_type::<Hash>(data_block, offset))
+            .then(|| {
+                let offset = self.optional_fields_offset(account_block)
+                    + AccountMetaOptionalFields::account_hash_offset(self.flags());
+                byte_block::read_type::<Hash>(account_block, offset)
+            })
             .flatten()
     }
 
     /// Returns the write version by parsing the specified account block.  None
     /// will be returned if this account does not persist this optional field.
-    fn write_version(&self, data_block: &[u8]) -> Option<StoredMetaWriteVersion> {
-        let offset = self.optional_fields_offset(data_block)
-            + AccountMetaOptionalFields::write_version_offset(self.flags());
+    fn write_version(&self, account_block: &[u8]) -> Option<StoredMetaWriteVersion> {
         self.flags
             .has_write_version()
-            .then(|| byte_block::read_type::<StoredMetaWriteVersion>(data_block, offset).copied())
+            .then(|| {
+                let offset = self.optional_fields_offset(account_block)
+                    + AccountMetaOptionalFields::write_version_offset(self.flags());
+                byte_block::read_type::<StoredMetaWriteVersion>(account_block, offset).copied()
+            })
             .flatten()
     }
 
     /// Returns the offset of the optional fields based on the specified account
     /// block.
-    fn optional_fields_offset(&self, data_block: &[u8]) -> usize {
-        data_block
+    fn optional_fields_offset(&self, account_block: &[u8]) -> usize {
+        account_block
             .len()
             .saturating_sub(AccountMetaOptionalFields::size_from_flags(&self.flags))
     }
 
     /// Returns the length of the data associated to this account based on the
     /// specified account block.
-    fn data_len(&self, data_block: &[u8]) -> usize {
-        self.optional_fields_offset(data_block)
+    fn data_len(&self, account_block: &[u8]) -> usize {
+        self.optional_fields_offset(account_block)
             .saturating_sub(self.account_data_padding() as usize)
     }
 
     /// Returns the data associated to this account based on the specified
     /// account block.
-    fn account_data<'a>(&self, data_block: &'a [u8]) -> &'a [u8] {
-        &data_block[..self.data_len(data_block)]
+    fn account_data<'a>(&self, account_block: &'a [u8]) -> &'a [u8] {
+        &account_block[..self.data_len(account_block)]
     }
 }
 

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -2,8 +2,16 @@
 //! The account meta and related structs for hot accounts.
 
 use {
-    crate::tiered_storage::meta::{AccountMetaFlags, TieredAccountMeta},
+    crate::{
+        account_storage::meta::StoredMetaWriteVersion,
+        tiered_storage::{
+            byte_block::ByteBlockReader,
+            meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+        },
+    },
     modular_bitfield::prelude::*,
+    solana_sdk::{hash::Hash, stake_history::Epoch},
+    std::option::Option,
 };
 
 /// The maximum number of padding bytes used in a hot account entry.
@@ -123,15 +131,86 @@ impl TieredAccountMeta for HotAccountMeta {
     fn supports_shared_account_block() -> bool {
         false
     }
+
+    /// Returns the epoch that this account will next owe rent by parsing
+    /// the specified account block.  None will be returned if this account
+    /// does not persist this optional field.
+    fn rent_epoch(&self, data_block: &[u8]) -> Option<Epoch> {
+        let offset = self.optional_fields_offset(data_block);
+        if self.flags.has_rent_epoch() {
+            let epoch = *ByteBlockReader::read_type::<Epoch>(data_block, offset)?;
+            return Some(epoch);
+        }
+        None
+    }
+
+    /// Returns the account hash by parsing the specified account block.  None
+    /// will be returned if this account does not persist this optional field.
+    fn account_hash<'a>(&self, data_block: &'a [u8]) -> Option<&'a Hash> {
+        let mut offset = self.optional_fields_offset(data_block);
+        if self.flags.has_rent_epoch() {
+            offset += std::mem::size_of::<Epoch>();
+        }
+        if self.flags.has_account_hash() {
+            return ByteBlockReader::read_type::<Hash>(data_block, offset);
+        }
+        None
+    }
+
+    /// Returns the write version by parsing the specified account block.  None
+    /// will be returned if this account does not persist this optional field.
+    fn write_version(&self, data_block: &[u8]) -> Option<StoredMetaWriteVersion> {
+        let mut offset = self.optional_fields_offset(data_block);
+        if self.flags.has_rent_epoch() {
+            offset += std::mem::size_of::<Epoch>();
+        }
+        if self.flags.has_account_hash() {
+            offset += std::mem::size_of::<Hash>();
+        }
+        if self.flags.has_write_version() {
+            let write_version =
+                ByteBlockReader::read_type::<StoredMetaWriteVersion>(data_block, offset)?;
+            return Some(*write_version);
+        }
+        None
+    }
+
+    /// Returns the offset of the optional fields based on the specified account
+    /// block.
+    fn optional_fields_offset(&self, data_block: &[u8]) -> usize {
+        data_block
+            .len()
+            .saturating_sub(AccountMetaOptionalFields::size_from_flags(&self.flags))
+    }
+
+    /// Returns the length of the data associated to this account based on the
+    /// specified account block.
+    fn data_len(&self, data_block: &[u8]) -> usize {
+        self.optional_fields_offset(data_block)
+            .saturating_sub(self.account_data_padding() as usize)
+    }
+
+    /// Returns the data associated to this account based on the specified
+    /// account block.
+    fn account_data<'a>(&self, data_block: &'a [u8]) -> &'a [u8] {
+        &data_block[0..self.data_len(data_block)]
+    }
 }
 
 #[cfg(test)]
 pub mod tests {
     use {
         super::*,
-        crate::tiered_storage::meta::AccountMetaOptionalFields,
+        crate::{
+            account_storage::meta::StoredMetaWriteVersion,
+            tiered_storage::{
+                byte_block::{ByteBlockReader, ByteBlockWriter},
+                footer::AccountBlockFormat,
+                meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+            },
+        },
+        ::solana_sdk::{hash::Hash, stake_history::Epoch},
         memoffset::offset_of,
-        solana_sdk::{hash::Hash, stake_history::Epoch},
     };
 
     #[test]
@@ -209,5 +288,62 @@ pub mod tests {
         assert_eq!(meta.data_size_for_shared_block(), None);
         assert_eq!(meta.owner_index(), TEST_OWNER_INDEX);
         assert_eq!(*meta.flags(), flags);
+    }
+
+    #[test]
+    fn test_hot_account_meta_full() {
+        let account_data = [11u8; 83];
+        let padding = [0u8; 5];
+
+        const TEST_LAMPORT: u64 = 2314232137;
+        const OWNER_INDEX: u32 = 0x1fef_1234;
+        const TEST_RENT_EPOCH: Epoch = 7;
+        const TEST_WRITE_VERSION: StoredMetaWriteVersion = 0;
+
+        let optional_fields = AccountMetaOptionalFields {
+            rent_epoch: Some(TEST_RENT_EPOCH),
+            account_hash: Some(Hash::new_unique()),
+            write_version: Some(TEST_WRITE_VERSION),
+        };
+
+        let flags = AccountMetaFlags::new_from(&optional_fields);
+        let expected_meta = HotAccountMeta::new()
+            .with_lamports(TEST_LAMPORT)
+            .with_account_data_padding(padding.len().try_into().unwrap())
+            .with_owner_index(OWNER_INDEX)
+            .with_flags(&flags);
+
+        let mut writer = ByteBlockWriter::new(AccountBlockFormat::AlignedRaw);
+        writer.write_type(&expected_meta).unwrap();
+        writer.write_type(&account_data).unwrap();
+        writer.write_type(&padding).unwrap();
+        writer.write_optional_fields(&optional_fields).unwrap();
+        let buffer = writer.finish().unwrap();
+
+        let meta = ByteBlockReader::read_type::<HotAccountMeta>(&buffer, 0).unwrap();
+        assert_eq!(expected_meta, *meta);
+        assert!(meta.flags().has_rent_epoch());
+        assert!(meta.flags().has_account_hash());
+        assert!(meta.flags().has_write_version());
+        assert_eq!(meta.account_data_padding() as usize, padding.len());
+
+        let account_block = &buffer[std::mem::size_of::<HotAccountMeta>()..];
+        assert_eq!(
+            meta.optional_fields_offset(account_block),
+            account_block
+                .len()
+                .saturating_sub(AccountMetaOptionalFields::size_from_flags(&flags))
+        );
+        assert_eq!(account_data.len(), meta.data_len(account_block));
+        assert_eq!(account_data, meta.account_data(account_block));
+        assert_eq!(meta.rent_epoch(account_block), optional_fields.rent_epoch);
+        assert_eq!(
+            *(meta.account_hash(account_block).unwrap()),
+            optional_fields.account_hash.unwrap()
+        );
+        assert_eq!(
+            meta.write_version(account_block),
+            optional_fields.write_version
+        );
     }
 }

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -168,9 +168,7 @@ impl TieredAccountMeta for HotAccountMeta {
         }
         self.flags
             .has_write_version()
-            .then(|| {
-                byte_block::read_type::<StoredMetaWriteVersion>(data_block, offset).copied()
-            })
+            .then(|| byte_block::read_type::<StoredMetaWriteVersion>(data_block, offset).copied())
             .flatten()
     }
 


### PR DESCRIPTION
#### Summary of Changes
This PR implements HotAccountMeta's getter functions for accessing
optional fields (e.g. rent_epoch, account_hash, etc) and account data.

#### Test Plan
A new unit test is included in this PR.

This PR depends on #32311 that adds functions for obtaining optional
fields offsets.