### PR TITLE
feature flag cleanup: cap_bpf_program_instruction_accounts

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -559,7 +559,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true, // should_cap_ix_accounts
         true, // copy_account_data
     )
     .unwrap();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -122,7 +122,6 @@ pub fn builtin_process_instruction(
         invoke_context
             .transaction_context
             .get_current_instruction_context()?,
-        true, // should_cap_ix_accounts
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
     )?;
 

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -126,8 +126,7 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -138,8 +137,7 @@ fn bench_serialize_unaligned_copy_account_data(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -151,8 +149,7 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -164,8 +161,7 @@ fn bench_serialize_aligned_copy_account_data(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -176,8 +172,7 @@ fn bench_serialize_unaligned_max_accounts(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -189,7 +184,6 @@ fn bench_serialize_aligned_max_accounts(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -33,10 +33,10 @@ use {
         entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         feature_set::{
             bpf_account_data_direct_mapping, cap_accounts_data_allocations_per_transaction,
-            cap_bpf_program_instruction_accounts, delay_visibility_of_program_deployment,
-            enable_bpf_loader_extend_program_ix, enable_bpf_loader_set_authority_checked_ix,
-            enable_program_redeployment_cooldown, limit_max_instruction_trace_length,
-            native_programs_consume_cu, remove_bpf_loader_incorrect_program_id, FeatureSet,
+            delay_visibility_of_program_deployment, enable_bpf_loader_extend_program_ix,
+            enable_bpf_loader_set_authority_checked_ix, enable_program_redeployment_cooldown,
+            limit_max_instruction_trace_length, native_programs_consume_cu,
+            remove_bpf_loader_incorrect_program_id, FeatureSet,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -1570,9 +1570,6 @@ fn execute<'a, 'b: 'a>(
     let (parameter_bytes, regions, account_lengths) = serialization::serialize_parameters(
         invoke_context.transaction_context,
         instruction_context,
-        invoke_context
-            .feature_set
-            .is_active(&cap_bpf_program_instruction_accounts::ID),
         !bpf_account_data_direct_mapping,
     )?;
     serialize_time.stop();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -259,7 +259,6 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true,            // should_cap_ix_accounts
         !direct_mapping, // copy_account_data
     )
     .unwrap();
@@ -294,7 +293,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true,            // should_cap_ix_accounts
         !direct_mapping, // copy_account_data
     )
     .unwrap();


### PR DESCRIPTION
#### Problem
`cap_bpf_program_instruction_accounts` is now activated on all clusters and unused code paths can be cleaned up

#### Summary of Changes
Removed now unused parameter in `fn serialize_parameters`

Closes https://github.com/solana-labs/solana/issues/26628
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
