### PR TITLE
Removes old accounts hash cache dir

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -586,6 +586,12 @@ impl Validator {
         timer.stop();
         info!("Cleaning orphaned account snapshot directories done. {timer}");
 
+        // The accounts hash cache dir was renamed, so cleanup the old dir if it exists.
+        let old_accounts_hash_cache_dir = ledger_path.join("calculate_accounts_hash_cache");
+        if old_accounts_hash_cache_dir.exists() {
+            snapshot_utils::move_and_async_delete_path(old_accounts_hash_cache_dir);
+        }
+
         {
             let exit = exit.clone();
             config


### PR DESCRIPTION
#### Problem

The directory that caches the result from accounts hash calculation was renamed in #29734. This required manual intervention on the part of node operators to remove the old cache directory. While it was harmless, the old directory did take up disk space. It should be cleaned up automatically.


#### Summary of Changes

Remove the old cache dir, if it exists.