### PR TITLE
Adds mark_time to HashStats total_time

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -190,11 +190,12 @@ impl HashStats {
     }
 
     pub fn log(&mut self) {
+        // NOTE: Purposely do *not* include `sort_time_total_us` in `total_time_us`, since it is
+        // overlapping parallel scans, which is not the wallclock time.
         let total_time_us = self.mark_time_us
             + self.scan_time_total_us
             + self.zeros_time_total_us
             + self.hash_time_total_us
-            + self.sort_time_total_us
             + self.collect_snapshots_us
             + self.storage_sort_us;
         datapoint_info!(


### PR DESCRIPTION
#### Problem

I'm trying to identify why the `HashStats` total time datapoint is drastically different from the measurement reported by AccountsHashVerifier[^1]. I believe there are status either (1) not added to the total, or (2) not added to `HashStats` at all.

The `HashStats` datapoint for total time, `total_us` seems to be missing fields.

[^1]: Running ledger-tool to calculate the accounts hash with a snapshot from mnb, the `HashStats` log message has total time ~ 17s, and the `measure!` around calculating the accounts hash in AHV says ~ 25s.


#### Summary of Changes

Add `mark_time_us` and `sort_time_total_us` to `total_time_us`