### PR TITLE
program-test: Prohibit setting the compute unit limit past `i64::MAX`

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -521,6 +521,10 @@ impl ProgramTest {
 
     /// Override the default maximum compute units
     pub fn set_compute_max_units(&mut self, compute_max_units: u64) {
+        debug_assert!(
+            compute_max_units <= i64::MAX as u64,
+            "Compute unit limit must fit in `i64::MAX`"
+        );
         self.compute_max_units = Some(compute_max_units);
     }
 
@@ -533,7 +537,7 @@ impl ProgramTest {
     #[allow(deprecated)]
     #[deprecated(since = "1.8.0", note = "please use `set_compute_max_units` instead")]
     pub fn set_bpf_compute_max_units(&mut self, bpf_compute_max_units: u64) {
-        self.compute_max_units = Some(bpf_compute_max_units);
+        self.set_compute_max_units(bpf_compute_max_units);
     }
 
     /// Add an account to the test environment

--- a/program-test/tests/compute_units.rs
+++ b/program-test/tests/compute_units.rs
@@ -1,0 +1,61 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        sysvar::rent,
+        transaction::Transaction,
+    },
+};
+
+#[should_panic]
+#[test]
+fn overflow_compute_units() {
+    let mut program_test = ProgramTest::default();
+    program_test.set_compute_max_units(i64::MAX as u64 + 1);
+}
+
+#[tokio::test]
+async fn max_compute_units() {
+    let mut program_test = ProgramTest::default();
+    program_test.set_compute_max_units(i64::MAX as u64);
+    let mut context = program_test.start_with_context().await;
+
+    // Invalid compute unit maximums are only triggered by BPF programs, so send
+    // a valid instruction into a BPF program to make sure the issue doesn't
+    // manifest.
+    let token_2022_id = Pubkey::try_from("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb").unwrap();
+    let mint = Keypair::new();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = 82;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &mint.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &token_2022_id,
+            ),
+            Instruction::new_with_bytes(
+                token_2022_id,
+                &[0; 35], // initialize mint
+                vec![
+                    AccountMeta::new(mint.pubkey(), false),
+                    AccountMeta::new_readonly(rent::id(), false),
+                ],
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
#### Problem

As reported by users, setting `u64::MAX` for the max compute units in solana-program-test causes all sBPF tests to fail: https://discord.com/channels/428295358100013066/774014770402689065/1136270266436173886

This happens because the rbpf vm actually represents compute unit budget with a `i64` in order to catch using too many units, so if we set anything larger than `i64::MAX`, the compute units becomes negative, which immediately errors.

#### Summary of Changes

While it may be better to change everything to use `i64` and match the vm, this would allow people to set negative numbers for their program's compute units, which we'll need to properly define.

Once that work is done, we can expose a new function on `solana-program-test` which accepts an `i64`. In the meantime, add a debug assertion to help users fix the problem themselves.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
