### PR TITLE
ci: allow retrying publish-crate although passed

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -28,6 +28,9 @@ steps:
     command: "ci/publish-crate.sh"
     agents:
       queue: "release-build"
+    retry:
+      manual:
+        permit_on_passed: true
     timeout_in_minutes: 240
     branches: "!master"
   - name: "publish tarball (aarch64-apple-darwin)"


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/910937142182682656/1127985494446325760

sometimes we need to re-run publish-crate step again for missing crates. re-triggering the whole pipeline does not quite make sense.

#### Summary of Changes

allow manually retrying publish-crate step although it passed
