### PR TITLE
Cleanup impl for remove_tmp_snapshot_archives()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -623,9 +623,12 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
 pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {
     if let Ok(entries) = std::fs::read_dir(snapshot_archives_dir) {
         for entry in entries.flatten() {
-            if entry.file_name().to_str().map_or(false, |file_name| {
-                file_name.starts_with(TMP_SNAPSHOT_ARCHIVE_PREFIX)
-            }) {
+            if entry
+                .file_name()
+                .to_str()
+                .map(|file_name| file_name.starts_with(TMP_SNAPSHOT_ARCHIVE_PREFIX))
+                .unwrap_or(false)
+            {
                 let path = entry.path();
                 let result = if path.is_dir() {
                     fs_err::remove_dir_all(path)


### PR DESCRIPTION
#### Problem

The impl for `snapshot_utils::remove_tmp_snapshot_archives()` is a bit sus w.r.t. checking if the file name indicates a tmp snapshot archive that should be removed.

Originally brought up in a previous PR here: https://github.com/solana-labs/solana/pull/32286#discussion_r1242887956


#### Summary of Changes

Un-sus it.