### PR TITLE
Fixes measure in log when calculating accounts hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7672,7 +7672,7 @@ impl AccountsDb {
                     AccountsHashEnum::Incremental(IncrementalAccountsHash(accounts_hash))
                 }
             };
-            info!("calculate_accounts_hash_from_storages: slot: {slot}, {accounts_hash:?}, capitalization: {capitalization},{total_time}");
+            info!("calculate_accounts_hash_from_storages: slot: {slot}, {accounts_hash:?}, capitalization: {capitalization}");
             Ok((accounts_hash, capitalization))
         };
 


### PR DESCRIPTION
#### Problem

The `total_time` `Measure` is not stopped when we log it, so it only ever will log `Running`.


#### Summary of Changes

Since we didn't log the total time before, go back to that. Right below we have a datapoint to log the total time anyway.