### PR TITLE
[TieredStorage] Improve TieredAccountMeta API's readability

### DIFF
--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -87,7 +87,7 @@ impl TieredAccountMeta for HotAccountMeta {
     }
 
     /// A builder function that initializes the account data size.
-    fn with_data_size(self, _data_size: u64) -> Self {
+    fn with_account_data_size(self, _data_size: u64) -> Self {
         // Hot meta does not store its data size as it derives its data length
         // by comparing the offets of two consecutive account meta entries.
         self
@@ -176,7 +176,7 @@ impl TieredAccountMeta for HotAccountMeta {
 
     /// Returns the length of the data associated to this account based on the
     /// specified account block.
-    fn data_len(&self, account_block: &[u8]) -> usize {
+    fn account_data_size(&self, account_block: &[u8]) -> usize {
         self.optional_fields_offset(account_block)
             .saturating_sub(self.account_data_padding() as usize)
     }
@@ -184,7 +184,7 @@ impl TieredAccountMeta for HotAccountMeta {
     /// Returns the data associated to this account based on the specified
     /// account block.
     fn account_data<'a>(&self, account_block: &'a [u8]) -> &'a [u8] {
-        &account_block[..self.data_len(account_block)]
+        &account_block[..self.account_data_size(account_block)]
     }
 }
 
@@ -324,7 +324,7 @@ pub mod tests {
                 .len()
                 .saturating_sub(AccountMetaOptionalFields::size_from_flags(&flags))
         );
-        assert_eq!(account_data.len(), meta.data_len(account_block));
+        assert_eq!(account_data.len(), meta.account_data_size(account_block));
         assert_eq!(account_data, meta.account_data(account_block));
         assert_eq!(meta.rent_epoch(account_block), optional_fields.rent_epoch);
         assert_eq!(

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -87,7 +87,7 @@ impl TieredAccountMeta for HotAccountMeta {
     }
 
     /// A builder function that initializes the account data size.
-    fn with_account_data_size(self, _data_size: u64) -> Self {
+    fn with_account_data_size(self, _account_data_size: u64) -> Self {
         // Hot meta does not store its data size as it derives its data length
         // by comparing the offets of two consecutive account meta entries.
         self

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -39,7 +39,7 @@ pub trait TieredAccountMeta: Sized {
 
     /// A builder function that initializes the account data size.
     /// The size here represents the logical data size without compression.
-    fn with_data_size(self, data_size: u64) -> Self;
+    fn with_account_data_size(self, data_size: u64) -> Self;
 
     /// A builder function that initializes the AccountMetaFlags of the current
     /// meta.
@@ -88,7 +88,7 @@ pub trait TieredAccountMeta: Sized {
 
     /// Returns the length of the data associated to this account based on the
     /// specified account block.
-    fn data_len(&self, _account_block: &[u8]) -> usize {
+    fn account_data_size(&self, _account_block: &[u8]) -> usize {
         unimplemented!();
     }
 

--- a/runtime/src/tiered_storage/meta.rs
+++ b/runtime/src/tiered_storage/meta.rs
@@ -39,7 +39,7 @@ pub trait TieredAccountMeta: Sized {
 
     /// A builder function that initializes the account data size.
     /// The size here represents the logical data size without compression.
-    fn with_account_data_size(self, data_size: u64) -> Self;
+    fn with_account_data_size(self, account_data_size: u64) -> Self;
 
     /// A builder function that initializes the AccountMetaFlags of the current
     /// meta.


### PR DESCRIPTION
#### Problem
In TieredAccountMeta, it uses `data` and `account_data` to refer to
the data associated with the account, and this could be confusing.

#### Summary of Changes
This PR makes TieredAccountMeta only use `account_data` to refer
to the data associated with the account.
