### PR TITLE
deprecates Signature::new in favor of Signature::{try_,}from

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -134,7 +134,7 @@ fn make_accounts_txs(
                 hash,
                 compute_unit_price,
             );
-            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
+            let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
             new.message.account_keys[0] = pubkey::new_rand();
             new.message.account_keys[1] = match contention {
                 WriteLockContention::None => pubkey::new_rand(),
@@ -148,7 +148,7 @@ fn make_accounts_txs(
                 }
                 WriteLockContention::Full => to_pubkey,
             };
-            new.signatures = vec![Signature::new(&sig[0..64])];
+            new.signatures = vec![Signature::from(sig)];
             new
         })
         .collect()
@@ -220,8 +220,8 @@ impl PacketsPerIteration {
     fn refresh_blockhash(&mut self, new_blockhash: Hash) {
         for tx in self.transactions.iter_mut() {
             tx.message.recent_blockhash = new_blockhash;
-            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
-            tx.signatures[0] = Signature::new(&sig[0..64]);
+            let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
+            tx.signatures[0] = Signature::from(sig);
         }
         self.packet_batches = to_packet_batches(&self.transactions, self.packets_per_batch);
     }
@@ -377,8 +377,8 @@ fn main() {
                     genesis_config.hash(),
                 );
                 // Ignore any pesky duplicate signature errors in the case we are using single-payer
-                let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
-                fund.signatures = vec![Signature::new(&sig[0..64])];
+                let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
+                fund.signatures = vec![Signature::from(sig)];
                 bank.process_transaction(&fund).unwrap();
             });
     });

--- a/bloom/benches/bloom.rs
+++ b/bloom/benches/bloom.rs
@@ -61,7 +61,7 @@ fn bench_sigs_bloom(bencher: &mut Bencher) {
         id = hash(id.as_ref());
         sigbytes.extend(id.as_ref());
 
-        let sig = Signature::new(&sigbytes);
+        let sig = Signature::try_from(sigbytes).unwrap();
         if sigs.contains(&sig) {
             falses += 1;
         }
@@ -89,7 +89,7 @@ fn bench_sigs_hashmap(bencher: &mut Bencher) {
         id = hash(id.as_ref());
         sigbytes.extend(id.as_ref());
 
-        let sig = Signature::new(&sigbytes);
+        let sig = Signature::try_from(sigbytes).unwrap();
         if sigs.contains(&sig) {
             falses += 1;
         }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3052,7 +3052,7 @@ mod tests {
             }
 
             fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
-                Ok(Signature::new(&[1u8; 64]))
+                Ok(Signature::from([1u8; 64]))
             }
 
             fn is_interactive(&self) -> bool {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1898,7 +1898,7 @@ mod tests {
         );
 
         // Test Confirm Subcommand
-        let signature = Signature::new(&[1; 64]);
+        let signature = Signature::from([1; 64]);
         let signature_string = format!("{signature:?}");
         let test_confirm =
             test_commands
@@ -2053,7 +2053,11 @@ mod tests {
         };
         assert_eq!(process_command(&config).unwrap(), "0.00000005 SOL");
 
-        let good_signature = Signature::new(&bs58::decode(SIGNATURE).into_vec().unwrap());
+        let good_signature = bs58::decode(SIGNATURE)
+            .into_vec()
+            .map(Signature::try_from)
+            .unwrap()
+            .unwrap();
         config.command = CliCommand::Confirm(good_signature);
         assert_eq!(
             process_command(&config).unwrap(),
@@ -2283,13 +2287,21 @@ mod tests {
 
         // sig_not_found case
         config.rpc_client = Some(Arc::new(RpcClient::new_mock("sig_not_found".to_string())));
-        let missing_signature = Signature::new(&bs58::decode("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW").into_vec().unwrap());
+        let missing_signature = bs58::decode("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW")
+            .into_vec()
+            .map(Signature::try_from)
+            .unwrap()
+            .unwrap();
         config.command = CliCommand::Confirm(missing_signature);
         assert_eq!(process_command(&config).unwrap(), "Not found");
 
         // Tx error case
         config.rpc_client = Some(Arc::new(RpcClient::new_mock("account_in_use".to_string())));
-        let any_signature = Signature::new(&bs58::decode(SIGNATURE).into_vec().unwrap());
+        let any_signature = bs58::decode(SIGNATURE)
+            .into_vec()
+            .map(Signature::try_from)
+            .unwrap()
+            .unwrap();
         config.command = CliCommand::Confirm(any_signature);
         assert_eq!(
             process_command(&config).unwrap(),

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -132,10 +132,10 @@ fn make_accounts_txs(txes: usize, mint_keypair: &Keypair, hash: Hash) -> Vec<Tra
         .into_par_iter()
         .map(|_| {
             let mut new = dummy.clone();
-            let sig: Vec<_> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
+            let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
             new.message.account_keys[0] = pubkey::new_rand();
             new.message.account_keys[1] = pubkey::new_rand();
-            new.signatures = vec![Signature::new(&sig[0..64])];
+            new.signatures = vec![Signature::from(sig)];
             new
         })
         .collect()

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -338,7 +338,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(vote.clone()),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
         verified_vote_packets
@@ -358,7 +358,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
         verified_vote_packets
@@ -380,7 +380,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
         verified_vote_packets
@@ -403,7 +403,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[2u8; 64]),
+            signature: Signature::from([2u8; 64]),
         }])
         .unwrap();
         verified_vote_packets
@@ -442,7 +442,7 @@ mod tests {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
                 packet_batch: PacketBatch::default(),
-                signature: Signature::new(&[1u8; 64]),
+                signature: Signature::from([1u8; 64]),
             }])
             .unwrap();
         }
