### PR TITLE
Adds error types for all of `add_bank_snapshot()`

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1304,7 +1304,7 @@ pub fn add_bank_snapshot(
 ) -> Result<BankSnapshotInfo> {
     // this lambda function is to facilitate converting between
     // the AddBankSnapshotError and SnapshotError types
-    let _add_bank_snapshot = || {
+    let do_add_bank_snapshot = || {
         let mut add_snapshot_time = Measure::start("add-snapshot-ms");
         let slot = bank.slot();
         let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
@@ -1397,7 +1397,7 @@ pub fn add_bank_snapshot(
         })
     };
 
-    _add_bank_snapshot().map_err(|err| SnapshotError::AddBankSnapshot(err, bank.slot()))
+    do_add_bank_snapshot().map_err(|err| SnapshotError::AddBankSnapshot(err, bank.slot()))
 }
 
 /// serializing needs Vec<Vec<Arc<AccountStorageEntry>>>, but data structure at runtime is Vec<Arc<AccountStorageEntry>>


### PR DESCRIPTION
#### Problem

Now that AccountsBackgroundService handles any errors from the snapshot-request-handler gracefully, we may not have a lot of context from the `Err` that's returned. This is due to SnapshotErrors being simple wrappers, many around `std::io:Error`, which doesn't contain additional context beyond the operation & sometimes path.

#### Summary of Changes

For every possible failure inside of `add_bank_snapshot()`, assign a unique error and add appropriate context.

Note: I find the diff easier to view when ignoring whitespace changes. This is only applicable to the changes within `add_bank_snapshot()`.