### PR TITLE
remove already activated features that are noops

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -497,10 +497,6 @@ pub mod disable_cpi_setting_executable_and_rent_epoch {
     solana_sdk::declare_id!("B9cdB55u4jQsDNsdTK525yE9dmSc5Ga7YBaBrDFvEhM9");
 }
 
-pub mod on_load_preserve_rent_epoch_for_rent_exempt_accounts {
-    solana_sdk::declare_id!("CpkdQmspsaZZ8FVAouQTtTWZkc8eeQ7V3uj7dWz543rZ");
-}
-
 pub mod account_hash_ignore_slot {
     solana_sdk::declare_id!("SVn36yVApPLYsa8koK3qUcy14zXDnqkNYWyUh1f4oK1");
 }
@@ -531,10 +527,6 @@ pub mod epoch_accounts_hash {
 
 pub mod remove_deprecated_request_unit_ix {
     solana_sdk::declare_id!("EfhYd3SafzGT472tYQDUc4dPd2xdEfKs5fwkowUgVt4W");
-}
-
-pub mod disable_rehash_for_rent_epoch {
-    solana_sdk::declare_id!("DTVTkmw3JSofd8CJVJte8PXEbxNQ2yZijvVr3pe2APPj");
 }
 
 pub mod increase_tx_account_lock_limit {
@@ -784,10 +776,8 @@ lazy_static! {
         (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),
         (skip_rent_rewrites::id(), "skip rewriting rent exempt accounts during rent collection #26491"),
         (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
-        (disable_rehash_for_rent_epoch::id(), "on accounts hash calculation, do not try to rehash accounts #28934"),
         (account_hash_ignore_slot::id(), "ignore slot when calculating an account hash #28420"),
         (set_exempt_rent_epoch_max::id(), "set rent epoch to Epoch::MAX for rent-exempt accounts #28683"),
-        (on_load_preserve_rent_epoch_for_rent_exempt_accounts::id(), "on bank load account, do not try to fix up rent_epoch #28541"),
         (prevent_crediting_accounts_that_end_rent_paying::id(), "prevent crediting rent paying accounts #26606"),
         (cap_bpf_program_instruction_accounts::id(), "enforce max number of accounts per bpf program instruction #26628"),
         (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),


### PR DESCRIPTION
#### Problem
These features were already activated on all clusters and can be removed. They are noops.

```
$solana feature status
Feature                                      | Status                  | Activation Slot | Description
CpkdQmspsaZZ8FVAouQTtTWZkc8eeQ7V3uj7dWz543rZ | active since epoch 473  | 204336000       | on bank load account, do not try to fix up rent_epoch #28541
DTVTkmw3JSofd8CJVJte8PXEbxNQ2yZijvVr3pe2APPj | active since epoch 473  | 204336000       | on accounts hash calculation, do not try to rehash accounts #28934

$solana feature status -ut
Feature                                      | Status                  | Activation Slot | Description
CpkdQmspsaZZ8FVAouQTtTWZkc8eeQ7V3uj7dWz543rZ | active since epoch 465  | 195356264       | on bank load account, do not try to fix up rent_epoch #28541
DTVTkmw3JSofd8CJVJte8PXEbxNQ2yZijvVr3pe2APPj | active since epoch 465  | 195356264       | on accounts hash calculation, do not try to rehash accounts #28934


$solana feature status -ud
Feature                                      | Status                  | Activation Slot | Description
CpkdQmspsaZZ8FVAouQTtTWZkc8eeQ7V3uj7dWz543rZ | active since epoch 497  | 214704000       | on bank load account, do not try to fix up rent_epoch #28541
DTVTkmw3JSofd8CJVJte8PXEbxNQ2yZijvVr3pe2APPj | active since epoch 497  | 214704000       | on accounts hash calculation, do not try to rehash accounts #28934
```

#### Summary of Changes
Remove features.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
