### PR TITLE
migrate runtime stake program dependencies to sdk

### DIFF
--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,15 +1,16 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
+use solana_sdk::genesis_config::GenesisConfig;
+#[deprecated(
+    since = "1.17.0",
+    note = "Please use `solana_sdk::stake::get_minimum_delegation` instead"
+)]
+pub use solana_sdk::stake::get_minimum_delegation;
 #[deprecated(
     since = "1.8.0",
     note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` instead"
 )]
 pub use solana_sdk::stake::program::{check_id, id};
-use solana_sdk::{
-    feature_set::{self, FeatureSet},
-    genesis_config::GenesisConfig,
-    native_token::LAMPORTS_PER_SOL,
-};
 
 pub mod config;
 pub mod stake_instruction;
@@ -17,18 +18,4 @@ pub mod stake_state;
 
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
     config::add_genesis_account(genesis_config)
-}
-
-/// The minimum stake amount that can be delegated, in lamports.
-/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
-/// rent exempt reserve _plus_ the minimum stake delegation.
-#[inline(always)]
-pub fn get_minimum_delegation(feature_set: &FeatureSet) -> u64 {
-    if feature_set.is_active(&feature_set::stake_raise_minimum_delegation_to_1_sol::id()) {
-        const MINIMUM_DELEGATION_SOL: u64 = 1;
-        MINIMUM_DELEGATION_SOL * LAMPORTS_PER_SOL
-    } else {
-        #[allow(deprecated)]
-        solana_sdk::stake::MINIMUM_STAKE_DELEGATION
-    }
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -54,6 +54,7 @@ use {
         pubkey::Pubkey,
         saturating_add_assign,
         slot_hashes::SlotHashes,
+        stake::program::check_id as solana_stake_program_check_id,
         sysvar::{self, instructions::construct_instructions_data},
         transaction::{Result, SanitizedTransaction, TransactionAccountLocks, TransactionError},
         transaction_context::{IndexOfAccount, TransactionAccount},
@@ -471,7 +472,7 @@ impl Accounts {
 
                     if in_reward_interval
                         && message.is_writable(i)
-                        && solana_stake_program::check_id(account.owner())
+                        && solana_stake_program_check_id(account.owner())
                     {
                         error_counters.program_execution_temporarily_restricted += 1;
                         return Err(TransactionError::ProgramExecutionTemporarilyRestricted {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -159,7 +159,7 @@ use {
         signature::{Keypair, Signature},
         slot_hashes::SlotHashes,
         slot_history::{Check, SlotHistory},
-        stake::state::Delegation,
+        stake::state::{Delegation, StakeState},
         system_transaction,
         sysvar::{self, last_restart_slot::LastRestartSlot, Sysvar, SysvarId},
         timing::years_as_slots,
@@ -171,9 +171,7 @@ use {
             ExecutionRecord, TransactionAccount, TransactionContext, TransactionReturnData,
         },
     },
-    solana_stake_program::stake_state::{
-        self, InflationPointCalculationEvent, PointValue, StakeState,
-    },
+    solana_stake_program::stake_state::{self, InflationPointCalculationEvent, PointValue},
     solana_system_program::{get_system_account_kind, SystemAccountKind},
     solana_vote_program::vote_state::VoteState,
     std::{

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -159,7 +159,10 @@ use {
         signature::{Keypair, Signature},
         slot_hashes::SlotHashes,
         slot_history::{Check, SlotHistory},
-        stake::state::{Delegation, StakeState},
+        stake::{
+            self,
+            state::{Delegation, StakeState},
+        },
         system_transaction,
         sysvar::{self, last_restart_slot::LastRestartSlot, Sysvar, SysvarId},
         timing::years_as_slots,
@@ -2629,8 +2632,7 @@ impl Bank {
         {
             let num_stake_delegations = stakes.stake_delegations().len();
             let min_stake_delegation =
-                solana_stake_program::get_minimum_delegation(&self.feature_set)
-                    .max(LAMPORTS_PER_SOL);
+                stake::get_minimum_delegation(&self.feature_set).max(LAMPORTS_PER_SOL);
 
             let (stake_delegations, filter_timer) = measure!(stakes
                 .stake_delegations()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -82,7 +82,7 @@ use {
         signature::{keypair_from_seed, Keypair, Signature, Signer},
         stake::{
             instruction as stake_instruction,
-            state::{Authorized, Delegation, Lockup, Stake},
+            state::{Authorized, Delegation, Lockup, Stake, StakeState},
         },
         system_instruction::{
             self, SystemError, MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
@@ -96,7 +96,7 @@ use {
         },
         transaction_context::{TransactionAccount, TransactionContext},
     },
-    solana_stake_program::stake_state::{self, StakeState},
+    solana_stake_program::stake_state,
     solana_vote_program::{
         vote_instruction,
         vote_state::{

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -81,7 +81,7 @@ use {
         secp256k1_program,
         signature::{keypair_from_seed, Keypair, Signature, Signer},
         stake::{
-            instruction as stake_instruction,
+            self, instruction as stake_instruction,
             state::{Authorized, Delegation, Lockup, Stake, StakeState},
         },
         system_instruction::{
@@ -4418,7 +4418,7 @@ fn test_bank_cloned_stake_delegations() {
         let rent = &bank.rent_collector().rent;
         let vote_rent_exempt_reserve = rent.minimum_balance(VoteState::size_of());
         let stake_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = stake::get_minimum_delegation(&bank.feature_set);
         (
             vote_rent_exempt_reserve,
             stake_rent_exempt_reserve + minimum_delegation,

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -2,6 +2,7 @@ use {
     solana_program_runtime::invoke_context::ProcessInstructionWithContext,
     solana_sdk::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, feature_set, pubkey::Pubkey,
+        stake::program::id as solana_stake_program_id,
     },
 };
 
@@ -55,7 +56,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     },
     BuiltinPrototype {
         feature_id: None,
-        program_id: solana_stake_program::id(),
+        program_id: solana_stake_program_id(),
         name: "stake_program",
         entrypoint: solana_stake_program::stake_instruction::process_instruction,
     },

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -6,7 +6,10 @@ use {
         account_utils::StateMut,
         instruction::InstructionError,
         pubkey::Pubkey,
-        stake::state::{Delegation, StakeState},
+        stake::{
+            program::id as solana_stake_program_id,
+            state::{Delegation, StakeState},
+        },
     },
     std::marker::PhantomData,
     thiserror::Error,
@@ -58,7 +61,7 @@ impl StakeAccount<Delegation> {
 impl TryFrom<AccountSharedData> for StakeAccount<()> {
     type Error = Error;
     fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
-        if account.owner() != &solana_stake_program::id() {
+        if account.owner() != &solana_stake_program_id() {
             return Err(Error::InvalidOwner(*account.owner()));
         }
         let stake_state = account.state()?;
@@ -119,7 +122,7 @@ impl AbiExample for StakeAccount<Delegation> {
             StakeState::Stake(Meta::example(), Stake::example(), StakeFlags::example());
         let mut account = Account::example();
         account.data.resize(200, 0u8);
-        account.owner = solana_stake_program::id();
+        account.owner = solana_stake_program_id();
         account.set_state(&stake_state).unwrap();
         Self::try_from(AccountSharedData::from(account)).unwrap()
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -16,7 +16,10 @@ use {
         account::{AccountSharedData, ReadableAccount},
         clock::{Epoch, Slot},
         pubkey::Pubkey,
-        stake::state::{Delegation, StakeActivationStatus},
+        stake::{
+            program::check_id as solana_stake_program_check_id,
+            state::{Delegation, StakeActivationStatus},
+        },
         vote::state::VoteStateVersions,
     },
     std::{
@@ -76,7 +79,7 @@ impl StakesCache {
             if solana_vote_program::check_id(owner) {
                 let mut stakes = self.0.write().unwrap();
                 stakes.remove_vote_account(pubkey);
-            } else if solana_stake_program::check_id(owner) {
+            } else if solana_stake_program_check_id(owner) {
                 let mut stakes = self.0.write().unwrap();
                 stakes.remove_stake_delegation(pubkey);
             }
@@ -103,7 +106,7 @@ impl StakesCache {
                 let mut stakes = self.0.write().unwrap();
                 stakes.remove_vote_account(pubkey)
             };
-        } else if solana_stake_program::check_id(owner) {
+        } else if solana_stake_program_check_id(owner) {
             match StakeAccount::try_from(account.to_account_shared_data()) {
                 Ok(stake_account) => {
                     let mut stakes = self.0.write().unwrap();

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -142,7 +142,7 @@ fn test_stake_create_and_split_single_signature() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = stake::get_minimum_delegation(&bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -218,7 +218,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = stake::get_minimum_delegation(&bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -310,7 +310,7 @@ fn test_stake_account_lifetime() {
         (
             rent.minimum_balance(VoteState::size_of()),
             rent.minimum_balance(StakeState::size_of()),
-            solana_stake_program::get_minimum_delegation(&bank.feature_set),
+            stake::get_minimum_delegation(&bank.feature_set),
         )
     };
 
@@ -611,7 +611,7 @@ fn test_create_stake_account_from_seed() {
     let (balance, delegation) = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = stake::get_minimum_delegation(&bank.feature_set);
         (rent_exempt_reserve + minimum_delegation, minimum_delegation)
     };
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -51,7 +51,7 @@ pub use solana_program::{
     loader_v4, loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
     program_memory, program_option, program_pack, rent, sanitize, sdk_ids, secp256k1_program,
     secp256k1_recover, serde_varint, serialize_utils, short_vec, slot_hashes, slot_history,
-    stable_layout, stake, stake_history, syscalls, system_instruction, system_program, sysvar,
+    stable_layout, stake_history, syscalls, system_instruction, system_program, sysvar,
     unchecked_div_by_const, vote, wasm_bindgen,
 };
 
@@ -93,6 +93,23 @@ pub mod secp256k1_instruction;
 pub mod shred_version;
 pub mod signature;
 pub mod signer;
+pub mod stake {
+    use super::{feature_set, native_token};
+    pub use solana_program::stake::*;
+    /// The minimum stake amount that can be delegated, in lamports.
+    /// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
+    /// rent exempt reserve _plus_ the minimum stake delegation.
+    #[inline(always)]
+    pub fn get_minimum_delegation(feature_set: &feature_set::FeatureSet) -> u64 {
+        if feature_set.is_active(&feature_set::stake_raise_minimum_delegation_to_1_sol::id()) {
+            const MINIMUM_DELEGATION_SOL: u64 = 1;
+            MINIMUM_DELEGATION_SOL.saturating_mul(native_token::LAMPORTS_PER_SOL)
+        } else {
+            #[allow(deprecated)]
+            MINIMUM_STAKE_DELEGATION
+        }
+    }
+}
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;


### PR DESCRIPTION
#### Problem

can't `ProgramTest` the stake program 'cause it depends on runtime and runtime depends on stake program :recycle:. luckily, nearly all of the symbols are already in sdk and (most of) those that aren't... should be.

#### Summary of Changes

* move straggler shared stake program bits to sdk
* get runtime's stake program dependencies from stake program
 