### PR TITLE
[TieredStorage] Implementation of AccountIndexFormat for hot accounts

### DIFF
--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod file;
 pub mod footer;
 pub mod hot;
+pub mod index;
 pub mod meta;
 pub mod mmap_utils;
 pub mod readable;

--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -85,6 +85,7 @@ pub enum OwnersBlockFormat {
     LocalIndex = 0,
 }
 
+/// The index format of a tiered accounts file.
 #[repr(u16)]
 #[derive(
     Clone,
@@ -98,13 +99,11 @@ pub enum OwnersBlockFormat {
     num_enum::TryFromPrimitive,
 )]
 pub enum AccountIndexFormat {
-    // This format does not support any fast lookup.
-    // Any query from account hash to account meta requires linear search.
+    /// This format optimizes the storage size by storing only account addresses
+    /// and offsets.  It skips storing the size of account data by storing account
+    /// block entries and index block entries in the same order.
     #[default]
-    Linear = 0,
-    // Similar to index, but this format also stores the offset of each account
-    // meta in the index block.
-    LinearIndex = 1,
+    AddressAndOffset = 0,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -262,7 +261,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            account_index_format: AccountIndexFormat::Linear,
+            account_index_format: AccountIndexFormat::AddressAndOffset,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,

--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -1,7 +1,7 @@
 use {
     crate::tiered_storage::{
-        error::TieredStorageError, file::TieredStorageFile, mmap_utils::get_type,
-        TieredStorageResult as TsResult,
+        error::TieredStorageError, file::TieredStorageFile, index::AccountIndexFormat,
+        mmap_utils::get_type, TieredStorageResult as TsResult,
     },
     memmap2::Mmap,
     solana_sdk::{hash::Hash, pubkey::Pubkey},
@@ -83,27 +83,6 @@ pub enum AccountBlockFormat {
 pub enum OwnersBlockFormat {
     #[default]
     LocalIndex = 0,
-}
-
-/// The index format of a tiered accounts file.
-#[repr(u16)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    PartialEq,
-    num_enum::IntoPrimitive,
-    num_enum::TryFromPrimitive,
-)]
-pub enum AccountIndexFormat {
-    /// This format optimizes the storage size by storing only account addresses
-    /// and offsets.  It skips storing the size of account data by storing account
-    /// block entries and index block entries in the same order.
-    #[default]
-    AddressAndOffset = 0,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -122,7 +122,7 @@ pub mod tests {
             ..TieredStorageFooter::default()
         };
         let path = get_append_vec_path("test_address_and_offset_indexer");
-        let addresses: Vec<_> = std::iter::repeat_with(|| Pubkey::new_unique())
+        let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(ENTRY_COUNT.try_into().unwrap())
             .collect();
         let mut rng = rand::thread_rng();

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -10,6 +10,7 @@ use {
 /// The in-memory struct for the writing index block.
 /// The actual storage format of a tiered account index entry might be different
 /// from this.
+#[derive(Debug)]
 pub struct AccountIndexWriterEntry<'a> {
     pub address: &'a Pubkey,
     pub block_offset: u64,
@@ -47,7 +48,7 @@ impl AccountIndexFormat {
     ) -> TieredStorageResult<usize> {
         match self {
             Self::AddressAndOffset => {
-                let mut bytes_written: usize = 0;
+                let mut bytes_written = 0;
                 for index_entry in index_entries {
                     bytes_written += file.write_type(index_entry.address)?;
                 }

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -75,8 +75,8 @@ impl AccountIndexFormat {
         Ok(address)
     }
 
-    /// Returns the offset to the account given the specified index
-    /// to the index block.
+    /// Returns the offset to the account block that contains the account
+    /// associated with the specified index to the index block.
     pub fn get_account_block_offset(
         &self,
         map: &Mmap,

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -117,10 +117,7 @@ pub mod tests {
             ..TieredStorageFooter::default()
         };
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir
-            .path()
-            .join("test_address_and_offset_indexer")
-            .to_path_buf();
+        let path = temp_dir.path().join("test_address_and_offset_indexer");
         let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(ENTRY_COUNT.try_into().unwrap())
             .collect();

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -1,0 +1,150 @@
+use {
+    crate::tiered_storage::{
+        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_type,
+        TieredStorageResult,
+    },
+    memmap2::Mmap,
+    solana_sdk::pubkey::Pubkey,
+};
+
+/// The in-memory struct for the writing index block.
+/// The actual storage format of a tiered account index entry might be different
+/// from this.
+pub struct AccountIndexWriterEntry<'a> {
+    pub address: &'a Pubkey,
+    pub block_offset: u64,
+    pub intra_block_offset: u64,
+}
+
+#[derive(Debug)]
+pub enum TieredStorageIndexer {
+    /// This format optimizes the storage size by storing only account addresses
+    /// and offsets.  It skips storing the size of account data by storing account
+    /// block entries and index block entries in the same order.
+    AddressAndOffset,
+}
+
+impl TieredStorageIndexer {
+    /// Persists the specified index_entries to the specified file and returns
+    /// the total number of bytes written.
+    pub fn write_index_block(
+        &self,
+        file: &TieredStorageFile,
+        index_entries: &Vec<AccountIndexWriterEntry>,
+    ) -> TieredStorageResult<u64> {
+        match self {
+            Self::AddressAndOffset => {
+                let mut cursor: u64 = 0;
+                for index_entry in index_entries {
+                    cursor += file.write_type(index_entry.address)? as u64;
+                }
+                for index_entry in index_entries {
+                    cursor += file.write_type(&index_entry.block_offset)? as u64;
+                }
+                Ok(cursor)
+            }
+        }
+    }
+
+    /// Returns the address of the account given the specified index.
+    pub fn get_account_address<'a>(
+        &self,
+        map: &'a Mmap,
+        footer: &TieredStorageFooter,
+        index: usize,
+    ) -> TieredStorageResult<&'a Pubkey> {
+        let offset = match self {
+            Self::AddressAndOffset => {
+                footer.account_index_offset as usize + std::mem::size_of::<Pubkey>() * index
+            }
+        };
+        let (address, _) = get_type::<Pubkey>(map, offset)?;
+        Ok(address)
+    }
+
+    /// Returns the offset to the accout given the specified index
+    /// to the index block.
+    pub fn get_account_offset(
+        &self,
+        map: &Mmap,
+        footer: &TieredStorageFooter,
+        index: usize,
+    ) -> TieredStorageResult<u64> {
+        match self {
+            Self::AddressAndOffset => {
+                let offset = footer.account_index_offset as usize
+                    + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
+                    + index * std::mem::size_of::<u64>();
+                let (meta_offset, _) = get_type(map, offset)?;
+                Ok(*meta_offset)
+            }
+        }
+    }
+
+    /// Returns the size of one index entry.
+    pub fn entry_size(&self) -> usize {
+        match self {
+            Self::AddressAndOffset => std::mem::size_of::<Pubkey>() + std::mem::size_of::<u64>(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        crate::{
+            append_vec::test_utils::get_append_vec_path, tiered_storage::file::TieredStorageFile,
+        },
+        memmap2::MmapOptions,
+        rand::Rng,
+        std::fs::OpenOptions,
+    };
+
+    #[test]
+    fn test_address_and_offset_indexer() {
+        const ENTRY_COUNT: usize = 100;
+        let footer = TieredStorageFooter {
+            account_entry_count: ENTRY_COUNT as u32,
+            ..TieredStorageFooter::default()
+        };
+        let path = get_append_vec_path("test_address_and_offset_indexer");
+
+        let mut addresses = vec![];
+        let mut index_entries = vec![];
+        let mut rng = rand::thread_rng();
+        for _ in 0..ENTRY_COUNT {
+            addresses.push(Pubkey::new_unique());
+        }
+
+        for address in addresses.iter() {
+            index_entries.push(AccountIndexWriterEntry {
+                address,
+                block_offset: rng.gen_range(128, 2048),
+                intra_block_offset: 0,
+            });
+        }
+
+        {
+            let file = TieredStorageFile::new_writable(&path.path);
+            let indexer = TieredStorageIndexer::AddressAndOffset;
+            indexer.write_index_block(&file, &index_entries).unwrap();
+        }
+
+        let indexer = TieredStorageIndexer::AddressAndOffset;
+        let file = OpenOptions::new()
+            .read(true)
+            .create(false)
+            .open(&path.path)
+            .unwrap();
+        let map = unsafe { MmapOptions::new().map(&file).unwrap() };
+        for (i, index_entry) in index_entries.iter().enumerate() {
+            assert_eq!(
+                index_entry.block_offset,
+                indexer.get_account_offset(&map, &footer, i).unwrap()
+            );
+            let address = indexer.get_account_address(&map, &footer, i).unwrap();
+            assert_eq!(index_entry.address, address);
+        }
+    }
+}

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -77,7 +77,7 @@ impl AccountIndexFormat {
 
     /// Returns the offset to the account given the specified index
     /// to the index block.
-    pub fn get_account_offset(
+    pub fn get_account_block_offset(
         &self,
         map: &Mmap,
         footer: &TieredStorageFooter,
@@ -88,8 +88,8 @@ impl AccountIndexFormat {
                 let offset = footer.account_index_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
                     + index * std::mem::size_of::<u64>();
-                let (meta_offset, _) = get_type(map, offset)?;
-                Ok(*meta_offset)
+                let (account_block_offset, _) = get_type(map, offset)?;
+                Ok(*account_block_offset)
             }
         }
     }
@@ -147,7 +147,7 @@ mod tests {
         for (i, index_entry) in index_entries.iter().enumerate() {
             assert_eq!(
                 index_entry.block_offset,
-                indexer.get_account_offset(&map, &footer, i).unwrap()
+                indexer.get_account_block_offset(&map, &footer, i).unwrap()
             );
             let address = indexer.get_account_address(&map, &footer, i).unwrap();
             assert_eq!(index_entry.address, address);


### PR DESCRIPTION
#### Summary of Changes
This PR implements AccountIndexFormat::AddressAndOffset, the index format
that will be used by the hot account storage.

#### Test Plan
Unit tests are included in this PR.
Tested via the prototype implementation of tiered-storage.

