### PR TITLE
`cargo fmt` using 1.6.0-nightly

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -75,7 +75,8 @@ impl AccountsHashVerifier {
                     )) = Self::get_next_accounts_package(
                         &accounts_package_sender,
                         &accounts_package_receiver,
-                    ) else {
+                    )
+                    else {
                         std::thread::sleep(LOOP_LIMITER);
                         continue;
                     };
@@ -302,7 +303,9 @@ impl AccountsHashVerifier {
                 (accounts_hash.into(), accounts_hash, None)
             }
             CalcAccountsHashFlavor::Incremental => {
-                let AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(base_slot)) = accounts_package.package_type else {
+                let AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(base_slot)) =
+                    accounts_package.package_type
+                else {
                     panic!("Calculating incremental accounts hash requires a base slot");
                 };
                 let (base_accounts_hash, base_capitalization) = accounts_package

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2373,7 +2373,9 @@ impl ReplayStage {
 
         // If we are a non voting validator or have an incorrect setup preventing us from
         // generating vote txs, no need to refresh
-        let Some(last_vote_tx_blockhash) = tower.last_vote_tx_blockhash() else { return };
+        let Some(last_vote_tx_blockhash) = tower.last_vote_tx_blockhash() else {
+            return;
+        };
 
         if my_latest_landed_vote >= last_voted_slot
             || heaviest_bank_on_same_fork

--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -425,7 +425,7 @@ pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
             "the required \"digest\" = ... attribute is missing.",
         )
         .to_compile_error()
-        .into()
+        .into();
     };
 
     let item = parse_macro_input!(item as Item);

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -127,15 +127,17 @@ impl GeyserPluginManager {
 
     pub(crate) fn unload_plugin(&mut self, name: &str) -> JsonRpcResult<()> {
         // Check if any plugin names match this one
-        let Some(idx) = self.plugins.iter().position(|plugin| plugin.name().eq(name)) else {
+        let Some(idx) = self
+            .plugins
+            .iter()
+            .position(|plugin| plugin.name().eq(name))
+        else {
             // If we don't find one return an error
-            return Err(
-                jsonrpc_core::error::Error {
-                    code: ErrorCode::InvalidRequest,
-                    message: String::from("The plugin you requested to unload is not loaded"),
-                    data: None,
-                }
-            )
+            return Err(jsonrpc_core::error::Error {
+                code: ErrorCode::InvalidRequest,
+                message: String::from("The plugin you requested to unload is not loaded"),
+                data: None,
+            });
         };
 
         // Unload and drop plugin and lib
@@ -149,15 +151,17 @@ impl GeyserPluginManager {
     /// Then, attempt to load a new plugin
     pub(crate) fn reload_plugin(&mut self, name: &str, config_file: &str) -> JsonRpcResult<()> {
         // Check if any plugin names match this one
-        let Some(idx) = self.plugins.iter().position(|plugin| plugin.name().eq(name)) else {
+        let Some(idx) = self
+            .plugins
+            .iter()
+            .position(|plugin| plugin.name().eq(name))
+        else {
             // If we don't find one return an error
-            return Err(
-                jsonrpc_core::error::Error {
-                    code: ErrorCode::InvalidRequest,
-                    message: String::from("The plugin you requested to reload is not loaded"),
-                    data: None,
-                }
-            )
+            return Err(jsonrpc_core::error::Error {
+                code: ErrorCode::InvalidRequest,
+                message: String::from("The plugin you requested to reload is not loaded"),
+                data: None,
+            });
         };
 
         // Unload and drop current plugin first in case plugin requires exclusive access to resource,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -990,10 +990,11 @@ fn get_latest_optimistic_slots(
     let Some(latest_slot) = blockstore
         .get_latest_optimistic_slots(1)
         .expect("get_latest_optimistic_slots() failed")
-        .pop() else {
-            eprintln!("Blockstore does not contain any optimistically confirmed slots");
-            return vec![];
-        };
+        .pop()
+    else {
+        eprintln!("Blockstore does not contain any optimistically confirmed slots");
+        return vec![];
+    };
     let latest_slot = latest_slot.0;
 
     let slot_iter = AncestorIterator::new_inclusive(latest_slot, blockstore).map(|slot| {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -112,7 +112,7 @@ pub fn load_bank_forks(
 
         let Some(full_snapshot_archive_info) =
             snapshot_utils::get_highest_full_snapshot_archive_info(
-                &snapshot_config.full_snapshot_archives_dir
+                &snapshot_config.full_snapshot_archives_dir,
             )
         else {
             warn!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1835,10 +1835,9 @@ impl Bank {
 
     /// Process reward distribution for the block if it is inside reward interval.
     fn distribute_partitioned_epoch_rewards(&mut self) {
-        let EpochRewardStatus::Active(status) = &self.epoch_reward_status
-            else {
-                return;
-            };
+        let EpochRewardStatus::Active(status) = &self.epoch_reward_status else {
+            return;
+        };
 
         let height = self.block_height();
         let start_block_height = status.start_block_height;

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -230,10 +230,14 @@ pub struct SnapshotPackage {
 impl SnapshotPackage {
     pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHashEnum) -> Self {
         let AccountsPackageType::Snapshot(snapshot_type) = accounts_package.package_type else {
-            panic!("The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!");
+            panic!(
+                "The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!"
+            );
         };
         let Some(snapshot_info) = accounts_package.snapshot_info else {
-            panic!("The AccountsPackage must have snapshot info in order to make a SnapshotPackage!");
+            panic!(
+                "The AccountsPackage must have snapshot info in order to make a SnapshotPackage!"
+            );
         };
         let snapshot_hash =
             SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref());

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -967,7 +967,11 @@ fn build_known_snapshot_hashes<'a>(
     }
 
     'to_next_node: for node in nodes {
-        let Some(SnapshotHash {full: full_snapshot_hash, incr: incremental_snapshot_hash}) = get_snapshot_hashes_for_node(node) else {
+        let Some(SnapshotHash {
+            full: full_snapshot_hash,
+            incr: incremental_snapshot_hash,
+        }) = get_snapshot_hashes_for_node(node)
+        else {
             continue 'to_next_node;
         };
 


### PR DESCRIPTION
Seems like rustfmt 1.6.0 can now format how `let/else` statements.
1.5.2 we use in our `solana-nightly` does not mind the reformatting.

```
❯ cargo +nightly fmt --version
rustfmt 1.6.0-nightly (f20afcc 2023-07-04)

❯ cargo +nightly fmt
❯ git add -u
❯ git commit

❯ ./cargo nightly fmt --version
+ exec cargo +nightly-2023-04-19 fmt --version
rustfmt 1.5.2-nightly (c609da5 2023-04-18)

❯ ./cargo nightly fmt
❯ git diff
[empty output]
```

#### Problem
`master` is not formatted according to the nightly rustfmt.
In particular, the `let/else` statements could be formatted inconsistently.

#### Summary of Changes
Ran `cargo +nightly fmt`.