### PR TITLE
[TieredAccountStorage] TieredReadableAccount

### DIFF
--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -5,6 +5,7 @@ pub mod footer;
 pub mod hot;
 pub mod meta;
 pub mod mmap_utils;
+pub mod readable;
 
 use crate::tiered_storage::error::TieredStorageError;
 

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -1,0 +1,95 @@
+use {
+    crate::{
+        account_storage::meta::StoredMetaWriteVersion, tiered_storage::meta::TieredAccountMeta,
+    },
+    solana_sdk::{
+        account::{Account, AccountSharedData, ReadableAccount},
+        hash::Hash,
+        pubkey::Pubkey,
+        stake_history::Epoch,
+    },
+};
+
+/// The struct that offers read APIs for accessing a TieredAccount.
+#[derive(PartialEq, Eq, Debug)]
+pub struct TieredReadableAccount<'a, T: TieredAccountMeta> {
+    /// TieredAccountMeta
+    pub(crate) meta: &'a T,
+    /// The address of the account
+    pub(crate) address: &'a Pubkey,
+    /// The pubkey of the account owner
+    pub(crate) owner: &'a Pubkey,
+    /// The index for accessing the account inside its belonging AccountsFile
+    pub(crate) index: usize,
+    /// The account block that contains this account.  Note that this account
+    /// block may be shared with other accounts.
+    pub(crate) account_block: &'a [u8],
+}
+
+impl<'a, T: TieredAccountMeta> TieredReadableAccount<'a, T> {
+    /// Returns the address of this account.
+    pub fn address(&self) -> &'a Pubkey {
+        self.address
+    }
+
+    /// Returns the hash of this account.
+    pub fn hash(&self) -> Option<&'a Hash> {
+        self.meta.account_hash(self.account_block)
+    }
+
+    /// Returns the index to this account in its AccountsFile.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns a cloned AccountSharedData from this account.
+    pub fn clone_account(&self) -> AccountSharedData {
+        AccountSharedData::from(Account {
+            lamports: self.lamports(),
+            owner: *self.owner(),
+            executable: self.executable(),
+            rent_epoch: self.rent_epoch(),
+            data: self.data().to_vec(),
+        })
+    }
+
+    /// Returns the write version of the account.
+    pub fn write_version(&self) -> Option<StoredMetaWriteVersion> {
+        self.meta.write_version(self.account_block)
+    }
+}
+
+impl<'a, T: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, T> {
+    /// Returns the balance of the lamports of this account.
+    fn lamports(&self) -> u64 {
+        self.meta.lamports()
+    }
+
+    /// Returns the address of the owner of this account.
+    fn owner(&self) -> &'a Pubkey {
+        self.owner
+    }
+
+    /// Returns true if the data associated to this account is executable.
+    ///
+    /// Temporarily unimplemented!() as program runtime v2 will use
+    /// a different API for executable.
+    fn executable(&self) -> bool {
+        unimplemented!();
+    }
+
+    /// Returns the epoch that this account will next owe rent by parsing
+    /// the specified account block.  u64::MAX will be returned if the account
+    /// is rent-exempt.
+    fn rent_epoch(&self) -> Epoch {
+        if let Some(rent_epoch) = self.meta.rent_epoch(self.account_block) {
+            return rent_epoch;
+        }
+        std::u64::MAX
+    }
+
+    /// Returns the data associated to this account.
+    fn data(&self) -> &'a [u8] {
+        self.meta.account_data(self.account_block)
+    }
+}

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -42,17 +42,6 @@ impl<'a, M: TieredAccountMeta> TieredReadableAccount<'a, M> {
         self.index
     }
 
