### PR TITLE
report received message signatures only on PUSH requests

### DIFF
--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -678,25 +678,22 @@ impl CrdsDataStats {
             }
         }
 
-        match route {
-            GossipRoute::PushMessage => {
-                if should_report_message_signature(&entry.value.signature) {
-                    datapoint_info!(
-                        "gossip_crds_sample",
-                        (
-                            "origin",
-                            entry.value.pubkey().to_string().get(..8),
-                            Option<String>
-                        ),
-                        (
-                            "signature",
-                            entry.value.signature.to_string().get(..8),
-                            Option<String>
-                        )
-                    );
-                }
+        if let GossipRoute::PushMessage = route {
+            if should_report_message_signature(&entry.value.signature) {
+                datapoint_info!(
+                    "gossip_crds_sample",
+                    (
+                        "origin",
+                        entry.value.pubkey().to_string().get(..8),
+                        Option<String>
+                    ),
+                    (
+                        "signature",
+                        entry.value.signature.to_string().get(..8),
+                        Option<String>
+                    )
+                );
             }
-            _ => {}
         }
     }
 

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -679,7 +679,7 @@ impl CrdsDataStats {
         }
 
         match route {
-            GossipRoute::LocalMessage => {
+            GossipRoute::PushMessage => {
                 if should_report_message_signature(&entry.value.signature) {
                     datapoint_info!(
                         "gossip_crds_sample",

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -669,7 +669,7 @@ impl Default for CrdsDataStats {
 }
 
 impl CrdsDataStats {
-    fn record_insert(&mut self, entry: &VersionedCrdsValue) {
+    fn record_insert(&mut self, entry: &VersionedCrdsValue, route: GossipRoute) {
         self.counts[Self::ordinal(entry)] += 1;
         if let CrdsData::Vote(_, vote) = &entry.value.data {
             if let Some(slot) = vote.slot() {
@@ -678,20 +678,25 @@ impl CrdsDataStats {
             }
         }
 
-        if should_report_message_signature(&entry.value.signature) {
-            datapoint_info!(
-                "gossip_crds_sample",
-                (
-                    "origin",
-                    entry.value.pubkey().to_string().get(..8),
-                    Option<String>
-                ),
-                (
-                    "signature",
-                    entry.value.signature.to_string().get(..8),
-                    Option<String>
-                )
-            );
+        match route {
+            GossipRoute::LocalMessage => {
+                if should_report_message_signature(&entry.value.signature) {
+                    datapoint_info!(
+                        "gossip_crds_sample",
+                        (
+                            "origin",
+                            entry.value.pubkey().to_string().get(..8),
+                            Option<String>
+                        ),
+                        (
+                            "signature",
+                            entry.value.signature.to_string().get(..8),
+                            Option<String>
+                        )
+                    );
+                }
+            }
+            _ => {}
         }
     }
 
@@ -723,8 +728,8 @@ impl CrdsStats {
         match route {
             GossipRoute::LocalMessage => (),
             GossipRoute::PullRequest => (),
-            GossipRoute::PushMessage => self.push.record_insert(entry),
-            GossipRoute::PullResponse => self.pull.record_insert(entry),
+            GossipRoute::PushMessage => self.push.record_insert(entry, route),
+            GossipRoute::PullResponse => self.pull.record_insert(entry, route),
         }
     }
 

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -678,22 +678,22 @@ impl CrdsDataStats {
             }
         }
 
-        if let GossipRoute::PushMessage = route {
-            if should_report_message_signature(&entry.value.signature) {
-                datapoint_info!(
-                    "gossip_crds_sample",
-                    (
-                        "origin",
-                        entry.value.pubkey().to_string().get(..8),
-                        Option<String>
-                    ),
-                    (
-                        "signature",
-                        entry.value.signature.to_string().get(..8),
-                        Option<String>
-                    )
-                );
-            }
+        if matches!(route, GossipRoute::PushMessage)
+            && should_report_message_signature(&entry.value.signature)
+        {
+            datapoint_info!(
+                "gossip_crds_sample",
+                (
+                    "origin",
+                    entry.value.pubkey().to_string().get(..8),
+                    Option<String>
+                ),
+                (
+                    "signature",
+                    entry.value.signature.to_string().get(..8),
+                    Option<String>
+                )
+            );
         }
     }
 


### PR DESCRIPTION
Slight modification to [PR: 32504](https://github.com/solana-labs/solana/pull/32504)
#### Problem
we want to track message coverage for push messages, not messages received via pull requests. Fixes this issue which was created in: [PR: 32504](https://github.com/solana-labs/solana/pull/32504).

#### Summary of Changes
update CrdsDataStats.record_insert() to accept a `GossipRoute` enum. If GossipRoute is of variant GossipRoute::PushMessage, then check if we need to report this message to metrics

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
