### PR TITLE
test force reward interval end fn

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12431,6 +12431,24 @@ fn test_rewards_point_calculation_empty() {
 }
 
 #[test]
+fn test_force_reward_interval_end() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+
+    let expected_num = 100;
+
+    let stake_rewards = (0..expected_num)
+        .map(|_| StakeReward::new_random())
+        .collect::<Vec<_>>();
+
+    bank.set_epoch_reward_status_active(vec![stake_rewards]);
+    assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
+
+    bank.force_reward_interval_end_for_tests();
+    assert!(bank.get_reward_interval() == RewardInterval::OutsideInterval);
+}
+
+#[test]
 fn test_is_partitioned_reward_feature_enable() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
 


### PR DESCRIPTION
#### Problem

https://app.codecov.io/gh/solana-labs/solana/pull/32506/blob/runtime/src/bank.rs#L1295

force_reward_interval_end fn is not covered in tests.

#### Summary of Changes

Impove test coverage on force_reward_interval_end fn

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
