### PR TITLE
Fix alt_bn128 declarations as expected by gen-headers and regenerate

### DIFF
--- a/sdk/sbf/c/inc/sol/alt_bn128.h
+++ b/sdk/sbf/c/inc/sol/alt_bn128.h
@@ -55,25 +55,10 @@ extern "C" {
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE sdk/sbf/c/inc/sol/inc/alt_bn128.inc AND RUN `cargo run --bin gen-headers` */
 #ifndef SOL_SBFV2
-uint64_t sol_alt_bn128_group_op(
-        const uint64_t group_op,
-        const uint8_t *input,
-        const uint64_t input_size,
-        uint8_t *result
-);
+uint64_t sol_alt_bn128_group_op(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
 #else
-typedef uint64_t(*sol_alt_bn128_group_op_pointer_type)(
-        const uint64_t group_op,
-        const uint8_t *input,
-        const uint64_t input_size,
-        uint8_t *result
-);
-static uint64_t sol_alt_bn128_group_op(
-        const uint64_t group_op arg1,
-        const uint8_t *input arg2,
-        const uint64_t input_size arg3,
-        uint8_t *result
- arg4) {
+typedef uint64_t(*sol_alt_bn128_group_op_pointer_type)(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
+static uint64_t sol_alt_bn128_group_op(const uint64_t arg1, const uint8_t * arg2, const uint64_t arg3, uint8_t * arg4) {
   sol_alt_bn128_group_op_pointer_type sol_alt_bn128_group_op_pointer = (sol_alt_bn128_group_op_pointer_type) 2920034699;
   return sol_alt_bn128_group_op_pointer(arg1, arg2, arg3, arg4);
 }

--- a/sdk/sbf/c/inc/sol/inc/alt_bn128.inc
+++ b/sdk/sbf/c/inc/sol/inc/alt_bn128.inc
@@ -53,12 +53,7 @@ extern "C" {
  * @param result 64 byte array to hold the result. ...
  * @return 0 if executed successfully
  */
-@SYSCALL uint64_t sol_alt_bn128_group_op(
-        const uint64_t group_op,
-        const uint8_t *input,
-        const uint64_t input_size,
-        uint8_t *result
-);
+@SYSCALL uint64_t sol_alt_bn128_group_op(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### Problem

C SDK header files are generated by a special program. This program expects syscall declarations to be in a specific format. One of the input files for the gen-header program is in incorrect format.

#### Summary of Changes

Fix the input file and regenerate the corresponding header file.
