### PR TITLE
[TieredStorage] TieredReadableAccount::data()

### DIFF
--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -41,6 +41,11 @@ impl<'a, M: TieredAccountMeta> TieredReadableAccount<'a, M> {
     pub fn write_version(&self) -> Option<StoredMetaWriteVersion> {
         self.meta.write_version(self.account_block)
     }
+
+    /// Returns the data associated to this account.
+    pub fn data(&self) -> &'a [u8] {
+        self.meta.account_data(self.account_block)
+    }
 }
 
 impl<'a, M: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, M> {

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -78,6 +78,6 @@ impl<'a, M: TieredAccountMeta> ReadableAccount for TieredReadableAccount<'a, M> 
 
     /// Returns the data associated to this account.
     fn data(&self) -> &'a [u8] {
-        self.meta.account_data(self.account_block)
+        self.data()
     }
 }


### PR DESCRIPTION
#### Problem
While TieredReadableAccount implements ReadableAccount that
already includes `fn data(&self) -> &'a [u8]`, a `data()` function that
directly under TieredReadableAccount is still needed in order to
correctly link the lifetime of the returned value and its member
account_block.  Otherwise, cargo will complain lifetime may not
live long enough.

```
error: lifetime may not live long enough
   --> runtime/src/account_storage/meta.rs:152:9
    |
118 |   impl<'a> StoredAccountMeta<'a> {
    |        -- lifetime `'a` defined here
...
151 |       pub fn data(&self) -> &'a [u8] {
    |                   - let's call the lifetime of this reference `'1`
152 | /         match self {
153 | |             Self::AppendVec(av) => av.data(),
154 | |             // Self::Cold(cs) => cs.data(),
155 | |             Self::Hot(hs) => hs.data(),
156 | |         }
    | |_________^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
```

#### Summary of Changes
This PR adds TieredReadableAccount::data() that directly links the lifetime
of its account_block to the returned value.

