### PR TITLE
Fix - Adds missing feature pubkeys to the `FEATURES_AFFECTING_RBPF` list

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -158,10 +158,11 @@ pub fn create_program_runtime_environment<'a>(
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
     let last_restart_slot_syscall_enabled = feature_set.is_active(&last_restart_slot_sysvar::id());
+    // !!! ATTENTION !!!
+    // When adding new features for RBPF here,
+    // also add them to `Bank::apply_builtin_program_feature_transitions()`.
 
     use rand::Rng;
-    // When adding new features for RBPF,
-    // also add them to `Bank::apply_builtin_program_feature_transitions()`.
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7981,6 +7981,13 @@ impl Bank {
             feature_set::switch_to_new_elf_parser::id(),
             feature_set::bpf_account_data_direct_mapping::id(),
             feature_set::enable_alt_bn128_syscall::id(),
+            feature_set::enable_big_mod_exp_syscall::id(),
+            feature_set::blake3_syscall_enabled::id(),
+            feature_set::curve25519_syscall_enabled::id(),
+            feature_set::disable_fees_sysvar::id(),
+            feature_set::enable_partitioned_epoch_reward::id(),
+            feature_set::disable_deploy_of_alloc_free_syscall::id(),
+            feature_set::last_restart_slot_sysvar::id(),
         ];
         if !only_apply_transitions_for_new_features
             || FEATURES_AFFECTING_RBPF


### PR DESCRIPTION
#### Problem
Some features which affect the RBPF config or available syscalls are not in the `FEATURES_AFFECTING_RBPF` list. This explicit list will not be required anymore once the automatic detection of #32172 works.

#### Summary of Changes
Adds the missing feature pubkeys to the list.