### PR TITLE
stake: Rename `StakeStateWithFlags` -> `StakeStateV2`

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -54,7 +54,7 @@ use {
         rpc_port::DEFAULT_RPC_PORT_STR,
         signature::Signature,
         slot_history,
-        stake::{self, state::StakeStateWithFlags},
+        stake::{self, state::StakeStateV2},
         system_instruction,
         sysvar::{
             self,
@@ -1768,7 +1768,7 @@ pub fn process_show_stakes(
         // Use server-side filtering if only one vote account is provided
         if vote_account_pubkeys.len() == 1 {
             program_accounts_config.filters = Some(vec![
-                // Filter by `StakeStateWithFlags::Stake(_, _)`
+                // Filter by `StakeStateV2::Stake(_, _)`
                 RpcFilterType::Memcmp(Memcmp::new_base58_encoded(0, &[2, 0, 0, 0])),
                 // Filter by `Delegation::voter_pubkey`, which begins at byte offset 124
                 RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
@@ -1809,7 +1809,7 @@ pub fn process_show_stakes(
     for (stake_pubkey, stake_account) in all_stake_accounts {
         if let Ok(stake_state) = stake_account.state() {
             match stake_state {
-                StakeStateWithFlags::Initialized(_) => {
+                StakeStateV2::Initialized(_) => {
                     if vote_account_pubkeys.is_none() {
                         stake_accounts.push(CliKeyedStakeState {
                             stake_pubkey: stake_pubkey.to_string(),
@@ -1824,7 +1824,7 @@ pub fn process_show_stakes(
                         });
                     }
                 }
-                StakeStateWithFlags::Stake(_, stake, _) => {
+                StakeStateV2::Stake(_, stake, _) => {
                     if vote_account_pubkeys.is_none()
                         || vote_account_pubkeys
                             .unwrap()
@@ -2157,7 +2157,7 @@ impl RentLengthValue {
     pub fn length(&self) -> usize {
         match self {
             Self::Nonce => NonceState::size(),
-            Self::Stake => StakeStateWithFlags::size_of(),
+            Self::Stake => StakeStateV2::size_of(),
             Self::System => 0,
             Self::Vote => VoteState::size_of(),
             Self::Bytes(l) => *l,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -26,7 +26,7 @@ use {
         stake::{
             self,
             instruction::LockupArgs,
-            state::{Lockup, StakeAuthorize, StakeStateWithFlags},
+            state::{Lockup, StakeAuthorize, StakeStateV2},
         },
     },
     solana_streamer::socket::SocketAddrSpace,
@@ -162,10 +162,10 @@ fn test_stake_redelegation() {
 
     // `stake_keypair` should now be delegated to `vote_keypair` and fully activated
     let stake_account = rpc_client.get_account(&stake_keypair.pubkey()).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
 
     let rent_exempt_reserve = match stake_state {
-        StakeStateWithFlags::Stake(meta, stake, _) => {
+        StakeStateV2::Stake(meta, stake, _) => {
             assert_eq!(stake.delegation.voter_pubkey, vote_keypair.pubkey());
             meta.rent_exempt_reserve
         }
@@ -268,10 +268,10 @@ fn test_stake_redelegation() {
 
     // `stake2_keypair` should now be delegated to `vote2_keypair` and fully activated
     let stake2_account = rpc_client.get_account(&stake2_keypair.pubkey()).unwrap();
-    let stake2_state: StakeStateWithFlags = stake2_account.state().unwrap();
+    let stake2_state: StakeStateV2 = stake2_account.state().unwrap();
 
     match stake2_state {
-        StakeStateWithFlags::Stake(_meta, stake, _) => {
+        StakeStateV2::Stake(_meta, stake, _) => {
             assert_eq!(stake.delegation.voter_pubkey, vote2_keypair.pubkey());
         }
         _ => panic!("Unexpected stake2 state!"),
@@ -966,9 +966,9 @@ fn test_stake_authorize() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.staker,
+        StakeStateV2::Initialized(meta) => meta.authorized.staker,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, online_authority_pubkey);
@@ -1008,11 +1008,9 @@ fn test_stake_authorize() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let (current_staker, current_withdrawer) = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => {
-            (meta.authorized.staker, meta.authorized.withdrawer)
-        }
+        StakeStateV2::Initialized(meta) => (meta.authorized.staker, meta.authorized.withdrawer),
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_staker, online_authority2_pubkey);
@@ -1042,9 +1040,9 @@ fn test_stake_authorize() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.staker,
+        StakeStateV2::Initialized(meta) => meta.authorized.staker,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, offline_authority_pubkey);
@@ -1099,9 +1097,9 @@ fn test_stake_authorize() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.staker,
+        StakeStateV2::Initialized(meta) => meta.authorized.staker,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, nonced_authority_pubkey);
@@ -1186,9 +1184,9 @@ fn test_stake_authorize() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.staker,
+        StakeStateV2::Initialized(meta) => meta.authorized.staker,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, online_authority_pubkey);
@@ -1436,7 +1434,7 @@ fn test_stake_split() {
 
     // Create stake account, identity is authority
     let stake_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(StakeStateWithFlags::size_of())
+        .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
         .unwrap()
         + 10_000_000_000;
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
@@ -1589,7 +1587,7 @@ fn test_stake_set_lockup() {
 
     // Create stake account, identity is authority
     let stake_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(StakeStateWithFlags::size_of())
+        .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
         .unwrap()
         + 10_000_000_000;
 
@@ -1647,9 +1645,9 @@ fn test_stake_set_lockup() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_lockup = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.lockup,
+        StakeStateV2::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(
@@ -1706,9 +1704,9 @@ fn test_stake_set_lockup() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_lockup = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.lockup,
+        StakeStateV2::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(
@@ -1813,9 +1811,9 @@ fn test_stake_set_lockup() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_lockup = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.lockup,
+        StakeStateV2::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(
@@ -2189,9 +2187,9 @@ fn test_stake_checked_instructions() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.staker,
+        StakeStateV2::Initialized(meta) => meta.authorized.staker,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, staker_pubkey);
@@ -2246,9 +2244,9 @@ fn test_stake_checked_instructions() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_authority = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.authorized.withdrawer,
+        StakeStateV2::Initialized(meta) => meta.authorized.withdrawer,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, new_withdrawer_pubkey);
@@ -2295,9 +2293,9 @@ fn test_stake_checked_instructions() {
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
-    let stake_state: StakeStateWithFlags = stake_account.state().unwrap();
+    let stake_state: StakeStateV2 = stake_account.state().unwrap();
     let current_lockup = match stake_state {
-        StakeStateWithFlags::Initialized(meta) => meta.lockup,
+        StakeStateV2::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(

--- a/docs/art/passive-staking-callflow.msc
+++ b/docs/art/passive-staking-callflow.msc
@@ -11,8 +11,8 @@ msc {
 
   VoteSigner <:> Validator [label="register\n\n(optional)"];
   Validator => Cluster [label="VoteState::Initialize(VoteSigner)"];
-  StakerX => Cluster [label="StakeStateWithFlags::Delegate(Validator)"];
-  StakerY => Cluster [label="StakeStateWithFlags::Delegate(Validator)"];
+  StakerX => Cluster [label="StakeStateV2::Delegate(Validator)"];
+  StakerY => Cluster [label="StakeStateV2::Delegate(Validator)"];
 
      |||;
   Validator box Cluster [label="\nvalidate\n"];

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -31,7 +31,7 @@ use {
         rent::Rent,
         signature::{Keypair, Signer},
         signer::keypair::read_keypair_file,
-        stake::state::StakeStateWithFlags,
+        stake::state::StakeStateV2,
         system_program, timing,
     },
     solana_stake_program::stake_state,
@@ -141,7 +141,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .to_string();
     // stake account
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
-        .max(rent.minimum_balance(StakeStateWithFlags::size_of()))
+        .max(rent.minimum_balance(StakeStateV2::size_of()))
         .to_string();
 
     let default_target_tick_duration =
@@ -444,7 +444,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_validator_stake_lamports = rent_exempt_check(
         &matches,
         "bootstrap_validator_stake_lamports",
-        rent.minimum_balance(StakeStateWithFlags::size_of()),
+        rent.minimum_balance(StakeStateV2::size_of()),
     )?;
 
     let bootstrap_stake_authorized_pubkey =

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -11,7 +11,7 @@ use {
         pubkey::Pubkey,
         stake::{
             self,
-            state::{Authorized, Lockup, StakeStateWithFlags},
+            state::{Authorized, Lockup, StakeStateV2},
         },
         system_program,
         timing::years_as_slots,
@@ -107,9 +107,7 @@ pub fn create_and_add_stakes(
 
     let mut address_generator = AddressGenerator::new(&authorized.staker, &stake::program::id());
 
-    let stake_rent_reserve = genesis_config
-        .rent
-        .minimum_balance(StakeStateWithFlags::size_of());
+    let stake_rent_reserve = genesis_config.rent.minimum_balance(StakeStateV2::size_of());
 
     for unlock in unlocks {
         let lamports = unlock.amount(stakes_lamports);
@@ -195,9 +193,7 @@ mod tests {
             .iter()
             .all(|(_pubkey, account)| account.lamports <= granularity
                 || account.lamports - granularity
-                    <= genesis_config
-                        .rent
-                        .minimum_balance(StakeStateWithFlags::size_of())));
+                    <= genesis_config.rent.minimum_balance(StakeStateV2::size_of())));
     }
 
     //    #[ignore]
@@ -242,7 +238,7 @@ mod tests {
             ..Rent::default()
         };
 
-        let reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let reserve = rent.minimum_balance(StakeStateV2::size_of());
         let staker_reserve = rent.minimum_balance(0);
 
         // verify that a small remainder ends up in the last stake

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -74,7 +74,7 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         shred_version::compute_shred_version,
-        stake::{self, state::StakeStateWithFlags},
+        stake::{self, state::StakeStateV2},
         system_program,
         transaction::{
             MessageHash, SanitizedTransaction, SimpleAddressLoader, VersionedTransaction,
@@ -1293,7 +1293,7 @@ fn main() {
         .max(VoteState::get_rent_exempt_reserve(&rent))
         .to_string();
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
-        .max(rent.minimum_balance(StakeStateWithFlags::size_of()))
+        .max(rent.minimum_balance(StakeStateV2::size_of()))
         .to_string();
     let default_graph_vote_account_mode = GraphVoteAccountMode::default();
 
@@ -2770,7 +2770,7 @@ fn main() {
                     value_t_or_exit!(arg_matches, "bootstrap_validator_lamports", u64);
                 let bootstrap_validator_stake_lamports =
                     value_t_or_exit!(arg_matches, "bootstrap_validator_stake_lamports", u64);
-                let minimum_stake_lamports = rent.minimum_balance(StakeStateWithFlags::size_of());
+                let minimum_stake_lamports = rent.minimum_balance(StakeStateV2::size_of());
                 if bootstrap_validator_stake_lamports < minimum_stake_lamports {
                     eprintln!(
                         "Error: insufficient --bootstrap-validator-stake-lamports. \
@@ -2998,9 +2998,7 @@ fn main() {
                                 .unwrap()
                                 .into_iter()
                             {
-                                if let Ok(StakeStateWithFlags::Stake(meta, stake, _)) =
-                                    account.state()
-                                {
+                                if let Ok(StakeStateV2::Stake(meta, stake, _)) = account.state() {
                                     if vote_accounts_to_destake
                                         .contains(&stake.delegation.voter_pubkey)
                                     {
@@ -3011,7 +3009,7 @@ fn main() {
                                             );
                                         }
                                         account
-                                            .set_state(&StakeStateWithFlags::Initialized(meta))
+                                            .set_state(&StakeStateV2::Initialized(meta))
                                             .unwrap();
                                         bank.store_account(&address, &account);
                                     }

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -18,7 +18,7 @@ use {
         signature::{Keypair, Signer},
         stake::{
             instruction as stake_instruction,
-            state::{Authorized, Lockup, StakeActivationStatus, StakeStateWithFlags},
+            state::{Authorized, Lockup, StakeActivationStatus, StakeStateV2},
         },
         system_instruction, system_program,
         sysvar::{
@@ -271,7 +271,7 @@ async fn stake_rewards_from_warp() {
         .expect("account exists")
         .unwrap();
 
-    let stake_state: StakeStateWithFlags = deserialize(&account.data).unwrap();
+    let stake_state: StakeStateV2 = deserialize(&account.data).unwrap();
     let stake_history: StakeHistory = deserialize(&stake_history_account.data).unwrap();
     let clock: Clock = deserialize(&clock_account.data).unwrap();
     let stake = stake_state.stake().unwrap();
@@ -387,7 +387,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         .expect("account exists")
         .unwrap();
 
-    let stake_state: StakeStateWithFlags = deserialize(&account.data).unwrap();
+    let stake_state: StakeStateV2 = deserialize(&account.data).unwrap();
     let stake_history: StakeHistory = deserialize(&stake_history_account.data).unwrap();
     let clock: Clock = deserialize(&clock_account.data).unwrap();
     let stake = stake_state.stake().unwrap();
@@ -409,7 +409,7 @@ async fn check_credits_observed(
         .await
         .unwrap()
         .unwrap();
-    let stake_state: StakeStateWithFlags = deserialize(&stake_account.data).unwrap();
+    let stake_state: StakeStateV2 = deserialize(&stake_account.data).unwrap();
     assert_eq!(
         stake_state.stake().unwrap().credits_observed,
         expected_credits
@@ -465,7 +465,7 @@ async fn stake_merge_immediately_after_activation() {
         .await
         .unwrap()
         .unwrap();
-    let stake_state: StakeStateWithFlags = deserialize(&stake_account.data).unwrap();
+    let stake_state: StakeStateV2 = deserialize(&stake_account.data).unwrap();
     assert_eq!(stake_state.stake().unwrap().credits_observed, 300);
     assert!(stake_account.lamports > stake_lamports);
 
@@ -476,7 +476,7 @@ async fn stake_merge_immediately_after_activation() {
         .await
         .unwrap()
         .unwrap();
-    let stake_state: StakeStateWithFlags = deserialize(&stake_account.data).unwrap();
+    let stake_state: StakeStateV2 = deserialize(&stake_account.data).unwrap();
     assert_eq!(stake_state.stake().unwrap().credits_observed, 300);
     assert_eq!(stake_account.lamports, stake_lamports);
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -467,7 +467,7 @@ mod tests {
             config,
             stake_state::{
                 authorized_from, create_stake_history_from_delegations, from, new_stake,
-                stake_from, Delegation, Meta, Stake, StakeStateWithFlags,
+                stake_from, Delegation, Meta, Stake, StakeStateV2,
             },
         },
         assert_matches::assert_matches,
@@ -626,8 +626,8 @@ mod tests {
         )
     }
 
-    fn just_stake(meta: Meta, stake: u64) -> StakeStateWithFlags {
-        StakeStateWithFlags::Stake(
+    fn just_stake(meta: Meta, stake: u64) -> StakeStateV2 {
+        StakeStateV2::Stake(
             meta,
             Stake {
                 delegation: Delegation {
@@ -909,7 +909,7 @@ mod tests {
         let config_address = stake_config::id();
         #[allow(deprecated)]
         let config_account = config::create_account(0, &stake_config::Config::default());
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let withdrawal_amount = rent_exempt_reserve + minimum_delegation;
 
@@ -1175,7 +1175,7 @@ mod tests {
         let rent = Rent::default();
         let rent_address = rent::id();
         let rent_account = create_account_shared_data_for_test(&rent);
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
 
         // Test InitializeChecked with non-signing withdrawer
@@ -1191,7 +1191,7 @@ mod tests {
         // Test InitializeChecked with withdrawer signer
         let stake_account = AccountSharedData::new(
             rent_exempt_reserve + minimum_delegation,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         );
         process_instruction(
@@ -1260,8 +1260,8 @@ mod tests {
         // Test AuthorizeChecked with authority signer
         let stake_account = AccountSharedData::new_data_with_space(
             42,
-            &StakeStateWithFlags::Initialized(Meta::auto(&authorized_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&authorized_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1376,8 +1376,8 @@ mod tests {
         // Test AuthorizeCheckedWithSeed with authority signer
         let stake_account = AccountSharedData::new_data_with_space(
             42,
-            &StakeStateWithFlags::Initialized(Meta::auto(&address_with_seed)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&address_with_seed)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1483,8 +1483,8 @@ mod tests {
         // Test SetLockupChecked with lockup custodian signer
         let stake_account = AccountSharedData::new_data_with_space(
             42,
-            &StakeStateWithFlags::Initialized(Meta::auto(&withdrawer)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&withdrawer)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1524,11 +1524,10 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_stake_initialize(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_lamports = rent_exempt_reserve;
         let stake_address = solana_sdk::pubkey::new_rand();
-        let stake_account =
-            AccountSharedData::new(stake_lamports, StakeStateWithFlags::size_of(), &id());
+        let stake_account = AccountSharedData::new(stake_lamports, StakeStateV2::size_of(), &id());
         let custodian_address = solana_sdk::pubkey::new_rand();
         let lockup = Lockup {
             epoch: 1,
@@ -1568,7 +1567,7 @@ mod tests {
         // check that we see what we expect
         assert_eq!(
             from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Initialized(Meta {
+            StakeStateV2::Initialized(Meta {
                 authorized: Authorized::auto(&stake_address),
                 rent_exempt_reserve,
                 lockup,
@@ -1604,7 +1603,7 @@ mod tests {
 
         // incorrect account sizes
         let stake_account =
-            AccountSharedData::new(stake_lamports, StakeStateWithFlags::size_of() + 1, &id());
+            AccountSharedData::new(stake_lamports, StakeStateV2::size_of() + 1, &id());
         transaction_accounts[0] = (stake_address, stake_account);
         process_instruction(
             Arc::clone(&feature_set),
@@ -1615,7 +1614,7 @@ mod tests {
         );
 
         let stake_account =
-            AccountSharedData::new(stake_lamports, StakeStateWithFlags::size_of() - 1, &id());
+            AccountSharedData::new(stake_lamports, StakeStateV2::size_of() - 1, &id());
         transaction_accounts[0] = (stake_address, stake_account);
         process_instruction(
             Arc::clone(&feature_set),
@@ -1636,8 +1635,8 @@ mod tests {
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::default(),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::default(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1694,8 +1693,8 @@ mod tests {
         // should pass
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1724,9 +1723,7 @@ mod tests {
             Ok(()),
         );
         transaction_accounts[0] = (stake_address, accounts[0].clone());
-        if let StakeStateWithFlags::Initialized(Meta { authorized, .. }) =
-            from(&accounts[0]).unwrap()
-        {
+        if let StakeStateV2::Initialized(Meta { authorized, .. }) = from(&accounts[0]).unwrap() {
             assert_eq!(authorized.staker, authority_address);
             assert_eq!(authorized.withdrawer, authority_address);
         } else {
@@ -1760,9 +1757,7 @@ mod tests {
             instruction_accounts.clone(),
             Ok(()),
         );
-        if let StakeStateWithFlags::Initialized(Meta { authorized, .. }) =
-            from(&accounts[0]).unwrap()
-        {
+        if let StakeStateV2::Initialized(Meta { authorized, .. }) = from(&accounts[0]).unwrap() {
             assert_eq!(authorized.staker, authority_address_2);
         } else {
             panic!();
@@ -1803,10 +1798,7 @@ mod tests {
             instruction_accounts.clone(),
             Ok(()),
         );
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
 
         // Test that withdrawal to account fails without authorized withdrawer
         instruction_accounts[4].is_signer = false;
@@ -1829,8 +1821,8 @@ mod tests {
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -1950,8 +1942,8 @@ mod tests {
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2067,8 +2059,8 @@ mod tests {
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2281,14 +2273,14 @@ mod tests {
         let stake_address = solana_sdk::pubkey::new_rand();
         let mut stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta {
+            &StakeStateV2::Initialized(Meta {
                 authorized: Authorized {
                     staker: stake_address,
                     withdrawer: stake_address,
                 },
                 ..Meta::default()
             }),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2491,7 +2483,7 @@ mod tests {
         );
 
         // verify that non-stakes fail delegate()
-        let stake_state = StakeStateWithFlags::RewardsPool;
+        let stake_state = StakeStateV2::RewardsPool;
         stake_account.set_state(&stake_state).unwrap();
         transaction_accounts[0] = (stake_address, stake_account);
         process_instruction(
@@ -2509,7 +2501,7 @@ mod tests {
     fn test_redelegate_consider_balance_changes(feature_set: Arc<FeatureSet>) {
         let mut clock = Clock::default();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let initial_lamports = 4242424242;
         let stake_lamports = rent_exempt_reserve + initial_lamports;
         let recipient_address = solana_sdk::pubkey::new_rand();
@@ -2520,11 +2512,11 @@ mod tests {
         let stake_address = solana_sdk::pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta {
+            &StakeStateV2::Initialized(Meta {
                 rent_exempt_reserve,
                 ..Meta::auto(&authority_address)
             }),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2720,8 +2712,8 @@ mod tests {
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2752,13 +2744,13 @@ mod tests {
         let feature_set = Arc::new(feature_set);
 
         for state in [
-            StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::Initialized(Meta::auto(&stake_address)),
             just_stake(Meta::auto(&stake_address), stake_lamports),
         ] {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -2789,10 +2781,10 @@ mod tests {
 
             assert_eq!(from(&accounts[0]).unwrap(), from(&accounts[1]).unwrap());
             match state {
-                StakeStateWithFlags::Initialized(_meta) => {
+                StakeStateV2::Initialized(_meta) => {
                     assert_eq!(from(&accounts[0]).unwrap(), state);
                 }
-                StakeStateWithFlags::Stake(_meta, _stake, _) => {
+                StakeStateV2::Stake(_meta, _stake, _) => {
                     let stake_0 = from(&accounts[0]).unwrap().stake();
                     assert_eq!(stake_0.unwrap().delegation.stake, stake_lamports / 2);
                 }
@@ -2803,8 +2795,8 @@ mod tests {
         // should fail, fake owner of destination
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &solana_sdk::pubkey::new_rand(),
         )
         .unwrap();
@@ -2830,8 +2822,8 @@ mod tests {
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -2920,10 +2912,7 @@ mod tests {
             Ok(()),
         );
         assert_eq!(accounts[0].lamports(), 0);
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
 
         // initialize stake
         let lockup = Lockup {
@@ -3068,17 +3057,14 @@ mod tests {
             Ok(()),
         );
         assert_eq!(accounts[0].lamports(), 0);
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
 
         // overflow
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_account = AccountSharedData::new_data_with_space(
             1_000_000_000,
-            &StakeStateWithFlags::Initialized(Meta {
+            &StakeStateV2::Initialized(Meta {
                 rent_exempt_reserve,
                 authorized: Authorized {
                     staker: authority_address,
@@ -3086,7 +3072,7 @@ mod tests {
                 },
                 lockup: Lockup::default(),
             }),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3104,8 +3090,8 @@ mod tests {
         // should fail, invalid state
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::RewardsPool,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::RewardsPool,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3130,8 +3116,8 @@ mod tests {
         let total_lamports = stake_lamports + 33;
         let stake_account = AccountSharedData::new_data_with_space(
             total_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3272,8 +3258,8 @@ mod tests {
         };
         let stake_account = AccountSharedData::new_data_with_space(
             total_lamports,
-            &StakeStateWithFlags::Initialized(meta),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(meta),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3342,18 +3328,15 @@ mod tests {
             instruction_accounts.clone(),
             Ok(()),
         );
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
 
         // should pass, custodian is the same as the withdraw authority
         instruction_accounts[5].pubkey = stake_address;
         meta.lockup.custodian = stake_address;
         let stake_account_self_as_custodian = AccountSharedData::new_data_with_space(
             total_lamports,
-            &StakeStateWithFlags::Initialized(meta),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(meta),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3365,10 +3348,7 @@ mod tests {
             instruction_accounts.clone(),
             Ok(()),
         );
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
         transaction_accounts[0] = (stake_address, stake_account);
 
         // should pass, lockup has expired
@@ -3382,10 +3362,7 @@ mod tests {
             instruction_accounts,
             Ok(()),
         );
-        assert_eq!(
-            from(&accounts[0]).unwrap(),
-            StakeStateWithFlags::Uninitialized
-        );
+        assert_eq!(from(&accounts[0]).unwrap(), StakeStateV2::Uninitialized);
     }
 
     #[test_case(feature_set_old_warmup_cooldown_no_minimum_delegation(); "old_warmup_cooldown_no_min_delegation")]
@@ -3396,16 +3373,16 @@ mod tests {
         let custodian_address = solana_sdk::pubkey::new_rand();
         let stake_address = solana_sdk::pubkey::new_rand();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = 7 * minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports + rent_exempt_reserve,
-            &StakeStateWithFlags::Initialized(Meta {
+            &StakeStateV2::Initialized(Meta {
                 rent_exempt_reserve,
                 ..Meta::auto(&stake_address)
             }),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3494,8 +3471,8 @@ mod tests {
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Initialized(Meta::auto(&stake_address)),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Initialized(Meta::auto(&stake_address)),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3627,8 +3604,8 @@ mod tests {
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -3911,7 +3888,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_initialize_minimum_balance(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let instruction_data = serialize(&StakeInstruction::Initialize(
             Authorized::auto(&stake_address),
@@ -3937,8 +3914,7 @@ mod tests {
                 Err(InstructionError::InsufficientFunds),
             ),
         ] {
-            let stake_account =
-                AccountSharedData::new(lamports, StakeStateWithFlags::size_of(), &id());
+            let stake_account = AccountSharedData::new(lamports, StakeStateV2::size_of(), &id());
             process_instruction(
                 Arc::clone(&feature_set),
                 &instruction_data,
@@ -3955,7 +3931,7 @@ mod tests {
     /// Ensure that `delegate()` respects the minimum delegation requirements
     /// - Assert 1: delegating an amount equal-to the minimum succeeds
     /// - Assert 2: delegating an amount less-than the minimum fails
-    /// Also test both asserts above over both StakeStateWithFlags::{Initialized and Stake}, since the logic
+    /// Also test both asserts above over both StakeStateV2::{Initialized and Stake}, since the logic
     /// is slightly different for the variants.
     ///
     /// NOTE: Even though new stake accounts must have a minimum balance that is at least
@@ -3969,7 +3945,7 @@ mod tests {
     fn test_delegate_minimum_stake_delegation(feature_set: Arc<FeatureSet>) {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
@@ -4014,13 +3990,13 @@ mod tests {
             ),
         ] {
             for stake_state in &[
-                StakeStateWithFlags::Initialized(meta),
+                StakeStateV2::Initialized(meta),
                 just_stake(meta, *stake_delegation),
             ] {
                 let stake_account = AccountSharedData::new_data_with_space(
                     stake_delegation + rent_exempt_reserve,
                     stake_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4071,7 +4047,7 @@ mod tests {
     fn test_split_minimum_stake_delegation(feature_set: Arc<FeatureSet>) {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -4080,8 +4056,8 @@ mod tests {
         let dest_address = Pubkey::new_unique();
         let dest_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -4119,7 +4095,7 @@ mod tests {
             // accounts' *final* balance
             let mut source_starting_balance = source_reserve + dest_reserve;
             for (delegation, source_stake_state) in &[
-                (0, StakeStateWithFlags::Initialized(source_meta)),
+                (0, StakeStateV2::Initialized(source_meta)),
                 (
                     minimum_delegation,
                     just_stake(
@@ -4132,7 +4108,7 @@ mod tests {
                 let source_account = AccountSharedData::new_data_with_space(
                     source_starting_balance,
                     source_stake_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4164,7 +4140,7 @@ mod tests {
     fn test_split_full_amount_minimum_stake_delegation(feature_set: Arc<FeatureSet>) {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -4173,8 +4149,8 @@ mod tests {
         let dest_address = Pubkey::new_unique();
         let dest_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -4198,7 +4174,7 @@ mod tests {
             ),
         ] {
             for (stake_delegation, source_stake_state) in &[
-                (0, StakeStateWithFlags::Initialized(source_meta)),
+                (0, StakeStateV2::Initialized(source_meta)),
                 (
                     minimum_delegation,
                     just_stake(source_meta, minimum_delegation),
@@ -4207,7 +4183,7 @@ mod tests {
                 let source_account = AccountSharedData::new_data_with_space(
                     stake_delegation + reserve,
                     source_stake_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4234,7 +4210,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_initialized_split_destination_minimum_balance(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let source_address = Pubkey::new_unique();
         let destination_address = Pubkey::new_unique();
         let instruction_accounts = vec![
@@ -4294,15 +4270,15 @@ mod tests {
             };
             let source_account = AccountSharedData::new_data_with_space(
                 source_balance,
-                &StakeStateWithFlags::Initialized(source_meta),
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Initialized(source_meta),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
             let destination_account = AccountSharedData::new_data_with_space(
                 destination_starting_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4333,7 +4309,7 @@ mod tests {
     ) {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let source_address = Pubkey::new_unique();
         let destination_address = Pubkey::new_unique();
         let instruction_accounts = vec![
@@ -4425,14 +4401,14 @@ mod tests {
             let source_account = AccountSharedData::new_data_with_space(
                 source_balance,
                 &just_stake(source_meta, source_stake_delegation),
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
             let destination_account = AccountSharedData::new_data_with_space(
                 destination_starting_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4447,20 +4423,15 @@ mod tests {
                 instruction_accounts.clone(),
                 expected_result.clone(),
             );
-            // For the expected OK cases, when the source's StakeStateWithFlags is Stake, then the
-            // destination's StakeStateWithFlags *must* also end up as Stake as well.  Additionally,
+            // For the expected OK cases, when the source's StakeStateV2 is Stake, then the
+            // destination's StakeStateV2 *must* also end up as Stake as well.  Additionally,
             // check to ensure the destination's delegation amount is correct.  If the
             // destination is already rent exempt, then the destination's stake delegation
             // *must* equal the split amount. Otherwise, the split amount must first be used to
             // make the destination rent exempt, and then the leftover lamports are delegated.
             if expected_result.is_ok() {
-                assert_matches!(
-                    accounts[0].state().unwrap(),
-                    StakeStateWithFlags::Stake(_, _, _)
-                );
-                if let StakeStateWithFlags::Stake(_, destination_stake, _) =
-                    accounts[1].state().unwrap()
-                {
+                assert_matches!(accounts[0].state().unwrap(), StakeStateV2::Stake(_, _, _));
+                if let StakeStateV2::Stake(_, destination_stake, _) = accounts[1].state().unwrap() {
                     let destination_initial_rent_deficit =
                         rent_exempt_reserve.saturating_sub(destination_starting_balance);
                     let expected_destination_stake_delegation =
@@ -4471,7 +4442,7 @@ mod tests {
                     );
                     assert!(destination_stake.delegation.stake >= minimum_delegation,);
                 } else {
-                    panic!("destination state must be StakeStake::Stake after successful split when source is also StakeStateWithFlags::Stake!");
+                    panic!("destination state must be StakeStake::Stake after successful split when source is also StakeStateV2::Stake!");
                 }
             }
         }
@@ -4486,7 +4457,7 @@ mod tests {
     fn test_withdraw_minimum_stake_delegation(feature_set: Arc<FeatureSet>) {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
@@ -4529,14 +4500,14 @@ mod tests {
             ),
         ] {
             for (stake_delegation, stake_state) in &[
-                (0, StakeStateWithFlags::Initialized(meta)),
+                (0, StakeStateV2::Initialized(meta)),
                 (minimum_delegation, just_stake(meta, minimum_delegation)),
             ] {
                 let rewards_balance = 123;
                 let stake_account = AccountSharedData::new_data_with_space(
                     stake_delegation + rent_exempt_reserve + rewards_balance,
                     stake_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4596,11 +4567,11 @@ mod tests {
         let feature_set = feature_set_all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let stake_account = AccountSharedData::new(
             rent_exempt_reserve + minimum_delegation,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         );
         let vote_address = solana_sdk::pubkey::new_rand();
@@ -4769,22 +4740,22 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_source_uninitialized(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -4874,7 +4845,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&stake_address), stake_lamports),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -4893,14 +4864,14 @@ mod tests {
         ];
 
         for split_to_state in &[
-            StakeStateWithFlags::Initialized(Meta::default()),
-            StakeStateWithFlags::Stake(Meta::default(), Stake::default(), StakeFlags::default()),
-            StakeStateWithFlags::RewardsPool,
+            StakeStateV2::Initialized(Meta::default()),
+            StakeStateV2::Stake(Meta::default(), Stake::default(), StakeFlags::default()),
+            StakeStateV2::RewardsPool,
         ] {
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
                 split_to_state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4922,7 +4893,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_more_than_staked(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -4935,15 +4906,15 @@ mod tests {
                 },
                 stake_lamports / 2 - 1,
             ),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -4979,14 +4950,14 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_with_rent(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_address = solana_sdk::pubkey::new_rand();
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5010,7 +4981,7 @@ mod tests {
 
         // test splitting both an Initialized stake and a Staked stake
         for (minimum_balance, state) in &[
-            (rent_exempt_reserve, StakeStateWithFlags::Initialized(meta)),
+            (rent_exempt_reserve, StakeStateV2::Initialized(meta)),
             (
                 rent_exempt_reserve + minimum_delegation,
                 just_stake(meta, minimum_delegation * 2 + rent_exempt_reserve),
@@ -5020,7 +4991,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5062,10 +5033,10 @@ mod tests {
             );
 
             // verify no stake leakage in the case of a stake
-            if let StakeStateWithFlags::Stake(meta, stake, stake_flags) = state {
+            if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
                 assert_eq!(
                     accounts[1].state(),
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         *meta,
                         Stake {
                             delegation: Delegation {
@@ -5088,7 +5059,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_to_account_with_rent_exempt_reserve(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5101,7 +5072,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5132,8 +5103,8 @@ mod tests {
         for initial_balance in split_lamport_balances {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5166,11 +5137,11 @@ mod tests {
                 stake_lamports + initial_balance,
             );
 
-            if let StakeStateWithFlags::Stake(meta, stake, stake_flags) = state {
+            if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
                 let expected_stake =
                     stake_lamports / 2 - (rent_exempt_reserve.saturating_sub(initial_balance));
                 assert_eq!(
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         meta,
                         Stake {
                             delegation: Delegation {
@@ -5191,7 +5162,7 @@ mod tests {
                         + initial_balance.saturating_sub(rent_exempt_reserve),
                 );
                 assert_eq!(
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         meta,
                         Stake {
                             delegation: Delegation {
@@ -5213,9 +5184,8 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_from_larger_sized_account(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let source_larger_rent_exempt_reserve =
-            rent.minimum_balance(StakeStateWithFlags::size_of() + 100);
-        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let source_larger_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (source_larger_rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5228,7 +5198,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            StakeStateWithFlags::size_of() + 100,
+            StakeStateV2::size_of() + 100,
             &id(),
         )
         .unwrap();
@@ -5259,8 +5229,8 @@ mod tests {
         for initial_balance in split_lamport_balances {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5293,7 +5263,7 @@ mod tests {
                 stake_lamports + initial_balance
             );
 
-            if let StakeStateWithFlags::Stake(meta, stake, stake_flags) = state {
+            if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
                 let expected_split_meta = Meta {
                     authorized: Authorized::auto(&stake_address),
                     rent_exempt_reserve: split_rent_exempt_reserve,
@@ -5303,7 +5273,7 @@ mod tests {
                     - (split_rent_exempt_reserve.saturating_sub(initial_balance));
 
                 assert_eq!(
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         expected_split_meta,
                         Stake {
                             delegation: Delegation {
@@ -5323,7 +5293,7 @@ mod tests {
                         + initial_balance.saturating_sub(split_rent_exempt_reserve)
                 );
                 assert_eq!(
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         meta,
                         Stake {
                             delegation: Delegation {
@@ -5345,9 +5315,8 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_from_smaller_sized_account(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let source_smaller_rent_exempt_reserve =
-            rent.minimum_balance(StakeStateWithFlags::size_of());
-        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of() + 100);
+        let source_smaller_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
         let stake_lamports = split_rent_exempt_reserve + 1;
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
@@ -5359,7 +5328,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5387,8 +5356,8 @@ mod tests {
         for initial_balance in split_lamport_balances {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of() + 100,
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of() + 100,
                 &id(),
             )
             .unwrap();
@@ -5423,7 +5392,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_100_percent_of_source(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5435,8 +5404,8 @@ mod tests {
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
-            &StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Uninitialized,
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5455,13 +5424,13 @@ mod tests {
 
         // test splitting both an Initialized stake and a Staked stake
         for state in &[
-            StakeStateWithFlags::Initialized(meta),
+            StakeStateV2::Initialized(meta),
             just_stake(meta, stake_lamports - rent_exempt_reserve),
         ] {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5487,13 +5456,13 @@ mod tests {
             );
 
             match state {
-                StakeStateWithFlags::Initialized(_) => {
+                StakeStateV2::Initialized(_) => {
                     assert_eq!(Ok(*state), accounts[1].state());
-                    assert_eq!(Ok(StakeStateWithFlags::Uninitialized), accounts[0].state());
+                    assert_eq!(Ok(StakeStateV2::Uninitialized), accounts[0].state());
                 }
-                StakeStateWithFlags::Stake(meta, stake, stake_flags) => {
+                StakeStateV2::Stake(meta, stake, stake_flags) => {
                     assert_eq!(
-                        Ok(StakeStateWithFlags::Stake(
+                        Ok(StakeStateV2::Stake(
                             *meta,
                             Stake {
                                 delegation: Delegation {
@@ -5506,7 +5475,7 @@ mod tests {
                         )),
                         accounts[1].state()
                     );
-                    assert_eq!(Ok(StakeStateWithFlags::Uninitialized), accounts[0].state());
+                    assert_eq!(Ok(StakeStateV2::Uninitialized), accounts[0].state());
                 }
                 _ => unreachable!(),
             }
@@ -5518,7 +5487,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_100_percent_of_source_to_account_with_lamports(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5531,7 +5500,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5562,8 +5531,8 @@ mod tests {
         for initial_balance in split_lamport_balances {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5588,9 +5557,9 @@ mod tests {
                 stake_lamports + initial_balance
             );
 
-            if let StakeStateWithFlags::Stake(meta, stake, stake_flags) = state {
+            if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
                 assert_eq!(
-                    Ok(StakeStateWithFlags::Stake(
+                    Ok(StakeStateV2::Stake(
                         meta,
                         Stake {
                             delegation: Delegation {
@@ -5603,7 +5572,7 @@ mod tests {
                     )),
                     accounts[1].state()
                 );
-                assert_eq!(Ok(StakeStateWithFlags::Uninitialized), accounts[0].state());
+                assert_eq!(Ok(StakeStateV2::Uninitialized), accounts[0].state());
             }
         }
     }
@@ -5613,8 +5582,8 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_rent_exemptness(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
-        let source_rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of() + 100);
-        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let source_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = source_rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5638,21 +5607,21 @@ mod tests {
         ];
 
         for state in &[
-            StakeStateWithFlags::Initialized(meta),
+            StakeStateV2::Initialized(meta),
             just_stake(meta, stake_lamports - source_rent_exempt_reserve),
         ] {
             // Test that splitting to a larger account fails
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of() + 10000,
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of() + 10000,
                 &id(),
             )
             .unwrap();
@@ -5674,14 +5643,14 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                StakeStateWithFlags::size_of() + 100,
+                StakeStateV2::size_of() + 100,
                 &id(),
             )
             .unwrap();
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
-                &StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Uninitialized,
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5705,20 +5674,20 @@ mod tests {
                 ..Meta::default()
             };
             match state {
-                StakeStateWithFlags::Initialized(_) => {
+                StakeStateV2::Initialized(_) => {
                     assert_eq!(
-                        Ok(StakeStateWithFlags::Initialized(expected_split_meta)),
+                        Ok(StakeStateV2::Initialized(expected_split_meta)),
                         accounts[1].state()
                     );
-                    assert_eq!(Ok(StakeStateWithFlags::Uninitialized), accounts[0].state());
+                    assert_eq!(Ok(StakeStateV2::Uninitialized), accounts[0].state());
                 }
-                StakeStateWithFlags::Stake(_meta, stake, stake_flags) => {
+                StakeStateV2::Stake(_meta, stake, stake_flags) => {
                     // Expected stake should reflect original stake amount so that extra lamports
                     // from the rent_exempt_reserve inequality do not magically activate
                     let expected_stake = stake_lamports - source_rent_exempt_reserve;
 
                     assert_eq!(
-                        Ok(StakeStateWithFlags::Stake(
+                        Ok(StakeStateV2::Stake(
                             expected_split_meta,
                             Stake {
                                 delegation: Delegation {
@@ -5735,7 +5704,7 @@ mod tests {
                         accounts[1].lamports(),
                         expected_stake + source_rent_exempt_reserve,
                     );
-                    assert_eq!(Ok(StakeStateWithFlags::Uninitialized), accounts[0].state());
+                    assert_eq!(Ok(StakeStateV2::Uninitialized), accounts[0].state());
                 }
                 _ => unreachable!(),
             }
@@ -5780,24 +5749,24 @@ mod tests {
         ];
 
         for state in &[
-            StakeStateWithFlags::Initialized(meta),
+            StakeStateV2::Initialized(meta),
             just_stake(meta, stake_lamports),
         ] {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
             for merge_from_state in &[
-                StakeStateWithFlags::Initialized(meta),
+                StakeStateV2::Initialized(meta),
                 just_stake(meta, stake_lamports),
             ] {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -5844,13 +5813,10 @@ mod tests {
 
                 // check state
                 match state {
-                    StakeStateWithFlags::Initialized(meta) => {
-                        assert_eq!(
-                            accounts[0].state(),
-                            Ok(StakeStateWithFlags::Initialized(*meta)),
-                        );
+                    StakeStateV2::Initialized(meta) => {
+                        assert_eq!(accounts[0].state(), Ok(StakeStateV2::Initialized(*meta)),);
                     }
-                    StakeStateWithFlags::Stake(meta, stake, stake_flags) => {
+                    StakeStateV2::Stake(meta, stake, stake_flags) => {
                         let expected_stake = stake.delegation.stake
                             + merge_from_state
                                 .stake()
@@ -5861,7 +5827,7 @@ mod tests {
                                 });
                         assert_eq!(
                             accounts[0].state(),
-                            Ok(StakeStateWithFlags::Stake(
+                            Ok(StakeStateV2::Stake(
                                 *meta,
                                 Stake {
                                     delegation: Delegation {
@@ -5876,7 +5842,7 @@ mod tests {
                     }
                     _ => unreachable!(),
                 }
-                assert_eq!(accounts[1].state(), Ok(StakeStateWithFlags::Uninitialized));
+                assert_eq!(accounts[1].state(), Ok(StakeStateV2::Uninitialized));
             }
         }
     }
@@ -5888,7 +5854,7 @@ mod tests {
         let stake_address = solana_sdk::pubkey::new_rand();
         let authorized_address = solana_sdk::pubkey::new_rand();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_amount = 4242424242;
         let stake_lamports = rent_exempt_reserve + stake_amount;
         let meta = Meta {
@@ -5905,8 +5871,8 @@ mod tests {
         };
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Stake(meta, stake, StakeFlags::empty()),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Stake(meta, stake, StakeFlags::empty()),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -5997,24 +5963,24 @@ mod tests {
         ];
 
         for state in &[
-            StakeStateWithFlags::Initialized(Meta::auto(&authorized_address)),
+            StakeStateV2::Initialized(Meta::auto(&authorized_address)),
             just_stake(Meta::auto(&authorized_address), stake_lamports),
         ] {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
             for merge_from_state in &[
-                StakeStateWithFlags::Initialized(Meta::auto(&wrong_authorized_address)),
+                StakeStateV2::Initialized(Meta::auto(&wrong_authorized_address)),
                 just_stake(Meta::auto(&wrong_authorized_address), stake_lamports),
             ] {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -6095,26 +6061,23 @@ mod tests {
         ];
 
         for state in &[
-            StakeStateWithFlags::Uninitialized,
-            StakeStateWithFlags::RewardsPool,
-            StakeStateWithFlags::Initialized(Meta::auto(&authorized_address)),
+            StakeStateV2::Uninitialized,
+            StakeStateV2::RewardsPool,
+            StakeStateV2::Initialized(Meta::auto(&authorized_address)),
             just_stake(Meta::auto(&authorized_address), stake_lamports),
         ] {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap();
-            for merge_from_state in &[
-                StakeStateWithFlags::Uninitialized,
-                StakeStateWithFlags::RewardsPool,
-            ] {
+            for merge_from_state in &[StakeStateV2::Uninitialized, StakeStateV2::RewardsPool] {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    StakeStateWithFlags::size_of(),
+                    StakeStateV2::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -6158,14 +6121,14 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&authorized_address), stake_lamports),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
         let merge_from_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&authorized_address), stake_lamports),
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &solana_sdk::pubkey::new_rand(),
         )
         .unwrap();
@@ -6228,7 +6191,7 @@ mod tests {
         let authorized_address = solana_sdk::pubkey::new_rand();
         let base_lamports = 4242424242;
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_amount = base_lamports;
         let stake_lamports = rent_exempt_reserve + stake_amount;
         let merge_from_amount = base_lamports;
@@ -6247,8 +6210,8 @@ mod tests {
         };
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
-            &StakeStateWithFlags::Stake(meta, stake, StakeFlags::empty()),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Stake(meta, stake, StakeFlags::empty()),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -6263,8 +6226,8 @@ mod tests {
         };
         let merge_from_account = AccountSharedData::new_data_with_space(
             merge_from_lamports,
-            &StakeStateWithFlags::Stake(meta, merge_from_stake, StakeFlags::empty()),
-            StakeStateWithFlags::size_of(),
+            &StakeStateV2::Stake(meta, merge_from_stake, StakeFlags::empty()),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -6343,7 +6306,7 @@ mod tests {
                 if expected_result.is_ok() {
                     assert_eq!(
                         accounts[1 - iteration].state(),
-                        Ok(StakeStateWithFlags::Uninitialized)
+                        Ok(StakeStateV2::Uninitialized)
                     );
                 }
             }
@@ -6442,11 +6405,7 @@ mod tests {
                 };
                 transaction_accounts[0]
                     .1
-                    .set_state(&StakeStateWithFlags::Stake(
-                        meta,
-                        stake,
-                        StakeFlags::empty(),
-                    ))
+                    .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
                     .unwrap();
             }
             if clock.epoch == merge_from_deactivation_epoch {
@@ -6460,7 +6419,7 @@ mod tests {
                 };
                 transaction_accounts[1]
                     .1
-                    .set_state(&StakeStateWithFlags::Stake(
+                    .set_state(&StakeStateV2::Stake(
                         meta,
                         merge_from_stake,
                         StakeFlags::empty(),
@@ -6559,8 +6518,7 @@ mod tests {
         let rent_account = create_account_shared_data_for_test(&rent);
 
         let good_stake_address = Pubkey::new_unique();
-        let good_stake_account =
-            AccountSharedData::new(u64::MAX, StakeStateWithFlags::size_of(), &id());
+        let good_stake_account = AccountSharedData::new(u64::MAX, StakeStateV2::size_of(), &id());
         let good_instruction = instruction::initialize(
             &good_stake_address,
             &Authorized::auto(&good_stake_address),
@@ -6628,7 +6586,7 @@ mod tests {
         let vote_address = Pubkey::new_unique();
         let stake_address = Pubkey::new_unique();
 
-        let initial_stake_state = StakeStateWithFlags::Stake(
+        let initial_stake_state = StakeStateV2::Stake(
             Meta::default(),
             new_stake(
                 1, /* stake */
@@ -6642,7 +6600,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             1, /* lamports */
             &initial_stake_state,
-            StakeStateWithFlags::size_of(),
+            StakeStateV2::size_of(),
             &id(),
         )
         .unwrap();
@@ -6827,7 +6785,7 @@ mod tests {
         let mut unrelated_stake_account = stake_account.clone();
         assert_ne!(unrelated_vote_address, vote_address);
         unrelated_stake_account
-            .serialize_data(&StakeStateWithFlags::Stake(
+            .serialize_data(&StakeStateV2::Stake(
                 Meta::default(),
                 new_stake(
                     1, /* stake */
@@ -6894,7 +6852,7 @@ mod tests {
 
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_history = StakeHistory::default();
         let current_epoch = 100;
 
@@ -6914,7 +6872,7 @@ mod tests {
 
         let prepare_stake_account = |activation_epoch, expected_stake_activation_status| {
             let initial_stake_delegation = minimum_delegation + rent_exempt_reserve;
-            let initial_stake_state = StakeStateWithFlags::Stake(
+            let initial_stake_state = StakeStateV2::Stake(
                 Meta {
                     authorized: Authorized {
                         staker: authorized_staker,
@@ -6949,7 +6907,7 @@ mod tests {
             AccountSharedData::new_data_with_space(
                 rent_exempt_reserve + initial_stake_delegation, /* lamports */
                 &initial_stake_state,
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &id(),
             )
             .unwrap()
@@ -7041,7 +6999,7 @@ mod tests {
         //
         let stake_account = prepare_stake_account(0 /*activation_epoch*/, None);
         let uninitialized_stake_account =
-            AccountSharedData::new(0 /* lamports */, StakeStateWithFlags::size_of(), &id());
+            AccountSharedData::new(0 /* lamports */, StakeStateV2::size_of(), &id());
 
         let _ = process_instruction_redelegate(
             &stake_address,
@@ -7069,8 +7027,7 @@ mod tests {
         );
 
         assert_eq!(output_accounts[0].lamports(), rent_exempt_reserve);
-        if let StakeStateWithFlags::Stake(meta, stake, _) =
-            output_accounts[0].deserialize_data().unwrap()
+        if let StakeStateV2::Stake(meta, stake, _) = output_accounts[0].deserialize_data().unwrap()
         {
             assert_eq!(meta.rent_exempt_reserve, rent_exempt_reserve);
             assert_eq!(
@@ -7086,8 +7043,7 @@ mod tests {
             output_accounts[1].lamports(),
             minimum_delegation + rent_exempt_reserve
         );
-        if let StakeStateWithFlags::Stake(meta, stake, _) =
-            output_accounts[1].deserialize_data().unwrap()
+        if let StakeStateV2::Stake(meta, stake, _) = output_accounts[1].deserialize_data().unwrap()
         {
             assert_eq!(meta.rent_exempt_reserve, rent_exempt_reserve);
             assert_eq!(stake.delegation.stake, minimum_delegation);
@@ -7218,11 +7174,8 @@ mod tests {
         //
         // Success: `uninitialized_stake_account` starts with 42 extra lamports
         //
-        let uninitialized_stake_account_with_extra_lamports = AccountSharedData::new(
-            42, /* lamports */
-            StakeStateWithFlags::size_of(),
-            &id(),
-        );
+        let uninitialized_stake_account_with_extra_lamports =
+            AccountSharedData::new(42 /* lamports */, StakeStateV2::size_of(), &id());
         let output_accounts = process_instruction_redelegate(
             &stake_address,
             &stake_account,
@@ -7239,8 +7192,7 @@ mod tests {
             output_accounts[1].lamports(),
             minimum_delegation + rent_exempt_reserve + 42
         );
-        if let StakeStateWithFlags::Stake(meta, stake, _) =
-            output_accounts[1].deserialize_data().unwrap()
+        if let StakeStateV2::Stake(meta, stake, _) = output_accounts[1].deserialize_data().unwrap()
         {
             assert_eq!(meta.rent_exempt_reserve, rent_exempt_reserve);
             assert_eq!(stake.delegation.stake, minimum_delegation + 42);
@@ -7255,12 +7207,12 @@ mod tests {
         //
         let mut stake_account_over_allocated =
             prepare_stake_account(0 /*activation_epoch:*/, None);
-        if let StakeStateWithFlags::Stake(mut meta, stake, stake_flags) =
+        if let StakeStateV2::Stake(mut meta, stake, stake_flags) =
             stake_account_over_allocated.deserialize_data().unwrap()
         {
             meta.rent_exempt_reserve += 42;
             stake_account_over_allocated
-                .set_state(&StakeStateWithFlags::Stake(meta, stake, stake_flags))
+                .set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
                 .unwrap();
         }
         stake_account_over_allocated
@@ -7283,8 +7235,7 @@ mod tests {
         );
 
         assert_eq!(output_accounts[0].lamports(), rent_exempt_reserve + 42);
-        if let StakeStateWithFlags::Stake(meta, _stake, _) =
-            output_accounts[0].deserialize_data().unwrap()
+        if let StakeStateV2::Stake(meta, _stake, _) = output_accounts[0].deserialize_data().unwrap()
         {
             assert_eq!(meta.rent_exempt_reserve, rent_exempt_reserve + 42);
         } else {
@@ -7294,8 +7245,7 @@ mod tests {
             output_accounts[1].lamports(),
             minimum_delegation + rent_exempt_reserve,
         );
-        if let StakeStateWithFlags::Stake(meta, stake, _) =
-            output_accounts[1].deserialize_data().unwrap()
+        if let StakeStateV2::Stake(meta, stake, _) = output_accounts[1].deserialize_data().unwrap()
         {
             assert_eq!(meta.rent_exempt_reserve, rent_exempt_reserve);
             assert_eq!(stake.delegation.stake, minimum_delegation);
@@ -7315,7 +7265,7 @@ mod tests {
             &uninitialized_stake_address,
             &AccountSharedData::new(
                 0, /* lamports */
-                StakeStateWithFlags::size_of(),
+                StakeStateV2::size_of(),
                 &Pubkey::new_unique(), // <-- Invalid program id
             ),
             Err(InstructionError::IncorrectProgramId),
@@ -7331,11 +7281,7 @@ mod tests {
             &new_vote_address,
             &new_vote_account,
             &uninitialized_stake_address,
-            &AccountSharedData::new(
-                0, /* lamports */
-                StakeStateWithFlags::size_of() - 1,
-                &id(),
-            ), // <-- size too small
+            &AccountSharedData::new(0 /* lamports */, StakeStateV2::size_of() - 1, &id()), // <-- size too small
             Err(InstructionError::InvalidAccountData),
         );
 
@@ -7349,11 +7295,7 @@ mod tests {
             &new_vote_address,
             &new_vote_account,
             &uninitialized_stake_address,
-            &AccountSharedData::new(
-                0, /* lamports */
-                StakeStateWithFlags::size_of() + 1,
-                &id(),
-            ), // <-- size too large
+            &AccountSharedData::new(0 /* lamports */, StakeStateV2::size_of() + 1, &id()), // <-- size too large
             Err(InstructionError::InvalidAccountData),
         );
 
@@ -7442,7 +7384,7 @@ mod tests {
 
         let mut deactivating_stake_account =
             prepare_stake_account(0 /*activation_epoch:*/, None);
-        if let StakeStateWithFlags::Stake(meta, mut stake, _stake_flags) =
+        if let StakeStateV2::Stake(meta, mut stake, _stake_flags) =
             deactivating_stake_account.deserialize_data().unwrap()
         {
             stake.deactivate(current_epoch).unwrap();
@@ -7460,11 +7402,7 @@ mod tests {
             );
 
             deactivating_stake_account
-                .set_state(&StakeStateWithFlags::Stake(
-                    meta,
-                    stake,
-                    StakeFlags::empty(),
-                ))
+                .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
                 .unwrap();
         }
         let _ = process_instruction_redelegate(
@@ -7483,7 +7421,7 @@ mod tests {
         //          (less than `minimum_delegation + rent_exempt_reserve`)
         //
         let mut stake_account_too_few_lamports = stake_account.clone();
-        if let StakeStateWithFlags::Stake(meta, mut stake, stake_flags) =
+        if let StakeStateV2::Stake(meta, mut stake, stake_flags) =
             stake_account_too_few_lamports.deserialize_data().unwrap()
         {
             stake.delegation.stake -= 1;
@@ -7492,7 +7430,7 @@ mod tests {
                 minimum_delegation + rent_exempt_reserve - 1
             );
             stake_account_too_few_lamports
-                .set_state(&StakeStateWithFlags::Stake(meta, stake, stake_flags))
+                .set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
                 .unwrap();
         } else {
             panic!("Invalid stake_account");

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -69,7 +69,7 @@ use {
         message::SanitizedMessage,
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Keypair, Signature, Signer},
-        stake::state::{StakeActivationStatus, StakeStateWithFlags},
+        stake::state::{StakeActivationStatus, StakeStateV2},
         stake_history::StakeHistory,
         system_instruction,
         sysvar::stake_history,
@@ -1732,7 +1732,7 @@ impl JsonRpcRequestProcessor {
         let stake_account = bank
             .get_account(pubkey)
             .ok_or_else(|| Error::invalid_params("Invalid param: account not found".to_string()))?;
-        let stake_state: StakeStateWithFlags = stake_account
+        let stake_state: StakeStateV2 = stake_account
             .state()
             .map_err(|_| Error::invalid_params("Invalid param: not a stake account".to_string()))?;
         let delegation = stake_state.delegation();

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -635,7 +635,7 @@ mod tests {
             signature::{Keypair, Signer},
             stake::{
                 self, instruction as stake_instruction,
-                state::{Authorized, Lockup, StakeAuthorize, StakeStateWithFlags},
+                state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
             },
             system_instruction, system_program, system_transaction,
             transaction::{self, Transaction},
@@ -907,7 +907,7 @@ mod tests {
         let balance = {
             let bank = bank_forks.read().unwrap().working_bank();
             let rent = &bank.rent_collector().rent;
-            rent.minimum_balance(StakeStateWithFlags::size_of())
+            rent.minimum_balance(StakeStateV2::size_of())
         };
 
         let tx = system_transaction::transfer(&alice, &from.pubkey(), balance, blockhash);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -176,7 +176,7 @@ use {
         },
     },
     solana_stake_program::stake_state::{
-        self, InflationPointCalculationEvent, PointValue, StakeStateWithFlags,
+        self, InflationPointCalculationEvent, PointValue, StakeStateV2,
     },
     solana_system_program::{get_system_account_kind, SystemAccountKind},
     solana_vote_program::vote_state::VoteState,
@@ -3090,7 +3090,7 @@ impl Bank {
 
                     let delegation = stake_account.delegation();
                     let (mut stake_account, stake_state) =
-                        <(AccountSharedData, StakeStateWithFlags)>::from(stake_account);
+                        <(AccountSharedData, StakeStateV2)>::from(stake_account);
                     let vote_pubkey = delegation.voter_pubkey;
                     let Some(vote_account) = get_vote_account(&vote_pubkey) else {
                         return None;
@@ -3221,7 +3221,7 @@ impl Bank {
                         }
                     });
                     let (mut stake_account, stake_state) =
-                        <(AccountSharedData, StakeStateWithFlags)>::from(stake_account);
+                        <(AccountSharedData, StakeStateV2)>::from(stake_account);
                     let redeemed = stake_state::redeem_rewards(
                         rewarded_epoch,
                         stake_state,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -98,7 +98,7 @@ use {
         },
         transaction_context::{TransactionAccount, TransactionContext},
     },
-    solana_stake_program::stake_state::{self, StakeStateWithFlags},
+    solana_stake_program::stake_state::{self, StakeStateV2},
     solana_vote_program::{
         vote_instruction,
         vote_state::{
@@ -4373,7 +4373,7 @@ fn test_bank_cloned_stake_delegations() {
     let (vote_balance, stake_balance) = {
         let rent = &bank.rent_collector().rent;
         let vote_rent_exempt_reserve = rent.minimum_balance(VoteState::size_of());
-        let stake_rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let stake_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
         (
             vote_rent_exempt_reserve,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -10,7 +10,7 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         signature::{Keypair, Signer},
-        stake::state::StakeStateWithFlags,
+        stake::state::StakeStateV2,
         system_program,
     },
     solana_stake_program::stake_state,
@@ -23,7 +23,7 @@ const VALIDATOR_LAMPORTS: u64 = 42;
 
 // fun fact: rustc is very close to make this const fn.
 pub fn bootstrap_validator_stake_lamports() -> u64 {
-    Rent::default().minimum_balance(StakeStateWithFlags::size_of())
+    Rent::default().minimum_balance(StakeStateV2::size_of())
 }
 
 // Number of lamports automatically used for genesis accounts

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -5,7 +5,7 @@ use {
     solana_sdk::{
         account::ReadableAccount,
         pubkey::Pubkey,
-        stake::{self, state::StakeStateWithFlags},
+        stake::{self, state::StakeStateV2},
     },
     solana_stake_program::stake_state,
     std::{collections::HashSet, sync::Arc},
@@ -51,14 +51,14 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCircu
     for (pubkey, account) in stake_accounts.iter() {
         let stake_account = stake_state::from(account).unwrap_or_default();
         match stake_account {
-            StakeStateWithFlags::Initialized(meta) => {
+            StakeStateV2::Initialized(meta) => {
                 if meta.lockup.is_in_force(&clock, None)
                     || withdraw_authority_list.contains(&meta.authorized.withdrawer)
                 {
                     non_circulating_accounts_set.insert(*pubkey);
                 }
             }
-            StakeStateWithFlags::Stake(meta, _stake, _stake_flags) => {
+            StakeStateV2::Stake(meta, _stake, _stake_flags) => {
                 if meta.lockup.is_in_force(&clock, None)
                     || withdraw_authority_list.contains(&meta.authorized.withdrawer)
                 {
@@ -262,8 +262,8 @@ mod tests {
             };
             let stake_account = Account::new_data_with_space(
                 balance,
-                &StakeStateWithFlags::Initialized(meta),
-                StakeStateWithFlags::size_of(),
+                &StakeStateV2::Initialized(meta),
+                StakeStateV2::size_of(),
                 &stake::program::id(),
             )
             .unwrap();

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -6,7 +6,7 @@ use {
         account_utils::StateMut,
         instruction::InstructionError,
         pubkey::Pubkey,
-        stake::state::{Delegation, StakeStateWithFlags},
+        stake::state::{Delegation, StakeStateV2},
     },
     std::marker::PhantomData,
     thiserror::Error,
@@ -19,7 +19,7 @@ use {
 #[derive(Clone, Debug, Default)]
 pub struct StakeAccount<T> {
     account: AccountSharedData,
-    stake_state: StakeStateWithFlags,
+    stake_state: StakeStateV2,
     _phantom: PhantomData<T>,
 }
 
@@ -29,7 +29,7 @@ pub enum Error {
     #[error(transparent)]
     InstructionError(#[from] InstructionError),
     #[error("Invalid delegation: {0:?}")]
-    InvalidDelegation(Box<StakeStateWithFlags>),
+    InvalidDelegation(Box<StakeStateV2>),
     #[error("Invalid stake account owner: {0}")]
     InvalidOwner(/*owner:*/ Pubkey),
 }
@@ -41,7 +41,7 @@ impl<T> StakeAccount<T> {
     }
 
     #[inline]
-    pub(crate) fn stake_state(&self) -> &StakeStateWithFlags {
+    pub(crate) fn stake_state(&self) -> &StakeStateV2 {
         &self.stake_state
     }
 }
@@ -61,7 +61,7 @@ impl TryFrom<AccountSharedData> for StakeAccount<Delegation> {
         if account.owner() != &solana_stake_program::id() {
             return Err(Error::InvalidOwner(*account.owner()));
         }
-        let stake_state: StakeStateWithFlags = account.state()?;
+        let stake_state: StakeStateV2 = account.state()?;
         if stake_state.delegation().is_none() {
             return Err(Error::InvalidDelegation(Box::new(stake_state)));
         }
@@ -73,7 +73,7 @@ impl TryFrom<AccountSharedData> for StakeAccount<Delegation> {
     }
 }
 
-impl<T> From<StakeAccount<T>> for (AccountSharedData, StakeStateWithFlags) {
+impl<T> From<StakeAccount<T>> for (AccountSharedData, StakeStateV2) {
     #[inline]
     fn from(stake_account: StakeAccount<T>) -> Self {
         (stake_account.account, stake_account.stake_state)
@@ -102,7 +102,7 @@ impl AbiExample for StakeAccount<Delegation> {
             },
         };
         let stake_state =
-            StakeStateWithFlags::Stake(Meta::example(), Stake::example(), StakeFlags::example());
+            StakeStateV2::Stake(Meta::example(), Stake::example(), StakeFlags::example());
         let mut account = Account::example();
         account.data.resize(200, 0u8);
         account.owner = solana_stake_program::id();

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -179,7 +179,7 @@ impl StakesCache {
 /// [`Stakes<Delegation>`] is equivalent to the old code and is used for backward
 /// compatibility in [`crate::bank::BankFieldsToDeserialize`].
 /// But banks cache [`Stakes<StakeAccount>`] which includes the entire stake
-/// account and StakeStateWithFlags deserialized from the account. Doing so, will remove
+/// account and StakeStateV2 deserialized from the account. Doing so, will remove
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
 #[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -19,7 +19,7 @@ use {
         signature::{Keypair, Signer},
         stake::{
             self, instruction as stake_instruction,
-            state::{Authorized, Lockup, StakeStateWithFlags},
+            state::{Authorized, Lockup, StakeStateV2},
         },
         sysvar::{self, stake_history::StakeHistory},
     },
@@ -145,7 +145,7 @@ fn test_stake_create_and_split_single_signature() {
 
     let lamports = {
         let rent = &bank.rent_collector().rent;
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
@@ -221,7 +221,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
 
     let lamports = {
         let rent = &bank.rent_collector().rent;
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
@@ -314,7 +314,7 @@ fn test_stake_account_lifetime() {
         let rent = &bank.rent_collector().rent;
         (
             rent.minimum_balance(VoteState::size_of()),
-            rent.minimum_balance(StakeStateWithFlags::size_of()),
+            rent.minimum_balance(StakeStateV2::size_of()),
             solana_stake_program::get_minimum_delegation(&bank.feature_set),
         )
     };
@@ -367,7 +367,7 @@ fn test_stake_account_lifetime() {
     // Test that correct lamports are staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeStateWithFlags::Stake(_meta, stake, _stake_flags) = stake_state {
+    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         assert_eq!(stake.delegation.stake, stake_starting_delegation,);
     } else {
         panic!("wrong account type found")
@@ -391,7 +391,7 @@ fn test_stake_account_lifetime() {
     // Test that lamports are still staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeStateWithFlags::Stake(_meta, stake, _stake_flags) = stake_state {
+    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         assert_eq!(stake.delegation.stake, stake_starting_delegation,);
     } else {
         panic!("wrong account type found")
@@ -615,7 +615,7 @@ fn test_create_stake_account_from_seed() {
     let authorized = Authorized::auto(&mint_pubkey);
     let (balance, delegation) = {
         let rent = &bank.rent_collector().rent;
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateWithFlags::size_of());
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
         (rent_exempt_reserve + minimum_delegation, minimum_delegation)
     };
@@ -641,7 +641,7 @@ fn test_create_stake_account_from_seed() {
     // Test that correct lamports are staked
     let account = bank.get_account(&stake_pubkey).expect("account not found");
     let stake_state = account.state().expect("couldn't unpack account data");
-    if let StakeStateWithFlags::Stake(_meta, stake, _) = stake_state {
+    if let StakeStateV2::Stake(_meta, stake, _) = stake_state {
         assert_eq!(stake.delegation.stake, delegation);
     } else {
         panic!("wrong account type found")

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -8,7 +8,7 @@ use {
         pubkey::Pubkey,
         stake::{
             program::id,
-            state::{Authorized, Lockup, StakeAuthorize, StakeStateWithFlags},
+            state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
         },
         system_instruction, sysvar,
     },
@@ -364,7 +364,7 @@ pub fn create_account_with_seed(
             base,
             seed,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -383,7 +383,7 @@ pub fn create_account(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -405,7 +405,7 @@ pub fn create_account_with_seed_checked(
             base,
             seed,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -423,7 +423,7 @@ pub fn create_account_checked(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -452,7 +452,7 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, StakeStateWithFlags::size_of() as u64),
+        system_instruction::allocate(split_stake_pubkey, StakeStateV2::size_of() as u64),
         system_instruction::assign(split_stake_pubkey, &id()),
         _split(
             stake_pubkey,
@@ -476,7 +476,7 @@ pub fn split_with_seed(
             split_stake_pubkey,
             base,
             seed,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         _split(
@@ -796,10 +796,7 @@ pub fn redelegate(
     uninitialized_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(
-            uninitialized_stake_pubkey,
-            StakeStateWithFlags::size_of() as u64,
-        ),
+        system_instruction::allocate(uninitialized_stake_pubkey, StakeStateV2::size_of() as u64),
         system_instruction::assign(uninitialized_stake_pubkey, &id()),
         _redelegate(
             stake_pubkey,
@@ -823,7 +820,7 @@ pub fn redelegate_with_seed(
             uninitialized_stake_pubkey,
             base,
             seed,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         _redelegate(

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -289,7 +289,7 @@ mod tests {
             client::SyncClient,
             genesis_config::create_genesis_config,
             signature::{Keypair, Signer},
-            stake::state::StakeStateWithFlags,
+            stake::state::StakeStateV2,
         },
         solana_stake_program::stake_state,
     };
@@ -297,8 +297,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair, u64, u64) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let bank = Bank::new_for_tests(&genesis_config);
-        let stake_rent =
-            bank.get_minimum_balance_for_rent_exemption(StakeStateWithFlags::size_of());
+        let stake_rent = bank.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of());
         let system_rent = bank.get_minimum_balance_for_rent_exemption(0);
         (bank, mint_keypair, stake_rent, system_rent)
     }


### PR DESCRIPTION
#### Problem

`StakeStateWithFlags` is not an amazing name, and doesn't allow for a good evolution over time, in case we need to add more information into `StakeState` for the next version. For example, when we add `Multistake`, it'll get very confusing for everyone.

It'll be easier in the longterm to explicitly version structs, so downstream developers can know more easily what the next upgrade step is.

#### Summary of Changes

This redoes the first commit of #32736 to change the name once more. This time, the command run was:

```
$ git grep -l "\<StakeStateWithFlags\>" | xargs sed -i'' 's/\<StakeStateWithFlags\>/StakeStateV2/g'
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
