### PR TITLE
keep active stats lock held

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7523,7 +7523,7 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
         filler_account_suffix: Option<&Pubkey>,
     ) -> Result<Vec<CacheHashDataFile>, AccountsHashVerificationError> {
-        let _ = self.active_stats.activate(ActiveStatItem::HashScan);
+        let _guard = self.active_stats.activate(ActiveStatItem::HashScan);
 
         let bin_calculator = PubkeyBinCalculator24::new(bins);
         assert!(bin_range.start < bins && bin_range.end <= bins && bin_range.start < bin_range.end);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -782,7 +782,7 @@ impl<'a> AccountsHasher<'a> {
         // a. vec: PUBKEY_BINS_FOR_CALCULATING_HASHES in pubkey order
         //      vec: individual hashes in pubkey order, 1 hash per
         // b. lamports
-        let _ = self.active_stats.activate(ActiveStatItem::HashDeDup);
+        let _guard = self.active_stats.activate(ActiveStatItem::HashDeDup);
 
         let mut zeros = Measure::start("eliminate zeros");
         let (hashes, hash_total, lamports_total) = (0..max_bin)
@@ -1114,7 +1114,7 @@ impl<'a> AccountsHasher<'a> {
 
         let cumulative = CumulativeHashesFromFiles::from_files(hashes);
 
-        let _ = self.active_stats.activate(ActiveStatItem::HashMerkleTree);
+        let _guard = self.active_stats.activate(ActiveStatItem::HashMerkleTree);
         let mut hash_time = Measure::start("hash");
         let (hash, _) = Self::compute_merkle_root_from_slices(
             cumulative.total_count(),


### PR DESCRIPTION
#### Problem
`let _ = ...` causes rhs to be dropped immediately.
So, active period was 0s.

#### Summary of Changes
use
`let _guard = ...`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
