### PR TITLE
hash accounts: scan straight to mmap file instead of allocating

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2336,8 +2336,6 @@ trait AppendVecScan: Send + Sync + Clone {
     fn scanning_complete(self) -> BinnedHashData;
     /// initialize accumulator
     fn init_accum(&mut self, count: usize);
-    fn get_accum(&mut self) -> BinnedHashData;
-    fn set_accum(&mut self, accum: BinnedHashData);
 }
 
 #[derive(Clone)]
@@ -2410,12 +2408,6 @@ impl<'a> AppendVecScan for ScanState<'a> {
         let (result, timing) = AccountsDb::sort_slot_storage_scan(self.accum);
         self.sort_time.fetch_add(timing, Ordering::Relaxed);
         result
-    }
-    fn get_accum(&mut self) -> BinnedHashData {
-        std::mem::take(&mut self.accum)
-    }
-    fn set_accum(&mut self, accum: BinnedHashData) {
-        self.accum = accum;
     }
 }
 
@@ -10890,12 +10882,6 @@ pub mod tests {
             self.current_slot = slot;
         }
         fn init_accum(&mut self, _count: usize) {}
-        fn get_accum(&mut self) -> BinnedHashData {
-            std::mem::take(&mut self.accum)
-        }
-        fn set_accum(&mut self, accum: BinnedHashData) {
-            self.accum = accum;
-        }
         fn found_account(&mut self, loaded_account: &LoadedAccount) {
             self.calls.fetch_add(1, Ordering::Relaxed);
             assert_eq!(loaded_account.pubkey(), &self.pubkey);
@@ -11193,12 +11179,6 @@ pub mod tests {
         }
         fn scanning_complete(self) -> BinnedHashData {
             self.accum
-        }
-        fn get_accum(&mut self) -> BinnedHashData {
-            std::mem::take(&mut self.accum)
-        }
-        fn set_accum(&mut self, accum: BinnedHashData) {
-            self.accum = accum;
         }
     }
 

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -285,7 +285,7 @@ impl CacheHashData {
     pub fn save(
         &self,
         file_name: impl AsRef<Path>,
-        data: &SavedTypeSlice,
+        data: &[EntryType],
     ) -> Result<(), std::io::Error> {
         let mut stats = CacheHashDataStats::default();
         let result = self.save_internal(file_name, data, &mut stats);
@@ -296,7 +296,7 @@ impl CacheHashData {
     fn save_internal(
         &self,
         file_name: impl AsRef<Path>,
-        data: &SavedTypeSlice,
+        data: &[EntryType],
         stats: &mut CacheHashDataStats,
     ) -> Result<(), std::io::Error> {
         let mut m = Measure::start("save");
@@ -305,11 +305,7 @@ impl CacheHashData {
         let _ignored = remove_file(&cache_path);
         let cell_size = std::mem::size_of::<EntryType>() as u64;
         let mut m1 = Measure::start("create save");
-        let entries = data
-            .iter()
-            .map(|x: &Vec<EntryType>| x.len())
-            .collect::<Vec<_>>();
-        let entries = entries.iter().sum::<usize>();
+        let entries = data.len();
         let capacity = cell_size * (entries as u64) + std::mem::size_of::<Header>() as u64;
 
         let mmap = CacheHashDataFile::new_map(&cache_path, capacity)?;
@@ -329,12 +325,10 @@ impl CacheHashData {
 
         let mut m2 = Measure::start("write_to_mmap");
         let mut i = 0;
-        data.iter().for_each(|x| {
-            x.iter().for_each(|item| {
-                let d = cache_file.get_mut(i as u64);
-                i += 1;
-                *d = item.clone();
-            })
+        data.iter().for_each(|item| {
+            let d = cache_file.get_mut(i as u64);
+            i += 1;
+            *d = item.clone();
         });
         assert_eq!(i, entries);
         m2.stop();


### PR DESCRIPTION
#### Problem
hash accounts can take large amounts of memory. We put scan results in a file anyway.

#### Summary of Changes
Put scan results in a file initially.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
