### PR TITLE
TieredStorage struct (1/N) -- new_writable

### DIFF
--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -14,15 +14,15 @@ use {
     error::TieredStorageError,
     footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
     index::AccountIndexFormat,
-    std::path::{Path, PathBuf},
+    std::path::PathBuf,
 };
 
 pub type TieredStorageResult<T> = Result<T, TieredStorageError>;
 
 /// The struct that defines the formats of all building blocks of a
-/// TieredAccountsFile.
+/// TieredStorage.
 #[derive(Debug)]
-pub struct TieredAccountsFileFormat {
+pub struct TieredStorageFormat {
     pub meta_entry_size: usize,
     pub account_meta_format: AccountMetaFormat,
     pub owners_block_format: OwnersBlockFormat,
@@ -30,45 +30,44 @@ pub struct TieredAccountsFileFormat {
     pub account_block_format: AccountBlockFormat,
 }
 
-/// The struct for a TieredAccountsFile.
+/// The struct for a TieredStorage.
 #[derive(Debug)]
-pub struct TieredAccountsFile {
-    format: Option<&'static TieredAccountsFileFormat>,
+pub struct TieredStorage {
+    format: Option<&'static TieredStorageFormat>,
     path: PathBuf,
 }
 
-impl TieredAccountsFile {
-    /// Creates a new writable instance of TieredAccountsFile basedon the
-    /// specified file_path and TieredAccountsFileFormat.
+impl TieredStorage {
+    /// Creates a new writable instance of TieredStorage based on the
+    /// specified file_path and TieredStorageFormat.
     ///
     /// Note that the actual file will not be created until append_accounts
     /// is called.
     pub fn new_writable(
-        file_path: &Path,
-        format: &'static TieredAccountsFileFormat,
+        path: impl Into<PathBuf>,
+        format: &'static TieredStorageFormat,
     ) -> TieredStorageResult<Self> {
         Ok(Self {
             format: Some(format),
-            path: file_path.to_path_buf(),
+            path: path.into(),
         })
     }
 
-    /// Returns the path to this TieredAccountsFile.
-    pub fn get_path(&self) -> PathBuf {
-        self.path.clone()
+    /// Returns the path to this TieredStorage.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
     }
 }
 
 #[cfg(test)]
-pub mod tests {
-    use {super::*, hot::HOT_FORMAT, tempfile::TempDir};
+mod tests {
+    use {super::*, hot::HOT_FORMAT, tempfile::NamedTempFile};
 
     #[test]
     fn test_new_writable() {
-        let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("test_new");
-        let ta_file = TieredAccountsFile::new_writable(&path, &HOT_FORMAT).unwrap();
+        let temp_file = NamedTempFile::new().unwrap();
+        let ts = TieredStorage::new_writable(temp_file.path(), &HOT_FORMAT).unwrap();
 
-        assert_eq!(ta_file.get_path(), path);
+        assert_eq!(ts.path(), temp_file.path());
     }
 }

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -42,13 +42,10 @@ impl TieredStorage {
     ///
     /// Note that the actual file will not be created until append_accounts
     /// is called.
-    pub fn new_writable(
-        path: impl Into<PathBuf>,
-        format: &TieredStorageFormat,
-    ) -> TieredStorageResult<Self> {
+    pub fn new_writable(path: PathBuf, format: &TieredStorageFormat) -> TieredStorageResult<Self> {
         Ok(Self {
             format: Some(format.clone()),
-            path: path.into(),
+            path,
         })
     }
 
@@ -65,7 +62,7 @@ mod tests {
     #[test]
     fn test_new_writable() {
         let path = PathBuf::default();
-        let ts = TieredStorage::new_writable(&path, &HOT_FORMAT).unwrap();
+        let ts = TieredStorage::new_writable(path.clone(), &HOT_FORMAT).unwrap();
 
         assert_eq!(ts.path(), path);
     }

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod byte_block;
 pub mod error;
 pub mod file;
@@ -8,6 +10,65 @@ pub mod meta;
 pub mod mmap_utils;
 pub mod readable;
 
-use crate::tiered_storage::error::TieredStorageError;
+use {
+    error::TieredStorageError,
+    footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
+    index::AccountIndexFormat,
+    std::path::{Path, PathBuf},
+};
 
 pub type TieredStorageResult<T> = Result<T, TieredStorageError>;
+
+/// The struct that defines the formats of all building blocks of a
+/// TieredAccountsFile.
+#[derive(Debug)]
+pub struct TieredAccountsFileFormat {
+    pub meta_entry_size: usize,
+    pub account_meta_format: AccountMetaFormat,
+    pub owners_block_format: OwnersBlockFormat,
+    pub account_index_format: AccountIndexFormat,
+    pub account_block_format: AccountBlockFormat,
+}
+
+/// The struct for a TieredAccountsFile.
+#[derive(Debug)]
+pub struct TieredAccountsFile {
+    format: Option<&'static TieredAccountsFileFormat>,
+    path: PathBuf,
+}
+
+impl TieredAccountsFile {
+    /// Creates a new writable instance of TieredAccountsFile basedon the
+    /// specified file_path and TieredAccountsFileFormat.
+    ///
+    /// Note that the actual file will not be created until append_accounts
+    /// is called.
+    pub fn new_writable(
+        file_path: &Path,
+        format: &'static TieredAccountsFileFormat,
+    ) -> TieredStorageResult<Self> {
+        Ok(Self {
+            format: Some(format),
+            path: file_path.to_path_buf(),
+        })
+    }
+
+    /// Returns the path to this TieredAccountsFile.
+    pub fn get_path(&self) -> PathBuf {
+        self.path.clone()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {super::*, hot::HOT_FORMAT, tempfile::TempDir};
+
+    #[test]
+    fn test_new_writable() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_new");
+        let ta_file = TieredAccountsFile::new_writable(&path, &HOT_FORMAT).unwrap();
+
+        assert_eq!(ta_file.get_path(), path);
+    }
+}

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -39,7 +39,7 @@ pub struct TieredStorage {
 
 impl TieredStorage {
     /// Creates a new writable instance of TieredStorage based on the
-    /// specified file_path and TieredStorageFormat.
+    /// specified path and TieredStorageFormat.
     ///
     /// Note that the actual file will not be created until append_accounts
     /// is called.

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -42,10 +42,10 @@ impl TieredStorage {
     ///
     /// Note that the actual file will not be created until append_accounts
     /// is called.
-    pub fn new_writable(path: PathBuf, format: &TieredStorageFormat) -> Self {
+    pub fn new_writable(path: impl Into<PathBuf>, format: TieredStorageFormat) -> Self {
         Self {
-            format: Some(format.clone()),
-            path,
+            format: Some(format),
+            path: path.into(),
         }
     }
 
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn test_new_writable() {
         let path = PathBuf::default();
-        let ts = TieredStorage::new_writable(path.clone(), &HOT_FORMAT);
+        let ts = TieredStorage::new_writable(&path, HOT_FORMAT.clone());
 
         assert_eq!(ts.path(), path);
     }

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -21,7 +21,7 @@ pub type TieredStorageResult<T> = Result<T, TieredStorageError>;
 
 /// The struct that defines the formats of all building blocks of a
 /// TieredStorage.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TieredStorageFormat {
     pub meta_entry_size: usize,
     pub account_meta_format: AccountMetaFormat,
@@ -33,7 +33,7 @@ pub struct TieredStorageFormat {
 /// The struct for a TieredStorage.
 #[derive(Debug)]
 pub struct TieredStorage {
-    format: Option<&'static TieredStorageFormat>,
+    format: Option<TieredStorageFormat>,
     path: PathBuf,
 }
 
@@ -45,10 +45,10 @@ impl TieredStorage {
     /// is called.
     pub fn new_writable(
         path: impl Into<PathBuf>,
-        format: &'static TieredStorageFormat,
+        format: &TieredStorageFormat,
     ) -> TieredStorageResult<Self> {
         Ok(Self {
-            format: Some(format),
+            format: Some(format.clone()),
             path: path.into(),
         })
     }

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -42,11 +42,11 @@ impl TieredStorage {
     ///
     /// Note that the actual file will not be created until append_accounts
     /// is called.
-    pub fn new_writable(path: PathBuf, format: &TieredStorageFormat) -> TieredStorageResult<Self> {
-        Ok(Self {
+    pub fn new_writable(path: PathBuf, format: &TieredStorageFormat) -> Self {
+        Self {
             format: Some(format.clone()),
             path,
-        })
+        }
     }
 
     /// Returns the path to this TieredStorage.
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn test_new_writable() {
         let path = PathBuf::default();
-        let ts = TieredStorage::new_writable(path.clone(), &HOT_FORMAT).unwrap();
+        let ts = TieredStorage::new_writable(path.clone(), &HOT_FORMAT);
 
         assert_eq!(ts.path(), path);
     }

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -14,7 +14,7 @@ use {
     error::TieredStorageError,
     footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
     index::AccountIndexFormat,
-    std::path::PathBuf,
+    std::path::{Path, PathBuf},
 };
 
 pub type TieredStorageResult<T> = Result<T, TieredStorageError>;
@@ -30,7 +30,6 @@ pub struct TieredStorageFormat {
     pub account_block_format: AccountBlockFormat,
 }
 
-/// The struct for a TieredStorage.
 #[derive(Debug)]
 pub struct TieredStorage {
     format: Option<TieredStorageFormat>,
@@ -54,20 +53,20 @@ impl TieredStorage {
     }
 
     /// Returns the path to this TieredStorage.
-    pub fn path(&self) -> &PathBuf {
-        &self.path
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, hot::HOT_FORMAT, tempfile::NamedTempFile};
+    use {super::*, hot::HOT_FORMAT};
 
     #[test]
     fn test_new_writable() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let ts = TieredStorage::new_writable(temp_file.path(), &HOT_FORMAT).unwrap();
+        let path = PathBuf::default();
+        let ts = TieredStorage::new_writable(&path, &HOT_FORMAT).unwrap();
 
-        assert_eq!(ts.path(), temp_file.path());
+        assert_eq!(ts.path(), path);
     }
 }

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -6,12 +6,23 @@ use {
         account_storage::meta::StoredMetaWriteVersion,
         tiered_storage::{
             byte_block,
+            footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
+            index::AccountIndexFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+            TieredAccountsFileFormat,
         },
     },
     modular_bitfield::prelude::*,
     solana_sdk::{hash::Hash, stake_history::Epoch},
     std::option::Option,
+};
+
+pub static HOT_FORMAT: TieredAccountsFileFormat = TieredAccountsFileFormat {
+    meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
+    account_meta_format: AccountMetaFormat::Hot,
+    owners_block_format: OwnersBlockFormat::LocalIndex,
+    account_index_format: AccountIndexFormat::AddressAndOffset,
+    account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
 /// The maximum number of padding bytes used in a hot account entry.

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -9,7 +9,7 @@ use {
             footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
             index::AccountIndexFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-            TieredAccountsFileFormat,
+            TieredStorageFormat,
         },
     },
     modular_bitfield::prelude::*,
@@ -17,7 +17,7 @@ use {
     std::option::Option,
 };
 
-pub static HOT_FORMAT: TieredAccountsFileFormat = TieredAccountsFileFormat {
+pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
     account_meta_format: AccountMetaFormat::Hot,
     owners_block_format: OwnersBlockFormat::LocalIndex,


### PR DESCRIPTION
#### Summary of Changes
This PR initiates the implementation of the main struct for the
tiered accounts storage --- TieredStorage.  Specifically,
it defines the TieredStorage struct, TieredStorageFormat,
and skeleton implementation of new_writable().

#### Test Plan
Unit tests are included in this PR.

