### PR TITLE
clarify how configuration values before/until deal with the range bou…

### DIFF
--- a/docs/src/api/methods/_getSignaturesForAddress.mdx
+++ b/docs/src/api/methods/_getSignaturesForAddress.mdx
@@ -45,12 +45,12 @@ Configuration object containing the following fields:
 </Field>
 
 <Field name="before" type="string" optional={true}>
-  start searching backwards from this transaction signature. If not provided the
+  start searching backwards from this transaction signature (exclusive). If not provided the
   search starts from the top of the highest max confirmed block.
 </Field>
 
 <Field name="until" type="string" optional={true}>
-  search until this transaction signature, if found before limit reached
+  search until this transaction signature (exclusive), if found before limit reached
 </Field>
 
 </Parameter>


### PR DESCRIPTION
#### Problem
Docs for  _getSignaturesForAddress_ are a bit unclear about range boundaries.

it says
> start searching backwards from this transaction signature

but does not state if _this signature_ is included or excluded

#### Summary of Changes
* change docs

Fixes #
* none
