### PR TITLE
Do not add bank snapshots for AccountsHashVerifier requests

### DIFF
--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -93,6 +93,24 @@ impl AccountsPackage {
         )
     }
 
+    /// Package up fields needed to verify an accounts hash
+    #[must_use]
+    pub fn new_for_accounts_hash_verifier(
+        package_type: AccountsPackageType,
+        bank: &Bank,
+        snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+        accounts_hash_for_testing: Option<AccountsHash>,
+    ) -> Self {
+        assert_eq!(package_type, AccountsPackageType::AccountsHashVerifier);
+        Self::_new(
+            package_type,
+            bank,
+            snapshot_storages,
+            accounts_hash_for_testing,
+            None,
+        )
+    }
+
     /// Package up fields needed to compute an EpochAccountsHash
     #[must_use]
     pub fn new_for_epoch_accounts_hash(


### PR DESCRIPTION
#### Problem

With fastboot, if an AccountsHashVerifier request is handled by AccountsBackgroundService, it will add a bank snapshot. Then after AccountsHashVerifier (the service) processes this accounts package, it'll be `BankSnapshotPost` on disk, which makes it eligible for fastboot.

HOWEVER, if we startup from this bank snapshot, and then try to create an incremental snapshot *and* the IncrementalAccountsHash feature gate is enabled, we will panic! This is because the incremental snapshot will be looking for account hash information from its base (i.e. full) snapshot. Since we started up from a bank snapshot *not* meant for a snapshot archive, we will not have that information available.

And really, we don't need a bank snapshot for accounts hash verifier requests; they just take up space (and hold on to AppendVecs) unnecessarily.


#### Summary of Changes

Do not add a bank snapshot when handling accounts hash verifier requests.