### PR TITLE
Do not unnecessarily re-verify unloaded program

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -365,6 +365,7 @@ fn load_program<'a>(
             account_size,
             slot,
             Arc::new(program_runtime_environment),
+            false,
         );
         match result {
             Ok(loaded_program) => match loaded_program.program {
@@ -548,7 +549,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .clone(),
     );
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key));
+        loaded_programs.replenish(key, bank.load_program(&key, false));
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -244,6 +244,8 @@ impl LoadedProgram {
 
     /// Reloads a user program, *without* running the verifier.
     ///
+    /// # Safety
+    ///
     /// This method is unsafe since it assumes that the program has already been verified. Should
     /// only be called when the program was previously verified and loaded in the cache, but was
     /// unloaded due to inactivity. It should also be checked that the `program_runtime_environment`

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -228,6 +228,58 @@ impl LoadedProgram {
         elf_bytes: &[u8],
         account_size: usize,
         metrics: &mut LoadProgramMetrics,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::new_internal(
+            loader_key,
+            program_runtime_environment,
+            deployment_slot,
+            effective_slot,
+            maybe_expiration_slot,
+            elf_bytes,
+            account_size,
+            metrics,
+            false, /* reloading */
+        )
+    }
+
+    /// Reloads a user program, *without* running the verifier.
+    ///
+    /// This method is unsafe since it assumes that the program has already been verified. Should
+    /// only be called when the program was previously verified and loaded in the cache, but was
+    /// unloaded due to inactivity. It should also be checked that the `program_runtime_environment`
+    /// hasn't changed since it was unloaded.
+    pub unsafe fn reload(
+        loader_key: &Pubkey,
+        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        deployment_slot: Slot,
+        effective_slot: Slot,
+        maybe_expiration_slot: Option<Slot>,
+        elf_bytes: &[u8],
+        account_size: usize,
+        metrics: &mut LoadProgramMetrics,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::new_internal(
+            loader_key,
+            program_runtime_environment,
+            deployment_slot,
+            effective_slot,
+            maybe_expiration_slot,
+            elf_bytes,
+            account_size,
+            metrics,
+            true, /* reloading */
+        )
+    }
+
+    fn new_internal(
+        loader_key: &Pubkey,
+        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        deployment_slot: Slot,
+        effective_slot: Slot,
+        maybe_expiration_slot: Option<Slot>,
+        elf_bytes: &[u8],
+        account_size: usize,
+        metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut load_elf_time = Measure::start("load_elf_time");

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -660,7 +660,12 @@ impl LoadedPrograms {
                             }
 
                             if let LoadedProgramType::Unloaded(environment) = &entry.program {
-                                if Arc::ptr_eq(environment, &self.program_runtime_environment_v1) {
+                                if Arc::ptr_eq(environment, &self.environments.program_runtime_v1)
+                                    || Arc::ptr_eq(
+                                        environment,
+                                        &self.environments.program_runtime_v2,
+                                    )
+                                {
                                     // if the environment hasn't changed since the entry was unloaded.
                                     unloaded.push((key, count));
                                 } else {
@@ -904,7 +909,7 @@ mod tests {
         let unloaded = Arc::new(
             LoadedProgram {
                 program: LoadedProgramType::TestLoaded(
-                    cache.program_runtime_environment_v1.clone(),
+                    cache.environments.program_runtime_v1.clone(),
                 ),
                 account_size: 0,
                 deployment_slot: slot,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -82,17 +82,32 @@ pub fn load_program_from_bytes(
     } else {
         deployment_slot
     };
-    let loaded_program = LoadedProgram::new(
-        loader_key,
-        program_runtime_environment,
-        deployment_slot,
-        effective_slot,
-        None,
-        programdata,
-        account_size,
-        load_program_metrics,
-        reloading,
-    )
+    let loaded_program = if reloading {
+        // Safety: this is safe because the program is being reloaded in the cache.
+        unsafe {
+            LoadedProgram::reload(
+                loader_key,
+                program_runtime_environment,
+                deployment_slot,
+                effective_slot,
+                None,
+                programdata,
+                account_size,
+                load_program_metrics,
+            )
+        }
+    } else {
+        LoadedProgram::new(
+            loader_key,
+            program_runtime_environment,
+            deployment_slot,
+            effective_slot,
+            None,
+            programdata,
+            account_size,
+            load_program_metrics,
+        )
+    }
     .map_err(|err| {
         ic_logger_msg!(log_collector, "{}", err);
         InstructionError::InvalidAccountData

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -75,6 +75,7 @@ pub fn load_program_from_bytes(
     account_size: usize,
     deployment_slot: Slot,
     program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    reloading: bool,
 ) -> Result<LoadedProgram, InstructionError> {
     let effective_slot = if feature_set.is_active(&delay_visibility_of_program_deployment::id()) {
         deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET)
@@ -90,6 +91,7 @@ pub fn load_program_from_bytes(
         programdata,
         account_size,
         load_program_metrics,
+        reloading,
     )
     .map_err(|err| {
         ic_logger_msg!(log_collector, "{}", err);
@@ -123,6 +125,7 @@ macro_rules! deploy_program {
             $account_size,
             $slot,
             Arc::new(program_runtime_environment),
+            false,
         )?;
         if let Some(old_entry) = $invoke_context.find_program_in_cache(&$program_id) {
             executor.tx_usage_counter.store(
@@ -1700,6 +1703,7 @@ pub mod test_utils {
                     account.data().len(),
                     0,
                     program_runtime_environment.clone(),
+                    false,
                 ) {
                     invoke_context
                         .programs_modified_by_tx

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -664,6 +664,7 @@ mod tests {
                         programdata,
                         account.data().len(),
                         &mut load_program_metrics,
+                        false,
                     ) {
                         invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -421,6 +421,7 @@ pub fn process_instruction_deploy(
         programdata,
         buffer.get_data().len(),
         &mut load_program_metrics,
+        false,
     )
     .map_err(|err| {
         ic_logger_msg!(log_collector, "{}", err);

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -421,7 +421,6 @@ pub fn process_instruction_deploy(
         programdata,
         buffer.get_data().len(),
         &mut load_program_metrics,
-        false,
     )
     .map_err(|err| {
         ic_logger_msg!(log_collector, "{}", err);
@@ -665,7 +664,6 @@ mod tests {
                         programdata,
                         account.data().len(),
                         &mut load_program_metrics,
-                        false,
                     ) {
                         invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4658,7 +4658,6 @@ impl Bank {
     }
 
     pub fn load_program(&self, pubkey: &Pubkey, reload: bool) -> Arc<LoadedProgram> {
-        let program_runtime_environment_v1 = self
         let environments = self
             .loaded_programs_cache
             .read()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4724,17 +4724,32 @@ impl Bank {
                     .data()
                     .get(LoaderV4State::program_data_offset()..)
                     .and_then(|elf_bytes| {
-                        LoadedProgram::new(
-                            &loader_v4::id(),
-                            environments.program_runtime_v2.clone(),
-                            slot,
-                            slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-                            None,
-                            elf_bytes,
-                            program_account.data().len(),
-                            &mut load_program_metrics,
-                            reload,
-                        )
+                        if reload {
+                            // Safety: this is safe because the program is being reloaded in the cache.
+                            unsafe {
+                                LoadedProgram::reload(
+                                    &loader_v4::id(),
+                                    environments.program_runtime_v2.clone(),
+                                    slot,
+                                    slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+                                    None,
+                                    elf_bytes,
+                                    program_account.data().len(),
+                                    &mut load_program_metrics,
+                                )
+                            }
+                        } else {
+                            LoadedProgram::new(
+                                &loader_v4::id(),
+                                environments.program_runtime_v2.clone(),
+                                slot,
+                                slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+                                None,
+                                elf_bytes,
+                                program_account.data().len(),
+                                &mut load_program_metrics,
+                            )
+                        }
                         .ok()
                     })
                     .unwrap_or(LoadedProgram::new_tombstone(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7230,7 +7230,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1);
+    let program = bank.load_program(&key1, false);
     assert_matches!(program.program, LoadedProgramType::LegacyV1(_));
     assert_eq!(
         program.account_size,
@@ -7385,7 +7385,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(*elf.get(i).unwrap(), *byte);
     }
 
-    let loaded_program = bank.load_program(&program_keypair.pubkey());
+    let loaded_program = bank.load_program(&program_keypair.pubkey(), false);
 
     // Invoke deployed program
     mock_process_instruction(


### PR DESCRIPTION
#### Problem
The programs might get unloaded from the cache due to cache overflow. The current code re-verifies these programs when reloaded. This is not needed if the runtime environment hasn't changed.

#### Summary of Changes
Do not re-verify the unloaded programs if the environment hasn't changed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
