### PR TITLE
Adds cache_hash_data_us to HashStats

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7616,7 +7616,12 @@ impl AccountsDb {
         let slot = storages.max_slot_inclusive();
         let use_bg_thread_pool = config.use_bg_thread_pool;
         let scan_and_hash = || {
-            let cache_hash_data = Self::get_cache_hash_data(accounts_hash_cache_path, config, slot);
+            let (cache_hash_data, cache_hash_data_us) = measure_us!(Self::get_cache_hash_data(
+                accounts_hash_cache_path,
+                config,
+                slot
+            ));
+            stats.cache_hash_data_us += cache_hash_data_us;
 
             let bounds = Range {
                 start: 0,

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -139,6 +139,7 @@ pub type StorageSizeQuartileStats = [usize; 6];
 #[derive(Debug, Default)]
 pub struct HashStats {
     pub mark_time_us: u64,
+    pub cache_hash_data_us: u64,
     pub scan_time_total_us: u64,
     pub zeros_time_total_us: u64,
     pub hash_time_total_us: u64,
@@ -193,6 +194,7 @@ impl HashStats {
         // NOTE: Purposely do *not* include `sort_time_total_us` in `total_time_us`, since it is
         // overlapping parallel scans, which is not the wallclock time.
         let total_time_us = self.mark_time_us
+            + self.cache_hash_data_us
             + self.scan_time_total_us
             + self.zeros_time_total_us
             + self.hash_time_total_us
@@ -201,6 +203,7 @@ impl HashStats {
         datapoint_info!(
             "calculate_accounts_hash_from_storages",
             ("mark_time_us", self.mark_time_us, i64),
+            ("cache_hash_data_us", self.cache_hash_data_us, i64),
             ("accounts_scan_us", self.scan_time_total_us, i64),
             ("eliminate_zeros_us", self.zeros_time_total_us, i64),
             ("hash_us", self.hash_time_total_us, i64),


### PR DESCRIPTION
#### Problem

The time to get the cache hash data is not factored into the accounts hash stats.

Using ledger-tool with a snapshot from mnb, caching the hash data took 4ms, so pretty small. Adding this for completeness, but it's likely not a big issue.

#### Summary of Changes

Add cache hash data time to `HashStats`