### PR TITLE
Remove improper uses of &Arc<Bank>

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -417,7 +417,7 @@ fn main() {
         );
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (exit, poh_recorder, poh_service, signal_receiver) =
-            create_test_recorder(&bank, blockstore.clone(), None, Some(leader_schedule_cache));
+            create_test_recorder(bank.clone(), blockstore.clone(), None, Some(leader_schedule_cache));
         let (banking_tracer, tracer_thread) =
             BankingTracer::new(matches.is_present("trace_banking").then_some((
                 &blockstore.banking_trace_path(),
@@ -528,7 +528,8 @@ fn main() {
                 poh_time.stop();
 
                 let mut new_bank_time = Measure::start("new_bank");
-                let new_bank = Bank::new_from_parent(&bank, &collector, bank.slot() + 1);
+                let new_slot = bank.slot() + 1;
+                let new_bank = Bank::new_from_parent(bank, &collector, new_slot);
                 new_bank_time.stop();
 
                 let mut insert_time = Measure::start("insert_time");

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -416,8 +416,12 @@ fn main() {
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, signal_receiver) =
-            create_test_recorder(bank.clone(), blockstore.clone(), None, Some(leader_schedule_cache));
+        let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(
+            bank.clone(),
+            blockstore.clone(),
+            None,
+            Some(leader_schedule_cache),
+        );
         let (banking_tracer, tracer_thread) =
             BankingTracer::new(matches.is_present("trace_banking").then_some((
                 &blockstore.banking_trace_path(),

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -136,7 +136,7 @@ fn test_account_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -342,7 +342,7 @@ fn test_program_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -429,7 +429,7 @@ fn test_root_subscription() {
     let bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
     let max_complete_rewards_slot = Arc::new(AtomicU64::default());

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -86,7 +86,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let (exit, poh_recorder, poh_service, _signal_receiver) =
-            create_test_recorder(&bank, blockstore, None, None);
+            create_test_recorder(bank, blockstore, None, None);
 
         let recorder = poh_recorder.read().unwrap().new_recorder();
         let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
@@ -282,7 +282,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let (exit, poh_recorder, poh_service, signal_receiver) =
-            create_test_recorder(&bank, blockstore, None, None);
+            create_test_recorder(bank.clone(), blockstore, None, None);
         let cluster_info = {
             let keypair = Arc::new(Keypair::new());
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());

--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -122,7 +122,7 @@ fn setup(apply_cost_tracker_during_replay: bool) -> BenchFrame {
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
     let (exit, poh_recorder, poh_service, signal_receiver) =
-        create_test_recorder(&bank, blockstore, None, None);
+        create_test_recorder(bank.clone(), blockstore, None, None);
 
     BenchFrame {
         bank,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -650,7 +650,7 @@ mod tests {
         let genesis_config = create_genesis_config(2).genesis_config;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = Arc::new(bank_forks.read().unwrap().get(0).unwrap());
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
         let (tpu_vote_sender, tpu_vote_receiver) = banking_tracer.create_channel_tpu_vote();
@@ -663,7 +663,7 @@ mod tests {
                     .expect("Expected to be able to open database ledger"),
             );
             let (exit, poh_recorder, poh_service, _entry_receiever) =
-                create_test_recorder(&bank, blockstore, None, None);
+                create_test_recorder(bank, blockstore, None, None);
             let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
             let cluster_info = Arc::new(cluster_info);
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -701,7 +701,7 @@ mod tests {
         let num_extra_ticks = 2;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = Arc::new(bank_forks.read().unwrap().get(0).unwrap());
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
@@ -719,7 +719,7 @@ mod tests {
                 ..PohConfig::default()
             };
             let (exit, poh_recorder, poh_service, entry_receiver) =
-                create_test_recorder(&bank, blockstore, Some(poh_config), None);
+                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
             let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
             let cluster_info = Arc::new(cluster_info);
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -780,7 +780,7 @@ mod tests {
         } = create_slow_genesis_config(10);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = Arc::new(bank_forks.read().unwrap().get(0).unwrap());
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
@@ -800,7 +800,7 @@ mod tests {
                 ..PohConfig::default()
             };
             let (exit, poh_recorder, poh_service, entry_receiver) =
-                create_test_recorder(&bank, blockstore, Some(poh_config), None);
+                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
             let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
             let cluster_info = Arc::new(cluster_info);
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -951,7 +951,7 @@ mod tests {
                 // start a banking_stage to eat verified receiver
                 let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
                 let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-                let bank = Arc::new(bank_forks.read().unwrap().get(0).unwrap());
+                let bank = bank_forks.read().unwrap().get(0).unwrap();
                 let blockstore = Arc::new(
                     Blockstore::open(ledger_path.path())
                         .expect("Expected to be able to open database ledger"),
@@ -963,7 +963,7 @@ mod tests {
                     ..PohConfig::default()
                 };
                 let (exit, poh_recorder, poh_service, entry_receiver) =
-                    create_test_recorder(&bank, blockstore, Some(poh_config), None);
+                    create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
                 let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
                 let cluster_info = Arc::new(cluster_info);
                 let _banking_stage = BankingStage::new_num_threads(
@@ -1136,7 +1136,7 @@ mod tests {
         );
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = Arc::new(bank_forks.read().unwrap().get(0).unwrap());
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
@@ -1156,7 +1156,7 @@ mod tests {
                 ..PohConfig::default()
             };
             let (exit, poh_recorder, poh_service, _entry_receiver) =
-                create_test_recorder(&bank, blockstore, Some(poh_config), None);
+                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
             let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
             let cluster_info = Arc::new(cluster_info);
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -144,7 +144,7 @@ impl Committer {
             let txs = batch.sanitized_transactions().to_vec();
             let post_balances = bank.collect_balances(batch);
             let post_token_balances =
-                collect_token_balances(&bank, batch, &mut pre_balance_info.mint_decimals);
+                collect_token_balances(bank, batch, &mut pre_balance_info.mint_decimals);
             let mut transaction_index = starting_transaction_index.unwrap_or_default();
             let batch_transaction_indexes: Vec<_> = tx_results
                 .execution_results

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -144,7 +144,7 @@ impl Committer {
             let txs = batch.sanitized_transactions().to_vec();
             let post_balances = bank.collect_balances(batch);
             let post_token_balances =
-                collect_token_balances(bank, batch, &mut pre_balance_info.mint_decimals);
+                collect_token_balances(&bank, batch, &mut pre_balance_info.mint_decimals);
             let mut transaction_index = starting_transaction_index.unwrap_or_default();
             let batch_transaction_indexes: Vec<_> = tx_results
                 .execution_results

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1701,7 +1701,7 @@ mod tests {
         let address_table_state = generate_new_address_lookup_table(None, 2);
         store_address_lookup_table(&bank, address_table_key, address_table_state);
 
-        let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::new_unique(), 1));
+        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), 1));
         let message = VersionedMessage::V0(v0::Message {
             header: MessageHeader {
                 num_required_signatures: 1,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -688,7 +688,7 @@ impl Consumer {
     /// * `transactions` - a batch of transactions deserialized from packets
     /// * `pending_indexes` - identifies which indexes in the `transactions` list are still pending
     fn filter_pending_packets_from_pending_txs(
-        bank: &Arc<Bank>,
+        bank: &Bank,
         transactions: &[SanitizedTransaction],
         pending_indexes: &[usize],
     ) -> Vec<usize> {

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -151,12 +151,13 @@ mod tests {
         let ledger_path = temp_dir();
         let blockstore = Arc::new(Blockstore::open(ledger_path.as_path()).unwrap());
         let (exit, poh_recorder, poh_service, _entry_receiver) =
-            create_test_recorder(&bank, blockstore, None, None);
+            create_test_recorder(bank.clone(), blockstore, None, None);
 
         let my_pubkey = Pubkey::new_unique();
         let decision_maker = DecisionMaker::new(my_pubkey, poh_recorder.clone());
         poh_recorder.write().unwrap().reset(bank.clone(), None);
-        let bank = Arc::new(Bank::new_from_parent(&bank, &my_pubkey, bank.slot() + 1));
+        let slot = bank.slot() + 1;
+        let bank = Arc::new(Bank::new_from_parent(bank, &my_pubkey, slot));
 
         // Currently Leader - Consume
         {

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -323,7 +323,7 @@ mod tests {
         };
 
         let (exit, poh_recorder, poh_service, _entry_receiver) =
-            create_test_recorder(&bank, blockstore, Some(poh_config), None);
+            create_test_recorder(bank, blockstore, Some(poh_config), None);
 
         let (local_node, cluster_info) = new_test_cluster_info(Some(validator_keypair));
         let cluster_info = Arc::new(cluster_info);

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -116,7 +116,7 @@ impl LatestValidatorVotePacket {
 // This requires updating dependencies of ed25519-dalek as rand_core is not compatible cross
 // version https://github.com/dalek-cryptography/ed25519-dalek/pull/214
 pub(crate) fn weighted_random_order_by_stake<'a>(
-    bank: &Arc<Bank>,
+    bank: &Bank,
     pubkeys: impl Iterator<Item = &'a Pubkey>,
 ) -> impl Iterator<Item = Pubkey> {
     // Efraimidis and Spirakis algo for weighted random sample without replacement

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -868,7 +868,7 @@ mod tests {
 
         // Create a child descended from the first bank
         let next_bank = Arc::new(Bank::new_from_parent(
-            &first_bank,
+            first_bank.clone(),
             &Pubkey::new_unique(),
             first_bank.slot() + 1,
         ));

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -16,7 +16,6 @@ use {
     },
     std::sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
     },
 };
 
@@ -137,7 +136,7 @@ impl QosService {
     pub fn update_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
     ) {
         if let Some(transaction_committed_status) = transaction_committed_status {
             Self::update_committed_transaction_costs(
@@ -152,7 +151,7 @@ impl QosService {
     pub fn remove_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
     ) {
         match transaction_committed_status {
             Some(transaction_committed_status) => Self::remove_uncommitted_transaction_costs(
@@ -167,7 +166,7 @@ impl QosService {
     fn remove_uncommitted_transaction_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: &Vec<CommitTransactionDetails>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
     ) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         transaction_cost_results
@@ -186,7 +185,7 @@ impl QosService {
     fn update_committed_transaction_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: &Vec<CommitTransactionDetails>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
     ) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         transaction_cost_results
@@ -206,7 +205,7 @@ impl QosService {
 
     fn remove_transaction_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
     ) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         transaction_cost_results.for_each(|tx_cost| {

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -596,6 +596,7 @@ mod tests {
             system_transaction,
         },
         solana_vote_program::vote_transaction,
+        std::sync::Arc,
     };
 
     #[test]

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -14,9 +14,7 @@ use {
         saturating_add_assign,
         transaction::{self, SanitizedTransaction, TransactionError},
     },
-    std::sync::{
-        atomic::{AtomicU64, Ordering},
-    },
+    std::sync::atomic::{AtomicU64, Ordering},
 };
 
 // QosService is local to each banking thread, each instance of QosService provides services to

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -184,11 +184,7 @@ mod tests {
 
         let slot = bank.slot() + 1;
         (
-            Arc::new(Bank::new_from_parent(
-                bank,
-                &Pubkey::new_unique(),
-                slot,
-            )),
+            Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot)),
             address_table_key,
         )
     }

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -182,11 +182,12 @@ mod tests {
         account.set_data(data);
         bank.store_account(&address_table_key, &account);
 
+        let slot = bank.slot() + 1;
         (
             Arc::new(Bank::new_from_parent(
-                &bank,
+                bank,
                 &Pubkey::new_unique(),
-                bank.slot() + 1,
+                slot,
             )),
             address_table_key,
         )

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -721,11 +721,7 @@ impl ThreadLocalUnprocessedPackets {
                 .enumerate()
                 .filter_map(|(packet_index, deserialized_packet)| {
                     deserialized_packet
-                        .build_sanitized_transaction(
-                            &bank.feature_set,
-                            bank.vote_only_bank(),
-                            bank,
-                        )
+                        .build_sanitized_transaction(&bank.feature_set, bank.vote_only_bank(), bank)
                         .map(|transaction| (transaction, packet_index))
                 })
                 .unzip();

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -711,7 +711,7 @@ impl ThreadLocalUnprocessedPackets {
     fn sanitize_unforwarded_packets(
         &mut self,
         packets_to_process: &[Arc<ImmutableDeserializedPacket>],
-        bank: &Arc<Bank>,
+        bank: &Bank,
         total_dropped_packets: &mut usize,
     ) -> (Vec<SanitizedTransaction>, Vec<usize>) {
         // Get ref of ImmutableDeserializedPacket
@@ -724,7 +724,7 @@ impl ThreadLocalUnprocessedPackets {
                         .build_sanitized_transaction(
                             &bank.feature_set,
                             bank.vote_only_bank(),
-                            bank.as_ref(),
+                            bank,
                         )
                         .map(|transaction| (transaction, packet_index))
                 })
@@ -740,7 +740,7 @@ impl ThreadLocalUnprocessedPackets {
     /// Checks sanitized transactions against bank, returns valid transaction indexes
     fn filter_invalid_transactions(
         transactions: &[SanitizedTransaction],
-        bank: &Arc<Bank>,
+        bank: &Bank,
         total_dropped_packets: &mut usize,
     ) -> Vec<usize> {
         let filter = vec![Ok(()); transactions.len()];

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -958,7 +958,7 @@ mod tests {
             .read()
             .unwrap()
             .contains_key(&bank.slot()));
-        let bank1 = Bank::new_from_parent(&bank, &Pubkey::default(), bank.slot() + 1);
+        let bank1 = Bank::new_from_parent(bank.clone(), &Pubkey::default(), bank.slot() + 1);
         vote_tracker.progress_with_new_root_bank(&bank1);
         assert!(!vote_tracker
             .slot_vote_trackers
@@ -969,11 +969,12 @@ mod tests {
         // Check `keys` and `epoch_authorized_voters` are purged when new
         // root bank moves to the next epoch
         let current_epoch = bank.epoch();
+        let new_epoch_slot = bank.epoch_schedule()
+            .get_first_slot_in_epoch(current_epoch + 1);
         let new_epoch_bank = Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            bank.epoch_schedule()
-                .get_first_slot_in_epoch(current_epoch + 1),
+            new_epoch_slot,
         );
         vote_tracker.progress_with_new_root_bank(&new_epoch_bank);
     }
@@ -1020,7 +1021,7 @@ mod tests {
         let bank0 = Bank::new_for_tests(&genesis_config);
         // Votes for slots less than the provided root bank's slot should not be processed
         let bank3 = Arc::new(Bank::new_from_parent(
-            &Arc::new(bank0),
+            Arc::new(bank0),
             &Pubkey::default(),
             3,
         ));
@@ -1541,7 +1542,7 @@ mod tests {
             .collect();
 
         let new_root_bank =
-            Bank::new_from_parent(&bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
+            Bank::new_from_parent(bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
         ClusterInfoVoteListener::filter_and_confirm_with_new_votes(
             &vote_tracker,
             vote_txs,
@@ -1757,10 +1758,11 @@ mod tests {
             1
         );
 
+        let slot = current_leader_bank.slot() + 1;
         let current_leader_bank = Arc::new(Bank::new_from_parent(
-            &current_leader_bank,
+            current_leader_bank,
             &Pubkey::default(),
-            current_leader_bank.slot() + 1,
+            slot,
         ));
         ClusterInfoVoteListener::check_for_leader_bank_and_send_votes(
             &mut bank_vote_sender_state_option,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -969,13 +969,10 @@ mod tests {
         // Check `keys` and `epoch_authorized_voters` are purged when new
         // root bank moves to the next epoch
         let current_epoch = bank.epoch();
-        let new_epoch_slot = bank.epoch_schedule()
+        let new_epoch_slot = bank
+            .epoch_schedule()
             .get_first_slot_in_epoch(current_epoch + 1);
-        let new_epoch_bank = Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            new_epoch_slot,
-        );
+        let new_epoch_bank = Bank::new_from_parent(bank, &Pubkey::default(), new_epoch_slot);
         vote_tracker.progress_with_new_root_bank(&new_epoch_bank);
     }
 

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_highest_super_majority_root_advance() {
-        fn get_vote_account_root_slot(vote_pubkey: Pubkey, bank: &Arc<Bank>) -> Slot {
+        fn get_vote_account_root_slot(vote_pubkey: Pubkey, bank: &Bank) -> Slot {
             let vote_account = bank.get_vote_account(&vote_pubkey).unwrap();
             let slot = vote_account
                 .vote_state()

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -515,7 +515,7 @@ mod tests {
         // Create enough banks such that vote account will root slots 0 and 1
         for x in 0..33 {
             let previous_bank = bank_forks.get(x).unwrap();
-            let bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), x + 1);
+            let bank = Bank::new_from_parent(previous_bank.clone(), &Pubkey::default(), x + 1);
             let vote = vote_transaction::new_vote_transaction(
                 vec![x],
                 previous_bank.hash(),
@@ -540,7 +540,7 @@ mod tests {
 
         // Add an additional bank/vote that will root slot 2
         let bank33 = bank_forks.get(33).unwrap();
-        let bank34 = Bank::new_from_parent(&bank33, &Pubkey::default(), 34);
+        let bank34 = Bank::new_from_parent(bank33.clone(), &Pubkey::default(), 34);
         let vote33 = vote_transaction::new_vote_transaction(
             vec![33],
             bank33.hash(),
@@ -583,7 +583,7 @@ mod tests {
         // Add a forked bank. Because the vote for bank 33 landed in the non-ancestor, the vote
         // account's root (and thus the highest_super_majority_root) rolls back to slot 1
         let bank33 = bank_forks.get(33).unwrap();
-        let bank35 = Bank::new_from_parent(&bank33, &Pubkey::default(), 35);
+        let bank35 = Bank::new_from_parent(bank33, &Pubkey::default(), 35);
         bank_forks.insert(bank35);
 
         let working_bank = bank_forks.working_bank();
@@ -608,7 +608,7 @@ mod tests {
         // continues normally
         for x in 35..=37 {
             let previous_bank = bank_forks.get(x).unwrap();
-            let bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), x + 1);
+            let bank = Bank::new_from_parent(previous_bank.clone(), &Pubkey::default(), x + 1);
             let vote = vote_transaction::new_vote_transaction(
                 vec![x],
                 previous_bank.hash(),

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -288,7 +288,7 @@ mod test {
             .bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(&bank6, &Pubkey::default(), 7));
+            .insert(Bank::new_from_parent(bank6, &Pubkey::default(), 7));
         let bank7 = vote_simulator.bank_forks.read().unwrap().get(7).unwrap();
         assert!(!bank7.ancestors.contains_key(&3));
 

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1812,7 +1812,7 @@ mod test {
         let bank_forks = &repair_info.bank_forks;
         let root_bank = bank_forks.read().unwrap().root_bank();
         let new_root_slot = dead_duplicate_confirmed_slot_2 + 1;
-        let new_root_bank = Bank::new_from_parent(&root_bank, &Pubkey::default(), new_root_slot);
+        let new_root_bank = Bank::new_from_parent(root_bank, &Pubkey::default(), new_root_slot);
         new_root_bank.freeze();
         {
             let mut w_bank_forks = bank_forks.write().unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1973,7 +1973,7 @@ impl ReplayStage {
 
     #[allow(clippy::too_many_arguments)]
     fn replay_blockstore_into_bank(
-        bank: Arc<Bank>,
+        bank: &Arc<Bank>,
         blockstore: &Blockstore,
         replay_stats: &RwLock<ReplaySlotStats>,
         replay_progress: &RwLock<ConfirmationProgress>,
@@ -2596,7 +2596,7 @@ impl ReplayStage {
                         let mut replay_blockstore_time =
                             Measure::start("replay_blockstore_into_bank");
                         let blockstore_result = Self::replay_blockstore_into_bank(
-                            bank,
+                            &bank,
                             blockstore,
                             &replay_stats,
                             &replay_progress,
@@ -2679,7 +2679,7 @@ impl ReplayStage {
             if bank.collector_id() != my_pubkey {
                 let mut replay_blockstore_time = Measure::start("replay_blockstore_into_bank");
                 let blockstore_result = Self::replay_blockstore_into_bank(
-                    bank,
+                    &bank,
                     blockstore,
                     &bank_progress.replay_stats,
                     &bank_progress.replay_progress,
@@ -4608,7 +4608,7 @@ pub(crate) mod tests {
             let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
             let exit = Arc::new(AtomicBool::new(false));
             let res = ReplayStage::replay_blockstore_into_bank(
-                bank1.clone(),
+                &bank1,
                 &blockstore,
                 &bank1_progress.replay_stats,
                 &bank1_progress.replay_progress,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -7166,11 +7166,8 @@ pub(crate) mod tests {
             let mut parent_bank = bank2.clone();
             for _ in 0..MAX_PROCESSING_AGE {
                 let slot = parent_bank.slot() + 1;
-                parent_bank = Arc::new(Bank::new_from_parent(
-                    parent_bank,
-                    &Pubkey::default(),
-                    slot,
-                ));
+                parent_bank =
+                    Arc::new(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
                 parent_bank.fill_bank_with_ticks_for_tests();
                 parent_bank.freeze();
             }
@@ -7394,7 +7391,8 @@ pub(crate) mod tests {
         // Add a new fork starting from 0 with bigger slot number, we assume it has a bigger
         // weight, but we cannot switch because of lockout.
         let other_fork_slot = 1;
-        let other_fork_bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), other_fork_slot);
+        let other_fork_bank =
+            Bank::new_from_parent(bank0.clone(), &Pubkey::default(), other_fork_slot);
         other_fork_bank.fill_bank_with_ticks_for_tests();
         other_fork_bank.freeze();
         progress.entry(other_fork_slot).or_insert_with(|| {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4093,7 +4093,7 @@ pub(crate) mod tests {
         // Insert a non-root bank so that the propagation logic will update this
         // bank
         let bank1 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(0).unwrap(),
+            bank_forks.read().unwrap().get(0).unwrap(),
             &leader_schedule_cache.slot_leader_at(1, None).unwrap(),
             1,
         );
@@ -4203,7 +4203,7 @@ pub(crate) mod tests {
 
         let root = 3;
         let root_bank = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(0).unwrap(),
+            bank_forks.read().unwrap().get(0).unwrap(),
             &Pubkey::default(),
             root,
         );
@@ -4289,20 +4289,20 @@ pub(crate) mod tests {
         let confirmed_root = 1;
         let fork = 2;
         let bank1 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(0).unwrap(),
+            bank_forks.read().unwrap().get(0).unwrap(),
             &Pubkey::default(),
             confirmed_root,
         );
         bank_forks.write().unwrap().insert(bank1);
         let bank2 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(confirmed_root).unwrap(),
+            bank_forks.read().unwrap().get(confirmed_root).unwrap(),
             &Pubkey::default(),
             fork,
         );
         bank_forks.write().unwrap().insert(bank2);
         let root = 3;
         let root_bank = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(confirmed_root).unwrap(),
+            bank_forks.read().unwrap().get(confirmed_root).unwrap(),
             &Pubkey::default(),
             root,
         );
@@ -4594,7 +4594,7 @@ pub(crate) mod tests {
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
             assert!(bank0.is_frozen());
             assert_eq!(bank0.tick_height(), bank0.max_tick_height());
-            let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+            let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
             let bank1 = bank_forks.read().unwrap().get(1).unwrap();
             let bank1_progress = progress
@@ -4608,7 +4608,7 @@ pub(crate) mod tests {
             let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
             let exit = Arc::new(AtomicBool::new(false));
             let res = ReplayStage::replay_blockstore_into_bank(
-                &bank1,
+                bank1.clone(),
                 &blockstore,
                 &bank1_progress.replay_stats,
                 &bank1_progress.replay_progress,
@@ -4721,7 +4721,8 @@ pub(crate) mod tests {
 
         for i in 1..=3 {
             let prev_bank = bank_forks.read().unwrap().get(i - 1).unwrap();
-            let bank = Bank::new_from_parent(&prev_bank, &Pubkey::default(), prev_bank.slot() + 1);
+            let slot = prev_bank.slot() + 1;
+            let bank = Bank::new_from_parent(prev_bank, &Pubkey::default(), slot);
             let _res = bank.transfer(
                 10,
                 &genesis_config_info.mint_keypair,
@@ -4816,7 +4817,7 @@ pub(crate) mod tests {
                 )
                 .unwrap();
 
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
             let slot = bank1.slot();
 
             let (entries, test_signatures) = create_test_transaction_entries(
@@ -4879,7 +4880,7 @@ pub(crate) mod tests {
         );
 
         let bank_forks = RwLock::new(bank_forks);
-        let bank1 = Bank::new_from_parent(&bank0, &my_node_pubkey, 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), &my_node_pubkey, 1);
         bank1.process_transaction(&vote_tx).unwrap();
         bank1.freeze();
 
@@ -5329,9 +5330,9 @@ pub(crate) mod tests {
             vote_simulator::initialize_state(&keypairs, stake);
 
         let bank0 = bank_forks.get(0).unwrap();
-        bank_forks.insert(Bank::new_from_parent(&bank0, &Pubkey::default(), 9));
+        bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
         let bank9 = bank_forks.get(9).unwrap();
-        bank_forks.insert(Bank::new_from_parent(&bank9, &Pubkey::default(), 10));
+        bank_forks.insert(Bank::new_from_parent(bank9, &Pubkey::default(), 10));
         bank_forks.set_root(9, &AbsRequestSender::default(), None);
         let total_epoch_stake = bank0.total_epoch_stake();
 
@@ -5431,7 +5432,7 @@ pub(crate) mod tests {
         for i in 1..=10 {
             let parent_bank = bank_forks.get(i - 1).unwrap().clone();
             let prev_leader_slot = ((i - 1) / 2) * 2;
-            bank_forks.insert(Bank::new_from_parent(&parent_bank, &Pubkey::default(), i));
+            bank_forks.insert(Bank::new_from_parent(parent_bank, &Pubkey::default(), i));
             progress_map.insert(
                 i,
                 ForkProgress::new(
@@ -5512,7 +5513,7 @@ pub(crate) mod tests {
         for i in 1..=10 {
             let parent_bank = bank_forks.get(i - 1).unwrap().clone();
             let prev_leader_slot = i - 1;
-            bank_forks.insert(Bank::new_from_parent(&parent_bank, &Pubkey::default(), i));
+            bank_forks.insert(Bank::new_from_parent(parent_bank, &Pubkey::default(), i));
             let mut fork_progress = ForkProgress::new(
                 Hash::default(),
                 Some(prev_leader_slot),
@@ -5654,10 +5655,10 @@ pub(crate) mod tests {
         // which implies confirmation
         let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
         let parent_slot_bank =
-            Bank::new_from_parent(&Arc::new(bank0), &Pubkey::default(), parent_slot);
+            Bank::new_from_parent(Arc::new(bank0), &Pubkey::default(), parent_slot);
         let mut bank_forks = BankForks::new(parent_slot_bank);
         let bank5 =
-            Bank::new_from_parent(&bank_forks.get(parent_slot).unwrap(), &Pubkey::default(), 5);
+            Bank::new_from_parent(bank_forks.get(parent_slot).unwrap(), &Pubkey::default(), 5);
         bank_forks.insert(bank5);
 
         // Should purge only `previous_leader_slot` from the progress map
@@ -5768,7 +5769,7 @@ pub(crate) mod tests {
         // Create bank 7
         let root_bank = bank_forks.read().unwrap().root_bank();
         let bank7 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(6).unwrap(),
+            bank_forks.read().unwrap().get(6).unwrap(),
             &Pubkey::default(),
             7,
         );
@@ -5931,7 +5932,7 @@ pub(crate) mod tests {
         // Create bank 7 and insert to blockstore and bank forks
         let root_bank = bank_forks.read().unwrap().root_bank();
         let bank7 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(6).unwrap(),
+            bank_forks.read().unwrap().get(6).unwrap(),
             &Pubkey::default(),
             7,
         );
@@ -7030,7 +7031,7 @@ pub(crate) mod tests {
         let (voting_sender, voting_receiver) = unbounded();
 
         // Simulate landing a vote for slot 0 landing in slot 1
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
         bank1.fill_bank_with_ticks_for_tests();
         tower.record_bank_vote(&bank0, &my_vote_pubkey);
         ReplayStage::push_vote(
@@ -7071,7 +7072,7 @@ pub(crate) mod tests {
 
         // Trying to refresh the vote for bank 0 in bank 1 or bank 2 won't succeed because
         // the last vote has landed already
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 2));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
         bank2.fill_bank_with_ticks_for_tests();
         bank2.freeze();
         for refresh_bank in &[&bank1, &bank2] {
@@ -7164,10 +7165,11 @@ pub(crate) mod tests {
         let expired_bank = {
             let mut parent_bank = bank2.clone();
             for _ in 0..MAX_PROCESSING_AGE {
+                let slot = parent_bank.slot() + 1;
                 parent_bank = Arc::new(Bank::new_from_parent(
-                    &parent_bank,
+                    parent_bank,
                     &Pubkey::default(),
-                    parent_bank.slot() + 1,
+                    slot,
                 ));
                 parent_bank.fill_bank_with_ticks_for_tests();
                 parent_bank.freeze();
@@ -7222,10 +7224,11 @@ pub(crate) mod tests {
         assert_eq!(tower.last_voted_slot().unwrap(), 1);
 
         // Processing the vote transaction should be valid
+        let expired_bank_child_slot = expired_bank.slot() + 1;
         let expired_bank_child = Arc::new(Bank::new_from_parent(
-            &expired_bank,
+            expired_bank.clone(),
             &Pubkey::default(),
-            expired_bank.slot() + 1,
+            expired_bank_child_slot,
         ));
         expired_bank_child.process_transaction(vote_tx).unwrap();
         let vote_account = expired_bank_child
@@ -7243,7 +7246,7 @@ pub(crate) mod tests {
         // 2) The latest refresh vote transaction's recent blockhash (the sibling's hash) doesn't exist
         // This will still not refresh because `MAX_VOTE_REFRESH_INTERVAL_MILLIS` has not expired yet
         let expired_bank_sibling = Arc::new(Bank::new_from_parent(
-            &bank2,
+            bank2,
             &Pubkey::default(),
             expired_bank_child.slot() + 1,
         ));
@@ -7280,7 +7283,7 @@ pub(crate) mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn send_vote_in_new_bank(
-        parent_bank: &Bank,
+        parent_bank: Arc<Bank>,
         my_slot: Slot,
         my_vote_keypair: &[Arc<Keypair>],
         tower: &mut Tower,
@@ -7298,9 +7301,9 @@ pub(crate) mod tests {
         progress: &mut ProgressMap,
     ) -> Arc<Bank> {
         let my_vote_pubkey = &my_vote_keypair[0].pubkey();
-        tower.record_bank_vote(parent_bank, my_vote_pubkey);
+        tower.record_bank_vote(&parent_bank, my_vote_pubkey);
         ReplayStage::push_vote(
-            parent_bank,
+            &parent_bank,
             my_vote_pubkey,
             identity_keypair,
             my_vote_keypair,
@@ -7391,7 +7394,7 @@ pub(crate) mod tests {
         // Add a new fork starting from 0 with bigger slot number, we assume it has a bigger
         // weight, but we cannot switch because of lockout.
         let other_fork_slot = 1;
-        let other_fork_bank = Bank::new_from_parent(&bank0, &Pubkey::default(), other_fork_slot);
+        let other_fork_bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), other_fork_slot);
         other_fork_bank.fill_bank_with_ticks_for_tests();
         other_fork_bank.freeze();
         progress.entry(other_fork_slot).or_insert_with(|| {
@@ -7410,7 +7413,7 @@ pub(crate) mod tests {
         let mut cursor = Cursor::default();
 
         let mut new_bank = send_vote_in_new_bank(
-            &bank0,
+            bank0,
             2,
             &my_vote_keypair,
             &mut tower,
@@ -7428,7 +7431,7 @@ pub(crate) mod tests {
             &mut progress,
         );
         new_bank = send_vote_in_new_bank(
-            &new_bank,
+            new_bank.clone(),
             new_bank.slot() + 1,
             &my_vote_keypair,
             &mut tower,
@@ -7450,7 +7453,7 @@ pub(crate) mod tests {
         let last_voted_slot = tower.last_voted_slot().unwrap();
         while new_bank.is_in_slot_hashes_history(&last_voted_slot) {
             let new_slot = new_bank.slot() + 1;
-            let bank = Bank::new_from_parent(&new_bank, &Pubkey::default(), new_slot);
+            let bank = Bank::new_from_parent(new_bank, &Pubkey::default(), new_slot);
             bank.fill_bank_with_ticks_for_tests();
             bank.freeze();
             progress.entry(new_slot).or_insert_with(|| {
@@ -7575,7 +7578,7 @@ pub(crate) mod tests {
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
 
         let bank1 = Bank::new_from_parent(
-            &bank_forks.read().unwrap().get(0).unwrap(),
+            bank_forks.read().unwrap().get(0).unwrap(),
             &leader_schedule_cache.slot_leader_at(1, None).unwrap(),
             1,
         );
@@ -7756,7 +7759,7 @@ pub(crate) mod tests {
         let mut prev_index = 0;
         for i in (1..10).chain(11..15) {
             let bank = Bank::new_from_parent(
-                &bank_forks.read().unwrap().get(prev_index).unwrap(),
+                bank_forks.read().unwrap().get(prev_index).unwrap(),
                 &leader_schedule_cache.slot_leader_at(i, None).unwrap(),
                 i,
             );

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1992,7 +1992,7 @@ impl ReplayStage {
         // will break!
         blockstore_processor::confirm_slot(
             blockstore,
-            &bank,
+            bank,
             &mut w_replay_stats,
             &mut w_replay_progress,
             false,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -417,7 +417,7 @@ pub mod tests {
         let blockstore = Arc::new(blockstore);
         let bank = bank_forks.working_bank();
         let (exit, poh_recorder, poh_service, _entry_receiver) =
-            create_test_recorder(&bank, blockstore.clone(), None, None);
+            create_test_recorder(bank.clone(), blockstore.clone(), None, None);
         let vote_keypair = Keypair::new();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2554,7 +2554,7 @@ mod tests {
 
         // bank=1, wait=0, should pass, bank is past the wait slot
         let bank_forks = RwLock::new(BankForks::new(Bank::new_from_parent(
-            &bank_forks.read().unwrap().root_bank(),
+            bank_forks.read().unwrap().root_bank(),
             &Pubkey::default(),
             1,
         )));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1444,7 +1444,7 @@ impl Validator {
     }
 }
 
-fn active_vote_account_exists_in_bank(bank: &Arc<Bank>, vote_account: &Pubkey) -> bool {
+fn active_vote_account_exists_in_bank(bank: &Bank, vote_account: &Pubkey) -> bool {
     if let Some(account) = &bank.get_account(vote_account) {
         if let Some(vote_state) = vote_state::from(account) {
             return !vote_state.votes.is_empty();
@@ -1922,7 +1922,7 @@ fn maybe_warp_slot(
         root_bank.force_flush_accounts_cache();
 
         bank_forks.insert(Bank::warp_from_parent(
-            &root_bank,
+            root_bank,
             &Pubkey::default(),
             warp_slot,
             solana_accounts_db::accounts_db::CalcAccountsHashDataSource::Storages,

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -510,10 +510,11 @@ mod tests {
 
         // Create a set of valid ancestor hashes for this fork
         for _ in 0..MAX_ENTRIES {
+            let slot = my_leader_bank.slot() + 1;
             my_leader_bank = Arc::new(Bank::new_from_parent(
-                &my_leader_bank,
+                my_leader_bank,
                 &Pubkey::default(),
-                my_leader_bank.slot() + 1,
+                slot,
             ));
         }
         let slot_hashes_account = my_leader_bank
@@ -585,10 +586,11 @@ mod tests {
         my_leader_bank.freeze();
         let vote_slot = my_leader_bank.slot();
         let vote_hash = my_leader_bank.hash();
+        let new_leader_slot = my_leader_bank.slot() + 1;
         let my_leader_bank = Arc::new(Bank::new_from_parent(
-            &my_leader_bank,
+            my_leader_bank,
             &Pubkey::default(),
-            my_leader_bank.slot() + 1,
+            new_leader_slot,
         ));
         let vote_account_key = vote_simulator.vote_pubkeys[1];
         let vote = VoteTransaction::from(Vote::new(vec![vote_slot], vote_hash));

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -82,7 +82,7 @@ impl VoteSimulator {
             }
             let parent = *walk.get_parent().unwrap().data();
             let parent_bank = self.bank_forks.read().unwrap().get(parent).unwrap();
-            let new_bank = Bank::new_from_parent(&parent_bank, &Pubkey::default(), slot);
+            let new_bank = Bank::new_from_parent(parent_bank.clone(), &Pubkey::default(), slot);
             self.progress
                 .entry(slot)
                 .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0));

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -602,11 +602,11 @@ fn test_epoch_accounts_hash_and_warping() {
         CalcAccountsHashDataSource::Storages,
     ));
     let slot = bank.slot().checked_add(1).unwrap();
-    let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-        bank,
-        &Pubkey::default(),
-        slot,
-    ));
+    let bank =
+        bank_forks
+            .write()
+            .unwrap()
+            .insert(Bank::new_from_parent(bank, &Pubkey::default(), slot));
     bank_forks.write().unwrap().set_root(
         bank.slot(),
         &test_environment
@@ -637,11 +637,11 @@ fn test_epoch_accounts_hash_and_warping() {
         CalcAccountsHashDataSource::Storages,
     ));
     let slot = bank.slot().checked_add(1).unwrap();
-    let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-        bank,
-        &Pubkey::default(),
-        slot,
-    ));
+    let bank =
+        bank_forks
+            .write()
+            .unwrap()
+            .insert(Bank::new_from_parent(bank, &Pubkey::default(), slot));
     bank_forks.write().unwrap().set_root(
         bank.slot(),
         &test_environment

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -273,10 +273,11 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
     for _ in 0..slots_per_epoch.checked_mul(NUM_EPOCHS_TO_TEST).unwrap() {
         let bank = {
             let parent = bank_forks.read().unwrap().working_bank();
+            let slot = parent.slot().checked_add(1).unwrap();
             let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-                &parent,
+                parent,
                 &Pubkey::default(),
-                parent.slot().checked_add(1).unwrap(),
+                slot,
             ));
 
             let transaction = system_transaction::transfer(
@@ -385,10 +386,11 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
     for _ in 0..slots_per_epoch.checked_mul(NUM_EPOCHS_TO_TEST).unwrap() {
         let bank = {
             let parent = bank_forks.read().unwrap().working_bank();
+            let slot = parent.slot().checked_add(1).unwrap();
             let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-                &parent,
+                parent,
                 &Pubkey::default(),
-                parent.slot() + 1,
+                slot,
             ));
 
             let transaction = system_transaction::transfer(
@@ -501,10 +503,11 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
     for _ in 0..slots_per_epoch.checked_mul(NUM_EPOCHS_TO_TEST).unwrap() {
         let bank = {
             let parent = bank_forks.read().unwrap().working_bank();
+            let slot = parent.slot().checked_add(1).unwrap();
             let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-                &parent,
+                parent,
                 &Pubkey::default(),
-                parent.slot() + 1,
+                slot,
             ));
 
             let transaction = system_transaction::transfer(
@@ -593,15 +596,16 @@ fn test_epoch_accounts_hash_and_warping() {
     // flush the write cache so warping can calculate the accounts hash from storages
     bank.force_flush_accounts_cache();
     let bank = bank_forks.write().unwrap().insert(Bank::warp_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         eah_stop_slot_in_next_epoch,
         CalcAccountsHashDataSource::Storages,
     ));
+    let slot = bank.slot().checked_add(1).unwrap();
     let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
-        bank.slot() + 1,
+        slot,
     ));
     bank_forks.write().unwrap().set_root(
         bank.slot(),
@@ -627,15 +631,16 @@ fn test_epoch_accounts_hash_and_warping() {
     // flush the write cache so warping can calculate the accounts hash from storages
     bank.force_flush_accounts_cache();
     let bank = bank_forks.write().unwrap().insert(Bank::warp_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         eah_start_slot_in_next_epoch,
         CalcAccountsHashDataSource::Storages,
     ));
+    let slot = bank.slot().checked_add(1).unwrap();
     let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
-        bank.slot() + 1,
+        slot,
     ));
     bank_forks.write().unwrap().set_root(
         bank.slot(),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -218,7 +218,7 @@ fn run_bank_forks_snapshot_n<F>(
         accounts_package_sender,
     };
     for slot in 1..=last_slot {
-        let mut bank = Bank::new_from_parent(&bank_forks[slot - 1], &Pubkey::default(), slot);
+        let mut bank = Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
         f(&mut bank, mint_keypair);
         let bank = bank_forks.insert(bank);
         // Set root to make sure we don't end up with too many account storage entries
@@ -376,11 +376,12 @@ fn test_concurrent_snapshot_packaging(
     let saved_slot = 4;
     let mut saved_archive_path = None;
 
-    for forks in 0..MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
+    for i in 0..MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
+        let parent_slot = i as u64;
         let bank = Bank::new_from_parent(
-            &bank_forks[forks as u64],
+            bank_forks.get(parent_slot).unwrap(),
             &Pubkey::default(),
-            (forks + 1) as u64,
+            parent_slot + 1,
         );
         let slot = bank.slot();
         let key1 = Keypair::new().pubkey();
@@ -595,7 +596,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         for _ in 0..num_set_roots {
             for _ in 0..*add_root_interval {
                 let new_slot = current_bank.slot() + 1;
-                let new_bank = Bank::new_from_parent(&current_bank, &Pubkey::default(), new_slot);
+                let new_bank = Bank::new_from_parent(current_bank, &Pubkey::default(), new_slot);
                 snapshot_test_config.bank_forks.insert(new_bank);
                 current_bank = snapshot_test_config.bank_forks[new_slot].clone();
             }
@@ -728,7 +729,7 @@ fn test_bank_forks_incremental_snapshot(
     for slot in 1..=LAST_SLOT {
         // Make a new bank and perform some transactions
         let bank = {
-            let bank = Bank::new_from_parent(&bank_forks[slot - 1], &Pubkey::default(), slot);
+            let bank = Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
 
             let key = solana_sdk::pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
@@ -1024,7 +1025,7 @@ fn test_snapshots_with_background_services(
         // Make a new bank and process some transactions
         {
             let bank = Bank::new_from_parent(
-                &bank_forks.read().unwrap().get(slot - 1).unwrap(),
+                bank_forks.read().unwrap().get(slot - 1).unwrap(),
                 &Pubkey::default(),
                 slot,
             );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -219,7 +219,7 @@ fn run_bank_forks_snapshot_n<F>(
     };
     for slot in 1..=last_slot {
         let mut bank =
-            Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
+            Bank::new_from_parent(bank_forks[slot - 1].clone(), &Pubkey::default(), slot);
         f(&mut bank, mint_keypair);
         let bank = bank_forks.insert(bank);
         // Set root to make sure we don't end up with too many account storage entries
@@ -731,7 +731,7 @@ fn test_bank_forks_incremental_snapshot(
         // Make a new bank and perform some transactions
         let bank = {
             let bank =
-                Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
+                Bank::new_from_parent(bank_forks[slot - 1].clone(), &Pubkey::default(), slot);
 
             let key = solana_sdk::pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -378,9 +378,9 @@ fn test_concurrent_snapshot_packaging(
     let mut saved_archive_path = None;
 
     for i in 0..MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
-        let parent_slot = i as u64;
+        let parent_slot = i as Slot;
         let bank = Bank::new_from_parent(
-            bank_forks.get(parent_slot).unwrap(),
+            bank_forks[parent_slot].clone(),
             &Pubkey::default(),
             parent_slot + 1,
         );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -218,7 +218,8 @@ fn run_bank_forks_snapshot_n<F>(
         accounts_package_sender,
     };
     for slot in 1..=last_slot {
-        let mut bank = Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
+        let mut bank =
+            Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
         f(&mut bank, mint_keypair);
         let bank = bank_forks.insert(bank);
         // Set root to make sure we don't end up with too many account storage entries
@@ -729,7 +730,8 @@ fn test_bank_forks_incremental_snapshot(
     for slot in 1..=LAST_SLOT {
         // Make a new bank and perform some transactions
         let bank = {
-            let bank = Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
+            let bank =
+                Bank::new_from_parent(bank_forks.get(slot - 1).unwrap(), &Pubkey::default(), slot);
 
             let key = solana_sdk::pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2931,7 +2931,7 @@ fn main() {
 
                         if child_bank_required {
                             let mut child_bank =
-                                Bank::new_from_parent(&bank, bank.collector_id(), bank.slot() + 1);
+                                Bank::new_from_parent(bank.clone(), bank.collector_id(), bank.slot() + 1);
 
                             if let Ok(rent_burn_percentage) = rent_burn_percentage {
                                 child_bank.set_rent_burn_percentage(rent_burn_percentage);
@@ -3137,7 +3137,7 @@ fn main() {
                             bank.rc.accounts.accounts_db.add_root(bank.slot());
                             bank.force_flush_accounts_cache();
                             Arc::new(Bank::warp_from_parent(
-                                &bank,
+                                bank.clone(),
                                 bank.collector_id(),
                                 warp_slot,
                                 CalcAccountsHashDataSource::Storages,
@@ -3606,7 +3606,7 @@ fn main() {
                                 }
                             };
                             let warped_bank = Bank::new_from_parent_with_tracer(
-                                &base_bank,
+                                base_bank.clone(),
                                 base_bank.collector_id(),
                                 next_epoch,
                                 tracer,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2930,8 +2930,11 @@ fn main() {
                             || bootstrap_validator_pubkeys.is_some();
 
                         if child_bank_required {
-                            let mut child_bank =
-                                Bank::new_from_parent(bank.clone(), bank.collector_id(), bank.slot() + 1);
+                            let mut child_bank = Bank::new_from_parent(
+                                bank.clone(),
+                                bank.collector_id(),
+                                bank.slot() + 1,
+                            );
 
                             if let Ok(rent_burn_percentage) = rent_burn_percentage {
                                 child_bank.set_rent_burn_percentage(rent_burn_percentage);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1372,7 +1372,7 @@ fn process_next_slots(
         // handles any partials
         if next_meta.is_full() {
             let next_bank = Bank::new_from_parent(
-                bank,
+                bank.clone(),
                 &leader_schedule_cache
                     .slot_leader_at(*next_slot, Some(bank))
                     .unwrap(),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3754,11 +3754,7 @@ pub mod tests {
             i += 1;
 
             let slot = bank.slot() + thread_rng().gen_range(1, 3);
-            bank = Arc::new(Bank::new_from_parent(
-                bank,
-                &Pubkey::default(),
-                slot,
-            ));
+            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
         }
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3592,13 +3592,14 @@ pub mod tests {
         };
         let recyclers = VerifyRecyclers::default();
         process_bank_0(&bank0, &blockstore, &opts, &recyclers, None, None);
-        let bank1 = bank_forks.insert(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+        let bank0_last_blockhash = bank0.last_blockhash();
+        let bank1 = bank_forks.insert(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
         confirm_full_slot(
             &blockstore,
             &bank1,
             &opts,
             &recyclers,
-            &mut ConfirmationProgress::new(bank0.last_blockhash()),
+            &mut ConfirmationProgress::new(bank0_last_blockhash),
             None,
             None,
             None,
@@ -3752,10 +3753,11 @@ pub mod tests {
             }
             i += 1;
 
+            let slot = bank.slot() + thread_rng().gen_range(1, 3);
             bank = Arc::new(Bank::new_from_parent(
-                &bank,
+                bank,
                 &Pubkey::default(),
-                bank.slot() + thread_rng().gen_range(1, 3),
+                slot,
             ));
         }
     }
@@ -3893,7 +3895,7 @@ pub mod tests {
         bank0.freeze();
 
         let bank1 = Arc::new(Bank::new_from_parent(
-            &bank0,
+            bank0.clone(),
             &solana_sdk::pubkey::new_rand(),
             1,
         ));
@@ -4465,7 +4467,7 @@ pub mod tests {
         assert_eq!(slot_0_bank.get_hash_age(&genesis_hash), Some(1));
         assert_eq!(slot_0_bank.get_hash_age(&slot_0_hash), Some(0));
 
-        let slot_2_bank = Arc::new(Bank::new_from_parent(&slot_0_bank, &collector_id, 2));
+        let slot_2_bank = Arc::new(Bank::new_from_parent(slot_0_bank, &collector_id, 2));
         assert_eq!(slot_2_bank.slot(), 2);
         assert_eq!(slot_2_bank.tick_height(), 2);
         assert_eq!(slot_2_bank.max_tick_height(), 6);

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -531,7 +531,7 @@ mod tests {
             target_slot += 1;
         }
 
-        let bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), target_slot);
+        let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), target_slot);
         let mut expected_slot = 0;
         let epoch = bank.get_leader_schedule_epoch(target_slot);
         for i in 0..epoch {
@@ -591,7 +591,7 @@ mod tests {
         assert_eq!(bank.get_epoch_and_slot_index(96).0, 2);
         assert!(cache.slot_leader_at(96, Some(&bank)).is_none());
 
-        let bank2 = Bank::new_from_parent(&bank, &solana_sdk::pubkey::new_rand(), 95);
+        let bank2 = Bank::new_from_parent(bank, &solana_sdk::pubkey::new_rand(), 95);
         assert!(bank2.epoch_vote_accounts(2).is_some());
 
         // Set root for a slot in epoch 1, so that epoch 2 is now confirmed

--- a/poh/src/leader_bank_notifier.rs
+++ b/poh/src/leader_bank_notifier.rs
@@ -46,7 +46,7 @@ impl LeaderBankNotifier {
         *state = SlotAndBankWithStatus {
             status: Status::InProgress,
             slot: Some(bank.slot()),
-            bank: Arc::downgrade(&bank),
+            bank: Arc::downgrade(bank),
         };
         drop(state);
 

--- a/poh/src/leader_bank_notifier.rs
+++ b/poh/src/leader_bank_notifier.rs
@@ -46,7 +46,7 @@ impl LeaderBankNotifier {
         *state = SlotAndBankWithStatus {
             status: Status::InProgress,
             slot: Some(bank.slot()),
-            bank: Arc::downgrade(bank),
+            bank: Arc::downgrade(&bank),
         };
         drop(state);
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -71,7 +71,7 @@ pub struct BankStart {
 }
 
 impl BankStart {
-    fn get_working_bank_if_not_expired(&self) -> Option<&Arc<Bank>> {
+    fn get_working_bank_if_not_expired(&self) -> Option<&Bank> {
         if self.should_working_bank_still_be_processing_txs() {
             Some(&self.working_bank)
         } else {
@@ -249,7 +249,7 @@ pub enum PohRecorderBank {
 }
 
 impl PohRecorderBank {
-    pub fn bank(&self) -> &Arc<Bank> {
+    pub fn bank(&self) -> &Bank {
         match self {
             PohRecorderBank::WorkingBank(bank_start) => &bank_start.working_bank,
             PohRecorderBank::LastResetBank(last_reset_bank) => last_reset_bank,
@@ -1024,7 +1024,7 @@ impl PohRecorder {
     // if it's still processing transactions
     pub fn get_working_bank_if_not_expired<'a>(
         bank_start: &Option<&'a BankStart>,
-    ) -> Option<&'a Arc<Bank>> {
+    ) -> Option<&'a Bank> {
         bank_start
             .as_ref()
             .and_then(|bank_start| bank_start.get_working_bank_if_not_expired())
@@ -1039,7 +1039,7 @@ impl PohRecorder {
 }
 
 pub fn create_test_recorder(
-    bank: &Arc<Bank>,
+    bank: Arc<Bank>,
     blockstore: Arc<Blockstore>,
     poh_config: Option<PohConfig>,
     leader_schedule_cache: Option<Arc<LeaderScheduleCache>>,
@@ -1051,7 +1051,7 @@ pub fn create_test_recorder(
 ) {
     let leader_schedule_cache = match leader_schedule_cache {
         Some(provided_cache) => provided_cache,
-        None => Arc::new(LeaderScheduleCache::new_from_bank(bank)),
+        None => Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
     };
     let exit = Arc::new(AtomicBool::new(false));
     let poh_config = poh_config.unwrap_or_default();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1236,7 +1236,7 @@ mod tests {
             );
 
             bank0.fill_bank_with_ticks_for_tests();
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
 
             // Set a working bank
             poh_recorder.set_bank(bank1.clone(), false);
@@ -1348,7 +1348,7 @@ mod tests {
             );
 
             bank0.fill_bank_with_ticks_for_tests();
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
             poh_recorder.set_bank(bank1.clone(), false);
             // Let poh_recorder tick up to bank1.tick_height() - 1
             for _ in 0..bank1.tick_height() - 1 {
@@ -1433,7 +1433,7 @@ mod tests {
             );
 
             bank0.fill_bank_with_ticks_for_tests();
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
             poh_recorder.set_bank(bank1.clone(), false);
 
             // Record up to exactly min tick height
@@ -1601,7 +1601,7 @@ mod tests {
             );
 
             bank0.fill_bank_with_ticks_for_tests();
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
             poh_recorder.set_bank(bank1, false);
 
             // Check we can make two ticks without hitting min_tick_height
@@ -1974,7 +1974,7 @@ mod tests {
             );
 
             // reset poh now. we should immediately be leader
-            let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+            let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
             assert_eq!(bank1.slot(), 1);
             poh_recorder.reset(bank1.clone(), Some((2, 2)));
             assert_eq!(
@@ -2017,7 +2017,7 @@ mod tests {
 
             // Let's test that correct grace ticks are reported
             // Set the leader slot one slot down
-            let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 2));
+            let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
             poh_recorder.reset(bank2.clone(), Some((4, 4)));
 
             // send ticks for a slot
@@ -2030,7 +2030,7 @@ mod tests {
                 poh_recorder.reached_leader_slot(),
                 PohLeaderStatus::NotReached
             );
-            let bank3 = Arc::new(Bank::new_from_parent(&bank2, &Pubkey::default(), 3));
+            let bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
             assert_eq!(bank3.slot(), 3);
             poh_recorder.reset(bank3.clone(), Some((4, 4)));
 
@@ -2046,7 +2046,7 @@ mod tests {
             // Let's test that if a node overshoots the ticks for its target
             // leader slot, reached_leader_slot() will return true, because it's overdue
             // Set the leader slot one slot down
-            let bank4 = Arc::new(Bank::new_from_parent(&bank3, &Pubkey::default(), 4));
+            let bank4 = Arc::new(Bank::new_from_parent(bank3, &Pubkey::default(), 4));
             poh_recorder.reset(bank4.clone(), Some((5, 5)));
 
             // Overshoot ticks for the slot
@@ -2110,7 +2110,7 @@ mod tests {
             assert!(!poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
 
             // Move the bank up a slot (so that max_tick_height > slot 0's tick_height)
-            let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1));
+            let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 1));
             // If we set the working bank, the node should be leader within next 2 slots
             poh_recorder.set_bank(bank.clone(), false);
             assert!(poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
@@ -2141,7 +2141,7 @@ mod tests {
                 Arc::new(AtomicBool::default()),
             );
             //create a new bank
-            let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 2));
+            let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 2));
             // add virtual ticks into poh for slots 0, 1, and 2
             for _ in 0..(bank.ticks_per_slot() * 3) {
                 poh_recorder.tick();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1067,14 +1067,15 @@ pub fn create_test_recorder(
         &poh_config,
         exit.clone(),
     );
-    poh_recorder.set_bank(bank.clone(), false);
+    let ticks_per_slot = bank.ticks_per_slot();
 
+    poh_recorder.set_bank(bank, false);
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &poh_config,
         exit.clone(),
-        bank.ticks_per_slot(),
+        ticks_per_slot,
         crate::poh_service::DEFAULT_PINNED_CPU_CORE,
         crate::poh_service::DEFAULT_HASHES_PER_BATCH,
         record_receiver,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -828,7 +828,7 @@ impl ProgramTest {
         let bank = {
             let bank = Arc::new(bank);
             bank.fill_bank_with_ticks_for_tests();
-            let bank = Bank::new_from_parent(&bank, bank.collector_id(), bank.slot() + 1);
+            let bank = Bank::new_from_parent(bank.clone(), bank.collector_id(), bank.slot() + 1);
             debug!("Bank slot: {}", bank.slot());
             bank
         };
@@ -1118,7 +1118,7 @@ impl ProgramTestContext {
             bank
         } else {
             bank_forks.insert(Bank::warp_from_parent(
-                &bank,
+                bank,
                 &Pubkey::default(),
                 pre_warp_slot,
                 // some warping tests cannot use the append vecs because of the sequence of adding roots and flushing
@@ -1154,7 +1154,7 @@ impl ProgramTestContext {
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         bank_forks.insert(Bank::new_from_parent(
-            &warp_bank,
+            warp_bank,
             &Pubkey::default(),
             warp_slot,
         ));
@@ -1191,7 +1191,7 @@ impl ProgramTestContext {
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         let warp_slot = pre_warp_slot + 1;
-        let mut warp_bank = Bank::new_from_parent(&bank, &Pubkey::default(), warp_slot);
+        let mut warp_bank = Bank::new_from_parent(bank, &Pubkey::default(), warp_slot);
 
         warp_bank.force_reward_interval_end_for_tests();
         bank_forks.insert(warp_bank);

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -201,7 +201,7 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     } = create_genesis_config(50);
     let bank = Bank::new_for_benches(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let invoke_program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
     let bank = bank_client

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -457,7 +457,7 @@ fn test_sol_alloc_free_no_longer_deployable() {
     // Try and finalize the program now that sol_alloc_free is re-enabled
     assert!(bank.process_transaction(&finalize_tx).is_ok());
     let new_slot = bank.slot() + 1;
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), new_slot);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), new_slot);
 
     // invoke the program
     assert!(bank.process_transaction(&invoke_tx).is_ok());

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -501,7 +501,7 @@ fn test_program_sbf_duplicate_accounts() {
         } = create_genesis_config(50);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank = Arc::new(bank);
-        let mut bank_client = BankClient::new_shared(&bank);
+        let mut bank_client = BankClient::new_shared(bank.clone());
         let (bank, program_id) = load_program_and_advance_slot(
             &mut bank_client,
             &bpf_loader::id(),
@@ -710,7 +710,7 @@ fn test_return_data_and_log_data_syscall() {
         } = create_genesis_config(50);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank = Arc::new(bank);
-        let mut bank_client = BankClient::new_shared(&bank);
+        let mut bank_client = BankClient::new_shared(bank.clone());
 
         let (bank, program_id) = load_program_and_advance_slot(
             &mut bank_client,
@@ -778,7 +778,7 @@ fn test_program_sbf_invoke_sanity() {
         } = create_genesis_config(50);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank = Arc::new(bank);
-        let mut bank_client = BankClient::new_shared(&bank);
+        let mut bank_client = BankClient::new_shared(bank.clone());
 
         let invoke_program_id =
             load_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.1);
@@ -1175,7 +1175,7 @@ fn test_program_sbf_program_id_spoofing() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let malicious_swap_pubkey = load_program(
         &bank_client,
@@ -1226,7 +1226,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let caller_pubkey = load_program(
         &bank_client,
@@ -1264,7 +1264,7 @@ fn test_program_sbf_ro_modify() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let (bank, program_pubkey) = load_program_and_advance_slot(
         &mut bank_client,
@@ -1479,7 +1479,7 @@ fn test_program_sbf_instruction_introspection() {
     } = create_genesis_config(50_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let (bank, program_id) = load_program_and_advance_slot(
         &mut bank_client,
@@ -1753,7 +1753,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
     } = get_stable_genesis_config();
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     // Deploy upgradeable program
     let buffer_keypair = Keypair::from_base58_string(
@@ -1927,7 +1927,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Deploy upgradeable program
     let buffer_keypair = Keypair::new();
@@ -2025,7 +2025,7 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Deploy upgradeable program
     let buffer_keypair = Keypair::new();
@@ -2133,7 +2133,7 @@ fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Deploy upgradeable program
     let buffer_keypair = Keypair::new();
@@ -2643,7 +2643,7 @@ fn test_program_upgradeable_locks() {
         } = create_genesis_config(2_000_000_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank = Arc::new(bank);
-        let mut bank_client = BankClient::new_shared(&bank);
+        let mut bank_client = BankClient::new_shared(bank.clone());
 
         load_upgradeable_program(
             &bank_client,
@@ -2766,7 +2766,7 @@ fn test_program_sbf_finalize() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let (_, program_pubkey) = load_program_and_advance_slot(
         &mut bank_client,
@@ -2814,7 +2814,7 @@ fn test_program_sbf_ro_account_modify() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let (bank, program_id) = load_program_and_advance_slot(
         &mut bank_client,
@@ -2885,7 +2885,7 @@ fn test_program_sbf_realloc() {
             feature_set.deactivate(&feature_set::bpf_account_data_direct_mapping::id());
         }
         let bank = Arc::new(bank);
-        let mut bank_client = BankClient::new_shared(&bank);
+        let mut bank_client = BankClient::new_shared(bank.clone());
 
         let (bank, program_id) = load_program_and_advance_slot(
             &mut bank_client,
@@ -3213,7 +3213,7 @@ fn test_program_sbf_realloc_invoke() {
 
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let realloc_program_id = load_program(
         &bank_client,
@@ -3729,7 +3729,7 @@ fn test_program_sbf_processed_inner_instruction() {
     } = create_genesis_config(50);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let sibling_program_id = load_program(
         &bank_client,
@@ -3887,7 +3887,7 @@ fn test_get_minimum_delegation() {
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     let (_, program_id) = load_program_and_advance_slot(
         &mut bank_client,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -591,7 +591,7 @@ mod tests {
 
         // Banks <= root do not get added to pending list, even if not frozen
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank6 = Bank::new_from_parent(bank5.clone(), &Pubkey::default(), 6);
+        let bank6 = Bank::new_from_parent(bank5, &Pubkey::default(), 6);
         bank_forks.write().unwrap().insert(bank6);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         let bank7 = Bank::new_from_parent(bank5, &Pubkey::default(), 7);

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -418,13 +418,13 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let optimistically_confirmed_bank =
@@ -520,7 +520,7 @@ mod tests {
 
         // Test higher root will be cached and clear pending_optimistically_confirmed_banks
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
-        let bank4 = Bank::new_from_parent(&bank3, &Pubkey::default(), 4);
+        let bank4 = Bank::new_from_parent(bank3, &Pubkey::default(), 4);
         bank_forks.write().unwrap().insert(bank4);
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(4),
@@ -540,7 +540,7 @@ mod tests {
         assert_eq!(highest_confirmed_slot, 4);
 
         let bank4 = bank_forks.read().unwrap().get(4).unwrap();
-        let bank5 = Bank::new_from_parent(&bank4, &Pubkey::default(), 5);
+        let bank5 = Bank::new_from_parent(bank4, &Pubkey::default(), 5);
         bank_forks.write().unwrap().insert(bank5);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
 
@@ -550,6 +550,7 @@ mod tests {
 
         let subscribers = Some(Arc::new(RwLock::new(bank_notification_senders)));
         let parent_roots = bank5.ancestors.keys();
+
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::NewRootBank(bank5),
             &bank_forks,
@@ -590,10 +591,10 @@ mod tests {
 
         // Banks <= root do not get added to pending list, even if not frozen
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank6 = Bank::new_from_parent(&bank5, &Pubkey::default(), 6);
+        let bank6 = Bank::new_from_parent(bank5.clone(), &Pubkey::default(), 6);
         bank_forks.write().unwrap().insert(bank6);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank7 = Bank::new_from_parent(&bank5, &Pubkey::default(), 7);
+        let bank7 = Bank::new_from_parent(bank5, &Pubkey::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
         bank_forks
             .write()

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -177,7 +177,7 @@ impl OptimisticallyConfirmedBankTracker {
     fn notify_or_defer(
         subscriptions: &RpcSubscriptions,
         bank_forks: &RwLock<BankForks>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         last_notified_confirmed_slot: &mut Slot,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
@@ -204,13 +204,13 @@ impl OptimisticallyConfirmedBankTracker {
     fn notify_or_defer_confirmed_banks(
         subscriptions: &RpcSubscriptions,
         bank_forks: &RwLock<BankForks>,
-        bank: &Arc<Bank>,
+        bank: Arc<Bank>,
         slot_threshold: Slot,
         last_notified_confirmed_slot: &mut Slot,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
     ) {
-        for confirmed_bank in bank.clone().parents_inclusive().iter().rev() {
+        for confirmed_bank in bank.parents_inclusive().iter().rev() {
             if confirmed_bank.slot() > slot_threshold {
                 debug!(
                     "Calling notify_or_defer for confirmed_bank {:?}",
@@ -286,7 +286,7 @@ impl OptimisticallyConfirmedBankTracker {
                         Self::notify_or_defer_confirmed_banks(
                             subscriptions,
                             bank_forks,
-                            &bank,
+                            bank,
                             *highest_confirmed_slot,
                             last_notified_confirmed_slot,
                             pending_optimistically_confirmed_banks,
@@ -343,7 +343,7 @@ impl OptimisticallyConfirmedBankTracker {
                     Self::notify_or_defer_confirmed_banks(
                         subscriptions,
                         bank_forks,
-                        &bank,
+                        bank.clone(),
                         *last_notified_confirmed_slot,
                         last_notified_confirmed_slot,
                         pending_optimistically_confirmed_banks,

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -20,7 +20,7 @@ pub fn get_parsed_token_account(
     account: AccountSharedData,
 ) -> UiAccount {
     let additional_data = get_token_account_mint(account.data())
-        .and_then(|mint_pubkey| get_mint_owner_and_decimals(&bank, &mint_pubkey).ok())
+        .and_then(|mint_pubkey| get_mint_owner_and_decimals(bank, &mint_pubkey).ok())
         .map(|(_, decimals)| AccountAdditionalData {
             spl_token_decimals: Some(decimals),
         });

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -15,7 +15,7 @@ use {
 };
 
 pub fn get_parsed_token_account(
-    bank: Arc<Bank>,
+    bank: &Bank,
     pubkey: &Pubkey,
     account: AccountSharedData,
 ) -> UiAccount {
@@ -72,7 +72,7 @@ where
 
 /// Analyze a mint Pubkey that may be the native_mint and get the mint-account owner (token
 /// program_id) and decimals
-pub fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(Pubkey, u8)> {
+pub fn get_mint_owner_and_decimals(bank: &Bank, mint: &Pubkey) -> Result<(Pubkey, u8)> {
     if mint == &spl_token::native_mint::id() {
         Ok((spl_token::id(), spl_token::native_mint::DECIMALS))
     } else {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2291,7 +2291,7 @@ fn get_encoded_account(
             let response = if is_known_spl_token_id(account.owner())
                 && encoding == UiAccountEncoding::JsonParsed
             {
-                get_parsed_token_account(&bank, pubkey, account)
+                get_parsed_token_account(bank, pubkey, account)
             } else {
                 encode_account(&account, pubkey, encoding, data_slice)?
             };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4999,11 +4999,7 @@ pub mod tests {
                 .bank_forks
                 .write()
                 .unwrap()
-                .insert(Bank::new_from_parent(
-                    parent_bank,
-                    &Pubkey::default(),
-                    slot,
-                ));
+                .insert(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
 
             let new_block_commitment = BlockCommitmentCache::new(
                 HashMap::new(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4956,7 +4956,7 @@ pub mod tests {
             let mut parent_bank = self.bank_forks.read().unwrap().working_bank();
             for (i, root) in roots.iter().enumerate() {
                 let new_bank =
-                    Bank::new_from_parent(&parent_bank, parent_bank.collector_id(), *root);
+                    Bank::new_from_parent(parent_bank.clone(), parent_bank.collector_id(), *root);
                 parent_bank = self.bank_forks.write().unwrap().insert(new_bank);
                 let parent = if i > 0 { roots[i - 1] } else { 0 };
                 fill_blockstore_slot_with_ticks(
@@ -4969,7 +4969,7 @@ pub mod tests {
             }
             self.blockstore.set_roots(roots.iter()).unwrap();
             let new_bank = Bank::new_from_parent(
-                &parent_bank,
+                parent_bank.clone(),
                 parent_bank.collector_id(),
                 roots.iter().max().unwrap() + 1,
             );
@@ -5000,7 +5000,7 @@ pub mod tests {
                 .write()
                 .unwrap()
                 .insert(Bank::new_from_parent(
-                    &parent_bank,
+                    parent_bank,
                     &Pubkey::default(),
                     slot,
                 ));
@@ -5057,7 +5057,7 @@ pub mod tests {
             .unwrap();
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let request_processor = JsonRpcRequestProcessor::new_from_bank(
-            &bank,
+            bank,
             SocketAddrSpace::Unspecified,
             connection_cache,
         );
@@ -5076,7 +5076,7 @@ pub mod tests {
         let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let meta = JsonRpcRequestProcessor::new_from_bank(
-            &bank,
+            bank,
             SocketAddrSpace::Unspecified,
             connection_cache,
         );
@@ -5108,7 +5108,7 @@ pub mod tests {
         let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let meta = JsonRpcRequestProcessor::new_from_bank(
-            &bank,
+            bank,
             SocketAddrSpace::Unspecified,
             connection_cache,
         );
@@ -5235,7 +5235,7 @@ pub mod tests {
 
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let meta = JsonRpcRequestProcessor::new_from_bank(
-            &bank,
+            bank,
             SocketAddrSpace::Unspecified,
             connection_cache,
         );
@@ -6381,7 +6381,7 @@ pub mod tests {
         let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let meta = JsonRpcRequestProcessor::new_from_bank(
-            &bank,
+            bank,
             SocketAddrSpace::Unspecified,
             connection_cache,
         );
@@ -8295,13 +8295,13 @@ pub mod tests {
 
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let optimistically_confirmed_bank =

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -873,7 +873,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
@@ -1001,7 +1001,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
@@ -1192,7 +1192,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bob = Keypair::new();
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1326,7 +1326,7 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let alice = Keypair::new();
 
@@ -1941,7 +1941,7 @@ pub(crate) mod tests {
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -1958,7 +1958,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -1975,7 +1975,7 @@ pub(crate) mod tests {
 
         bank2.process_transaction(&tx).unwrap();
 
-        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2136,7 +2136,7 @@ pub(crate) mod tests {
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2153,7 +2153,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2252,7 +2252,7 @@ pub(crate) mod tests {
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2269,7 +2269,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2372,7 +2372,7 @@ pub(crate) mod tests {
             })
         };
 
-        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2452,7 +2452,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let next_bank = Bank::new_from_parent(
-            &bank_forks.get(0).unwrap(),
+            bank_forks.get(0).unwrap(),
             &solana_sdk::pubkey::new_rand(),
             1,
         );
@@ -2757,9 +2757,9 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // we need a pubkey that will pass its rent collection slot so rent_epoch gets updated to max since this account is exempt

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -383,7 +383,7 @@ fn filter_account_result(
         if is_known_spl_token_id(account.owner())
             && params.encoding == UiAccountEncoding::JsonParsed
         {
-            get_parsed_token_account(bank, &params.pubkey, account)
+            get_parsed_token_account(&bank, &params.pubkey, account)
         } else {
             UiAccount::encode(&params.pubkey, &account, params.encoding, None, None)
         }

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -75,7 +75,11 @@ fn test_accounts_squash(bencher: &mut Bencher) {
     // merkle hash of the account state and distribution of fees and rent
     let mut slot = 1u64;
     bencher.iter(|| {
-        let next_bank = Arc::new(Bank::new_from_parent(prev_bank.clone(), &Pubkey::default(), slot));
+        let next_bank = Arc::new(Bank::new_from_parent(
+            prev_bank.clone(),
+            &Pubkey::default(),
+            slot,
+        ));
         next_bank.deposit(&pubkeys[0], 1).unwrap();
         next_bank.squash();
         slot += 1;

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -75,7 +75,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
     // merkle hash of the account state and distribution of fees and rent
     let mut slot = 1u64;
     bencher.iter(|| {
-        let next_bank = Arc::new(Bank::new_from_parent(&prev_bank, &Pubkey::default(), slot));
+        let next_bank = Arc::new(Bank::new_from_parent(prev_bank.clone(), &Pubkey::default(), slot));
         next_bank.deposit(&pubkeys[0], 1).unwrap();
         next_bank.squash();
         slot += 1;

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -134,7 +134,7 @@ fn do_bench_transactions(
     bank.add_mockup_builtin(Pubkey::from(BUILTIN_PROGRAM_ID), process_instruction);
     bank.add_builtin_account("solana_noop_program", &Pubkey::from(NOOP_PROGRAM_ID), false);
     let bank = Arc::new(bank);
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
     let transactions = create_transactions(&bank_client, &mint_keypair);
 
     // Do once to fund accounts, load modules, etc...
@@ -189,7 +189,7 @@ fn bench_bank_update_recent_blockhashes(bencher: &mut Bencher) {
     // Prime blockhash_queue
     for i in 0..(MAX_RECENT_BLOCKHASHES + 1) {
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
             (i + 1) as u64,
         ));

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -130,7 +130,7 @@ fn do_bench_transactions(
         Ok(())
     });
 
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 1);
     bank.add_mockup_builtin(Pubkey::from(BUILTIN_PROGRAM_ID), process_instruction);
     bank.add_builtin_account("solana_noop_program", &Pubkey::from(NOOP_PROGRAM_ID), false);
     let bank = Arc::new(bank);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -78,12 +78,12 @@ pub fn create_native_loader_transactions(
         .collect()
 }
 
-fn sync_bencher(bank: &Arc<Bank>, _bank_client: &BankClient, transactions: &[Transaction]) {
+fn sync_bencher(bank: &Bank, _bank_client: &BankClient, transactions: &[Transaction]) {
     let results = bank.process_transactions(transactions.iter());
     assert!(results.iter().all(Result::is_ok));
 }
 
-fn async_bencher(bank: &Arc<Bank>, bank_client: &BankClient, transactions: &[Transaction]) {
+fn async_bencher(bank: &Bank, bank_client: &BankClient, transactions: &[Transaction]) {
     for transaction in transactions.iter().cloned() {
         bank_client.async_send_transaction(transaction).unwrap();
     }
@@ -113,7 +113,7 @@ fn async_bencher(bank: &Arc<Bank>, bank_client: &BankClient, transactions: &[Tra
 #[allow(clippy::type_complexity)]
 fn do_bench_transactions(
     bencher: &mut Bencher,
-    bench_work: &dyn Fn(&Arc<Bank>, &BankClient, &[Transaction]),
+    bench_work: &dyn Fn(&Bank, &BankClient, &[Transaction]),
     create_transactions: &dyn Fn(&BankClient, &Keypair) -> Vec<Transaction>,
 ) {
     solana_logger::setup();

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -104,7 +104,7 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
     let bank = bank_forks.working_bank();
     let collector = solana_sdk::pubkey::new_rand();
     let banks = (1..=NUM_SLOTS)
-        .map(|n| Arc::new(Bank::new_from_parent(&bank, &collector, n as u64)))
+        .map(|n| Arc::new(Bank::new_from_parent(bank.clone(), &collector, n as u64)))
         .collect::<Vec<_>>();
 
     bencher.iter(|| {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -873,7 +873,7 @@ mod test {
         let mut genesis_config_info = create_genesis_config(10);
         genesis_config_info.genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
         bank.set_startup_verification_complete();
         // Need to set the EAH to Valid so that `Bank::new_from_parent()` doesn't panic during
         // freeze when parent is in the EAH calculation window.
@@ -905,10 +905,14 @@ mod test {
         // Also, incremental snapshots before slot 240 (the first full snapshot handled), will
         // actually be AHV since the last full snapshot slot will be `None`.  This is expected and
         // fine; but maybe unexpected for a reader/debugger without this additional context.
-        let make_banks = |mut bank: Arc<Bank>, num_banks| {
+        let mut make_banks = |num_banks| {
             for _ in 0..num_banks {
                 let slot = bank.slot() + 1;
-                bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
+                bank = Arc::new(Bank::new_from_parent(
+                    bank.clone(),
+                    &Pubkey::new_unique(),
+                    slot,
+                ));
 
                 // Since we're not using `BankForks::set_root()`, we have to handle sending the
                 // correct snapshot requests ourself.
@@ -922,7 +926,7 @@ mod test {
                 }
             }
         };
-        make_banks(bank.clone(), 303);
+        make_banks(303);
 
         // Ensure the EAH is handled 1st
         let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
@@ -985,7 +989,7 @@ mod test {
         //
         // This test differs from the one above by having an older full snapshot request that must
         // be handled before the new epoch accounts hash request.
-        make_banks(bank, 240);
+        make_banks(240);
 
         // Ensure the full snapshot is handled 1st
         let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -985,7 +985,7 @@ mod test {
         //
         // This test differs from the one above by having an older full snapshot request that must
         // be handled before the new epoch accounts hash request.
-        make_banks(bank.clone(), 240);
+        make_banks(bank, 240);
 
         // Ensure the full snapshot is handled 1st
         let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -908,11 +908,7 @@ mod test {
         let make_banks = |mut bank: Arc<Bank>, num_banks| {
             for _ in 0..num_banks {
                 let slot = bank.slot() + 1;
-                bank = Arc::new(Bank::new_from_parent(
-                    bank,
-                    &Pubkey::new_unique(),
-                    slot,
-                ));
+                bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
 
                 // Since we're not using `BankForks::set_root()`, we have to handle sending the
                 // correct snapshot requests ourself.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1172,7 +1172,7 @@ impl Bank {
     }
 
     /// Create a new bank that points to an immutable checkpoint of another bank.
-    pub fn new_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
+    pub fn new_from_parent(parent: Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
         Self::_new_from_parent(
             parent,
             collector_id,
@@ -1183,7 +1183,7 @@ impl Bank {
     }
 
     pub fn new_from_parent_with_options(
-        parent: &Arc<Bank>,
+        parent: Arc<Bank>,
         collector_id: &Pubkey,
         slot: Slot,
         new_bank_options: NewBankOptions,
@@ -1192,7 +1192,7 @@ impl Bank {
     }
 
     pub fn new_from_parent_with_tracer(
-        parent: &Arc<Bank>,
+        parent: Arc<Bank>,
         collector_id: &Pubkey,
         slot: Slot,
         reward_calc_tracer: impl RewardCalcTracer,
@@ -1281,7 +1281,7 @@ impl Bank {
     }
 
     fn _new_from_parent(
-        parent: &Arc<Bank>,
+        parent: Arc<Bank>,
         collector_id: &Pubkey,
         slot: Slot,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
@@ -1301,7 +1301,7 @@ impl Bank {
             accounts_db.insert_default_bank_hash_stats(slot, parent.slot());
             BankRc {
                 accounts: Arc::new(Accounts::new(accounts_db)),
-                parent: RwLock::new(Some(Arc::clone(parent))),
+                parent: RwLock::new(Some(Arc::clone(&parent))),
                 slot,
                 bank_id_generator: Arc::clone(&parent.rc.bank_id_generator),
             }
@@ -1721,7 +1721,7 @@ impl Bank {
     /// * Freezes the new bank, assuming that the user will `Bank::new_from_parent` from this bank
     /// * Calculates and sets the epoch accounts hash from the parent
     pub fn warp_from_parent(
-        parent: &Arc<Bank>,
+        parent: Arc<Bank>,
         collector_id: &Pubkey,
         slot: Slot,
         data_source: CalcAccountsHashDataSource,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -103,7 +103,7 @@ mod tests {
         genesis_config.epoch_schedule = EpochSchedule::custom(400, 400, false);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let eah_start_slot = epoch_accounts_hash_utils::calculation_start(&bank0);
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank0.squash();
 
         // Create an account on a non-root fork
@@ -118,7 +118,7 @@ mod tests {
         } else {
             0
         } + 2;
-        let bank2 = Bank::new_from_parent(&bank0, &Pubkey::default(), bank2_slot);
+        let bank2 = Bank::new_from_parent(bank0, &Pubkey::default(), bank2_slot);
 
         // Test new account
         let key2 = Keypair::new();
@@ -346,7 +346,7 @@ mod tests {
                 BankTestConfig::default(),
             ));
             bank0.squash();
-            let mut bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+            let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
 
             add_root_and_flush_write_cache(&bank0);
             bank.rc
@@ -448,7 +448,7 @@ mod tests {
             activate_all_features(&mut genesis_config);
 
             let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-            let mut bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+            let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
             while !bank.is_complete() {
                 bank.fill_bank_with_ticks_for_tests();
             }
@@ -538,7 +538,7 @@ mod tests {
             BankTestConfig::default(),
         ));
         bank0.squash();
-        let mut bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         add_root_and_flush_write_cache(&bank0);
         bank.rc
             .accounts

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -53,10 +53,11 @@ mod tests {
         assert!(bank0_sysvar_cache.get_slot_hashes().is_err());
         assert!(bank0_sysvar_cache.get_epoch_rewards().is_err()); // partitioned epoch reward feature is not enabled
 
+        let bank1_slot = bank0.slot() + 1;
         let bank1 = Arc::new(Bank::new_from_parent(
-            &bank0,
+            bank0.clone(),
             &Pubkey::default(),
-            bank0.slot() + 1,
+            bank1_slot,
         ));
 
         let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
@@ -77,7 +78,8 @@ mod tests {
         assert_ne!(bank0_cached_fees, bank1_cached_fees);
         assert_eq!(bank0_cached_rent, bank1_cached_rent);
 
-        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), bank1.slot() + 1);
+        let bank2_slot = bank1.slot() + 1;
+        let bank2 = Bank::new_from_parent(bank1.clone(), &Pubkey::default(), bank2_slot);
 
         let bank2_sysvar_cache = bank2.sysvar_cache.read().unwrap();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
@@ -107,7 +109,8 @@ mod tests {
     fn test_reset_and_fill_sysvar_cache() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let mut bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), bank0.slot() + 1);
+        let bank1_slot = bank0.slot() + 1;
+        let mut bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), bank1_slot);
 
         let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8730,7 +8730,7 @@ fn test_remove_unrooted_scan_then_recreate_same_slot_before_scan() {
          pubkeys_to_modify,
          program_id,
          starting_lamports| {
-            let mut prev_bank = bank0.clone();
+            let mut prev_bank = bank0;
             loop {
                 let start = Instant::now();
                 let (bank_at_fork_tip, slots_on_fork, ancestors) = setup_banks_on_fork_to_remove(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -611,7 +611,7 @@ fn store_accounts_for_rent_test(
     }
 }
 
-fn create_child_bank_for_rent_test(root_bank: &Arc<Bank>, genesis_config: &GenesisConfig) -> Bank {
+fn create_child_bank_for_rent_test(root_bank: &Bank, genesis_config: &GenesisConfig) -> Bank {
     let mut bank = Bank::new_from_parent(
         root_bank,
         &Pubkey::default(),
@@ -1902,7 +1902,7 @@ fn test_rent_eager_collect_rent_in_partition() {
     );
 }
 
-fn new_from_parent_next_epoch(parent: &Arc<Bank>, epochs: Epoch) -> Bank {
+fn new_from_parent_next_epoch(parent: &Bank, epochs: Epoch) -> Bank {
     let mut slot = parent.slot();
     let mut epoch = parent.epoch();
     for _ in 0..epochs {
@@ -3413,7 +3413,7 @@ fn test_bank_pay_to_self() {
         .unwrap();
 }
 
-fn new_from_parent(parent: &Arc<Bank>) -> Bank {
+fn new_from_parent(parent: &Bank) -> Bank {
     Bank::new_from_parent(parent, &Pubkey::default(), parent.slot() + 1)
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1752,11 +1752,7 @@ fn test_rent_eager_under_fixed_cycle_for_development() {
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (3, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(224, 225, 432_000)]);
 
-    bank = Arc::new(Bank::new_from_parent(
-        bank,
-        &Pubkey::default(),
-        432_000 - 2,
-    ));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 432_000 - 2));
     bank = Arc::new(new_from_parent(bank));
     assert_eq!(
         bank.rent_collection_partitions(),
@@ -11702,20 +11698,12 @@ fn test_accounts_data_size_and_rent_collection() {
         activate_all_features(&mut genesis_config);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let slot = bank.slot() + bank.slot_count_per_normal_epoch();
-        let bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            slot,
-        ));
+        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
         // make another bank so that any reclaimed accounts from the previous bank do not impact
         // this test
         let slot = bank.slot() + bank.slot_count_per_normal_epoch();
-        let bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            slot,
-        ));
+        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
         // Store an account into the bank that is rent-paying and has data
         let data_size = 123;
@@ -11781,11 +11769,7 @@ fn test_accounts_data_size_from_genesis() {
     // Create accounts over a number of banks and ensure the accounts data size remains correct
     for _ in 0..10 {
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            slot,
-        ));
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
         // Store an account into the bank that is rent-exempt and has data
         let data_size = rand::thread_rng().gen_range(3333, 4444);
@@ -12212,11 +12196,7 @@ fn test_bank_verify_accounts_hash_with_base() {
     // make some banks, do some transactions, ensure there's some zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::new_unique(),
-            slot,
-        ));
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
         do_transfers(&bank);
     }
 
@@ -12230,11 +12210,7 @@ fn test_bank_verify_accounts_hash_with_base() {
     // make more banks, do more transactions, ensure there's more zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::new_unique(),
-            slot,
-        ));
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
         do_transfers(&bank);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -223,7 +223,7 @@ fn test_bank_unix_timestamp_from_genesis() {
             * genesis_config.ticks_per_slot as f32);
 
     for _i in 0..slots_per_sec as usize + 1 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     assert!(bank.unix_timestamp_from_genesis() - genesis_config.creation_time >= 1);
@@ -280,7 +280,7 @@ fn create_simple_test_arc_bank(lamports: u64) -> Arc<Bank> {
 fn test_bank_block_height() {
     let bank0 = create_simple_test_arc_bank(1);
     assert_eq!(bank0.block_height(), 0);
-    let bank1 = Arc::new(new_from_parent(&bank0));
+    let bank1 = Arc::new(new_from_parent(bank0));
     assert_eq!(bank1.block_height(), 1);
 }
 
@@ -382,7 +382,7 @@ fn test_bank_capitalization() {
         42 * 42 + genesis_sysvar_and_builtin_program_lamports() + bank0_sysvar_delta(),
     );
 
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     assert_eq!(
         bank1.capitalization(),
         42 * 42
@@ -417,10 +417,10 @@ fn test_credit_debit_rent_no_side_effect_on_hash() {
             genesis_config.ticks_per_slot,
         ) as u64;
         let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let bank = Bank::new_from_parent(&root_bank, &Pubkey::default(), slot);
+        let bank = Bank::new_from_parent(root_bank, &Pubkey::default(), slot);
 
         let root_bank_2 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let bank_with_success_txs = Bank::new_from_parent(&root_bank_2, &Pubkey::default(), slot);
+        let bank_with_success_txs = Bank::new_from_parent(root_bank_2, &Pubkey::default(), slot);
 
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
@@ -611,7 +611,7 @@ fn store_accounts_for_rent_test(
     }
 }
 
-fn create_child_bank_for_rent_test(root_bank: &Bank, genesis_config: &GenesisConfig) -> Bank {
+fn create_child_bank_for_rent_test(root_bank: Arc<Bank>, genesis_config: &GenesisConfig) -> Bank {
     let mut bank = Bank::new_from_parent(
         root_bank,
         &Pubkey::default(),
@@ -1201,7 +1201,7 @@ fn test_rent_exempt_executable_account() {
     genesis_config.rent = rent_with_exemption_threshold(1000.0);
 
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank = create_child_bank_for_rent_test(&root_bank, &genesis_config);
+    let bank = create_child_bank_for_rent_test(root_bank, &genesis_config);
 
     let account_pubkey = solana_sdk::pubkey::new_rand();
     let account_balance = 1;
@@ -1270,7 +1270,7 @@ fn test_rent_complex() {
     // we must ensure lazy rent collection doens't get broken!
     root_bank.restore_old_behavior_for_fragile_tests();
     let root_bank = Arc::new(root_bank);
-    let mut bank = create_child_bank_for_rent_test(&root_bank, &genesis_config);
+    let mut bank = create_child_bank_for_rent_test(root_bank, &genesis_config);
     bank.add_mockup_builtin(mock_program_id, process_instruction);
 
     assert_eq!(bank.last_blockhash(), genesis_config.hash());
@@ -1457,13 +1457,13 @@ fn test_rent_eager_across_epoch_without_gap() {
     let mut bank = create_simple_test_arc_bank(1);
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 32)]);
     for _ in 2..32 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(bank.rent_collection_partitions(), vec![(30, 31, 32)]);
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 64)]);
 }
 
@@ -1476,13 +1476,13 @@ fn test_rent_eager_across_epoch_without_gap_mnb() {
     let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
     assert_eq!(test_rent_collection_partitions(&bank), vec![(0, 0, 32)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(test_rent_collection_partitions(&bank), vec![(0, 1, 32)]);
     for _ in 2..32 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(test_rent_collection_partitions(&bank), vec![(30, 31, 32)]);
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(test_rent_collection_partitions(&bank), vec![(0, 0, 64)]);
 }
 
@@ -1494,18 +1494,18 @@ fn test_rent_eager_across_epoch_with_full_gap() {
     let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 32)]);
     for _ in 2..15 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(bank.rent_collection_partitions(), vec![(13, 14, 32)]);
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 49));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 49));
     assert_eq!(
         bank.rent_collection_partitions(),
         vec![(14, 31, 32), (0, 0, 64), (0, 17, 64)]
     );
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(17, 18, 64)]);
 }
 
@@ -1517,18 +1517,18 @@ fn test_rent_eager_across_epoch_with_half_gap() {
     let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 32)]);
     for _ in 2..15 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(bank.rent_collection_partitions(), vec![(13, 14, 32)]);
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 32));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 32));
     assert_eq!(
         bank.rent_collection_partitions(),
         vec![(14, 31, 32), (0, 0, 64)]
     );
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 64)]);
 }
 
@@ -1552,30 +1552,30 @@ fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 432_000)]);
 
     for _ in 2..32 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 31));
     assert_eq!(bank.rent_collection_partitions(), vec![(30, 31, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(31, 32, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(32, 33, 432_000)]);
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1000));
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1001));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 1000));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 1001));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (31, 9));
     assert_eq!(
@@ -1583,8 +1583,8 @@ fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
         vec![(1000, 1001, 432_000)]
     );
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 431_998));
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 431_999));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 431_998));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 431_999));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (13499, 31));
     assert_eq!(
@@ -1592,12 +1592,12 @@ fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
         vec![(431_998, 431_999, 432_000)]
     );
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (13500, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (13500, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 432_000)]);
@@ -1622,19 +1622,19 @@ fn test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle() {
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 432_000)]);
 
     for _ in 2..19 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 18));
     assert_eq!(bank.rent_collection_partitions(), vec![(17, 18, 432_000)]);
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 44));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 44));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1, 12));
     assert_eq!(
@@ -1642,13 +1642,13 @@ fn test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle() {
         vec![(18, 31, 432_000), (31, 31, 432_000), (31, 44, 432_000)]
     );
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1, 13));
     assert_eq!(bank.rent_collection_partitions(), vec![(44, 45, 432_000)]);
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 431_993));
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 432_011));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 431_993));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 432_011));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (13500, 11));
     assert_eq!(
@@ -1681,29 +1681,29 @@ fn test_rent_eager_with_warmup_epochs_under_multi_epoch_cycle() {
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 222));
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 222));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 128);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (2, 127));
     assert_eq!(bank.rent_collection_partitions(), vec![(126, 127, 128)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (3, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 431_872)]);
     assert_eq!(431_872 % bank.get_slots_in_epoch(bank.epoch()), 0);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (3, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 431_872)]);
 
     bank = Arc::new(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         431_872 + 223 - 1,
     ));
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1689, 255));
     assert_eq!(
@@ -1711,7 +1711,7 @@ fn test_rent_eager_with_warmup_epochs_under_multi_epoch_cycle() {
         vec![(431_870, 431_871, 431_872)]
     );
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (1690, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 431_872)]);
@@ -1736,44 +1736,44 @@ fn test_rent_eager_under_fixed_cycle_for_development() {
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 432_000)]);
 
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 222));
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 222));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 128);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (2, 127));
     assert_eq!(bank.rent_collection_partitions(), vec![(222, 223, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (3, 0));
     assert_eq!(bank.rent_collection_partitions(), vec![(223, 224, 432_000)]);
 
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 256);
     assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (3, 1));
     assert_eq!(bank.rent_collection_partitions(), vec![(224, 225, 432_000)]);
 
     bank = Arc::new(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         432_000 - 2,
     ));
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(
         bank.rent_collection_partitions(),
         vec![(431_998, 431_999, 432_000)]
     );
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 432_000)]);
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 432_000)]);
 
     bank = Arc::new(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         864_000 - 20,
     ));
     bank = Arc::new(Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         864_000 + 39,
     ));
@@ -1843,7 +1843,7 @@ fn test_rent_eager_collect_rent_in_partition() {
     let ancestors = vec![(some_slot, 0), (0, 1)].into_iter().collect();
 
     let previous_epoch = bank.epoch();
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), some_slot));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), some_slot));
     let current_epoch = bank.epoch();
     assert_eq!(previous_epoch + 1, current_epoch);
 
@@ -1902,7 +1902,7 @@ fn test_rent_eager_collect_rent_in_partition() {
     );
 }
 
-fn new_from_parent_next_epoch(parent: &Bank, epochs: Epoch) -> Bank {
+fn new_from_parent_next_epoch(parent: Arc<Bank>, epochs: Epoch) -> Bank {
     let mut slot = parent.slot();
     let mut epoch = parent.epoch();
     for _ in 0..epochs {
@@ -1922,7 +1922,7 @@ fn test_collect_rent_from_accounts() {
         let zero_lamport_pubkey = Pubkey::from([0; 32]);
 
         let genesis_bank = create_simple_test_arc_bank(100000);
-        let mut first_bank = new_from_parent(&genesis_bank);
+        let mut first_bank = new_from_parent(genesis_bank.clone());
         if skip_rewrites {
             first_bank.activate_feature(&feature_set::skip_rent_rewrites::id());
         }
@@ -1931,7 +1931,7 @@ fn test_collect_rent_from_accounts() {
         let first_slot = 1;
         assert_eq!(first_slot, first_bank.slot());
         let epoch_delta = 4;
-        let later_bank = Arc::new(new_from_parent_next_epoch(&first_bank, epoch_delta)); // a bank a few epochs in the future
+        let later_bank = Arc::new(new_from_parent_next_epoch(first_bank, epoch_delta)); // a bank a few epochs in the future
         let later_slot = later_bank.slot();
         assert!(later_bank.epoch() == genesis_bank.epoch() + epoch_delta);
 
@@ -1972,8 +1972,8 @@ fn test_rent_eager_collect_rent_zero_lamport_deterministic() {
 
     let genesis_bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
     let genesis_bank2 = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank1_with_zero = Arc::new(new_from_parent(&genesis_bank1));
-    let bank1_without_zero = Arc::new(new_from_parent(&genesis_bank2));
+    let bank1_with_zero = Arc::new(new_from_parent(genesis_bank1.clone()));
+    let bank1_without_zero = Arc::new(new_from_parent(genesis_bank2));
 
     let zero_lamports = 0;
     let data_size = 12345; // use non-zero data size to also test accounts_data_size
@@ -1997,13 +1997,13 @@ fn test_rent_eager_collect_rent_zero_lamport_deterministic() {
     // genesis_config.epoch_schedule.slots_per_epoch == 432_000 and is unsuitable for this test
     let some_slot = MINIMUM_SLOTS_PER_EPOCH; // 1 epoch
     let bank2_with_zero = Arc::new(Bank::new_from_parent(
-        &bank1_with_zero,
+        bank1_with_zero.clone(),
         &Pubkey::default(),
         some_slot,
     ));
     assert_eq!(bank1_with_zero.epoch() + 1, bank2_with_zero.epoch());
     let bank2_without_zero = Arc::new(Bank::new_from_parent(
-        &bank1_without_zero,
+        bank1_without_zero.clone(),
         &Pubkey::default(),
         some_slot,
     ));
@@ -2109,7 +2109,7 @@ where
 
     // put a child bank in epoch 1, which calls update_rewards()...
     let bank1 = Bank::new_from_parent(
-        &bank0,
+        bank0.clone(),
         &Pubkey::default(),
         bank0.get_slots_in_epoch(bank0.epoch()) + 1,
     );
@@ -2231,7 +2231,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
 
     // put a child bank in epoch 1, which calls update_rewards()...
     let bank1 = Bank::new_from_parent(
-        &bank,
+        bank.clone(),
         &Pubkey::default(),
         bank.get_slots_in_epoch(bank.epoch()) + 1,
     );
@@ -2304,7 +2304,7 @@ fn test_purge_empty_accounts() {
             bank.process_transaction(&tx).unwrap();
             bank.freeze();
             bank.squash();
-            bank = Arc::new(new_from_parent(&bank));
+            bank = Arc::new(new_from_parent(bank));
         }
 
         bank.freeze();
@@ -2314,13 +2314,13 @@ fn test_purge_empty_accounts() {
         bank.clean_accounts_for_tests();
         assert_eq!(bank.update_accounts_hash_for_tests(), hash);
 
-        let bank0 = Arc::new(new_from_parent(&bank));
+        let bank0 = Arc::new(new_from_parent(bank.clone()));
         let blockhash = bank.last_blockhash();
         let keypair = Keypair::new();
         let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), amount, blockhash);
         bank0.process_transaction(&tx).unwrap();
 
-        let bank1 = Arc::new(new_from_parent(&bank0));
+        let bank1 = Arc::new(new_from_parent(bank0.clone()));
         let pubkey = solana_sdk::pubkey::new_rand();
         let blockhash = bank.last_blockhash();
         let tx = system_transaction::transfer(&keypair, &pubkey, amount, blockhash);
@@ -2573,7 +2573,7 @@ fn test_executed_transaction_count_post_bank_transaction_count_fix() {
 
     let bank = Arc::new(bank);
     let bank2 = Bank::new_from_parent(
-        &bank,
+        bank,
         &Pubkey::default(),
         genesis_config.epoch_schedule.first_normal_slot,
     );
@@ -2622,7 +2622,7 @@ fn test_transfer_to_sysvar() {
     assert_eq!(bank.get_balance(&normal_pubkey), amount);
     assert_eq!(bank.get_balance(&sysvar_pubkey), 1_169_280);
 
-    let bank = Arc::new(new_from_parent(&bank));
+    let bank = Arc::new(new_from_parent(bank));
     assert_eq!(bank.get_balance(&normal_pubkey), amount);
     assert_eq!(bank.get_balance(&sysvar_pubkey), 1_169_280);
 }
@@ -2773,7 +2773,7 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2886,7 +2886,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2942,13 +2942,13 @@ fn test_bank_blockhash_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
     goto_end_of_slot(&mut bank);
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent(&Arc::new(bank), &leader, 2);
+    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -2994,13 +2994,13 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
     goto_end_of_slot(&mut bank);
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent(&Arc::new(bank), &leader, 2);
+    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -3413,8 +3413,10 @@ fn test_bank_pay_to_self() {
         .unwrap();
 }
 
-fn new_from_parent(parent: &Bank) -> Bank {
-    Bank::new_from_parent(parent, &Pubkey::default(), parent.slot() + 1)
+fn new_from_parent(parent: Arc<Bank>) -> Bank {
+    let slot = parent.slot() + 1;
+    let collector_id = Pubkey::default();
+    Bank::new_from_parent(parent, &collector_id, slot)
 }
 
 /// Verify that the parent's vector is computed correctly
@@ -3423,7 +3425,7 @@ fn test_bank_parents() {
     let (genesis_config, _) = create_genesis_config(1);
     let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
-    let bank = new_from_parent(&parent);
+    let bank = new_from_parent(parent.clone());
     assert!(Arc::ptr_eq(&bank.parents()[0], &parent));
 }
 
@@ -3472,7 +3474,7 @@ fn test_bank_parent_already_processed() {
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent(&parent);
+    let bank = new_from_parent(parent);
     assert_eq!(
         bank.process_transaction(&tx),
         Err(TransactionError::AlreadyProcessed)
@@ -3491,7 +3493,7 @@ fn test_bank_parent_account_spend() {
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent(&parent);
+    let bank = new_from_parent(parent.clone());
     let tx = system_transaction::transfer(&key1, &key2.pubkey(), amount, genesis_config.hash());
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(parent.get_signature_status(&tx.signatures[0]), None);
@@ -3514,7 +3516,7 @@ fn test_bank_hash_internal_state() {
 
     // Checkpointing should always result in a new state
     let bank1 = Arc::new(bank1);
-    let bank2 = new_from_parent(&bank1);
+    let bank2 = new_from_parent(bank1.clone());
     assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
     let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -3542,7 +3544,7 @@ fn test_bank_hash_internal_state_verify() {
         let bank0_state = bank0.hash_internal_state();
         let bank0 = Arc::new(bank0);
         // Checkpointing should result in a new state while freezing the parent
-        let bank2 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1);
+        let bank2 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 1);
         assert_ne!(bank0_state, bank2.hash_internal_state());
         // Checkpointing should modify the checkpoint's state when freezed
         assert_ne!(bank0_state, bank0.hash_internal_state());
@@ -3556,7 +3558,7 @@ fn test_bank_hash_internal_state_verify() {
             bank2.update_accounts_hash_for_tests();
             assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
         }
-        let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
+        let bank3 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set the bank hash in the pass==0 if above
@@ -3622,7 +3624,7 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
     let amount = genesis_config.rent.minimum_balance(0);
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     let initial_state = bank0.hash_internal_state();
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
     assert_ne!(bank1.hash_internal_state(), initial_state);
 
     info!("transfer bank1");
@@ -3632,7 +3634,7 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
 
     info!("transfer bank2");
     // bank2 should not hash the same as bank1
-    let bank2 = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
+    let bank2 = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
     bank2.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_ne!(bank2.hash_internal_state(), initial_state);
     assert_ne!(bank1.hash_internal_state(), bank2.hash_internal_state());
@@ -3695,7 +3697,7 @@ fn test_bank_hash_internal_state_squash() {
     // save hash0 because new_from_parent
     // updates sysvar entries
 
-    let bank1 = Bank::new_from_parent(&bank0, &collector_id, 1);
+    let bank1 = Bank::new_from_parent(bank0, &collector_id, 1);
 
     // no delta in bank1, hashes should always update
     assert_ne!(hash0, bank1.hash_internal_state());
@@ -3728,7 +3730,7 @@ fn test_bank_squash() {
     );
 
     trace!("new from parent");
-    let bank = new_from_parent(&parent);
+    let bank = new_from_parent(parent.clone());
     trace!("done new from parent");
     assert_eq!(
         bank.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
@@ -3790,7 +3792,7 @@ fn test_bank_get_account_in_parent_after_squash() {
         .transfer(amount, &mint_keypair, &key1.pubkey())
         .unwrap();
     assert_eq!(parent.get_balance(&key1.pubkey()), amount);
-    let bank = new_from_parent(&parent);
+    let bank = new_from_parent(parent.clone());
     bank.squash();
     assert_eq!(parent.get_balance(&key1.pubkey()), amount);
 }
@@ -3809,15 +3811,15 @@ fn test_bank_get_account_in_parent_after_squash2() {
         .unwrap();
     assert_eq!(bank0.get_balance(&key1.pubkey()), amount);
 
-    let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+    let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
     bank1
         .transfer(3 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank2 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 2));
+    let bank2 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 2));
     bank2
         .transfer(2 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank3 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 3));
+    let bank3 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 3));
     bank1.squash();
 
     // This picks up the values from 1 which is the highest root:
@@ -3829,16 +3831,16 @@ fn test_bank_get_account_in_parent_after_squash2() {
     bank3.squash();
     assert_eq!(bank1.get_balance(&key1.pubkey()), 4 * amount);
 
-    let bank4 = Arc::new(Bank::new_from_parent(&bank3, &Pubkey::default(), 4));
+    let bank4 = Arc::new(Bank::new_from_parent(bank3.clone(), &Pubkey::default(), 4));
     bank4
         .transfer(4 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
     assert_eq!(bank4.get_balance(&key1.pubkey()), 8 * amount);
     assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
     bank4.squash();
-    let bank5 = Arc::new(Bank::new_from_parent(&bank4, &Pubkey::default(), 5));
+    let bank5 = Arc::new(Bank::new_from_parent(bank4.clone(), &Pubkey::default(), 5));
     bank5.squash();
-    let bank6 = Arc::new(Bank::new_from_parent(&bank5, &Pubkey::default(), 6));
+    let bank6 = Arc::new(Bank::new_from_parent(bank5, &Pubkey::default(), 6));
     bank6.squash();
 
     // This picks up the values from 4 which is the highest root:
@@ -3864,7 +3866,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     assert_eq!(account.lamports(), amount);
     assert_eq!(slot, 0);
 
-    let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 1));
+    let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 1));
     assert!(bank2
         .get_account_modified_since_parent_with_fixed_root(&pubkey)
         .is_none());
@@ -3882,7 +3884,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
     bank1.squash();
 
-    let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+    let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
     assert_eq!(
         None,
         bank3.get_account_modified_since_parent_with_fixed_root(&pubkey)
@@ -3978,7 +3980,7 @@ fn test_bank_update_sysvar_account() {
         }
 
         // Updating should increment the clock's slot
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 1));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 1));
         add_root_and_flush_write_cache(&bank1);
         assert_capitalization_diff(
             &bank2,
@@ -4117,7 +4119,7 @@ fn test_bank_epoch_vote_accounts() {
 
     // child crosses epoch boundary and is the first slot in the epoch
     let child = Bank::new_from_parent(
-        &parent,
+        parent.clone(),
         &leader_pubkey,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH),
     );
@@ -4136,7 +4138,7 @@ fn test_bank_epoch_vote_accounts() {
     // child crosses epoch boundary but isn't the first slot in the epoch, still
     //  makes an epoch stakes snapshot at 1
     let child = Bank::new_from_parent(
-        &parent,
+        parent,
         &leader_pubkey,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH) + 1,
     );
@@ -4200,7 +4202,7 @@ fn test_is_delta_true() {
     assert_eq!(bank.process_transaction(&tx_transfer_mint_to_1), Ok(()));
     assert!(bank.is_delta.load(Relaxed));
 
-    let bank1 = new_from_parent(&bank);
+    let bank1 = new_from_parent(bank.clone());
     let hash1 = bank1.hash_internal_state();
     assert!(!bank1.is_delta.load(Relaxed));
     assert_ne!(hash1, bank.hash());
@@ -4237,12 +4239,12 @@ fn test_bank_inherit_tx_count() {
 
     // Bank 1
     let bank1 = Arc::new(Bank::new_from_parent(
-        &bank0,
+        bank0.clone(),
         &solana_sdk::pubkey::new_rand(),
         1,
     ));
     // Bank 2
-    let bank2 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
+    let bank2 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 2);
 
     // transfer a token
     assert_eq!(
@@ -4271,7 +4273,7 @@ fn test_bank_inherit_tx_count() {
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
-    let bank6 = Bank::new_from_parent(&bank1, &solana_sdk::pubkey::new_rand(), 3);
+    let bank6 = Bank::new_from_parent(bank1.clone(), &solana_sdk::pubkey::new_rand(), 3);
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
     assert_eq!(bank6.transaction_count(), 1);
@@ -4290,7 +4292,7 @@ fn test_bank_inherit_fee_rate_governor() {
         .target_lamports_per_signature = 123;
 
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank1 = Arc::new(new_from_parent(&bank0));
+    let bank1 = Arc::new(new_from_parent(bank0.clone()));
     assert_eq!(
         bank0.fee_rate_governor.target_lamports_per_signature / 2,
         bank1
@@ -4493,7 +4495,7 @@ fn test_bank_get_program_accounts() {
         "no sysvars found"
     );
 
-    let bank0 = Arc::new(new_from_parent(&parent));
+    let bank0 = Arc::new(new_from_parent(parent));
     let pubkey0 = solana_sdk::pubkey::new_rand();
     let program_id = Pubkey::from([2; 32]);
     let account0 = AccountSharedData::new(1, 0, &program_id);
@@ -4504,7 +4506,7 @@ fn test_bank_get_program_accounts() {
         vec![(pubkey0, account0.clone())]
     );
 
-    let bank1 = Arc::new(new_from_parent(&bank0));
+    let bank1 = Arc::new(new_from_parent(bank0.clone()));
     bank1.squash();
     assert_eq!(
         bank0
@@ -4523,7 +4525,7 @@ fn test_bank_get_program_accounts() {
         vec![]
     );
 
-    let bank2 = Arc::new(new_from_parent(&bank1));
+    let bank2 = Arc::new(new_from_parent(bank1.clone()));
     let pubkey1 = solana_sdk::pubkey::new_rand();
     let account1 = AccountSharedData::new(3, 0, &program_id);
     bank2.store_account(&pubkey1, &account1);
@@ -4532,7 +4534,7 @@ fn test_bank_get_program_accounts() {
     let account2 = AccountSharedData::new(0, 0, &program_id);
     bank2.store_account(&pubkey2, &account2);
 
-    let bank3 = Arc::new(new_from_parent(&bank2));
+    let bank3 = Arc::new(new_from_parent(bank2));
     bank3.squash();
     assert_eq!(
         bank1
@@ -4609,7 +4611,7 @@ fn test_get_filtered_indexed_accounts() {
     // demonstrates the need for a redundant post-processing filter.
     let another_program_id = Pubkey::new_unique();
     let new_account = AccountSharedData::new(1, 0, &another_program_id);
-    let bank = Arc::new(new_from_parent(&bank));
+    let bank = Arc::new(new_from_parent(bank));
     bank.store_account(&address, &new_account);
     let indexed_accounts = bank
         .get_filtered_indexed_accounts(
@@ -4658,14 +4660,14 @@ fn test_get_filtered_indexed_accounts() {
 fn test_status_cache_ancestors() {
     solana_logger::setup();
     let parent = create_simple_test_arc_bank(500);
-    let bank1 = Arc::new(new_from_parent(&parent));
+    let bank1 = Arc::new(new_from_parent(parent));
     let mut bank = bank1;
     for _ in 0..MAX_CACHE_ENTRIES * 2 {
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
         bank.squash();
     }
 
-    let bank = new_from_parent(&bank);
+    let bank = new_from_parent(bank);
     assert_eq!(
         bank.status_cache_ancestors(),
         (bank.slot() - MAX_CACHE_ENTRIES as u64..=bank.slot()).collect::<Vec<_>>()
@@ -4764,7 +4766,7 @@ fn test_add_duplicate_static_program() {
     );
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
 
     let vote_loader_account = bank.get_account(&solana_vote_program::id()).unwrap();
     bank.add_mockup_builtin(solana_vote_program::id(), process_instruction);
@@ -4887,7 +4889,7 @@ fn test_recent_blockhashes_sysvar() {
         // Check order
         assert!(bank.is_hash_valid_for_age(&most_recent_hash, 0));
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 }
 
@@ -4912,7 +4914,7 @@ fn test_hash_internal_state_unchanged() {
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     bank0.freeze();
     let bank0_hash = bank0.hash();
-    let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank1.freeze();
     let bank1_hash = bank1.hash();
     // Checkpointing should always result in a new state
@@ -4923,7 +4925,7 @@ fn test_hash_internal_state_unchanged() {
 fn test_hash_internal_state_unchanged_with_ticks() {
     let (genesis_config, _) = create_genesis_config(500);
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank1 = new_from_parent(&bank);
+    let bank1 = new_from_parent(bank);
     let hash1 = bank1.hash_internal_state();
     // ticks don't change its state even if a slot boundary is crossed
     // because blockhashes are only recorded at block boundaries
@@ -4965,7 +4967,7 @@ fn test_banks_leak() {
     );
     loop {
         num_banks += 1;
-        bank = std::sync::Arc::new(new_from_parent(&bank));
+        bank = std::sync::Arc::new(new_from_parent(bank));
         if num_banks % 100 == 0 {
             #[cfg(target_os = "linux")]
             {
@@ -5055,7 +5057,7 @@ where
     // initializing our nonce accounts
     for _ in 0..2 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let (custodian_keypair, nonce_keypair) = nonce_setup(
@@ -5069,7 +5071,7 @@ where
     // The setup nonce is not valid to be used until the next bank
     // so wait one more block
     goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-    bank = Arc::new(new_from_parent(&bank));
+    bank = Arc::new(new_from_parent(bank));
 
     Ok((bank, mint_keypair, custodian_keypair, nonce_keypair))
 }
@@ -5324,7 +5326,7 @@ fn test_nonce_transaction() {
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     /* Expect a non-Nonce transfer to fail */
@@ -5393,7 +5395,7 @@ fn test_nonce_transaction() {
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let nonce_tx = Transaction::new_signed_with_payer(
@@ -5451,7 +5453,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     /* Expect a non-Nonce transfer to fail */
@@ -5520,7 +5522,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let nonce_tx = Transaction::new_signed_with_payer(
@@ -5588,7 +5590,7 @@ fn test_nonce_authority() {
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let nonce_tx = Transaction::new_signed_with_payer(
@@ -5646,7 +5648,7 @@ fn test_nonce_payer() {
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let nonce_tx = Transaction::new_signed_with_payer(
@@ -5711,7 +5713,7 @@ fn test_nonce_payer_tx_wide_cap() {
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     let nonce_tx = Transaction::new_signed_with_payer(
@@ -5779,7 +5781,7 @@ fn test_nonce_fee_calculator_updates() {
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     // Nonce transfer
@@ -5847,7 +5849,7 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 
     // Nonce transfer
@@ -5927,7 +5929,7 @@ fn test_check_ro_durable_nonce_fails() {
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
     // Caught by the runtime because it is a nonce transaction
     assert_eq!(
@@ -5946,7 +5948,7 @@ fn test_check_ro_durable_nonce_fails() {
 #[test]
 fn test_collect_balances() {
     let parent = create_simple_test_arc_bank(500);
-    let bank0 = Arc::new(new_from_parent(&parent));
+    let bank0 = Arc::new(new_from_parent(parent));
 
     let keypair = Keypair::new();
     let pubkey0 = solana_sdk::pubkey::new_rand();
@@ -5996,7 +5998,7 @@ fn test_pre_post_transaction_balances() {
     let fee_rate_governor = FeeRateGovernor::new(5000, 0);
     genesis_config.fee_rate_governor = fee_rate_governor;
     let parent = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank0 = Arc::new(new_from_parent(&parent));
+    let bank0 = Arc::new(new_from_parent(parent));
 
     let keypair0 = Keypair::new();
     let keypair1 = Keypair::new();
@@ -6192,7 +6194,7 @@ fn test_account_ids_after_program_ids() {
     tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
 
     bank.add_mockup_builtin(solana_vote_program::id(), process_instruction);
     let result = bank.process_transaction(&tx);
@@ -6209,7 +6211,7 @@ fn test_incinerator() {
 
     // Move to the first normal slot so normal rent behaviour applies
     let bank = Bank::new_from_parent(
-        &bank0,
+        bank0,
         &Pubkey::default(),
         genesis_config.epoch_schedule.first_normal_slot,
     );
@@ -6350,7 +6352,7 @@ fn test_ref_account_key_after_program_id() {
     ];
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
 
     bank.add_mockup_builtin(solana_vote_program::id(), process_instruction);
 
@@ -6573,7 +6575,7 @@ fn test_bank_hash_consistency() {
             );
             break;
         }
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
     }
 }
 
@@ -6674,7 +6676,7 @@ fn test_clean_nonrooted() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let mut bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+    let mut bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
     bank1.deposit(&pubkey0, some_lamports).unwrap();
     goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank1).unwrap());
     bank1.freeze();
@@ -6684,7 +6686,7 @@ fn test_clean_nonrooted() {
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
     // bank2's parent is bank0
-    let mut bank2 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 2));
+    let mut bank2 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 2));
     bank2.deposit(&pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account_zero);
     goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank2).unwrap());
@@ -6699,7 +6701,7 @@ fn test_clean_nonrooted() {
     // candidate set
     bank2.clean_accounts_for_tests();
 
-    let mut bank3 = Arc::new(Bank::new_from_parent(&bank2, &Pubkey::default(), 3));
+    let mut bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
     bank3.deposit(&pubkey1, some_lamports + 1).unwrap();
     goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank3).unwrap());
     bank3.freeze();
@@ -6753,7 +6755,7 @@ fn test_shrink_candidate_slots_cached() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let mut bank1 = Arc::new(new_from_parent(&bank0));
+    let mut bank1 = Arc::new(new_from_parent(bank0));
     bank1.deposit(&pubkey1, some_lamports).unwrap();
     bank1.deposit(&pubkey2, some_lamports).unwrap();
     goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank1).unwrap());
@@ -6764,7 +6766,7 @@ fn test_shrink_candidate_slots_cached() {
     bank1.force_flush_accounts_cache();
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
-    let mut bank2 = Arc::new(new_from_parent(&bank1));
+    let mut bank2 = Arc::new(new_from_parent(bank1));
     bank2.deposit(&pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account0);
     goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank2).unwrap());
@@ -6802,7 +6804,7 @@ fn test_add_builtin_no_overwrite() {
     let program_id = solana_sdk::pubkey::new_rand();
 
     let mut bank = Arc::new(Bank::new_from_parent(
-        &create_simple_test_arc_bank(100_000),
+        create_simple_test_arc_bank(100_000),
         &Pubkey::default(),
         slot,
     ));
@@ -6813,7 +6815,7 @@ fn test_add_builtin_no_overwrite() {
         .add_mockup_builtin(program_id, process_instruction);
     assert_eq!(bank.get_account_modified_slot(&program_id).unwrap().1, slot);
 
-    let mut bank = Arc::new(new_from_parent(&bank));
+    let mut bank = Arc::new(new_from_parent(bank));
     Arc::get_mut(&mut bank)
         .unwrap()
         .add_mockup_builtin(program_id, process_instruction);
@@ -6826,7 +6828,7 @@ fn test_add_builtin_loader_no_overwrite() {
     let loader_id = solana_sdk::pubkey::new_rand();
 
     let mut bank = Arc::new(Bank::new_from_parent(
-        &create_simple_test_arc_bank(100_000),
+        create_simple_test_arc_bank(100_000),
         &Pubkey::default(),
         slot,
     ));
@@ -6837,7 +6839,7 @@ fn test_add_builtin_loader_no_overwrite() {
         .add_mockup_builtin(loader_id, process_instruction);
     assert_eq!(bank.get_account_modified_slot(&loader_id).unwrap().1, slot);
 
-    let mut bank = Arc::new(new_from_parent(&bank));
+    let mut bank = Arc::new(new_from_parent(bank));
     Arc::get_mut(&mut bank)
         .unwrap()
         .add_mockup_builtin(loader_id, process_instruction);
@@ -6854,7 +6856,7 @@ fn test_add_builtin_account() {
         let program_id = solana_sdk::pubkey::new_rand();
 
         let bank = Arc::new(Bank::new_from_parent(
-            &Arc::new(Bank::new_for_tests(&genesis_config)),
+            Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         ));
@@ -6875,7 +6877,7 @@ fn test_add_builtin_account() {
 
         assert_eq!(bank.get_account_modified_slot(&program_id).unwrap().1, slot);
 
-        let bank = Arc::new(new_from_parent(&bank));
+        let bank = Arc::new(new_from_parent(bank));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         assert_capitalization_diff(
             &bank,
@@ -6891,7 +6893,7 @@ fn test_add_builtin_account() {
 
         assert_eq!(bank.get_account_modified_slot(&program_id).unwrap().1, slot);
 
-        let bank = Arc::new(new_from_parent(&bank));
+        let bank = Arc::new(new_from_parent(bank));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         // When replacing builtin_program, name must change to disambiguate from repeated
         // invocations.
@@ -6912,7 +6914,7 @@ fn test_add_builtin_account() {
             bank.slot()
         );
 
-        let bank = Arc::new(new_from_parent(&bank));
+        let bank = Arc::new(new_from_parent(bank));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         assert_capitalization_diff(
             &bank,
@@ -7013,7 +7015,7 @@ fn test_add_builtin_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let bank = Bank::new_from_parent(
-        &create_simple_test_arc_bank(100_000),
+        create_simple_test_arc_bank(100_000),
         &Pubkey::default(),
         slot,
     );
@@ -7032,7 +7034,7 @@ fn test_add_builtin_account_replace_none() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let bank = Bank::new_from_parent(
-        &create_simple_test_arc_bank(100_000),
+        create_simple_test_arc_bank(100_000),
         &Pubkey::default(),
         slot,
     );
@@ -7050,7 +7052,7 @@ fn test_add_precompiled_account() {
         let program_id = solana_sdk::pubkey::new_rand();
 
         let bank = Arc::new(Bank::new_from_parent(
-            &Arc::new(Bank::new_for_tests_with_config(
+            Arc::new(Bank::new_for_tests_with_config(
                 &genesis_config,
                 BankTestConfig::default(),
             )),
@@ -7074,7 +7076,7 @@ fn test_add_precompiled_account() {
 
         assert_eq!(bank.get_account_modified_slot(&program_id).unwrap().1, slot);
 
-        let bank = Arc::new(new_from_parent(&bank));
+        let bank = Arc::new(new_from_parent(bank));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         assert_capitalization_diff(
             &bank,
@@ -7165,7 +7167,7 @@ fn test_add_precompiled_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let bank = Bank::new_from_parent(
-        &create_simple_test_arc_bank(100_000),
+        create_simple_test_arc_bank(100_000),
         &Pubkey::default(),
         slot,
     );
@@ -7245,7 +7247,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
     let bank = Arc::new(bank);
-    let mut bank_client = BankClient::new_shared(&bank);
+    let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Setup keypairs and addresses
     let payer_keypair = Keypair::new();
@@ -7962,7 +7964,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
 #[test]
 fn test_compute_active_feature_set() {
     let bank0 = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
 
     let test_feature = "TestFeature11111111111111111111111111111111"
         .parse::<Pubkey>()
@@ -8095,8 +8097,8 @@ fn test_update_clock_timestamp() {
     } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
     let mut bank = Bank::new_for_tests(&genesis_config);
     // Advance past slot 0, which has special handling.
-    bank = new_from_parent(&Arc::new(bank));
-    bank = new_from_parent(&Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(
         bank.clock().unix_timestamp,
         bank.unix_timestamp_from_genesis()
@@ -8151,7 +8153,7 @@ fn test_update_clock_timestamp() {
     );
 
     // Timestamp cannot go backward from ancestor Bank to child
-    bank = new_from_parent(&Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     update_vote_account_timestamp(
         BlockTimestamp {
             slot: bank.slot(),
@@ -8212,7 +8214,7 @@ fn test_timestamp_slow() {
     // additional_secs greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2 for an epoch
     // timestamp bounded to 150% deviation
     for _ in 0..31 {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
         assert_eq!(
             bank.clock().unix_timestamp,
             bank.clock().epoch_start_timestamp
@@ -8254,7 +8256,7 @@ fn test_timestamp_fast() {
     // additional_secs greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST for an epoch
     // timestamp bounded to 25% deviation
     for _ in 0..31 {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
         assert_eq!(
             bank.clock().unix_timestamp,
             bank.clock().epoch_start_timestamp
@@ -8499,10 +8501,11 @@ fn test_store_scan_consistency_unrooted() {
                     .iter()
                     .chunks(pubkeys_to_modify.len() / num_new_banks)
                 {
+                    let slot = current_minor_fork_bank.slot() + 2;
                     current_minor_fork_bank = Arc::new(Bank::new_from_parent(
-                        &current_minor_fork_bank,
+                        current_minor_fork_bank,
                         &solana_sdk::pubkey::new_rand(),
-                        current_minor_fork_bank.slot() + 2,
+                        slot,
                     ));
                     let account = AccountSharedData::new(lamports, 0, &program_id);
                     // Write partial updates to each of the banks in the minor fork so if any of them
@@ -8525,7 +8528,7 @@ fn test_store_scan_consistency_unrooted() {
                 // That way, after the squash(), the minor fork has the potential to see a
                 // *partial* clean of the banks < `next_major_bank`.
                 current_major_fork_bank = Arc::new(Bank::new_from_parent(
-                    &current_major_fork_bank,
+                    current_major_fork_bank,
                     &solana_sdk::pubkey::new_rand(),
                     current_minor_fork_bank.slot() - 1,
                 ));
@@ -8605,10 +8608,11 @@ fn test_store_scan_consistency_root() {
                     current_bank.clean_accounts(None);
                 }
                 prev_bank = current_bank.clone();
+                let slot = current_bank.slot() + 1;
                 current_bank = Arc::new(Bank::new_from_parent(
-                    &current_bank,
+                    current_bank,
                     &solana_sdk::pubkey::new_rand(),
-                    current_bank.slot() + 1,
+                    slot,
                 ));
             }
         },
@@ -8646,10 +8650,11 @@ fn setup_banks_on_fork_to_remove(
     for _ in (0..num_banks_on_fork).step_by(step_size) {
         let mut lamports_this_round = 0;
         for i in 0..step_size {
+            let slot = bank_at_fork_tip.slot() + 1;
             bank_at_fork_tip = Arc::new(Bank::new_from_parent(
-                &bank_at_fork_tip,
+                bank_at_fork_tip,
                 &solana_sdk::pubkey::new_rand(),
-                bank_at_fork_tip.slot() + 1,
+                slot,
             ));
             if lamports_this_round == 0 {
                 lamports_this_round = bank_at_fork_tip.bank_id() + starting_lamports + 1;
@@ -8861,8 +8866,8 @@ fn test_get_inflation_start_slot_devnet_testnet() {
     let bank = Bank::new_for_tests(&genesis_config);
 
     // Advance slot
-    let mut bank = new_from_parent(&Arc::new(bank));
-    bank = new_from_parent(&Arc::new(bank));
+    let mut bank = new_from_parent(Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.get_inflation_start_slot(), 0);
     assert_eq!(bank.slot(), 2);
 
@@ -8880,7 +8885,7 @@ fn test_get_inflation_start_slot_devnet_testnet() {
     assert_eq!(bank.get_inflation_start_slot(), 1);
 
     // Advance slot
-    bank = new_from_parent(&Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.slot(), 3);
 
     // Request `full_inflation::devnet_and_testnet` activation,
@@ -8942,8 +8947,8 @@ fn test_get_inflation_start_slot_mainnet() {
     let bank = Bank::new_for_tests(&genesis_config);
 
     // Advance slot
-    let mut bank = new_from_parent(&Arc::new(bank));
-    bank = new_from_parent(&Arc::new(bank));
+    let mut bank = new_from_parent(Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.get_inflation_start_slot(), 0);
     assert_eq!(bank.slot(), 2);
 
@@ -8961,7 +8966,7 @@ fn test_get_inflation_start_slot_mainnet() {
     assert_eq!(bank.get_inflation_start_slot(), 1);
 
     // Advance slot
-    bank = new_from_parent(&Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.slot(), 3);
 
     // Request `full_inflation::mainnet::certusone` activation,
@@ -8988,7 +8993,7 @@ fn test_get_inflation_start_slot_mainnet() {
     assert_eq!(bank.get_inflation_start_slot(), 2);
 
     // Advance slot
-    bank = new_from_parent(&Arc::new(bank));
+    bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.slot(), 4);
 
     // Request `full_inflation::devnet_and_testnet` activation,
@@ -9029,7 +9034,7 @@ fn test_get_inflation_num_slots_with_activations() {
     let mut bank = Bank::new_for_tests(&genesis_config);
     assert_eq!(bank.get_inflation_num_slots(), 0);
     for _ in 0..2 * slots_per_epoch {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), 2 * slots_per_epoch);
 
@@ -9047,7 +9052,7 @@ fn test_get_inflation_num_slots_with_activations() {
     bank.feature_set = Arc::new(bank.compute_active_feature_set(true).0);
     assert_eq!(bank.get_inflation_num_slots(), slots_per_epoch);
     for _ in 0..slots_per_epoch {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), 2 * slots_per_epoch);
 
@@ -9065,7 +9070,7 @@ fn test_get_inflation_num_slots_with_activations() {
     bank.feature_set = Arc::new(bank.compute_active_feature_set(true).0);
     assert_eq!(bank.get_inflation_num_slots(), slots_per_epoch);
     for _ in 0..slots_per_epoch {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), 2 * slots_per_epoch);
 }
@@ -9080,11 +9085,11 @@ fn test_get_inflation_num_slots_already_activated() {
     let mut bank = Bank::new_for_tests(&genesis_config);
     assert_eq!(bank.get_inflation_num_slots(), 0);
     for _ in 0..slots_per_epoch {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), slots_per_epoch);
     for _ in 0..slots_per_epoch {
-        bank = new_from_parent(&Arc::new(bank));
+        bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), 2 * slots_per_epoch);
 }
@@ -9240,7 +9245,7 @@ fn test_vote_epoch_panic() {
     assert!(result.is_ok());
 
     let _bank = Bank::new_from_parent(
-        &bank,
+        bank,
         &mint_keypair.pubkey(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
     );
@@ -9648,7 +9653,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank0.freeze();
 
     let slot = 1;
-    let bank1 = Bank::new_from_parent(&bank0, &collector, slot);
+    let bank1 = Bank::new_from_parent(bank0.clone(), &collector, slot);
     add_root_and_flush_write_cache(&bank0);
     bank1
         .transfer(amount, &mint_keypair, &key1.pubkey())
@@ -9661,7 +9666,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     }
 
     let slot = slot + 1;
-    let bank2 = Bank::new_from_parent(&bank0, &collector, slot);
+    let bank2 = Bank::new_from_parent(bank0, &collector, slot);
     bank2
         .transfer(amount * 2, &mint_keypair, &key2.pubkey())
         .unwrap();
@@ -11696,18 +11701,20 @@ fn test_accounts_data_size_and_rent_collection() {
         genesis_config.rent = Rent::default();
         activate_all_features(&mut genesis_config);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let slot = bank.slot() + bank.slot_count_per_normal_epoch();
         let bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            bank.slot() + bank.slot_count_per_normal_epoch(),
+            slot,
         ));
 
         // make another bank so that any reclaimed accounts from the previous bank do not impact
         // this test
+        let slot = bank.slot() + bank.slot_count_per_normal_epoch();
         let bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            bank.slot() + bank.slot_count_per_normal_epoch(),
+            slot,
         ));
 
         // Store an account into the bank that is rent-paying and has data
@@ -11773,10 +11780,11 @@ fn test_accounts_data_size_from_genesis() {
 
     // Create accounts over a number of banks and ensure the accounts data size remains correct
     for _ in 0..10 {
+        let slot = bank.slot() + 1;
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            bank.slot() + 1,
+            slot,
         ));
 
         // Store an account into the bank that is rent-exempt and has data
@@ -11911,7 +11919,7 @@ fn test_stake_account_consistency_with_rent_epoch_max_feature(
     );
     let slot = 1;
     let slots_per_epoch = bank.epoch_schedule().get_slots_in_epoch(0);
-    let mut bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
     if !rent_epoch_max_enabled_initially {
         bank.activate_feature(&solana_sdk::feature_set::set_exempt_rent_epoch_max::id());
     }
@@ -11926,7 +11934,7 @@ fn test_stake_account_consistency_with_rent_epoch_max_feature(
         // rent has been collected, so if rent epoch is max is activated, this will be max by now
         expected_initial_rent_epoch
     );
-    let mut bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), slot));
+    let mut bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
     let last_slot_in_epoch = bank.epoch_schedule().get_last_slot_in_epoch(1);
     let slot = last_slot_in_epoch - 2;
@@ -11937,7 +11945,7 @@ fn test_stake_account_consistency_with_rent_epoch_max_feature(
             .rent_epoch(),
         expected_initial_rent_epoch
     );
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), slot));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
     assert_eq!(
         bank.load_slow(&bank.ancestors, &stake_id1)
             .unwrap()
@@ -11946,7 +11954,7 @@ fn test_stake_account_consistency_with_rent_epoch_max_feature(
         expected_initial_rent_epoch
     );
     let slot = last_slot_in_epoch - 1;
-    bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), slot));
+    bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
     assert_eq!(
         bank.load_slow(&bank.ancestors, &stake_id1)
             .unwrap()
@@ -12078,11 +12086,11 @@ fn test_is_in_slot_hashes_history() {
     assert!(!bank0.is_in_slot_hashes_history(&1));
     let mut last_bank = bank0;
     for _ in 0..MAX_ENTRIES {
-        let new_bank = Arc::new(new_from_parent(&last_bank));
+        let new_bank = Arc::new(new_from_parent(last_bank));
         assert!(new_bank.is_in_slot_hashes_history(&0));
         last_bank = new_bank;
     }
-    let new_bank = Arc::new(new_from_parent(&last_bank));
+    let new_bank = Arc::new(new_from_parent(last_bank));
     assert!(!new_bank.is_in_slot_hashes_history(&0));
 }
 
@@ -12125,7 +12133,7 @@ fn test_runtime_feature_enable_with_program_cache() {
 
     // Advance the bank so the next transaction can be submitted.
     goto_end_of_slot(&mut root_bank);
-    let mut bank = new_from_parent(&Arc::new(root_bank));
+    let mut bank = new_from_parent(Arc::new(root_bank));
 
     // Compose second instruction using the same program with a different block hash
     let instruction2 = Instruction::new_with_bytes(program_keypair.pubkey(), &[], Vec::new());
@@ -12203,10 +12211,11 @@ fn test_bank_verify_accounts_hash_with_base() {
 
     // make some banks, do some transactions, ensure there's some zero-lamport accounts
     for _ in 0..2 {
+        let slot = bank.slot() + 1;
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::new_unique(),
-            bank.slot() + 1,
+            slot,
         ));
         do_transfers(&bank);
     }
@@ -12220,10 +12229,11 @@ fn test_bank_verify_accounts_hash_with_base() {
 
     // make more banks, do more transactions, ensure there's more zero-lamport accounts
     for _ in 0..2 {
+        let slot = bank.slot() + 1;
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::new_unique(),
-            bank.slot() + 1,
+            slot,
         ));
         do_transfers(&bank);
     }
@@ -12652,7 +12662,7 @@ fn test_rewards_computation_and_partitioned_distribution_one_block() {
     assert_eq!(num_slots_in_epoch, 32);
 
     let mut previous_bank = Arc::new(Bank::new_from_parent(
-        &Arc::new(bank0),
+        Arc::new(bank0),
         &Pubkey::default(),
         1,
     ));
@@ -12660,7 +12670,7 @@ fn test_rewards_computation_and_partitioned_distribution_one_block() {
     // simulate block progress
     for slot in 2..=num_slots_in_epoch + 2 {
         let pre_cap = previous_bank.capitalization();
-        let curr_bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), slot);
+        let curr_bank = Bank::new_from_parent(previous_bank, &Pubkey::default(), slot);
         let post_cap = curr_bank.capitalization();
 
         // Fill banks with banks with votes landing in the next slot
@@ -12765,7 +12775,7 @@ fn test_rewards_computation_and_partitioned_distribution_two_blocks() {
     assert_eq!(num_slots_in_epoch, 32);
 
     let mut previous_bank = Arc::new(Bank::new_from_parent(
-        &Arc::new(bank0),
+        Arc::new(bank0),
         &Pubkey::default(),
         1,
     ));
@@ -12773,7 +12783,7 @@ fn test_rewards_computation_and_partitioned_distribution_two_blocks() {
     // simulate block progress
     for slot in 2..=num_slots_in_epoch + 3 {
         let pre_cap = previous_bank.capitalization();
-        let curr_bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), slot);
+        let curr_bank = Bank::new_from_parent(previous_bank, &Pubkey::default(), slot);
         let post_cap = curr_bank.capitalization();
 
         // Fill banks with banks with votes landing in the next slot
@@ -12905,7 +12915,7 @@ fn test_program_execution_restricted_for_stake_account_in_reward_period() {
 
     let mut previous_bank = Arc::new(bank0);
     for slot in 1..=num_slots_in_epoch + 2 {
-        let bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), slot);
+        let bank = Bank::new_from_parent(previous_bank.clone(), &Pubkey::default(), slot);
 
         // Fill bank_forks with banks with votes landing in the next slot
         // So that rewards will be paid out at the epoch boundary, i.e. slot = 32
@@ -13154,19 +13164,21 @@ where
     // create initial bank and fund the alice account
     let (genesis_config, mint_keypair) = create_genesis_config(mint_lamports);
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
     bank_client
         .transfer_and_confirm(mint_lamports, &mint_keypair, &alice_pubkey)
         .unwrap();
 
     // create zero-lamports account to be cleaned
     let account = AccountSharedData::new(0, len1, &program);
-    let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
+    let slot = bank.slot() + 1;
+    let bank = Arc::new(Bank::new_from_parent(bank, &collector, slot));
     bank.store_account(&bob_pubkey, &account);
 
     // transfer some to bogus pubkey just to make previous bank (=slot) really cleanable
-    let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
-    let bank_client = BankClient::new_shared(&bank);
+    let slot = bank.slot() + 1;
+    let bank = Arc::new(Bank::new_from_parent(bank, &collector, slot));
+    let bank_client = BankClient::new_shared(bank.clone());
     bank_client
         .transfer_and_confirm(
             genesis_config.rent.minimum_balance(0),
@@ -13176,13 +13188,15 @@ where
         .unwrap();
 
     // super fun time; callback chooses to .clean_accounts(None) or not
-    let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
+    let slot = bank.slot() + 1;
+    let bank = Arc::new(Bank::new_from_parent(bank, &collector, slot));
     callback(&bank);
 
     // create a normal account at the same pubkey as the zero-lamports account
     let lamports = genesis_config.rent.minimum_balance(len2);
-    let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
-    let bank_client = BankClient::new_shared(&bank);
+    let slot = bank.slot() + 1;
+    let bank = Arc::new(Bank::new_from_parent(bank, &collector, slot));
+    let bank_client = BankClient::new_shared(bank);
     let ix = system_instruction::create_account(
         &alice_pubkey,
         &bob_pubkey,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8730,7 +8730,7 @@ fn test_remove_unrooted_scan_then_recreate_same_slot_before_scan() {
          pubkeys_to_modify,
          program_id,
          starting_lamports| {
-            let mut prev_bank = bank0;
+            let mut prev_bank = bank0.clone();
             loop {
                 let start = Instant::now();
                 let (bank_at_fork_tip, slots_on_fork, ancestors) = setup_banks_on_fork_to_remove(

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -308,11 +308,10 @@ impl BankClient {
         }
     }
 
-    pub fn new_shared(bank: &Arc<Bank>) -> Self {
+    pub fn new_shared(bank: Arc<Bank>) -> Self {
         let (transaction_sender, transaction_receiver) = unbounded();
         let transaction_sender = Mutex::new(transaction_sender);
         let thread_bank = bank.clone();
-        let bank = bank.clone();
         Builder::new()
             .name("solBankClient".to_string())
             .spawn(move || Self::run(&thread_bank, transaction_receiver))
@@ -324,7 +323,7 @@ impl BankClient {
     }
 
     pub fn new(bank: Bank) -> Self {
-        Self::new_shared(&Arc::new(bank))
+        Self::new_shared(Arc::new(bank))
     }
 
     pub fn set_sysvar_for_tests<T: Sysvar + SysvarId>(&self, sysvar: &T) {
@@ -333,7 +332,7 @@ impl BankClient {
 
     pub fn advance_slot(&mut self, by: u64, collector_id: &Pubkey) -> Option<Arc<Bank>> {
         self.bank = Arc::new(Bank::new_from_parent(
-            &self.bank,
+            self.bank.clone(),
             collector_id,
             self.bank.slot().checked_add(by)?,
         ));

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -696,7 +696,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank_forks[0u64].clone(), &Pubkey::default(), 1);
         child_bank.register_tick(&Hash::default());
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks[1u64].tick_height(), 1);
@@ -707,7 +707,7 @@ mod tests {
     fn test_bank_forks_new_from_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let child_bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1));
+        let child_bank = Arc::new(Bank::new_from_parent(bank.clone(), &Pubkey::default(), 1));
 
         let bank_forks = BankForks::new_from_banks(&[bank.clone(), child_bank.clone()], 0);
         assert_eq!(bank_forks.root(), 0);
@@ -723,10 +723,10 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank0 = bank_forks.get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
+        let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
         bank_forks.insert(bank);
         let descendants = bank_forks.descendants();
         let children: HashSet<u64> = [1u64, 2u64].iter().copied().collect();
@@ -740,10 +740,10 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let bank0 = bank_forks.get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
+        let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
         bank_forks.insert(bank);
         let ancestors = bank_forks.ancestors();
         assert!(ancestors[&0].is_empty());
@@ -758,7 +758,8 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
+        let bank0 = bank_forks.get(0).unwrap();
+        let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
         assert!(bank_forks.frozen_banks().get(&0).is_some());
         assert!(bank_forks.frozen_banks().get(&1).is_none());
@@ -769,7 +770,8 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
+        let bank0 = bank_forks.get(0).unwrap();
+        let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks.active_bank_slots(), vec![1]);
     }
@@ -833,8 +835,8 @@ mod tests {
             // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()
             let update_timestamp_case = slot == slots_in_epoch;
 
-            let child1 = Bank::new_from_parent(&bank_forks0[slot - 1], &Pubkey::default(), slot);
-            let child2 = Bank::new_from_parent(&bank_forks1[slot - 1], &Pubkey::default(), slot);
+            let child1 = Bank::new_from_parent(bank_forks0[slot - 1].clone(), &Pubkey::default(), slot);
+            let child2 = Bank::new_from_parent(bank_forks1[slot - 1].clone(), &Pubkey::default(), slot);
 
             if update_timestamp_case {
                 for child in &[&child1, &child2] {
@@ -880,7 +882,7 @@ mod tests {
     fn extend_bank_forks(bank_forks: &mut BankForks, parent_child_pairs: &[(Slot, Slot)]) {
         for (parent, child) in parent_child_pairs.iter() {
             bank_forks.insert(Bank::new_from_parent(
-                &bank_forks[*parent],
+                bank_forks[*parent].clone(),
                 &Pubkey::default(),
                 *child,
             ));

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -696,7 +696,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let child_bank = Bank::new_from_parent(bank_forks[0u64].clone(), &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank_forks[0].clone(), &Pubkey::default(), 1);
         child_bank.register_tick(&Hash::default());
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks[1u64].tick_height(), 1);
@@ -723,7 +723,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks.get(0).unwrap();
+        let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.insert(bank);
         let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
@@ -740,7 +740,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks.get(0).unwrap();
+        let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.insert(bank);
         let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
@@ -758,7 +758,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks.get(0).unwrap();
+        let bank0 = bank_forks[0].clone();
         let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
         assert!(bank_forks.frozen_banks().get(&0).is_some());
@@ -770,7 +770,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
-        let bank0 = bank_forks.get(0).unwrap();
+        let bank0 = bank_forks[0].clone();
         let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks.active_bank_slots(), vec![1]);

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -835,8 +835,10 @@ mod tests {
             // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()
             let update_timestamp_case = slot == slots_in_epoch;
 
-            let child1 = Bank::new_from_parent(bank_forks0[slot - 1].clone(), &Pubkey::default(), slot);
-            let child2 = Bank::new_from_parent(bank_forks1[slot - 1].clone(), &Pubkey::default(), slot);
+            let child1 =
+                Bank::new_from_parent(bank_forks0[slot - 1].clone(), &Pubkey::default(), slot);
+            let child2 =
+                Bank::new_from_parent(bank_forks1[slot - 1].clone(), &Pubkey::default(), slot);
 
             if update_timestamp_case {
                 for child in &[&child1, &child2] {

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -8,7 +8,7 @@ use {
         stake::{self, state::StakeStateV2},
     },
     solana_stake_program::stake_state,
-    std::{collections::HashSet, sync::Arc},
+    std::{collections::HashSet},
 };
 
 pub struct NonCirculatingSupply {
@@ -16,7 +16,7 @@ pub struct NonCirculatingSupply {
     pub accounts: Vec<Pubkey>,
 }
 
-pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCirculatingSupply> {
+pub fn calculate_non_circulating_supply(bank: &Bank) -> ScanResult<NonCirculatingSupply> {
     debug!("Updating Bank supply, epoch: {}", bank.epoch());
     let mut non_circulating_accounts_set: HashSet<Pubkey> = HashSet::new();
 
@@ -228,7 +228,7 @@ mod tests {
         std::{collections::BTreeMap, sync::Arc},
     };
 
-    fn new_from_parent(parent: &Arc<Bank>) -> Bank {
+    fn new_from_parent(parent: &Bank) -> Bank {
         Bank::new_from_parent(parent, &Pubkey::default(), parent.slot() + 1)
     }
 

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -8,7 +8,7 @@ use {
         stake::{self, state::StakeStateV2},
     },
     solana_stake_program::stake_state,
-    std::{collections::HashSet},
+    std::collections::HashSet,
 };
 
 pub struct NonCirculatingSupply {

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -228,8 +228,10 @@ mod tests {
         std::{collections::BTreeMap, sync::Arc},
     };
 
-    fn new_from_parent(parent: &Bank) -> Bank {
-        Bank::new_from_parent(parent, &Pubkey::default(), parent.slot() + 1)
+    fn new_from_parent(parent: Arc<Bank>) -> Bank {
+        let slot = parent.slot() + 1;
+        let collector_id = Pubkey::default();
+        Bank::new_from_parent(parent, &collector_id, slot)
     }
 
     #[test]
@@ -294,7 +296,7 @@ mod tests {
             num_non_circulating_accounts as usize + num_stake_accounts as usize
         );
 
-        bank = Arc::new(new_from_parent(&bank));
+        bank = Arc::new(new_from_parent(bank));
         let new_balance = 11;
         for key in non_circulating_accounts {
             bank.store_account(
@@ -314,7 +316,7 @@ mod tests {
 
         // Advance bank an epoch, which should unlock stakes
         for _ in 0..slots_per_epoch {
-            bank = Arc::new(new_from_parent(&bank));
+            bank = Arc::new(new_from_parent(bank));
         }
         assert_eq!(bank.epoch(), 1);
         let non_circulating_supply = calculate_non_circulating_supply(&bank).unwrap();

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -567,9 +567,9 @@ mod tests {
         let bank_forks = BankForks::new(bank0);
         let bank = bank_forks.working_bank();
         let collector = solana_sdk::pubkey::new_rand();
-        let bank1 = Arc::new(Bank::new_from_parent(&bank, &collector, 1));
-        let bank2 = Arc::new(Bank::new_from_parent(&bank, &collector, 2));
-        let bank3 = Arc::new(Bank::new_from_parent(&bank, &collector, 3));
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
+        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
 
         let mut prioritization_fee_cache = PrioritizationFeeCache::default();
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -569,7 +569,7 @@ mod tests {
         let collector = solana_sdk::pubkey::new_rand();
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
         let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
-        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let bank3 = Arc::new(Bank::new_from_parent(bank, &collector, 3));
 
         let mut prioritization_fee_cache = PrioritizationFeeCache::default();
 

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -68,7 +68,7 @@ mod tests {
         assert_eq!(bank, root_bank_cache.root_bank());
 
         {
-            let child_bank = Bank::new_from_parent(&bank, &Pubkey::default(), 1);
+            let child_bank = Bank::new_from_parent(bank.clone(), &Pubkey::default(), 1);
             bank_forks.write().unwrap().insert(child_bank);
 
             // cached slot is still 0 since we have not set root

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1214,7 +1214,8 @@ pub fn create_snapshot_dirs_for_tests(
     // loop to create the banks at slot 1 to num_total
     for _ in 0..num_total {
         // prepare the bank
-        bank = Arc::new(Bank::new_from_parent(&bank, &collecter_id, bank.slot() + 1));
+        let slot = bank.slot() + 1;
+        bank = Arc::new(Bank::new_from_parent(bank, &collecter_id, slot));
         bank.fill_bank_with_ticks_for_tests();
         bank.squash();
         bank.force_flush_accounts_cache();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1363,7 +1363,7 @@ mod tests {
         }
 
         let slot = 1;
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &collector, slot));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &collector, slot));
         bank1
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1378,7 +1378,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, &collector, slot));
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1387,7 +1387,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank3 = Arc::new(Bank::new_from_parent(&bank2, &collector, slot));
+        let bank3 = Arc::new(Bank::new_from_parent(bank2, &collector, slot));
         bank3
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1396,7 +1396,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank4 = Arc::new(Bank::new_from_parent(&bank3, &collector, slot));
+        let bank4 = Arc::new(Bank::new_from_parent(bank3, &collector, slot));
         bank4
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1480,7 +1480,7 @@ mod tests {
         }
 
         let slot = 1;
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &collector, slot));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &collector, slot));
         bank1
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1514,7 +1514,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, &collector, slot));
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1523,7 +1523,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank3 = Arc::new(Bank::new_from_parent(&bank2, &collector, slot));
+        let bank3 = Arc::new(Bank::new_from_parent(bank2, &collector, slot));
         bank3
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1532,7 +1532,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank4 = Arc::new(Bank::new_from_parent(&bank3, &collector, slot));
+        let bank4 = Arc::new(Bank::new_from_parent(bank3, &collector, slot));
         bank4
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1601,7 +1601,7 @@ mod tests {
         }
 
         let slot = 1;
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &collector, slot));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &collector, slot));
         bank1
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1635,7 +1635,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, &collector, slot));
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1644,7 +1644,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank3 = Arc::new(Bank::new_from_parent(&bank2, &collector, slot));
+        let bank3 = Arc::new(Bank::new_from_parent(bank2, &collector, slot));
         bank3
             .transfer(sol_to_lamports(2.), &mint_keypair, &key2.pubkey())
             .unwrap();
@@ -1653,7 +1653,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank4 = Arc::new(Bank::new_from_parent(&bank3, &collector, slot));
+        let bank4 = Arc::new(Bank::new_from_parent(bank3, &collector, slot));
         bank4
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1750,7 +1750,7 @@ mod tests {
         }
 
         let slot = 1;
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &collector, slot));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &collector, slot));
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
@@ -1772,7 +1772,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, &collector, slot));
         let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
@@ -1838,7 +1838,7 @@ mod tests {
         );
 
         let slot = slot + 1;
-        let bank3 = Arc::new(Bank::new_from_parent(&bank2, &collector, slot));
+        let bank3 = Arc::new(Bank::new_from_parent(bank2, &collector, slot));
         // Update Account2 so that it no longer holds a reference to slot2
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -1848,7 +1848,7 @@ mod tests {
         }
 
         let slot = slot + 1;
-        let bank4 = Arc::new(Bank::new_from_parent(&bank3, &collector, slot));
+        let bank4 = Arc::new(Bank::new_from_parent(bank3, &collector, slot));
         while !bank4.is_complete() {
             bank4.register_tick(&Hash::new_unique());
         }
@@ -1921,7 +1921,7 @@ mod tests {
         }
 
         let slot = 1;
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &collector, slot));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &collector, slot));
         while !bank1.is_complete() {
             bank1.register_tick(&Hash::new_unique());
         }
@@ -1943,7 +1943,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, &collector, slot));
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -2186,10 +2186,11 @@ mod tests {
 
         // make some banks, do some transactions, ensure there's some zero-lamport accounts
         for _ in 0..5 {
+            let slot = bank.slot() + 1;
             bank = Arc::new(Bank::new_from_parent(
-                &bank,
+                bank,
                 &Pubkey::new_unique(),
-                bank.slot() + 1,
+                slot,
             ));
             do_transfers(&bank);
         }
@@ -2215,10 +2216,11 @@ mod tests {
 
         // make more banks, do more transactions, ensure there's more zero-lamport accounts
         for _ in 0..5 {
+            let slot = bank.slot() + 1;
             bank = Arc::new(Bank::new_from_parent(
-                &bank,
+                bank,
                 &Pubkey::new_unique(),
-                bank.slot() + 1,
+                slot,
             ));
             do_transfers(&bank);
         }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2187,11 +2187,7 @@ mod tests {
         // make some banks, do some transactions, ensure there's some zero-lamport accounts
         for _ in 0..5 {
             let slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(
-                bank,
-                &Pubkey::new_unique(),
-                slot,
-            ));
+            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
             do_transfers(&bank);
         }
 
@@ -2217,11 +2213,7 @@ mod tests {
         // make more banks, do more transactions, ensure there's more zero-lamport accounts
         for _ in 0..5 {
             let slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(
-                bank,
-                &Pubkey::new_unique(),
-                slot,
-            ));
+            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
             do_transfers(&bank);
         }
 

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -48,14 +48,13 @@ fn next_epoch_and_n_slots(bank: Arc<Bank>, mut n: usize) -> Arc<Bank> {
 }
 
 fn fill_epoch_with_votes(
-    bank: Arc<Bank>,
+    mut bank: Arc<Bank>,
     vote_keypair: &Keypair,
     mint_keypair: &Keypair,
 ) -> Arc<Bank> {
     let mint_pubkey = mint_keypair.pubkey();
     let vote_pubkey = vote_keypair.pubkey();
     let old_epoch = bank.epoch();
-    let mut bank = bank;
     while bank.epoch() != old_epoch + 1 {
         bank.squash();
         let slot = bank.slot() + 1;

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -32,20 +32,22 @@ use {
 };
 
 /// get bank at next epoch + `n` slots
-fn next_epoch_and_n_slots(bank: &Arc<Bank>, mut n: usize) -> Arc<Bank> {
+fn next_epoch_and_n_slots(bank: Arc<Bank>, mut n: usize) -> Arc<Bank> {
     bank.squash();
+    let slot = bank.get_slots_in_epoch(bank.epoch()) + bank.slot();
     let mut bank = Arc::new(Bank::new_from_parent(
         bank,
         &Pubkey::default(),
-        bank.get_slots_in_epoch(bank.epoch()) + bank.slot(),
+        slot,
     ));
 
     while n > 0 {
         bank.squash();
+        let slot = bank.slot() + 1;
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            1 + bank.slot(),
+            slot,
         ));
         n -= 1;
     }
@@ -54,23 +56,24 @@ fn next_epoch_and_n_slots(bank: &Arc<Bank>, mut n: usize) -> Arc<Bank> {
 }
 
 fn fill_epoch_with_votes(
-    bank: &Arc<Bank>,
+    bank: Arc<Bank>,
     vote_keypair: &Keypair,
     mint_keypair: &Keypair,
 ) -> Arc<Bank> {
     let mint_pubkey = mint_keypair.pubkey();
     let vote_pubkey = vote_keypair.pubkey();
     let old_epoch = bank.epoch();
-    let mut bank = bank.clone();
+    let mut bank = bank;
     while bank.epoch() != old_epoch + 1 {
         bank.squash();
+        let slot = bank.slot() + 1;
         bank = Arc::new(Bank::new_from_parent(
-            &bank,
+            bank,
             &Pubkey::default(),
-            1 + bank.slot(),
+            slot,
         ));
 
-        let bank_client = BankClient::new_shared(&bank);
+        let bank_client = BankClient::new_shared(bank.clone());
         let parent = bank.parent().unwrap();
 
         let message = Message::new(
@@ -136,7 +139,7 @@ fn test_stake_create_and_split_single_signature() {
     let staker_pubkey = staker_keypair.pubkey();
 
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     let stake_address =
         Pubkey::create_with_seed(&staker_pubkey, "stake", &stake::program::id()).unwrap();
@@ -212,7 +215,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     let staker_pubkey = staker_keypair.pubkey();
 
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     let stake_address =
         Pubkey::create_with_seed(&staker_pubkey, "stake", &stake::program::id()).unwrap();
@@ -308,7 +311,7 @@ fn test_stake_account_lifetime() {
         .accounts_db
         .epoch_accounts_hash_manager
         .set_valid(EpochAccountsHash::new(Hash::new_unique()), bank.slot());
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     let (vote_balance, stake_rent_exempt_reserve, stake_minimum_delegation) = {
         let rent = &bank.rent_collector().rent;
@@ -402,12 +405,12 @@ fn test_stake_account_lifetime() {
             break;
         }
         // Cycle thru banks until we're fully warmed up
-        bank = next_epoch_and_n_slots(&bank, 0);
+        bank = next_epoch_and_n_slots(bank, 0);
     }
 
     // Reward redemption
     // Submit enough votes to generate rewards
-    bank = fill_epoch_with_votes(&bank, &vote_keypair, &mint_keypair);
+    bank = fill_epoch_with_votes(bank, &vote_keypair, &mint_keypair);
 
     // Test that votes and credits are there
     let account = bank.get_account(&vote_pubkey).expect("account not found");
@@ -420,13 +423,13 @@ fn test_stake_account_lifetime() {
     // one vote per slot, might be more slots than 32 in the epoch
     assert!(vote_state.credits() >= 1);
 
-    bank = fill_epoch_with_votes(&bank, &vote_keypair, &mint_keypair);
+    bank = fill_epoch_with_votes(bank, &vote_keypair, &mint_keypair);
 
     let pre_staked = get_staked(&bank, &stake_pubkey);
     let pre_balance = bank.get_balance(&stake_pubkey);
 
     // next epoch bank plus one additional slot should pay rewards
-    bank = next_epoch_and_n_slots(&bank, 1);
+    bank = next_epoch_and_n_slots(bank, 1);
 
     // Test that balance increased, and that the balance got staked
     let staked = get_staked(&bank, &stake_pubkey);
@@ -438,7 +441,7 @@ fn test_stake_account_lifetime() {
     let split_stake_keypair = Keypair::new();
     let split_stake_pubkey = split_stake_keypair.pubkey();
 
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
     // Test split
     let split_starting_delegation = stake_minimum_delegation + bonus_delegation;
     let split_starting_balance = split_starting_delegation + stake_rent_exempt_reserve;
@@ -494,9 +497,9 @@ fn test_stake_account_lifetime() {
         .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_err());
 
-    let mut bank = next_epoch_and_n_slots(&bank, 1);
+    let mut bank = next_epoch_and_n_slots(bank, 1);
 
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     // assert we're still cooling down
     let split_staked = get_staked(&bank, &split_stake_pubkey);
@@ -540,9 +543,9 @@ fn test_stake_account_lifetime() {
         if get_staked(&bank, &split_stake_pubkey) == 0 {
             break;
         }
-        bank = next_epoch_and_n_slots(&bank, 1);
+        bank = next_epoch_and_n_slots(bank, 1);
     }
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     // Test that we can withdraw everything else out of the split
     let split_remaining_balance = split_balance - split_unstaked;
@@ -584,7 +587,7 @@ fn test_create_stake_account_from_seed() {
     let bank = Bank::new_for_tests(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank = Arc::new(bank);
-    let bank_client = BankClient::new_shared(&bank);
+    let bank_client = BankClient::new_shared(bank.clone());
 
     let seed = "test-string";
     let stake_pubkey = Pubkey::create_with_seed(&mint_pubkey, seed, &stake::program::id()).unwrap();

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -35,20 +35,12 @@ use {
 fn next_epoch_and_n_slots(bank: Arc<Bank>, mut n: usize) -> Arc<Bank> {
     bank.squash();
     let slot = bank.get_slots_in_epoch(bank.epoch()) + bank.slot();
-    let mut bank = Arc::new(Bank::new_from_parent(
-        bank,
-        &Pubkey::default(),
-        slot,
-    ));
+    let mut bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
     while n > 0 {
         bank.squash();
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            slot,
-        ));
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
         n -= 1;
     }
 
@@ -67,11 +59,7 @@ fn fill_epoch_with_votes(
     while bank.epoch() != old_epoch + 1 {
         bank.squash();
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(
-            bank,
-            &Pubkey::default(),
-            slot,
-        ));
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
 
         let bank_client = BankClient::new_shared(bank.clone());
         let parent = bank.parent().unwrap();

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -888,7 +888,11 @@ mod test {
             .transfer(1, &mint_keypair, &mint_keypair.pubkey())
             .unwrap();
 
-        let working_bank = Arc::new(Bank::new_from_parent(root_bank.clone(), &Pubkey::default(), 2));
+        let working_bank = Arc::new(Bank::new_from_parent(
+            root_bank.clone(),
+            &Pubkey::default(),
+            2,
+        ));
 
         let non_rooted_signature = working_bank
             .transfer(2, &mint_keypair, &mint_keypair.pubkey())
@@ -1159,7 +1163,11 @@ mod test {
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
         root_bank.store_account(&nonce_address, &nonce_account);
 
-        let working_bank = Arc::new(Bank::new_from_parent(root_bank.clone(), &Pubkey::default(), 2));
+        let working_bank = Arc::new(Bank::new_from_parent(
+            root_bank.clone(),
+            &Pubkey::default(),
+            2,
+        ));
         let non_rooted_signature = working_bank
             .transfer(2, &mint_keypair, &mint_keypair.pubkey())
             .unwrap();

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -584,8 +584,8 @@ impl SendTransactionService {
 
     /// Retry transactions sent before.
     fn process_transactions<T: TpuInfo + std::marker::Send + 'static>(
-        working_bank: &Arc<Bank>,
-        root_bank: &Arc<Bank>,
+        working_bank: &Bank,
+        root_bank: &Bank,
         tpu_address: &SocketAddr,
         transactions: &mut HashMap<Signature, TransactionInfo>,
         leader_info_provider: &Arc<Mutex<CurrentLeaderInfo<T>>>,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -880,7 +880,7 @@ mod test {
         };
 
         let root_bank = Arc::new(Bank::new_from_parent(
-            &bank_forks.read().unwrap().working_bank(),
+            bank_forks.read().unwrap().working_bank(),
             &Pubkey::default(),
             1,
         ));
@@ -888,7 +888,7 @@ mod test {
             .transfer(1, &mint_keypair, &mint_keypair.pubkey())
             .unwrap();
 
-        let working_bank = Arc::new(Bank::new_from_parent(&root_bank, &Pubkey::default(), 2));
+        let working_bank = Arc::new(Bank::new_from_parent(root_bank.clone(), &Pubkey::default(), 2));
 
         let non_rooted_signature = working_bank
             .transfer(2, &mint_keypair, &mint_keypair.pubkey())
@@ -1142,7 +1142,7 @@ mod test {
         };
 
         let root_bank = Arc::new(Bank::new_from_parent(
-            &bank_forks.read().unwrap().working_bank(),
+            bank_forks.read().unwrap().working_bank(),
             &Pubkey::default(),
             1,
         ));
@@ -1159,7 +1159,7 @@ mod test {
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
         root_bank.store_account(&nonce_address, &nonce_account);
 
-        let working_bank = Arc::new(Bank::new_from_parent(&root_bank, &Pubkey::default(), 2));
+        let working_bank = Arc::new(Bank::new_from_parent(root_bank.clone(), &Pubkey::default(), 2));
         let non_rooted_signature = working_bank
             .transfer(2, &mint_keypair, &mint_keypair.pubkey())
             .unwrap();

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -129,7 +129,7 @@ mod tests {
     fn test_recv_slot_entries_1() {
         let (genesis_config, bank0, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
         let (s, r) = unbounded();
         let mut last_hash = genesis_config.hash();
 
@@ -158,8 +158,8 @@ mod tests {
     fn test_recv_slot_entries_2() {
         let (genesis_config, bank0, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 2));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
         let (s, r) = unbounded();
 
         let mut last_hash = genesis_config.hash();

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -685,7 +685,7 @@ mod test {
 
         // Step 2: Make a transmission for another bank that interrupts the transmission for
         // slot 0
-        let bank2 = Arc::new(Bank::new_from_parent(&bank0, &leader_keypair.pubkey(), 2));
+        let bank2 = Arc::new(Bank::new_from_parent(bank0, &leader_keypair.pubkey(), 2));
         let interrupted_slot = unfinished_slot.slot;
         // Interrupting the slot should cause the unfinished_slot and stats to reset
         let num_shreds = 1;


### PR DESCRIPTION
#### Problem
`&Arc<T>` is a bit of paradox:
- `&T` is used to borrow a `T`
- `Arc<T>` is used to get a ref-counted pointer to a `T`
Having both is a little off.

#### Summary of Changes
Adjust function signatures and code to take either `Arc<Bank>` or `&Bank` when possible. There are a few cases where I left `&Arc<Bank>` around. One such case is where the `.clone()` is based on a conditional at some bottommost function. In these cases, pass the `&Arc<Bank>` to defer the `.clone()` unless we will actually use it. One case where this happens is with sending transaction status in banking stage and replay (blockstore_processor).

This is a big diff. I tried to break things up into several commits to make it more manageable to wade through (ie `cargo fmt` in separate commits).
