### PR TITLE
Use existing runtime environment for newly deployed program

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,8 +536,10 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs =
-        LoadedProgramsForTxBatch::new(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
+    let mut loaded_programs = LoadedProgramsForTxBatch::new_from_cache(
+        bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET,
+        &bank.loaded_programs_cache.read().unwrap(),
+    );
     for key in cached_account_keys {
         loaded_programs.replenish(key, bank.load_program(&key));
         debug!("Loaded program {}", key);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -367,16 +367,34 @@ pub struct LoadedProgramsForTxBatch {
     /// LoadedProgram is the corresponding program entry valid for the slot in which a transaction is being executed.
     entries: HashMap<Pubkey, Arc<LoadedProgram>>,
     slot: Slot,
+    /// Runtime environment reference from LoadedProgram cache
+    pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    /// RuntimeV2 environment reference from LoadedProgram cache
+    pub program_runtime_environment_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
 }
 
 impl LoadedProgramsForTxBatch {
-    pub fn new(slot: Slot) -> Self {
+    pub fn new_from_cache(slot: Slot, loaded_programs_cache: &LoadedPrograms) -> Self {
         Self {
             entries: HashMap::new(),
             slot,
+            program_runtime_environment_v1: loaded_programs_cache
+                .program_runtime_environment_v1
+                .clone(),
+            program_runtime_environment_v2: loaded_programs_cache
+                .program_runtime_environment_v2
+                .clone(),
         }
     }
 
+    pub fn new_from_tx_batch_cache(slot: Slot, tx_batch_cache: &LoadedProgramsForTxBatch) -> Self {
+        Self {
+            entries: HashMap::new(),
+            slot,
+            program_runtime_environment_v1: tx_batch_cache.program_runtime_environment_v1.clone(),
+            program_runtime_environment_v2: tx_batch_cache.program_runtime_environment_v2.clone(),
+        }
+    }
     /// Refill the cache with a single entry. It's typically called during transaction loading, and
     /// transaction processing (for program management instructions).
     /// It replaces the existing entry (if any) with the provided entry. The return value contains
@@ -654,6 +672,8 @@ impl LoadedPrograms {
             LoadedProgramsForTxBatch {
                 entries: found,
                 slot: working_slot.current_slot(),
+                program_runtime_environment_v1: self.program_runtime_environment_v1.clone(),
+                program_runtime_environment_v2: self.program_runtime_environment_v2.clone(),
             },
             missing,
         )

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4773,8 +4773,15 @@ impl Bank {
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
 
         let mut executed_units = 0u64;
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(self.slot);
-        let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::new(self.slot);
+        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new_from_tx_batch_cache(
+            self.slot,
+            &programs_loaded_for_tx_batch,
+        );
+        let mut programs_updated_only_for_global_cache =
+            LoadedProgramsForTxBatch::new_from_tx_batch_cache(
+                self.slot,
+                &programs_loaded_for_tx_batch,
+            );
         let mut process_message_time = Measure::start("process_message_time");
         let process_result = MessageProcessor::process_message(
             tx.message(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4775,12 +4775,12 @@ impl Bank {
         let mut executed_units = 0u64;
         let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new_from_tx_batch_cache(
             self.slot,
-            &programs_loaded_for_tx_batch,
+            programs_loaded_for_tx_batch,
         );
         let mut programs_updated_only_for_global_cache =
             LoadedProgramsForTxBatch::new_from_tx_batch_cache(
                 self.slot,
-                &programs_loaded_for_tx_batch,
+                programs_loaded_for_tx_batch,
             );
         let mut process_message_time = Measure::start("process_message_time");
         let process_result = MessageProcessor::process_message(


### PR DESCRIPTION
#### Problem
The `deploy_program` macro creates a new instance of program runtime environment every time a program gets deployed. This instance of the environment will fail the following check, and would cause the program to get pruned.

https://github.com/solana-labs/solana/blob/58cca78067740030642456e4ec2a19bb44b25390/program-runtime/src/loaded_programs.rs#L497

#### Summary of Changes
Use the runtime environment from the program cache to load newly deployed programs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
