### PR TITLE
Removes `set_no_remove_on_drop()` from AppendVec/AccountsFile

### DIFF
--- a/runtime/src/accounts_file.rs
+++ b/runtime/src/accounts_file.rs
@@ -58,15 +58,6 @@ impl AccountsFile {
         Ok((Self::AppendVec(av), num_accounts))
     }
 
-    /// By default, all AccountsFile will remove its underlying file on
-    /// drop.  Calling this function to disable such behavior for this
-    /// instance.
-    pub fn set_no_remove_on_drop(&mut self) {
-        match self {
-            Self::AppendVec(av) => av.set_no_remove_on_drop(),
-        }
-    }
-
     pub fn flush(&self) -> Result<()> {
         match self {
             Self::AppendVec(av) => av.flush(),

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -292,10 +292,6 @@ impl AppendVec {
         }
     }
 
-    pub fn set_no_remove_on_drop(&mut self) {
-        // noop: will be removed next
-    }
-
     fn sanitize_len_and_size(current_len: usize, file_size: usize) -> Result<()> {
         if file_size == 0 {
             Err(AccountsFileError::AppendVecError(


### PR DESCRIPTION
#### Problem

The `set_no_remove_on_drop()` method on AppendVec and AccountsFile is unused (and should not be used). It should be removed.


#### Summary of Changes

Remove the methods.