### PR TITLE
fix sbf sysvar test

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -25,7 +25,7 @@ use {
         runtime_config::RuntimeConfig,
     },
     solana_sdk::{
-        account::{Account, AccountSharedData},
+        account::{create_account_shared_data_for_test, Account, AccountSharedData},
         account_info::AccountInfo,
         clock::Slot,
         entrypoint::{deserialize, ProgramResult, SUCCESS},
@@ -585,6 +585,11 @@ impl ProgramTest {
                 rent_epoch: 0,
             },
         );
+    }
+
+    pub fn add_sysvar_account<S: Sysvar>(&mut self, address: Pubkey, sysvar: &S) {
+        let account = create_account_shared_data_for_test(sysvar);
+        self.add_account(address, account.into());
     }
 
     /// Add a SBF program to the test environment.

--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -129,13 +129,9 @@ pub fn process_instruction(
     {
         msg!("EpochRewards identifier:");
         sysvar::epoch_rewards::id().log();
-        let epoch_rewards = EpochRewards::from_account_info(&accounts[11]);
-        // epoch_rewards sysvar should only be valid during epoch reward period. In this test case,
-        // the test bank is outside reward period. Therefore, we expect that the epoch_rewards
-        // sysvar doesn't exist.
-        assert!(epoch_rewards.is_err());
-        let got_epoch_rewards = EpochRewards::get();
-        assert!(got_epoch_rewards.is_err());
+        let epoch_rewards = EpochRewards::from_account_info(&accounts[11]).unwrap();
+        let got_epoch_rewards = EpochRewards::get()?;
+        assert_eq!(epoch_rewards, got_epoch_rewards);
     }
 
     Ok(())

--- a/programs/sbf/rust/sysvar/tests/lib.rs
+++ b/programs/sbf/rust/sysvar/tests/lib.rs
@@ -27,10 +27,10 @@ async fn test_sysvars() {
     );
 
     let epoch_rewards = epoch_rewards::EpochRewards {
-            total_rewards: 100,
-            distributed_rewards: 50,
-            distribution_complete_block_height: 42,
-        };
+        total_rewards: 100,
+        distributed_rewards: 50,
+        distribution_complete_block_height: 42,
+    };
     program_test.add_sysvar_account(epoch_rewards::id(), &epoch_rewards);
     let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
 

--- a/programs/sbf/rust/sysvar/tests/lib.rs
+++ b/programs/sbf/rust/sysvar/tests/lib.rs
@@ -20,11 +20,18 @@ use {
 async fn test_sysvars() {
     let program_id = Pubkey::new_unique();
 
-    let program_test = ProgramTest::new(
+    let mut program_test = ProgramTest::new(
         "solana_sbf_rust_sysvar",
         program_id,
         processor!(process_instruction),
     );
+
+    let epoch_rewards = epoch_rewards::EpochRewards {
+            total_rewards: 100,
+            distributed_rewards: 50,
+            distribution_complete_block_height: 42,
+        };
+    program_test.add_sysvar_account(epoch_rewards::id(), &epoch_rewards);
     let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
 
     let mut transaction = Transaction::new_with_payer(
@@ -59,6 +66,7 @@ async fn test_sysvars() {
         processor!(process_instruction),
     );
     program_test.deactivate_feature(disable_fees_sysvar::id());
+    program_test.add_sysvar_account(epoch_rewards::id(), &epoch_rewards);
     let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
 
     let mut transaction = Transaction::new_with_payer(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3538,7 +3538,7 @@ impl Bank {
         }
     }
 
-    /// Create EpochRewards syavar with calculated rewards
+    /// Create EpochRewards sysvar with calculated rewards
     fn create_epoch_rewards_sysvar(
         &self,
         total_rewards: u64,


### PR DESCRIPTION
#### Problem

when running sbf program, sbf loader will use runtime sysvar cache to load
sysvar. Therefore, the program will return unsupported sysvar error if the
sysvar doesn't  exist in the cache. For normal sysvar, this is not a problem
because the sysvar always exists for every bank. However, for `epoch_rewards`
sysvar, the situation is different. `epoch_rewards` sysvar only exists during
the epoch reward period. Therefore, the current `program_test` framework, by
default, doesn't support `epoch_rewards` sysvar. 


#### Summary of Changes

1. add api in `program_test` to allow mock sysvar.
2. mock  epoch rewards sysvar for sbf tests


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
