### PR TITLE
adds extensions to contact-info

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -271,7 +271,7 @@ pub fn make_accounts_hashes_message(
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[frozen_abi(digest = "3U6DqJ4X4UE1DxRP1sbwP5QtyFxexMxzjLSKXXRDrt4q")]
+#[frozen_abi(digest = "9eS1agTwFQxCcCWgoBYhPfEVBfXkppan1zbob5rRRu7u")]
 #[derive(Serialize, Deserialize, Debug, AbiEnumVisitor, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {


### PR DESCRIPTION
#### Problem
Difficult to make changes to `ContactInfo` because of backward compatibility issues.

#### Summary of Changes
The commit adds a `Vec<Extension>` to `ContactInfo` so that future additions to `ContactInfo` can be done by only adding new `Extension`s instead of modifying the entire `ContactInfo`.