### PR TITLE
Unzips Option when rebuilding bank

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -709,10 +709,11 @@ fn rebuild_bank_from_unarchived_snapshots(
             let (snapshot_version, bank_snapshot_info) = verify_unpacked_snapshots_dir_and_version(
                 snapshot_unpacked_snapshots_dir_and_version,
             )?;
-            (Some(snapshot_version), Some(bank_snapshot_info))
+            Some((snapshot_version, bank_snapshot_info))
         } else {
-            (None, None)
-        };
+            None
+        }
+        .unzip();
     info!(
         "Rebuilding bank from full snapshot {} and incremental snapshot {:?}",
         full_snapshot_root_paths.snapshot_path().display(),


### PR DESCRIPTION
#### Problem

A cleanup PR.

Before [`Option::unzip`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unzip), we had to specify `Some`s and `None`s for all the values, even though logically we either had all `Some` or all `None`. Using `unzip` fixes this.

#### Summary of Changes

Replace with `unzip`.