### PR TITLE
Replace AccountsFile::cloned_account by ReadableAccount::to_account_shared_data()

### DIFF
--- a/runtime/src/account_storage/meta.rs
+++ b/runtime/src/account_storage/meta.rs
@@ -1,11 +1,6 @@
 use {
     crate::{append_vec::AppendVecStoredAccountMeta, storable_accounts::StorableAccounts},
-    solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
-        hash::Hash,
-        pubkey::Pubkey,
-        stake_history::Epoch,
-    },
+    solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
     std::{borrow::Borrow, marker::PhantomData},
 };
 
@@ -108,13 +103,6 @@ pub enum StoredAccountMeta<'a> {
 }
 
 impl<'a> StoredAccountMeta<'a> {
-    /// Return a new Account by copying all the data referenced by the `StoredAccountMeta`.
-    pub fn clone_account(&self) -> AccountSharedData {
-        match self {
-            Self::AppendVec(av) => av.clone_account(),
-        }
-    }
-
     pub fn pubkey(&self) -> &'a Pubkey {
         match self {
             Self::AppendVec(av) => av.pubkey(),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -933,7 +933,9 @@ impl<'a> LoadedAccount<'a> {
 
     pub fn take_account(self) -> AccountSharedData {
         match self {
-            LoadedAccount::Stored(stored_account_meta) => stored_account_meta.clone_account(),
+            LoadedAccount::Stored(stored_account_meta) => {
+                stored_account_meta.to_account_shared_data()
+            }
             LoadedAccount::Cached(cached_account) => match cached_account {
                 Cow::Owned(cached_account) => cached_account.account.clone(),
                 Cow::Borrowed(cached_account) => cached_account.account.clone(),
@@ -12720,7 +12722,7 @@ pub mod tests {
             stored_size: CACHE_VIRTUAL_STORED_SIZE as usize,
             hash: &hash,
         });
-        let account = stored_account.clone_account();
+        let account = stored_account.to_account_shared_data();
 
         let expected_account_hash = if cfg!(debug_assertions) {
             Hash::from_str("6qtBXmRrLdTdAV5bK6bZZJxQA4fPSUBxzQGq2BQSat25").unwrap()

--- a/runtime/src/accounts_db/geyser_plugin_utils.rs
+++ b/runtime/src/accounts_db/geyser_plugin_utils.rs
@@ -215,7 +215,7 @@ pub mod tests {
             self.accounts_notified
                 .entry(*account.pubkey())
                 .or_default()
-                .push((slot, account.clone_account()));
+                .push((slot, account.to_account_shared_data()));
         }
 
         fn notify_end_of_restore_from_snapshot(&self) {

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -65,7 +65,7 @@ fn is_account_zeroed(account: &StoredAccountMeta) -> bool {
         && account.data_len() == 0
         && account.write_version() == 0
         && account.pubkey() == &Pubkey::default()
-        && account.clone_account() == AccountSharedData::default()
+        && account.to_account_shared_data() == AccountSharedData::default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Both AppendVec::cloned_account() and ReadableAccount::to_account_shard_data()
returns an AccountSharedData instance by cloning itself as pointed out under
a [comment](https://github.com/solana-labs/solana/pull/32380#discussion_r1253856793) in PR #32380.

#### Summary of Changes
This PR removes AccountsFile::cloned_account() and replaces its call-sites by
ReadableAccount::to_account_shared_data().

