### PR TITLE
stake: pub use config constants for api backwards compatibility

### DIFF
--- a/sdk/program/src/stake/config.rs
+++ b/sdk/program/src/stake/config.rs
@@ -1,10 +1,8 @@
 //! config for staking
 //!  carries variables that the stake program cares about
 
-use {
-    super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE},
-    serde_derive::{Deserialize, Serialize},
-};
+pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
+use serde_derive::{Deserialize, Serialize};
 
 // stake config ID
 crate::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");

--- a/sdk/program/src/stake/config.rs
+++ b/sdk/program/src/stake/config.rs
@@ -1,6 +1,10 @@
 //! config for staking
 //!  carries variables that the stake program cares about
 
+#[deprecated(
+    since = "1.16.7",
+    note = "Please use `solana_sdk::stake::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
+)]
 pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
 use serde_derive::{Deserialize, Serialize};
 


### PR DESCRIPTION
#### Problem
These constants were moved out of the stake config which might break downstream imports. 

#### Summary of Changes
Re-export these constants. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
