### PR TITLE
New method to send large number of transactions to the cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5487,6 +5487,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
+ "dashmap 4.0.2",
  "futures 0.3.28",
  "futures-util",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5520,6 +5520,7 @@ version = "1.17.0"
 dependencies = [
  "futures-util",
  "serde_json",
+ "solana-client",
  "solana-ledger",
  "solana-logger",
  "solana-measure",

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -21,6 +21,7 @@ use {
     },
     solana_client::{
         connection_cache::ConnectionCache,
+        send_and_confirm_transactions_in_parallel::send_and_confirm_transactions_in_parallel_with_spinner_blocking,
         tpu_client::{TpuClient, TpuClientConfig},
     },
     solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
@@ -2162,37 +2163,37 @@ fn send_deploy_messages(
     if !write_messages.is_empty() {
         if let Some(write_signer) = write_signer {
             trace!("Writing program data");
-            let connection_cache = if config.use_quic {
-                ConnectionCache::new_quic("connection_cache_cli_program_quic", 1)
+            let transaction_errors = if config.use_quic {
+                send_and_confirm_transactions_in_parallel_with_spinner_blocking(
+                    rpc_client.clone(),
+                    config.websocket_url.clone(),
+                    write_messages,
+                    &[payer_signer, write_signer],
+                )
             } else {
-                ConnectionCache::with_udp("connection_cache_cli_program_udp", 1)
+                let connection_cache =
+                    ConnectionCache::with_udp("connection_cache_cli_program_udp", 1);
+                if let ConnectionCache::Udp(cache) = connection_cache {
+                    TpuClient::new_with_connection_cache(
+                        rpc_client.clone(),
+                        &config.websocket_url,
+                        TpuClientConfig::default(),
+                        cache,
+                    )?
+                    .send_and_confirm_messages_with_spinner(
+                        write_messages,
+                        &[payer_signer, write_signer],
+                    )
+                } else {
+                    // should not happen
+                    return Err("Expected UDP connection cache".into());
+                }
             };
-            let transaction_errors = match connection_cache {
-                ConnectionCache::Udp(cache) => TpuClient::new_with_connection_cache(
-                    rpc_client.clone(),
-                    &config.websocket_url,
-                    TpuClientConfig::default(),
-                    cache,
-                )?
-                .send_and_confirm_messages_with_spinner(
-                    write_messages,
-                    &[payer_signer, write_signer],
-                ),
-                ConnectionCache::Quic(cache) => TpuClient::new_with_connection_cache(
-                    rpc_client.clone(),
-                    &config.websocket_url,
-                    TpuClientConfig::default(),
-                    cache,
-                )?
-                .send_and_confirm_messages_with_spinner(
-                    write_messages,
-                    &[payer_signer, write_signer],
-                ),
-            }
-            .map_err(|err| format!("Data writes to account failed: {err}"))?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+            let transaction_errors = transaction_errors
+                .map_err(|err| format!("Data writes to account failed: {err}"))?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
 
             if !transaction_errors.is_empty() {
                 for transaction_error in &transaction_errors {

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 [dependencies]
 futures-util = { workspace = true }
 serde_json = { workspace = true }
-solana-client = {workspace = true}
+solana-client = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-merkle-tree = { workspace = true }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 [dependencies]
 futures-util = { workspace = true }
 serde_json = { workspace = true }
+solana-client = {workspace = true}
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-merkle-tree = { workspace = true }

--- a/client-test/tests/send_and_confrim_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confrim_transactions_in_parallel.rs
@@ -1,0 +1,139 @@
+use {
+    solana_client::{
+        nonblocking::tpu_client::TpuClient,
+        send_and_confirm_transactions_in_parallel::{
+            send_and_confirm_transactions_in_parallel_blocking, SendAndConfrimConfig,
+        },
+    },
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig, message::Message, native_token::sol_to_lamports,
+        pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction,
+    },
+    solana_streamer::socket::SocketAddrSpace,
+    solana_test_validator::TestValidator,
+    std::sync::Arc,
+};
+
+const NB_TRANSACTIONS: usize = 1000;
+
+fn create_messages(from: Pubkey, to: Pubkey) -> (Vec<Message>, f64) {
+    let mut messages = vec![];
+    let mut sum = 0.0;
+    for i in 1..NB_TRANSACTIONS {
+        let amount_to_transfer = i as f64;
+        let ix = system_instruction::transfer(&from, &to, sol_to_lamports(amount_to_transfer));
+        let message = Message::new(&[ix], Some(&from));
+        messages.push(message);
+        sum += amount_to_transfer;
+    }
+    (messages, sum)
+}
+
+#[test]
+fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
+    solana_logger::setup();
+
+    let alice = Keypair::new();
+    let test_validator =
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+
+    let bob_pubkey = solana_sdk::pubkey::new_rand();
+    let alice_pubkey = alice.pubkey();
+
+    let client = Arc::new(RpcClient::new(test_validator.rpc_url()));
+
+    assert_eq!(
+        client.get_version().unwrap().solana_core,
+        solana_version::semver!()
+    );
+
+    let original_alice_balance = client.get_balance(&alice.pubkey()).unwrap();
+    let (messages, sum) = create_messages(alice_pubkey, bob_pubkey);
+
+    let txs_errors = send_and_confirm_transactions_in_parallel_blocking(
+        client.clone(),
+        None,
+        &messages,
+        &[&alice],
+        SendAndConfrimConfig {
+            with_spinner: false,
+            resign_txs_count: Some(5),
+        },
+    );
+    assert!(txs_errors.is_ok());
+    assert!(txs_errors.unwrap().iter().all(|x| x.is_none()));
+
+    assert_eq!(
+        client
+            .get_balance_with_commitment(&bob_pubkey, CommitmentConfig::processed())
+            .unwrap()
+            .value,
+        sol_to_lamports(sum)
+    );
+    assert_eq!(
+        client
+            .get_balance_with_commitment(&alice_pubkey, CommitmentConfig::processed())
+            .unwrap()
+            .value,
+        original_alice_balance - sol_to_lamports(sum)
+    );
+}
+
+#[test]
+fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
+    solana_logger::setup();
+
+    let alice = Keypair::new();
+    let test_validator =
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+
+    let bob_pubkey = solana_sdk::pubkey::new_rand();
+    let alice_pubkey = alice.pubkey();
+
+    let client = Arc::new(RpcClient::new(test_validator.rpc_url()));
+
+    assert_eq!(
+        client.get_version().unwrap().solana_core,
+        solana_version::semver!()
+    );
+
+    let original_alice_balance = client.get_balance(&alice.pubkey()).unwrap();
+    let (messages, sum) = create_messages(alice_pubkey, bob_pubkey);
+    let ws_url = test_validator.rpc_pubsub_url();
+    let tpu_client_fut = TpuClient::new(
+        "temp",
+        client.get_inner_client().clone(),
+        ws_url.as_str(),
+        solana_client::tpu_client::TpuClientConfig::default(),
+    );
+    let tpu_client = client.runtime().block_on(tpu_client_fut).unwrap();
+
+    let txs_errors = send_and_confirm_transactions_in_parallel_blocking(
+        client.clone(),
+        Some(tpu_client),
+        &messages,
+        &[&alice],
+        SendAndConfrimConfig {
+            with_spinner: false,
+            resign_txs_count: Some(5),
+        },
+    );
+    assert!(txs_errors.is_ok());
+    assert!(txs_errors.unwrap().iter().all(|x| x.is_none()));
+
+    assert_eq!(
+        client
+            .get_balance_with_commitment(&bob_pubkey, CommitmentConfig::processed())
+            .unwrap()
+            .value,
+        sol_to_lamports(sum)
+    );
+    assert_eq!(
+        client
+            .get_balance_with_commitment(&alice_pubkey, CommitmentConfig::processed())
+            .unwrap()
+            .value,
+        original_alice_balance - sol_to_lamports(sum)
+    );
+}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -35,6 +35,7 @@ solana-tpu-client = { workspace = true, features = ["default"] }
 solana-udp-client = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+dashmap = { workspace = true }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 indexmap = { workspace = true }
@@ -35,7 +36,6 @@ solana-tpu-client = { workspace = true, features = ["default"] }
 solana-udp-client = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-dashmap = { workspace = true }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod connection_cache;
 pub mod nonblocking;
 pub mod quic_client;
+pub mod send_and_confirm_transactions_in_parallel;
 pub mod thin_client;
 pub mod tpu_client;
 pub mod tpu_connection;

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -6,10 +6,11 @@ use {
     },
     bincode::serialize,
     dashmap::DashMap,
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::spinner,
     solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
     solana_sdk::{
-        clock::{MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES},
+        hash::Hash,
         message::Message,
         signature::Signature,
         signers::Signers,
@@ -17,7 +18,7 @@ use {
     },
     solana_tpu_client::{
         nonblocking::tpu_client::set_message_for_confirmed_transactions,
-        tpu_client::{Result, TpuClientConfig},
+        tpu_client::{Result, TpuClientConfig, TpuSenderError},
     },
     std::{
         sync::{
@@ -26,7 +27,7 @@ use {
         },
         time::Duration,
     },
-    tokio::sync::{Mutex, RwLock},
+    tokio::{sync::RwLock, task::JoinHandle, time::Instant},
 };
 
 const BLOCKHASH_REFRESH_RATE: Duration = Duration::from_secs(5);
@@ -35,35 +36,236 @@ const TPU_RESEND_REFRESH_RATE: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Debug)]
 struct TransactionData {
-    blockheight: u64,
     last_valid_blockheight: u64,
     transaction: Transaction,
     index: usize,
 }
 
-pub fn send_and_confirm_transactions_in_parallel_with_spinner_blocking<T: Signers + ?Sized>(
+#[derive(Clone, Debug, Copy)]
+struct BlockHashData {
+    pub blockhash: Hash,
+    pub last_valid_blockheight: u64,
+}
+
+pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
     rpc_client: Arc<BlockingRpcClient>,
     websocket_url: String,
     messages: &[Message],
     signers: &T,
+    resign_txs_count: Option<usize>,
+    with_spinner: bool,
 ) -> Result<Vec<Option<TransactionError>>> {
-    let fut = send_and_confirm_transactions_in_parallel_with_spinner(
+    let fut = send_and_confirm_transactions_in_parallel(
         rpc_client.get_inner_client().clone(),
         websocket_url,
         messages,
         signers,
+        resign_txs_count,
+        with_spinner,
     );
     tokio::task::block_in_place(|| rpc_client.runtime().block_on(fut))
+}
+
+fn create_blockhash_data_updating_task(
+    rpc_client: Arc<RpcClient>,
+    blockhash_data_rw: Arc<RwLock<BlockHashData>>,
+    current_blockheight: Arc<AtomicU64>,
+    exit_signal: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while !exit_signal.load(std::sync::atomic::Ordering::Relaxed) {
+            if let Ok(blockhash_and_valid_height) = rpc_client
+                .get_latest_blockhash_with_commitment(rpc_client.commitment())
+                .await
+            {
+                *blockhash_data_rw.write().await = BlockHashData {
+                    blockhash: blockhash_and_valid_height.0,
+                    last_valid_blockheight: blockhash_and_valid_height.1,
+                };
+            }
+
+            if let Ok(blockheight) = rpc_client.get_block_height().await {
+                current_blockheight.store(blockheight, Ordering::Relaxed);
+            }
+            tokio::time::sleep(BLOCKHASH_REFRESH_RATE).await;
+        }
+    })
+}
+
+fn create_transaction_confirmation_task(
+    nb_transasction_count: usize,
+    rpc_client: Arc<RpcClient>,
+    current_blockheight: Arc<AtomicU64>,
+    transaction_map: Arc<DashMap<Signature, TransactionData>>,
+    confirmed_transactions: Arc<AtomicU32>,
+    exit_signal: Arc<AtomicBool>,
+) -> JoinHandle<Vec<Option<TransactionError>>> {
+    tokio::spawn(async move {
+        let mut transaction_errors = vec![None; nb_transasction_count];
+        while !exit_signal.load(Ordering::Relaxed) {
+            let instant = Instant::now();
+            if !transaction_map.is_empty() {
+                let current_blockheight = current_blockheight.load(Ordering::Relaxed);
+                let transactions_to_verify: Vec<Signature> = transaction_map
+                    .iter()
+                    .filter(|x| current_blockheight < x.last_valid_blockheight)
+                    .map(|x| *x.key())
+                    .collect();
+                for signatures in
+                    transactions_to_verify.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
+                {
+                    if let Ok(result) = rpc_client.get_signature_statuses(signatures).await {
+                        let statuses = result.value;
+                        for (signature, status) in signatures.iter().zip(statuses.into_iter()) {
+                            if let Some(status) = status {
+                                if status.satisfies_commitment(rpc_client.commitment()) {
+                                    if let Some((_, data)) = transaction_map.remove(signature) {
+                                        confirmed_transactions.fetch_add(1, Ordering::Relaxed);
+                                        transaction_errors[data.index] = status.err;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            let elapsed = instant.elapsed();
+            if elapsed < CONFIRMATION_REFRESH_RATE {
+                tokio::time::sleep(CONFIRMATION_REFRESH_RATE - elapsed).await;
+            }
+        }
+        transaction_errors
+    })
+}
+
+async fn sign_all_messages_and_send<T: Signers + ?Sized>(
+    progress_bar: &Option<indicatif::ProgressBar>,
+    tpu_client: &TpuClient<QuicPool, QuicConnectionManager, QuicConfig>,
+    transaction_map: Arc<DashMap<Signature, TransactionData>>,
+    messages_with_index: Vec<(usize, Message)>,
+    blockhash_data_rw: Arc<RwLock<BlockHashData>>,
+    signers: &T,
+    confirmed_transactions: Arc<AtomicU32>,
+    total_transactions: usize,
+) -> Result<()> {
+    // send all the transaction meesages
+    for (index, message) in messages_with_index.iter() {
+        let mut transaction = Transaction::new_unsigned(message.clone());
+        let blockhashdata = *blockhash_data_rw.read().await;
+        transaction.try_sign(signers, blockhashdata.blockhash)?;
+        let signature = transaction.signatures[0];
+        if !tpu_client.send_transaction(&transaction).await {
+            let _ = tpu_client
+                .rpc_client()
+                .send_transaction(&transaction)
+                .await
+                .is_ok();
+        }
+        // send to confirm the transaction
+        transaction_map.insert(
+            signature,
+            TransactionData {
+                index: *index,
+                transaction,
+                last_valid_blockheight: blockhashdata.last_valid_blockheight,
+            },
+        );
+
+        if let Some(progress_bar) = progress_bar {
+            set_message_for_confirmed_transactions(
+                progress_bar,
+                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                total_transactions,
+                None,
+                blockhashdata.last_valid_blockheight,
+                &format!("Sending {}/{} transactions", index + 1, total_transactions,),
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
+    progress_bar: &Option<indicatif::ProgressBar>,
+    tpu_client: &TpuClient<QuicPool, QuicConnectionManager, QuicConfig>,
+    transaction_map: Arc<DashMap<Signature, TransactionData>>,
+    current_blockheight: Arc<AtomicU64>,
+    confirmed_transactions: Arc<AtomicU32>,
+    wait_till_blockheight: u64,
+    total_transactions: usize,
+) {
+    let transactions_to_confirm = transaction_map.len();
+
+    if let Some(progress_bar) = progress_bar {
+        set_message_for_confirmed_transactions(
+            progress_bar,
+            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+            total_transactions,
+            Some(current_blockheight.load(Ordering::Relaxed)),
+            wait_till_blockheight,
+            &format!("Waiting for next block, {transactions_to_confirm} transactions pending..."),
+        );
+    }
+
+    // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
+    while !transaction_map.is_empty()
+        && current_blockheight.load(Ordering::Relaxed) < wait_till_blockheight
+    {
+        let blockheight = current_blockheight.load(Ordering::Relaxed);
+
+        if let Some(progress_bar) = progress_bar {
+            set_message_for_confirmed_transactions(
+                progress_bar,
+                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                total_transactions,
+                Some(blockheight),
+                wait_till_blockheight,
+                "Checking transaction status...",
+            );
+        }
+
+        let instant = Instant::now();
+        // retry sending transaction only over TPU port / any transactions sent over RPC will be automatically rebroadcast by the RPC server
+        let txs_to_resend_over_tpu = transaction_map
+            .iter()
+            .filter(|x| blockheight < x.last_valid_blockheight)
+            .map(|x| {
+                serialize(&x.transaction)
+                    .expect("Should serialize as it has been serialized before")
+            })
+            .collect();
+        let _ = tpu_client
+            .try_send_wire_transaction_batch(txs_to_resend_over_tpu)
+            .await;
+
+        let elapsed = instant.elapsed();
+        if elapsed < TPU_RESEND_REFRESH_RATE {
+            tokio::time::sleep(TPU_RESEND_REFRESH_RATE - elapsed).await;
+        }
+    }
+
+    if let Some(progress_bar) = progress_bar {
+        set_message_for_confirmed_transactions(
+            progress_bar,
+            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+            total_transactions,
+            Some(current_blockheight.load(Ordering::Relaxed)),
+            wait_till_blockheight,
+            "Checking transaction status...",
+        );
+    }
 }
 
 // This is a new method which will be able to send and confirm a large amount of transactions
 // usually the send_and_confirm_transactions_with_spinner for QUIC clients are optimized for small number of transactions
 // If we use these methods
-pub async fn send_and_confirm_transactions_in_parallel_with_spinner<T: Signers + ?Sized>(
+pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     rpc_client: Arc<RpcClient>,
     websocket_url: String,
     messages: &[Message],
     signers: &T,
+    resign_txs_count: Option<usize>,
+    with_spinner: bool,
 ) -> Result<Vec<Option<TransactionError>>> {
     let connection_cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
     let tpu_client = if let ConnectionCache::Quic(cache) = connection_cache {
@@ -76,99 +278,58 @@ pub async fn send_and_confirm_transactions_in_parallel_with_spinner<T: Signers +
         .await?
     } else {
         // should not ever happen
-        return Err(solana_tpu_client::tpu_client::TpuSenderError::Custom(
-            "Exepeced quic connection cache".to_string(),
-        ));
+        panic!("Expected a quic connection cache");
     };
-    // get current blockhash
-    let original_block_hash = rpc_client.get_latest_blockhash().await?;
-    let block_hash_rw = Arc::new(RwLock::new(original_block_hash));
-    let current_block_height = Arc::new(AtomicU64::new(0));
+    // get current blockhash and corresponding last valid block height
+    let blockhash_and_valid_height = rpc_client
+        .get_latest_blockhash_with_commitment(rpc_client.commitment())
+        .await?;
+    let blockhash_data_rw = Arc::new(RwLock::new(BlockHashData {
+        blockhash: blockhash_and_valid_height.0,
+        last_valid_blockheight: blockhash_and_valid_height.1,
+    }));
 
-    let progress_bar = spinner::new_progress_bar();
-    progress_bar.set_message("Setting up...");
+    // get current blockheight
+    let block_height = rpc_client.get_block_height().await?;
+    let current_blockheight = Arc::new(AtomicU64::new(block_height));
+
+    let progress_bar = if with_spinner {
+        let progress_bar = spinner::new_progress_bar();
+        progress_bar.set_message("Setting up...");
+        Some(progress_bar)
+    } else {
+        None
+    };
 
     let exit_signal = Arc::new(AtomicBool::new(false));
 
     // blockhash anc blockheight update task
-    {
-        let rpc_client = rpc_client.clone();
-        let block_hash_rw = block_hash_rw.clone();
-        let exit_signal = exit_signal.clone();
-        let current_block_height = current_block_height.clone();
-        tokio::spawn(async move {
-            while !exit_signal.load(std::sync::atomic::Ordering::Relaxed) {
-                if let Ok(blockhash) = rpc_client.get_latest_blockhash().await {
-                    *block_hash_rw.write().await = blockhash;
-                }
-
-                if let Ok(block_height) = rpc_client.get_block_height().await {
-                    current_block_height.store(block_height, std::sync::atomic::Ordering::Relaxed);
-                }
-                tokio::time::sleep(BLOCKHASH_REFRESH_RATE).await;
-            }
-        });
-    }
+    let block_data_task = create_blockhash_data_updating_task(
+        rpc_client.clone(),
+        blockhash_data_rw.clone(),
+        current_blockheight.clone(),
+        exit_signal.clone(),
+    );
 
     let transaction_map = Arc::new(DashMap::<Signature, TransactionData>::new());
-    let transaction_errors = Arc::new(Mutex::new(vec![None; messages.len()]));
     let confirmed_transactions = Arc::new(AtomicU32::new(0));
     // tasks which confirms the transactions that were sent
-    {
-        let exit_signal = exit_signal.clone();
-        let current_block_height = current_block_height.clone();
-        let transaction_map = transaction_map.clone();
-        let rpc_client = rpc_client.clone();
-        let confirmed_transactions = confirmed_transactions.clone();
-        let transaction_errors = transaction_errors.clone();
-        tokio::spawn(async move {
-            while !exit_signal.load(Ordering::Relaxed) {
-                if !transaction_map.is_empty() {
-                    // transaction is valid for MAX_PROCESSING_AGE
-                    // We only verify the transactions till MAX_RECENT_BLOCKHASHES which is 2*MAX_PROCESSING_AGE
-                    // If the transaction is not confirmed in MAX_RECENT_BLOCKHASHES we declare that it is expired.
-                    // give our CONFIRMATION_REFRESH_RATE of 5 secs we can have maximum 12.5 blocks
-                    // So there are 300 slots for the transactions to get confirmed
-                    let current_block_height = current_block_height.load(Ordering::Relaxed);
-                    let transactions_to_verify: Vec<Signature> = transaction_map
-                        .iter()
-                        .filter(|x| {
-                            current_block_height < x.blockheight + MAX_RECENT_BLOCKHASHES as u64
-                        })
-                        .map(|x| *x.key())
-                        .collect();
-                    for signatures in
-                        transactions_to_verify.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
-                    {
-                        if let Ok(result) = rpc_client.get_signature_statuses(signatures).await {
-                            let statuses = result.value;
-                            for (signature, status) in signatures.iter().zip(statuses.into_iter()) {
-                                if let Some(status) = status {
-                                    if status.satisfies_commitment(rpc_client.commitment()) {
-                                        if let Some((_, data)) = transaction_map.remove(signature) {
-                                            confirmed_transactions.fetch_add(1, Ordering::Relaxed);
-                                            let mut transaction_errors =
-                                                transaction_errors.lock().await;
-                                            transaction_errors[data.index] = status.err;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                tokio::time::sleep(CONFIRMATION_REFRESH_RATE).await;
-            }
-        });
-    }
+    let transaction_confirming_task = create_transaction_confirmation_task(
+        messages.len(),
+        rpc_client.clone(),
+        current_blockheight.clone(),
+        transaction_map.clone(),
+        confirmed_transactions.clone(),
+        exit_signal.clone(),
+    );
 
     // transaction sender task
     let total_transactions = messages.len();
     let mut initial = true;
-    for expired_blockhash_retries in (0..5).rev() {
+    let signing_count = resign_txs_count.unwrap_or(1);
+    for expired_blockhash_retries in (0..signing_count).rev() {
         // only send messages which have not been confirmed
-        let nb_transaction = messages.len();
-        let messages: Vec<(usize, Message)> = if initial {
+        let messages_with_index: Vec<(usize, Message)> = if initial {
             initial = false;
             messages.iter().cloned().enumerate().collect()
         } else {
@@ -179,100 +340,60 @@ pub async fn send_and_confirm_transactions_in_parallel_with_spinner<T: Signers +
                 .collect()
         };
 
-        if messages.is_empty() {
+        if messages_with_index.is_empty() {
             break;
         }
 
         // clear the map so that we can start resending
         transaction_map.clear();
 
-        for (index, message) in messages.iter() {
-            let mut transaction = Transaction::new_unsigned(message.clone());
-            let blockhash = *block_hash_rw.read().await;
-            transaction.try_sign(signers, blockhash)?;
-            let signautre = transaction.signatures[0];
-            if !tpu_client.send_transaction(&transaction).await {
-                let _ = tpu_client
-                    .rpc_client()
-                    .send_transaction(&transaction)
-                    .await
-                    .is_ok();
-            }
-            let blockheight = current_block_height.load(std::sync::atomic::Ordering::Relaxed);
-            let last_valid_blockheight = blockheight + MAX_PROCESSING_AGE as u64;
-            // send to confirm the transaction
-            transaction_map.insert(
-                signautre,
-                TransactionData {
-                    index: *index,
-                    blockheight,
-                    transaction,
-                    last_valid_blockheight,
-                },
-            );
-
-            set_message_for_confirmed_transactions(
-                &progress_bar,
-                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
-                total_transactions,
-                Some(blockheight), //block_height,
-                last_valid_blockheight,
-                &format!("Sending {}/{} transactions", index + 1, nb_transaction,),
-            );
-        }
-        let blockheight = current_block_height.load(std::sync::atomic::Ordering::Relaxed);
-        let wait_till_blockheight = blockheight + MAX_PROCESSING_AGE as u64;
-
-        let transactions_to_confirm = transaction_map.len();
-        set_message_for_confirmed_transactions(
+        sign_all_messages_and_send(
             &progress_bar,
-            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+            &tpu_client,
+            transaction_map.clone(),
+            messages_with_index,
+            blockhash_data_rw.clone(),
+            signers,
+            confirmed_transactions.clone(),
             total_transactions,
-            Some(blockheight),
-            wait_till_blockheight,
-            &format!("Waiting for next block, {transactions_to_confirm} transactions pending..."),
-        );
+        )
+        .await?;
 
-        // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
-        while !transaction_map.is_empty()
-            && current_block_height.load(Ordering::Relaxed) < wait_till_blockheight
-        {
-            let blockheight = current_block_height.load(Ordering::Relaxed);
-            set_message_for_confirmed_transactions(
-                &progress_bar,
-                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
-                total_transactions,
-                Some(blockheight),
-                wait_till_blockheight,
-                "Checking transaction status...",
-            );
-            // retry sending transaction only over TPU port / usually we should send transaction once over RPC port but multiple times over tpu port
-            let txs_to_resend_over_tpu = transaction_map
-                .iter()
-                .filter(|x| blockheight < x.last_valid_blockheight)
-                .map(|x| {
-                    serialize(&x.transaction)
-                        .expect("Should serialize as it has been serialized before")
-                })
-                .collect();
-            let _ = tpu_client
-                .try_send_wire_transaction_batch(txs_to_resend_over_tpu)
-                .await;
-            tokio::time::sleep(TPU_RESEND_REFRESH_RATE).await;
-        }
+        // wait till block height till all the transactions are confirmed
+        let block_data = *blockhash_data_rw.read().await;
+        let wait_till_blockheight = block_data.last_valid_blockheight;
+        confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
+            &progress_bar,
+            &tpu_client,
+            transaction_map.clone(),
+            current_blockheight.clone(),
+            confirmed_transactions.clone(),
+            wait_till_blockheight,
+            total_transactions,
+        )
+        .await;
 
         if transaction_map.is_empty() {
             break;
         }
 
-        progress_bar.println(format!(
-            "Blockhash expired. {expired_blockhash_retries} retries remaining"
-        ));
+        if let Some(progress_bar) = &progress_bar {
+            progress_bar.println(format!(
+                "Blockhash expired. {expired_blockhash_retries} retries remaining"
+            ));
+        }
     }
+
     exit_signal.store(true, Ordering::Relaxed);
 
-    let progress_bar = spinner::new_progress_bar();
-    progress_bar.set_message("Setting up...");
-    let return_data = transaction_errors.lock().await;
-    Ok(return_data.clone())
+    block_data_task.abort();
+    if transaction_map.is_empty() {
+        let transaction_errors = transaction_confirming_task
+            .await
+            .expect("Confirmation task should join correctly");
+        Ok(transaction_errors)
+    } else {
+        transaction_confirming_task.abort();
+        Err(TpuSenderError::Custom("Max retries exceeded".into()))
+    }
 }

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -22,7 +22,7 @@ use {
     },
     std::{
         sync::{
-            atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+            atomic::{AtomicU32, AtomicU64, Ordering},
             Arc,
         },
         time::Duration,
@@ -30,8 +30,7 @@ use {
     tokio::{sync::RwLock, task::JoinHandle, time::Instant},
 };
 
-const BLOCKHASH_REFRESH_RATE: Duration = Duration::from_secs(5);
-const CONFIRMATION_REFRESH_RATE: Duration = Duration::from_secs(5);
+const BLOCKHASH_REFRESH_RATE: Duration = Duration::from_secs(10);
 const TPU_RESEND_REFRESH_RATE: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Debug)]
@@ -54,6 +53,7 @@ pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
     signers: &T,
     resign_txs_count: Option<usize>,
     with_spinner: bool,
+    send_over_tpu: bool,
 ) -> Result<Vec<Option<TransactionError>>> {
     let fut = send_and_confirm_transactions_in_parallel(
         rpc_client.get_inner_client().clone(),
@@ -62,6 +62,7 @@ pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
         signers,
         resign_txs_count,
         with_spinner,
+        send_over_tpu,
     );
     tokio::task::block_in_place(|| rpc_client.runtime().block_on(fut))
 }
@@ -70,10 +71,9 @@ fn create_blockhash_data_updating_task(
     rpc_client: Arc<RpcClient>,
     blockhash_data_rw: Arc<RwLock<BlockHashData>>,
     current_blockheight: Arc<AtomicU64>,
-    exit_signal: Arc<AtomicBool>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        while !exit_signal.load(std::sync::atomic::Ordering::Relaxed) {
+        loop {
             if let Ok(blockhash_and_valid_height) = rpc_client
                 .get_latest_blockhash_with_commitment(rpc_client.commitment())
                 .await
@@ -93,21 +93,17 @@ fn create_blockhash_data_updating_task(
 }
 
 fn create_transaction_confirmation_task(
-    nb_transasction_count: usize,
     rpc_client: Arc<RpcClient>,
     current_blockheight: Arc<AtomicU64>,
     transaction_map: Arc<DashMap<Signature, TransactionData>>,
+    errors_map: Arc<DashMap<usize, TransactionError>>,
     confirmed_transactions: Arc<AtomicU32>,
-    exit_signal: Arc<AtomicBool>,
-) -> JoinHandle<Vec<Option<TransactionError>>> {
+) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let mut transaction_errors = vec![None; nb_transasction_count];
-
         // we also check last time all transaction that have just expired between two checks
         let mut last_block_height = current_blockheight.load(Ordering::Relaxed);
 
-        while !exit_signal.load(Ordering::Relaxed) {
-            let instant = Instant::now();
+        loop {
             if !transaction_map.is_empty() {
                 let current_blockheight = current_blockheight.load(Ordering::Relaxed);
                 let transactions_to_verify: Vec<Signature> = transaction_map
@@ -132,7 +128,9 @@ fn create_transaction_confirmation_task(
                                 if status.satisfies_commitment(rpc_client.commitment()) {
                                     if let Some((_, data)) = transaction_map.remove(signature) {
                                         confirmed_transactions.fetch_add(1, Ordering::Relaxed);
-                                        transaction_errors[data.index] = status.err;
+                                        if let Some(error) = status.err {
+                                            errors_map.insert(data.index, error);
+                                        }
                                     }
                                 }
                             }
@@ -142,19 +140,18 @@ fn create_transaction_confirmation_task(
 
                 last_block_height = current_blockheight;
             }
-            let elapsed = instant.elapsed();
-            if elapsed < CONFIRMATION_REFRESH_RATE {
-                tokio::time::sleep(CONFIRMATION_REFRESH_RATE - elapsed).await;
-            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        transaction_errors
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn sign_all_messages_and_send<T: Signers + ?Sized>(
     progress_bar: &Option<indicatif::ProgressBar>,
-    tpu_client: &TpuClient<QuicPool, QuicConnectionManager, QuicConfig>,
+    rpc_client: Arc<RpcClient>,
+    tpu_client: &Option<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
     transaction_map: Arc<DashMap<Signature, TransactionData>>,
+    error_map: Arc<DashMap<usize, TransactionError>>,
     messages_with_index: Vec<(usize, Message)>,
     blockhash_data_rw: Arc<RwLock<BlockHashData>>,
     signers: &T,
@@ -166,14 +163,33 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
     for (counter, (index, message)) in messages_with_index.iter().enumerate() {
         let mut transaction = Transaction::new_unsigned(message.clone());
         let blockhashdata = *blockhash_data_rw.read().await;
-        transaction.try_sign(signers, blockhashdata.blockhash)?;
+
+        // we have already checked if all transactions are signable.
+        transaction
+            .try_sign(signers, blockhashdata.blockhash)
+            .expect("Transaction should be signable");
         let signature = transaction.signatures[0];
-        if !tpu_client.send_transaction(&transaction).await {
-            let _ = tpu_client
-                .rpc_client()
-                .send_transaction(&transaction)
-                .await
-                .is_ok();
+        let send_over_rpc = if let Some(tpu_client) = tpu_client {
+            !tpu_client.send_transaction(&transaction).await
+        } else {
+            true
+        };
+        if send_over_rpc {
+            if let Err(e) = rpc_client.send_transaction(&transaction).await {
+                match e.kind {
+                    solana_rpc_client_api::client_error::ErrorKind::Io(_)
+                    | solana_rpc_client_api::client_error::ErrorKind::Reqwest(_) => {
+                        // continue on io error, we will retry the transaction
+                    }
+                    solana_rpc_client_api::client_error::ErrorKind::TransactionError(e) => {
+                        error_map.insert(*index, e);
+                        continue;
+                    }
+                    _ => {
+                        return Err(e.into());
+                    }
+                }
+            }
         }
         // send to confirm the transaction
         transaction_map.insert(
@@ -205,72 +221,90 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
 
 async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
     progress_bar: &Option<indicatif::ProgressBar>,
-    tpu_client: &TpuClient<QuicPool, QuicConnectionManager, QuicConfig>,
+    tpu_client: &Option<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
     transaction_map: Arc<DashMap<Signature, TransactionData>>,
     current_blockheight: Arc<AtomicU64>,
     confirmed_transactions: Arc<AtomicU32>,
-    wait_till_blockheight: u64,
     total_transactions: usize,
 ) {
     let transactions_to_confirm = transaction_map.len();
+    let max_valid_block_height = transaction_map
+        .iter()
+        .map(|x| x.last_valid_blockheight)
+        .max();
 
-    if let Some(progress_bar) = progress_bar {
-        set_message_for_confirmed_transactions(
-            progress_bar,
-            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
-            total_transactions,
-            Some(current_blockheight.load(Ordering::Relaxed)),
-            wait_till_blockheight,
-            &format!("Waiting for next block, {transactions_to_confirm} transactions pending..."),
-        );
-    }
+    if let Some(mut max_valid_block_height) = max_valid_block_height {
+        if let Some(progress_bar) = progress_bar {
+            set_message_for_confirmed_transactions(
+                progress_bar,
+                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                total_transactions,
+                Some(current_blockheight.load(Ordering::Relaxed)),
+                max_valid_block_height,
+                &format!(
+                    "Waiting for next block, {transactions_to_confirm} transactions pending..."
+                ),
+            );
+        }
 
-    // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
-    while !transaction_map.is_empty()
-        && current_blockheight.load(Ordering::Relaxed) < wait_till_blockheight
-    {
-        let blockheight = current_blockheight.load(Ordering::Relaxed);
+        // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
+        while !transaction_map.is_empty()
+            && current_blockheight.load(Ordering::Relaxed) < max_valid_block_height
+        {
+            let blockheight = current_blockheight.load(Ordering::Relaxed);
+
+            if let Some(progress_bar) = progress_bar {
+                set_message_for_confirmed_transactions(
+                    progress_bar,
+                    confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                    total_transactions,
+                    Some(blockheight),
+                    max_valid_block_height,
+                    "Checking transaction status...",
+                );
+            }
+
+            if let Some(tpu_client) = tpu_client {
+                let instant = Instant::now();
+                // retry sending transaction only over TPU port / any transactions sent over RPC will be automatically rebroadcast by the RPC server
+                let txs_to_resend_over_tpu = transaction_map
+                    .iter()
+                    .filter(|x| blockheight < x.last_valid_blockheight)
+                    .map(|x| {
+                        serialize(&x.transaction)
+                            .expect("Should serialize as it has been serialized before")
+                    })
+                    .collect();
+                let _ = tpu_client
+                    .try_send_wire_transaction_batch(txs_to_resend_over_tpu)
+                    .await;
+
+                let elapsed = instant.elapsed();
+                if elapsed < TPU_RESEND_REFRESH_RATE {
+                    tokio::time::sleep(TPU_RESEND_REFRESH_RATE - elapsed).await;
+                }
+            } else {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            if let Some(max_valid_block_height_in_remaining_transaction) = transaction_map
+                .iter()
+                .map(|x| x.last_valid_blockheight)
+                .max()
+            {
+                max_valid_block_height = max_valid_block_height_in_remaining_transaction;
+            }
+        }
 
         if let Some(progress_bar) = progress_bar {
             set_message_for_confirmed_transactions(
                 progress_bar,
                 confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
                 total_transactions,
-                Some(blockheight),
-                wait_till_blockheight,
+                Some(current_blockheight.load(Ordering::Relaxed)),
+                max_valid_block_height,
                 "Checking transaction status...",
             );
         }
-
-        let instant = Instant::now();
-        // retry sending transaction only over TPU port / any transactions sent over RPC will be automatically rebroadcast by the RPC server
-        let txs_to_resend_over_tpu = transaction_map
-            .iter()
-            .filter(|x| blockheight < x.last_valid_blockheight)
-            .map(|x| {
-                serialize(&x.transaction)
-                    .expect("Should serialize as it has been serialized before")
-            })
-            .collect();
-        let _ = tpu_client
-            .try_send_wire_transaction_batch(txs_to_resend_over_tpu)
-            .await;
-
-        let elapsed = instant.elapsed();
-        if elapsed < TPU_RESEND_REFRESH_RATE {
-            tokio::time::sleep(TPU_RESEND_REFRESH_RATE - elapsed).await;
-        }
-    }
-
-    if let Some(progress_bar) = progress_bar {
-        set_message_for_confirmed_transactions(
-            progress_bar,
-            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
-            total_transactions,
-            Some(current_blockheight.load(Ordering::Relaxed)),
-            wait_till_blockheight,
-            "Checking transaction status...",
-        );
     }
 }
 
@@ -284,19 +318,26 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     signers: &T,
     resign_txs_count: Option<usize>,
     with_spinner: bool,
+    send_over_tpu: bool,
 ) -> Result<Vec<Option<TransactionError>>> {
-    let connection_cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
-    let tpu_client = if let ConnectionCache::Quic(cache) = connection_cache {
-        TpuClient::new_with_connection_cache(
-            rpc_client.clone(),
-            &websocket_url,
-            TpuClientConfig::default(),
-            cache,
-        )
-        .await?
+    let tpu_client = if send_over_tpu {
+        let connection_cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
+        if let ConnectionCache::Quic(cache) = connection_cache {
+            Some(
+                TpuClient::new_with_connection_cache(
+                    rpc_client.clone(),
+                    &websocket_url,
+                    TpuClientConfig::default(),
+                    cache,
+                )
+                .await?,
+            )
+        } else {
+            // should not ever happen
+            panic!("Expected a quic connection cache");
+        }
     } else {
-        // should not ever happen
-        panic!("Expected a quic connection cache");
+        None
     };
     // get current blockhash and corresponding last valid block height
     let blockhash_and_valid_height = rpc_client
@@ -307,38 +348,45 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
         last_valid_blockheight: blockhash_and_valid_height.1,
     }));
 
+    // check if all the messages are signable by the signer
+    let signature_results = messages.iter().map(|x| {
+        let mut transaction = Transaction::new_unsigned(x.clone());
+        transaction.try_sign(signers, blockhash_and_valid_height.0)
+    });
+
+    for signature_result in signature_results {
+        if let Err(e) = signature_result {
+            return Err(e.into());
+        }
+    }
+
     // get current blockheight
     let block_height = rpc_client.get_block_height().await?;
     let current_blockheight = Arc::new(AtomicU64::new(block_height));
 
-    let progress_bar = if with_spinner {
+    let progress_bar = with_spinner.then(|| {
         let progress_bar = spinner::new_progress_bar();
         progress_bar.set_message("Setting up...");
-        Some(progress_bar)
-    } else {
-        None
-    };
-
-    let exit_signal = Arc::new(AtomicBool::new(false));
+        progress_bar
+    });
 
     // blockhash anc blockheight update task
     let block_data_task = create_blockhash_data_updating_task(
         rpc_client.clone(),
         blockhash_data_rw.clone(),
         current_blockheight.clone(),
-        exit_signal.clone(),
     );
 
     let transaction_map = Arc::new(DashMap::<Signature, TransactionData>::new());
+    let error_map = Arc::new(DashMap::new());
     let confirmed_transactions = Arc::new(AtomicU32::new(0));
     // tasks which confirms the transactions that were sent
     let transaction_confirming_task = create_transaction_confirmation_task(
-        messages.len(),
         rpc_client.clone(),
         current_blockheight.clone(),
         transaction_map.clone(),
+        error_map.clone(),
         confirmed_transactions.clone(),
-        exit_signal.clone(),
     );
 
     // transaction sender task
@@ -367,8 +415,10 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
 
         sign_all_messages_and_send(
             &progress_bar,
+            rpc_client.clone(),
             &tpu_client,
             transaction_map.clone(),
+            error_map.clone(),
             messages_with_index,
             blockhash_data_rw.clone(),
             signers,
@@ -378,15 +428,12 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
         .await?;
 
         // wait till block height till all the transactions are confirmed
-        let block_data = *blockhash_data_rw.read().await;
-        let wait_till_blockheight = block_data.last_valid_blockheight;
         confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
             &progress_bar,
             &tpu_client,
             transaction_map.clone(),
             current_blockheight.clone(),
             confirmed_transactions.clone(),
-            wait_till_blockheight,
             total_transactions,
         )
         .await;
@@ -402,16 +449,15 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
         }
     }
 
-    exit_signal.store(true, Ordering::Relaxed);
-
     block_data_task.abort();
+    transaction_confirming_task.abort();
     if transaction_map.is_empty() {
-        let transaction_errors = transaction_confirming_task
-            .await
-            .expect("Confirmation task should join correctly");
+        let mut transaction_errors = vec![None; messages.len()];
+        for iterator in error_map.iter() {
+            transaction_errors[*iterator.key()] = Some(iterator.value().clone());
+        }
         Ok(transaction_errors)
     } else {
-        transaction_confirming_task.abort();
         Err(TpuSenderError::Custom("Max retries exceeded".into()))
     }
 }

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -1,0 +1,254 @@
+use {
+    crate::{
+        connection_cache::ConnectionCache,
+        nonblocking::{rpc_client::RpcClient, tpu_client::TpuClient},
+    },
+    bincode::serialize,
+    dashmap::DashMap,
+    solana_rpc_client::spinner,
+    solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
+    solana_sdk::{
+        clock::{MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES},
+        message::Message,
+        signature::Signature,
+        signers::Signers,
+        transaction::{Transaction, TransactionError},
+    },
+    solana_tpu_client::{
+        nonblocking::tpu_client::set_message_for_confirmed_transactions,
+        tpu_client::{Result, TpuClientConfig},
+    },
+    std::{
+        sync::{
+            atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+    tokio::sync::{Mutex, RwLock},
+};
+
+const BLOCKHASH_REFRESH_RATE: Duration = Duration::from_secs(5);
+const CONFIRMATION_REFRESH_RATE: Duration = Duration::from_secs(5);
+const TPU_RESEND_REFRESH_RATE: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug)]
+struct TransactionData {
+    blockheight: u64,
+    last_valid_blockheight: u64,
+    transaction: Transaction,
+    index: usize,
+}
+
+// This is a new method which will be able to send and confirm a large amount of transactions
+// usually the send_and_confirm_transactions_with_spinner for QUIC clients are optimized for small number of transactions
+// If we use these methods
+pub async fn send_and_confirm_transactions_in_parallel_with_spinner<T: Signers + ?Sized>(
+    rpc_client: Arc<RpcClient>,
+    websocket_url: String,
+    messages: &[Message],
+    signers: &T,
+) -> Result<Vec<Option<TransactionError>>> {
+    let connection_cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
+    let tpu_client = if let ConnectionCache::Quic(cache) = connection_cache {
+        TpuClient::new_with_connection_cache(
+            rpc_client.clone(),
+            &websocket_url,
+            TpuClientConfig::default(),
+            cache,
+        )
+        .await?
+    } else {
+        // should not ever happen
+        return Err(solana_tpu_client::tpu_client::TpuSenderError::Custom(
+            "Exepeced quic connection cache".to_string(),
+        ));
+    };
+    // get current blockhash
+    let original_block_hash = rpc_client.get_latest_blockhash().await?;
+    let block_hash_rw = Arc::new(RwLock::new(original_block_hash));
+    let current_block_height = Arc::new(AtomicU64::new(0));
+
+    let progress_bar = spinner::new_progress_bar();
+    progress_bar.set_message("Setting up...");
+
+    let exit_signal = Arc::new(AtomicBool::new(false));
+
+    // blockhash anc blockheight update task
+    {
+        let rpc_client = rpc_client.clone();
+        let block_hash_rw = block_hash_rw.clone();
+        let exit_signal = exit_signal.clone();
+        let current_block_height = current_block_height.clone();
+        tokio::spawn(async move {
+            while !exit_signal.load(std::sync::atomic::Ordering::Relaxed) {
+                if let Ok(blockhash) = rpc_client.get_latest_blockhash().await {
+                    *block_hash_rw.write().await = blockhash;
+                }
+
+                if let Ok(block_height) = rpc_client.get_block_height().await {
+                    current_block_height.store(block_height, std::sync::atomic::Ordering::Relaxed);
+                }
+                tokio::time::sleep(BLOCKHASH_REFRESH_RATE).await;
+            }
+        });
+    }
+
+    let transaction_map = Arc::new(DashMap::<Signature, TransactionData>::new());
+    let transaction_errors = Arc::new(Mutex::new(vec![None; messages.len()]));
+    let confirmed_transactions = Arc::new(AtomicU32::new(0));
+    // tasks which confirms the transactions that were sent
+    {
+        let exit_signal = exit_signal.clone();
+        let current_block_height = current_block_height.clone();
+        let transaction_map = transaction_map.clone();
+        let rpc_client = rpc_client.clone();
+        let confirmed_transactions = confirmed_transactions.clone();
+        let transaction_errors = transaction_errors.clone();
+        tokio::spawn(async move {
+            while !exit_signal.load(Ordering::Relaxed) {
+                if !transaction_map.is_empty() {
+                    // transaction is valid for MAX_PROCESSING_AGE
+                    // We only verify the transactions till MAX_RECENT_BLOCKHASHES which is 2*MAX_PROCESSING_AGE
+                    // If the transaction is not confirmed in MAX_RECENT_BLOCKHASHES we declare that it is expired.
+                    // give our CONFIRMATION_REFRESH_RATE of 5 secs we can have maximum 12.5 blocks
+                    // So there are 300 slots for the transactions to get confirmed
+                    let current_block_height = current_block_height.load(Ordering::Relaxed);
+                    let transactions_to_verify: Vec<Signature> = transaction_map
+                        .iter()
+                        .filter(|x| {
+                            current_block_height < x.blockheight + MAX_RECENT_BLOCKHASHES as u64
+                        })
+                        .map(|x| *x.key())
+                        .collect();
+                    for signatures in
+                        transactions_to_verify.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
+                    {
+                        if let Ok(result) = rpc_client.get_signature_statuses(signatures).await {
+                            let statuses = result.value;
+                            for (signature, status) in signatures.iter().zip(statuses.into_iter()) {
+                                if let Some(status) = status {
+                                    if status.satisfies_commitment(rpc_client.commitment()) {
+                                        if let Some((_, data)) = transaction_map.remove(signature) {
+                                            confirmed_transactions.fetch_add(1, Ordering::Relaxed);
+                                            let mut transaction_errors =
+                                                transaction_errors.lock().await;
+                                            transaction_errors[data.index] = status.err;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                tokio::time::sleep(CONFIRMATION_REFRESH_RATE).await;
+            }
+        });
+    }
+
+    // transaction sender task
+    let total_transactions = messages.len();
+    let mut initial = true;
+    for expired_blockhash_retries in (0..5).rev() {
+        // only send messages which have not been confirmed
+        let nb_transaction = messages.len();
+        let messages: Vec<(usize, Message)> = if initial {
+            initial = false;
+            messages.iter().cloned().enumerate().collect()
+        } else {
+            // remove all the confirmed transactions
+            transaction_map
+                .iter()
+                .map(|x| (x.index, x.transaction.message.clone()))
+                .collect()
+        };
+
+        // clear the map so that we can start resending
+        transaction_map.clear();
+
+        for (index, message) in messages.iter() {
+            let mut transaction = Transaction::new_unsigned(message.clone());
+            let blockhash = *block_hash_rw.read().await;
+            transaction.try_sign(signers, blockhash)?;
+            let signautre = transaction.signatures[0];
+            if !tpu_client.send_transaction(&transaction).await {
+                let _ = tpu_client
+                    .rpc_client()
+                    .send_transaction(&transaction)
+                    .await
+                    .is_ok();
+            }
+            let blockheight = current_block_height.load(std::sync::atomic::Ordering::Relaxed);
+            let last_valid_blockheight = blockheight + MAX_PROCESSING_AGE as u64;
+            // send to confirm the transaction
+            transaction_map.insert(
+                signautre,
+                TransactionData {
+                    index: *index,
+                    blockheight,
+                    transaction,
+                    last_valid_blockheight,
+                },
+            );
+
+            set_message_for_confirmed_transactions(
+                &progress_bar,
+                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                total_transactions,
+                Some(blockheight), //block_height,
+                last_valid_blockheight,
+                &format!("Sending {}/{} transactions", index + 1, nb_transaction,),
+            );
+        }
+        let blockheight = current_block_height.load(std::sync::atomic::Ordering::Relaxed);
+        let wait_till_blockheight = blockheight + MAX_PROCESSING_AGE as u64;
+
+        let transactions_to_confirm = transaction_map.len();
+        set_message_for_confirmed_transactions(
+            &progress_bar,
+            confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+            total_transactions,
+            Some(blockheight),
+            wait_till_blockheight,
+            &format!("Waiting for next block, {transactions_to_confirm} transactions pending..."),
+        );
+
+        // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
+        while !transaction_map.is_empty()
+            && current_block_height.load(Ordering::Relaxed) < wait_till_blockheight
+        {
+            let blockheight = current_block_height.load(Ordering::Relaxed);
+            set_message_for_confirmed_transactions(
+                &progress_bar,
+                confirmed_transactions.load(std::sync::atomic::Ordering::Relaxed),
+                total_transactions,
+                Some(blockheight),
+                blockheight + MAX_PROCESSING_AGE as u64,
+                "Checking transaction status...",
+            );
+            // retry sending transaction only over TPU port / usually we should send transaction once over RPC port but multiple times over tpu port
+            let txs_to_resend_over_tpu = transaction_map
+                .iter()
+                .filter(|x| blockheight < x.last_valid_blockheight)
+                .map(|x| {
+                    serialize(&x.transaction)
+                        .expect("Should serialize as it has been serialized before")
+                })
+                .collect();
+            let _ = tpu_client
+                .try_send_wire_transaction_batch(txs_to_resend_over_tpu)
+                .await;
+            tokio::time::sleep(TPU_RESEND_REFRESH_RATE).await;
+        }
+
+        progress_bar.println(format!(
+            "Blockhash expired. {expired_blockhash_retries} retries remaining"
+        ));
+    }
+    exit_signal.store(true, Ordering::Relaxed);
+
+    let progress_bar = spinner::new_progress_bar();
+    progress_bar.set_message("Setting up...");
+    let return_data = transaction_errors.lock().await;
+    Ok(return_data.clone())
+}

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -187,7 +187,7 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
                 match e.kind {
                     solana_rpc_client_api::client_error::ErrorKind::Io(_)
                     | solana_rpc_client_api::client_error::ErrorKind::Reqwest(_) => {
-                        // continue on io error, we will retry the transaction
+                        // fall through on io error, we will retry the transaction
                     }
                     solana_rpc_client_api::client_error::ErrorKind::TransactionError(e) => {
                         error_map.insert(*index, e);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4666,6 +4666,7 @@ version = "1.17.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "dashmap",
  "futures 0.3.28",
  "futures-util",
  "indexmap 1.9.3",

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -52,7 +52,7 @@ use {
 };
 
 #[cfg(feature = "spinner")]
-fn set_message_for_confirmed_transactions(
+pub fn set_message_for_confirmed_transactions(
     progress_bar: &ProgressBar,
     confirmed_transactions: u32,
     total_transactions: usize,


### PR DESCRIPTION
#### Problem

Uploading a program with a large size is very difficult because the program is broken into small transactions and sent to the cluster. It will try to send all the transactions at once and then confirm them. If the program needs to send 1000 transaction to be uploaded, it will sign all transactions with a blockhash and while uploading the transactions will expire and will not be confirmed.

#### Summary of Changes

Updating continuously the blockhash with a task, and confirming the transaction with another. 
Using the new algorithm to update programs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
