### PR TITLE
Don't attempt to refresh votes on non voting validators

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -224,7 +224,8 @@ pub struct Tower {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    last_vote_tx_blockhash: Hash,
+    // For non voting validators this is None
+    last_vote_tx_blockhash: Option<Hash>,
     last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root
@@ -247,7 +248,7 @@ impl Default for Tower {
             vote_state: VoteState::default(),
             last_vote: VoteTransaction::from(VoteStateUpdate::default()),
             last_timestamp: BlockTimestamp::default(),
-            last_vote_tx_blockhash: Hash::default(),
+            last_vote_tx_blockhash: None,
             stray_restored_slot: Option::default(),
             last_switch_threshold_check: Option::default(),
         };
@@ -460,7 +461,7 @@ impl Tower {
         self.vote_state.tower()
     }
 
-    pub fn last_vote_tx_blockhash(&self) -> Hash {
+    pub fn last_vote_tx_blockhash(&self) -> Option<Hash> {
         self.last_vote_tx_blockhash
     }
 
@@ -504,7 +505,7 @@ impl Tower {
     }
 
     pub fn refresh_last_vote_tx_blockhash(&mut self, new_vote_tx_blockhash: Hash) {
-        self.last_vote_tx_blockhash = new_vote_tx_blockhash;
+        self.last_vote_tx_blockhash = Some(new_vote_tx_blockhash);
     }
 
     // Returns true if we have switched the new vote instruction that directly sets vote state

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -19,7 +19,7 @@ pub struct Tower1_14_11 {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    pub(crate) last_vote_tx_blockhash: Hash,
+    pub(crate) last_vote_tx_blockhash: Option<Hash>,
     pub(crate) last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -22,7 +22,7 @@ pub struct Tower1_7_14 {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    pub(crate) last_vote_tx_blockhash: Hash,
+    pub(crate) last_vote_tx_blockhash: Option<Hash>,
     pub(crate) last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -403,7 +403,7 @@ pub mod test {
             vote_state: VoteState1_14_11::from(vote_state),
             last_vote: vote.clone(),
             last_timestamp: BlockTimestamp::default(),
-            last_vote_tx_blockhash: Hash::default(),
+            last_vote_tx_blockhash: None,
             stray_restored_slot: Some(2),
             last_switch_threshold_check: Option::default(),
         };


### PR DESCRIPTION
#### Problem
Non voting validators or validators with unstaked identities in hotswap setups will never generate a tower blockhash, although they will continue adding votes to the tower. 
The default blockhash is expired, so this will prompt these validators to attempt to refresh their vote. Although they can't vote anyway this will print an extra `WARN` cluttering the log. 

#### Summary of Changes
Return early if blockhash is default.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
