### PR TITLE
Optimize account index scan fn

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -97,3 +97,6 @@ rustc_version = { workspace = true }
 
 [[bench]]
 name = "prioritization_fee_cache"
+
+[[bench]]
+name = "accounts_db"

--- a/runtime/benches/accounts_db.rs
+++ b/runtime/benches/accounts_db.rs
@@ -1,0 +1,58 @@
+#![allow(clippy::integer_arithmetic)]
+#![feature(test)]
+
+extern crate test;
+
+use {
+    solana_runtime::{
+        account_info::AccountInfo,
+        accounts_db::AccountsDb,
+        accounts_index::{AccountsIndexScanResult, UpsertReclaim},
+    },
+    solana_sdk::{account::AccountSharedData, pubkey},
+    test::Bencher,
+};
+
+// 1k (old/new)
+// test bench_scan ... bench:     130,526 ns/iter (+/- 3,402)
+// test bench_scan ... bench:     128,999 ns/iter (+/- 3,811)
+//
+// 10k (old/new)
+// test bench_scan ... bench:   1,417,961 ns/iter (+/- 32,285)
+// test bench_scan ... bench:   1,393,143 ns/iter (+/- 36,120)
+//
+// 100k (old/new)
+// test bench_scan ... bench:  16,982,083 ns/iter (+/- 168,999)
+// test bench_scan ... bench:  16,877,242 ns/iter (+/- 231,343)
+#[bench]
+fn bench_scan(bencher: &mut Bencher) {
+    let db = AccountsDb::new_single_for_tests();
+    let empty_account = AccountSharedData::default();
+    let count = 1_000;
+    let pubkeys = (0..count).map(|_| pubkey::new_rand()).collect::<Vec<_>>();
+
+    pubkeys.iter().for_each(|k| {
+        for slot in 0..2 {
+            // each upsert here (to a different slot) adds a refcount of 1 since entry is NOT cached
+            db.accounts_index.upsert(
+                slot,
+                slot,
+                k,
+                &empty_account,
+                &solana_runtime::accounts_index::AccountSecondaryIndexes::default(),
+                AccountInfo::default(),
+                &mut Vec::default(),
+                UpsertReclaim::IgnoreReclaims,
+            );
+        }
+    });
+
+    const AVOID_CALLBACK_RESULT: u8 = AccountsIndexScanResult::Unknown as u8;
+    bencher.iter(move || {
+        db.accounts_index
+            .scan::<_, _, false, AVOID_CALLBACK_RESULT>(
+                pubkeys.iter(),
+                |_k, _slot_refs, _entry| AccountsIndexScanResult::OnlyKeepInMemoryIfDirty,
+            );
+    });
+}

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3186,7 +3186,7 @@ impl AccountsDb {
                         let mut not_found_on_fork = 0;
                         let mut missing = 0;
                         let mut useful = 0;
-                        self.accounts_index.scan(
+                        self.accounts_index.scan::<_, _, false>(
                             pubkeys.iter(),
                             |pubkey, slots_refs, _entry| {
                                 let mut useless = true;
@@ -3254,7 +3254,6 @@ impl AccountsDb {
                                 }
                             },
                             None,
-                            false,
                         );
                         found_not_zero_accum.fetch_add(found_not_zero, Ordering::Relaxed);
                         not_found_on_fork_accum.fetch_add(not_found_on_fork, Ordering::Relaxed);
@@ -3743,7 +3742,7 @@ impl AccountsDb {
         let mut index = 0;
         let mut all_are_zero_lamports = true;
         let mut index_entries_being_shrunk = Vec::with_capacity(accounts.len());
-        self.accounts_index.scan(
+        self.accounts_index.scan::<_, _, true>(
             accounts.iter().map(|account| account.pubkey()),
             |pubkey, slots_refs, entry| {
                 let mut result = AccountsIndexScanResult::OnlyKeepInMemoryIfDirty;
@@ -3774,7 +3773,6 @@ impl AccountsDb {
                 result
             },
             None,
-            true,
         );
         assert_eq!(index, std::cmp::min(accounts.len(), count));
         stats.alive_accounts.fetch_add(alive, Ordering::Relaxed);
@@ -8143,7 +8141,7 @@ impl AccountsDb {
         self.thread_pool_clean.install(|| {
             (0..batches).into_par_iter().for_each(|batch| {
                 let skip = batch * UNREF_ACCOUNTS_BATCH_SIZE;
-                self.accounts_index.scan(
+                self.accounts_index.scan::<_, _, false>(
                     pubkeys
                         .clone()
                         .skip(skip)
@@ -8159,7 +8157,6 @@ impl AccountsDb {
                         AccountsIndexScanResult::Unref
                     },
                     Some(AccountsIndexScanResult::Unref),
-                    false,
                 )
             });
         });

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1352,13 +1352,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ///   apply 'avoid_callback_result' if specified.
     ///   otherwise, call `callback`
     /// if 'PROVIDE_ENTRY_IN_CALLBACK' is true, populate callback with the Arc of the entry itself.
-    pub(crate) fn scan<
-        'a,
-        F,
-        I,
-        const PROVIDE_ENTRY_IN_CALLBACK: bool,
-        const AVOID_CALLBACK_RESULT: u8,
-    >(
+    pub fn scan<'a, F, I, const PROVIDE_ENTRY_IN_CALLBACK: bool, const AVOID_CALLBACK_RESULT: u8>(
         &self,
         pubkeys: I,
         mut callback: F,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1402,7 +1402,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     PROVIDE_ENTRY_IN_CALLBACK.then_some(locked_entry),
                                 )
                             } else {
-                                unsafe { std::mem::transmute(AVOID_CALLBACK_RESULT as u8) }
+                                unsafe { std::mem::transmute(AVOID_CALLBACK_RESULT) }
                             };
 
                         cache = match result {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1349,12 +1349,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ///   apply 'avoid_callback_result' if specified.
     ///   otherwise, call `callback`
     /// if 'provide_entry_in_callback' is true, populate callback with the Arc of the entry itself.
-    pub(crate) fn scan<'a, F, I>(
+    pub(crate) fn scan<'a, F, I, const PROVIDE_ENTRY_IN_CALLBACK: bool>(
         &self,
         pubkeys: I,
         mut callback: F,
         avoid_callback_result: Option<AccountsIndexScanResult>,
-        provide_entry_in_callback: bool,
     ) where
         // params:
         //  pubkey looked up
@@ -1392,7 +1391,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             callback(
                                 pubkey,
                                 Some((slot_list, locked_entry.ref_count())),
-                                provide_entry_in_callback.then_some(locked_entry),
+                                PROVIDE_ENTRY_IN_CALLBACK.then_some(locked_entry),
                             )
                         };
                         cache = match result {


### PR DESCRIPTION
#### Problem

AccountsIndex `scan` function is used in account-db cleaning code. Scans take up about 16% of the total clean time.

```
"time","clean_accounts.mean_accounts_scan","clean_accounts.mean_total_us"
"2023-08-03T14:44:35.000Z","790327.5714285715","4723039.571428572"
``` 

Optimize this fn will help the account-db clean time. 

#### Summary of Changes

Improve codegen for `scan` function 
1. moving the boolean flag `provide_entry_in_callback` parameter into constant template parameter.
2. roll Option<AccountsIndexScanResult>into `AccountsIndexScanResult` enum and move it to constant template parameter.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
