### PR TITLE
BorrowedAccount: reserve() doesn't need to check for can_data_be_changed()

### DIFF
--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -964,7 +964,10 @@ impl<'a> BorrowedAccount<'a> {
     /// in the given account. Does nothing if capacity is already sufficient.
     #[cfg(not(target_os = "solana"))]
     pub fn reserve(&mut self, additional: usize) -> Result<(), InstructionError> {
-        self.can_data_be_changed()?;
+        // Note that we don't need to call can_data_be_changed() here nor
+        // touch() the account. reserve() only changes the capacity of the
+        // memory that holds the account but it doesn't actually change content
+        // nor length of the account.
         self.make_data_mut();
         self.account.reserve(additional);
 


### PR DESCRIPTION
reserve() only changes the capacity of the vector that holds the account data, it doesn't modify the account in any way

Extracted from https://github.com/solana-labs/solana/pull/31986 since it's a self contained change.