### PR TITLE
use BTreeMap to get unique accounts in sorted order

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3794,16 +3794,15 @@ impl AccountsDb {
         &self,
         store: &'a Arc<AccountStorageEntry>,
     ) -> GetUniqueAccountsResult<'a> {
-        let mut stored_accounts: HashMap<Pubkey, StoredAccountMeta> = HashMap::new();
+        use std::collections::BTreeMap;
+        // Use BTreeMap to reorganize the accounts by sorted pubkeys
+        let mut stored_accounts: BTreeMap<Pubkey, StoredAccountMeta> = BTreeMap::new();
         let capacity = store.capacity();
         store.accounts.account_iter().for_each(|account| {
             stored_accounts.insert(*account.pubkey(), account);
         });
 
-        // sort by pubkey to keep account index lookups close
-        let mut stored_accounts = stored_accounts.drain().map(|(_k, v)| v).collect::<Vec<_>>();
-        stored_accounts.sort_unstable_by(|a, b| a.pubkey().cmp(b.pubkey()));
-
+        let stored_accounts = stored_accounts.into_values().collect::<Vec<_>>();
         GetUniqueAccountsResult {
             stored_accounts,
             capacity,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8967,7 +8967,7 @@ impl AccountsDb {
                 // these write directly to disk, so the more threads, the better
                 num_cpus::get()
             } else {
-                // seems to be a good hueristic given varying # cpus for in-mem disk index
+                // seems to be a good heuristic given varying # cpus for in-mem disk index
                 8
             };
             let chunk_size = (outer_slots_len / (std::cmp::max(1, threads.saturating_sub(1)))) + 1; // approximately 400k slots in a snapshot
@@ -9205,7 +9205,7 @@ impl AccountsDb {
     /// Calling this can slow down the insertion process to allow flushing to disk to keep pace.
     fn maybe_throttle_index_generation(&self) {
         // This number is chosen to keep the initial ram usage sufficiently small
-        // The process of generating the index is goverened entirely by how fast the disk index can be populated.
+        // The process of generating the index is governed entirely by how fast the disk index can be populated.
         // 10M accounts is sufficiently small that it will never have memory usage. It seems sufficiently large that it will provide sufficient performance.
         // Performance is measured by total time to generate the index.
         // Just estimating - 150M accounts can easily be held in memory in the accounts index on a 256G machine. 2-300M are also likely 'fine' during startup.

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8840,27 +8840,29 @@ impl AccountsDb {
         }
     }
 
-    fn filler_unique_id_bytes() -> usize {
+    const fn filler_unique_id_bytes() -> usize {
         std::mem::size_of::<u32>()
     }
 
-    fn filler_rent_partition_prefix_bytes() -> usize {
+    const fn filler_rent_partition_prefix_bytes() -> usize {
         std::mem::size_of::<u64>()
     }
 
-    fn filler_prefix_bytes() -> usize {
+    const fn filler_prefix_bytes() -> usize {
         Self::filler_unique_id_bytes() + Self::filler_rent_partition_prefix_bytes()
     }
+
+    const FILLER_PREFIX_BYTES: usize = Self::filler_prefix_bytes();
 
     pub fn is_filler_account_helper(
         pubkey: &Pubkey,
         filler_account_suffix: Option<&Pubkey>,
     ) -> bool {
-        let offset = Self::filler_prefix_bytes();
         filler_account_suffix
             .as_ref()
             .map(|filler_account_suffix| {
-                pubkey.as_ref()[offset..] == filler_account_suffix.as_ref()[offset..]
+                pubkey.as_ref()[Self::FILLER_PREFIX_BYTES..]
+                    == filler_account_suffix.as_ref()[Self::FILLER_PREFIX_BYTES..]
             })
             .unwrap_or_default()
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8662,28 +8662,23 @@ impl AccountsDb {
     }
 
     pub fn add_root(&self, slot: Slot) -> AccountsAddRootTiming {
-        let mut index_time = Measure::start("index_add_root");
-        self.accounts_index.add_root(slot);
-        index_time.stop();
-        let mut cache_time = Measure::start("cache_add_root");
-        self.accounts_cache.add_root(slot);
-        cache_time.stop();
-        let mut store_time = Measure::start("store_add_root");
-        // We would not expect this slot to be shrinking right now, but other slots may be.
-        // But, even if it was, we would just mark a store id as dirty unnecessarily and that is ok.
-        // So, allow shrinking to be in progress.
-        if let Some(store) = self
+        let (_, index_time) = measure_us!(self.accounts_index.add_root(slot));
+        let (_, cache_time) = measure_us!(self.accounts_cache.add_root(slot));
+        let (_, store_time) = measure_us!(self
             .storage
             .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-        {
-            self.dirty_stores.insert(slot, store);
-        }
-        store_time.stop();
+            .map_or((), |store| {
+                // We would not expect this slot to be shrinking right now, but other slots may be.
+                // But, even if it was, we would just mark a store id as dirty unnecessarily and that is ok.
+                // So, allow shrinking to be in progress.
+                self.dirty_stores.insert(slot, store);
+                ()
+            }));
 
         AccountsAddRootTiming {
-            index_us: index_time.as_us(),
-            cache_us: cache_time.as_us(),
-            store_us: store_time.as_us(),
+            index_us: index_time,
+            cache_us: cache_time,
+            store_us: store_time,
         }
     }
 


### PR DESCRIPTION
#### Problem

Using HashMap + sort to get unique accounts from append_vec before shrinking can be optimized. 

#### Summary of Changes

Use BTree to get unique accounts in sorted order by pubkey


https://github.com/HaoranYi/solana/blob/bench_unique_account/runtime/src/ancient_append_vecs.rs#L3165

```
+    // $ cargo test --release --package solana-runtime --lib -- ancient_append_vecs::tests::bench_uniq_accounts  --nocapture --test-threads 1
+    // running 2 tests
+    // 1k
+    // test ancient_append_vecs::tests::bench_uniq_accounts ... New Elapsed: 173.13µs
+    // test ancient_append_vecs::tests::bench_uniq_accounts_orig ... Old Elapsed: 276.47µs
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
