### PR TITLE
Renames HashStats "sort" to "sort_us"

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -201,7 +201,7 @@ impl HashStats {
             ("accounts_scan_us", self.scan_time_total_us, i64),
             ("eliminate_zeros_us", self.zeros_time_total_us, i64),
             ("hash_us", self.hash_time_total_us, i64),
-            ("sort", self.sort_time_total_us, i64),
+            ("sort_us", self.sort_time_total_us, i64),
             ("hash_total", self.hash_total, i64),
             ("storage_sort_us", self.storage_sort_us, i64),
             ("unreduced_entries", self.unreduced_entries, i64),


### PR DESCRIPTION
#### Problem

The `sort_time_total_us` stat in `HashStats` is submitted without `_us` and without `_time`, so it's not obvious this is a time datapoint without looking at the code first.

#### Summary of Changes

Add a `_us` suffix to the `sort` datapoint. 

Note: Since most of the other datapoints don't include `time` in their name, I also did not do that here.