### PR TITLE
Restore ntapi patching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8986,3 +8986,8 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[patch.unused]]
+name = "ntapi"
+version = "0.3.7"
+source = "git+https://github.com/solana-labs/ntapi?rev=97ede981a1777883ff86d142b75024b023f04fad#97ede981a1777883ff86d142b75024b023f04fad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,6 +411,10 @@ zstd = "0.11.2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 
+# Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
+#   https://github.com/MSxDOS/ntapi/pull/12
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "97ede981a1777883ff86d142b75024b023f04fad" }
+
 # We include the following crates as our dependencies above from crates.io:
 #
 #  * spl-associated-token-account

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7906,3 +7906,8 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[patch.unused]]
+name = "ntapi"
+version = "0.3.7"
+source = "git+https://github.com/solana-labs/ntapi?rev=97ede981a1777883ff86d142b75024b023f04fad#97ede981a1777883ff86d142b75024b023f04fad"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -160,6 +160,10 @@ members = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [patch.crates-io]
+# Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
+#   https://github.com/MSxDOS/ntapi/pull/12
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "97ede981a1777883ff86d142b75024b023f04fad" }
+
 # We include the following crates as our dependencies from crates.io:
 #
 #  * spl-associated-token-account

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -144,7 +144,10 @@ mkdir -p "$installDir/bin"
   if [[ -z "$validatorOnly" ]]; then
     # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
+    "$cargo" $maybeRustVersion \
+      --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
+      --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
+      install --locked spl-token-cli --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
not tested at all :)

seems ntapi is still used somehow even after #32430 

so, just restore the ntapi patch.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
