### PR TITLE
ci: fix cc only support unix and window since 1.0.80

### DIFF
--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -28,7 +28,6 @@ ahash = { workspace = true }
 blake3 = { workspace = true, features = ["digest", "traits-preview"] }
 block-buffer = { workspace = true }
 byteorder = { workspace = true, features = ["i128"] }
-cc = { workspace = true, features = ["jobserver", "parallel"] }
 either = { workspace = true, features = ["use_std"] }
 generic-array = { workspace = true, features = ["serde", "more_lengths"] }
 getrandom = { workspace = true, features = ["dummy"] }
@@ -37,6 +36,9 @@ memmap2 = { workspace = true }
 once_cell = { workspace = true, features = ["alloc", "race"] }
 rand_core = { workspace = true, features = ["std"] }
 subtle = { workspace = true }
+
+[target.'cfg(any(unix, windows))'.dependencies]
+cc = { workspace = true, features = ["jobserver", "parallel"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 solana-logger = { workspace = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -83,8 +83,10 @@ serde_json = { workspace = true }
 static_assertions = { workspace = true }
 
 [build-dependencies]
-cc = { workspace = true, features = ["jobserver", "parallel"] }
 rustc_version = { workspace = true }
+
+[target.'cfg(any(unix, windows))'.build-dependencies]
+cc = { workspace = true, features = ["jobserver", "parallel"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem

we bumped cc to 1.0.80 in https://github.com/solana-labs/solana/pull/32681 and it only supports unix and window atm.

https://github.com/rust-lang/cc-rs/blob/7adebb9d8c235a53800c4ac3a160615aa1c5028c/src/os_pipe.rs#L19-L28
```rust
#[cfg(unix)]
#[path = "os_pipe/unix.rs"]
mod sys;

#[cfg(windows)]
#[path = "os_pipe/windows.rs"]
mod sys;

#[cfg(all(not(unix), not(windows)))]
compile_error!("Only unix and windows support os_pipe!");
```
#### Summary of Changes

update our Cargo.toml to fit the requirement
