### PR TITLE
add metric read_only_cache_load_us

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8403,8 +8403,12 @@ impl AccountsDb {
 
     fn report_store_timings(&self) {
         if self.stats.last_store_report.should_update(1000) {
-            let (read_only_cache_hits, read_only_cache_misses, read_only_cache_evicts) =
-                self.read_only_accounts_cache.get_and_reset_stats();
+            let (
+                read_only_cache_hits,
+                read_only_cache_misses,
+                read_only_cache_evicts,
+                read_only_cache_load_us,
+            ) = self.read_only_accounts_cache.get_and_reset_stats();
             datapoint_info!(
                 "accounts_db_store_timings",
                 (
@@ -8468,6 +8472,11 @@ impl AccountsDb {
                 (
                     "read_only_accounts_cache_evicts",
                     read_only_cache_evicts,
+                    i64
+                ),
+                (
+                    "read_only_accounts_cache_load_us",
+                    read_only_cache_load_us,
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem
Working on improving load time from read cache.

#### Summary of Changes
Add `read_only_cache_load_us` metric to measure cost of load and update eviction queue.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
