### PR TITLE
Moves accounts-db test-only code into a dev-context-only-utils feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6769,6 +6769,7 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
+ "solana-runtime",
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -18,5 +18,8 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -14,7 +14,7 @@ log = { workspace = true }
 rayon = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
-solana-runtime = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -85,6 +85,8 @@ libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
@@ -94,6 +96,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+dev-context-only-utils = []
 
 [[bench]]
 name = "prioritization_fee_cache"

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9432,7 +9432,7 @@ impl AccountsDb {
         }
     }
 
-    pub fn accounts_delta_hashes_for_tests(&self) -> &Mutex<HashMap<Slot, AccountsDeltaHash>> {
+    pub fn accounts_delta_hashes(&self) -> &Mutex<HashMap<Slot, AccountsDeltaHash>> {
         &self.accounts_delta_hashes
     }
 
@@ -9444,9 +9444,7 @@ impl AccountsDb {
         self.set_accounts_delta_hash(slot, accounts_delta_hash);
     }
 
-    pub fn accounts_hashes_for_tests(
-        &self,
-    ) -> &Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>> {
+    pub fn accounts_hashes(&self) -> &Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>> {
         &self.accounts_hashes
     }
 
@@ -12330,18 +12328,8 @@ mod tests {
 
             // Get the hashes for the latest slot, which should be the only hashes in the
             // map on the deserialized AccountsDb
-            assert_eq!(
-                daccounts
-                    .accounts_delta_hashes_for_tests()
-                    .lock()
-                    .unwrap()
-                    .len(),
-                1
-            );
-            assert_eq!(
-                daccounts.accounts_hashes_for_tests().lock().unwrap().len(),
-                1
-            );
+            assert_eq!(daccounts.accounts_delta_hashes().lock().unwrap().len(), 1);
+            assert_eq!(daccounts.accounts_hashes().lock().unwrap().len(), 1);
             assert_eq!(
                 daccounts.get_accounts_delta_hash(latest_slot).unwrap(),
                 accounts.get_accounts_delta_hash(latest_slot).unwrap(),
@@ -13095,10 +13083,7 @@ mod tests {
             Ok(_)
         );
 
-        db.accounts_hashes_for_tests()
-            .lock()
-            .unwrap()
-            .remove(&some_slot);
+        db.accounts_hashes().lock().unwrap().remove(&some_slot);
 
         assert_matches!(
             db.verify_accounts_hash_and_lamports(some_slot, 1, None, config.clone()),

--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -911,7 +911,7 @@ pub mod tests {
             account_storage::meta::{AccountMeta, StoredAccountMeta, StoredMeta},
             accounts_db::{
                 get_temp_accounts_paths,
-                tests::{
+                test_utils::{
                     append_single_account_with_default_hash, compare_all_accounts,
                     create_db_with_storages_and_index, create_storages_and_update_index,
                     get_all_accounts, remove_account_for_tests, CAN_RANDOMLY_SHRINK_FALSE,

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -59,6 +59,7 @@ impl ReadOnlyAccountsCache {
 
     /// reset the read only accounts cache
     /// useful for benches/tests
+    #[allow(dead_code)]
     pub fn reset_for_tests(&self) {
         self.cache.clear();
         self.queue.lock().unwrap().clear();

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -29,6 +29,7 @@ source ci/rust-version.sh nightly
 # reason to bend dev-context-only-utils's original intention and that listed
 # package isn't part of released binaries.
 declare tainted_packages=(
+    solana-accounts-bench
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem

To prepare for splitting the runtime crate, we'll need access to some private/test-only functions from accounts-db. To simplify that move, we can consolidate the test-only code within accounts-db into `dev-context-only-utils` feature blocks.


#### Summary of Changes

Moves all the test-only code into dev-context-only-utils feature blocks, and update the callers.

Refer to https://github.com/solana-labs/solana/pull/32169 for more information about `dev-context-only-utils`.

Note, this diff is *large*. No actual implementations changed. There is a lot of moving code. There is some changing private to public (but only public within a test-only feature).