### PR TITLE
Re-enable periodic compaction on several columns

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -52,6 +52,14 @@ const BLOCKSTORE_METRICS_ERROR: i64 = -1;
 const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 const FIFO_WRITE_BUFFER_SIZE: u64 = 2 * MAX_WRITE_BUFFER_SIZE;
 
+// SST files older than this value will be picked up for compaction. This value
+// chosen to be one day to strike a balance between storage getting reclaimed
+// in a timely manner and the additional I/O overhead that compaction incurs.
+// For more details on this property, see
+// https://github.com/facebook/rocksdb/blob/749b179c041347d150fa6721992ae8398b7d2b39/
+//   include/rocksdb/advanced_options.h#L908C30-L908C30
+const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
+
 // Column family for metadata about a leader slot
 const META_CF: &str = "meta";
 // Column family for slots that have been marked as dead
@@ -362,9 +370,6 @@ impl Rocks {
         fs::create_dir_all(path)?;
 
         // Use default database options
-        if should_disable_auto_compactions(&access_type) {
-            info!("Disabling rocksdb's automatic compactions...");
-        }
         let mut db_options = get_db_options(&access_type);
         if let Some(recovery_mode) = recovery_mode {
             db_options.set_wal_recovery_mode(recovery_mode.into());
@@ -408,6 +413,7 @@ impl Rocks {
                 }
             }
         };
+        db.configure_compaction();
 
         Ok(db)
     }
@@ -469,6 +475,50 @@ impl Rocks {
             ProgramCosts::NAME,
             OptimisticSlots::NAME,
         ]
+    }
+
+    // Configure compaction on a per-column basis
+    fn configure_compaction(&self) {
+        // If compactions are disabled altogether, no need to tune values
+        if should_disable_auto_compactions(&self.access_type) {
+            info!("rocksdb's automatic compactions will be disabled ...");
+            return;
+        }
+
+        // Some columns make use of rocksdb's compaction to help in cleaning
+        // the database. See comments in should_enable_cf_compaction() for more
+        // details on why some columns need compaction and why others do not.
+        //
+        // More specifically, periodic (automatic) compaction is used as
+        // opposed to manual compaction requests on a range.
+        // - Periodic compaction operates on individual files once the file
+        //   has reached a certain (configurable) age. See comments at
+        //   PERIODIC_COMPACTION_SECONDS for some more deatil.
+        // - Manual compaction operates on a range and could end up propagating
+        //   through several files and/or levels of the db.
+        //
+        // Given that data is inserted into the db at a somewhat steady rate,
+        // the age of the individual files will be fairly evently distributed
+        // over time as well. Thus, the I/O to perform cleanup with periodic
+        // compaction is also evenly distributed over time. On the other hand,
+        // a manual compaction spanning a large numbers of files could cause
+        // a sudden burst in I/O. Such a burst could potentially cause a write
+        // stall in addition to negatively impacting other parts of the system.
+        // Thus, the choice to use periodic compactions is fairly easy.
+        for cf_name in Self::columns() {
+            if should_enable_cf_compaction(cf_name) {
+                let cf_handle = self.cf_handle(cf_name);
+                self.db
+                    .set_options_cf(
+                        &cf_handle,
+                        &[(
+                            "periodic_compaction_seconds",
+                            &format!("{}", PERIODIC_COMPACTION_SECONDS),
+                        )],
+                    )
+                    .unwrap();
+            }
+        }
     }
 
     fn destroy(path: &Path) -> Result<()> {
@@ -1610,7 +1660,9 @@ impl<'a> WriteBatch<'a> {
     }
 }
 
