### PR TITLE
Simplify root slot lookup from BankForks

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1859,7 +1859,7 @@ impl<'a> ProcessBlockStore<'a> {
 
             if let Some(hard_fork_restart_slot) = maybe_cluster_restart_with_hard_fork(
                 self.config,
-                self.bank_forks.read().unwrap().root_bank().slot(),
+                self.bank_forks.read().unwrap().root(),
             ) {
                 // reconciliation attempt 2 of 2 with hard fork
                 // this should be #2 because hard fork root > tower root in almost all cases

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -188,7 +188,7 @@ impl OptimisticallyConfirmedBankTracker {
                     SlotNotification::OptimisticallyConfirmed(bank.slot()),
                 );
             }
-        } else if bank.slot() > bank_forks.read().unwrap().root_bank().slot() {
+        } else if bank.slot() > bank_forks.read().unwrap().root() {
             pending_optimistically_confirmed_banks.insert(bank.slot());
             debug!("notify_or_defer defer notifying for slot {:?}", bank.slot());
         }
@@ -287,7 +287,7 @@ impl OptimisticallyConfirmedBankTracker {
                         *highest_confirmed_slot = slot;
                     }
                     drop(w_optimistically_confirmed_bank);
-                } else if slot > bank_forks.read().unwrap().root_bank().slot() {
+                } else if slot > bank_forks.read().unwrap().root() {
                     pending_optimistically_confirmed_banks.insert(slot);
                 } else {
                     inc_new_counter_info!("dropped-already-rooted-optimistic-bank-notification", 1);


### PR DESCRIPTION
#### Problem
No need to get an Arc<Bank> when we want the root slot from BankForks; can just use BankForks::root().

Note that `root_bank()` calls `root()` internally, so these are equivalent:
https://github.com/solana-labs/solana/blob/a310dd776c8f33ef3ca6ce78dc00738f7dc800ee/runtime/src/bank_forks.rs#L152-L154