### PR TITLE
ci: remove wasm-pack version lock

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
  && cargo install mdbook \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \
- && cargo install --version 0.11.1 wasm-pack \
+ && cargo install wasm-pack \
  && cargo install sccache \
  && rustc --version \
  && cargo --version

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -2,7 +2,6 @@
 # ci/rust-version.sh to pick up the new image tag
 FROM rust:1.69.0
 
-# we need to pin wasm-pack due to https://github.com/rustwasm/wasm-pack/issues/1308
 RUN set -x \
  && apt update \
  && apt-get install apt-transport-https \


### PR DESCRIPTION
#### Problem

we added a version lock for wasm-pack cuz they removed `--version` accidentally. A good news is that they brought it back in 0.12.1. (https://github.com/rustwasm/wasm-pack/releases/tag/v0.12.1)

#### Summary of Changes

remove the wasm-pack version lock
