### PR TITLE
Update Solang Solidity compiler to v0.3.1

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -171,7 +171,7 @@ fi
 # Add Solidity Compiler
 if [[ -z "$validatorOnly" ]]; then
   base="https://github.com/hyperledger/solang/releases/download"
-  version="v0.3.0"
+  version="v0.3.1"
   curlopt="-sSfL --retry 5 --retry-delay 2 --retry-connrefused"
 
   case $(uname -s) in


### PR DESCRIPTION
#### Problem

We've released a new version of Solang and would like to update it in the installation script.
https://github.com/hyperledger/solang/releases/tag/v0.3.1

#### Summary of Changes
Changed the version number at `scripts/cargo-install-all.sh`.

