### PR TITLE
Fixes `cargo check --tests` on macOS

### DIFF
--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -90,7 +90,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os = "linux")]
     use super::*;
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
#### Problem

Running `cargo check --tests` on macOS will fail with errors like:
```
error[E0425]: cannot find function `is_niceness_adjustment_valid` in this scope
   --> perf/src/thread.rs:128:20
    |
128 |         assert_eq!(is_niceness_adjustment_valid("0"), Ok(()));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this function
    |
93  |     use crate::thread::is_niceness_adjustment_valid;
    |

error[E0425]: cannot find function `is_niceness_adjustment_valid` in this scope
   --> perf/src/thread.rs:129:17
    |
129 |         assert!(is_niceness_adjustment_valid("128").is_err());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this function
    |
93  |     use crate::thread::is_niceness_adjustment_valid;
    |

error[E0425]: cannot find function `is_niceness_adjustment_valid` in this scope
   --> perf/src/thread.rs:130:17
    |
130 |         assert!(is_niceness_adjustment_valid("-129").is_err());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this function
    |
93  |     use crate::thread::is_niceness_adjustment_valid;
    |
```

because the import statement is only enabled for linux.


#### Summary of Changes

Inside the tests, import `super::*` for all target operating systems.