### PR TITLE
Add required cluster argument to solana feature activate subcommand

### DIFF
--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -51,6 +51,22 @@ pub enum ClusterType {
 
 impl ClusterType {
     pub const STRINGS: [&'static str; 4] = ["development", "devnet", "testnet", "mainnet-beta"];
+
+    /// Get the known genesis hash for this ClusterType
+    pub fn get_genesis_hash(&self) -> Option<Hash> {
+        match self {
+            Self::MainnetBeta => {
+                Some(Hash::from_str("5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d").unwrap())
+            }
+            Self::Testnet => {
+                Some(Hash::from_str("4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY").unwrap())
+            }
+            Self::Devnet => {
+                Some(Hash::from_str("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG").unwrap())
+            }
+            Self::Development => None,
+        }
+    }
 }
 
 impl FromStr for ClusterType {


### PR DESCRIPTION
#### Problem
Activating features can have major implications on the target cluster. Currently, the target cluster is determined by the RPC url, which has both a default value as well as a value that can be set in a config-file and forgotten about.

#### Summary of Changes
This extra argument serves as a guardrail by forcing the feature key holder to explicitly type out the cluster they intend to activate the feature on.

I did a little testing with this, and things appeared to look good. However, I don't hold any unactivated feature keys at the moment, so my testing involved hacking things up to allow the command to proceed with an invalid feature.