### PR TITLE
Preliminary Changes for Updating Cargo

### DIFF
--- a/frozen-abi/src/abi_example.rs
+++ b/frozen-abi/src/abi_example.rs
@@ -318,7 +318,7 @@ impl<T: AbiExample> AbiExample for Box<[T]> {
 impl<T: AbiExample> AbiExample for std::marker::PhantomData<T> {
     fn example() -> Self {
         info!("AbiExample for (PhantomData<T>): {}", type_name::<Self>());
-        <std::marker::PhantomData<T>>::default()
+        std::marker::PhantomData::<T>
     }
 }
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -620,7 +620,7 @@ mod tests {
         let address = IpAddr::from([
             525u16, 524u16, 523u16, 522u16, 521u16, 520u16, 519u16, 518u16,
         ]);
-        let mut data = vec![0u8; IP_ECHO_SERVER_RESPONSE_LENGTH];
+        let mut data = [0u8; IP_ECHO_SERVER_RESPONSE_LENGTH];
         bincode::serialize_into(&mut data[HEADER_LENGTH..], &address).unwrap();
         let response: Result<IpEchoServerResponse, _> =
             bincode::deserialize(&data[HEADER_LENGTH..]);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -857,8 +857,8 @@ mod tests {
         let mut cache = LoadedPrograms::default();
 
         let program1 = Pubkey::new_unique();
-        let program1_deployment_slots = vec![0, 10, 20];
-        let program1_usage_counters = vec![4, 5, 25];
+        let program1_deployment_slots = [0, 10, 20];
+        let program1_usage_counters = [4, 5, 25];
         program1_deployment_slots
             .iter()
             .enumerate()
@@ -891,8 +891,8 @@ mod tests {
         }
 
         let program2 = Pubkey::new_unique();
-        let program2_deployment_slots = vec![5, 11];
-        let program2_usage_counters = vec![0, 2];
+        let program2_deployment_slots = [5, 11];
+        let program2_usage_counters = [0, 2];
         program2_deployment_slots
             .iter()
             .enumerate()
@@ -924,8 +924,8 @@ mod tests {
         }
 
         let program3 = Pubkey::new_unique();
-        let program3_deployment_slots = vec![0, 5, 15];
-        let program3_usage_counters = vec![100, 3, 20];
+        let program3_deployment_slots = [0, 5, 15];
+        let program3_usage_counters = [100, 3, 20];
         program3_deployment_slots
             .iter()
             .enumerate()

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -426,6 +426,7 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
             let name = &item_struct.ident;
             quote! {
                 impl Clone for #name {
+                    #[allow(clippy::incorrect_clone_impl_on_copy_type)]
                     fn clone(&self) -> Self {
                         let mut value = std::mem::MaybeUninit::<Self>::uninit();
                         unsafe {

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -426,6 +426,10 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
             let name = &item_struct.ident;
             quote! {
                 impl Clone for #name {
+                    // Clippy lint `incorrect_clone_impl_on_copy_type` requires that clone
+                    // implementations on `Copy` types are simply wrappers of `Copy`.
+                    // This is not the case here, and intentionally so because we want to
+                    // guarantee zeroed padding.
                     #[allow(clippy::incorrect_clone_impl_on_copy_type)]
                     fn clone(&self) -> Self {
                         let mut value = std::mem::MaybeUninit::<Self>::uninit();

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -378,7 +378,7 @@ mod test {
     fn test_bump_allocator() {
         // alloc the entire
         {
-            let heap = vec![0u8; 128];
+            let heap = [0u8; 128];
             let allocator = BumpAllocator {
                 start: heap.as_ptr() as *const _ as usize,
                 len: heap.len(),
@@ -398,7 +398,7 @@ mod test {
         }
         // check alignment
         {
-            let heap = vec![0u8; 128];
+            let heap = [0u8; 128];
             let allocator = BumpAllocator {
                 start: heap.as_ptr() as *const _ as usize,
                 len: heap.len(),
@@ -423,7 +423,7 @@ mod test {
         }
         // alloc entire block (minus the pos ptr)
         {
-            let heap = vec![0u8; 128];
+            let heap = [0u8; 128];
             let allocator = BumpAllocator {
                 start: heap.as_ptr() as *const _ as usize,
                 len: heap.len(),

--- a/sdk/program/src/message/compiled_keys.rs
+++ b/sdk/program/src/message/compiled_keys.rs
@@ -533,7 +533,7 @@ mod tests {
 
     #[test]
     fn test_try_drain_keys_found_in_lookup_table() {
-        let orig_keys = vec![
+        let orig_keys = [
             Pubkey::new_unique(),
             Pubkey::new_unique(),
             Pubkey::new_unique(),
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_try_drain_keys_found_in_lookup_table_with_empty_table() {
-        let original_keys = vec![
+        let original_keys = [
             Pubkey::new_unique(),
             Pubkey::new_unique(),
             Pubkey::new_unique(),

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -92,7 +92,6 @@ pub struct BorrowedInstruction<'a> {
 #[cfg(not(target_os = "solana"))]
 bitflags! {
     struct InstructionsSysvarAccountMeta: u8 {
-        const NONE = 0b00000000;
         const IS_SIGNER = 0b00000001;
         const IS_WRITABLE = 0b00000010;
     }
@@ -126,7 +125,7 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
         data[start..start + 2].copy_from_slice(&start_instruction_offset.to_le_bytes());
         append_u16(&mut data, instruction.accounts.len() as u16);
         for account_meta in &instruction.accounts {
-            let mut account_meta_flags = InstructionsSysvarAccountMeta::NONE;
+            let mut account_meta_flags = InstructionsSysvarAccountMeta::empty();
             if account_meta.is_signer {
                 account_meta_flags |= InstructionsSysvarAccountMeta::IS_SIGNER;
             }


### PR DESCRIPTION
#### Problem
We've been sitting on an oldish version of Cargo that spits out a ton of warning on nightly. This is extremely frustrating as we need to look more carefully at our output warning to make sure they are not from changes we made, instead of just checking if there are warnings.

#### Summary of Changes
Wanted to begin tackling some of the clippy warnings and errors that have been introduced since our cargo freeze. This is a step towards upgrading, but does not include fixes necessary to upgrade.

- ee65ea315d1bff4a7cd0f44f939a7f51b58ff1cb - don't need to call default() here to create `PhantomData`
- 040b0f7a033a932411630e1e5874544fb8b361d9 - new lint `incorrect_clone_impl_on_copy_type` doesn't like if `Clone != Copy` for `Copy`able types. Ignore this lint on our `CloneZeroed` macro.
- 1245cef790667c5ff08b3d45ff3e375f5e1b50ae - bitflags doesn't work as expected with Zero-flags. This is even a listed edge-case in the docs https://docs.rs/bitflags/latest/bitflags/#zero-flags. I replaced the single use of the `NONE` with `empty()`.
- b00cc2ec62674cbb39a7365788522781531d4997 - new lint `useless_vec` which detects usage of `vec![...]` where we could just use `[...]`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
