### PR TITLE
JSON RPC API docs updates

### DIFF
--- a/docs/src/api/methods/_getBlocksWithLimit.mdx
+++ b/docs/src/api/methods/_getBlocksWithLimit.mdx
@@ -24,7 +24,7 @@ Returns a list of confirmed blocks starting at the given slot
   start_slot, as <code>u64</code> integer
 </Parameter>
 
-<Parameter type={"u64"} optional={true}>
+<Parameter type={"u64"} required={true}>
   limit, as <code>u64</code> integer (must be no more than 500,000 blocks higher
   than the <code>start_slot</code>)
 </Parameter>

--- a/docs/src/api/methods/_getHighestSnapshotSlot.mdx
+++ b/docs/src/api/methods/_getHighestSnapshotSlot.mdx
@@ -34,7 +34,7 @@ NEW: This method is only available in solana-core v1.9 or newer. Please use
 When the node has a snapshot, this returns a JSON object with the following fields:
 
 - `full: <u64>` - Highest full snapshot slot
-- `incremental: <u64|undefined>` - Highest incremental snapshot slot _based on_ `full`
+- `incremental: <u64|null>` - Highest incremental snapshot slot _based on_ `full`
 
 </CodeParams>
 

--- a/docs/src/api/methods/_getSignatureStatuses.mdx
+++ b/docs/src/api/methods/_getSignatureStatuses.mdx
@@ -25,7 +25,7 @@ retains statuses for all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots
 
 ### Parameters:
 
-<Parameter type={"array"} optional={true}>
+<Parameter type={"array"} required={true}>
   An array of transaction signatures to confirm, as base-58 encoded strings (up
   to a maximum of 256)
 </Parameter>

--- a/docs/src/api/methods/_getVersion.mdx
+++ b/docs/src/api/methods/_getVersion.mdx
@@ -26,7 +26,7 @@ Returns the current Solana version running on the node
 The result field will be a JSON object with the following fields:
 
 - `solana-core` - software version of solana-core as a `string`
-- `feature-set` - unique identifier of the current software's feature set as a `number`
+- `feature-set` - unique identifier of the current software's feature set as a `u32`
 
 </CodeParams>
 

--- a/docs/src/api/methods/_getVersion.mdx
+++ b/docs/src/api/methods/_getVersion.mdx
@@ -25,8 +25,8 @@ Returns the current Solana version running on the node
 
 The result field will be a JSON object with the following fields:
 
-- `solana-core` - software version of solana-core
-- `feature-set` - unique identifier of the current software's feature set
+- `solana-core` - software version of solana-core as a `string`
+- `feature-set` - unique identifier of the current software's feature set as a `number`
 
 </CodeParams>
 
@@ -43,7 +43,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 ### Response:
 
 ```json
-{ "jsonrpc": "2.0", "result": { "solana-core": "1.15.0" }, "id": 1 }
+{ "jsonrpc": "2.0", "result": { "feature-set": 2891131721, "solana-core": "1.16.7" }, "id": 1 }
 ```
 
 </CodeSnippets>


### PR DESCRIPTION
#### Problem
We've noticed a few things that are inaccurate in the JSON RPC docs while building out the new Web3 JS library.

Some methods have parameters marked as `optional` that are actually `required`, and other similar minor errors.

#### Summary of Changes
- `getBlocksWithLimit`: Make `limit` a required parameter
- `getHighestSnapshotSlot`: Response field `incremental` should be of type `<u64|null>` not `<u64|undefined>`
- `getSignatureStatuses`: Make `signatures` a required parameter
- `getVersion`:
  - Response code block should include `feature-set`
  - Added types of both response fields (ie. `solana-core: string` & `feature-set: number`)

Fixes #32696 

---

I'm curious why the response for `RpcVersionInfo` is set to Kebab case, rather than Camel case. Surely there's a good reason for this, but it throws off client library management since the rest of the methods appear to adhere to Camel case. Just curious why this is done ([Source](https://github.com/solana-labs/solana/blob/master/rpc-client-api/src/response.rs#L332))

---

Note: This will remain a draft until we've finished implementing all remaining RPC HTTP methods (see https://github.com/solana-labs/solana-web3.js/issues/1449) and Web Socket methods (see https://github.com/solana-labs/solana-web3.js/issues/1505)