### PR TITLE
ledger-tool: Add flag to ignore open file descriptor limit error

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -990,6 +990,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let verbose = matches.is_present("verbose");
     let force_update_to_open = matches.is_present("force_update_to_open");
     let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
+    let enforce_ulimit_nofile = !matches.is_present("ignore_ulimit_nofile_error");
 
     let (subcommand, sub_matches) = matches.subcommand();
     let instance_name = get_global_subcommand_arg(
@@ -1015,6 +1016,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 AccessType::Secondary,
                 None,
                 force_update_to_open,
+                enforce_ulimit_nofile,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -304,6 +304,7 @@ pub fn load_and_process_ledger(
                     AccessType::PrimaryForMaintenance,
                     None,
                     false,
+                    false,
                 ))
             } else {
                 blockstore.clone()
@@ -356,6 +357,7 @@ pub fn open_blockstore(
     access_type: AccessType,
     wal_recovery_mode: Option<BlockstoreRecoveryMode>,
     force_update_to_open: bool,
+    enforce_ulimit_nofile: bool,
 ) -> Blockstore {
     let shred_storage_type = get_shred_storage_type(
         ledger_path,
@@ -370,7 +372,7 @@ pub fn open_blockstore(
         BlockstoreOptions {
             access_type: access_type.clone(),
             recovery_mode: wal_recovery_mode.clone(),
-            enforce_ulimit_nofile: true,
+            enforce_ulimit_nofile,
             column_options: LedgerColumnOptions {
                 shred_storage_type,
                 ..LedgerColumnOptions::default()

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -77,6 +77,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
     let debug_keys = pubkeys_of(arg_matches, "debug_key")
         .map(|pubkeys| Arc::new(pubkeys.into_iter().collect::<HashSet<_>>()));
     let force_update_to_open = arg_matches.is_present("force_update_to_open");
+    let enforce_ulimit_nofile = !arg_matches.is_present("ignore_ulimit_nofile_error");
     let process_options = ProcessOptions {
         new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
         run_verification: false,
@@ -116,6 +117,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
         AccessType::Secondary,
         wal_recovery_mode,
         force_update_to_open,
+        enforce_ulimit_nofile,
     );
     let (bank_forks, ..) = load_and_process_ledger(
         arg_matches,

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -8,7 +8,8 @@ pub struct BlockstoreOptions {
     pub access_type: AccessType,
     // Whether to open a blockstore under a recovery mode. Default: None.
     pub recovery_mode: Option<BlockstoreRecoveryMode>,
-    // Whether to allow unlimited number of open files. Default: true.
+    // When opening the Blockstore, determines whether to error or not if the
+    // desired open file descriptor limit cannot be configured. Default: true.
     pub enforce_ulimit_nofile: bool,
     pub column_options: LedgerColumnOptions,
 }


### PR DESCRIPTION
#### Problem
The current desired open file descriptor limit is 1,000,000. This is quite a large number, and not needed for every command. Namely, commands that do not unpack a snapshot and create an AccountsDB will likely not use this many files.

#### Summary of Changes
There is already an option in BlockstoreOptions to ignore errors if the desired value cannot be set; this PR just bubbles that option up to a CLI flag in ledger-tool.

Think it makes sense to keep the default of enforcing the limit. This flag is mostly orientated towards advanced users who know which command won't incur as many open files and want to run those commands without the file limitation