### PR TITLE
ci: allow local bypass of stale Cargo.lock check with custom variable instead of `CI`

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -15,7 +15,7 @@ cargoNightly="$(readlink -f "./cargo") nightly"
 
 scripts/increment-cargo-version.sh check
 
-if [ -n "$CI" ] ; then
+if ! [ -v SOLANA_CI_ALLOW_STALE_CARGO_LOCK ] ; then
 # Disallow uncommitted Cargo.lock changes
 (
   _ scripts/cargo-for-all-lock-files.sh tree >/dev/null


### PR DESCRIPTION
#### Problem

#32728 introduced skipping the stale Cargo.lock check when running `ci/test-checks.sh` locally, based around the `CI` envvar being set. this causes two problems
1) the less safe behavior is opt-out, not opt-in
2) one cannot opt-out without modifying the scripts since the `CI` variable being set effects many behaviors which are not compatible with a local ci run

#### Summary of Changes

* gate skipping the stale Cargo.lock check on `SOLANA_CI_ALLOW_STALE_CARGO_LOCK` being instead of `CI`
* switch to `opt-in` instead of `opt-out` of the less safe behavior

if you want this
```bash
echo "export SOLANA_CI_ALLOW_STALE_CARGO_LOCK=" >> ~/.profile
```