### PR TITLE
docs: fix sendAndConfirmTransaction interface changed

### DIFF
--- a/docs/src/developing/lookup-tables.md
+++ b/docs/src/developing/lookup-tables.md
@@ -130,17 +130,12 @@ transactionV0.sign([payer]);
 
 // send and confirm the transaction
 // (NOTE: There is NOT an array of Signers here; see the note below...)
-const txid = await web3.sendAndConfirmTransaction(connection, transactionV0);
+const txid = await connection.sendTransaction(transactionV0);
 
 console.log(
   `Transaction: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
 );
 ```
-
-> NOTE:
-> When sending a `VersionedTransaction` to the cluster, it must be signed BEFORE calling the
-> `sendAndConfirmTransaction` method. If you pass an array of `Signer`
-> (like with `legacy` transactions) the method will trigger an error!
 
 ## More Resources
 


### PR DESCRIPTION
#### Problem

seems that `sendAndConfirmTransaction` doesn't support only two args atm. 

https://github.com/solana-labs/solana-web3.js/blob/954995a9cdebcdf97a99e1834c6d90d75c09a926/packages/library-legacy/src/utils/send-and-confirm-transaction.ts#L18-L27

#### Summary of Changes

use `connection.sendTransaction` as a stopgap

