### PR TITLE
enables merkle shreds for devnet and development clusters

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6162,7 +6162,8 @@ pub mod tests {
         let gap: u64 = 10;
         assert!(gap > 3);
         // Create enough entries to ensure there are at least two shreds created
-        let num_entries = max_ticks_per_n_shreds(1, None) + 1;
+        let data_buffer_size = ShredData::capacity(/*merkle_proof_size:*/ None).unwrap();
+        let num_entries = max_ticks_per_n_shreds(1, Some(data_buffer_size)) + 1;
         let entries = create_ticks(num_entries, 0, Hash::default());
         let mut shreds =
             entries_to_test_shreds(&entries, slot, 0, true, 0, /*merkle_variant:*/ false);

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -995,7 +995,9 @@ pub fn max_entries_per_n_shred(
     num_shreds: u64,
     shred_data_size: Option<usize>,
 ) -> u64 {
-    let data_buffer_size = ShredData::capacity(/*merkle_proof_size:*/ None).unwrap();
+    // Default 32:32 erasure batches yields 64 shreds; log2(64) = 6.
+    let merkle_proof_size = Some(6);
+    let data_buffer_size = ShredData::capacity(merkle_proof_size).unwrap();
     let shred_data_size = shred_data_size.unwrap_or(data_buffer_size) as u64;
     let vec_size = bincode::serialized_size(&vec![entry]).unwrap();
     let entry_size = bincode::serialized_size(entry).unwrap();


### PR DESCRIPTION
#### Problem
Switching from Legacy to Merkle shreds.

#### Summary of Changes
Enable Merkle shreds for devnet and development clusters.