### PR TITLE
Fixup is_niceness_adjustment_valid unit test for non-linux case

### DIFF
--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -125,6 +125,7 @@ mod tests {
 
     #[test]
     fn test_is_niceness_adjustment_valid() {
+        use super::is_niceness_adjustment_valid;
         assert_eq!(is_niceness_adjustment_valid("0"), Ok(()));
         assert!(is_niceness_adjustment_valid("128").is_err());
         assert!(is_niceness_adjustment_valid("-129").is_err());


### PR DESCRIPTION
#### Problem
The test needs to be aware of is_niceness_adjustment_valid from super scope; however, the use directive in test module only runs on Linux systems via the attached `#[cfg(target_os = "linux")]` statement.