### PR TITLE
ci: pass coverage env statically

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -107,12 +107,23 @@ ARGS+=(
   --env CRATES_IO_TOKEN
 )
 
-# Also propagate environment variables needed for codecov
-# https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
-# We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
-# Unfortunately, codecov.io fails sometimes:
-#   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
-CODECOV_ENVS=$(CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused https://codecov.io/env; do sleep 10; done))
+# https://docs.codecov.com/docs/testing-with-docker
+# inline those environment variables for avoiding various curl errors
+# coverage env
+ARGS+=(
+  --env CODECOV_ENV
+  --env CODECOV_TOKEN
+  --env CODECOV_URL
+  --env CODECOV_SLUG
+  --env VCS_COMMIT_ID
+  --env VCS_BRANCH_NAME
+  --env VCS_PULL_REQUEST
+  --env VCS_SLUG
+  --env VCS_TAG
+  --env CI_BUILD_URL
+  --env CI_BUILD_ID
+  --env CI_JOB_ID
+)
 
 if $INTERACTIVE; then
   if [[ -n $1 ]]; then
@@ -122,9 +133,9 @@ if $INTERACTIVE; then
   fi
   set -x
   # shellcheck disable=SC2086
-  exec docker run --interactive --tty "${ARGS[@]}" $CODECOV_ENVS "$IMAGE" bash
+  exec docker run --interactive --tty "${ARGS[@]}" "$IMAGE" bash
 fi
 
 set -x
 # shellcheck disable=SC2086
-exec docker run "${ARGS[@]}" $CODECOV_ENVS -t "$IMAGE" "$@"
+exec docker run "${ARGS[@]}" -t "$IMAGE" "$@"


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1129158185052278854

we may get this message when fetching `CODECOV_ENV`
```
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```

seems that we don't handle this error and also I think those environment variables won't change. we can just passed them.

#### Summary of Changes

pass those environment variables statically instead of a dynamic method, setting via curl.
