### PR TITLE
Returns Self instead of Result<Self> for AccountsPackage::new_for_snapshot()

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -250,8 +250,7 @@ fn run_bank_forks_snapshot_n<F>(
         snapshot_config.archive_format,
         snapshot_version,
         None,
-    )
-    .unwrap();
+    );
     last_bank.force_flush_accounts_cache();
     let accounts_hash =
         last_bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
@@ -418,8 +417,7 @@ fn test_concurrent_snapshot_packaging(
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
             None,
-        )
-        .unwrap();
+        );
         accounts_package_sender.send(accounts_package).unwrap();
 
         bank_forks.insert(bank);

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -403,7 +403,7 @@ impl SnapshotRequestHandler {
                     self.snapshot_config.archive_format,
                     self.snapshot_config.snapshot_version,
                     accounts_hash_for_testing,
-                )?
+                )
             }
             SnapshotRequestType::EpochAccountsHash => {
                 // skip the bank snapshot, just make an accounts package to send to AHV

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -8,7 +8,7 @@ use {
         rent_collector::RentCollector,
         snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
         snapshot_hash::SnapshotHash,
-        snapshot_utils::{self, ArchiveFormat, BankSnapshotInfo, Result, SnapshotVersion},
+        snapshot_utils::{self, ArchiveFormat, BankSnapshotInfo, SnapshotVersion},
     },
     log::*,
     solana_sdk::{clock::Slot, feature_set, sysvar::epoch_schedule::EpochSchedule},
@@ -57,7 +57,7 @@ impl AccountsPackage {
         archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
         accounts_hash_for_testing: Option<AccountsHash>,
-    ) -> Result<Self> {
+    ) -> Self {
         if let AccountsPackageType::Snapshot(snapshot_type) = package_type {
             info!(
                 "Package snapshot for bank {} has {} account storage entries (snapshot type: {:?})",
@@ -84,13 +84,13 @@ impl AccountsPackage {
                 .to_path_buf(),
             epoch_accounts_hash: bank.get_epoch_accounts_hash_to_serialize(),
         };
-        Ok(Self::_new(
+        Self::_new(
             package_type,
             bank,
             snapshot_storages,
             accounts_hash_for_testing,
             Some(snapshot_info),
-        ))
+        )
     }
 
     /// Package up fields needed to compute an EpochAccountsHash

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3142,7 +3142,7 @@ pub fn package_and_archive_full_snapshot(
         archive_format,
         snapshot_version,
         None,
-    )?;
+    );
 
     let accounts_hash = bank
         .get_accounts_hash()
@@ -3194,7 +3194,7 @@ pub fn package_and_archive_incremental_snapshot(
         archive_format,
         snapshot_version,
         None,
-    )?;
+    );
 
     let (accounts_hash_enum, accounts_hash_for_reserialize, bank_incremental_snapshot_persistence) =
         if bank


### PR DESCRIPTION
#### Problem

`AccountsPackage::new_for_snapshot()` cannot fail, but it returns a `Result<Self>`, which is confusing. It also bleeds out to the callers, which they then have to handle.

#### Summary of Changes

Remove the `Result` wrapper and clean up the callers.