### PR TITLE
Simplify signature for Blockstore::is_shred_duplicate()

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -144,9 +144,7 @@ fn run_check_duplicate(
     let check_duplicate = |shred: Shred| -> Result<()> {
         let shred_slot = shred.slot();
         if !blockstore.has_duplicate_shreds_in_slot(shred_slot) {
-            if let Some(existing_shred_payload) =
-                blockstore.is_shred_duplicate(shred.id(), shred.payload().clone())
-            {
+            if let Some(existing_shred_payload) = blockstore.is_shred_duplicate(&shred) {
                 cluster_info.push_duplicate_shred(&shred, &existing_shred_payload)?;
                 blockstore.store_duplicate_slot(
                     shred_slot,


### PR DESCRIPTION
#### Problem
The existing signature unpacked elements from a Shred and took an owned Vec<u8>, forcing a .clone() from the caller.

#### Summary of Changes
The Shred can be passed in directly to simplify argument list and avoid the clone.

Stumbled across this while reviewing https://github.com/solana-labs/solana/pull/32528