@@ -628,7 +628,7 @@ mod tests {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
                 packet_batch: PacketBatch::default(),
-                signature: Signature::new(&[1u8; 64]),
+                signature: Signature::from([1u8; 64]),
             }])
             .unwrap();
         }
@@ -651,7 +651,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(third_vote.clone()),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
 
@@ -671,7 +671,7 @@ mod tests {
                 vote_account_key,
                 vote: VoteTransaction::from(vote),
                 packet_batch: PacketBatch::default(),
-                signature: Signature::new(&[1u8; 64]),
+                signature: Signature::from([1u8; 64]),
             }])
             .unwrap();
         }
@@ -702,7 +702,7 @@ mod tests {
             vote_account_key,
             vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
         verified_vote_packets
@@ -803,7 +803,7 @@ mod tests {
                 vote_account_key,
                 vote,
                 packet_batch: PacketBatch::default(),
-                signature: Signature::new(&[1u8; 64]),
+                signature: Signature::from([1u8; 64]),
             }])
             .unwrap();
         }
@@ -838,7 +838,7 @@ mod tests {
                 vote_account_key,
                 vote,
                 packet_batch: PacketBatch::default(),
-                signature: Signature::new(&[1u8; 64]),
+                signature: Signature::from([1u8; 64]),
             }])
             .unwrap();
         }
