### PR TITLE
Initialize and store PRv2 environment in cache

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -10,7 +10,7 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
-    solana_bpf_loader_program::syscalls::create_program_runtime_environment,
+    solana_bpf_loader_program::syscalls::create_program_runtime_v1_environment,
     solana_clap_utils::{
         self, hidden_unless_forced, input_parsers::*, input_validators::*, keypair::*,
     },
@@ -2022,7 +2022,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         .map_err(|err| format!("Unable to read program file: {err}"))?;
 
     // Verify the program
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &FeatureSet::all_enabled(),
         &ComputeBudget::default(),
         true,

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -10,7 +10,7 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
-    solana_bpf_loader_program::syscalls::create_program_runtime_v1_environment,
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_clap_utils::{
         self, hidden_unless_forced, input_parsers::*, input_validators::*, keypair::*,
     },
@@ -2022,7 +2022,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         .map_err(|err| format!("Unable to read program file: {err}"))?;
 
     // Verify the program
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &FeatureSet::all_enabled(),
         &ComputeBudget::default(),
         true,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -6,7 +6,7 @@ use {
     serde_json::Result,
     solana_bpf_loader_program::{
         create_vm, load_program_from_bytes, serialization::serialize_parameters,
-        syscalls::create_program_runtime_environment,
+        syscalls::create_program_runtime_v1_environment,
     },
     solana_clap_utils::input_parsers::pubkeys_of,
     solana_ledger::{
@@ -346,7 +346,7 @@ fn load_program<'a>(
         ..LoadProgramMetrics::default()
     };
     let account_size = contents.len();
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &invoke_context.feature_set,
         invoke_context.get_compute_budget(),
         false, /* deployment */

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -6,7 +6,7 @@ use {
     serde_json::Result,
     solana_bpf_loader_program::{
         create_vm, load_program_from_bytes, serialization::serialize_parameters,
-        syscalls::create_program_runtime_v1_environment,
+        syscalls::create_program_runtime_environment_v1,
     },
     solana_clap_utils::input_parsers::pubkeys_of,
     solana_ledger::{
@@ -346,7 +346,7 @@ fn load_program<'a>(
         ..LoadProgramMetrics::default()
     };
     let account_size = contents.len();
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &invoke_context.feature_set,
         invoke_context.get_compute_budget(),
         false, /* deployment */

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -355,6 +355,8 @@ pub struct LoadedPrograms {
     entries: HashMap<Pubkey, Vec<Arc<LoadedProgram>>>,
     /// Globally shared RBPF config and syscall registry
     pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    /// Globally shared RBPF config and syscall registry for runtime V2
+    pub program_runtime_environment_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
     latest_root: Slot,
     pub stats: Stats,
 }
@@ -501,7 +503,16 @@ impl LoadedPrograms {
                     }
                     LoadedProgramType::Unloaded(environment)
                     | LoadedProgramType::FailedVerification(environment)
-                        if Arc::ptr_eq(environment, &self.program_runtime_environment_v1) =>
+                        if Arc::ptr_eq(environment, &self.program_runtime_environment_v1)
+                            || Arc::ptr_eq(environment, &self.program_runtime_environment_v2) =>
+                    {
+                        true
+                    }
+                    LoadedProgramType::Typed(program)
+                        if Arc::ptr_eq(
+                            program.get_loader(),
+                            &self.program_runtime_environment_v2,
+                        ) =>
                     {
                         true
                     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -59,7 +59,7 @@ use {
         rc::Rc,
         sync::{atomic::Ordering, Arc},
     },
-    syscalls::create_program_runtime_v1_environment,
+    syscalls::create_program_runtime_environment_v1,
 };
 
 pub const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
@@ -116,7 +116,7 @@ macro_rules! deploy_program {
      $account_size:expr, $slot:expr, $drop:expr, $new_programdata:expr $(,)?) => {{
         let mut load_program_metrics = LoadProgramMetrics::default();
         let mut register_syscalls_time = Measure::start("register_syscalls_time");
-        let program_runtime_environment = create_program_runtime_v1_environment(
+        let program_runtime_environment = create_program_runtime_environment_v1(
             &$invoke_context.feature_set,
             $invoke_context.get_compute_budget(),
             true, /* deployment */
@@ -1654,7 +1654,7 @@ pub mod test_utils {
 
     pub fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
         let mut load_program_metrics = LoadProgramMetrics::default();
-        let program_runtime_environment = create_program_runtime_v1_environment(
+        let program_runtime_environment = create_program_runtime_environment_v1(
             &invoke_context.feature_set,
             invoke_context.get_compute_budget(),
             false, /* deployment */

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -59,7 +59,7 @@ use {
         rc::Rc,
         sync::{atomic::Ordering, Arc},
     },
-    syscalls::create_program_runtime_environment,
+    syscalls::create_program_runtime_v1_environment,
 };
 
 pub const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
@@ -116,7 +116,7 @@ macro_rules! deploy_program {
      $account_size:expr, $slot:expr, $drop:expr, $new_programdata:expr $(,)?) => {{
         let mut load_program_metrics = LoadProgramMetrics::default();
         let mut register_syscalls_time = Measure::start("register_syscalls_time");
-        let program_runtime_environment = create_program_runtime_environment(
+        let program_runtime_environment = create_program_runtime_v1_environment(
             &$invoke_context.feature_set,
             $invoke_context.get_compute_budget(),
             true, /* deployment */
@@ -1654,7 +1654,7 @@ pub mod test_utils {
 
     pub fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
         let mut load_program_metrics = LoadProgramMetrics::default();
-        let program_runtime_environment = create_program_runtime_environment(
+        let program_runtime_environment = create_program_runtime_v1_environment(
             &invoke_context.feature_set,
             invoke_context.get_compute_budget(),
             false, /* deployment */

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -142,7 +142,7 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn create_program_runtime_v1_environment<'a>(
+pub fn create_program_runtime_environment_v1<'a>(
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,
     reject_deployment_of_broken_elfs: bool,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -142,7 +142,7 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn create_program_runtime_environment<'a>(
+pub fn create_program_runtime_v1_environment<'a>(
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,
     reject_deployment_of_broken_elfs: bool,

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -68,7 +68,7 @@ fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError
     }
 }
 
-pub fn create_program_runtime_v2_environment<'a>(
+pub fn create_program_runtime_environment_v2<'a>(
     compute_budget: &ComputeBudget,
     debugging_features: bool,
 ) -> BuiltinProgram<InvokeContext<'a>> {
@@ -118,7 +118,7 @@ pub fn load_program_from_account(
         .ok_or(InstructionError::AccountDataTooSmall)?;
     let loaded_program = LoadedProgram::new(
         &loader_v4::id(),
-        Arc::new(create_program_runtime_v2_environment(
+        Arc::new(create_program_runtime_environment_v2(
             compute_budget,
             debugging_features,
         )),

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -68,17 +68,10 @@ fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError
     }
 }
 
-pub fn load_program_from_account(
-    _feature_set: &FeatureSet,
+pub fn create_program_runtime_v2_environment<'a>(
     compute_budget: &ComputeBudget,
-    log_collector: Option<Rc<RefCell<LogCollector>>>,
-    program: &BorrowedAccount,
     debugging_features: bool,
-) -> Result<(Arc<LoadedProgram>, LoadProgramMetrics), InstructionError> {
-    let mut load_program_metrics = LoadProgramMetrics {
-        program_id: program.get_key().to_string(),
-        ..LoadProgramMetrics::default()
-    };
+) -> BuiltinProgram<InvokeContext<'a>> {
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
@@ -104,7 +97,20 @@ pub fn load_program_from_account(
         aligned_memory_mapping: true,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
-    let loader = BuiltinProgram::new_loader(config);
+    BuiltinProgram::new_loader(config)
+}
+
+pub fn load_program_from_account(
+    _feature_set: &FeatureSet,
+    compute_budget: &ComputeBudget,
+    log_collector: Option<Rc<RefCell<LogCollector>>>,
+    program: &BorrowedAccount,
+    debugging_features: bool,
+) -> Result<(Arc<LoadedProgram>, LoadProgramMetrics), InstructionError> {
+    let mut load_program_metrics = LoadProgramMetrics {
+        program_id: program.get_key().to_string(),
+        ..LoadProgramMetrics::default()
+    };
     let state = get_state(program.get_data())?;
     let programdata = program
         .get_data()
@@ -112,7 +118,10 @@ pub fn load_program_from_account(
         .ok_or(InstructionError::AccountDataTooSmall)?;
     let loaded_program = LoadedProgram::new(
         &loader_v4::id(),
-        Arc::new(loader),
+        Arc::new(create_program_runtime_v2_environment(
+            compute_budget,
+            debugging_features,
+        )),
         state.slot,
         state.slot.saturating_add(1),
         None,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -14,7 +14,7 @@ use {
     byteorder::{ByteOrder, LittleEndian, WriteBytesExt},
     solana_bpf_loader_program::{
         create_vm, serialization::serialize_parameters,
-        syscalls::create_program_runtime_v1_environment,
+        syscalls::create_program_runtime_environment_v1,
     },
     solana_measure::measure::Measure,
     solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
@@ -90,7 +90,7 @@ macro_rules! with_mock_invoke_context {
 fn bench_program_create_executable(bencher: &mut Bencher) {
     let elf = load_program_from_file("bench_alu");
 
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &FeatureSet::default(),
         &ComputeBudget::default(),
         true,
@@ -118,7 +118,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let elf = load_program_from_file("bench_alu");
     with_mock_invoke_context!(invoke_context, bpf_loader::id(), 10000001);
 
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -237,7 +237,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
     let direct_mapping = invoke_context
         .feature_set
         .is_active(&bpf_account_data_direct_mapping::id());
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -299,7 +299,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     )
     .unwrap();
 
-    let program_runtime_environment = create_program_runtime_v1_environment(
+    let program_runtime_environment = create_program_runtime_environment_v1(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -14,7 +14,7 @@ use {
     byteorder::{ByteOrder, LittleEndian, WriteBytesExt},
     solana_bpf_loader_program::{
         create_vm, serialization::serialize_parameters,
-        syscalls::create_program_runtime_environment,
+        syscalls::create_program_runtime_v1_environment,
     },
     solana_measure::measure::Measure,
     solana_program_runtime::{compute_budget::ComputeBudget, invoke_context::InvokeContext},
@@ -90,7 +90,7 @@ macro_rules! with_mock_invoke_context {
 fn bench_program_create_executable(bencher: &mut Bencher) {
     let elf = load_program_from_file("bench_alu");
 
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &FeatureSet::default(),
         &ComputeBudget::default(),
         true,
@@ -118,7 +118,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let elf = load_program_from_file("bench_alu");
     with_mock_invoke_context!(invoke_context, bpf_loader::id(), 10000001);
 
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -237,7 +237,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
     let direct_mapping = invoke_context
         .feature_set
         .is_active(&bpf_account_data_direct_mapping::id());
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,
@@ -299,7 +299,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     )
     .unwrap();
 
-    let program_runtime_environment = create_program_runtime_environment(
+    let program_runtime_environment = create_program_runtime_v1_environment(
         &invoke_context.feature_set,
         &ComputeBudget::default(),
         true,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -99,7 +99,7 @@ use {
             TransactionResults,
         },
     },
-    solana_bpf_loader_program::syscalls::create_program_runtime_environment,
+    solana_bpf_loader_program::syscalls::create_program_runtime_v1_environment,
     solana_cost_model::cost_tracker::CostTracker,
     solana_measure::{measure, measure::Measure, measure_us},
     solana_perf::perf_libs,
@@ -7996,7 +7996,7 @@ impl Bank {
                 .iter()
                 .any(|key| new_feature_activations.contains(key))
         {
-            let program_runtime_environment_v1 = create_program_runtime_environment(
+            let program_runtime_environment_v1 = create_program_runtime_v1_environment(
                 &self.feature_set,
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* deployment */
@@ -8009,6 +8009,17 @@ impl Bank {
             {
                 loaded_programs_cache.program_runtime_environment_v1 =
                     Arc::new(program_runtime_environment_v1);
+            }
+            let program_runtime_environment_v2 =
+                solana_loader_v4_program::create_program_runtime_v2_environment(
+                    &self.runtime_config.compute_budget.unwrap_or_default(),
+                    false, /* deployment */
+                );
+            if *loaded_programs_cache.program_runtime_environment_v2
+                != program_runtime_environment_v2
+            {
+                loaded_programs_cache.program_runtime_environment_v2 =
+                    Arc::new(program_runtime_environment_v2);
             }
             loaded_programs_cache.prune_feature_set_transition();
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -99,7 +99,7 @@ use {
             TransactionResults,
         },
     },
-    solana_bpf_loader_program::syscalls::create_program_runtime_v1_environment,
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_cost_model::cost_tracker::CostTracker,
     solana_measure::{measure, measure::Measure, measure_us},
     solana_perf::perf_libs,
@@ -7996,7 +7996,7 @@ impl Bank {
                 .iter()
                 .any(|key| new_feature_activations.contains(key))
         {
-            let program_runtime_environment_v1 = create_program_runtime_v1_environment(
+            let program_runtime_environment_v1 = create_program_runtime_environment_v1(
                 &self.feature_set,
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* deployment */
@@ -8011,9 +8011,9 @@ impl Bank {
                     Arc::new(program_runtime_environment_v1);
             }
             let program_runtime_environment_v2 =
-                solana_loader_v4_program::create_program_runtime_v2_environment(
+                solana_loader_v4_program::create_program_runtime_environment_v2(
                     &self.runtime_config.compute_budget.unwrap_or_default(),
-                    false, /* deployment */
+                    false, /* debugging_features */
                 );
             if *loaded_programs_cache.program_runtime_environment_v2
                 != program_runtime_environment_v2


### PR DESCRIPTION
#### Problem
Program runtime V2 environment is created every time a program is loaded. This can be optimized.

#### Summary of Changes
Store the environment in the cache.
Another refactor is needed to reuse the cached environment.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
