### PR TITLE
Formats `let-else` block

### DIFF
--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                                                return Err(A::Error::custom("Invalid Sequence"));
-                                            };
+                        return Err(A::Error::custom("Invalid Sequence"));
+                    };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was


### PR DESCRIPTION
#### Problem

A `let-else` block is formatted incorrectly.

Unfortunately our versions of Rut do not format `let-else` blocks. Yet, because I have newer nightly toolchains, when I run `cargo +nightly fmt` on the repo, I get changed files. This is a little annoying to always ignore them—I might as well fix them.


#### Summary of Changes

Manually run `cargo +nightly fmt`