### PR TITLE
cli: fix program deployment elf verification issue 

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2023,7 +2023,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
 
     // Verify the program
     let program_runtime_environment = create_program_runtime_environment(
-        &FeatureSet::default(),
+        &FeatureSet::all_enabled(),
         &ComputeBudget::default(),
         true,
         false,


### PR DESCRIPTION
#### Problem
Deployment of solana programs using the alt bn128 syscall fails with cli versions 1.16.*, with the following error:
```
Error: ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #16736 (ELF file offset 0x20a18
```

See this example for steps to replicate the issue:
https://github.com/ananas-block/exec_test/tree/altbn_deploy

#### Summary of Changes

- replaces  FeatureSet::default() with   FeatureSet::all_enabled()

Fixes #
https://github.com/solana-labs/solana/issues/32447
