### PR TITLE
feature flag cleanup: stake_split_uses_rent_sysvar

### DIFF
--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -70,11 +70,6 @@ impl Rent {
     }
 
     /// Minimum balance due for rent-exemption of a given account data size.
-    ///
-    /// Note: a stripped-down version of this calculation is used in
-    /// `calculate_split_rent_exempt_reserve` in the stake program. When this
-    /// function is updated, eg. when making rent variable, the stake program
-    /// will need to be refactored.
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
         (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year) as f64


### PR DESCRIPTION
#### Problem
`stake_split_uses_rent_sysvar` is now activated on all clusters and unused code paths can be cleaned up

#### Summary of Changes
- Removed `calculate_split_rent_exempt_reserve` function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
