### PR TITLE
TieredStorage struct (3/N) -- new_readonly and reader structs

### DIFF
--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -151,7 +151,7 @@ mod tests {
         footer::{TieredStorageFooter, TieredStorageMagicNumber},
         hot::HOT_FORMAT,
         solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey},
-        tempfile::NamedTempFile,
+        tempfile::tempdir,
     };
 
     impl TieredStorage {
@@ -200,7 +200,10 @@ mod tests {
 
     #[test]
     fn test_new_meta_file_only() {
-        let tiered_storage_path = NamedTempFile::new().unwrap().path().to_path_buf();
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let temp_dir = tempdir().unwrap();
+        let tiered_storage_path = temp_dir.path().join("test_new_meta_file_only");
+
         {
             let tiered_storage =
                 TieredStorage::new_writable(&tiered_storage_path, HOT_FORMAT.clone());
@@ -231,7 +234,10 @@ mod tests {
 
     #[test]
     fn test_write_accounts_twice() {
-        let tiered_storage_path = NamedTempFile::new().unwrap().path().to_path_buf();
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let temp_dir = tempdir().unwrap();
+        let tiered_storage_path = temp_dir.path().join("test_write_accounts_twice");
+
         let tiered_storage = TieredStorage::new_writable(&tiered_storage_path, HOT_FORMAT.clone());
         // Expect the result to be TieredStorageError::Unsupported as the feature
         // is not yet fully supported, but we can still check its partial results

--- a/runtime/src/tiered_storage.rs
+++ b/runtime/src/tiered_storage.rs
@@ -66,14 +66,14 @@ impl TieredStorage {
 
     /// Creates a new read-only instance of TieredStorage from the
     /// specified path.
-    pub fn new_readonly(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
-        let reader = TieredStorageReader::new_from_path(path.as_ref())?;
-        let reader_cell = OnceCell::<TieredStorageReader>::new();
-        reader_cell.set(reader).unwrap();
+    pub fn new_readonly(path: impl Into<PathBuf>) -> TieredStorageResult<Self> {
+        let pathbuf = path.into();
+        let reader = TieredStorageReader::new_from_path(&pathbuf)?;
+        let reader_cell = OnceCell::with_value(reader);
         Ok(Self {
             reader: reader_cell,
             format: None,
-            path: path.as_ref().to_path_buf(),
+            path: pathbuf,
         })
     }
 

--- a/runtime/src/tiered_storage/error.rs
+++ b/runtime/src/tiered_storage/error.rs
@@ -8,8 +8,11 @@ pub enum TieredStorageError {
     #[error("MagicNumberMismatch: expected {0}, found {1}")]
     MagicNumberMismatch(u64, u64),
 
-    #[error("ReadOnlyFileUpdateError: attempted to update read-only file {0}")]
-    ReadOnlyFileUpdateError(PathBuf),
+    #[error("AttemptToUpdateReadOnly: attempted to update read-only file {0}")]
+    AttemptToUpdateReadOnly(PathBuf),
+
+    #[error("UnableToCreateReader: unable to create tiered-storage reader for {0}")]
+    UnableToCreateReader(PathBuf),
 
     #[error("UnknownFormat: the tiered storage format is unavailable for file {0}")]
     UnknownFormat(PathBuf),

--- a/runtime/src/tiered_storage/error.rs
+++ b/runtime/src/tiered_storage/error.rs
@@ -11,9 +11,6 @@ pub enum TieredStorageError {
     #[error("AttemptToUpdateReadOnly: attempted to update read-only file {0}")]
     AttemptToUpdateReadOnly(PathBuf),
 
-    #[error("UnableToCreateReader: unable to create tiered-storage reader for {0}")]
-    UnableToCreateReader(PathBuf),
-
     #[error("UnknownFormat: the tiered storage format is unavailable for file {0}")]
     UnknownFormat(PathBuf),
 

--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -47,7 +47,8 @@ impl Default for TieredStorageMagicNumber {
 pub enum AccountMetaFormat {
     #[default]
     Hot = 0,
-    Cold = 1,
+    // Temporarily comment out to avoid unimplemented!() block
+    // Cold = 1,
 }
 
 #[repr(u16)]

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -214,6 +214,10 @@ impl HotStorageReader {
     pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
         let file = OpenOptions::new().read(true).open(path)?;
         let mmap = unsafe { MmapOptions::new().map(&file)? };
+        // Here we are cloning the footer as accessing any data in a
+        // TieredStorage instance requires accessing its Footer.
+        // This can help improve cache locality and reduce the overhead
+        // of indirection associated with memory-mapped accesses.
         let footer = TieredStorageFooter::new_from_mmap(&mmap)?.clone();
         assert_ne!(mmap.len(), 0);
 

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -205,22 +205,19 @@ impl TieredAccountMeta for HotAccountMeta {
 /// The reader to a hot accounts file.
 #[derive(Debug)]
 pub struct HotStorageReader {
-    map: Mmap,
+    mmap: Mmap,
     footer: TieredStorageFooter,
 }
 
 impl HotStorageReader {
     /// Constructs a HotStorageReader from the specified path.
-    pub fn new_from_path<P: AsRef<Path>>(path: P) -> TieredStorageResult<Self> {
-        let file = OpenOptions::new()
-            .read(true)
-            .create(false)
-            .open(path.as_ref())?;
-        let map = unsafe { MmapOptions::new().map(&file)? };
-        let footer = TieredStorageFooter::new_from_mmap(&map)?.clone();
-        assert!(map.len() > 0);
+    pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
+        let file = OpenOptions::new().read(true).open(path)?;
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
+        let footer = TieredStorageFooter::new_from_mmap(&mmap)?.clone();
+        assert_ne!(mmap.len(), 0);
 
-        Ok(Self { map, footer })
+        Ok(Self { mmap, footer })
     }
 
     /// Returns the footer of the underlying tiered-storage accounts file.

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -6,15 +6,18 @@ use {
         account_storage::meta::StoredMetaWriteVersion,
         tiered_storage::{
             byte_block,
-            footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
+            footer::{
+                AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat, TieredStorageFooter,
+            },
             index::AccountIndexFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-            TieredStorageFormat,
+            TieredStorageFormat, TieredStorageResult,
         },
     },
+    memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
     solana_sdk::{hash::Hash, stake_history::Epoch},
-    std::option::Option,
+    std::{fs::OpenOptions, option::Option, path::Path},
 };
 
 pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
@@ -196,6 +199,39 @@ impl TieredAccountMeta for HotAccountMeta {
     /// account block.
     fn account_data<'a>(&self, account_block: &'a [u8]) -> &'a [u8] {
         &account_block[..self.account_data_size(account_block)]
+    }
+}
+
+/// The reader to a hot accounts file.
+#[derive(Debug)]
+pub struct HotStorageReader {
+    map: Mmap,
+    footer: TieredStorageFooter,
+}
+
+impl HotStorageReader {
+    /// Constructs a HotStorageReader from the specified path.
+    pub fn new_from_path<P: AsRef<Path>>(path: P) -> TieredStorageResult<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .create(false)
+            .open(path.as_ref())?;
+        let map = unsafe { MmapOptions::new().map(&file)? };
+        let footer = TieredStorageFooter::new_from_mmap(&map)?.clone();
+        assert!(map.len() > 0);
+
+        Ok(Self { map, footer })
+    }
+
+    /// Returns the footer of the underlying tiered-storage accounts file.
+    pub fn footer(&self) -> &TieredStorageFooter {
+        &self.footer
+    }
+
+    /// Returns the number of files inside the underlying tiered-storage
+    /// accounts file.
+    pub fn num_accounts(&self) -> usize {
+        self.footer.account_entry_count as usize
     }
 }
 

--- a/runtime/src/tiered_storage/hot.rs
+++ b/runtime/src/tiered_storage/hot.rs
@@ -219,7 +219,6 @@ impl HotStorageReader {
         // This can help improve cache locality and reduce the overhead
         // of indirection associated with memory-mapped accesses.
         let footer = TieredStorageFooter::new_from_mmap(&mmap)?.clone();
-        assert_ne!(mmap.len(), 0);
 
         Ok(Self { mmap, footer })
     }

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -116,7 +116,7 @@ impl TieredStorageReader {
     /// Returns the total number of accounts.
     pub fn num_accounts(&self) -> usize {
         match self {
-            Self::Hot(hs) => hs.num_accounts(),
+            Self::Hot(hot) => hot.num_accounts(),
         }
     }
 }

--- a/runtime/src/tiered_storage/readable.rs
+++ b/runtime/src/tiered_storage/readable.rs
@@ -1,8 +1,15 @@
 use {
     crate::{
-        account_storage::meta::StoredMetaWriteVersion, tiered_storage::meta::TieredAccountMeta,
+        account_storage::meta::StoredMetaWriteVersion,
+        tiered_storage::{
+            footer::{AccountMetaFormat, TieredStorageFooter},
+            hot::HotStorageReader,
+            meta::TieredAccountMeta,
+            TieredStorageResult,
+        },
     },
     solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
+    std::path::Path,
 };
 
 /// The struct that offers read APIs for accessing a TieredAccount.
@@ -81,5 +88,35 @@ impl<'accounts_file, M: TieredAccountMeta> ReadableAccount
     /// Returns the data associated to this account.
     fn data(&self) -> &'accounts_file [u8] {
         self.data()
+    }
+}
+
+/// The reader of a tiered storage instance.
+#[derive(Debug)]
+pub enum TieredStorageReader {
+    Hot(HotStorageReader),
+}
+
+impl TieredStorageReader {
+    /// Creates a reader for the specified tiered storage accounts file.
+    pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
+        let footer = TieredStorageFooter::new_from_path(&path)?;
+        match footer.account_meta_format {
+            AccountMetaFormat::Hot => Ok(Self::Hot(HotStorageReader::new_from_path(path)?)),
+        }
+    }
+
+    /// Returns the footer of the associated HotAccountsFile.
+    pub fn footer(&self) -> &TieredStorageFooter {
+        match self {
+            Self::Hot(hot) => hot.footer(),
+        }
+    }
+
+    /// Returns the total number of accounts.
+    pub fn num_accounts(&self) -> usize {
+        match self {
+            Self::Hot(hs) => hs.num_accounts(),
+        }
     }
 }


### PR DESCRIPTION
#### Summary of Changes
This PR implements TieredStorage::new_readonly() and introduces
TieredStorageReader and HotStorageReader.


#### Test Plan
Updated the existing unit test.

This PR depends on #32541.