### PR TITLE
stake: Set the Delegation's warmup / cooldown to the correct default

### DIFF
--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -436,7 +436,7 @@ impl Default for Delegation {
             stake: 0,
             activation_epoch: 0,
             deactivation_epoch: std::u64::MAX,
-            warmup_cooldown_rate: 0.0,
+            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE,
         }
     }
 }


### PR DESCRIPTION
#### Problem

As mentioned in https://github.com/solana-labs/solana/pull/32723#issuecomment-1670896396, #32723 is causing mismatches in the canaries on mainnet.

I'm almost 100% sure this is due to the warmup-cooldown rate no longer being set on new stake accounts. Every other mainnet node is setting it to 0.25, but master is setting it to 0.0, causing an immediate mismatch.

#### Summary of Changes

Just set the warmup / cooldown rate to the old value in the default `Delegation` constructor.

Following the discussion at https://discord.com/channels/428295358100013066/1027231858565586985/1138603784768069783, I built `solana-ledger-tool` with this patch, and re-ran:

```
$ ./target/release/solana-ledger-tool verify --ledger ~/ledger --halt-at-slot 214149339  > jontest.txt 2>&1
```

And compared it against `good.txt` which was on the failing machine. Big thanks to @willhickey for leaving ample breadcrumbs to make testing so easy and @steviez for explaining how to repro!

With this change, we're getting the correct bankhash, but someone can also double-check my work to make sure I did the right thing. I reverted the code change on tce1 since there was no branch with this yet.

You can find the binaries built against master with this patch at `~/.local/share/solana/install/releases/edge-jontest`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
