### PR TITLE
Unstable sort slots when generating index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8937,8 +8937,7 @@ impl AccountsDb {
         genesis_config: &GenesisConfig,
     ) -> IndexGenerationInfo {
         let mut slots = self.storage.all_slots();
-        #[allow(clippy::stable_sort_primitive)]
-        slots.sort();
+        slots.sort_unstable();
         if let Some(limit) = limit_load_slot_count_from_snapshot {
             slots.truncate(limit); // get rid of the newer slots and keep just the older
         }


### PR DESCRIPTION
#### Problem

When generating the accounts index, we first get all the slots from the storages, and then sort the slots. This does not need to be a stable sort, as the elements of the Vec are only `u64`/true value types.


#### Summary of Changes

Replace stable sort with unstable sort.