### PR TITLE
Make prepare_simulation_batch() more usable

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4812,7 +4812,7 @@ impl Bank {
     }
 
     /// Prepare a transaction batch from a single transaction without locking accounts
-    pub(crate) fn prepare_sanitized_batch_without_locking<'a>(
+    pub(crate) fn prepare_unlocked_batch_from_single_tx<'a>(
         &'a self,
         transaction: &'a SanitizedTransaction,
     ) -> TransactionBatch<'_, '_> {
@@ -4848,7 +4848,7 @@ impl Bank {
         let account_keys = transaction.message().account_keys();
         let number_of_accounts = account_keys.len();
         let account_overrides = self.get_account_overrides_for_simulation(&account_keys);
-        let batch = self.prepare_sanitized_batch_without_locking(&transaction);
+        let batch = self.prepare_unlocked_batch_from_single_tx(&transaction);
         let mut timings = ExecuteTimings::default();
 
         let LoadAndExecuteTransactionsOutput {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -180,6 +180,7 @@ use {
         ops::{AddAssign, RangeInclusive},
         path::PathBuf,
         rc::Rc,
+        slice,
         sync::{
             atomic::{
                 AtomicBool, AtomicI64, AtomicU64, AtomicUsize,
@@ -4823,7 +4824,7 @@ impl Bank {
         let mut batch = TransactionBatch::new(
             vec![lock_result],
             self,
-            Cow::Borrowed(std::slice::from_ref(transaction)),
+            Cow::Borrowed(slice::from_ref(transaction)),
         );
         batch.set_needs_unlock(false);
         batch

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4811,17 +4811,20 @@ impl Bank {
         TransactionBatch::new(lock_results, self, Cow::Borrowed(transactions))
     }
 
-    /// Prepare a transaction batch without locking accounts for transaction simulation.
-    pub(crate) fn prepare_simulation_batch(
-        &self,
-        transaction: SanitizedTransaction,
+    /// Prepare a transaction batch from a single transaction without locking accounts
+    pub(crate) fn prepare_sanitized_batch_without_locking<'a>(
+        &'a self,
+        transaction: &'a SanitizedTransaction,
     ) -> TransactionBatch<'_, '_> {
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();
         let lock_result = transaction
             .get_account_locks(tx_account_lock_limit)
             .map(|_| ());
-        let mut batch =
-            TransactionBatch::new(vec![lock_result], self, Cow::Owned(vec![transaction]));
+        let mut batch = TransactionBatch::new(
+            vec![lock_result],
+            self,
+            Cow::Borrowed(std::slice::from_ref(transaction)),
+        );
         batch.set_needs_unlock(false);
         batch
     }
@@ -4845,7 +4848,7 @@ impl Bank {
         let account_keys = transaction.message().account_keys();
         let number_of_accounts = account_keys.len();
         let account_overrides = self.get_account_overrides_for_simulation(&account_keys);
-        let batch = self.prepare_simulation_batch(transaction);
+        let batch = self.prepare_sanitized_batch_without_locking(&transaction);
         let mut timings = ExecuteTimings::default();
 
         let LoadAndExecuteTransactionsOutput {

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -90,7 +90,7 @@ mod tests {
         let (bank, txs) = setup();
 
         // Prepare batch without locks
-        let batch = bank.prepare_simulation_batch(txs[0].clone());
+        let batch = bank.prepare_sanitized_batch_without_locking(&txs[0]);
         assert!(batch.lock_results().iter().all(|x| x.is_ok()));
 
         // Grab locks
@@ -98,7 +98,7 @@ mod tests {
         assert!(batch2.lock_results().iter().all(|x| x.is_ok()));
 
         // Prepare another batch without locks
-        let batch3 = bank.prepare_simulation_batch(txs[0].clone());
+        let batch3 = bank.prepare_sanitized_batch_without_locking(&txs[0]);
         assert!(batch3.lock_results().iter().all(|x| x.is_ok()));
     }
 

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -90,7 +90,7 @@ mod tests {
         let (bank, txs) = setup();
 
         // Prepare batch without locks
-        let batch = bank.prepare_sanitized_batch_without_locking(&txs[0]);
+        let batch = bank.prepare_unlocked_batch_from_single_tx(&txs[0]);
         assert!(batch.lock_results().iter().all(|x| x.is_ok()));
 
         // Grab locks
@@ -98,7 +98,7 @@ mod tests {
         assert!(batch2.lock_results().iter().all(|x| x.is_ok()));
 
         // Prepare another batch without locks
-        let batch3 = bank.prepare_sanitized_batch_without_locking(&txs[0]);
+        let batch3 = bank.prepare_unlocked_batch_from_single_tx(&txs[0]);
         assert!(batch3.lock_results().iter().all(|x| x.is_ok()));
     }
 


### PR DESCRIPTION
#### Problem

- `prepare_simulation_batch` requires `.clone()`-ing.
- its name isn't generic to be used by others (ref: #31239 )

#### Summary of Changes

- make it take refs; seems there's no practical merit of transferring the ownership into `TransactionBatch` in the hope of avoiding some internal cloning... Originally, i thought generic approach made sense: https://github.com/solana-labs/solana/pull/31239#discussion_r1211183825
  - less is more. :)
- and rename it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
