### PR TITLE
dcou: mod banking_trace::for_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5649,6 +5649,7 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-bloom",
  "solana-client",
+ "solana-core",
  "solana-cost-model",
  "solana-entry",
  "solana-frozen-abi",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -80,7 +80,11 @@ matches = { workspace = true }
 raptorq = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
+# Even if we want to activate features only for dev-dep., `cargo publish`
+# complains about self-dep with version specified. So don't inherit with
+# `workspace = true`. In this way, `cargo publish` will strip this self-dep
+# according to https://github.com/rust-lang/cargo/pull/7333
+solana-core = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-stake-program = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -80,6 +80,7 @@ matches = { workspace = true }
 raptorq = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-stake-program = { workspace = true }
@@ -92,6 +93,9 @@ sysctl = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+dev-context-only-utils = []
 
 [[bench]]
 name = "banking_stage"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -80,10 +80,7 @@ matches = { workspace = true }
 raptorq = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
-# Even if we want to activate features only for dev-dep., `cargo publish`
-# complains about self-dep with version specified. So don't inherit with
-# `workspace = true`. In this way, `cargo publish` will strip this self-dep
-# according to https://github.com/rust-lang/cargo/pull/7333
+# See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-core = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -4,10 +4,7 @@ use {
     chrono::{DateTime, Local},
     crossbeam_channel::{unbounded, Receiver, SendError, Sender, TryRecvError},
     rolling_file::{RollingCondition, RollingConditionBasic, RollingFileAppender},
-    solana_perf::{
-        packet::{to_packet_batches, PacketBatch},
-        test_tx::test_tx,
-    },
+    solana_perf::packet::PacketBatch,
     solana_sdk::{hash::Hash, slot_history::Slot},
     std::{
         fs::{create_dir_all, remove_dir_all},
@@ -20,7 +17,6 @@ use {
         thread::{self, sleep, JoinHandle},
         time::{Duration, SystemTime},
     },
-    tempfile::TempDir,
     thiserror::Error,
 };
 
@@ -358,8 +354,13 @@ impl TracedSender {
     }
 }
 
+#[cfg(any(test, feature = "dev-context-only-utils"))]
 pub mod for_test {
-    use super::*;
+    use {
+        super::*,
+        solana_perf::{packet::to_packet_batches, test_tx::test_tx},
+        tempfile::TempDir,
+    };
 
     pub fn sample_packet_batch() -> BankingPacketBatch {
         BankingPacketBatch::new((to_packet_batches(&vec![test_tx(); 4], 10), None))
@@ -400,6 +401,7 @@ mod tests {
             io::{BufReader, ErrorKind::UnexpectedEof},
             str::FromStr,
         },
+        tempfile::TempDir,
     };
 
     #[test]


### PR DESCRIPTION
(this is the 3rd use of the shiny `dev-context-only-utils`, introduced at https://github.com/solana-labs/solana/pull/32169)

Finally, i atone for another sin at #29196... lol

~currently, blocked by #32432~ (EDIT: unblocked now)