### PR TITLE
ledger-tool: Workaround clap bug for encoding arg in genesis command

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1488,7 +1488,7 @@ fn main() {
                     .requires("accounts")
                     .help("Do not print account data when printing account contents."),
             )
-            .arg(&accounts_data_encoding_arg.clone().requires("accounts"))
+            .arg(&accounts_data_encoding_arg)
         )
         .subcommand(
             SubCommand::with_name("genesis-hash")


### PR DESCRIPTION
#### Problem
The --encoding flag only makes sense for the genesis command if the genesis accounts will be printed. Hence, the encoding flag used the Arg::requires() function on --accounts argument.

However, in what appears to be a clap bug, this made the --accounts flag required even though it should not be.

#### Summary of Changes
So, remove the .requires() dependency between these two arguments.

Prior to this change, running the following would error:
```
$ solana-ledger-tool genesis --ledger ~/ledger/
error: The following required arguments were not provided:
    --accounts
```
When I removed the `.default_value()` specifier on the encoding arg, the error went away. So, there is seemingly some clap bug, but given how old of a version we're using, I do not plan on submitting a PR to them