### PR TITLE
docs: change getSlotLeaders params to required

### DIFF
--- a/docs/src/api/methods/_getSlotLeaders.mdx
+++ b/docs/src/api/methods/_getSlotLeaders.mdx
@@ -19,11 +19,11 @@ Returns the slot leaders for a given slot range
 
 ### Parameters:
 
-<Parameter type={"u64"} optional={true}>
+<Parameter type={"u64"} required={true}>
   Start slot, as u64 integer
 </Parameter>
 
-<Parameter type={"u64"} optional={true}>
+<Parameter type={"u64"} required={true}>
   Limit, as u64 integer (between 1 and 5,000)
 </Parameter>
 


### PR DESCRIPTION
#### Problem

The [docs for `getSlotLeaders` ](https://docs.solana.com/api/http#getslotleaders) currently indicate that both params are optional, but they are both required

```sh
$ curl https://api.devnet.solana.com/ -X POST -H "Content-Type: application/json" -d '                                                               
  {
    "jsonrpc":"2.0", "id": 1,
    "method": "getSlotLeaders",
    "params": []
  }
'
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid length 0, expected a tuple of size 2."},"id":1}
```

#### Summary of Changes

Update docs to mark both params required