### PR TITLE
revises turbine epoch stakes for shreds propagation

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -687,6 +687,10 @@ pub mod reduce_stake_warmup_cooldown {
     }
 }
 
+pub mod revise_turbine_epoch_stakes {
+    solana_sdk::declare_id!("BTWmtJC8U5ZLMbBUUA1k6As62sYjPEjAiNAT55xYGdJU");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -851,6 +855,7 @@ lazy_static! {
         (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
         (reduce_stake_warmup_cooldown::id(), "reduce stake warmup cooldown from 25% to 9%"),
+        (revise_turbine_epoch_stakes::id(), "revise turbine epoch stakes"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -362,7 +362,7 @@ impl<T: 'static> ClusterNodesCache<T> {
         working_bank: &Bank,
         cluster_info: &ClusterInfo,
     ) -> Arc<ClusterNodes<T>> {
-        let epoch = root_bank.get_leader_schedule_epoch(shred_slot);
+        let epoch = get_epoch(shred_slot, root_bank);
         let entry = self.get_cache_entry(epoch);
         if let Some((_, nodes)) = entry
             .read()
@@ -383,7 +383,7 @@ impl<T: 'static> ClusterNodesCache<T> {
             .find_map(|bank| bank.epoch_staked_nodes(epoch));
         if epoch_staked_nodes.is_none() {
             inc_new_counter_debug!("cluster_nodes-unknown_epoch_staked_nodes", 1);
-            if epoch != root_bank.get_leader_schedule_epoch(root_bank.slot()) {
+            if epoch != get_epoch(root_bank.slot(), root_bank) {
                 return self.get(root_bank.slot(), root_bank, working_bank, cluster_info);
             }
             inc_new_counter_info!("cluster_nodes-unknown_epoch_staked_nodes_root", 1);
@@ -394,6 +394,18 @@ impl<T: 'static> ClusterNodesCache<T> {
         ));
         *entry = Some((Instant::now(), Arc::clone(&nodes)));
         nodes
+    }
+}
+
+fn get_epoch(shred_slot: Slot, root_bank: &Bank) -> Epoch {
+    if check_feature_activation(
+        &feature_set::revise_turbine_epoch_stakes::id(),
+        shred_slot,
+        root_bank,
+    ) {
+        root_bank.epoch_schedule().get_epoch(shred_slot)
+    } else {
+        root_bank.get_leader_schedule_epoch(shred_slot)
     }
 }
 


### PR DESCRIPTION
#### Problem
`Bank::get_leader_schedule_epoch` returns: `1 + EpochSchedule::get_epoch`. As a result, at the epoch boundaries when the propagated shred is from the next epoch, we are looking for epoch stakes for 2 epochs ahead of the root or working bank's epoch.
However, the bank structure only contains epoch stakes for one epoch ahead. This results in shreds propagated at epoch boundary having unknown epoch stakes.


#### Summary of Changes
Use `EpochSchedule::get_epoch` instead of  `Bank::get_leader_schedule_epoch` for turbine epoch stakes when propagating shreds.

Previous discussion on this: https://github.com/solana-labs/solana/pull/18971#discussion_r681930509

**NOTE:**
The commit effectively uses current epoch instead of next epoch for stakes.
One question is that if that may cause more dead stake which would cause holes in turbine propagation tree?
e.g. if some nodes destake, then they will be removed from the next epoch stakes but not the current one.
In other words, how many epochs it will take for a destaked node not to be used in turbine propagation anymore?