### PR TITLE
Uses while-let

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -356,8 +356,7 @@ impl HeaviestSubtreeForkChoice {
         let mut tree_root = None;
         // Find the subtrees to prune
         let mut to_visit = vec![self.tree_root];
-        while !to_visit.is_empty() {
-            let cur_slot = to_visit.pop().unwrap();
+        while let Some(cur_slot) = to_visit.pop() {
             if cur_slot == new_root {
                 tree_root = Some(new_root);
                 continue;
@@ -532,8 +531,7 @@ impl HeaviestSubtreeForkChoice {
         let mut split_tree_fork_infos = HashMap::new();
         let mut to_visit = vec![*slot_hash_key];
 
-        while !to_visit.is_empty() {
-            let current_node = to_visit.pop().unwrap();
+        while let Some(current_node) = to_visit.pop() {
             let current_fork_info = self
                 .fork_infos
                 .remove(&current_node)

--- a/core/src/consensus/tree_diff.rs
+++ b/core/src/consensus/tree_diff.rs
@@ -15,8 +15,7 @@ pub trait TreeDiff<'a> {
         }
         let mut pending_keys = vec![root1];
         let mut reachable_set = HashSet::new();
-        while !pending_keys.is_empty() {
-            let current_key = pending_keys.pop().unwrap();
+        while let Some(current_key) = pending_keys.pop() {
             if current_key == root2 {
                 continue;
             }

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -112,8 +112,7 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         use SingleValidatorVotes::*;
-        while !self.vote_account_keys.is_empty() {
-            let vote_account_key = self.vote_account_keys.pop().unwrap();
+        while let Some(vote_account_key) = self.vote_account_keys.pop() {
             // Get all the gossip votes we've queued up for this validator
             // that are:
             // 1) missing from the current leader bank

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -184,8 +184,7 @@ pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
         .into_iter()
         .map(|slot| (slot, 0, last_id))
         .collect();
-    while !pending_slots.is_empty() {
-        let (slot, parent_slot, last_id) = pending_slots.pop().unwrap();
+    while let Some((slot, parent_slot, last_id)) = pending_slots.pop() {
         let next_slots = ledger
             .get_slots_since(&[slot])
             .unwrap()


### PR DESCRIPTION
#### Problem

When upgrading Rust to 1.71.0, clippy has new lints around manually writing a `while-let`[^1]. This can be replaced with using an actual `while-let`.

[^1]: https://rust-lang.github.io/rust-clippy/master/index.html#/manual_while_let_some

#### Summary of Changes

Use `while-let`.