### PR TITLE
Moves some accounts-db test-only code into a dev-context-only-utils feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6769,6 +6769,7 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
+ "solana-runtime",
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -85,6 +85,8 @@ libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
@@ -94,6 +96,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+dev-context-only-utils = []
 
 [[bench]]
 name = "prioritization_fee_cache"

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1421,8 +1421,8 @@ pub struct AccountsDb {
     pub thread_pool_clean: ThreadPool,
 
     bank_hash_stats: Mutex<HashMap<Slot, BankHashStats>>,
-    pub accounts_delta_hashes: Mutex<HashMap<Slot, AccountsDeltaHash>>,
-    pub accounts_hashes: Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>>,
+    accounts_delta_hashes: Mutex<HashMap<Slot, AccountsDeltaHash>>,
+    accounts_hashes: Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>>,
     incremental_accounts_hashes:
         Mutex<HashMap<Slot, (IncrementalAccountsHash, /*capitalization*/ u64)>>,
 
@@ -9503,6 +9503,30 @@ impl AccountsDb {
     }
 }
 
+// These functions/fields are only usable from a dev context (i.e. tests and benches)
+#[cfg(feature = "dev-context-only-utils")]
+impl AccountsDb {
+    pub fn accounts_delta_hashes(&self) -> &Mutex<HashMap<Slot, AccountsDeltaHash>> {
+        &self.accounts_delta_hashes
+    }
+
+    pub fn set_accounts_delta_hash_for_tests(
+        &self,
+        slot: Slot,
+        accounts_delta_hash: AccountsDeltaHash,
+    ) {
+        self.set_accounts_delta_hash(slot, accounts_delta_hash);
+    }
+
+    pub fn accounts_hashes(&self) -> &Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>> {
+        &self.accounts_hashes
+    }
+
+    pub fn set_accounts_hash_for_tests(&self, slot: Slot, accounts_hash: AccountsHash) {
+        self.set_accounts_hash(slot, (accounts_hash, u64::default()));
+    }
+}
+
 /// A set of utility functions used for testing and benchmarking
 pub mod test_utils {
     use {
@@ -9648,20 +9672,6 @@ pub mod tests {
 
         fn get_storage_for_slot(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
             self.storage.get_slot_storage_entry(slot)
-        }
-
-        // used by serde_snapshot tests
-        pub fn set_accounts_hash_for_tests(&self, slot: Slot, accounts_hash: AccountsHash) {
-            self.set_accounts_hash(slot, (accounts_hash, u64::default()));
-        }
-
-        // used by serde_snapshot tests
-        pub fn set_accounts_delta_hash_for_tests(
-            &self,
-            slot: Slot,
-            accounts_delta_hash: AccountsDeltaHash,
-        ) {
-            self.set_accounts_delta_hash(slot, accounts_delta_hash);
         }
     }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -398,8 +398,8 @@ mod serde_snapshot_tests {
 
             // Get the hashes for the latest slot, which should be the only hashes in the
             // map on the deserialized AccountsDb
-            assert_eq!(daccounts.accounts_delta_hashes.lock().unwrap().len(), 1);
-            assert_eq!(daccounts.accounts_hashes.lock().unwrap().len(), 1);
+            assert_eq!(daccounts.accounts_delta_hashes().lock().unwrap().len(), 1);
+            assert_eq!(daccounts.accounts_hashes().lock().unwrap().len(), 1);
             assert_eq!(
                 daccounts.get_accounts_delta_hash(latest_slot).unwrap(),
                 accounts.get_accounts_delta_hash(latest_slot).unwrap(),


### PR DESCRIPTION
#### Problem

To prepare for splitting the runtime crate, we'll need access to some private/test-only functions from accounts-db. To simplify that move, we can consolidate the test-only code within accounts-db into `dev-context-only-utils` feature blocks.

The AccountsDb `accounts_hashes` and `accounts_delta_hashes` fields were made public recently (#32671) to keep tests working. This PR only adds/moves code to return those two fields back to private. Future PRs can/will more move test-only accounts-db code into dcou blocks.


#### Summary of Changes

Add a dcou block for getting/setting the AccountsDb accounts hashes and accounts delta hashes, and update the callers.

Refer to https://github.com/solana-labs/solana/pull/32169 for more information about `dev-context-only-utils`.