### PR TITLE
Install jq in docker

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -13,6 +13,7 @@ RUN set -x \
       buildkite-agent \
       clang \
       cmake \
+      jq \
       lcov \
       libudev-dev \
       mscgen \


### PR DESCRIPTION
#### Problem

`jq` is missing...... T_T:

https://buildkite.com/solana-labs/solana/builds/98449#01890a36-b5e8-4438-8b4d-b81fb0a2bae7/3083-3084

![image](https://github.com/solana-labs/solana/assets/117807/6cd51c45-76c9-4f61-91d4-466cffb36abe)



#### Summary of Changes

add it

blocking #32169 