### PR TITLE
rolls out merkle shreds to 100% of testnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -501,8 +501,8 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_use_merkle_variant(slot: Slot, cluster_type: ClusterType, shred_version: u16) -> bool {
-    cluster_type == ClusterType::Testnet && shred_version == 28353 && (slot % 19 < 10)
+fn should_use_merkle_variant(_: Slot, cluster_type: ClusterType, shred_version: u16) -> bool {
+    cluster_type == ClusterType::Testnet && shred_version == 28353
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Ramping up Merkle shreds rollout as the results look good: https://github.com/solana-labs/solana/pull/31950#issuecomment-1611911159


#### Summary of Changes
Rolls out merkle shreds to 100% of testnet slots.