### PR TITLE
Bank: Add function to replace empty account with upgradeable program on feature activation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -42,6 +42,7 @@ use {
         builtins::{BuiltinPrototype, BUILTINS},
         epoch_rewards_hasher::hash_rewards_into_partitions,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
+        inline_feature_gate_program,
         runtime_config::RuntimeConfig,
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
@@ -8053,6 +8054,14 @@ impl Bank {
 
         if new_feature_activations.contains(&feature_set::update_hashes_per_tick::id()) {
             self.apply_updated_hashes_per_tick(DEFAULT_HASHES_PER_TICK);
+        }
+
+        if new_feature_activations.contains(&feature_set::feature_gate_program::id()) {
+            self.replace_empty_account_with_upgradeable_program(
+                &feature::id(),
+                &inline_feature_gate_program::noop_program::id(),
+                "bank-apply_feature_gate_program",
+            );
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8280,22 +8280,10 @@ impl Bank {
                     self.capitalization
                         .fetch_sub(new_account.lamports(), Relaxed);
                     self.store_account(new_address, &AccountSharedData::default());
-                } else if let Some(old_data_account) =
-                    self.get_account_with_fixed_root(&old_data_address)
+                } else if self
+                    .get_account_with_fixed_root(&old_data_address)
+                    .is_none()
                 {
-                    // A data account exists for the old program, but not the
-                    // new program
-                    // Swap program accounts and delete the old data account
-                    self.replace_account(
-                        old_address,
-                        new_address,
-                        Some(&old_account),
-                        &new_account,
-                    );
-                    self.capitalization
-                        .fetch_sub(old_data_account.lamports(), Relaxed);
-                    self.store_account(&old_data_address, &AccountSharedData::default());
-                } else {
                     // A data account does not exist for the new program
                     // Swap program accounts only
                     self.replace_account(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8058,12 +8058,21 @@ impl Bank {
         }
 
         if new_feature_activations.contains(&feature_set::programify_feature_gate_program::id()) {
-            replace_account::replace_empty_account_with_upgradeable_program(
+            let datapoint_name = "bank-progamify_feature_gate_program";
+            if let Err(e) = replace_account::replace_empty_account_with_upgradeable_program(
                 self,
                 &feature::id(),
                 &inline_feature_gate_program::noop_program::id(),
-                "bank-apply_feature_gate_program",
-            );
+                datapoint_name,
+            ) {
+                warn!(
+                    "{}: Failed to replace empty account {} with upgradeable program: {}",
+                    datapoint_name,
+                    feature::id(),
+                    e
+                );
+                datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
+            }
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8259,7 +8259,6 @@ impl Bank {
     }
 
     /// Use to replace an empty account with a program by feature activation
-    #[allow(dead_code)]
     fn replace_empty_account_with_upgradeable_program(
         &mut self,
         old_address: &Pubkey,
@@ -8285,7 +8284,7 @@ impl Bank {
 
                 // Replace the old data account with the new one
                 // If the old data account does not exist, it will be created
-                // If the new data account does exist, it will be overwritten
+                // If it does exist, it will be overwritten
                 self.replace_account(
                     &old_data_address,
                     &new_data_address,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8266,7 +8266,7 @@ impl Bank {
                         let account = Account {
                             lamports,
                             data,
-                            ..Account::from(old_account.clone())
+                            ..Account::from(new_account.clone())
                         };
                         self.store_account(old_address, &account);
                         new_account.lamports() + old_account.lamports() - account.lamports

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8260,29 +8260,15 @@ impl Bank {
                     .unwrap()
                     .remove_programs([*dst_address].into_iter());
             } else {
-                warn!("Unable to find source program {}", src_address);
-                datapoint_warn!(
-                    datapoint_name,
-                    ("slot", self.slot(), i64),
-                    ("source program pubkey", src_address.to_string(), String),
-                    (
-                        "destination program pubkey",
-                        dst_address.to_string(),
-                        String
-                    ),
+                warn!(
+                    "Unable to find source program {}. Destination: {}",
+                    src_address, dst_address
                 );
+                datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
             }
         } else {
             warn!("Unable to find destination program {}", dst_address);
-            datapoint_warn!(
-                datapoint_name,
-                ("slot", self.slot(), i64),
-                (
-                    "destination program pubkey",
-                    dst_address.to_string(),
-                    String
-                ),
-            );
+            datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
         }
     }
 
@@ -8357,75 +8343,30 @@ impl Bank {
                                 .fetch_sub(change_in_capitalization, Relaxed);
                         }
                     } else {
-                        error!("Unable to serialize program account state");
-                        datapoint_error!(
-                            datapoint_name,
-                            ("slot", self.slot(), i64),
-                            ("source program pubkey", src_address.to_string(), String),
-                            (
-                                "source data account pubkey",
-                                src_data_address.to_string(),
-                                String
-                            ),
-                            (
-                                "destination program pubkey",
-                                dst_address.to_string(),
-                                String
-                            ),
-                            (
-                                "destination data account pubkey",
-                                dst_data_address.to_string(),
-                                String
-                            ),
-                            (
-                                "destination data account pubkey",
-                                format!(
-                                    "UpgradeableLoaderState::Program with data address {}",
-                                    dst_data_address
-                                ),
-                                String
-                            ),
+                        error!(
+                            "Unable to serialize program account state. \
+                            Source program: {} Source data account: {} \
+                            Destination program: {} Destination data account: {}",
+                            src_address, src_data_address, dst_address, dst_data_address,
                         );
+                        datapoint_error!(datapoint_name, ("slot", self.slot(), i64),);
                     }
                 }
             } else {
                 warn!(
-                    "Unable to find data account for source program {}",
-                    src_address
+                    "Unable to find data account for source program. \
+                    Source program: {} Source data account: {} \
+                    Destination program: {} Destination data account: {}",
+                    src_address, src_data_address, dst_address, dst_data_address,
                 );
-                datapoint_warn!(
-                    datapoint_name,
-                    ("slot", self.slot(), i64),
-                    ("source program pubkey", src_address.to_string(), String),
-                    (
-                        "source data account pubkey",
-                        src_data_address.to_string(),
-                        String
-                    ),
-                    (
-                        "destination program pubkey",
-                        dst_address.to_string(),
-                        String
-                    ),
-                    (
-                        "destination data account pubkey",
-                        dst_data_address.to_string(),
-                        String
-                    ),
-                );
+                datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
             }
         } else {
-            warn!("Unable to find source program {}", src_address);
-            datapoint_warn!(
-                datapoint_name,
-                ("slot", self.slot(), i64),
-                ("source program pubkey", src_address.to_string(), String),
-                (
-                    "destination program pubkey",
-                    dst_address.to_string(),
-                    String
-                ),
+            warn!(
+                "Unable to find source program {}. Destination: {}",
+                src_address, dst_address
             );
+            datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8206,8 +8206,8 @@ impl Bank {
     }
 
     /// Moves one account in place of another
-    /// `source`: the program to replace with
-    /// `destination`: the program to be replaced
+    /// `source`: the account to replace with
+    /// `destination`: the account to be replaced
     fn move_account<U, V>(
         &mut self,
         source_address: &Pubkey,
@@ -8241,9 +8241,9 @@ impl Bank {
         );
     }
 
-    /// Use to replace programs by feature activation
-    /// `source`: the program to replace with
-    /// `destination`: the program to be replaced
+    /// Use to replace non-upgradeable programs by feature activation
+    /// `source`: the non-upgradeable program account to replace with
+    /// `destination`: the non-upgradeable program account to be replaced
     #[allow(dead_code)]
     fn replace_non_upgradeable_program_account(
         &mut self,
@@ -8281,6 +8281,11 @@ impl Bank {
     }
 
     /// Use to replace an empty account with a program by feature activation
+    /// Note: The upgradeable program should have both:
+    ///     - Program account
+    ///     - Program data account
+    /// `source`: the upgradeable program account to replace with
+    /// `destination`: the empty account to be replaced
     fn replace_empty_account_with_upgradeable_program(
         &mut self,
         source_address: &Pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8314,13 +8314,11 @@ impl Bank {
                     .get_account_with_fixed_root(destination_address)
                     .is_none()
                 {
-                    let lamports = self.get_minimum_balance_for_rent_exemption(
-                        UpgradeableLoaderState::size_of_program(),
-                    );
                     let state = UpgradeableLoaderState::Program {
                         programdata_address: destination_data_address,
                     };
                     if let Ok(data) = bincode::serialize(&state) {
+                        let lamports = self.get_minimum_balance_for_rent_exemption(data.len());
                         let created_program_account = Account {
                             lamports,
                             data,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8288,10 +8288,10 @@ impl Bank {
                     let state = UpgradeableLoaderState::Program {
                         programdata_address: old_data_address,
                     };
-                    if let Ok(data_len) = bincode::serialized_size(&state) {
-                        let mut created_program_account = Account {
+                    if let Ok(data) = bincode::serialize(&state) {
+                        let created_program_account = Account {
                             lamports,
-                            data: vec![0u8; data_len as usize],
+                            data,
                             owner: bpf_loader_upgradeable::id(),
                             executable: true,
                             rent_epoch: new_account.rent_epoch(),
@@ -8301,11 +8301,9 @@ impl Bank {
                         // lamports for the empty account that will now house the
                         // PDA, and we can properly serialize the program account's
                         // state
-                        if new_account.lamports() >= lamports
-                            && created_program_account.serialize_data(&state).is_ok()
-                        {
-                            let change_in_cap = new_account.lamports().saturating_sub(lamports);
+                        if new_account.lamports() >= lamports {
                             datapoint_info!(datapoint_name, ("slot", self.slot, i64));
+                            let change_in_cap = new_account.lamports().saturating_sub(lamports);
 
                             // Replace the old data account with the new one
                             // If the old data account does not exist, it will be created

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8303,7 +8303,7 @@ impl Bank {
                         // state
                         if new_account.lamports() >= lamports {
                             datapoint_info!(datapoint_name, ("slot", self.slot, i64));
-                            let change_in_cap = new_account.lamports().saturating_sub(lamports);
+                            let change_in_capitalization = new_account.lamports().saturating_sub(lamports);
 
                             // Replace the old data account with the new one
                             // If the old data account does not exist, it will be created
@@ -8324,7 +8324,7 @@ impl Bank {
                             );
 
                             // Any remaining lamports in the new program account are burnt
-                            self.capitalization.fetch_sub(change_in_cap, Relaxed);
+                            self.capitalization.fetch_sub(change_in_capitalization, Relaxed);
                         }
                     }
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8056,7 +8056,7 @@ impl Bank {
             self.apply_updated_hashes_per_tick(DEFAULT_HASHES_PER_TICK);
         }
 
-        if new_feature_activations.contains(&feature_set::feature_gate_program::id()) {
+        if new_feature_activations.contains(&feature_set::programify_feature_gate_program::id()) {
             self.replace_empty_account_with_upgradeable_program(
                 &feature::id(),
                 &inline_feature_gate_program::noop_program::id(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8210,10 +8210,10 @@ impl Bank {
     /// `dst`: the program to be replaced
     fn move_account<U, V>(
         &mut self,
-        dst_address: &Pubkey,
         src_address: &Pubkey,
-        dst_account: Option<&U>,
         src_account: &V,
+        dst_address: &Pubkey,
+        dst_account: Option<&U>,
     ) where
         U: ReadableAccount + Sync + ZeroLamport,
         V: ReadableAccount + Sync + ZeroLamport,
@@ -8244,15 +8244,15 @@ impl Bank {
     #[allow(dead_code)]
     fn replace_non_upgradeable_program_account(
         &mut self,
-        dst_address: &Pubkey,
         src_address: &Pubkey,
+        dst_address: &Pubkey,
         datapoint_name: &'static str,
     ) {
         if let Some(dst_account) = self.get_account_with_fixed_root(dst_address) {
             if let Some(src_account) = self.get_account_with_fixed_root(src_address) {
                 datapoint_info!(datapoint_name, ("slot", self.slot, i64));
 
-                self.move_account(dst_address, src_address, Some(&dst_account), &src_account);
+                self.move_account(src_address, &src_account, dst_address, Some(&dst_account));
 
                 // Unload a program from the bank's cache
                 self.loaded_programs_cache
@@ -8266,8 +8266,8 @@ impl Bank {
     /// Use to replace an empty account with a program by feature activation
     fn replace_empty_account_with_upgradeable_program(
         &mut self,
-        dst_address: &Pubkey,
         src_address: &Pubkey,
+        dst_address: &Pubkey,
         datapoint_name: &'static str,
     ) {
         // Must be attempting to replace an empty account with a program
@@ -8314,18 +8314,18 @@ impl Bank {
                             // If the destination data account does not exist, it will be created
                             // If it does exist, it will be overwritten
                             self.move_account(
-                                &dst_data_address,
                                 &src_data_address,
-                                self.get_account_with_fixed_root(&dst_data_address).as_ref(),
                                 &src_data_account,
+                                &dst_data_address,
+                                self.get_account_with_fixed_root(&dst_data_address).as_ref(),
                             );
 
                             // Write the source data account's PDA into the destination program account
                             self.move_account(
-                                dst_address,
                                 src_address,
-                                None::<&AccountSharedData>,
                                 &created_program_account,
+                                dst_address,
+                                None::<&AccountSharedData>,
                             );
 
                             // Any remaining lamports in the source program account are burnt

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -216,6 +216,7 @@ pub mod bank_hash_details;
 mod builtin_programs;
 pub mod epoch_accounts_hash_utils;
 mod metrics;
+mod replace_account;
 mod serde_snapshot;
 mod sysvar_cache;
 #[cfg(test)]
@@ -8057,7 +8058,8 @@ impl Bank {
         }
 
         if new_feature_activations.contains(&feature_set::programify_feature_gate_program::id()) {
-            self.replace_empty_account_with_upgradeable_program(
+            replace_account::replace_empty_account_with_upgradeable_program(
+                self,
                 &feature::id(),
                 &inline_feature_gate_program::noop_program::id(),
                 "bank-apply_feature_gate_program",
@@ -8202,216 +8204,6 @@ impl Bank {
             }) {
                 self.add_precompile(&precompile.program_id);
             }
-        }
-    }
-
-    /// Moves one account in place of another
-    /// `source`: the account to replace with
-    /// `destination`: the account to be replaced
-    fn move_account<U, V>(
-        &mut self,
-        source_address: &Pubkey,
-        source_account: &V,
-        destination_address: &Pubkey,
-        destination_account: Option<&U>,
-    ) where
-        U: ReadableAccount + Sync + ZeroLamport,
-        V: ReadableAccount + Sync + ZeroLamport,
-    {
-        let (destination_lamports, destination_len) = match destination_account {
-            Some(destination_account) => (
-                destination_account.lamports(),
-                destination_account.data().len(),
-            ),
-            None => (0, 0),
-        };
-
-        // Burn lamports in the destination account
-        self.capitalization.fetch_sub(destination_lamports, Relaxed);
-
-        // Transfer source account to destination account
-        self.store_account(destination_address, source_account);
-
-        // Clear source account
-        self.store_account(source_address, &AccountSharedData::default());
-
-        self.calculate_and_update_accounts_data_size_delta_off_chain(
-            destination_len,
-            source_account.data().len(),
-        );
-    }
-
-    /// Use to replace non-upgradeable programs by feature activation
-    /// `source`: the non-upgradeable program account to replace with
-    /// `destination`: the non-upgradeable program account to be replaced
-    #[allow(dead_code)]
-    fn replace_non_upgradeable_program_account(
-        &mut self,
-        source_address: &Pubkey,
-        destination_address: &Pubkey,
-        datapoint_name: &'static str,
-    ) {
-        if let Some(destination_account) = self.get_account_with_fixed_root(destination_address) {
-            if let Some(source_account) = self.get_account_with_fixed_root(source_address) {
-                datapoint_info!(datapoint_name, ("slot", self.slot, i64));
-
-                self.move_account(
-                    source_address,
-                    &source_account,
-                    destination_address,
-                    Some(&destination_account),
-                );
-
-                // Unload a program from the bank's cache
-                self.loaded_programs_cache
-                    .write()
-                    .unwrap()
-                    .remove_programs([*destination_address].into_iter());
-            } else {
-                warn!(
-                    "Unable to find source program {}. Destination: {}",
-                    source_address, destination_address
-                );
-                datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
-            }
-        } else {
-            warn!("Unable to find destination program {}", destination_address);
-            datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
-        }
-    }
-
-    /// Use to replace an empty account with a program by feature activation
-    /// Note: The upgradeable program should have both:
-    ///     - Program account
-    ///     - Program data account
-    /// `source`: the upgradeable program account to replace with
-    /// `destination`: the empty account to be replaced
-    fn replace_empty_account_with_upgradeable_program(
-        &mut self,
-        source_address: &Pubkey,
-        destination_address: &Pubkey,
-        datapoint_name: &'static str,
-    ) {
-        // Must be attempting to replace an empty account with a program
-        // account _and_ data account
-        if let Some(source_account) = self.get_account_with_fixed_root(source_address) {
-            let (destination_data_address, _) = Pubkey::find_program_address(
-                &[destination_address.as_ref()],
-                &bpf_loader_upgradeable::id(),
-            );
-            let (source_data_address, _) = Pubkey::find_program_address(
-                &[source_address.as_ref()],
-                &bpf_loader_upgradeable::id(),
-            );
-
-            // Make sure the data within the source account is the PDA of its
-            // data account. This also means it has at least the necessary
-            // lamports for rent.
-            if let Ok(source_state) =
-                bincode::deserialize::<UpgradeableLoaderState>(source_account.data())
-            {
-                match source_state {
-                    UpgradeableLoaderState::Program {
-                        programdata_address: _,
-                    } => {
-                        if let Some(source_data_account) =
-                            self.get_account_with_fixed_root(&source_data_address)
-                        {
-                            // Make sure the destination account is empty
-                            // We aren't going to check that there isn't a data account at
-                            // the known program-derived address (ie. `destination_data_address`),
-                            // because if it exists, it will be overwritten
-                            if self
-                                .get_account_with_fixed_root(destination_address)
-                                .is_none()
-                            {
-                                let state = UpgradeableLoaderState::Program {
-                                    programdata_address: destination_data_address,
-                                };
-                                if let Ok(data) = bincode::serialize(&state) {
-                                    let lamports =
-                                        self.get_minimum_balance_for_rent_exemption(data.len());
-                                    let created_program_account = Account {
-                                        lamports,
-                                        data,
-                                        owner: bpf_loader_upgradeable::id(),
-                                        executable: true,
-                                        rent_epoch: source_account.rent_epoch(),
-                                    };
-
-                                    datapoint_info!(datapoint_name, ("slot", self.slot, i64));
-                                    let change_in_capitalization =
-                                        source_account.lamports().saturating_sub(lamports);
-
-                                    // Replace the destination data account with the source one
-                                    // If the destination data account does not exist, it will be created
-                                    // If it does exist, it will be overwritten
-                                    self.move_account(
-                                        &source_data_address,
-                                        &source_data_account,
-                                        &destination_data_address,
-                                        self.get_account_with_fixed_root(&destination_data_address)
-                                            .as_ref(),
-                                    );
-
-                                    // Write the source data account's PDA into the destination program account
-                                    self.move_account(
-                                        source_address,
-                                        &created_program_account,
-                                        destination_address,
-                                        None::<&AccountSharedData>,
-                                    );
-
-                                    // Any remaining lamports in the source program account are burnt
-                                    self.capitalization
-                                        .fetch_sub(change_in_capitalization, Relaxed);
-                                } else {
-                                    error!(
-                                        "Unable to serialize program account state. \
-                                        Source program: {} Source data account: {} \
-                                        Destination program: {} Destination data account: {}",
-                                        source_address,
-                                        source_data_address,
-                                        destination_address,
-                                        destination_data_address,
-                                    );
-                                    datapoint_error!(datapoint_name, ("slot", self.slot(), i64),);
-                                }
-                            }
-                        } else {
-                            warn!(
-                                "Unable to find data account for source program. \
-                                Source program: {} Source data account: {} \
-                                Destination program: {} Destination data account: {}",
-                                source_address,
-                                source_data_address,
-                                destination_address,
-                                destination_data_address,
-                            );
-                            datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
-                        }
-                    }
-                    _ => {
-                        warn!(
-                            "Source program account is not an upgradeable program. \
-                            Source program: {} Source data account: {} \
-                            Destination program: {} Destination data account: {}",
-                            source_address,
-                            source_data_address,
-                            destination_address,
-                            destination_data_address,
-                        );
-                        datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
-                        return;
-                    }
-                }
-            }
-        } else {
-            warn!(
-                "Unable to find source program {}. Destination: {}",
-                source_address, destination_address
-            );
-            datapoint_warn!(datapoint_name, ("slot", self.slot(), i64),);
         }
     }
 

--- a/runtime/src/bank/replace_account.rs
+++ b/runtime/src/bank/replace_account.rs
@@ -116,7 +116,7 @@ pub(crate) fn replace_empty_account_with_upgradeable_program(
     let source_account = bank
         .get_account_with_fixed_root(source_address)
         .ok_or(ReplaceAccountError::AccountNotFound(*source_address))?;
-    
+
     let (destination_data_address, _) = Pubkey::find_program_address(
         &[destination_address.as_ref()],
         &bpf_loader_upgradeable::id(),

--- a/runtime/src/bank/replace_account.rs
+++ b/runtime/src/bank/replace_account.rs
@@ -12,23 +12,16 @@ use {
 };
 
 /// Errors returned by `replace_account` methods
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum ReplaceAccountError {
-    /// Source account not found
-    #[error("Source account not found")]
-    SourceAccountNotFound,
-    /// Source data account not found
-    #[error("Source data account not found")]
-    SourceDataAccountNotFound,
-    /// Destination account not found
-    #[error("Destination account not found")]
-    DestinationAccountNotFound,
-    /// Destination account exists
-    #[error("Destination account exists")]
-    DestinationAccountExists,
-    /// Unable to serialize program account state
-    #[error("Unable to serialize program account state")]
-    UnableToSerializeProgramAccountState,
+    /// Account not found
+    #[error("Account not found: {0:?}")]
+    AccountNotFound(Pubkey),
+    /// Account exists
+    #[error("Account exists: {0:?}")]
+    AccountExists(Pubkey),
+    #[error("Bincode Error: {0}")]
+    BincodeError(#[from] bincode::Error),
     /// Not an upgradeable program
     #[error("Not an upgradeable program")]
     NotAnUpgradeableProgram,
@@ -38,7 +31,7 @@ pub enum ReplaceAccountError {
 /// `source`: the account to replace with
 /// `destination`: the account to be replaced
 fn move_account<U, V>(
-    bank: &mut Bank,
+    bank: &Bank,
     source_address: &Pubkey,
     source_account: &V,
     destination_address: &Pubkey,
@@ -75,36 +68,35 @@ fn move_account<U, V>(
 /// `destination`: the non-upgradeable program account to be replaced
 #[allow(dead_code)]
 pub(crate) fn replace_non_upgradeable_program_account(
-    bank: &mut Bank,
+    bank: &Bank,
     source_address: &Pubkey,
     destination_address: &Pubkey,
     datapoint_name: &'static str,
 ) -> Result<(), ReplaceAccountError> {
-    if let Some(destination_account) = bank.get_account_with_fixed_root(destination_address) {
-        if let Some(source_account) = bank.get_account_with_fixed_root(source_address) {
-            datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
+    let destination_account = bank
+        .get_account_with_fixed_root(destination_address)
+        .ok_or(ReplaceAccountError::AccountNotFound(*destination_address))?;
+    let source_account = bank
+        .get_account_with_fixed_root(source_address)
+        .ok_or(ReplaceAccountError::AccountNotFound(*source_address))?;
 
-            move_account(
-                bank,
-                source_address,
-                &source_account,
-                destination_address,
-                Some(&destination_account),
-            );
+    datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
 
-            // Unload a program from the bank's cache
-            bank.loaded_programs_cache
-                .write()
-                .unwrap()
-                .remove_programs([*destination_address].into_iter());
+    move_account(
+        bank,
+        source_address,
+        &source_account,
+        destination_address,
+        Some(&destination_account),
+    );
 
-            Ok(())
-        } else {
-            Err(ReplaceAccountError::SourceAccountNotFound)
-        }
-    } else {
-        Err(ReplaceAccountError::DestinationAccountNotFound)
-    }
+    // Unload a program from the bank's cache
+    bank.loaded_programs_cache
+        .write()
+        .unwrap()
+        .remove_programs([*destination_address].into_iter());
+
+    Ok(())
 }
 
 /// Use to replace an empty account with a program by feature activation
@@ -114,102 +106,86 @@ pub(crate) fn replace_non_upgradeable_program_account(
 /// `source`: the upgradeable program account to replace with
 /// `destination`: the empty account to be replaced
 pub(crate) fn replace_empty_account_with_upgradeable_program(
-    bank: &mut Bank,
+    bank: &Bank,
     source_address: &Pubkey,
     destination_address: &Pubkey,
     datapoint_name: &'static str,
 ) -> Result<(), ReplaceAccountError> {
     // Must be attempting to replace an empty account with a program
     // account _and_ data account
-    if let Some(source_account) = bank.get_account_with_fixed_root(source_address) {
-        let (destination_data_address, _) = Pubkey::find_program_address(
-            &[destination_address.as_ref()],
-            &bpf_loader_upgradeable::id(),
-        );
-        let (source_data_address, _) =
-            Pubkey::find_program_address(&[source_address.as_ref()], &bpf_loader_upgradeable::id());
+    let source_account = bank
+        .get_account_with_fixed_root(source_address)
+        .ok_or(ReplaceAccountError::AccountNotFound(*source_address))?;
+    
+    let (destination_data_address, _) = Pubkey::find_program_address(
+        &[destination_address.as_ref()],
+        &bpf_loader_upgradeable::id(),
+    );
+    let (source_data_address, _) =
+        Pubkey::find_program_address(&[source_address.as_ref()], &bpf_loader_upgradeable::id());
 
-        // Make sure the data within the source account is the PDA of its
-        // data account. This also means it has at least the necessary
-        // lamports for rent.
-        if let Ok(source_state) =
-            bincode::deserialize::<UpgradeableLoaderState>(source_account.data())
-        {
-            match source_state {
-                UpgradeableLoaderState::Program {
-                    programdata_address: _,
-                } => {
-                    if let Some(source_data_account) =
-                        bank.get_account_with_fixed_root(&source_data_address)
-                    {
-                        // Make sure the destination account is empty
-                        // We aren't going to check that there isn't a data account at
-                        // the known program-derived address (ie. `destination_data_address`),
-                        // because if it exists, it will be overwritten
-                        if bank
-                            .get_account_with_fixed_root(destination_address)
-                            .is_none()
-                        {
-                            let state = UpgradeableLoaderState::Program {
-                                programdata_address: destination_data_address,
-                            };
-                            if let Ok(data) = bincode::serialize(&state) {
-                                let lamports =
-                                    bank.get_minimum_balance_for_rent_exemption(data.len());
-                                let created_program_account = Account {
-                                    lamports,
-                                    data,
-                                    owner: bpf_loader_upgradeable::id(),
-                                    executable: true,
-                                    rent_epoch: source_account.rent_epoch(),
-                                };
-
-                                datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
-                                let change_in_capitalization =
-                                    source_account.lamports().saturating_sub(lamports);
-
-                                // Replace the destination data account with the source one
-                                // If the destination data account does not exist, it will be created
-                                // If it does exist, it will be overwritten
-                                move_account(
-                                    bank,
-                                    &source_data_address,
-                                    &source_data_account,
-                                    &destination_data_address,
-                                    bank.get_account_with_fixed_root(&destination_data_address)
-                                        .as_ref(),
-                                );
-
-                                // Write the source data account's PDA into the destination program account
-                                move_account(
-                                    bank,
-                                    source_address,
-                                    &created_program_account,
-                                    destination_address,
-                                    None::<&AccountSharedData>,
-                                );
-
-                                // Any remaining lamports in the source program account are burnt
-                                bank.capitalization
-                                    .fetch_sub(change_in_capitalization, Relaxed);
-
-                                Ok(())
-                            } else {
-                                Err(ReplaceAccountError::UnableToSerializeProgramAccountState)
-                            }
-                        } else {
-                            Err(ReplaceAccountError::DestinationAccountExists)
-                        }
-                    } else {
-                        Err(ReplaceAccountError::SourceDataAccountNotFound)
-                    }
-                }
-                _ => Err(ReplaceAccountError::NotAnUpgradeableProgram),
-            }
-        } else {
-            Err(ReplaceAccountError::NotAnUpgradeableProgram)
-        }
-    } else {
-        Err(ReplaceAccountError::SourceAccountNotFound)
+    // Make sure the data within the source account is the PDA of its
+    // data account. This also means it has at least the necessary
+    // lamports for rent.
+    let source_state = bincode::deserialize::<UpgradeableLoaderState>(source_account.data())?;
+    if !matches!(source_state, UpgradeableLoaderState::Program { .. }) {
+        return Err(ReplaceAccountError::NotAnUpgradeableProgram);
     }
+
+    let source_data_account = bank
+        .get_account_with_fixed_root(&source_data_address)
+        .ok_or(ReplaceAccountError::AccountNotFound(source_data_address))?;
+
+    // Make sure the destination account is empty
+    // We aren't going to check that there isn't a data account at
+    // the known program-derived address (ie. `destination_data_address`),
+    // because if it exists, it will be overwritten
+    if bank
+        .get_account_with_fixed_root(destination_address)
+        .is_some()
+    {
+        return Err(ReplaceAccountError::AccountExists(*destination_address));
+    }
+    let state = UpgradeableLoaderState::Program {
+        programdata_address: destination_data_address,
+    };
+    let data = bincode::serialize(&state)?;
+    let lamports = bank.get_minimum_balance_for_rent_exemption(data.len());
+    let created_program_account = Account {
+        lamports,
+        data,
+        owner: bpf_loader_upgradeable::id(),
+        executable: true,
+        rent_epoch: source_account.rent_epoch(),
+    };
+
+    datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
+    let change_in_capitalization = source_account.lamports().saturating_sub(lamports);
+
+    // Replace the destination data account with the source one
+    // If the destination data account does not exist, it will be created
+    // If it does exist, it will be overwritten
+    move_account(
+        bank,
+        &source_data_address,
+        &source_data_account,
+        &destination_data_address,
+        bank.get_account_with_fixed_root(&destination_data_address)
+            .as_ref(),
+    );
+
+    // Write the source data account's PDA into the destination program account
+    move_account(
+        bank,
+        source_address,
+        &created_program_account,
+        destination_address,
+        None::<&AccountSharedData>,
+    );
+
+    // Any remaining lamports in the source program account are burnt
+    bank.capitalization
+        .fetch_sub(change_in_capitalization, Relaxed);
+
+    Ok(())
 }

--- a/runtime/src/bank/replace_account.rs
+++ b/runtime/src/bank/replace_account.rs
@@ -1,0 +1,222 @@
+use {
+    super::Bank,
+    log::*,
+    solana_accounts_db::accounts_index::ZeroLamport,
+    solana_sdk::{
+        account::{Account, AccountSharedData, ReadableAccount},
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+        pubkey::Pubkey,
+    },
+    std::sync::atomic::Ordering::Relaxed,
+};
+
+/// Moves one account in place of another
+/// `source`: the account to replace with
+/// `destination`: the account to be replaced
+fn move_account<U, V>(
+    bank: &mut Bank,
+    source_address: &Pubkey,
+    source_account: &V,
+    destination_address: &Pubkey,
+    destination_account: Option<&U>,
+) where
+    U: ReadableAccount + Sync + ZeroLamport,
+    V: ReadableAccount + Sync + ZeroLamport,
+{
+    let (destination_lamports, destination_len) = match destination_account {
+        Some(destination_account) => (
+            destination_account.lamports(),
+            destination_account.data().len(),
+        ),
+        None => (0, 0),
+    };
+
+    // Burn lamports in the destination account
+    bank.capitalization.fetch_sub(destination_lamports, Relaxed);
+
+    // Transfer source account to destination account
+    bank.store_account(destination_address, source_account);
+
+    // Clear source account
+    bank.store_account(source_address, &AccountSharedData::default());
+
+    bank.calculate_and_update_accounts_data_size_delta_off_chain(
+        destination_len,
+        source_account.data().len(),
+    );
+}
+
+/// Use to replace non-upgradeable programs by feature activation
+/// `source`: the non-upgradeable program account to replace with
+/// `destination`: the non-upgradeable program account to be replaced
+#[allow(dead_code)]
+pub(crate) fn replace_non_upgradeable_program_account(
+    bank: &mut Bank,
+    source_address: &Pubkey,
+    destination_address: &Pubkey,
+    datapoint_name: &'static str,
+) {
+    if let Some(destination_account) = bank.get_account_with_fixed_root(destination_address) {
+        if let Some(source_account) = bank.get_account_with_fixed_root(source_address) {
+            datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
+
+            move_account(
+                bank,
+                source_address,
+                &source_account,
+                destination_address,
+                Some(&destination_account),
+            );
+
+            // Unload a program from the bank's cache
+            bank.loaded_programs_cache
+                .write()
+                .unwrap()
+                .remove_programs([*destination_address].into_iter());
+        } else {
+            warn!(
+                "Unable to find source program {}. Destination: {}",
+                source_address, destination_address
+            );
+            datapoint_warn!(datapoint_name, ("slot", bank.slot(), i64),);
+        }
+    } else {
+        warn!("Unable to find destination program {}", destination_address);
+        datapoint_warn!(datapoint_name, ("slot", bank.slot(), i64),);
+    }
+}
+
+/// Use to replace an empty account with a program by feature activation
+/// Note: The upgradeable program should have both:
+///     - Program account
+///     - Program data account
+/// `source`: the upgradeable program account to replace with
+/// `destination`: the empty account to be replaced
+pub(crate) fn replace_empty_account_with_upgradeable_program(
+    bank: &mut Bank,
+    source_address: &Pubkey,
+    destination_address: &Pubkey,
+    datapoint_name: &'static str,
+) {
+    // Must be attempting to replace an empty account with a program
+    // account _and_ data account
+    if let Some(source_account) = bank.get_account_with_fixed_root(source_address) {
+        let (destination_data_address, _) = Pubkey::find_program_address(
+            &[destination_address.as_ref()],
+            &bpf_loader_upgradeable::id(),
+        );
+        let (source_data_address, _) =
+            Pubkey::find_program_address(&[source_address.as_ref()], &bpf_loader_upgradeable::id());
+
+        // Make sure the data within the source account is the PDA of its
+        // data account. This also means it has at least the necessary
+        // lamports for rent.
+        if let Ok(source_state) =
+            bincode::deserialize::<UpgradeableLoaderState>(source_account.data())
+        {
+            match source_state {
+                UpgradeableLoaderState::Program {
+                    programdata_address: _,
+                } => {
+                    if let Some(source_data_account) =
+                        bank.get_account_with_fixed_root(&source_data_address)
+                    {
+                        // Make sure the destination account is empty
+                        // We aren't going to check that there isn't a data account at
+                        // the known program-derived address (ie. `destination_data_address`),
+                        // because if it exists, it will be overwritten
+                        if bank
+                            .get_account_with_fixed_root(destination_address)
+                            .is_none()
+                        {
+                            let state = UpgradeableLoaderState::Program {
+                                programdata_address: destination_data_address,
+                            };
+                            if let Ok(data) = bincode::serialize(&state) {
+                                let lamports =
+                                    bank.get_minimum_balance_for_rent_exemption(data.len());
+                                let created_program_account = Account {
+                                    lamports,
+                                    data,
+                                    owner: bpf_loader_upgradeable::id(),
+                                    executable: true,
+                                    rent_epoch: source_account.rent_epoch(),
+                                };
+
+                                datapoint_info!(datapoint_name, ("slot", bank.slot, i64));
+                                let change_in_capitalization =
+                                    source_account.lamports().saturating_sub(lamports);
+
+                                // Replace the destination data account with the source one
+                                // If the destination data account does not exist, it will be created
+                                // If it does exist, it will be overwritten
+                                move_account(
+                                    bank,
+                                    &source_data_address,
+                                    &source_data_account,
+                                    &destination_data_address,
+                                    bank.get_account_with_fixed_root(&destination_data_address)
+                                        .as_ref(),
+                                );
+
+                                // Write the source data account's PDA into the destination program account
+                                move_account(
+                                    bank,
+                                    source_address,
+                                    &created_program_account,
+                                    destination_address,
+                                    None::<&AccountSharedData>,
+                                );
+
+                                // Any remaining lamports in the source program account are burnt
+                                bank.capitalization
+                                    .fetch_sub(change_in_capitalization, Relaxed);
+                            } else {
+                                error!(
+                                    "Unable to serialize program account state. \
+                                    Source program: {} Source data account: {} \
+                                    Destination program: {} Destination data account: {}",
+                                    source_address,
+                                    source_data_address,
+                                    destination_address,
+                                    destination_data_address,
+                                );
+                                datapoint_error!(datapoint_name, ("slot", bank.slot(), i64),);
+                            }
+                        }
+                    } else {
+                        warn!(
+                            "Unable to find data account for source program. \
+                            Source program: {} Source data account: {} \
+                            Destination program: {} Destination data account: {}",
+                            source_address,
+                            source_data_address,
+                            destination_address,
+                            destination_data_address,
+                        );
+                        datapoint_warn!(datapoint_name, ("slot", bank.slot(), i64),);
+                    }
+                }
+                _ => {
+                    warn!(
+                        "Source program account is not an upgradeable program. \
+                        Source program: {} Source data account: {} \
+                        Destination program: {} Destination data account: {}",
+                        source_address,
+                        source_data_address,
+                        destination_address,
+                        destination_data_address,
+                    );
+                    datapoint_warn!(datapoint_name, ("slot", bank.slot(), i64),);
+                    return;
+                }
+            }
+        }
+    } else {
+        warn!(
+            "Unable to find source program {}. Destination: {}",
+            source_address, destination_address
+        );
+        datapoint_warn!(datapoint_name, ("slot", bank.slot(), i64),);
+    }
+}

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8008,7 +8008,7 @@ fn test_compute_active_feature_set() {
 }
 
 fn test_program_replace_set_up_account<T: serde::Serialize>(
-    bank: &mut Bank,
+    bank: &Bank,
     pubkey: &Pubkey,
     lamports: u64,
     state: &T,
@@ -8038,13 +8038,13 @@ fn test_replace_non_upgradeable_program_account() {
     // Should replace the destination program account with the source program account:
     // - Destination:       [*Source program data]
     let bpf_id = bpf_loader::id();
-    let mut bank = create_simple_test_bank(0);
+    let bank = create_simple_test_bank(0);
 
     let destination = Pubkey::new_unique();
     let destination_state = vec![0u8; 4];
     let destination_lamports = bank.get_minimum_balance_for_rent_exemption(destination_state.len());
     test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &destination,
         destination_lamports,
         &destination_state,
@@ -8056,7 +8056,7 @@ fn test_replace_non_upgradeable_program_account() {
     let source_state = vec![6; 30];
     let source_lamports = bank.get_minimum_balance_for_rent_exemption(source_state.len());
     let check_source_account = test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &source,
         source_lamports,
         &source_state,
@@ -8068,7 +8068,7 @@ fn test_replace_non_upgradeable_program_account() {
     let original_capitalization = bank.capitalization();
 
     replace_non_upgradeable_program_account(
-        &mut bank,
+        &bank,
         &source,
         &destination,
         "bank-apply_program_replacement",
@@ -8128,7 +8128,7 @@ fn test_replace_empty_account_with_upgradeable_program_success(
     //
     // If the destination data account exists, it will be overwritten
     let bpf_upgradeable_id = bpf_loader_upgradeable::id();
-    let mut bank = create_simple_test_bank(0);
+    let bank = create_simple_test_bank(0);
 
     // Create the test source accounts, one for program and one for data
     let source = Pubkey::new_unique();
@@ -8141,7 +8141,7 @@ fn test_replace_empty_account_with_upgradeable_program_success(
     let source_data_state = vec![6; 30];
     let source_data_lamports = bank.get_minimum_balance_for_rent_exemption(source_data_state.len());
     test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &source,
         source_lamports,
         &source_state,
@@ -8149,7 +8149,7 @@ fn test_replace_empty_account_with_upgradeable_program_success(
         true,
     );
     let check_source_data_account = test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &source_data,
         source_data_lamports,
         &source_data_state,
@@ -8168,7 +8168,7 @@ fn test_replace_empty_account_with_upgradeable_program_success(
         let destination_data_lamports =
             bank.get_minimum_balance_for_rent_exemption(destination_data_state.len());
         test_program_replace_set_up_account(
-            &mut bank,
+            &bank,
             &destination_data,
             destination_data_lamports,
             &destination_data_state,
@@ -8186,7 +8186,7 @@ fn test_replace_empty_account_with_upgradeable_program_success(
 
     // Do the replacement
     replace_empty_account_with_upgradeable_program(
-        &mut bank,
+        &bank,
         &source,
         &destination,
         "bank-apply_empty_account_replacement_for_program",
@@ -8250,14 +8250,14 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
 ) {
     // Should not be allowed to execute replacement
     let bpf_upgradeable_id = bpf_loader_upgradeable::id();
-    let mut bank = create_simple_test_bank(0);
+    let bank = create_simple_test_bank(0);
 
     // Create the test destination account with some arbitrary data and lamports balance
     let destination = Pubkey::new_unique();
     let destination_state = vec![0, 0, 0, 0]; // Arbitrary bytes, doesn't matter
     let destination_lamports = bank.get_minimum_balance_for_rent_exemption(destination_state.len());
     let destination_account = test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &destination,
         destination_lamports,
         &destination_state,
@@ -8276,7 +8276,7 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
     let source_data_state = vec![6; 30];
     let source_data_lamports = bank.get_minimum_balance_for_rent_exemption(source_data_state.len());
     let source_account = test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &source,
         source_lamports,
         &source_state,
@@ -8284,7 +8284,7 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
         true,
     );
     let source_data_account = test_program_replace_set_up_account(
-        &mut bank,
+        &bank,
         &source_data,
         source_data_lamports,
         &source_data_state,
@@ -8302,7 +8302,7 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
             let destination_data_lamports =
                 bank.get_minimum_balance_for_rent_exemption(destination_data_state.len());
             let destination_data_account = test_program_replace_set_up_account(
-                &mut bank,
+                &bank,
                 &destination_data,
                 destination_data_lamports,
                 &destination_data_state,
@@ -8317,15 +8317,15 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
     let original_capitalization = bank.capitalization();
 
     // Attempt the replacement
-    assert_eq!(
+    assert_matches!(
         replace_empty_account_with_upgradeable_program(
-            &mut bank,
+            &bank,
             &source,
             &destination,
             "bank-apply_empty_account_replacement_for_program",
         )
         .unwrap_err(),
-        ReplaceAccountError::DestinationAccountExists
+        ReplaceAccountError::AccountExists(..)
     );
 
     // Everything should be unchanged

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8083,22 +8083,22 @@ fn test_replace_non_upgradeable_program_account() {
 #[test_case(
     Pubkey::new_unique(),
     None;
-    "Empty account _without_ corresponding data account"
+    "Empty destination account _without_ corresponding data account"
 )]
 #[test_case(
     Pubkey::new_unique(),
     Some(vec![4; 40]);
-    "Empty account _with_ corresponding data account"
+    "Empty destination account _with_ corresponding data account"
 )]
 #[test_case(
     feature::id(), // `Feature11111111`
     None;
-    "Native account _without_ corresponding data account"
+    "Native destination account _without_ corresponding data account"
 )]
 #[test_case(
     feature::id(), // `Feature11111111`
     Some(vec![4; 40]);
-    "Native account _with_ corresponding data account"
+    "Native destination account _with_ corresponding data account"
 )]
 fn test_replace_empty_account_with_upgradeable_program_success(
     dst: Pubkey,
@@ -8218,11 +8218,11 @@ fn test_replace_empty_account_with_upgradeable_program_success(
 
 #[test_case(
     None;
-    "Existing account _without_ corresponding data account"
+    "Existing destination account _without_ corresponding data account"
 )]
 #[test_case(
     Some(vec![4; 40]);
-    "Existing account _with_ corresponding data account"
+    "Existing destination account _with_ corresponding data account"
 )]
 fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
     maybe_dst_data_state: Option<Vec<u8>>, // Inner data of the destination program _data_ account

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8056,7 +8056,7 @@ fn test_replace_non_upgradeable_program_account() {
 
     let original_capitalization = bank.capitalization();
 
-    bank.replace_non_upgradeable_program_account(&dst, &src, "bank-apply_program_replacement");
+    bank.replace_non_upgradeable_program_account(&src, &dst, "bank-apply_program_replacement");
 
     // Destination program account balance is now the source program account's balance
     assert_eq!(bank.get_balance(&dst), src_lamports);
@@ -8167,8 +8167,8 @@ fn test_replace_empty_account_with_upgradeable_program_success(
 
     // Do the replacement
     bank.replace_empty_account_with_upgradeable_program(
-        &dst,
         &src,
+        &dst,
         "bank-apply_empty_account_replacement_for_program",
     );
 
@@ -8294,8 +8294,8 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
 
     // Attempt the replacement
     bank.replace_empty_account_with_upgradeable_program(
-        &dst,
         &src,
+        &dst,
         "bank-apply_empty_account_replacement_for_program",
     );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8084,7 +8084,7 @@ fn test_replace_non_upgradeable_program_account() {
     assert_eq!(destination_account.owner(), &bpf_id);
     assert!(destination_account.executable());
 
-    // Lamports from the source program account were burnt
+    // The destination account's original lamports balance was burnt
     assert_eq!(
         bank.capitalization(),
         original_capitalization - destination_lamports

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9,7 +9,8 @@ use {
     crate::{
         accounts_background_service::{PrunedBanksRequestHandler, SendDroppedBankCallback},
         bank::replace_account::{
-            replace_empty_account_with_upgradeable_program, replace_non_upgradeable_program_account,
+            replace_empty_account_with_upgradeable_program,
+            replace_non_upgradeable_program_account, ReplaceAccountError,
         },
         bank_client::BankClient,
         epoch_rewards_hasher::hash_rewards_into_partitions,
@@ -8071,7 +8072,8 @@ fn test_replace_non_upgradeable_program_account() {
         &source,
         &destination,
         "bank-apply_program_replacement",
-    );
+    )
+    .unwrap();
 
     // Destination program account balance is now the source program account's balance
     assert_eq!(bank.get_balance(&destination), source_lamports);
@@ -8188,7 +8190,8 @@ fn test_replace_empty_account_with_upgradeable_program_success(
         &source,
         &destination,
         "bank-apply_empty_account_replacement_for_program",
-    );
+    )
+    .unwrap();
 
     // Destination program account was created and funded to pay for minimum rent
     // for the PDA
@@ -8314,11 +8317,15 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
     let original_capitalization = bank.capitalization();
 
     // Attempt the replacement
-    replace_empty_account_with_upgradeable_program(
-        &mut bank,
-        &source,
-        &destination,
-        "bank-apply_empty_account_replacement_for_program",
+    assert_eq!(
+        replace_empty_account_with_upgradeable_program(
+            &mut bank,
+            &source,
+            &destination,
+            "bank-apply_empty_account_replacement_for_program",
+        )
+        .unwrap_err(),
+        ReplaceAccountError::DestinationAccountExists
     );
 
     // Everything should be unchanged

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8077,6 +8077,26 @@ fn test_program_replace() {
     );
 }
 
+#[test_case(
+    Pubkey::new_unique(),
+    None;
+    "Empty account _without_ corresponding data account"
+)]
+#[test_case(
+    Pubkey::new_unique(),
+    Some(vec![4; 40]);
+    "Empty account _with_ corresponding data account"
+)]
+#[test_case(
+    feature::id(), // `Feature11111111`
+    None;
+    "Native account _without_ corresponding data account"
+)]
+#[test_case(
+    feature::id(), // `Feature11111111`
+    Some(vec![4; 40]);
+    "Native account _with_ corresponding data account"
+)]
 fn test_replace_empty_account_success(
     old: Pubkey,
     maybe_old_data_bytes: Option<Vec<u8>>, // Inner data of the old program _data_ account
@@ -8176,57 +8196,6 @@ fn test_replace_empty_account_success(
     assert_eq!(
         bank.capitalization(),
         original_capitalization - burnt_after_rent
-    );
-}
-
-#[test]
-fn test_replace_empty_account() {
-    // Empty account _without_ corresponding data account
-    // - Old:     ** Does not exist! **
-    // - New:     PDA(NewData)
-    // - NewData: [*New program data]
-    //
-    // Should create the program account and the data account, ie:
-    // - Old:     PDA(OldData)
-    // - OldData: [Old program data]
-    test_replace_empty_account_success(Pubkey::new_unique(), None);
-
-    // Empty account _with_ corresponding data account
-    // - Old:     ** Does not exist! **
-    // - OldData: [Old program data]
-    // - New:     PDA(NewData)
-    // - NewData: [*New program data]
-    //
-    // Should create the program account and the data account, ie:
-    // - Old:     PDA(OldData)
-    // - OldData: [Old program data]
-    test_replace_empty_account_success(Pubkey::new_unique(), Some(vec![4; 40]));
-
-    // Native account _without_ corresponding data account
-    // - Old:     ** Native account (ie. `Feature11111111`) **
-    // - New:     PDA(NewData)
-    // - NewData: [*New program data]
-    //
-    // Should create the program account and the data account, ie:
-    // - Old:     PDA(OldData)
-    // - OldData: [Old program data]
-    test_replace_empty_account_success(
-        feature::id(), // `Feature11111111`
-        None,
-    );
-
-    // Native account _with_ corresponding data account
-    // - Old:     ** Native account (ie. `Feature11111111`) **
-    // - OldData: [Old program data]
-    // - New:     PDA(NewData)
-    // - NewData: [*New program data]
-    //
-    // Should create the program account and the data account, ie:
-    // - Old:     PDA(OldData)
-    // - OldData: [Old program data]
-    test_replace_empty_account_success(
-        feature::id(), // `Feature11111111`
-        Some(vec![4; 40]),
     );
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8,6 +8,9 @@ use {
     },
     crate::{
         accounts_background_service::{PrunedBanksRequestHandler, SendDroppedBankCallback},
+        bank::replace_account::{
+            replace_empty_account_with_upgradeable_program, replace_non_upgradeable_program_account,
+        },
         bank_client::BankClient,
         epoch_rewards_hasher::hash_rewards_into_partitions,
         genesis_utils::{
@@ -8063,7 +8066,8 @@ fn test_replace_non_upgradeable_program_account() {
 
     let original_capitalization = bank.capitalization();
 
-    bank.replace_non_upgradeable_program_account(
+    replace_non_upgradeable_program_account(
+        &mut bank,
         &source,
         &destination,
         "bank-apply_program_replacement",
@@ -8179,7 +8183,8 @@ fn test_replace_empty_account_with_upgradeable_program_success(
     let original_capitalization = bank.capitalization();
 
     // Do the replacement
-    bank.replace_empty_account_with_upgradeable_program(
+    replace_empty_account_with_upgradeable_program(
+        &mut bank,
         &source,
         &destination,
         "bank-apply_empty_account_replacement_for_program",
@@ -8309,7 +8314,8 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
     let original_capitalization = bank.capitalization();
 
     // Attempt the replacement
-    bank.replace_empty_account_with_upgradeable_program(
+    replace_empty_account_with_upgradeable_program(
+        &mut bank,
         &source,
         &destination,
         "bank-apply_empty_account_replacement_for_program",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8012,71 +8012,71 @@ fn test_program_replace_set_up_account<T: serde::Serialize>(
     executable: bool,
 ) -> AccountSharedData {
     let data_len = bincode::serialized_size(state).unwrap() as usize;
-    let mut new_account = AccountSharedData::from(Account {
+    let mut account = AccountSharedData::from(Account {
         lamports,
         owner: *owner,
         executable,
         data: vec![0u8; data_len],
         ..Account::default()
     });
-    new_account.serialize_data(state).unwrap();
-    bank.store_account_and_update_capitalization(pubkey, &new_account);
+    account.serialize_data(state).unwrap();
+    bank.store_account_and_update_capitalization(pubkey, &account);
     assert_eq!(bank.get_balance(pubkey), lamports);
-    new_account
+    account
 }
 
 #[test]
 fn test_replace_non_upgradeable_program_account() {
     // Non-upgradeable program
-    // - Old:     [Old program data]
-    // - New:     [*New program data]
+    // - Destination:       [Destination program data]
+    // - Source:            [*Source program data]
     //
-    // Should replace the old program account with the new program account:
-    // - Old:     [*New program data]
+    // Should replace the destination program account with the source program account:
+    // - Destination:       [*Source program data]
     let bpf_id = bpf_loader::id();
     let mut bank = create_simple_test_bank(0);
 
-    let old = Pubkey::new_unique();
-    let old_state = vec![0u8; 4];
-    let old_lamports = bank.get_minimum_balance_for_rent_exemption(old_state.len());
-    test_program_replace_set_up_account(&mut bank, &old, old_lamports, &old_state, &bpf_id, true);
+    let dst = Pubkey::new_unique();
+    let dst_state = vec![0u8; 4];
+    let dst_lamports = bank.get_minimum_balance_for_rent_exemption(dst_state.len());
+    test_program_replace_set_up_account(&mut bank, &dst, dst_lamports, &dst_state, &bpf_id, true);
 
-    let new = Pubkey::new_unique();
-    let new_state = vec![6; 30];
-    let new_lamports = bank.get_minimum_balance_for_rent_exemption(new_state.len());
-    let check_new_account = test_program_replace_set_up_account(
+    let src = Pubkey::new_unique();
+    let src_state = vec![6; 30];
+    let src_lamports = bank.get_minimum_balance_for_rent_exemption(src_state.len());
+    let check_src_account = test_program_replace_set_up_account(
         &mut bank,
-        &new,
-        new_lamports,
-        &new_state,
+        &src,
+        src_lamports,
+        &src_state,
         &bpf_id,
         true,
     );
-    let check_data_account_data = check_new_account.data().to_vec();
+    let check_data_account_data = check_src_account.data().to_vec();
 
     let original_capitalization = bank.capitalization();
 
-    bank.replace_non_upgradeable_program_account(&old, &new, "bank-apply_program_replacement");
+    bank.replace_non_upgradeable_program_account(&dst, &src, "bank-apply_program_replacement");
 
-    // Old program account balance is now the new program account's balance
-    assert_eq!(bank.get_balance(&old), new_lamports);
+    // Destination program account balance is now the source program account's balance
+    assert_eq!(bank.get_balance(&dst), src_lamports);
 
-    // New program account is now empty
-    assert_eq!(bank.get_balance(&new), 0);
+    // Source program account is now empty
+    assert_eq!(bank.get_balance(&src), 0);
 
-    // Old program account now holds the new program data, ie:
-    // - Old:     [*New program data]
-    let old_account = bank.get_account(&old).unwrap();
-    assert_eq!(old_account.data(), &check_data_account_data);
+    // Destination program account now holds the source program data, ie:
+    // - Destination:       [*Source program data]
+    let dst_account = bank.get_account(&dst).unwrap();
+    assert_eq!(dst_account.data(), &check_data_account_data);
 
-    // Ownership & executable match the new program account
-    assert_eq!(old_account.owner(), &bpf_id);
-    assert!(old_account.executable());
+    // Ownership & executable match the source program account
+    assert_eq!(dst_account.owner(), &bpf_id);
+    assert!(dst_account.executable());
 
-    // Lamports from the new program account were burnt
+    // Lamports from the source program account were burnt
     assert_eq!(
         bank.capitalization(),
-        original_capitalization - old_lamports
+        original_capitalization - dst_lamports
     );
 }
 
@@ -8101,65 +8101,65 @@ fn test_replace_non_upgradeable_program_account() {
     "Native account _with_ corresponding data account"
 )]
 fn test_replace_empty_account_with_upgradeable_program_success(
-    old: Pubkey,
-    maybe_old_data_state: Option<Vec<u8>>, // Inner data of the old program _data_ account
+    dst: Pubkey,
+    maybe_dst_data_state: Option<Vec<u8>>, // Inner data of the destination program _data_ account
 ) {
     // Ensures a program account and data account are created when replacing an
     // empty account, ie:
-    // - Old:     PDA(OldData)
-    // - OldData: [Old program data]
+    // - Destination:       PDA(DestinationData)
+    // - DestinationData:   [Destination program data]
     //
-    // If the old data account exists, it will be overwritten
+    // If the destination data account exists, it will be overwritten
     let bpf_upgradeable_id = bpf_loader_upgradeable::id();
     let mut bank = create_simple_test_bank(0);
 
-    // Create the test new accounts, one for program and one for data
-    let new = Pubkey::new_unique();
-    let (new_data, _) = Pubkey::find_program_address(&[new.as_ref()], &bpf_upgradeable_id);
-    let new_state = UpgradeableLoaderState::Program {
-        programdata_address: new_data,
+    // Create the test source accounts, one for program and one for data
+    let src = Pubkey::new_unique();
+    let (src_data, _) = Pubkey::find_program_address(&[src.as_ref()], &bpf_upgradeable_id);
+    let src_state = UpgradeableLoaderState::Program {
+        programdata_address: src_data,
     };
-    let new_lamports =
+    let src_lamports =
         bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program());
-    let new_data_state = vec![6; 30];
-    let new_data_lamports = bank.get_minimum_balance_for_rent_exemption(new_data_state.len());
+    let src_data_state = vec![6; 30];
+    let src_data_lamports = bank.get_minimum_balance_for_rent_exemption(src_data_state.len());
     test_program_replace_set_up_account(
         &mut bank,
-        &new,
-        new_lamports,
-        &new_state,
+        &src,
+        src_lamports,
+        &src_state,
         &bpf_upgradeable_id,
         true,
     );
-    let check_new_data_account = test_program_replace_set_up_account(
+    let check_src_data_account = test_program_replace_set_up_account(
         &mut bank,
-        &new_data,
-        new_data_lamports,
-        &new_data_state,
+        &src_data,
+        src_data_lamports,
+        &src_data_state,
         &bpf_upgradeable_id,
         false,
     );
-    let check_data_account_data = check_new_data_account.data().to_vec();
+    let check_data_account_data = check_src_data_account.data().to_vec();
 
-    // Derive the well-known PDA address for the old data account
-    let (old_data, _) = Pubkey::find_program_address(&[old.as_ref()], &bpf_upgradeable_id);
+    // Derive the well-known PDA address for the destination data account
+    let (dst_data, _) = Pubkey::find_program_address(&[dst.as_ref()], &bpf_upgradeable_id);
 
     // Determine the lamports that will be burnt after the replacement
-    let burnt_after_rent = if let Some(old_data_state) = maybe_old_data_state {
+    let burnt_after_rent = if let Some(dst_data_state) = maybe_dst_data_state {
         // Create the data account if necessary
-        let old_data_lamports = bank.get_minimum_balance_for_rent_exemption(old_data_state.len());
+        let dst_data_lamports = bank.get_minimum_balance_for_rent_exemption(dst_data_state.len());
         test_program_replace_set_up_account(
             &mut bank,
-            &old_data,
-            old_data_lamports,
-            &old_data_state,
+            &dst_data,
+            dst_data_lamports,
+            &dst_data_state,
             &bpf_upgradeable_id,
             false,
         );
-        old_data_lamports + new_lamports
+        dst_data_lamports + src_lamports
             - bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
     } else {
-        new_lamports
+        src_lamports
             - bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
     };
 
@@ -8167,46 +8167,46 @@ fn test_replace_empty_account_with_upgradeable_program_success(
 
     // Do the replacement
     bank.replace_empty_account_with_upgradeable_program(
-        &old,
-        &new,
+        &dst,
+        &src,
         "bank-apply_empty_account_replacement_for_program",
     );
 
-    // Old program account was created and funded to pay for minimum rent
+    // Destination program account was created and funded to pay for minimum rent
     // for the PDA
     assert_eq!(
-        bank.get_balance(&old),
+        bank.get_balance(&dst),
         bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program()),
     );
 
-    // Old data account was created, now holds the new data account's balance
-    assert_eq!(bank.get_balance(&old_data), new_data_lamports);
+    // Destination data account was created, now holds the source data account's balance
+    assert_eq!(bank.get_balance(&dst_data), src_data_lamports);
 
-    // New program accounts are now empty
-    assert_eq!(bank.get_balance(&new), 0);
-    assert_eq!(bank.get_balance(&new_data), 0);
+    // Source program accounts are now empty
+    assert_eq!(bank.get_balance(&src), 0);
+    assert_eq!(bank.get_balance(&src_data), 0);
 
-    // Old program account holds the PDA, ie:
-    // - Old:     PDA(OldData)
-    let old_account = bank.get_account(&old).unwrap();
+    // Destination program account holds the PDA, ie:
+    // - Destination:       PDA(DestinationData)
+    let dst_account = bank.get_account(&dst).unwrap();
     assert_eq!(
-        old_account.data(),
+        dst_account.data(),
         &bincode::serialize(&UpgradeableLoaderState::Program {
-            programdata_address: old_data
+            programdata_address: dst_data
         })
         .unwrap(),
     );
 
-    // Old data account holds the new data, ie:
-    // - OldData: [*New program data]
-    let old_data_account = bank.get_account(&old_data).unwrap();
-    assert_eq!(old_data_account.data(), &check_data_account_data);
+    // Destination data account holds the source data, ie:
+    // - DestinationData:   [*Source program data]
+    let dst_data_account = bank.get_account(&dst_data).unwrap();
+    assert_eq!(dst_data_account.data(), &check_data_account_data);
 
-    // Ownership & executable match the new program accounts
-    assert_eq!(old_account.owner(), &bpf_upgradeable_id);
-    assert!(old_account.executable());
-    assert_eq!(old_data_account.owner(), &bpf_upgradeable_id);
-    assert!(!old_data_account.executable());
+    // Ownership & executable match the source program accounts
+    assert_eq!(dst_account.owner(), &bpf_upgradeable_id);
+    assert!(dst_account.executable());
+    assert_eq!(dst_data_account.owner(), &bpf_upgradeable_id);
+    assert!(!dst_data_account.executable());
 
     // The remaining lamports from both program accounts minus the rent-exempt
     // minimum were burnt
@@ -8225,67 +8225,67 @@ fn test_replace_empty_account_with_upgradeable_program_success(
     "Existing account _with_ corresponding data account"
 )]
 fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
-    maybe_old_data_state: Option<Vec<u8>>, // Inner data of the old program _data_ account
+    maybe_dst_data_state: Option<Vec<u8>>, // Inner data of the destination program _data_ account
 ) {
     // Should not be allowed to execute replacement
     let bpf_upgradeable_id = bpf_loader_upgradeable::id();
     let mut bank = create_simple_test_bank(0);
 
-    // Create the test old account with some arbitrary data and lamports balance
-    let old = Pubkey::new_unique();
-    let old_state = vec![0, 0, 0, 0]; // Arbitrary bytes, doesn't matter
-    let old_lamports = bank.get_minimum_balance_for_rent_exemption(old_state.len());
-    let old_account = test_program_replace_set_up_account(
+    // Create the test destination account with some arbitrary data and lamports balance
+    let dst = Pubkey::new_unique();
+    let dst_state = vec![0, 0, 0, 0]; // Arbitrary bytes, doesn't matter
+    let dst_lamports = bank.get_minimum_balance_for_rent_exemption(dst_state.len());
+    let dst_account = test_program_replace_set_up_account(
         &mut bank,
-        &old,
-        old_lamports,
-        &old_state,
+        &dst,
+        dst_lamports,
+        &dst_state,
         &bpf_upgradeable_id,
         true,
     );
 
-    // Create the test new accounts, one for program and one for data
-    let new = Pubkey::new_unique();
-    let (new_data, _) = Pubkey::find_program_address(&[new.as_ref()], &bpf_upgradeable_id);
-    let new_state = UpgradeableLoaderState::Program {
-        programdata_address: new_data,
+    // Create the test source accounts, one for program and one for data
+    let src = Pubkey::new_unique();
+    let (src_data, _) = Pubkey::find_program_address(&[src.as_ref()], &bpf_upgradeable_id);
+    let src_state = UpgradeableLoaderState::Program {
+        programdata_address: src_data,
     };
-    let new_lamports =
+    let src_lamports =
         bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program());
-    let new_data_state = vec![6; 30];
-    let new_data_lamports = bank.get_minimum_balance_for_rent_exemption(new_data_state.len());
-    let new_account = test_program_replace_set_up_account(
+    let src_data_state = vec![6; 30];
+    let src_data_lamports = bank.get_minimum_balance_for_rent_exemption(src_data_state.len());
+    let src_account = test_program_replace_set_up_account(
         &mut bank,
-        &new,
-        new_lamports,
-        &new_state,
+        &src,
+        src_lamports,
+        &src_state,
         &bpf_upgradeable_id,
         true,
     );
-    let new_data_account = test_program_replace_set_up_account(
+    let src_data_account = test_program_replace_set_up_account(
         &mut bank,
-        &new_data,
-        new_data_lamports,
-        &new_data_state,
+        &src_data,
+        src_data_lamports,
+        &src_data_state,
         &bpf_upgradeable_id,
         false,
     );
 
-    // Derive the well-known PDA address for the old data account
-    let (old_data, _) = Pubkey::find_program_address(&[old.as_ref()], &bpf_upgradeable_id);
+    // Derive the well-known PDA address for the destination data account
+    let (dst_data, _) = Pubkey::find_program_address(&[dst.as_ref()], &bpf_upgradeable_id);
 
     // Create the data account if necessary
-    let old_data_account = if let Some(old_data_state) = maybe_old_data_state {
-        let old_data_lamports = bank.get_minimum_balance_for_rent_exemption(old_data_state.len());
-        let old_data_account = test_program_replace_set_up_account(
+    let dst_data_account = if let Some(dst_data_state) = maybe_dst_data_state {
+        let dst_data_lamports = bank.get_minimum_balance_for_rent_exemption(dst_data_state.len());
+        let dst_data_account = test_program_replace_set_up_account(
             &mut bank,
-            &old_data,
-            old_data_lamports,
-            &old_data_state,
+            &dst_data,
+            dst_data_lamports,
+            &dst_data_state,
             &bpf_upgradeable_id,
             false,
         );
-        Some(old_data_account)
+        Some(dst_data_account)
     } else {
         None
     };
@@ -8294,18 +8294,18 @@ fn test_replace_empty_account_with_upgradeable_program_fail_when_account_exists(
 
     // Attempt the replacement
     bank.replace_empty_account_with_upgradeable_program(
-        &old,
-        &new,
+        &dst,
+        &src,
         "bank-apply_empty_account_replacement_for_program",
     );
 
     // Everything should be unchanged
-    assert_eq!(bank.get_account(&old).unwrap(), old_account);
-    if let Some(old_data_account) = old_data_account {
-        assert_eq!(bank.get_account(&old_data).unwrap(), old_data_account);
+    assert_eq!(bank.get_account(&dst).unwrap(), dst_account);
+    if let Some(dst_data_account) = dst_data_account {
+        assert_eq!(bank.get_account(&dst_data).unwrap(), dst_data_account);
     }
-    assert_eq!(bank.get_account(&new).unwrap(), new_account);
-    assert_eq!(bank.get_account(&new_data).unwrap(), new_data_account);
+    assert_eq!(bank.get_account(&src).unwrap(), src_account);
+    assert_eq!(bank.get_account(&src_data).unwrap(), src_data_account);
     assert_eq!(bank.capitalization(), original_capitalization);
 }
 

--- a/runtime/src/inline_feature_gate_program.rs
+++ b/runtime/src/inline_feature_gate_program.rs
@@ -1,5 +1,5 @@
 //! Contains replacement program IDs for the feature gate program
 
 pub(crate) mod noop_program {
-    solana_sdk::declare_id!("5Re2FUHmvSdem1KV2bU5GFvqZpP2MXj76yVhMKKbP45o");
+    solana_sdk::declare_id!("2rqZsQBbacRbuAuTSuJ7n49UQT9fzes8RLggFcmB9YuN");
 }

--- a/runtime/src/inline_feature_gate_program.rs
+++ b/runtime/src/inline_feature_gate_program.rs
@@ -1,4 +1,4 @@
-solana_sdk::declare_id!("Feature111111111111111111111111111111111111");
+//! Contains replacement program IDs for the feature gate program
 
 pub(crate) mod noop_program {
     solana_sdk::declare_id!("5Re2FUHmvSdem1KV2bU5GFvqZpP2MXj76yVhMKKbP45o");

--- a/runtime/src/inline_feature_gate_program.rs
+++ b/runtime/src/inline_feature_gate_program.rs
@@ -1,0 +1,5 @@
+solana_sdk::declare_id!("Feature111111111111111111111111111111111111");
+
+pub(crate) mod noop_program {
+    solana_sdk::declare_id!("5Re2FUHmvSdem1KV2bU5GFvqZpP2MXj76yVhMKKbP45o");
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod commitment;
 mod epoch_rewards_hasher;
 pub mod epoch_stakes;
 pub mod genesis_utils;
+pub mod inline_feature_gate_program;
 pub mod inline_spl_associated_token_account;
 pub mod loader_utils;
 pub mod non_circulating_supply;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -874,7 +874,7 @@ lazy_static! {
         (require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"),
         (better_error_codes_for_tx_lamport_check::id(), "better error codes for tx lamport check #33353"),
         (enable_alt_bn128_compression_syscall::id(), "add alt_bn128 compression syscalls"),
-        (feature_gate_program::id(), "control feature activations with an on-chain program"),
+        (feature_gate_program::id(), "control feature activations with an on-chain program #32783"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -700,6 +700,10 @@ pub mod better_error_codes_for_tx_lamport_check {
     solana_sdk::declare_id!("Ffswd3egL3tccB6Rv3XY6oqfdzn913vUcjCSnpvCKpfx");
 }
 
+pub mod feature_gate_program {
+    solana_sdk::declare_id!("8GdovDzVwWU5edz2G697bbB7GZjrUc6aQZLWyNNAtHdg");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -870,6 +874,7 @@ lazy_static! {
         (require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"),
         (better_error_codes_for_tx_lamport_check::id(), "better error codes for tx lamport check #33353"),
         (enable_alt_bn128_compression_syscall::id(), "add alt_bn128 compression syscalls"),
+        (feature_gate_program::id(), "control feature activations with an on-chain program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -700,7 +700,7 @@ pub mod better_error_codes_for_tx_lamport_check {
     solana_sdk::declare_id!("Ffswd3egL3tccB6Rv3XY6oqfdzn913vUcjCSnpvCKpfx");
 }
 
-pub mod feature_gate_program {
+pub mod programify_feature_gate_program {
     solana_sdk::declare_id!("8GdovDzVwWU5edz2G697bbB7GZjrUc6aQZLWyNNAtHdg");
 }
 
@@ -874,7 +874,7 @@ lazy_static! {
         (require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"),
         (better_error_codes_for_tx_lamport_check::id(), "better error codes for tx lamport check #33353"),
         (enable_alt_bn128_compression_syscall::id(), "add alt_bn128 compression syscalls"),
-        (feature_gate_program::id(), "control feature activations with an on-chain program #32783"),
+        (programify_feature_gate_program::id(), "move feature gate activation logic to an on-chain program #32783"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Currently, `replace_program_account` will only replace a program's account, but not the program's **data account**.

In order to complete Step 1 of #32780, we need to be able to replace an empty account with an upgradeable program on feature activation.

#### Summary of Changes
This PR adds a function `replace_empty_account_with_upgradeable_program` to replace an empty account - such as `Feature111111111` with a program account and a data account, effectively replacing this account with an upgradeable program.