### PR TITLE
Unzips Option when deserializing snapshot data files

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1036,15 +1036,10 @@ fn deserialize_snapshot_data_files_capped<T: Sized>(
         if let Some(ref incremental_snapshot_root_file_path) =
             snapshot_root_paths.incremental_snapshot_root_file_path
         {
-            let (incremental_snapshot_file_size, incremental_snapshot_data_file_stream) =
-                create_snapshot_data_file_stream(
-                    incremental_snapshot_root_file_path,
-                    maximum_file_size,
-                )?;
-            Some((
-                incremental_snapshot_file_size,
-                incremental_snapshot_data_file_stream,
-            ))
+            Some(create_snapshot_data_file_stream(
+                incremental_snapshot_root_file_path,
+                maximum_file_size,
+            )?)
         } else {
             None
         }


### PR DESCRIPTION
#### Problem

A cleanup PR.

Before [`Option::unzip`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unzip), we had to specify `Some`s and `None`s for all the values, even though logically we either had all `Some` or all `None`. Using `unzip` fixes this.

#### Summary of Changes

Replace with `unzip`.