### PR TITLE
ledger-tool: Add flag to store tx metadata in verify subcommand

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -301,7 +301,7 @@ pub fn load_and_process_ledger(
             let tss_blockstore = if enable_rpc_transaction_history {
                 Arc::new(open_blockstore(
                     blockstore.ledger_path(),
-                    AccessType::Primary,
+                    AccessType::PrimaryForMaintenance,
                     None,
                     false,
                 ))

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1621,6 +1621,12 @@ fn main() {
                     .help("Skip ledger PoH and transaction verification."),
             )
             .arg(
+                Arg::with_name("enable_rpc_transaction_history")
+                    .long("enable-rpc-transaction-history")
+                    .takes_value(false)
+                    .help("Store transaction info for processed slots into local ledger"),
+            )
+            .arg(
                 Arg::with_name("run_final_hash_calc")
                     .long("run-final-accounts-hash-calculation")
                     .takes_value(false)


### PR DESCRIPTION
#### Problem
It can be useful to store tx status information in the ledger after the fact.

#### Summary of Changes
Add a flag to `verify` command to store tx metadata

Did a quick test and confirmed that transaction status gets populated after running. Ie, without the change,
```
      Status: Unavailable
```
and with it:
```
      Status: Ok
        Fee: ◎0.000005
        ...
```
