### PR TITLE
TransactionPriorityId

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,2 +1,4 @@
 #[allow(dead_code)]
 mod thread_aware_account_locks;
+#[allow(dead_code)]
+mod transaction_priority_id;

--- a/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
@@ -1,0 +1,28 @@
+use crate::banking_stage::scheduler_messages::TransactionId;
+
+/// Simple wrapper around a unique `TransactionId` and a `priority` value.
+/// Intended for use in `priority`-ordered queue, while also tracking the
+/// unique identifier for each transaction/packet.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TransactionPriorityId {
+    pub(crate) priority: u64,
+    pub(crate) id: TransactionId,
+}
+
+impl TransactionPriorityId {
+    pub(crate) fn new(priority: u64, id: TransactionId) -> Self {
+        Self { priority, id }
+    }
+}
+
+impl Ord for TransactionPriorityId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.priority.cmp(&other.priority)
+    }
+}
+
+impl PartialOrd for TransactionPriorityId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}


### PR DESCRIPTION
#### Problem
Scheduler will use a priority-ordered queue for transaction ids.

#### Summary of Changes
* Create a simple wrapper `TransactionPriorityId` that wraps `priority` and unique `TransactionId`
* Initially, ordering is based **solely** on `priority`.

Blocked by #32298

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
