### PR TITLE
accounts hash sort_slot_storage_scan sorts in place

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2404,10 +2404,10 @@ impl<'a> AppendVecScan for ScanState<'a> {
         self.init_accum(self.range);
         self.accum[self.pubkey_to_bin_index].push(source_item);
     }
-    fn scanning_complete(self) -> BinnedHashData {
-        let (result, timing) = AccountsDb::sort_slot_storage_scan(self.accum);
+    fn scanning_complete(mut self) -> BinnedHashData {
+        let timing = AccountsDb::sort_slot_storage_scan(&mut self.accum);
         self.sort_time.fetch_add(timing, Ordering::Relaxed);
-        result
+        self.accum
     }
 }
 
@@ -7564,24 +7564,17 @@ impl AccountsDb {
         Ok(result)
     }
 
-    fn sort_slot_storage_scan(accum: BinnedHashData) -> (BinnedHashData, u64) {
+    fn sort_slot_storage_scan(accum: &mut BinnedHashData) -> u64 {
         let time = AtomicU64::new(0);
-        (
-            accum
-                .into_iter()
-                .map(|mut items| {
-                    let mut sort_time = Measure::start("sort");
-                    {
-                        // sort_by vs unstable because slot and write_version are already in order
-                        items.sort_by(AccountsHasher::compare_two_hash_entries);
-                    }
-                    sort_time.stop();
-                    time.fetch_add(sort_time.as_us(), Ordering::Relaxed);
-                    items
-                })
-                .collect(),
-            time.load(Ordering::Relaxed),
-        )
+        accum.iter_mut().for_each(|items| {
+            let mut sort_time = Measure::start("sort");
+            // sort_by vs unstable because slot and write_version are already in order
+            items.sort_by(AccountsHasher::compare_two_hash_entries);
+            sort_time.stop();
+            time.fetch_add(sort_time.as_us(), Ordering::Relaxed);
+        });
+
+        time.load(Ordering::Relaxed)
     }
 
     /// normal code path returns the common cache path


### PR DESCRIPTION
#### Problem
Accounts hash scan is migrating towards using mmapped files earlier instead of memory allocations initially. After sorting here, the memory allocations are written to mmapped files for downstream processing. We are transitioning to using memory mapped files earlier on to avoid large memory allocation spikes during hash calculation.
As such, it makes sense for the sort at the end of accounts hash scanning in a chunk to happen in place instead of by copying. That made sense previously anyway...

#### Summary of Changes
Sort in place instead of always making copies.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
