### PR TITLE
fix: check if platform-tool/rust/bin/rustc exists

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -166,6 +166,9 @@ fn get_base_rust_version(platform_tools_version: &str) -> String {
     let target_path =
         make_platform_tools_path_for_version("platform-tools", platform_tools_version);
     let rustc = target_path.join("rust").join("bin").join("rustc");
+    if !rustc.exists() {
+        return String::from("");
+    }
     let args = vec!["--version"];
     let output = spawn(&rustc, args, false);
     let rustc_re = Regex::new(r"(rustc [0-9]+\.[0-9]+\.[0-9]+).*").unwrap();


### PR DESCRIPTION
#### Problem

make a note here: this steps can reproduce the unexpected error

1. cd to monorepo
2. ./cargo-build-sbf --help
3. rm -rf ~/.cache/solana
4. ./cargo-build-sbf --help

#### Summary of Changes

check if rustc exists

(btw, feel free to just close this one and create a new one if you would like to refactor these code hehe)