### PR TITLE
Correct docs for getMultipleAccounts RPC

### DIFF
--- a/docs/src/api/methods/_getMultipleAccounts.mdx
+++ b/docs/src/api/methods/_getMultipleAccounts.mdx
@@ -19,7 +19,7 @@ Returns the account information for a list of Pubkeys.
 
 ### Parameters:
 
-<Parameter type={"array"} optional={true}>
+<Parameter type={"array"} required={true}>
   An array of Pubkeys to query, as base-58 encoded strings (up to a maximum of
   100)
 </Parameter>
@@ -50,7 +50,7 @@ Data slicing is only available for <code>base58</code>, <code>base64</code>, or 
 :::
 </Field>
 
-<Field name="encoding" type="string" optional={true} defaultValue={"json"} href="/api/http#parsed-responses">
+<Field name="encoding" type="string" optional={true} defaultValue={"base64"} href="/api/http#parsed-responses">
 
 encoding format for the returned Account data
 


### PR DESCRIPTION
- list of pubkeys is required:

```bash
curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
{
    "method": "getMultipleAccounts",
    "jsonrpc": "2.0",
    "params": [],
    "id": "1"
}'
{"jsonrpc":"2.0","error":{"code":-32602,"message":"`params` should have at least 1 argument(s)"},"id":"1"}
```

- encoding defaults to `base64` if not provided: https://github.com/solana-labs/solana/blob/69336ab5daa31e659ed189c955ecd5002cbff308/rpc/src/rpc.rs#L445 