### PR TITLE
remove type cast in scan metric report

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3494,17 +3494,17 @@ impl AccountsDb {
             ),
             (
                 "roots_added",
-                self.accounts_index.roots_added.swap(0, Ordering::Relaxed) as i64,
+                self.accounts_index.roots_added.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "roots_removed",
-                self.accounts_index.roots_removed.swap(0, Ordering::Relaxed) as i64,
+                self.accounts_index.roots_removed.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "active_scans",
-                self.accounts_index.active_scans.load(Ordering::Relaxed) as i64,
+                self.accounts_index.active_scans.load(Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

Remove cast in scan metric reporting

peeled off from https://github.com/solana-labs/solana/pull/32558


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