@@ -866,7 +866,7 @@ mod tests {
             vote_account_key,
             vote,
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
 
@@ -895,7 +895,7 @@ mod tests {
             vote_account_key,
             vote,
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
 
@@ -918,7 +918,7 @@ mod tests {
             vote_account_key,
             vote,
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
 
@@ -939,7 +939,7 @@ mod tests {
             vote_account_key,
             vote,
             packet_batch: PacketBatch::default(),
-            signature: Signature::new(&[1u8; 64]),
+            signature: Signature::from([1u8; 64]),
         }])
         .unwrap();
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7331,7 +7331,7 @@ pub mod tests {
         }
         .into();
         assert!(transaction_status_cf
-            .put_protobuf((0, Signature::new(&[2u8; 64]), 9), &status,)
+            .put_protobuf((0, Signature::from([2u8; 64]), 9), &status,)
             .is_ok());
 
         // result found
@@ -7351,7 +7351,7 @@ pub mod tests {
         } = transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((
                 0,
-                Signature::new(&[2u8; 64]),
+                Signature::from([2u8; 64]),
                 9,
             ))
             .unwrap()
@@ -7388,11 +7388,11 @@ pub mod tests {
         assert!(transaction_status_index_cf.get(1).unwrap().is_some());
 
         for _ in 0..5 {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
             blockstore
                 .write_transaction_status(
                     slot0,
-                    Signature::new(&random_bytes),
+                    Signature::from(random_bytes),
                     vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
                     vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
                     TransactionStatusMeta::default(),
@@ -7454,11 +7454,11 @@ pub mod tests {
 
         let slot1 = 20;
         for _ in 0..5 {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
             blockstore
                 .write_transaction_status(
                     slot1,
-                    Signature::new(&random_bytes),
+                    Signature::from(random_bytes),
                     vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
                     vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
                     TransactionStatusMeta::default(),
@@ -7605,13 +7605,13 @@ pub mod tests {
         }
         .into();
 
-        let signature1 = Signature::new(&[1u8; 64]);
-        let signature2 = Signature::new(&[2u8; 64]);
-        let signature3 = Signature::new(&[3u8; 64]);
-        let signature4 = Signature::new(&[4u8; 64]);
-        let signature5 = Signature::new(&[5u8; 64]);
-        let signature6 = Signature::new(&[6u8; 64]);
-        let signature7 = Signature::new(&[7u8; 64]);
+        let signature1 = Signature::from([1u8; 64]);
+        let signature2 = Signature::from([2u8; 64]);
+        let signature3 = Signature::from([3u8; 64]);
+        let signature4 = Signature::from([4u8; 64]);
+        let signature5 = Signature::from([5u8; 64]);
+        let signature6 = Signature::from([6u8; 64]);
+        let signature7 = Signature::from([7u8; 64]);
 
         // Insert slots with fork
         //   0 (root)
@@ -7799,8 +7799,8 @@ pub mod tests {
         }
         .into();
 
-        let signature1 = Signature::new(&[2u8; 64]);
-        let signature2 = Signature::new(&[3u8; 64]);
+        let signature1 = Signature::from([2u8; 64]);
+        let signature2 = Signature::from([3u8; 64]);
 
         // Insert rooted slots 0..=3 with no fork
         let meta0 = SlotMeta::new(0, Some(0));
@@ -8171,7 +8171,7 @@ pub mod tests {
 
         let slot0 = 10;
         for x in 1..5 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot0,
@@ -8184,7 +8184,7 @@ pub mod tests {
         }
         let slot1 = 20;
         for x in 5..9 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot1,
@@ -8202,7 +8202,7 @@ pub mod tests {
             .unwrap();
         assert_eq!(all0.len(), 8);
         for x in 1..9 {
-            let expected_signature = Signature::new(&[x; 64]);
+            let expected_signature = Signature::from([x; 64]);
             assert_eq!(all0[x as usize - 1], expected_signature);
         }
         assert_eq!(
@@ -8236,7 +8236,7 @@ pub mod tests {
             .unwrap();
         assert_eq!(all1.len(), 8);
         for x in 1..9 {
-            let expected_signature = Signature::new(&[x; 64]);
+            let expected_signature = Signature::from([x; 64]);
             assert_eq!(all1[x as usize - 1], expected_signature);
         }
 
@@ -8276,8 +8276,8 @@ pub mod tests {
 
         // Test sort, regardless of entry order or signature value
         for slot in (21..25).rev() {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
-            let signature = Signature::new(&random_bytes);
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
+            let signature = Signature::from(random_bytes);
             blockstore
                 .write_transaction_status(
                     slot,
@@ -8306,7 +8306,7 @@ pub mod tests {
 
         let slot1 = 1;
         for x in 1..5 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot1,
@@ -8319,7 +8319,7 @@ pub mod tests {
         }
         let slot2 = 2;
         for x in 5..7 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot2,
@@ -8331,7 +8331,7 @@ pub mod tests {
                 .unwrap();
         }
         for x in 7..9 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot2,
@@ -8344,7 +8344,7 @@ pub mod tests {
         }
         let slot3 = 3;
         for x in 9..13 {
-            let signature = Signature::new(&[x; 64]);
+            let signature = Signature::from([x; 64]);
             blockstore
                 .write_transaction_status(
                     slot3,
@@ -8362,7 +8362,7 @@ pub mod tests {
             .unwrap();
         for (i, (slot, signature)) in slot1_signatures.iter().enumerate() {
             assert_eq!(*slot, slot1);
-            assert_eq!(*signature, Signature::new(&[i as u8 + 1; 64]));
+            assert_eq!(*signature, Signature::from([i as u8 + 1; 64]));
         }
 
         let slot2_signatures = blockstore
@@ -8370,7 +8370,7 @@ pub mod tests {
             .unwrap();
         for (i, (slot, signature)) in slot2_signatures.iter().enumerate() {
             assert_eq!(*slot, slot2);
-            assert_eq!(*signature, Signature::new(&[i as u8 + 5; 64]));
+            assert_eq!(*signature, Signature::from([i as u8 + 5; 64]));
         }
 
         let slot3_signatures = blockstore
@@ -8378,7 +8378,7 @@ pub mod tests {
             .unwrap();
         for (i, (slot, signature)) in slot3_signatures.iter().enumerate() {
             assert_eq!(*slot, slot3);
-            assert_eq!(*signature, Signature::new(&[i as u8 + 9; 64]));
+            assert_eq!(*signature, Signature::from([i as u8 + 9; 64]));
         }
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -471,11 +471,11 @@ pub mod tests {
 
         let max_slot = 10;
         for x in 0..max_slot {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
             blockstore
                 .write_transaction_status(
                     x,
-                    Signature::new(&random_bytes),
+                    Signature::from(random_bytes),
                     vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
                     vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
                     TransactionStatusMeta::default(),
@@ -486,11 +486,11 @@ pub mod tests {
         blockstore.run_purge(0, 1, PurgeType::PrimaryIndex).unwrap();
 
         for x in max_slot..2 * max_slot {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
             blockstore
                 .write_transaction_status(
                     x,
-                    Signature::new(&random_bytes),
+                    Signature::from(random_bytes),
                     vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
                     vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
                     TransactionStatusMeta::default(),
@@ -521,11 +521,11 @@ pub mod tests {
         let transaction_status_index_cf = &blockstore.transaction_status_index_cf;
         let slot = 10;
         for _ in 0..5 {
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+            let random_bytes: [u8; 64] = std::array::from_fn(|_| rand::random::<u8>());
             blockstore
                 .write_transaction_status(
                     slot,
-                    Signature::new(&random_bytes),
+                    Signature::from(random_bytes),
                     vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
                     vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
                     TransactionStatusMeta::default(),

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -693,7 +693,7 @@ impl Column for columns::TransactionStatus {
             Self::as_index(0)
         } else {
             let index = BigEndian::read_u64(&key[0..8]);
-            let signature = Signature::new(&key[8..72]);
+            let signature = Signature::try_from(&key[8..72]).unwrap();
             let slot = BigEndian::read_u64(&key[72..80]);
             (index, signature, slot)
         }
@@ -734,7 +734,7 @@ impl Column for columns::AddressSignatures {
         let index = BigEndian::read_u64(&key[0..8]);
         let pubkey = Pubkey::try_from(&key[8..40]).unwrap();
         let slot = BigEndian::read_u64(&key[40..48]);
-        let signature = Signature::new(&key[48..112]);
+        let signature = Signature::try_from(&key[48..112]).unwrap();
         (index, pubkey, slot, signature)
     }
 
@@ -764,7 +764,7 @@ impl Column for columns::TransactionMemos {
     }
 
     fn index(key: &[u8]) -> Signature {
-        Signature::new(&key[0..64])
+        Signature::try_from(&key[..64]).unwrap()
     }
 
     fn primary_index(_index: Self::Index) -> u64 {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -578,7 +578,10 @@ pub mod layout {
     }
 
     pub(crate) fn get_signature(shred: &[u8]) -> Option<Signature> {
-        Some(Signature::new(shred.get(..SIZE_OF_SIGNATURE)?))
+        shred
+            .get(..SIZE_OF_SIGNATURE)
+            .map(Signature::try_from)?
+            .ok()
     }
 
     pub(crate) const fn get_signature_range() -> Range<usize> {

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -988,7 +988,7 @@ mod tests {
             // Also randomize the signatre bytes.
             let mut signature = [0u8; 64];
             rng.fill(&mut signature[..]);
-            tx.signatures = vec![Signature::new(&signature)];
+            tx.signatures = vec![Signature::from(signature)];
             tx
         })
         .take(num_tx)

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -134,7 +134,7 @@ fn verify_packet(packet: &mut Packet, reject_non_vote: bool) -> bool {
         let Some(sig_end) = sig_start.checked_add(size_of::<Signature>()) else {
             return false;
         };
-        let Some(signature) = packet.data(sig_start..sig_end).map(Signature::new) else {
+        let Some(Ok(signature)) = packet.data(sig_start..sig_end).map(Signature::try_from) else {
             return false;
         };
         let Some(pubkey) = packet.data(pubkey_start..pubkey_end) else {

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -516,12 +516,8 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
             }
         }
 
-        if result.len() != 64 {
-            return Err(RemoteWalletError::Protocol(
-                "Signature packet size mismatch",
-            ));
-        }
-        Ok(Signature::new(&result))
+        Signature::try_from(result)
+            .map_err(|_| RemoteWalletError::Protocol("Signature packet size mismatch"))
     }
 
     fn sign_offchain_message(
@@ -552,12 +548,8 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         }
 
         let result = self.send_apdu(commands::SIGN_OFFCHAIN_MESSAGE, p1, p2, payload)?;
-        if result.len() != 64 {
-            return Err(RemoteWalletError::Protocol(
-                "Signature packet size mismatch",
-            ));
-        }
-        Ok(Signature::new(&result))
+        Signature::try_from(result)
+            .map_err(|_| RemoteWalletError::Protocol("Signature packet size mismatch"))
     }
 }
 

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -241,7 +241,7 @@ impl RpcSender for MockSender {
             "getTransactionCount" => json![1234],
             "getSlot" => json![0],
             "getMaxShredInsertSlot" => json![0],
-            "requestAirdrop" => Value::String(Signature::new(&[8; 64]).to_string()),
+            "requestAirdrop" => Value::String(Signature::from([8; 64]).to_string()),
             "getSnapshotSlot" => Value::Number(Number::from(0)),
             "getHighestSnapshotSlot" => json!(RpcSnapshotSlotInfo {
                 full: 100,
@@ -333,7 +333,7 @@ impl RpcSender for MockSender {
             }
             "sendTransaction" => {
                 let signature = if self.url == "malicious" {
-                    Signature::new(&[8; 64]).to_string()
+                    Signature::from([8; 64]).to_string()
                 } else {
                     let tx_str = params.as_array().unwrap()[0].as_str().unwrap().to_string();
                     let data = BASE64_STANDARD.decode(tx_str).unwrap();

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -24,7 +24,7 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
             let mut sigbytes = Vec::from(id.as_ref());
             id = hash(id.as_ref());
             sigbytes.extend(id.as_ref());
-            let sig = Signature::new(&sigbytes);
+            let sig = Signature::try_from(sigbytes).unwrap();
             status_cache.insert(&blockhash, sig, 0, Ok(()));
         }
     }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -9,7 +9,7 @@ use {
     std::{
         borrow::{Borrow, Cow},
         convert::TryInto,
-        fmt, mem,
+        fmt,
         str::FromStr,
     },
     thiserror::Error,
@@ -29,13 +29,16 @@ pub struct Signature(GenericArray<u8, U64>);
 impl crate::sanitize::Sanitize for Signature {}
 
 impl Signature {
+    #[deprecated(
+        since = "1.16.4",
+        note = "Please use 'Signature::from' or 'Signature::try_from' instead"
+    )]
     pub fn new(signature_slice: &[u8]) -> Self {
         Self(GenericArray::clone_from_slice(signature_slice))
     }
 
     pub fn new_unique() -> Self {
-        let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
-        Self::new(&random_bytes)
+        Self::from(std::array::from_fn(|_| rand::random()))
     }
 
     pub(self) fn verify_verbose(
@@ -93,6 +96,31 @@ impl From<Signature> for [u8; 64] {
     }
 }
 
+impl From<[u8; SIGNATURE_BYTES]> for Signature {
+    #[inline]
+    fn from(signature: [u8; SIGNATURE_BYTES]) -> Self {
+        Self(GenericArray::from(signature))
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Signature {
+    type Error = <[u8; SIGNATURE_BYTES] as TryFrom<&'a [u8]>>::Error;
+
+    #[inline]
+    fn try_from(signature: &'a [u8]) -> Result<Self, Self::Error> {
+        <[u8; SIGNATURE_BYTES]>::try_from(signature).map(Self::from)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Signature {
+    type Error = <[u8; SIGNATURE_BYTES] as TryFrom<Vec<u8>>>::Error;
+
+    #[inline]
+    fn try_from(signature: Vec<u8>) -> Result<Self, Self::Error> {
+        <[u8; SIGNATURE_BYTES]>::try_from(signature).map(Self::from)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ParseSignatureError {
     #[error("string decoded to wrong size for signature")]
@@ -111,11 +139,7 @@ impl FromStr for Signature {
         let bytes = bs58::decode(s)
             .into_vec()
             .map_err(|_| ParseSignatureError::Invalid)?;
-        if bytes.len() != mem::size_of::<Signature>() {
-            Err(ParseSignatureError::WrongSize)
-        } else {
-            Ok(Signature::new(&bytes))
-        }
+        Signature::try_from(bytes).map_err(|_| ParseSignatureError::WrongSize)
     }
 }
 

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -91,7 +91,7 @@ impl Signer for Keypair {
     }
 
     fn sign_message(&self, message: &[u8]) -> Signature {
-        Signature::new(&self.0.sign(message).to_bytes())
+        Signature::from(self.0.sign(message).to_bytes())
     }
 
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -1068,7 +1068,7 @@ mod test {
 
         info!("Transactions are only retried until max_retries");
         transactions.insert(
-            Signature::new(&[1; 64]),
+            Signature::from([1; 64]),
             TransactionInfo::new(
                 Signature::default(),
                 vec![],
@@ -1079,7 +1079,7 @@ mod test {
             ),
         );
         transactions.insert(
-            Signature::new(&[2; 64]),
+            Signature::from([2; 64]),
             TransactionInfo::new(
                 Signature::default(),
                 vec![],


### PR DESCRIPTION

#### Problem
`Signature::new` lacks type-safety and may panic.

#### Summary of Changes
The commit deprecates this interface and instead implements `Signature::{try_,}from`.