### PR TITLE
Increase push fanout from 6 to 9

### DIFF
--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -42,15 +42,15 @@ use {
     },
 };
 
-const CRDS_GOSSIP_PUSH_FANOUT: usize = 6;
-// With a fanout of 6, a 1000 node cluster should only take ~4 hops to converge.
+const CRDS_GOSSIP_PUSH_FANOUT: usize = 9;
+// With a fanout of 6, a 2000 node cluster should only take ~3.5 hops to converge.
 // However since pushes are stake weighed, some trailing nodes
 // might need more time to receive values. 30 seconds should be plenty.
 pub const CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS: u64 = 30000;
 const CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS: u64 = 500;
 const CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT: f64 = 0.15;
 const CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES: usize = 2;
-const CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE: usize = CRDS_GOSSIP_PUSH_FANOUT * 2;
+const CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE: usize = CRDS_GOSSIP_PUSH_FANOUT + 3;
 
 pub struct CrdsGossipPush {
     /// Max bytes per message

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -43,7 +43,7 @@ use {
 };
 
 const CRDS_GOSSIP_PUSH_FANOUT: usize = 9;
-// With a fanout of 6, a 2000 node cluster should only take ~3.5 hops to converge.
+// With a fanout of 9, a 2000 node cluster should only take ~3.5 hops to converge.
 // However since pushes are stake weighed, some trailing nodes
 // might need more time to receive values. 30 seconds should be plenty.
 pub const CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS: u64 = 30000;


### PR DESCRIPTION
#### Problem
A Push Fanout of 6 is too small, resulting in the following:
* slow message propagation
* sparse network

The key here is that by increasing push fanout, gossip is able to reach more nodes in fewer hops. The pruning logic then removes the redundant paths, leaving us with a more dense MST without significant overhead (in steady state). 

All numbers and claims below are based off of a simulated gossip framework here: [gossip-sim](https://github.com/gregcusack/gossip-sim)
Data from simulated gossip framework can be found here: [Grafana Dashboard
](https://internal-metrics.solana.com:3000/d/EO2GyD_4k/gossip-simulation?orgId=1&from=1687973935288&to=1687975889674&var-TimeWindow=1h&var-start_time_2=1687962090627912000&var-start_time=0)

#### Summary of Changes
* Increase `CRDS_GOSSIP_PUSH_FANOUT` from 6 to 9, while leaving `CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE` at 12

#### Supporting Data
Increasing Push Fanout from 6 to 9:
Pros
* Reduces the mean and median number of hops per gossip iteration by ~14.5% (~1 hop)
  * Result: More nodes receive gossip messages sooner
* Reduces Last Delivery Hop (essentially message latency) by 16.6% (3 hops)
* Reduces Relative Message Redundancy by ~2.8%
* Reduces the number of total messages sent in the network by ~1-2%
* Reduces mean # of egress messages for 99.7% of validators
* The increase in the number of prunes in steady state is nominal

Cons
* Slight decrease in network coverage by 0.1% -- translates to an average of ~5 additional nodes (out of 4210 - including unstaked nodes) left out of an origin's MST
* Some higher staked nodes see a slight increase in egress messages
* obviously, each origin node will be sending to 3 additional nodes per message

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
