### PR TITLE
dcou: SlotMeta::unset_parent()

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -82,6 +82,9 @@ test-case = { workspace = true }
 [build-dependencies]
 rustc_version = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [lib]
 crate-type = ["lib"]
 name = "solana_ledger"

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -289,7 +289,8 @@ impl SlotMeta {
         self.is_connected()
     }
 
-    /// Dangerous. Currently only needed for a local-cluster test
+    /// Dangerous.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn unset_parent(&mut self) {
         self.parent_slot = None;
     }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -41,6 +41,7 @@ fs_extra = { workspace = true }
 gag = { workspace = true }
 serial_test = { workspace = true }
 solana-download-utils = { workspace = true }
+solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
(this is the 2nd use of the shiny `dev-context-only-utils`, introduced at https://github.com/solana-labs/solana/pull/32169)

Finally, i atone for my aged sin at https://github.com/solana-labs/solana/pull/19912#discussion_r1257413361... lol
