### PR TITLE
abs purge slots in parallel

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -491,7 +491,7 @@ impl PrunedBanksRequestHandler {
     pub fn handle_request(&self, bank: &Bank, is_serialized_with_abs: bool) -> usize {
         let slots = self.pruned_banks_receiver.try_iter().collect::<Vec<_>>();
         let count = slots.len();
-        bank.accounts().accounts_db.thread_pool_clean.install(|| {
+        bank.rc.accounts.accounts_db.thread_pool_clean.install(|| {
             slots
                 .into_par_iter()
                 .for_each(|(pruned_slot, pruned_bank_id)| {


### PR DESCRIPTION
#### Problem
accounts background service blocks while purging slots.
High account count simulations have demonstrated that when index operations are expensive, purging slots can block accounts background service. This causes flush, clean, shrink to stall, putting stress on the system.

#### Summary of Changes
Purge slots in parallel using the accounts_db clean threads. These are the same threads clean, shrink, flush, etc. use for processing from accounts background service.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
