### PR TITLE
correctly log stats at remove_unrooted_slots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6072,7 +6072,7 @@ impl AccountsDb {
             &remove_unrooted_purge_stats,
             true,
         );
-        remove_unrooted_purge_stats.report("remove_unrooted_slots_purge_slots_stats", Some(0));
+        remove_unrooted_purge_stats.report("remove_unrooted_slots_purge_slots_stats", None);
 
         let mut currently_contended_slots = slots_under_contention.lock().unwrap();
         for (remove_slot, _) in remove_slots {


### PR DESCRIPTION
#### Problem
During high account count testing, we discovered `remove_unrooted_slots` taking a very long time (hours).
Unfortunately, the log metrics had a bug in when to log the metrics. The metric logging code is shared. In this case, the metrics are created new each call. This means the first time to check if sufficient duration has passed will ALWAYS skip the first call and say 'no'. This prevents startup noise and gives periodic, useful metrics over time. However, in this case since we never call it a second time on the same temporary metrics struct, the metrics NEVER get logged. This is related to the skip first parameter within the elapsed time checker.

#### Summary of Changes
Change duration to None so that we always log the metrics NOW, the one and only time it is called from abs loop.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
