### PR TITLE
ledger-tool: Relax ledger requirements for program subcommand

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2172,6 +2172,8 @@ fn main() {
 
     if let ("bigtable", Some(arg_matches)) = matches.subcommand() {
         bigtable_process_command(&ledger_path, arg_matches)
+    } else if let ("program", Some(arg_matches)) = matches.subcommand() {
+        program(&ledger_path, arg_matches)
     } else {
         let ledger_path = canonicalize_ledger_path(&ledger_path);
 
@@ -4197,9 +4199,6 @@ fn main() {
                 if let Err(err) = print_blockstore_file_metadata(&blockstore, &sst_file_name) {
                     eprintln!("{err}");
                 }
-            }
-            ("program", Some(arg_matches)) => {
-                program(&ledger_path, arg_matches);
             }
             ("", _) => {
                 eprintln!("{}", matches.usage());

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{args::*, ledger_utils::*},
+    crate::{args::*, canonicalize_ledger_path, ledger_utils::*},
     clap::{value_t, App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     serde::{Deserialize, Serialize},
@@ -162,13 +162,11 @@ impl ProgramSubCommand for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("cfg")
                 .about("generates Control Flow Graph of the program.")
-                .arg(&max_genesis_arg)
                 .arg(&program_arg)
         )
         .subcommand(
             SubCommand::with_name("disassemble")
                 .about("dumps disassembled code of the program.")
-                .arg(&max_genesis_arg)
                 .arg(&program_arg)
         )
         .subcommand(
@@ -435,7 +433,8 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         ("run", Some(arg_matches)) => arg_matches,
         _ => unreachable!(),
     };
-    let bank = load_blockstore(ledger_path, matches);
+    let ledger_path = canonicalize_ledger_path(ledger_path);
+    let bank = load_blockstore(&ledger_path, matches);
     let loader_id = bpf_loader_upgradeable::id();
     let mut transaction_accounts = Vec::new();
     let mut instruction_accounts = Vec::new();


### PR DESCRIPTION
#### Problem
Several of the program command subcommands do not require a ledger as they act solely on the program object. 

#### Summary of Changes
So, defer checking the ledger path until we know we need to load. Additionally, remove genesis arg from these commands that do not load a genesis.bin

Without this commit, a `ledger` directory had to be findable, whether there was one in the working directory or one supplied by user via `--ledger` arg