### PR TITLE
add metrics around purge_exact

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1531,6 +1531,9 @@ pub struct AccountsStats {
     store_find_existing: AtomicU64,
     dropped_stores: AtomicU64,
     store_uncleaned_update: AtomicU64,
+    handle_dead_keys_us: AtomicU64,
+    purge_exact_us: AtomicU64,
+    purge_exact_count: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -2845,18 +2848,30 @@ impl AccountsDb {
         let mut reclaims = Vec::new();
         let mut dead_keys = Vec::new();
 
-        for (pubkey, slots_set) in pubkey_to_slot_set {
+        let mut purge_exact_count = 0;
+        let (_, purge_exact_us) = measure_us!(for (pubkey, slots_set) in pubkey_to_slot_set {
+            purge_exact_count += 1;
             let is_empty = self
                 .accounts_index
                 .purge_exact(pubkey, slots_set, &mut reclaims);
             if is_empty {
                 dead_keys.push(pubkey);
             }
-        }
+        });
 
-        let pubkeys_removed_from_accounts_index = self
+        let (pubkeys_removed_from_accounts_index, handle_dead_keys_us) = measure_us!(self
             .accounts_index
-            .handle_dead_keys(&dead_keys, &self.account_indexes);
+            .handle_dead_keys(&dead_keys, &self.account_indexes));
+
+        self.stats
+            .purge_exact_count
+            .fetch_add(purge_exact_count, Ordering::Relaxed);
+        self.stats
+            .handle_dead_keys_us
+            .fetch_add(handle_dead_keys_us, Ordering::Relaxed);
+        self.stats
+            .purge_exact_us
+            .fetch_add(purge_exact_us, Ordering::Relaxed);
         (reclaims, pubkeys_removed_from_accounts_index)
     }
 
@@ -8461,6 +8476,21 @@ impl AccountsDb {
                 (
                     "calc_stored_meta_us",
                     self.stats.calc_stored_meta.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "handle_dead_keys_us",
+                    self.stats.handle_dead_keys_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "purge_exact_us",
+                    self.stats.purge_exact_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "purge_exact_count",
+                    self.stats.purge_exact_count.swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1260,7 +1260,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .collect()
     }
 
-    pub fn purge_exact<'a, C>(
+    /// returns true if, after this fn call:
+    /// accounts index entry for `pubkey` has an empty slot list
+    /// or `pubkey` does not exist in accounts index
+    pub(crate) fn purge_exact<'a, C>(
         &'a self,
         pubkey: &Pubkey,
         slots_to_purge: &'a C,


### PR DESCRIPTION
#### Problem
`purge_exact` is slow in some instances in the high accounts simulation.

#### Summary of Changes
Add metrics to track how many keys are affected and the cost of the major pieces of the algorithm.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
