### PR TITLE
Fix length while deploying extended program

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1433,7 +1433,7 @@ fn process_loader_upgradeable_instruction(
                 invoke_context,
                 program_key,
                 &program_id,
-                UpgradeableLoaderState::size_of_program().saturating_add(new_len),
+                new_len,
                 clock_slot,
                 {
                     drop(programdata_account);


### PR DESCRIPTION
#### Problem
Incorrect length is passed to `deploy_program` while processing `ExtendProgram` instruction.

#### Summary of Changes
Fix the value of the length.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
