### PR TITLE
[TieredStorage] Make data_size related APIs cleaner

### DIFF
--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -102,12 +102,6 @@ impl TieredAccountMeta for HotAccountMeta {
         self.packed_fields.padding()
     }
 
-    /// Always return None as a HotAccountMeta entry never shares its account
-    /// block with other account meta entries.
-    fn data_size_for_shared_block(&self) -> Option<usize> {
-        None
-    }
-
     /// Returns the index to the accounts' owner in the current AccountsFile.
     fn owner_index(&self) -> u32 {
         self.packed_fields.owner_index()
@@ -206,7 +200,6 @@ pub mod tests {
 
         assert_eq!(meta.lamports(), TEST_LAMPORTS);
         assert_eq!(meta.account_data_padding(), TEST_PADDING);
-        assert_eq!(meta.data_size_for_shared_block(), None);
         assert_eq!(meta.owner_index(), TEST_OWNER_INDEX);
         assert_eq!(*meta.flags(), flags);
     }

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -51,12 +51,6 @@ pub trait TieredAccountMeta: Sized {
     /// Returns the number of padding bytes for the associated account data
     fn account_data_padding(&self) -> u8;
 
-    /// Returns the size of its account data if the current accout meta
-    /// shares its account block with other account meta entries.
-    ///
-    /// Otherwise, None will be returned.
-    fn data_size_for_shared_block(&self) -> Option<usize>;
-
     /// Returns the index to the accounts' owner in the current AccountsFile.
     fn owner_index(&self) -> u32;
 


### PR DESCRIPTION
#### Problem
Function data_size_for_shared_block() is designed to provide
the data_size when its account shares its account block with
other accounts.  However, TieredAccountMeta already has another
function for returning data size.

#### Summary of Changes
This PR removes data_size_for_shared_block() from TieredAccountMeta.
Will follow-up with another PR that includes a better API.
