### PR TITLE
Removes unnecessary default()

### DIFF
--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -69,7 +69,7 @@ impl<T: BloomHashIndex> Bloom<T> {
             keys,
             bits,
             num_bits_set: 0,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
     /// Create filter optimal for num size given the `FALSE_RATE`.
@@ -157,7 +157,7 @@ impl<T: BloomHashIndex> From<Bloom<T>> for AtomicBloom<T> {
                 .iter()
                 .map(|&x| AtomicU64::new(x))
                 .collect(),
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }
@@ -215,7 +215,7 @@ impl<T: BloomHashIndex> From<AtomicBloom<T>> for Bloom<T> {
             keys: atomic_bloom.keys,
             bits,
             num_bits_set,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -32,7 +32,7 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
             clock: Instant::now(),
             bits: repeat_with(AtomicU64::default).take(size).collect(),
             popcount: AtomicU64::default(),
-            _phantom: PhantomData::<T>::default(),
+            _phantom: PhantomData::<T>,
         }
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -402,7 +402,7 @@ where
             &SerializableBankAndStorage::<newer::Context> {
                 bank,
                 snapshot_storages,
-                phantom: std::marker::PhantomData::default(),
+                phantom: std::marker::PhantomData,
             },
         ),
     }
@@ -424,7 +424,7 @@ where
             &SerializableBankAndStorageNoExtra::<newer::Context> {
                 bank,
                 snapshot_storages,
-                phantom: std::marker::PhantomData::default(),
+                phantom: std::marker::PhantomData,
             },
         ),
     }

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -211,7 +211,7 @@ impl<'a> TypeContext<'a> for Context {
                 accounts_db: &serializable_bank.bank.rc.accounts.accounts_db,
                 slot: serializable_bank.bank.rc.slot,
                 account_storage_entries: serializable_bank.snapshot_storages,
-                phantom: std::marker::PhantomData::default(),
+                phantom: std::marker::PhantomData,
             },
             // Additional fields, we manually store the lamps per signature here so that
             // we can grab it on restart.
@@ -245,7 +245,7 @@ impl<'a> TypeContext<'a> for Context {
                 accounts_db: &serializable_bank.bank.rc.accounts.accounts_db,
                 slot: serializable_bank.bank.rc.slot,
                 account_storage_entries: serializable_bank.snapshot_storages,
-                phantom: std::marker::PhantomData::default(),
+                phantom: std::marker::PhantomData,
             },
         )
             .serialize(serializer)

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -166,7 +166,7 @@ where
                 accounts_db,
                 slot,
                 account_storage_entries,
-                phantom: std::marker::PhantomData::default(),
+                phantom: std::marker::PhantomData,
             },
         ),
     }

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -44,7 +44,7 @@ pub mod solana_rpc_client {
                 &self,
                 _transaction: &Transaction,
             ) -> ClientResult<Signature> {
-                Ok(Signature::default())
+                Ok(Signature)
             }
 
             pub fn get_minimum_balance_for_rent_exemption(

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -58,7 +58,7 @@ where
     deserializer.deserialize_tuple(
         (std::mem::size_of::<T>() * 8 + 6) / 7,
         VarIntVisitor {
-            phantom: PhantomData::default(),
+            phantom: PhantomData,
         },
     )
 }

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -35,7 +35,7 @@ impl Keypair {
 
     /// Constructs a new, random `Keypair` using `OsRng`
     pub fn new() -> Self {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         Self::generate(&mut rng)
     }
 


### PR DESCRIPTION
#### Problem

When upgrading Rust to 1.71.0, clippy has new lints around unecessary calls to `default()` on unit structs[^1]:

```
warning: use of `default` to create a unit struct
  --> sdk/program/src/serde_varint.rs:61:33
   |
61 |             phantom: PhantomData::default(),
   |                                 ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `#[warn(clippy::default_constructed_unit_structs)]` on by default
```

[^1]: https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs

#### Summary of Changes

Remove unnecessary calls to `default()`