### PR TITLE
improve prioritization fee cache accuracy

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2719,7 +2719,6 @@ impl ReplayStage {
         ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
         block_metadata_notifier: Option<BlockMetadataNotifierLock>,
         replay_result_vec: &[ReplaySlotFromBlockstore],
-        prioritization_fee_cache: &PrioritizationFeeCache,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
     ) -> bool {
         // TODO: See if processing of blockstore replay results and bank completion can be made thread safe.
@@ -2794,9 +2793,6 @@ impl ReplayStage {
                     .unwrap_or_else(|err| {
                         warn!("cost_update_sender failed sending bank stats: {:?}", err)
                     });
-
-                // finalize block's minimum prioritization fee cache for this bank
-                prioritization_fee_cache.finalize_priority_fee(bank.slot());
 
                 assert_ne!(bank.hash(), Hash::default());
                 // Needs to be updated before `check_slot_agrees_with_cluster()` so that
@@ -2985,7 +2981,6 @@ impl ReplayStage {
                 ancestor_hashes_replay_update_sender,
                 block_metadata_notifier,
                 &replay_result_vec,
-                prioritization_fee_cache,
                 purge_repair_slot_counter,
             )
         } else {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -989,6 +989,7 @@ impl Validator {
                     optimistically_confirmed_bank,
                     rpc_subscriptions.clone(),
                     confirmed_bank_subscribers,
+                    prioritization_fee_cache.clone(),
                 )),
                 Some(BankNotificationSenderConfig {
                     sender: bank_notification_sender,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -12,7 +12,9 @@ use {
     crate::rpc_subscriptions::RpcSubscriptions,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_rpc_client_api::response::{SlotTransactionStats, SlotUpdate},
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::{
+        bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
+    },
     solana_sdk::{clock::Slot, timing::timestamp},
     std::{
         collections::HashSet,
@@ -92,6 +94,7 @@ impl OptimisticallyConfirmedBankTracker {
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
         subscriptions: Arc<RpcSubscriptions>,
         slot_notification_subscribers: Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
+        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
     ) -> Self {
         let mut pending_optimistically_confirmed_banks = HashSet::new();
         let mut last_notified_confirmed_slot: Slot = 0;
@@ -114,6 +117,7 @@ impl OptimisticallyConfirmedBankTracker {
                     &mut highest_confirmed_slot,
                     &mut newest_root_slot,
                     &slot_notification_subscribers,
+                    &prioritization_fee_cache,
                 ) {
                     break;
                 }
@@ -122,6 +126,7 @@ impl OptimisticallyConfirmedBankTracker {
         Self { thread_hdl }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn recv_notification(
         receiver: &Receiver<BankNotification>,
         bank_forks: &Arc<RwLock<BankForks>>,
@@ -132,6 +137,7 @@ impl OptimisticallyConfirmedBankTracker {
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
+        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
     ) -> Result<(), RecvTimeoutError> {
         let notification = receiver.recv_timeout(Duration::from_secs(1))?;
         Self::process_notification(
@@ -144,6 +150,7 @@ impl OptimisticallyConfirmedBankTracker {
             highest_confirmed_slot,
             newest_root_slot,
             slot_notification_subscribers,
+            prioritization_fee_cache,
         );
         Ok(())
     }
@@ -249,6 +256,7 @@ impl OptimisticallyConfirmedBankTracker {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn process_notification(
         notification: BankNotification,
         bank_forks: &Arc<RwLock<BankForks>>,
@@ -259,6 +267,7 @@ impl OptimisticallyConfirmedBankTracker {
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
+        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
     ) {
         debug!("received bank notification: {:?}", notification);
         match notification {
@@ -298,6 +307,9 @@ impl OptimisticallyConfirmedBankTracker {
                     slot,
                     timestamp: timestamp(),
                 });
+
+                // finalize block's minimum prioritization fee cache for this bank
+                prioritization_fee_cache.finalize_priority_fee(slot);
             }
             BankNotification::Frozen(bank) => {
                 let frozen_slot = bank.slot();
@@ -457,6 +469,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(highest_confirmed_slot, 2);
@@ -472,6 +485,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(highest_confirmed_slot, 2);
@@ -487,6 +501,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
@@ -507,6 +522,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(highest_confirmed_slot, 3);
@@ -526,6 +542,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
@@ -553,6 +570,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -571,6 +589,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         assert_eq!(newest_root_slot, 5);
@@ -600,6 +619,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -621,6 +641,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 7);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -638,6 +659,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         assert_eq!(newest_root_slot, 7);

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -137,7 +137,7 @@ impl OptimisticallyConfirmedBankTracker {
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: &PrioritizationFeeCache,
     ) -> Result<(), RecvTimeoutError> {
         let notification = receiver.recv_timeout(Duration::from_secs(1))?;
         Self::process_notification(
@@ -267,7 +267,7 @@ impl OptimisticallyConfirmedBankTracker {
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: &PrioritizationFeeCache,
     ) {
         debug!("received bank notification: {:?}", notification);
         match notification {

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -469,7 +469,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(highest_confirmed_slot, 2);
@@ -485,7 +485,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(highest_confirmed_slot, 2);
@@ -501,7 +501,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
@@ -522,7 +522,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(highest_confirmed_slot, 3);
@@ -542,7 +542,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
@@ -570,7 +570,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -589,7 +589,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         assert_eq!(newest_root_slot, 5);
@@ -619,7 +619,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -641,7 +641,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 7);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
@@ -659,7 +659,7 @@ mod tests {
             &mut highest_confirmed_slot,
             &mut newest_root_slot,
             &subscribers,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         assert_eq!(newest_root_slot, 7);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8355,7 +8355,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8375,7 +8375,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8395,7 +8395,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8416,7 +8416,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8355,6 +8355,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8374,6 +8375,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8393,6 +8395,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -8413,6 +8416,7 @@ pub mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1267,6 +1267,7 @@ pub(crate) mod tests {
         solana_runtime::{
             commitment::BlockCommitment,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            prioritization_fee_cache::PrioritizationFeeCache,
         },
         solana_sdk::{
             commitment_config::CommitmentConfig,
@@ -2050,6 +2051,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         // a closure to reduce code duplications in building expected responses:
@@ -2102,6 +2104,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         let response = receiver.recv();
@@ -2223,6 +2226,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         // The following should panic
@@ -2340,6 +2344,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         // a closure to reduce code duplications in building expected responses:
@@ -2394,6 +2399,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         let response = receiver.recv();
@@ -2830,6 +2836,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         // Now, notify the frozen bank and ensure its notifications are processed
@@ -2844,6 +2851,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
 
         let response = receiver0.recv();
@@ -2898,6 +2906,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
+            &Arc::new(PrioritizationFeeCache::default()),
         );
         let response = receiver1.recv();
         let expected = json!({

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -2051,7 +2051,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         // a closure to reduce code duplications in building expected responses:
@@ -2104,7 +2104,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         let response = receiver.recv();
@@ -2226,7 +2226,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         // The following should panic
@@ -2344,7 +2344,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         // a closure to reduce code duplications in building expected responses:
@@ -2399,7 +2399,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         let response = receiver.recv();
@@ -2836,7 +2836,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         // Now, notify the frozen bank and ensure its notifications are processed
@@ -2851,7 +2851,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
 
         let response = receiver0.recv();
@@ -2906,7 +2906,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &Arc::new(PrioritizationFeeCache::default()),
+            &PrioritizationFeeCache::default(),
         );
         let response = receiver1.recv();
         let expected = json!({


### PR DESCRIPTION
#### Problem

Prioritization fee cache accuracy can be improved.

#### Summary of Changes
- moved cache's finalization from "bank replayed" to "bank opt-confirmed" 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
