### PR TITLE
ci: harden buildkite `group` generator

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -8,8 +8,14 @@ indent() {
 }
 
 group() {
+  # shellcheck disable=SC2016 # don't want these expressions expanded
+  local name="${1:?'buildkite `group` generator requires a `name`'}"
+  if [[ $# -lt 2 ]]; then
+    echo "no steps provided for buildkite group \`$name\`, omitting from pipeline" 1>&2
+    return
+  fi
   cat <<EOF | indent
-- group: "$1"
+- group: "$name"
   steps:
 EOF
   shift


### PR DESCRIPTION
#### Problem

the buildkite `group` generator helper emits an empty skeleton when no steps are passed, which buildkite pukes on when the pipeline is uploaded

as seen in, https://buildkite.com/solana-labs/solana/builds/99283#01897551-c842-4618-8c70-0a0d845c9c48/179-182

#### Summary of Changes

harden it via:
1. strictly enforce all generated groups to pass a `name`
2. skip `group` generation altogether if no steps are passed. log on stderr instead