### PR TITLE
Allow pending changes for `test-checks.sh` for local build

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -19,23 +19,6 @@ Run sanity check for solana build
 EOF
 }
 
-local=false
-
-while getopts ":h:l" opt; do
-  case $opt in
-  h)
-    usage
-    exit 0
-    ;;
-  l)
-    local=true
-    ;;
- *)
-    ;;
-  esac
-done
-shift $((OPTIND - 1))
-
 source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
@@ -44,7 +27,7 @@ cargoNightly="$(readlink -f "./cargo") nightly"
 
 scripts/increment-cargo-version.sh check
 
-if [ "$local" = false ] ; then
+if [ -n "$CI" ] ; then
 # Disallow uncommitted Cargo.lock changes
 (
   _ scripts/cargo-for-all-lock-files.sh tree >/dev/null

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -7,18 +7,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-usage() {
-  cat <<EOF
-usage: $0 [-h] [-l]
-
-Run sanity check for solana build
-
-  -h              Show help
-  -l              Run sanity check for local repo (allow uncommitted changes)
-
-EOF
-}
-
 source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -7,6 +7,35 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+usage() {
+  cat <<EOF
+usage: $0 [-h] [-l]
+
+Run sanity check for solana build
+
+  -h              Show help
+  -l              Run sanity check for local repo (allow uncommitted changes)
+
+EOF
+}
+
+local=false
+
+while getopts ":h:l" opt; do
+  case $opt in
+  h)
+    usage
+    exit 0
+    ;;
+  l)
+    local=true
+    ;;
+ *)
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
@@ -15,6 +44,7 @@ cargoNightly="$(readlink -f "./cargo") nightly"
 
 scripts/increment-cargo-version.sh check
 
+if [ "$local" = false ] ; then
 # Disallow uncommitted Cargo.lock changes
 (
   _ scripts/cargo-for-all-lock-files.sh tree >/dev/null
@@ -28,6 +58,7 @@ EOF
     exit 1
   fi
 )
+fi
 
 echo --- build environment
 (


### PR DESCRIPTION
#### Problem

During development, it is very nice to run sanity build check (i.e. `test-checks.sh`) with local changes before committing them. However, the `test-check.sh` script requires that there are no uncommitted changes locally. To work around this, developers usually have to commit the pending changes first, then run this script. After finding/fixing errors, commit again and then rerun the scripts ... This is annoying. We should allow the scripts to run with pending changes during development.


#### Summary of Changes

Only check `git diff` for ci build


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
