### PR TITLE
Replaces `unwrap` with `?` when writing snapshot version file

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1286,7 +1286,7 @@ pub fn add_bank_snapshot(
         measure!(serialize_status_cache(&slot_deltas, &status_cache_path)?);
 
     let version_path = bank_snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
-    write_snapshot_version_file(version_path, snapshot_version).unwrap();
+    write_snapshot_version_file(version_path, snapshot_version)?;
 
     // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
     let state_complete_path = bank_snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);


### PR DESCRIPTION
#### Problem

When adding a bank snapshot, we `unwrap` after calling `write_snapshot_version_file()`. If this fails, we'll panic instead of returning the Result (which is what we do for all other code within `add_bank_snapshot()`).


#### Summary of Changes

Replace `unwrap` with `?` when calling `write_snapshot_version_file()` when adding a bank snapshot.