### PR TITLE
Add csv output option to stake and vote account rewards

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -331,6 +331,7 @@ pub enum CliCommand {
     ShowVoteAccount {
         pubkey: Pubkey,
         use_lamports_unit: bool,
+        use_csv: bool,
         with_rewards: Option<usize>,
     },
     WithdrawFromVoteAccount {
@@ -1429,12 +1430,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
             use_lamports_unit,
+            use_csv,
             with_rewards,
         } => process_show_vote_account(
             &rpc_client,
             config,
             vote_account_pubkey,
             *use_lamports_unit,
+            *use_csv,
             *with_rewards,
         ),
         CliCommand::WithdrawFromVoteAccount {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -259,6 +259,7 @@ pub enum CliCommand {
         pubkey: Pubkey,
         use_lamports_unit: bool,
         with_rewards: Option<usize>,
+        use_csv: bool,
     },
     StakeAuthorize {
         stake_account_pubkey: Pubkey,
@@ -1266,12 +1267,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             pubkey: stake_account_pubkey,
             use_lamports_unit,
             with_rewards,
+            use_csv,
         } => process_show_stake_account(
             &rpc_client,
             config,
             stake_account_pubkey,
             *use_lamports_unit,
             *with_rewards,
+            *use_csv,
         ),
         CliCommand::ShowStakeHistory {
             use_lamports_unit,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1821,6 +1821,7 @@ pub fn process_show_stakes(
                                 &stake_history,
                                 &clock,
                                 new_rate_activation_epoch,
+                                false,
                             ),
                         });
                     }
@@ -1840,6 +1841,7 @@ pub fn process_show_stakes(
                                 &stake_history,
                                 &clock,
                                 new_rate_activation_epoch,
+                                false,
                             ),
                         });
                     }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -690,11 +690,17 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("Display inflation rewards"),
                 )
                 .arg(
+                    Arg::with_name("csv")
+                        .long("csv")
+                        .takes_value(false)
+                        .help("Format stake account data in csv")
+                )
+                .arg(
                     Arg::with_name("num_rewards_epochs")
                         .long("num-rewards-epochs")
                         .takes_value(true)
                         .value_name("NUM")
-                        .validator(|s| is_within_range(s, 1..=10))
+                        .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
@@ -1274,6 +1280,7 @@ pub fn parse_show_stake_account(
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
     let use_lamports_unit = matches.is_present("lamports");
+    let use_csv = matches.is_present("csv");
     let with_rewards = if matches.is_present("with_rewards") {
         Some(value_of(matches, "num_rewards_epochs").unwrap())
     } else {
@@ -1284,6 +1291,7 @@ pub fn parse_show_stake_account(
             pubkey: stake_account_pubkey,
             use_lamports_unit,
             with_rewards,
+            use_csv,
         },
         signers: vec![],
     })
@@ -2192,6 +2200,7 @@ pub fn build_stake_state(
     stake_history: &StakeHistory,
     clock: &Clock,
     new_rate_activation_epoch: Option<Epoch>,
+    use_csv: bool,
 ) -> CliStakeState {
     match stake_state {
         StakeStateV2::Stake(
@@ -2248,6 +2257,7 @@ pub fn build_stake_state(
                 active_stake: u64_some_if_not_zero(effective),
                 activating_stake: u64_some_if_not_zero(activating),
                 deactivating_stake: u64_some_if_not_zero(deactivating),
+                use_csv,
                 ..CliStakeState::default()
             }
         }
@@ -2414,6 +2424,7 @@ pub fn process_show_stake_account(
     stake_account_address: &Pubkey,
     use_lamports_unit: bool,
     with_rewards: Option<usize>,
+    use_csv: bool,
 ) -> ProcessResult {
     let stake_account = rpc_client.get_account(stake_account_address)?;
     if stake_account.owner != stake::program::id() {
@@ -2444,6 +2455,7 @@ pub fn process_show_stake_account(
                 &stake_history,
                 &clock,
                 new_rate_activation_epoch,
+                use_csv,
             );
 
             if state.stake_type == CliStakeType::Stake && state.activation_epoch.is_some() {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -334,11 +334,17 @@ impl VoteSubCommands for App<'_, '_> {
                         .help("Display inflation rewards"),
                 )
                 .arg(
+                    Arg::with_name("csv")
+                        .long("csv")
+                        .takes_value(false)
+                        .help("Format rewards in a CSV table"),
+                )
+                .arg(
                     Arg::with_name("num_rewards_epochs")
                         .long("num-rewards-epochs")
                         .takes_value(true)
                         .value_name("NUM")
-                        .validator(|s| is_within_range(s, 1..=10))
+                        .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
@@ -648,6 +654,7 @@ pub fn parse_vote_get_account_command(
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
     let use_lamports_unit = matches.is_present("lamports");
+    let use_csv = matches.is_present("csv");
     let with_rewards = if matches.is_present("with_rewards") {
         Some(value_of(matches, "num_rewards_epochs").unwrap())
     } else {
@@ -657,6 +664,7 @@ pub fn parse_vote_get_account_command(
         command: CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
             use_lamports_unit,
+            use_csv,
             with_rewards,
         },
         signers: vec![],
@@ -1208,6 +1216,7 @@ pub fn process_show_vote_account(
     config: &CliConfig,
     vote_account_address: &Pubkey,
     use_lamports_unit: bool,
+    use_csv: bool,
     with_rewards: Option<usize>,
 ) -> ProcessResult {
     let (vote_account, vote_state) =
@@ -1257,6 +1266,7 @@ pub fn process_show_vote_account(
         votes,
         epoch_voting_history,
         use_lamports_unit,
+        use_csv,
         epoch_rewards,
     };
 


### PR DESCRIPTION
#### Problem

Rewards data for `solana vote-account` and `solana stake-account` not importable programmatically to a spreadsheet or other program

#### Summary of Changes

Add an option to output rewards in CSV format

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
