### PR TITLE
fix type param in translate_and_check_program_address_inputs

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -580,7 +580,7 @@ fn translate_and_check_program_address_inputs<'a>(
     check_aligned: bool,
     check_size: bool,
 ) -> Result<(Vec<&'a [u8]>, &'a Pubkey), Error> {
-    let untranslated_seeds = translate_slice::<&[&u8]>(
+    let untranslated_seeds = translate_slice::<&[u8]>(
         memory_mapping,
         seeds_addr,
         seeds_len,


### PR DESCRIPTION
#### Problem

There is a subtle typo in the `translate_and_check_program_address_inputs` function used in the PDA syscalls. The type annotation in `translate_slice::<&[&u8]>` is incorrect when translating seeds: It means "slice of slices of reference to u8", which makes no sense. Seeds are "slice of slices of u8".

Fortunately, this doesn't actually cause any bugs. The size and align of the outer type of the type annotation are unchanged. The inner slice is then type punned to the correct type.

#### Summary of Changes

Removes a single character

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
