### PR TITLE
Uses Mutex::into_inner() at end of de_dup_accounts()

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -856,7 +856,7 @@ impl AccountsHasher {
         zeros.stop();
         stats.zeros_time_total_us += zeros.as_us();
         let (min, max, lamports_sum, entries, hash_total) =
-            *min_max_sum_entries_hashes.lock().unwrap();
+            min_max_sum_entries_hashes.into_inner().unwrap();
         stats.min_bin_size = min;
         stats.max_bin_size = max;
         stats.unreduced_entries += entries;


### PR DESCRIPTION
#### Problem

We create a mutex at the start of `de_dup_accounts()` that is used by the parallel threads inside. At the end of the function, we get the data out of the mutex to update stats. Since we know all the parallel threads are done, we are the only one left with access to the Mutex, and thus we can skip the final lock.

#### Summary of Changes

Replace the final mutex lock with an `into_inner()`.