### PR TITLE
moves DATA_PLANE_FANOUT to turbine

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -99,8 +99,6 @@ use {
     thiserror::Error,
 };
 
-/// The Data plane fanout size, also used as the neighborhood size
-pub const DATA_PLANE_FANOUT: usize = 200;
 /// milliseconds we sleep for between gossip requests
 pub const GOSSIP_SLEEP_MILLIS: u64 = 100;
 /// The maximum size of a bloom filter

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -44,11 +44,8 @@ fn get_retransmit_peers_deterministic(
             0,
             0,
         );
-        let _retransmit_peers = cluster_nodes.get_retransmit_peers(
-            slot_leader,
-            &shred.id(),
-            solana_gossip::cluster_info::DATA_PLANE_FANOUT,
-        );
+        let _retransmit_peers =
+            cluster_nodes.get_retransmit_peers(slot_leader, &shred.id(), /*fanout:*/ 200);
     }
 }
 

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -5,7 +5,7 @@ use {
     rand::{seq::SliceRandom, Rng, SeedableRng},
     rand_chacha::ChaChaRng,
     solana_gossip::{
-        cluster_info::{ClusterInfo, DATA_PLANE_FANOUT},
+        cluster_info::ClusterInfo,
         contact_info::{LegacyContactInfo as ContactInfo, LegacyContactInfo, Protocol},
         crds::GossipRoute,
         crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
@@ -36,6 +36,7 @@ use {
     thiserror::Error,
 };
 
+const DATA_PLANE_FANOUT: usize = 200;
 pub(crate) const MAX_NUM_TURBINE_HOPS: usize = 4;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
#### Problem
`DATA_PLANE_FANOUT` is a turbine specific constant and shouldn't be defined in gossip.

#### Summary of Changes
Moved `DATA_PLANE_FANOUT` to turbine.
