### PR TITLE
rolls out merkle shreds to ~50% of mainnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -509,7 +509,7 @@ impl BroadcastRun for StandardBroadcastRun {
 fn should_use_merkle_variant(slot: Slot, cluster_type: ClusterType) -> bool {
     match cluster_type {
         ClusterType::Testnet | ClusterType::Devnet | ClusterType::Development => true,
-        ClusterType::MainnetBeta => (slot % 19) < 4,
+        ClusterType::MainnetBeta => (slot % 19) < 10,
     }
 }
 


### PR DESCRIPTION
#### Problem
Ramping up Merkle shreds on mainnet.

#### Summary of Changes
Roll out Merkle shreds to ~50% of mainnet slots.