### PR TITLE
hook up ancient.slots_considered metric

### DIFF
--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -285,6 +285,9 @@ impl AccountsDb {
         tuning: PackedAncientStorageTuning,
         metrics: &mut ShrinkStatsSub,
     ) {
+        self.shrink_ancient_stats
+            .slots_considered
+            .fetch_add(sorted_slots.len() as u64, Ordering::Relaxed);
         let ancient_slot_infos = self.collect_sort_filter_ancient_slots(sorted_slots, &tuning);
 
         if ancient_slot_infos.all_infos.is_empty() {


### PR DESCRIPTION
#### Problem
Ancient append vecs were initially implemented with append behavior. The current, newer version uses a packing algorithm. The stat for `slots_considered` didn't get hooked up for packed ancient append vecs.

#### Summary of Changes
Hook up metric.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
