### PR TITLE
big_mod_exp syscall: exclude inputs of numbers larger than 4096-bits

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1719,7 +1719,7 @@ declare_syscall!(
         .ok_or(SyscallError::InvalidLength)?;
 
         if params.base_len > 512 || params.exponent_len > 512 || params.modulus_len > 512 {
-            return Err(SyscallError::InvalidLength);
+            return Err(Box::new(SyscallError::InvalidLength));
         }
 
         let input_len: u64 = std::cmp::max(params.base_len, params.exponent_len);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3925,9 +3925,9 @@ mod tests {
                 exponent: VADDR_DATA as *const u8,
                 exponent_len: MAX_LEN,
                 modulus: VADDR_DATA as *const u8,
-                modulus_len: MAX_LEN
+                modulus_len: MAX_LEN,
             };
-    
+
             let mut memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(bytes_of(&params_max_len), VADDR_PARAMS),
@@ -3937,10 +3937,13 @@ mod tests {
                 &config,
             )
             .unwrap();
-    
+
             let budget = invoke_context.get_compute_budget();
-            invoke_context.mock_set_remaining(budget.syscall_base_cost + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost);
-    
+            invoke_context.mock_set_remaining(
+                budget.syscall_base_cost
+                    + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost,
+            );
+
             let mut result = ProgramResult::Ok(0);
             SyscallBigModExp::call(
                 &mut invoke_context,
@@ -3952,7 +3955,7 @@ mod tests {
                 &mut memory_mapping,
                 &mut result,
             );
-    
+
             assert_eq!(result.unwrap(), 0);
         }
 
@@ -3964,9 +3967,9 @@ mod tests {
                 exponent: VADDR_DATA as *const u8,
                 exponent_len: INV_LEN,
                 modulus: VADDR_DATA as *const u8,
-                modulus_len: INV_LEN
+                modulus_len: INV_LEN,
             };
-    
+
             let mut memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(bytes_of(&params_inv_len), VADDR_PARAMS),
@@ -3976,11 +3979,13 @@ mod tests {
                 &config,
             )
             .unwrap();
-    
-    
+
             let budget = invoke_context.get_compute_budget();
-            invoke_context.mock_set_remaining(budget.syscall_base_cost + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost);
-    
+            invoke_context.mock_set_remaining(
+                budget.syscall_base_cost
+                    + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost,
+            );
+
             let mut result = ProgramResult::Ok(0);
             SyscallBigModExp::call(
                 &mut invoke_context,
@@ -3992,7 +3997,7 @@ mod tests {
                 &mut memory_mapping,
                 &mut result,
             );
-    
+
             assert!(matches!(
                 result,
                 ProgramResult::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::InvalidLength,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3935,6 +3935,7 @@ mod tests {
                     MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
                 ],
                 &config,
+                &SBPFVersion::V2,
             )
             .unwrap();
 
@@ -3977,6 +3978,7 @@ mod tests {
                     MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
                 ],
                 &config,
+                &SBPFVersion::V2,
             )
             .unwrap();
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3904,6 +3904,103 @@ mod tests {
     }
 
     #[test]
+    fn test_syscall_big_mod_exp() {
+        let config = Config::default();
+        prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+
+        const VADDR_PARAMS: u64 = 0x100000000;
+        const MAX_LEN: u64 = 512;
+        const INV_LEN: u64 = MAX_LEN + 1;
+        let data: [u8; INV_LEN as usize] = [0; INV_LEN as usize];
+        const VADDR_DATA: u64 = 0x200000000;
+
+        let mut data_out: [u8; INV_LEN as usize] = [0; INV_LEN as usize];
+        const VADDR_OUT: u64 = 0x300000000;
+
+        // Test that SyscallBigModExp succeeds with the maximum param size
+        {
+            let params_max_len = BigModExpParams {
+                base: VADDR_DATA as *const u8,
+                base_len: MAX_LEN,
+                exponent: VADDR_DATA as *const u8,
+                exponent_len: MAX_LEN,
+                modulus: VADDR_DATA as *const u8,
+                modulus_len: MAX_LEN
+            };
+    
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(bytes_of(&params_max_len), VADDR_PARAMS),
+                    MemoryRegion::new_readonly(&data, VADDR_DATA),
+                    MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
+                ],
+                &config,
+            )
+            .unwrap();
+    
+            let budget = invoke_context.get_compute_budget();
+            invoke_context.mock_set_remaining(budget.syscall_base_cost + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost);
+    
+            let mut result = ProgramResult::Ok(0);
+            SyscallBigModExp::call(
+                &mut invoke_context,
+                VADDR_PARAMS,
+                VADDR_OUT,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+                &mut result,
+            );
+    
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        // Test that SyscallBigModExp fails when the maximum param size is exceeded
+        {
+            let params_inv_len = BigModExpParams {
+                base: VADDR_DATA as *const u8,
+                base_len: INV_LEN,
+                exponent: VADDR_DATA as *const u8,
+                exponent_len: INV_LEN,
+                modulus: VADDR_DATA as *const u8,
+                modulus_len: INV_LEN
+            };
+    
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(bytes_of(&params_inv_len), VADDR_PARAMS),
+                    MemoryRegion::new_readonly(&data, VADDR_DATA),
+                    MemoryRegion::new_writable(&mut data_out, VADDR_OUT),
+                ],
+                &config,
+            )
+            .unwrap();
+    
+    
+            let budget = invoke_context.get_compute_budget();
+            invoke_context.mock_set_remaining(budget.syscall_base_cost + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost);
+    
+            let mut result = ProgramResult::Ok(0);
+            SyscallBigModExp::call(
+                &mut invoke_context,
+                VADDR_PARAMS,
+                VADDR_OUT,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+                &mut result,
+            );
+    
+            assert!(matches!(
+                result,
+                ProgramResult::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::InvalidLength,
+            ));
+        }
+    }
+
+    #[test]
     fn test_check_type_assumptions() {
         check_type_assumptions();
     }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1718,6 +1718,10 @@ declare_syscall!(
         .get(0)
         .ok_or(SyscallError::InvalidLength)?;
 
+        if params.base_len > 512 || params.exponent_len > 512 || params.modulus_len > 512 {
+            return Err(SyscallError::InvalidLength);
+        }
+
         let input_len: u64 = std::cmp::max(params.base_len, params.exponent_len);
         let input_len: u64 = std::cmp::max(input_len, params.modulus_len);
 


### PR DESCRIPTION
#### Problem
The changes related to Big integer modular exponentiation (EIP-198). The calculation is implemented as syscall.

The formula that was used to approximate the compute budgets for large number exponentiation seems to under-approximate the costs for exponentiation of very large numbers (i.e. >>1000 byte numbers). This could lead to a negative impact on the network if the syscall was to be invoked with very large numbers.
In practice, it seems like any normal/non-adversarial use of the syscall will be on numbers of size less than or equal to 4096-bits (i.e. for RSA-4096)

#### Summary of Changes
Inside syscall all inputs are limited by value 4069 bits (512 bytes).
If the length is exceeded, an error SyscallError::InvalidLength returned.

This is a combination of the fixes by @valiksinev and the tests by @derrekr and subsumes https://github.com/solana-labs/solana/pull/31859.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
