### PR TITLE
Removes unnecessary clippy-allow for needless-collect when generating index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8929,7 +8929,6 @@ impl AccountsDb {
         );
     }
 
-    #[allow(clippy::needless_collect)]
     pub fn generate_index(
         &self,
         limit_load_slot_count_from_snapshot: Option<usize>,


### PR DESCRIPTION
#### Problem

`generate_index()` has a clippy-allow for `needless_collect`, but it is not needed.



#### Summary of Changes

Remove it.