+/// A CompactionFilter implementation to remove keys older than a given slot.
 struct PurgedSlotFilter<C: Column + ColumnName> {
+    /// The oldest slot to keep; any slot < oldest_slot will be removed
     oldest_slot: Slot,
     name: CString,
     _phantom: PhantomData<C>,
@@ -1621,8 +1673,6 @@ impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
         use rocksdb::CompactionDecision::*;
 
         let slot_in_key = C::slot(C::index(key));
-        // Refer to a comment about periodic_compaction_seconds, especially regarding implicit
-        // periodic execution of compaction_filters
         if slot_in_key >= self.oldest_slot {
             Keep
         } else {
@@ -1693,7 +1743,7 @@ fn get_cf_options<C: 'static + Column + ColumnName>(
         cf_options.set_disable_auto_compactions(true);
     }
 
-    if !disable_auto_compactions && !should_exclude_from_compaction(C::NAME) {
+    if !disable_auto_compactions && should_enable_cf_compaction(C::NAME) {
         cf_options.set_compaction_filter_factory(PurgedSlotFilterFactory::<C> {
             oldest_slot: oldest_slot.clone(),
             name: CString::new(format!("purged_slot_filter_factory({})", C::NAME)).unwrap(),
@@ -1841,25 +1891,38 @@ fn get_db_options(access_type: &AccessType) -> Options {
     options
 }
 
-// Returns whether automatic compactions should be disabled based upon access type
+// Returns whether automatic compactions should be disabled for the entire
+// database based upon the given access type.
 fn should_disable_auto_compactions(access_type: &AccessType) -> bool {
     // Leave automatic compactions enabled (do not disable) in Primary mode;
     // disable in all other modes to prevent accidental cleaning
     !matches!(access_type, AccessType::Primary)
 }
 
-// Returns whether the supplied column (name) should be excluded from compaction
-fn should_exclude_from_compaction(cf_name: &str) -> bool {
-    // List of column families to be excluded from compactions
-    let no_compaction_cfs: HashSet<&'static str> = vec![
-        columns::TransactionStatusIndex::NAME,
-        columns::ProgramCosts::NAME,
-        columns::TransactionMemos::NAME,
-    ]
-    .into_iter()
-    .collect();
+// Returns whether compactions should be enabled for the given column (name).
+fn should_enable_cf_compaction(cf_name: &str) -> bool {
+    // In order to keep the ledger storage footprint within a desired size,
+    // LedgerCleanupService removes data in FIFO order by slot.
+    //
+    // Several columns do not contain slot in their key. These columns must
+    // be manually managed to avoid unbounded storage growth.
+    //
+    // Columns where slot is the primary index can be efficiently cleaned via
+    // Database::delete_range_cf() && Database::delete_file_in_range_cf().
+    //
+    // Columns where a slot is part of the key but not the primary index can
+    // not be range deleted like above. Instead, the individual key/value pairs
+    // must be iterated over and a decision to keep or discard that pair is
+    // made. The comparison logic is implemented in PurgedSlotFilter which is
+    // configured to run as part of rocksdb's automatic compactions. Storage
+    // space is reclaimed on this class of columns once compaction has
+    // completed on a given range or file.
+    let compaction_cfs = HashSet::from([
+        columns::TransactionStatus::NAME,
+        columns::AddressSignatures::NAME,
+    ]);
 
-    no_compaction_cfs.get(cf_name).is_some()
+    compaction_cfs.get(cf_name).is_some()
 }
 
 // Returns true if the column family enables compression.
@@ -1942,15 +2005,14 @@ pub mod tests {
     }
 
     #[test]
-    fn test_should_exclude_from_compaction() {
-        // currently there are three CFs excluded from compaction:
-        assert!(should_exclude_from_compaction(
-            columns::TransactionStatusIndex::NAME
-        ));
-        assert!(should_exclude_from_compaction(columns::ProgramCosts::NAME));
-        assert!(should_exclude_from_compaction(
-            columns::TransactionMemos::NAME
-        ));
-        assert!(!should_exclude_from_compaction("something else"));
+    fn test_should_enable_cf_compaction() {
+        let columns_to_compact = vec![
+            columns::TransactionStatus::NAME,
+            columns::AddressSignatures::NAME,
+        ];
+        columns_to_compact.iter().for_each(|cf_name| {
+            assert!(should_enable_cf_compaction(cf_name));
+        });
+        assert!(!should_enable_cf_compaction("something else"));
     }
 }


### PR DESCRIPTION
#### Problem
Periodic compaction was previously disabled on all columns in #27571 in favor of the delete_file_in_range() approach that #26651 introduced. However, several columns still rely on periodic compaction to reclaim storage. Namely, the `TransactionStatus` and `AddressSignatures` columns as these columns contain a slot in their key, but as a non-primary index.

The result of periodic compaction not running on these columns is that no storage space was being reclaimed from columns. This is obviously bad and would lead to a node eventually running of storage space and crashing.

Between the two PR's above and another one (#28409), we might have gotten a little overzealous in removing "dead" code and ended up deleted something that we still needed (I reviewed that PR and missed it 😢 ). This change affects master & v1.16, and probably ran undetected for so long since I imagine there are not as many nodes running with `--enable-rpc-transaction-history` on testnet.

#### Summary of Changes
This PR reintroduces periodic compaction, but only for the columns that need it. Again, note that this change only affects validators running with `--enable-rpc-transaction-history`, as the `TransactionStatus` and `AddressSignatures` are not populated without this flag.

A lot of the comment is adapted from content that ryoqun originally wrote, but that got ripped out with 27571; this PR adds back a rewrite, lots of things are similar but some things are different as well.

The below graph shows the `blockstore_rocksdb_cfs.total_sst_files_size` for the largest columns; this statistic reports how much space is occupied on disk by SST's (the rocksdb backing file):
- Pink ==> data shreds
- Purple ==> coding shreds
- Orange ==> transaction status
- Blue ==> address signatures
- The reported value is in bytes, and the dividers on the vertical scale are 100B increments. Thus, each divider is 100 GB
<img width="2468" alt="image" src="https://github.com/solana-labs/solana/assets/5400107/fd6ed741-0720-41d6-9e40-3e0aaff47a5e">


A few notes to describe why the traces:
- A: The node was running without `--enable-rpc-transaction-history` in this period. So, there is no space occupied by the extra columns and the amount of space occupied by data and shred columns stays relatively flat around around ~230 GB each.
- B: The node was restarted with `--enable-rpc-transaction-history`; you can immediately see the space occupied by transaction status and address signatures columns begin to grow. More importantly, this growth is unbounded over the course of several days as it reaches almost 800 GB for address signatures and ~230 GB for transaction status.
- C: The node was restarted with this PR on top of master. The node immediately gets to work on cleaning outdated files from transaction status and address signatures columns, and we can see the occupied space drops pretty quickly. Note that the node remained healthy while it was doing this cleaning