### PR TITLE
update max reward block factor

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1278,13 +1278,17 @@ impl Bank {
         if self.epoch_schedule.warmup && self.epoch < self.first_normal_epoch() {
             1
         } else {
+            const MAX_FACTOR_OF_REWARD_BLOCKS_IN_EPOCH: u64 = 10;
             let num_chunks = crate::accounts_hash::AccountsHasher::div_ceil(
                 total_stake_accounts,
                 self.partitioned_rewards_stake_account_stores_per_block() as usize,
             ) as u64;
 
-            // Limit the reward credit interval to 5% of the total number of slots in a epoch
-            num_chunks.clamp(1, (self.epoch_schedule.slots_per_epoch / 20).max(1))
+            // Limit the reward credit interval to 10% of the total number of slots in a epoch
+            num_chunks.clamp(
+                1,
+                (self.epoch_schedule.slots_per_epoch / MAX_FACTOR_OF_REWARD_BLOCKS_IN_EPOCH).max(1),
+            )
         }
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13331,7 +13331,7 @@ fn test_get_reward_distribution_num_blocks_normal() {
 }
 
 /// Test get_reward_distribution_num_blocks, get_reward_calculation_num_blocks, get_reward_total_num_blocks during small epoch
-/// The num_credit_blocks should be cap to 5% of the total number of blocks in the epoch.
+/// The num_credit_blocks should be cap to 10% of the total number of blocks in the epoch.
 #[test]
 fn test_get_reward_distribution_num_blocks_cap() {
     let (mut genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
@@ -13339,14 +13339,14 @@ fn test_get_reward_distribution_num_blocks_cap() {
 
     let bank = Bank::new_for_tests(&genesis_config);
 
-    // Given 8k rewards, normally it will take 2 blocks to credit all the rewards. However, because of
-    // the short epoch, i.e. 32 slots, we should cap the number of credit blocks to 32/20 = 1.
-    let expected_num = 8192;
+    // Given 16k rewards, normally it will take 4 blocks to credit all the rewards. However, because of
+    // the short epoch, i.e. 32 slots, we should cap the number of credit blocks to 32/10 = 3.
+    let expected_num = 4096 * 4;
     let stake_rewards = (0..expected_num)
         .map(|_| StakeReward::new_random())
         .collect::<Vec<_>>();
 
-    assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 1);
+    assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 3);
     assert_eq!(bank.get_reward_calculation_num_blocks(), 1);
     assert_eq!(
         bank.get_reward_total_num_blocks(&stake_rewards),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13343,6 +13343,10 @@ fn test_get_reward_distribution_num_blocks_cap() {
         PartitionedEpochRewardsConfig::default().stake_account_stores_per_block;
     assert_eq!(stake_account_stores_per_block, 4096);
 
+    let mut stake_rewards = (0..4096 * 5)
+        .map(|_| StakeReward::new_random())
+        .collect::<Vec<_>>();
+
     let check_num_reward_distribution_blocks =
         |num_stakes: u64,
          expected_num_reward_distribution_blocks: u64,
@@ -13367,12 +13371,20 @@ fn test_get_reward_distribution_num_blocks_cap() {
             );
         };
 
-    check_num_reward_distribution_blocks(stake_account_stores_per_block, 1, 1);
-    check_num_reward_distribution_blocks(2 * stake_account_stores_per_block, 2, 1);
-    check_num_reward_distribution_blocks(3 * stake_account_stores_per_block, 3, 1);
-    check_num_reward_distribution_blocks(4 * stake_account_stores_per_block, 3, 1); // cap at 3
-    check_num_reward_distribution_blocks(5 * stake_account_stores_per_block, 3, 1);
-    //cap at 3
+    for test_record in [
+        (5 * stake_account_stores_per_block, 3, 1), //cap at 3
+        (4 * stake_account_stores_per_block, 3, 1), // cap at 3
+        (3 * stake_account_stores_per_block, 3, 1),
+        (3 * stake_account_stores_per_block - 1, 3, 1),
+        (2 * stake_account_stores_per_block, 2, 1),
+        (2 * stake_account_stores_per_block - 1, 2, 1),
+        (stake_account_stores_per_block, 1, 1),
+        (1, 1, 1),
+        (0, 1, 1),
+    ] {
+        stake_rewards.truncate(test_record.0 as usize);
+        check_num_reward_distribution_blocks(test_record.0, test_record.1, test_record.2);
+    }
 }
 
 /// Test get_reward_distribution_num_blocks, get_reward_calculation_num_blocks, get_reward_total_num_blocks during warm up epoch gives the expected result.


### PR DESCRIPTION
#### Problem

part of https://github.com/solana-labs/solana/pull/32415


Given that small epoch only have 32 slots, 5% factor will result in just one
block for reward, which will not cover multiple reward blocks for testing.


Update max reward block factor from 5% to 10%, so that we can cover multilple
reward blocks for testing.




#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
