### PR TITLE
Removes unnecessary mut

### DIFF
--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -551,7 +551,7 @@ mod test {
         account_state
             .init_extension::<ImmutableOwner>(true)
             .unwrap();
-        let mut memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
+        let memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
         memo_transfer.require_incoming_transfer_memos = true.into();
 
         assert!(parse_token(&account_data, None).is_err());
@@ -618,7 +618,7 @@ mod test {
         let mut mint_state =
             StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
 
-        let mut mint_close_authority = mint_state
+        let mint_close_authority = mint_state
             .init_extension::<MintCloseAuthority>(true)
             .unwrap();
         mint_close_authority.close_authority =

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1958,14 +1958,14 @@ pub fn process_show_validators(
 
     let mut stake_by_version: BTreeMap<CliVersion, CliValidatorsStakeByVersion> = BTreeMap::new();
     for validator in current_validators.iter() {
-        let mut entry = stake_by_version
+        let entry = stake_by_version
             .entry(validator.version.clone())
             .or_default();
         entry.current_validators += 1;
         entry.current_active_stake += validator.activated_stake;
     }
     for validator in delinquent_validators.iter() {
-        let mut entry = stake_by_version
+        let entry = stake_by_version
             .entry(validator.version.clone())
             .or_default();
         entry.delinquent_validators += 1;

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -546,7 +546,7 @@ impl ClusterInfoStats {
     fn aggregate_by_feature_set(&self) -> HashMap<u32, FeatureSetStatsEntry> {
         let mut feature_set_map = HashMap::<u32, FeatureSetStatsEntry>::new();
         for ((feature_set, software_version), stats_entry) in &self.stats_map {
-            let mut map_entry = feature_set_map.entry(*feature_set).or_default();
+            let map_entry = feature_set_map.entry(*feature_set).or_default();
             map_entry.rpc_nodes_percent += stats_entry.rpc_percent;
             map_entry.stake_percent += stats_entry.stake_percent;
             map_entry.software_versions.push(software_version.clone());
@@ -562,7 +562,7 @@ impl ClusterInfoStats {
     fn aggregate_by_software_version(&self) -> HashMap<CliVersion, ClusterInfoStatsEntry> {
         let mut software_version_map = HashMap::<CliVersion, ClusterInfoStatsEntry>::new();
         for ((_feature_set, software_version), stats_entry) in &self.stats_map {
-            let mut map_entry = software_version_map
+            let map_entry = software_version_map
                 .entry(software_version.clone())
                 .or_default();
             map_entry.rpc_percent += stats_entry.rpc_percent;

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -510,7 +510,7 @@ impl HeaviestSubtreeForkChoice {
     pub fn split_off(&mut self, slot_hash_key: &SlotHashKey) -> Self {
         assert_ne!(self.tree_root, *slot_hash_key);
         let mut split_tree_root = {
-            let mut node_to_split_at = self
+            let node_to_split_at = self
                 .fork_infos
                 .get_mut(slot_hash_key)
                 .expect("Slot hash key must exist in tree");

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3169,7 +3169,7 @@ impl ReplayStage {
         }
 
         // Otherwise we have to check the votes for confirmation
-        let mut propagated_stats = progress
+        let propagated_stats = progress
             .get_propagated_stats_mut(slot)
             .unwrap_or_else(|| panic!("slot={slot} must exist in ProgressMap"));
 

--- a/ledger/src/slot_stats.rs
+++ b/ledger/src/slot_stats.rs
@@ -99,7 +99,7 @@ impl SlotsStats {
     ) {
         let mut slot_full_reporting_info = None;
         let mut stats = self.stats.lock().unwrap();
-        let (mut slot_stats, evicted) = Self::get_or_default_with_eviction_check(&mut stats, slot);
+        let (slot_stats, evicted) = Self::get_or_default_with_eviction_check(&mut stats, slot);
         match source {
             ShredSource::Recovered => slot_stats.num_recovered += 1,
             ShredSource::Repaired => slot_stats.num_repaired += 1,

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -305,7 +305,7 @@ mod test {
         mint_state.base = mint_base;
         mint_state.pack_base();
         mint_state.init_account_type().unwrap();
-        let mut mint_close_authority = mint_state
+        let mint_close_authority = mint_state
             .init_extension::<MintCloseAuthority>(true)
             .unwrap();
         mint_close_authority.close_authority =
@@ -353,7 +353,7 @@ mod test {
         account_state
             .init_extension::<ImmutableOwner>(true)
             .unwrap();
-        let mut memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
+        let memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
         memo_transfer.require_incoming_transfer_memos = true.into();
 
         let spl_token_account = Account {
@@ -395,7 +395,7 @@ mod test {
         account_state
             .init_extension::<ImmutableOwner>(true)
             .unwrap();
-        let mut memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
+        let memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
         memo_transfer.require_incoming_transfer_memos = true.into();
 
         let other_mint_token_account = Account {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2913,7 +2913,7 @@ pub mod rpc_bank {
                     }
                 }
 
-                let mut entry = block_production.entry(identity).or_default();
+                let entry = block_production.entry(identity).or_default();
                 if slot_history.check(slot) == solana_sdk::slot_history::Check::Found {
                     entry.1 += 1; // Increment blocks_produced
                 }
@@ -7448,7 +7448,7 @@ pub mod tests {
                 account_state
                     .init_extension::<ImmutableOwner>(true)
                     .unwrap();
-                let mut memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
+                let memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
                 memo_transfer.require_incoming_transfer_memos = true.into();
 
                 let token_account = AccountSharedData::from(Account {
@@ -7476,7 +7476,7 @@ pub mod tests {
                 mint_state.base = mint_base;
                 mint_state.pack_base();
                 mint_state.init_account_type().unwrap();
-                let mut mint_close_authority = mint_state
+                let mint_close_authority = mint_state
                     .init_extension::<MintCloseAuthority>(true)
                     .unwrap();
                 mint_close_authority.close_authority =
@@ -7940,7 +7940,7 @@ pub mod tests {
                 account_state
                     .init_extension::<ImmutableOwner>(true)
                     .unwrap();
-                let mut memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
+                let memo_transfer = account_state.init_extension::<MemoTransfer>(true).unwrap();
                 memo_transfer.require_incoming_transfer_memos = true.into();
 
                 let token_account = AccountSharedData::from(Account {
@@ -7967,7 +7967,7 @@ pub mod tests {
                 mint_state.base = mint_base;
                 mint_state.pack_base();
                 mint_state.init_account_type().unwrap();
-                let mut mint_close_authority = mint_state
+                let mint_close_authority = mint_state
                     .init_extension::<MintCloseAuthority>(true)
                     .unwrap();
                 mint_close_authority.close_authority =

--- a/sdk/program/src/message/compiled_keys.rs
+++ b/sdk/program/src/message/compiled_keys.rs
@@ -40,7 +40,7 @@ impl CompiledKeys {
     pub(crate) fn compile(instructions: &[Instruction], payer: Option<Pubkey>) -> Self {
         let mut key_meta_map = BTreeMap::<Pubkey, CompiledKeyMeta>::new();
         for ix in instructions {
-            let mut meta = key_meta_map.entry(ix.program_id).or_default();
+            let meta = key_meta_map.entry(ix.program_id).or_default();
             meta.is_invoked = true;
             for account_meta in &ix.accounts {
                 let meta = key_meta_map.entry(account_meta.pubkey).or_default();
@@ -49,7 +49,7 @@ impl CompiledKeys {
             }
         }
         if let Some(payer) = &payer {
-            let mut meta = key_meta_map.entry(*payer).or_default();
+            let meta = key_meta_map.entry(*payer).or_default();
             meta.is_signer = true;
             meta.is_writable = true;
         }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -357,7 +357,7 @@ impl TransactionContext {
             }
         }
         {
-            let mut instruction_context = self.get_next_instruction_context()?;
+            let instruction_context = self.get_next_instruction_context()?;
             instruction_context.nesting_level = nesting_level;
             instruction_context.instruction_accounts_lamport_sum =
                 callee_instruction_accounts_lamport_sum;

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -598,7 +598,7 @@ impl SendTransactionService {
         let mut batched_transactions = HashSet::new();
         let retry_rate = Duration::from_millis(config.retry_rate_ms);
 
-        transactions.retain(|signature, mut transaction_info| {
+        transactions.retain(|signature, transaction_info| {
             if transaction_info.durable_nonce_info.is_some() {
                 stats.nonced_transactions.fetch_add(1, Ordering::Relaxed);
             }
@@ -1399,7 +1399,7 @@ mod test {
         );
         // Advance nonce, simulate the transaction was again last sent 4 seconds ago.
         // This time the transaction should have been dropped.
-        for mut transaction in transactions.values_mut() {
+        for transaction in transactions.values_mut() {
             transaction.last_sent_time = Some(Instant::now().sub(Duration::from_millis(4000)));
         }
         let new_durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());


### PR DESCRIPTION
#### Problem

There are unnecessary mutable variables that clippy will complain about when upgrading Rust to 1.71.0

```
warning: variable does not need to be mutable
  --> sdk/program/src/message/compiled_keys.rs:43:17
   |
43 |             let mut meta = key_meta_map.entry(ix.program_id).or_default();
   |                 ----^^^^
   |                 |
   |                 help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default
```


#### Summary of Changes

Remove unnecessary `mut`