### PR TITLE
remove unnecessary read cache remove

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6722,7 +6722,10 @@ impl AccountsDb {
         let slot = accounts.target_slot();
         (0..accounts.len()).for_each(|index| {
             let pubkey = accounts.pubkey(index);
-            self.read_only_accounts_cache.remove(*pubkey, slot);
+            assert!(self
+                .read_only_accounts_cache
+                .remove(*pubkey, slot)
+                .is_none());
         });
         calc_stored_meta_time.stop();
         self.stats


### PR DESCRIPTION
#### Problem
When storing an account in a slot, the read cache can be cleared for that (slot, pubkey) tuple.
Write cache takes precedence over read cache.
However, it should never be the case that we are writing an account which was loaded FROM the same slot. Otherwise, the account would have been written first. Being written first means it would already be in the write cache, meaning it would never get put in the read cache.

#### Summary of Changes
Assert that removing from the read cache never finds the account there.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
