### PR TITLE
Remove unnecessary ref of arc

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -124,8 +124,8 @@ impl OptimisticallyConfirmedBankTracker {
 
     fn recv_notification(
         receiver: &Receiver<BankNotification>,
-        bank_forks: &Arc<RwLock<BankForks>>,
-        optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
+        bank_forks: &RwLock<BankForks>,
+        optimistically_confirmed_bank: &RwLock<OptimisticallyConfirmedBank>,
         subscriptions: &RpcSubscriptions,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         last_notified_confirmed_slot: &mut Slot,
@@ -169,7 +169,7 @@ impl OptimisticallyConfirmedBankTracker {
 
     fn notify_or_defer(
         subscriptions: &RpcSubscriptions,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         bank: &Arc<Bank>,
         last_notified_confirmed_slot: &mut Slot,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
@@ -196,7 +196,7 @@ impl OptimisticallyConfirmedBankTracker {
 
     fn notify_or_defer_confirmed_banks(
         subscriptions: &RpcSubscriptions,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         bank: &Arc<Bank>,
         slot_threshold: Slot,
         last_notified_confirmed_slot: &mut Slot,
@@ -251,8 +251,8 @@ impl OptimisticallyConfirmedBankTracker {
 
     pub fn process_notification(
         notification: BankNotification,
-        bank_forks: &Arc<RwLock<BankForks>>,
-        optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
+        bank_forks: &RwLock<BankForks>,
+        optimistically_confirmed_bank: &RwLock<OptimisticallyConfirmedBank>,
         subscriptions: &RpcSubscriptions,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         last_notified_confirmed_slot: &mut Slot,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -126,7 +126,7 @@ impl OptimisticallyConfirmedBankTracker {
         receiver: &Receiver<BankNotification>,
         bank_forks: &Arc<RwLock<BankForks>>,
         optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
-        subscriptions: &Arc<RpcSubscriptions>,
+        subscriptions: &RpcSubscriptions,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         last_notified_confirmed_slot: &mut Slot,
         highest_confirmed_slot: &mut Slot,
@@ -168,7 +168,7 @@ impl OptimisticallyConfirmedBankTracker {
     }
 
     fn notify_or_defer(
-        subscriptions: &Arc<RpcSubscriptions>,
+        subscriptions: &RpcSubscriptions,
         bank_forks: &Arc<RwLock<BankForks>>,
         bank: &Arc<Bank>,
         last_notified_confirmed_slot: &mut Slot,
@@ -195,7 +195,7 @@ impl OptimisticallyConfirmedBankTracker {
     }
 
     fn notify_or_defer_confirmed_banks(
-        subscriptions: &Arc<RpcSubscriptions>,
+        subscriptions: &RpcSubscriptions,
         bank_forks: &Arc<RwLock<BankForks>>,
         bank: &Arc<Bank>,
         slot_threshold: Slot,
@@ -253,7 +253,7 @@ impl OptimisticallyConfirmedBankTracker {
         notification: BankNotification,
         bank_forks: &Arc<RwLock<BankForks>>,
         optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
-        subscriptions: &Arc<RpcSubscriptions>,
+        subscriptions: &RpcSubscriptions,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         last_notified_confirmed_slot: &mut Slot,
         highest_confirmed_slot: &mut Slot,


### PR DESCRIPTION
#### Problem
To be consistent on `&Arc` usage, when no need to own or clone, use `&` instead of `&Arc<>`

#### Summary of Changes
- use `&` for those read-only parameters

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
