### PR TITLE
direct mapping: misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,6 +5372,7 @@ dependencies = [
  "log",
  "memoffset 0.9.0",
  "rand 0.8.5",
+ "scopeguard",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk",

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -153,6 +153,10 @@ pub struct SyscallContext {
 #[derive(Debug, Clone)]
 pub struct SerializedAccountMetadata {
     pub original_data_len: usize,
+    pub vm_data_addr: u64,
+    pub vm_key_addr: u64,
+    pub vm_lamports_addr: u64,
+    pub vm_owner_addr: u64,
 }
 
 pub struct InvokeContext<'a> {

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = { workspace = true }
 libsecp256k1 = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+scopeguard = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -101,7 +101,7 @@ impl Serializer {
         } else {
             self.push_region(true);
             let vaddr = self.vaddr;
-            self.push_account_region(account)?;
+            self.push_account_data_region(account)?;
             vaddr
         };
 
@@ -128,7 +128,7 @@ impl Serializer {
         Ok(vm_data_addr)
     }
 
-    fn push_account_region(
+    fn push_account_data_region(
         &mut self,
         account: &mut BorrowedAccount<'_>,
     ) -> Result<(), InstructionError> {

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1246,11 +1246,7 @@ fn update_callee_account(
                         .get_data_mut()?
                         .get_mut(caller_account.original_data_len..post_len)
                         .ok_or(SyscallError::InvalidLength)?
-                        .copy_from_slice(
-                            serialized_data
-                                .get(0..realloc_bytes_used)
-                                .ok_or(SyscallError::InvalidLength)?,
-                        );
+                        .copy_from_slice(serialized_data);
                 }
             }
             Err(err) if prev_len != post_len => {

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    crate::declare_syscall,
+    crate::{declare_syscall, serialization::account_data_region_memory_state},
     scopeguard::defer,
     solana_program_runtime::invoke_context::SerializedAccountMetadata,
     solana_rbpf::memory_region::{MemoryRegion, MemoryState},
@@ -1306,29 +1306,9 @@ fn update_caller_account_perms(
 
     let data_region = account_data_region(memory_mapping, *vm_data_addr, *original_data_len)?;
     if let Some(region) = data_region {
-        match (
-            region.state.get(),
-            callee_account.can_data_be_changed().is_ok(),
-        ) {
-            (MemoryState::Readable, true) => {
-                // If the account is still shared it means it wasn't written to yet during this
-                // transaction. We map it as CoW and it'll be copied the first time something
-                // tries to write into it.
-                if callee_account.is_shared() {
-                    let index_in_transaction = callee_account.get_index_in_transaction();
-                    region
-                        .state
-                        .set(MemoryState::Cow(index_in_transaction as u64));
-                } else {
-                    region.state.set(MemoryState::Writable);
-                }
-            }
-
-            (MemoryState::Writable | MemoryState::Cow(_), false) => {
-                region.state.set(MemoryState::Readable);
-            }
-            _ => {}
-        }
+        region
+            .state
+            .set(account_data_region_memory_state(callee_account));
     }
     let realloc_region = account_realloc_region(
         memory_mapping,

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1,7 +1,9 @@
 use {
     super::*,
     crate::declare_syscall,
+    scopeguard::defer,
     solana_program_runtime::invoke_context::SerializedAccountMetadata,
+    solana_rbpf::memory_region::{MemoryRegion, MemoryState},
     solana_sdk::{
         feature_set::enable_bpf_loader_set_authority_checked_ix,
         stable_layout::stable_instruction::StableInstruction,
@@ -10,7 +12,7 @@ use {
         },
         transaction_context::BorrowedAccount,
     },
-    std::{mem, ptr, slice},
+    std::{mem, ptr},
 };
 
 fn check_account_info_pointer(
@@ -83,10 +85,8 @@ struct CallerAccount<'a, 'b> {
     // mapped inside the vm (see serialize_parameters() in
     // BpfExecutor::execute).
     //
-    // When direct mapping is off, this includes both the account data _and_ the
-    // realloc padding. When direct mapping is on, account data is mapped in its
-    // own separate memory region which is directly mutated from inside the vm,
-    // and the serialized buffer includes only the realloc padding.
+    // This is only set when direct mapping is off (see the relevant comment in
+    // CallerAccount::from_account_info).
     serialized_data: &'a mut [u8],
     // Given the corresponding input AccountInfo::data, vm_data_addr points to
     // the pointer field and ref_to_len_in_vm points to the length field.
@@ -103,7 +103,6 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
     fn from_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &'b MemoryMapping<'a>,
-        is_loader_deprecated: bool,
         _vm_addr: u64,
         account_info: &AccountInfo,
         account_metadata: &SerializedAccountMetadata,
@@ -209,26 +208,29 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             };
             let vm_data_addr = data.as_ptr() as u64;
 
-            let serialized_data = translate_slice_mut::<u8>(
-                memory_mapping,
-                if direct_mapping {
-                    vm_data_addr.saturating_add(original_data_len as u64)
-                } else {
-                    vm_data_addr
-                },
-                if direct_mapping {
-                    if is_loader_deprecated {
-                        0
-                    } else {
-                        MAX_PERMITTED_DATA_INCREASE
-                    }
-                } else {
-                    data.len()
-                } as u64,
-                invoke_context.get_check_aligned(),
-                invoke_context.get_check_size(),
-            )?;
-
+            let serialized_data = if direct_mapping {
+                // when direct mapping is enabled, the permissions on the
+                // realloc region can change during CPI so we must delay
+                // translating until when we know whether we're going to mutate
+                // the realloc region or not. Consider this case:
+                //
+                // [caller can't write to an account] <- we are here
+                // [callee grows and assigns account to the caller]
+                // [caller can now write to the account]
+                //
+                // If we always translated the realloc area here, we'd get a
+                // memory access violation since we can't write to the account
+                // _yet_, but we will be able to once the caller returns.
+                &mut []
+            } else {
+                translate_slice_mut::<u8>(
+                    memory_mapping,
+                    vm_data_addr,
+                    data.len() as u64,
+                    invoke_context.get_check_aligned(),
+                    invoke_context.get_check_size(),
+                )?
+            };
             (
                 serialized_data,
                 vm_data_addr,
@@ -254,7 +256,6 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
     fn from_sol_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &'b MemoryMapping<'a>,
-        _is_loader_deprecated: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
         account_metadata: &SerializedAccountMetadata,
@@ -377,6 +378,19 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             executable: account_info.executable,
             rent_epoch: account_info.rent_epoch,
         })
+    }
+
+    fn realloc_region(
+        &self,
+        memory_mapping: &'b MemoryMapping<'_>,
+        is_loader_deprecated: bool,
+    ) -> Result<Option<&'a MemoryRegion>, Error> {
+        account_realloc_region(
+            memory_mapping,
+            self.vm_data_addr,
+            self.original_data_len,
+            is_loader_deprecated,
+        )
     }
 }
 
@@ -849,7 +863,6 @@ where
     F: Fn(
         &InvokeContext,
         &'b MemoryMapping<'a>,
-        bool,
         u64,
         &T,
         &SerializedAccountMetadata,
@@ -918,7 +931,6 @@ where
                 do_translate(
                     invoke_context,
                     memory_mapping,
-                    is_loader_deprecated,
                     account_infos_addr.saturating_add(
                         caller_account_index.saturating_mul(mem::size_of::<T>()) as u64,
                     ),
@@ -934,6 +946,7 @@ where
             // changes.
             update_callee_account(
                 invoke_context,
+                memory_mapping,
                 is_loader_deprecated,
                 &caller_account,
                 callee_account,
@@ -1129,6 +1142,25 @@ fn cpi_common<S: SyscallInvokeSigned>(
         .feature_set
         .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
+    if direct_mapping {
+        // Update all perms at once before doing account data updates. This
+        // isn't strictly required as we forbid updates to an account to touch
+        // other accounts, but since we did have bugs around this in the past,
+        // it's better to be safe than sorry.
+        for (index_in_caller, caller_account) in accounts.iter() {
+            if let Some(caller_account) = caller_account {
+                let callee_account = instruction_context
+                    .try_borrow_instruction_account(transaction_context, *index_in_caller)?;
+                update_caller_account_perms(
+                    memory_mapping,
+                    caller_account,
+                    &callee_account,
+                    is_loader_deprecated,
+                )?;
+            }
+        }
+    }
+
     for (index_in_caller, caller_account) in accounts.iter_mut() {
         if let Some(caller_account) = caller_account {
             let mut callee_account = instruction_context
@@ -1157,6 +1189,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
 // changes.
 fn update_callee_account(
     invoke_context: &InvokeContext,
+    memory_mapping: &MemoryMapping,
     is_loader_deprecated: bool,
     caller_account: &CallerAccount,
     mut callee_account: BorrowedAccount<'_>,
@@ -1177,16 +1210,28 @@ fn update_callee_account(
             .and_then(|_| callee_account.can_data_be_changed())
         {
             Ok(()) => {
-                callee_account.set_data_length(post_len)?;
                 let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
-                if !is_loader_deprecated && realloc_bytes_used > 0 {
+                // bpf_loader_deprecated programs don't have a realloc region
+                if is_loader_deprecated && realloc_bytes_used > 0 {
+                    return Err(InstructionError::InvalidRealloc.into());
+                }
+                callee_account.set_data_length(post_len)?;
+                if realloc_bytes_used > 0 {
+                    let serialized_data = translate_slice::<u8>(
+                        memory_mapping,
+                        caller_account
+                            .vm_data_addr
+                            .saturating_add(caller_account.original_data_len as u64),
+                        realloc_bytes_used as u64,
+                        invoke_context.get_check_aligned(),
+                        invoke_context.get_check_size(),
+                    )?;
                     callee_account
                         .get_data_mut()?
                         .get_mut(caller_account.original_data_len..post_len)
                         .ok_or(SyscallError::InvalidLength)?
                         .copy_from_slice(
-                            caller_account
-                                .serialized_data
+                            serialized_data
                                 .get(0..realloc_bytes_used)
                                 .ok_or(SyscallError::InvalidLength)?,
                         );
@@ -1247,6 +1292,63 @@ fn update_callee_account(
     Ok(())
 }
 
+fn update_caller_account_perms(
+    memory_mapping: &MemoryMapping,
+    caller_account: &CallerAccount,
+    callee_account: &BorrowedAccount<'_>,
+    is_loader_deprecated: bool,
+) -> Result<(), Error> {
+    let CallerAccount {
+        original_data_len,
+        vm_data_addr,
+        ..
+    } = caller_account;
+
+    let data_region = account_data_region(memory_mapping, *vm_data_addr, *original_data_len)?;
+    if let Some(region) = data_region {
+        match (
+            region.state.get(),
+            callee_account.can_data_be_changed().is_ok(),
+        ) {
+            (MemoryState::Readable, true) => {
+                // If the account is still shared it means it wasn't written to yet during this
+                // transaction. We map it as CoW and it'll be copied the first time something
+                // tries to write into it.
+                if callee_account.is_shared() {
+                    let index_in_transaction = callee_account.get_index_in_transaction();
+                    region
+                        .state
+                        .set(MemoryState::Cow(index_in_transaction as u64));
+                } else {
+                    region.state.set(MemoryState::Writable);
+                }
+            }
+
+            (MemoryState::Writable | MemoryState::Cow(_), false) => {
+                region.state.set(MemoryState::Readable);
+            }
+            _ => {}
+        }
+    }
+    let realloc_region = account_realloc_region(
+        memory_mapping,
+        *vm_data_addr,
+        *original_data_len,
+        is_loader_deprecated,
+    )?;
+    if let Some(region) = realloc_region {
+        region
+            .state
+            .set(if callee_account.can_data_be_changed().is_ok() {
+                MemoryState::Writable
+            } else {
+                MemoryState::Readable
+            });
+    }
+
+    Ok(())
+}
+
 // Update the given account after executing CPI.
 //
 // caller_account and callee_account describe to the same account. At CPI exit
@@ -1266,34 +1368,36 @@ fn update_caller_account(
     *caller_account.lamports = callee_account.get_lamports();
     *caller_account.owner = *callee_account.get_owner();
 
-    if direct_mapping && caller_account.original_data_len > 0 {
-        // Since each instruction account is directly mapped in a memory region
-        // with a *fixed* length, upon returning from CPI we must ensure that the
-        // current capacity is at least the original length (what is mapped in
-        // memory), so that the account's memory region never points to an
-        // invalid address.
-        let min_capacity = caller_account.original_data_len;
-        if callee_account.capacity() < min_capacity {
-            callee_account.reserve(min_capacity.saturating_sub(callee_account.capacity()))?
-        }
+    if direct_mapping {
+        if let Some(region) = account_data_region(
+            memory_mapping,
+            caller_account.vm_data_addr,
+            caller_account.original_data_len,
+        )? {
+            // Since each instruction account is directly mapped in a memory region
+            // with a *fixed* length, upon returning from CPI we must ensure that the
+            // current capacity is at least the original length (what is mapped in
+            // memory), so that the account's memory region never points to an
+            // invalid address.
+            let min_capacity = caller_account.original_data_len;
+            if callee_account.capacity() < min_capacity {
+                callee_account.reserve(min_capacity.saturating_sub(callee_account.capacity()))?
+            }
 
-        // If an account's data pointer has changed - because of CoW or because
-        // of using AccountSharedData directly (deprecated) - we must update the
-        // corresponding MemoryRegion in the caller's address space. Address
-        // spaces are fixed so we don't need to update the MemoryRegion's
-        // length.
-        //
-        // We can trust vm_data_addr to point to the correct region because we
-        // enforce that in CallerAccount::from_(sol_)account_info.
-        let region = memory_mapping.region(AccessType::Load, caller_account.vm_data_addr)?;
-        let callee_ptr = callee_account.get_data().as_ptr() as u64;
-        if region.host_addr.get() != callee_ptr {
-            region.host_addr.set(callee_ptr);
+            // If an account's data pointer has changed - because of CoW, reserve() as called above
+            // or because of using AccountSharedData directly (deprecated) - we must update the
+            // corresponding MemoryRegion in the caller's address space. Address spaces are fixed so
+            // we don't need to update the MemoryRegion's length.
+            let callee_ptr = callee_account.get_data().as_ptr() as u64;
+            if region.host_addr.get() != callee_ptr {
+                region.host_addr.set(callee_ptr);
+            }
         }
     }
 
     let prev_len = *caller_account.ref_to_len_in_vm.get()? as usize;
     let post_len = callee_account.get_data().len();
+    let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
     if prev_len != post_len {
         let max_increase = if direct_mapping && !invoke_context.get_check_aligned() {
             0
@@ -1311,8 +1415,15 @@ fn update_caller_account(
             );
             return Err(Box::new(InstructionError::InvalidRealloc));
         }
+
+        // If the account has been shrunk, we're going to zero the unused memory
+        // *that was previously used*.
         if post_len < prev_len {
             if direct_mapping {
+                // We have two separate regions to zero out: the account data
+                // and the realloc region.
+                //
+                // Here we zero the account data region.
                 if post_len < caller_account.original_data_len {
                     // zero the spare capacity in the account data. We only need
                     // to zero up to the original data length, everything else
@@ -1326,15 +1437,57 @@ fn update_caller_account(
                     // Safety: we check bounds above
                     unsafe { ptr::write_bytes(dst, 0, spare_len) };
                 }
+                // Here we zero the realloc region.
+                //
+                // This is done for compatibility but really only necessary for
+                // the fringe case of a program calling itself, see
+                // TEST_CPI_ACCOUNT_UPDATE_CALLER_GROWS_CALLEE_SHRINKS.
+                //
+                // Zeroing the realloc region isn't necessary in the normal
+                // invoke case because consider the following scenario:
+                //
+                // 1. Caller grows an account (prev_len > original_data_len)
+                // 2. Caller assigns the account to the callee (needed for 3 to
+                //    work)
+                // 3. Callee shrinks the account (post_len < prev_len)
+                //
+                // In order for the caller to assign the account to the callee,
+                // the caller _must_ either set the account length to zero,
+                // therefore making prev_len > original_data_len impossible,
+                // or it must zero the account data, therefore making the
+                // zeroing we do here redundant.
+                if prev_len > caller_account.original_data_len {
+                    // If we get here and prev_len > original_data_len, then
+                    // we've already returned InvalidRealloc for the
+                    // bpf_loader_deprecated case.
+                    debug_assert!(!is_loader_deprecated);
 
-                // zero the spare capacity in the realloc padding
-                let spare_realloc = unsafe {
-                    slice::from_raw_parts_mut(
-                        caller_account.serialized_data.as_mut_ptr(),
-                        prev_len.saturating_sub(caller_account.original_data_len),
-                    )
-                };
-                spare_realloc.fill(0);
+                    // Temporarily configure the realloc region as writable then set it back to
+                    // whatever state it had.
+                    let realloc_region = caller_account
+                        .realloc_region(memory_mapping, is_loader_deprecated)?
+                        .unwrap(); // unwrapping here is fine, we already asserted !is_loader_deprecated
+                    let original_state = realloc_region.state.replace(MemoryState::Writable);
+                    defer! {
+                        realloc_region.state.set(original_state);
+                    };
+
+                    // We need to zero the unused space in the realloc region, starting after the
+                    // last byte of the new data which might be > original_data_len.
+                    let dirty_realloc_start = caller_account.original_data_len.max(post_len);
+                    // and we want to zero up to the old length
+                    let dirty_realloc_len = prev_len.saturating_sub(dirty_realloc_start);
+                    let serialized_data = translate_slice_mut::<u8>(
+                        memory_mapping,
+                        caller_account
+                            .vm_data_addr
+                            .saturating_add(dirty_realloc_start as u64),
+                        dirty_realloc_len as u64,
+                        invoke_context.get_check_aligned(),
+                        invoke_context.get_check_size(),
+                    )?;
+                    serialized_data.fill(0);
+                }
             } else {
                 caller_account
                     .serialized_data
@@ -1344,8 +1497,8 @@ fn update_caller_account(
             }
         }
 
-        // with direct_mapping on, serialized_data is fixed and holds the
-        // realloc padding
+        // when direct mapping is enabled we don't cache the serialized data in
+        // caller_account.serialized_data. See CallerAccount::from_account_info.
         if !direct_mapping {
             caller_account.serialized_data = translate_slice_mut::<u8>(
                 memory_mapping,
@@ -1377,7 +1530,6 @@ fn update_caller_account(
             }
         }
     }
-    let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
     if !direct_mapping {
         let to_slice = &mut caller_account.serialized_data;
         let from_slice = callee_account
@@ -1388,19 +1540,86 @@ fn update_caller_account(
             return Err(Box::new(InstructionError::AccountDataTooSmall));
         }
         to_slice.copy_from_slice(from_slice);
-    } else if !is_loader_deprecated && realloc_bytes_used > 0 {
-        let to_slice = caller_account
-            .serialized_data
-            .get_mut(0..realloc_bytes_used)
-            .ok_or(SyscallError::InvalidLength)?;
+    } else if realloc_bytes_used > 0 {
+        // In the is_loader_deprecated case, we must have failed with
+        // InvalidRealloc by now.
+        debug_assert!(!is_loader_deprecated);
+
+        let to_slice = {
+            // If a callee reallocs an account, we write into the caller's
+            // realloc region regardless of whether the caller has write
+            // permissions to the account or not. If the callee has been able to
+            // make changes, it means they had permissions to do so, and here
+            // we're just going to reflect those changes to the caller's frame.
+            //
+            // Therefore we temporarily configure the realloc region as writable
+            // then set it back to whatever state it had.
+            let realloc_region = caller_account
+                .realloc_region(memory_mapping, is_loader_deprecated)?
+                .unwrap(); // unwrapping here is fine, we asserted !is_loader_deprecated
+            let original_state = realloc_region.state.replace(MemoryState::Writable);
+            defer! {
+                realloc_region.state.set(original_state);
+            };
+
+            translate_slice_mut::<u8>(
+                memory_mapping,
+                caller_account
+                    .vm_data_addr
+                    .saturating_add(caller_account.original_data_len as u64),
+                realloc_bytes_used as u64,
+                invoke_context.get_check_aligned(),
+                invoke_context.get_check_size(),
+            )?
+        };
         let from_slice = callee_account
             .get_data()
             .get(caller_account.original_data_len..post_len)
             .ok_or(SyscallError::InvalidLength)?;
+        if to_slice.len() != from_slice.len() {
+            return Err(Box::new(InstructionError::AccountDataTooSmall));
+        }
         to_slice.copy_from_slice(from_slice);
     }
 
     Ok(())
+}
+
+fn account_data_region<'a>(
+    memory_mapping: &'a MemoryMapping<'_>,
+    vm_data_addr: u64,
+    original_data_len: usize,
+) -> Result<Option<&'a MemoryRegion>, Error> {
+    if original_data_len == 0 {
+        return Ok(None);
+    }
+
+    // We can trust vm_data_addr to point to the correct region because we
+    // enforce that in CallerAccount::from_(sol_)account_info.
+    let data_region = memory_mapping.region(AccessType::Load, vm_data_addr)?;
+    // vm_data_addr must always point to the beginning of the region
+    debug_assert_eq!(data_region.vm_addr, vm_data_addr);
+    Ok(Some(data_region))
+}
+
+fn account_realloc_region<'a>(
+    memory_mapping: &'a MemoryMapping<'_>,
+    vm_data_addr: u64,
+    original_data_len: usize,
+    is_loader_deprecated: bool,
+) -> Result<Option<&'a MemoryRegion>, Error> {
+    if is_loader_deprecated {
+        return Ok(None);
+    }
+
+    let realloc_vm_addr = vm_data_addr.saturating_add(original_data_len as u64);
+    let realloc_region = memory_mapping.region(AccessType::Load, realloc_vm_addr)?;
+    debug_assert_eq!(realloc_region.vm_addr, realloc_vm_addr);
+    debug_assert!((MAX_PERMITTED_DATA_INCREASE
+        ..MAX_PERMITTED_DATA_INCREASE.saturating_add(BPF_ALIGN_OF_U128))
+        .contains(&(realloc_region.len as usize)));
+    debug_assert!(!matches!(realloc_region.state.get(), MemoryState::Cow(_)));
+    Ok(Some(realloc_region))
 }
 
 #[allow(clippy::indexing_slicing)]
@@ -1593,7 +1812,6 @@ mod tests {
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
             &memory_mapping,
-            false,
             vm_addr,
             account_info,
             &account_metadata,
@@ -1886,8 +2104,16 @@ mod tests {
                 // the length slot in the serialization parameters must be updated
                 assert_eq!(data_len, serialized_len());
 
-                // with direct mapping on, serialized_data contains the realloc padding
-                let realloc_area = &caller_account.serialized_data;
+                let realloc_area = translate_slice::<u8>(
+                    &memory_mapping,
+                    caller_account
+                        .vm_data_addr
+                        .saturating_add(caller_account.original_data_len as u64),
+                    MAX_PERMITTED_DATA_INCREASE as u64,
+                    invoke_context.get_check_aligned(),
+                    invoke_context.get_check_size(),
+                )
+                .unwrap();
 
                 if data_len < original_data_len {
                     // if an account gets resized below its original data length,
@@ -2063,6 +2289,17 @@ mod tests {
             false,
         );
 
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(
+            mock_caller_account.regions.split_off(0),
+            &config,
+            &SBPFVersion::V2,
+        )
+        .unwrap();
+
         let caller_account = mock_caller_account.caller_account();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2072,6 +2309,7 @@ mod tests {
 
         update_callee_account(
             &invoke_context,
+            &memory_mapping,
             false,
             &caller_account,
             callee_account,
@@ -2107,6 +2345,17 @@ mod tests {
             false,
         );
 
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(
+            mock_caller_account.regions.split_off(0),
+            &config,
+            &SBPFVersion::V2,
+        )
+        .unwrap();
+
         let mut caller_account = mock_caller_account.caller_account();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2116,6 +2365,7 @@ mod tests {
 
         update_callee_account(
             &invoke_context,
+            &memory_mapping,
             false,
             &caller_account,
             callee_account,
@@ -2134,6 +2384,7 @@ mod tests {
         caller_account.owner = &mut owner;
         update_callee_account(
             &invoke_context,
+            &memory_mapping,
             false,
             &caller_account,
             callee_account,
@@ -2167,6 +2418,17 @@ mod tests {
             false,
         );
 
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(
+            mock_caller_account.regions.split_off(0),
+            &config,
+            &SBPFVersion::V2,
+        )
+        .unwrap();
+
         let mut caller_account = mock_caller_account.caller_account();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2175,6 +2437,7 @@ mod tests {
         assert!(matches!(
             update_callee_account(
                 &invoke_context,
+                &memory_mapping,
                 false,
                 &caller_account,
                 callee_account,
@@ -2192,6 +2455,7 @@ mod tests {
         assert!(matches!(
             update_callee_account(
                 &invoke_context,
+                &memory_mapping,
                 false,
                 &caller_account,
                 callee_account,
@@ -2209,6 +2473,7 @@ mod tests {
         assert!(matches!(
             update_callee_account(
                 &invoke_context,
+                &memory_mapping,
                 false,
                 &caller_account,
                 callee_account,
@@ -2241,6 +2506,17 @@ mod tests {
             true,
         );
 
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping = MemoryMapping::new(
+            mock_caller_account.regions.split_off(0),
+            &config,
+            &SBPFVersion::V2,
+        )
+        .unwrap();
+
         let mut caller_account = mock_caller_account.caller_account();
 
         let mut callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2250,8 +2526,17 @@ mod tests {
         // with enough padding to hold the realloc padding
         callee_account.get_data_mut().unwrap();
 
-        let mut data = b"baz".to_vec();
-        caller_account.serialized_data = &mut data;
+        let serialized_data = translate_slice_mut::<u8>(
+            &memory_mapping,
+            caller_account
+                .vm_data_addr
+                .saturating_add(caller_account.original_data_len as u64),
+            3,
+            invoke_context.get_check_aligned(),
+            invoke_context.get_check_size(),
+        )
+        .unwrap();
+        serialized_data.copy_from_slice(b"baz");
 
         for (len, expected) in [
             (9, b"foobarbaz".to_vec()), // > original_data_len, copies from realloc region
@@ -2261,6 +2546,7 @@ mod tests {
             *caller_account.ref_to_len_in_vm.get_mut().unwrap() = len as u64;
             update_callee_account(
                 &invoke_context,
+                &memory_mapping,
                 false,
                 &caller_account,
                 callee_account,
@@ -2279,6 +2565,7 @@ mod tests {
         caller_account.owner = &mut owner;
         update_callee_account(
             &invoke_context,
+            &memory_mapping,
             false,
             &caller_account,
             callee_account,
@@ -2358,6 +2645,7 @@ mod tests {
         data: Vec<u8>,
         len: u64,
         regions: Vec<MemoryRegion>,
+        direct_mapping: bool,
     }
 
     impl MockCallerAccount {
@@ -2417,6 +2705,7 @@ mod tests {
                 data: d,
                 len: data.len() as u64,
                 regions,
+                direct_mapping,
             }
         }
 
@@ -2431,7 +2720,11 @@ mod tests {
         }
 
         fn caller_account(&mut self) -> CallerAccount<'_, '_> {
-            let data = &mut self.data[mem::size_of::<u64>()..];
+            let data = if self.direct_mapping {
+                &mut []
+            } else {
+                &mut self.data[mem::size_of::<u64>()..]
+            };
             CallerAccount {
                 lamports: &mut self.lamports,
                 owner: &mut self.owner,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -123,6 +123,8 @@ pub enum SyscallError {
     },
     #[error("InvalidAttribute")]
     InvalidAttribute,
+    #[error("Invalid pointer")]
+    InvalidPointer,
 }
 
 type Error = Box<dyn std::error::Error>;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4613,6 +4613,7 @@ dependencies = [
  "libsecp256k1 0.6.0",
  "log",
  "rand 0.8.5",
+ "scopeguard",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk",

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -1000,8 +1000,8 @@ impl<'a> BorrowedAccount<'a> {
         // transaction reallocs, we don't have to copy the whole account data a
         // second time to fullfill the realloc.
         //
-        // NOTE: The account memory region CoW code in Serializer::push_account_region() implements
-        // the same logic and must be kept in sync.
+        // NOTE: The account memory region CoW code in bpf_loader::create_vm() implements the same
+        // logic and must be kept in sync.
         if self.account.is_shared() {
             self.account.reserve(MAX_PERMITTED_DATA_INCREASE);
         }


### PR DESCRIPTION
This fixes the following issues with the direct mapping feature, it has no impact on !direct_mapping code:

- `bpf_loader: direct_mapping: enforce account info pointers to be immutable` ensures that all AccountInfo pointers are not mutated. CPI looks up memory regions based on an account's data address so it can't be changed, and other pointers are locked too since there's no (legitimate) reason to ever mutate them, they point to address space setup by the program runtime.

- `bpf_loader: cpi: access ref_to_len_in_vm through VmValue` disables "caching" of vm->host address translations. Vm address space under direct mapping has some dynamic properties (CoW, changing permissions), so memory accesses must always to go through the vm.

- `direct mapping: improve memory permission tracking across CPI calls` ensures that account data and realloc memory regions are correctly updated to match their respective account's permissions, and that the permissions are all synchronized in one go _before_ the individual accounts are synchronized. This is required to guarantee that while synchronizing accounts across CPI calls memory region permissions are in a consistent state.

 - `cpi: fix slow edge case zeroing extra account capacity after shrinking an account` fixes a slow edge case when resizing large accounts. 

- ` cpi: direct_mapping: error out if ref_to_len_in_vm points to account memory` forbids `AccountInfo::data` from being put in account memory. CPI updates that slice and we don't want CPI to write into account data.

- `bpf_loader: direct_mapping: map AccessViolation -> InstructionError` maps low level `AccessViolation` errors to higher level `InstructionError`s for better debuggability

Extracted from https://github.com/solana-labs/solana/pull/31986 to not include other small refactorings and new tests which will be PR-d separately. 