### PR TITLE
Move calculate_fee() out of bank.rs

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3828,10 +3828,9 @@ fn test_program_fees() {
     feature_set.deactivate(&remove_deprecated_request_unit_ix::id());
 
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
-    let expected_normal_fee = Bank::calculate_fee(
+    let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
-        &fee_structure,
         &ComputeBudget::fee_budget_limits(
             sanitized_message.program_instructions_iter(),
             &feature_set,
@@ -3857,10 +3856,9 @@ fn test_program_fees() {
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
     let mut feature_set = FeatureSet::all_enabled();
     feature_set.deactivate(&remove_deprecated_request_unit_ix::id());
-    let expected_prioritized_fee = Bank::calculate_fee(
+    let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
-        &fee_structure,
         &ComputeBudget::fee_budget_limits(
             sanitized_message.program_instructions_iter(),
             &feature_set,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -13,7 +13,6 @@ use {
         },
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::Ancestors,
-        bank::Bank,
         blockhash_queue::BlockhashQueue,
         nonce_info::{NonceFull, NonceInfo},
         rent_collector::RentCollector,
@@ -722,10 +721,9 @@ impl Accounts {
                             hash_queue.get_lamports_per_signature(tx.message().recent_blockhash())
                         });
                     let fee = if let Some(lamports_per_signature) = lamports_per_signature {
-                        Bank::calculate_fee(
+                        fee_structure.calculate_fee(
                             tx.message(),
                             lamports_per_signature,
-                            fee_structure,
                             &ComputeBudget::fee_budget_limits(tx.message().program_instructions_iter(), feature_set, Some(self.accounts_db.expected_cluster_type())),
                             feature_set.is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                             feature_set.is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
@@ -1761,10 +1759,9 @@ mod tests {
         feature_set.deactivate(&remove_deprecated_request_unit_ix::id());
 
         let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
-        let fee = Bank::calculate_fee(
+        let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,
-            &FeeStructure::default(),
             &ComputeBudget::fee_budget_limits(
                 message.program_instructions_iter(),
                 &feature_set,
@@ -4329,10 +4326,9 @@ mod tests {
         feature_set.deactivate(&remove_deprecated_request_unit_ix::id());
 
         let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
-        let fee = Bank::calculate_fee(
+        let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,
-            &FeeStructure::default(),
             &ComputeBudget::fee_budget_limits(
                 message.program_instructions_iter(),
                 &feature_set,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -267,7 +267,6 @@ pub struct BankRc {
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 use solana_frozen_abi::abi_example::AbiExample;
-use solana_sdk::fee::FeeBudgetLimits;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl AbiExample for BankRc {
@@ -4262,10 +4261,9 @@ impl Bank {
         message: &SanitizedMessage,
         lamports_per_signature: u64,
     ) -> u64 {
-        Self::calculate_fee(
+        self.fee_structure.calculate_fee(
             message,
             lamports_per_signature,
-            &self.fee_structure,
             &ComputeBudget::fee_budget_limits(
                 message.program_instructions_iter(),
                 &self.feature_set,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5524,67 +5524,6 @@ impl Bank {
         self.update_accounts_data_size_delta_off_chain(amount)
     }
 
-    /// Calculate fee for `SanitizedMessage`
-    pub fn calculate_fee(
-        message: &SanitizedMessage,
-        lamports_per_signature: u64,
-        fee_structure: &FeeStructure,
-        budget_limits: &FeeBudgetLimits,
-        remove_congestion_multiplier: bool,
-        include_loaded_account_data_size_in_fee: bool,
-    ) -> u64 {
-        // Fee based on compute units and signatures
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
-        } else if remove_congestion_multiplier {
-            1.0 // multiplier that has no effect
-        } else {
-            const BASE_CONGESTION: f64 = 5_000.0;
-            let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
-            BASE_CONGESTION / current_congestion
-        };
-
-        let signature_fee = message
-            .num_signatures()
-            .saturating_mul(fee_structure.lamports_per_signature);
-        let write_lock_fee = message
-            .num_write_locks()
-            .saturating_mul(fee_structure.lamports_per_write_lock);
-
-        // `compute_fee` covers costs for both requested_compute_units and
-        // requested_loaded_account_data_size
-        let loaded_accounts_data_size_cost = if include_loaded_account_data_size_in_fee {
-            FeeStructure::calculate_memory_usage_cost(
-                budget_limits.loaded_accounts_data_size_limit,
-                budget_limits.heap_cost,
-            )
-        } else {
-            0_u64
-        };
-        let total_compute_units =
-            loaded_accounts_data_size_cost.saturating_add(budget_limits.compute_unit_limit);
-        let compute_fee = fee_structure
-            .compute_fee_bins
-            .iter()
-            .find(|bin| total_compute_units <= bin.limit)
-            .map(|bin| bin.fee)
-            .unwrap_or_else(|| {
-                fee_structure
-                    .compute_fee_bins
-                    .last()
-                    .map(|bin| bin.fee)
-                    .unwrap_or_default()
-            });
-
-        ((budget_limits
-            .prioritization_fee
-            .saturating_add(signature_fee)
-            .saturating_add(write_lock_fee)
-            .saturating_add(compute_fee) as f64)
-            * congestion_multiplier)
-            .round() as u64
-    }
-
     fn filter_program_errors_and_collect_fee(
         &self,
         txs: &[SanitizedTransaction],

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10131,10 +10131,9 @@ fn calculate_test_fee(
 
     let budget_limits =
         ComputeBudget::fee_budget_limits(message.program_instructions_iter(), &feature_set, None);
-    Bank::calculate_fee(
+    fee_structure.calculate_fee(
         message,
         lamports_per_signature,
-        fee_structure,
         &budget_limits,
         remove_congestion_multiplier,
         false,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -72,6 +72,67 @@ impl FeeStructure {
             .saturating_div(ACCOUNT_DATA_COST_PAGE_SIZE)
             .saturating_mul(heap_cost)
     }
+
+    /// Calculate fee for `SanitizedMessage`
+    pub fn calculate_fee(
+        message: &SanitizedMessage,
+        lamports_per_signature: u64,
+        fee_structure: &FeeStructure,
+        budget_limits: &FeeBudgetLimits,
+        remove_congestion_multiplier: bool,
+        include_loaded_account_data_size_in_fee: bool,
+    ) -> u64 {
+        // Fee based on compute units and signatures
+        let congestion_multiplier = if lamports_per_signature == 0 {
+            0.0 // test only
+        } else if remove_congestion_multiplier {
+            1.0 // multiplier that has no effect
+        } else {
+            const BASE_CONGESTION: f64 = 5_000.0;
+            let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
+            BASE_CONGESTION / current_congestion
+        };
+
+        let signature_fee = message
+            .num_signatures()
+            .saturating_mul(fee_structure.lamports_per_signature);
+        let write_lock_fee = message
+            .num_write_locks()
+            .saturating_mul(fee_structure.lamports_per_write_lock);
+
+        // `compute_fee` covers costs for both requested_compute_units and
+        // requested_loaded_account_data_size
+        let loaded_accounts_data_size_cost = if include_loaded_account_data_size_in_fee {
+            FeeStructure::calculate_memory_usage_cost(
+                budget_limits.loaded_accounts_data_size_limit,
+                budget_limits.heap_cost,
+            )
+        } else {
+            0_u64
+        };
+        let total_compute_units =
+            loaded_accounts_data_size_cost.saturating_add(budget_limits.compute_unit_limit);
+        let compute_fee = fee_structure
+            .compute_fee_bins
+            .iter()
+            .find(|bin| total_compute_units <= bin.limit)
+            .map(|bin| bin.fee)
+            .unwrap_or_else(|| {
+                fee_structure
+                    .compute_fee_bins
+                    .last()
+                    .map(|bin| bin.fee)
+                    .unwrap_or_default()
+            });
+
+        ((budget_limits
+            .prioritization_fee
+            .saturating_add(signature_fee)
+            .saturating_add(write_lock_fee)
+            .saturating_add(compute_fee) as f64)
+            * congestion_multiplier)
+            .round() as u64
+    }
 }
 
 impl Default for FeeStructure {


### PR DESCRIPTION
#### Problem
`calculate_fee()` function doesn't require access to `Bank`. Having it in bank.rs puts unnecessary dependency on `bank` in rest of the codebase.

#### Summary of Changes
Move `calculate_fee()` out of bank.rs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
