### PR TITLE
ci: stop spl downstream project test temporarily

### DIFF
--- a/.buildkite/scripts/build-downstream-projects.sh
+++ b/.buildkite/scripts/build-downstream-projects.sh
@@ -9,5 +9,5 @@ source "$here"/common.sh
 agent="${1-solana}"
 
 group "downstream projects" \
-  '{ "name": "spl", "command": "./ci/downstream-projects/run-spl.sh", "timeout_in_minutes": 30, "agent": "'"$agent"'" }'
+#  '{ "name": "spl", "command": "./ci/downstream-projects/run-spl.sh", "timeout_in_minutes": 30, "agent": "'"$agent"'" }'
 #  '{ "name": "openbook-dex", "command": "./ci/downstream-projects/run-openbook-dex.sh", "timeout_in_minutes": 30, "agent": "'"$agent"'" }' \


### PR DESCRIPTION
#### Problem

we introduced a sdk breaking changes in https://github.com/solana-labs/solana/pull/32524 but we haven't released a crate for it. It makes spl project need to use a future crate for monorepo's downstream project test.(started from https://github.com/solana-labs/solana-program-library/pull/4504 and reverted in https://github.com/solana-labs/solana-program-library/pull/4841)

I guess we should follow these steps:

1. released a new crate for sdk
2. spl project upgrade to the new version
3. restore spl downstream project

(thank @joncinque for the insight <3 )

#### Summary of Changes

stop spl downstream project test temporarily till we bump release new sdk version
