### PR TITLE
cleanup feature: Use default units per instruction in fee calculation

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -128,7 +128,6 @@ impl CostModel {
         let enable_request_heap_frame_ix = true;
         let result = compute_budget.process_instructions(
             transaction.message().program_instructions_iter(),
-            true, // default_units_per_instruction has enabled in MNB
             !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
             enable_request_heap_frame_ix,
             feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -6,7 +6,7 @@ use {
         entrypoint::HEAP_LENGTH as MIN_HEAP_FRAME_BYTES,
         feature_set::{
             add_set_tx_loaded_accounts_data_size_instruction, enable_request_heap_frame_ix,
-            remove_deprecated_request_unit_ix, use_default_units_in_fee_calculation, FeatureSet,
+            remove_deprecated_request_unit_ix, FeatureSet,
         },
         fee::FeeBudgetLimits,
         genesis_config::ClusterType,
@@ -177,7 +177,6 @@ impl ComputeBudget {
     pub fn process_instructions<'a>(
         &mut self,
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-        default_units_per_instruction: bool,
         support_request_units_deprecated: bool,
         enable_request_heap_frame_ix: bool,
         support_set_loaded_accounts_data_size_limit_ix: bool,
@@ -261,18 +260,15 @@ impl ComputeBudget {
             self.heap_size = Some(bytes as usize);
         }
 
-        let compute_unit_limit = if default_units_per_instruction {
-            updated_compute_unit_limit.or_else(|| {
+        let compute_unit_limit = updated_compute_unit_limit
+            .or_else(|| {
                 Some(
                     num_non_compute_budget_instructions
                         .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 )
             })
-        } else {
-            updated_compute_unit_limit
-        }
-        .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
-        .min(MAX_COMPUTE_UNIT_LIMIT);
+            .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
+            .min(MAX_COMPUTE_UNIT_LIMIT);
         self.compute_unit_limit = u64::from(compute_unit_limit);
 
         self.loaded_accounts_data_size_limit = updated_loaded_accounts_data_size_limit
@@ -302,7 +298,6 @@ impl ComputeBudget {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 instructions,
-                feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                 !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                 enable_request_heap_frame_ix,
                 feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),
@@ -345,7 +340,6 @@ mod tests {
             let mut compute_budget = ComputeBudget::default();
             let result = compute_budget.process_instructions(
                 tx.message().program_instructions_iter(),
-                true,
                 false, /*not support request_units_deprecated*/
                 $enable_request_heap_frame_ix,
                 $support_set_loaded_accounts_data_size_limit_ix,
@@ -895,7 +889,6 @@ mod tests {
         let mut compute_budget = ComputeBudget::default();
         let result = compute_budget.process_instructions(
             transaction.message().program_instructions_iter(),
-            true,
             false, //not support request_units_deprecated
             true,  //enable_request_heap_frame_ix,
             true,  //support_set_loaded_accounts_data_size_limit_ix,

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -261,13 +261,10 @@ impl ComputeBudget {
         }
 
         let compute_unit_limit = updated_compute_unit_limit
-            .or_else(|| {
-                Some(
-                    num_non_compute_budget_instructions
-                        .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
-                )
+            .unwrap_or_else(|| {
+                num_non_compute_budget_instructions
+                    .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
             })
-            .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
             .min(MAX_COMPUTE_UNIT_LIMIT);
         self.compute_unit_limit = u64::from(compute_unit_limit);
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -251,7 +251,6 @@ impl Accounts {
                 ComputeBudget::new(compute_budget::MAX_COMPUTE_UNIT_LIMIT as u64);
             let _process_transaction_result = compute_budget.process_instructions(
                 tx.message().program_instructions_iter(),
-                true, // default_units_per_instruction has enabled in MNB
                 !feature_set.is_active(&remove_deprecated_request_unit_ix::id()),
                 true, // don't reject txs that use request heap size ix
                 feature_set.is_active(&add_set_tx_loaded_accounts_data_size_instruction::id()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5242,7 +5242,6 @@ impl Bank {
                             Measure::start("compute_budget_process_transaction_time");
                         let process_transaction_result = compute_budget.process_instructions(
                             tx.message().program_instructions_iter(),
-                            true,
                             !self
                                 .feature_set
                                 .is_active(&remove_deprecated_request_unit_ix::id()),

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -27,7 +27,6 @@ pub trait GetTransactionPriorityDetails {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 instructions,
-                true, // use default units per instruction
                 true, // supports prioritization by request_units_deprecated instruction
                 true, // enable request heap frame instruction
                 true, // enable support set accounts data size instruction


### PR DESCRIPTION
#### Problem

Feature `8sKQrMQoUHtQSUP83SPG4ta2JDjSAiWs7t5aJ9uEd6To` has been enabled since epoch 478

#### Summary of Changes
cleanup feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
