### PR TITLE
ci: make test_batched_range_proof_u256 use all threads in nextest

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -7,3 +7,7 @@ fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"
+
+[[profile.ci.overrides]]
+filter = "package(solana-zk-token-proof-program-tests) & test(/^test_batched_range_proof_u256$/)"
+threads-required = "num-cpus"


### PR DESCRIPTION
#### Problem

`test_batched_range_proof_u256` is flaky when test it with nextest

#### Summary of Changes

make it use all threads during nextest testing
