### PR TITLE
Replaces clippy-allow integer_arithmetic with arithmetic_side_effects

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 #[macro_use]
 extern crate log;

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     clap::{crate_description, crate_name, value_t, values_t_or_exit, App, Arg},
     log::*,

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     clap::{crate_description, crate_name, Arg, ArgEnum, Command},
     crossbeam_channel::{unbounded, Receiver},

--- a/banks-server/src/lib.rs
+++ b/banks-server/src/lib.rs
@@ -1,2 +1,2 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod banks_server;

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     clap::{crate_description, crate_name, Arg, Command},

--- a/bench-tps/src/lib.rs
+++ b/bench-tps/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod bench;
 pub mod bench_tps_client;
 pub mod cli;

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     clap::value_t,
     log::*,

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     serial_test::serial,

--- a/bucket_map/src/lib.rs
+++ b/bucket_map/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 mod bucket;
 pub mod bucket_api;
 mod bucket_item;

--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 mod cli_output;
 pub mod cli_version;
 pub mod display;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 macro_rules! ACCOUNT_STRING {
     () => {
         r#", one of:

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::{
         check_balance,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     serde_json::Value,

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::cli::{process_command, CliCommand, CliConfig},
     solana_faucet::faucet::run_local_faucet,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::redundant_closure)]
 use {
     solana_cli::{

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::redundant_closure)]
 use {
     solana_cli::{

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::{
         check_balance,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod connection_cache;
 pub mod nonblocking;

--- a/client/src/transaction_executor.rs
+++ b/client/src/transaction_executor.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     log::*,
     solana_measure::measure::Measure,

--- a/connection-cache/src/lib.rs
+++ b/connection-cache/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod client_connection;
 pub mod connection_cache;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![recursion_limit = "2048"]
 //! The `solana` library implements the Solana high-performance blockchain architecture.
 //! It includes a full Rust implementation of the architecture (see

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
     log::*,

--- a/core/tests/fork-selection.rs
+++ b/core/tests/fork-selection.rs
@@ -71,7 +71,7 @@
 //! ```
 //! time: 4007, tip converged: 10, trunk id: 3830, trunk time: 3827, trunk converged 100, trunk height 348
 //! ```
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 extern crate rand;
 use {

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Long-running ledger_cleanup tests
 
 #[cfg(test)]

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod block_cost_limits;
 pub mod cost_model;

--- a/dos/src/lib.rs
+++ b/dos/src/lib.rs
@@ -1,2 +1,2 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod cli;

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -38,7 +38,7 @@
 //! solana-dos $COMMON --valid-blockhash --transaction-type account-creation
 //! ```
 //!
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crossbeam_channel::{select, tick, unbounded, Receiver, Sender},
     itertools::Itertools,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     console::Emoji,
     indicatif::{ProgressBar, ProgressStyle},

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod entry;
 pub mod poh;
 

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod address_generator;
 pub mod genesis_accounts;
 pub mod stakes;

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,5 +1,5 @@
 //! A command-line executable for generating the chain's genesis config.
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod cluster_info;
 pub mod cluster_info_metrics;

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     bincode::serialized_size,
     log::*,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[macro_use]
 extern crate log;
 

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[macro_use]
 extern crate lazy_static;
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{args::*, bigtable::*, ledger_path::*, ledger_utils::*, output::*, program::*},
     chrono::{DateTime, Utc},

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod bank_forks_utils;
 pub mod bigtable_delete;

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     solana_entry::entry::Entry,
     solana_ledger::shred::{

--- a/local-cluster/src/lib.rs
+++ b/local-cluster/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod cluster;
 pub mod cluster_tests;
 pub mod local_cluster;

--- a/local-cluster/tests/common/mod.rs
+++ b/local-cluster/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     log::*,
     solana_core::{

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     assert_matches::assert_matches,
     common::*,

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 extern crate byte_unit;
 
 use {

--- a/measure/src/lib.rs
+++ b/measure/src/lib.rs
@@ -1,3 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod macros;
 pub mod measure;

--- a/memory-management/src/aligned_memory.rs
+++ b/memory-management/src/aligned_memory.rs
@@ -208,7 +208,7 @@ impl<const ALIGN: usize, T: AsRef<[u8]>> From<T> for AlignedMemory<ALIGN> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::integer_arithmetic)]
+    #![allow(clippy::arithmetic_side_effects)]
     use {super::*, std::io::Write};
 
     fn do_test<const ALIGN: usize>() {

--- a/memory-management/src/lib.rs
+++ b/memory-management/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::integer_arithmetic)]
+#![deny(clippy::arithmetic_side_effects)]
 pub mod aligned_memory;
 
 /// Returns true if `ptr` is aligned to `align`.

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 #[cfg(target_os = "solana")]
 #[macro_use]

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod counter;
 pub mod datapoint;
 pub mod metrics;

--- a/net-shaper/src/main.rs
+++ b/net-shaper/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     clap::{crate_description, crate_name, crate_version, Arg, ArgMatches, Command},
     rand::{thread_rng, Rng},

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `net_utils` module assists with networking
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crossbeam_channel::unbounded,
     log::*,

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -64,7 +64,7 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
 
     // Returns true if the data is duplicate.
     #[must_use]
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn dedup(&self, data: &T) -> bool {
         let mut out = true;
         let hashers = self.state.iter().map(RandomState::build_hasher);
@@ -114,7 +114,7 @@ pub fn dedup_packets_and_count_discards<const K: usize>(
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod tests {
     use {
         super::*,

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -674,7 +674,7 @@ pub fn ed25519_verify(
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod tests {
     use {
         super::*,

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use solana_entry::entry::{self, create_ticks, init_poh, EntrySlice, VerifyRecyclers};
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod leader_bank_notifier;
 pub mod poh_recorder;
 pub mod poh_service;

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![deny(clippy::integer_arithmetic)]
+#![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::indexing_slicing)]
 #![recursion_limit = "2048"]
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1,5 +1,5 @@
 //! The solana-program-test provides a BanksClient-based test framework SBF programs
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 // Export tokio for test clients
 pub use tokio;

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     bincode::deserialize,
     log::debug,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::integer_arithmetic)]
+#![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::indexing_slicing)]
 
 pub mod serialization;

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     byteorder::{ByteOrder, LittleEndian},

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1260,7 +1260,7 @@ fn update_caller_account(
 }
 
 #[allow(clippy::indexing_slicing)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 #[cfg(test)]
 mod tests {
     use {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1771,7 +1771,7 @@ declare_syscall!(
 );
 
 #[cfg(test)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
     #[allow(deprecated)]

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod config_instruction;
 pub mod config_processor;
 pub mod date_instruction;

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[deprecated(
     since = "1.8.0",
     note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` instead"

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod system_instruction;
 pub mod system_processor;
 

--- a/pubsub-client/src/lib.rs
+++ b/pubsub-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod nonblocking;
 pub mod pubsub_client;

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod nonblocking;
 pub mod quic_client;

--- a/remote-wallet/src/lib.rs
+++ b/remote-wallet/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![allow(dead_code)]
 pub mod ledger;
 pub mod ledger_error;

--- a/rpc-client-api/src/lib.rs
+++ b/rpc-client-api/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod client_error;
 pub mod config;

--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod http_sender;
 pub mod mock_sender;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 mod cluster_tpu_info;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     solana_runtime::{
         bank::Bank,

--- a/sdk/gen-headers/src/main.rs
+++ b/sdk/gen-headers/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     log::info,

--- a/sdk/program/src/borsh.rs
+++ b/sdk/program/src/borsh.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 //! Utilities for the [borsh] serialization format.
 //!
 //! [borsh]: https://borsh.io/

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -234,7 +234,7 @@ pub struct BumpAllocator {
 /// Integer arithmetic in this global allocator implementation is safe when
 /// operating on the prescribed `HEAP_START_ADDRESS` and `HEAP_LENGTH`. Any
 /// other use may overflow and is thus unsupported and at one's own risk.
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -272,7 +272,7 @@ pub const BPF_ALIGN_OF_U128: usize = 8;
 /// done at one's own risk.
 ///
 /// # Safety
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 #[allow(clippy::type_complexity)]
 pub unsafe fn deserialize<'a>(input: *mut u8) -> (&'a Pubkey, Vec<AccountInfo<'a>>, &'a [u8]) {
     let mut offset: usize = 0;

--- a/sdk/program/src/entrypoint_deprecated.rs
+++ b/sdk/program/src/entrypoint_deprecated.rs
@@ -7,7 +7,7 @@
 //!
 //! [`bpf_loader_deprecated`]: crate::bpf_loader_deprecated
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 extern crate alloc;
 use {

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -1,6 +1,6 @@
 //! Calculation of transaction fees.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{clock::DEFAULT_MS_PER_SLOT, ed25519_program, message::Message, secp256k1_program},
     log::*,

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -11,7 +11,7 @@
 //! [`AccountMeta`] values. The runtime uses this information to efficiently
 //! schedule execution of transactions.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     crate::{pubkey::Pubkey, sanitize::Sanitize, short_vec, wasm_bindgen},

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -739,7 +739,7 @@ macro_rules! unchecked_div_by_const {
         // ugly error messages!
         // https://users.rust-lang.org/t/unexpected-behavior-of-compile-time-integer-div-by-zero-check-in-declarative-macro/56718
         let _ = [(); ($den as usize) - 1];
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let quotient = $num / $den;
         quotient
     }};

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -9,7 +9,7 @@
 //! [`v0`]: crate::message::v0
 //! [future message format]: https://docs.solana.com/proposals/versioned-transactions
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     crate::{
@@ -597,7 +597,7 @@ impl Message {
         // `bench_has_duplicates` in benches/message_processor.rs shows that this implementation is
         // ~50 times faster than using HashSet for very short slices.
         for i in 1..self.account_keys.len() {
-            #[allow(clippy::integer_arithmetic)]
+            #[allow(clippy::arithmetic_side_effects)]
             if self.account_keys[i..].contains(&self.account_keys[i - 1]) {
                 return true;
             }

--- a/sdk/program/src/native_token.rs
+++ b/sdk/program/src/native_token.rs
@@ -1,6 +1,6 @@
 //! Definitions for the native SOL token and its fractional lamports.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 /// There are 10^9 lamports in one SOL
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;

--- a/sdk/program/src/program.rs
+++ b/sdk/program/src/program.rs
@@ -392,7 +392,7 @@ pub fn get_return_data() -> Option<(Pubkey, Vec<u8>)> {
 
 /// Do sanity checks of type layout.
 #[doc(hidden)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn check_type_assumptions() {
     extern crate memoffset;
     use {

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -1,6 +1,6 @@
 //! The [`ProgramError`] type and related definitions.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{decode_error::DecodeError, instruction::InstructionError, msg, pubkey::PubkeyError},
     borsh::maybestd::io::Error as BorshIoError,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -22,7 +22,7 @@ pub fn set_syscall_stubs(syscall_stubs: Box<dyn SyscallStubs>) -> Box<dyn Syscal
     std::mem::replace(&mut SYSCALL_STUBS.write().unwrap(), syscall_stubs)
 }
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub trait SyscallStubs: Sync + Send {
     fn sol_log(&self, message: &str) {
         println!("{message}");

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -1,6 +1,6 @@
 //! Solana account addresses.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{decode_error::DecodeError, hash::hashv, wasm_bindgen},
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -2,7 +2,7 @@
 //!
 //! [rent]: https://docs.solana.com/implemented-proposals/rent
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {crate::clock::DEFAULT_SLOTS_PER_EPOCH, solana_sdk_macro::CloneZeroed};
 

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -1,6 +1,6 @@
 //! Integers that serialize to variable size.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     serde::{
         de::{Error as _, SeqAccess, Visitor},

--- a/sdk/program/src/serialize_utils.rs
+++ b/sdk/program/src/serialize_utils.rs
@@ -1,6 +1,6 @@
 //! Helpers for reading and writing bytes.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use crate::{pubkey::Pubkey, sanitize::SanitizeError};
 
 pub fn append_u16(buf: &mut Vec<u8>, data: u16) {

--- a/sdk/program/src/short_vec.rs
+++ b/sdk/program/src/short_vec.rs
@@ -1,6 +1,6 @@
 //! Compact serde-encoding of vectors with small length.
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     serde::{
         de::{self, Deserializer, SeqAccess, Visitor},

--- a/sdk/program/src/slot_history.rs
+++ b/sdk/program/src/slot_history.rs
@@ -6,7 +6,7 @@
 //!
 //! [`sysvar::slot_history`]: crate::sysvar::slot_history
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub use crate::clock::Slot;
 use bv::{BitVec, BitsMut};
 

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{
         clock::{Clock, Epoch, UnixTimestamp},

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -27,7 +27,7 @@
 //!
 //! [`secp256k1_instruction`]: https://docs.rs/solana-sdk/latest/solana_sdk/secp256k1_instruction/index.html
 
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use crate::{
     account_info::AccountInfo,

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -17,7 +17,7 @@
 //! [sdoc]: https://docs.solana.com/developing/runtime-facilities/sysvars#recentblockhashes
 
 #![allow(deprecated)]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{
         declare_deprecated_sysvar_id, fee_calculator::FeeCalculator, hash::Hash, sysvar::Sysvar,

--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use super::*;
 
 const MAX_ITEMS: usize = 32;

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -42,7 +42,7 @@ pub enum MessageFormat {
     ExtendedUtf8,
 }
 
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub mod v0 {
     use {
         super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},

--- a/sdk/src/shred_version.rs
+++ b/sdk/src/shred_version.rs
@@ -20,7 +20,7 @@ pub fn version_from_hash(hash: &Hash) -> u16 {
     });
     // convert accum into a u16
     // Because accum[0] is a u8, 8bit left shift of the u16 can never overflow
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     let version = ((accum[0] as u16) << 8) | accum[1] as u16;
 
     // ensure version is never zero, to avoid looking like an uninitialized version

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -298,7 +298,7 @@ impl SanitizedTransaction {
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 mod tests {
     use {
         super::*,

--- a/send-transaction-service/src/lib.rs
+++ b/send-transaction-service/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod send_transaction_service;
 pub mod tpu_info;
 

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 mod arg_parser;
 mod args;
 mod stake_accounts;

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     crate::bigtable::RowKey,

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod nonblocking;
 pub mod packet;
 pub mod quic;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     crossbeam_channel::Receiver,

--- a/thin-client/src/lib.rs
+++ b/thin-client/src/lib.rs
@@ -1,3 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod thin_client;

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub mod arg_parser;
 pub mod args;
 pub mod commands;

--- a/tpu-client/src/lib.rs
+++ b/tpu-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod nonblocking;
 pub mod tpu_client;

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     clap::{crate_description, crate_name, value_t, values_t_or_exit, App, Arg},

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub use {crate::extract_memos::extract_and_fmt_memos, solana_sdk::reward_type::RewardType};
 use {

--- a/turbine/src/lib.rs
+++ b/turbine/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod broadcast_stage;
 pub mod cluster_nodes;

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod nonblocking;
 pub mod udp_client;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 pub use solana_test_validator as test_validator;
 use {
     console::style,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #[cfg(not(target_env = "msvc"))]
 use jemallocator::Jemalloc;
 use {

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -1,5 +1,5 @@
 //! A command-line executable for monitoring the health of a cluster
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic, clippy::op_ref)]
+#![allow(clippy::arithmetic_side_effects, clippy::op_ref)]
 
 // The warning `clippy::op_ref` is disabled to allow efficient operator arithmetic of structs that
 // implement the `Copy` trait.


### PR DESCRIPTION
#### Problem

Clippy renamed the `integer_arithmetic` lint to `arithmetic_side_effects`[^1]. This will cause build failures when upgrading rust to 1.71.0.

[^1]: https://rust-lang.github.io/rust-clippy/master/index.html#/arithmetic_side_effects


#### Summary of Changes

Replaces `integer_arithmetic` with `arithmetic_side_effects`