### PR TITLE
Display more information if loading bank fails at startup

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -268,7 +268,19 @@ fn bank_forks_from_snapshot(
             accounts_update_notifier,
             exit,
         )
-        .expect("load bank from snapshot archives");
+        .unwrap_or_else(|err| {
+            error!(
+                "Failed to load bank: {err} \
+                \nfull snapshot archive: {} \
+                \nincremental snapshot archive: {}",
+                full_snapshot_archive_info.path().display(),
+                incremental_snapshot_archive_info
+                    .as_ref()
+                    .map(|archive| archive.path().display().to_string())
+                    .unwrap_or("none".to_string()),
+            );
+            process::exit(1);
+        });
         bank
     } else {
         let Some(bank_snapshot) = latest_bank_snapshot else {
@@ -313,7 +325,14 @@ fn bank_forks_from_snapshot(
             accounts_update_notifier,
             exit,
         )
-        .expect("load bank from local state");
+        .unwrap_or_else(|err| {
+            error!(
+                "Failed to load bank: {err} \
+                \nsnapshot: {}",
+                bank_snapshot.snapshot_path().display(),
+            );
+            process::exit(1);
+        });
         bank
     };
 


### PR DESCRIPTION
#### Problem

A validator ran into an error when loading from snapshot archives after upgrading their testnet node. The error message is from an `except` block, which uses `Debug` to print, and also causes a panic. Here's the snippet from [Discord](https://discord.com/channels/428295358100013066/670512312339398668/1128131912553222254):

```
thread 'main' panicked at 'Load from snapshot failed: MismatchedSlotHash((208431775, 51XHNaDAw2AEmREMXckVd1msheETZz8UursFhrSE8MLD), (208431775, PcAsVDtC9CtoC8KNAgTvhdAoAtaD2CgRiVnxhQk96bu))', ledger/src/bank_forks_utils.rs:217:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::result::unwrap_failed
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/result.rs:1749:5
   3: solana_ledger::bank_forks_utils::load_bank_forks
   4: solana_core::validator::load_blockstore
   5: solana_core::validator::Validator::new
   6: solana_validator::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Since startup *can* fail, using `except` doesn't really seem the best. We should (1) gracefully shutdown and not panic, and (2) log out better error messages and information.



#### Summary of Changes

If there's an error when loading the bank at startup, print out better error messages and shutdown gracefully.