### PR TITLE
program: Explicitly pull in `getrandom` with `custom` feature

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -36,6 +36,15 @@ solana-frozen-abi-macro = { workspace = true }
 solana-sdk-macro = { workspace = true }
 thiserror = { workspace = true }
 
+# This is currently needed to build on-chain programs reliably.
+# Borsh 0.10 may pull in hashbrown 0.13, which uses ahash 0.8, which uses
+# getrandom 0.2 underneath. This explicit dependency allows for no-std if cargo
+# upgrades Borsh's dependency to hashbrown 0.13.
+# Remove this once borsh 0.11 or 1.0 is released, which correctly declares the
+# hashbrown dependency as optional.
+[target.'cfg(target_os = "solana")'.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }


### PR DESCRIPTION
#### Problem

Currently, it's possible for programs to become unbuildable due to a transitive dependency from borsh 0.10 -> hashbrown 0.13 -> ahash 0.8 -> getrandom 0.2.

It's possible to constantly update the Cargo.lock file to force hashbrown 0.12, but cargo will constantly update it, making this a losing battle.

#### Summary of Changes

As pointed out in https://github.com/solana-labs/solana-program-library/pull/4703, we just need to explicitly declare the dependency on getrandom.

It's fine to do it in individual programs, but other downstream users won't know, so let's put it at the highest point where the problem is introduced, in `solana-program`.

I tested that this works for SPL using a local monorepo, thanks for finding the fix @KirillLykov !

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