-    /// Returns a cloned AccountSharedData from this account.
-    pub fn clone_account(&self) -> AccountSharedData {
-        AccountSharedData::from(Account {
-            lamports: self.lamports(),
-            owner: *self.owner(),
-            executable: self.executable(),
-            rent_epoch: self.rent_epoch(),
-            data: self.data().to_vec(),
-        })
-    }
-
     /// Returns the write version of the account.
     pub fn write_version(&self) -> Option<StoredMetaWriteVersion> {
         self.meta.write_version(self.account_block)

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -82,7 +82,9 @@ impl<'a, T: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, T> 
     /// the specified account block.  Epoch::MAX will be returned if the account
     /// is rent-exempt.
     fn rent_epoch(&self) -> Epoch {
-        self.meta.rent_epoch(self.account_block).unwrap_or(Epoch::MAX)
+        self.meta
+            .rent_epoch(self.account_block)
+            .unwrap_or(Epoch::MAX)
     }
 
     /// Returns the data associated to this account.

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -17,7 +17,7 @@ pub struct TieredReadableAccount<'a, T: TieredAccountMeta> {
     pub(crate) meta: &'a T,
     /// The address of the account
     pub(crate) address: &'a Pubkey,
-    /// The pubkey of the account owner
+    /// The address of the account owner
     pub(crate) owner: &'a Pubkey,
     /// The index for accessing the account inside its belonging AccountsFile
     pub(crate) index: usize,
@@ -79,13 +79,10 @@ impl<'a, T: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, T> 
     }
 
     /// Returns the epoch that this account will next owe rent by parsing
-    /// the specified account block.  u64::MAX will be returned if the account
+    /// the specified account block.  Epoch::MAX will be returned if the account
     /// is rent-exempt.
     fn rent_epoch(&self) -> Epoch {
-        if let Some(rent_epoch) = self.meta.rent_epoch(self.account_block) {
-            return rent_epoch;
-        }
-        std::u64::MAX
+        self.meta.rent_epoch(self.account_block).unwrap_or(Epoch::MAX)
     }
 
     /// Returns the data associated to this account.

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -2,12 +2,7 @@ use {
     crate::{
         account_storage::meta::StoredMetaWriteVersion, tiered_storage::meta::TieredAccountMeta,
     },
-    solana_sdk::{
-        account::{Account, AccountSharedData, ReadableAccount},
-        hash::Hash,
-        pubkey::Pubkey,
-        stake_history::Epoch,
-    },
+    solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
 };
 
 /// The struct that offers read APIs for accessing a TieredAccount.

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -12,9 +12,9 @@ use {
 
 /// The struct that offers read APIs for accessing a TieredAccount.
 #[derive(PartialEq, Eq, Debug)]
-pub struct TieredReadableAccount<'a, T: TieredAccountMeta> {
+pub struct TieredReadableAccount<'a, M: TieredAccountMeta> {
     /// TieredAccountMeta
-    pub(crate) meta: &'a T,
+    pub(crate) meta: &'a M,
     /// The address of the account
     pub(crate) address: &'a Pubkey,
     /// The address of the account owner
@@ -26,7 +26,7 @@ pub struct TieredReadableAccount<'a, T: TieredAccountMeta> {
     pub(crate) account_block: &'a [u8],
 }
 
-impl<'a, T: TieredAccountMeta> TieredReadableAccount<'a, T> {
+impl<'a, M: TieredAccountMeta> TieredReadableAccount<'a, M> {
     /// Returns the address of this account.
     pub fn address(&self) -> &'a Pubkey {
         self.address
@@ -59,7 +59,7 @@ impl<'a, T: TieredAccountMeta> TieredReadableAccount<'a, T> {
     }
 }
 
-impl<'a, T: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, T> {
+impl<'a, M: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, M> {
     /// Returns the balance of the lamports of this account.
     fn lamports(&self) -> u64 {
         self.meta.lamports()


### PR DESCRIPTION
#### Summary of Changes
This PR introduces TieredReadableAccount, a struct that takes a generic
TieredAccountMeta that implements ReadableAccount and support
StoredAccountMeta.

#### Test Plan
More tests will be added once more reader and writer functions for hot
accounts have been added.