### PR TITLE
TieredStorage struct (6/N) -- write_accounts part 2 (account block)

### DIFF
--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -22,6 +22,8 @@ pub const FOOTER_TAIL_SIZE: usize = 24;
 /// The ending 8 bytes of a valid tiered account storage file.
 pub const FOOTER_MAGIC_NUMBER: u64 = 0x502A2AB5; // SOLALABS -> SOLANA LABS
 
+pub const DEFAULT_ACCOUNT_BLOCK_SIZE: u64 = 4096;
+
 #[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct TieredStorageMagicNumber(pub u64);
@@ -153,7 +155,7 @@ impl Default for TieredStorageFooter {
             account_block_format: AccountBlockFormat::default(),
             account_entry_count: 0,
             account_meta_entry_size: 0,
-            account_block_size: 0,
+            account_block_size: DEFAULT_ACCOUNT_BLOCK_SIZE,
             owner_count: 0,
             owner_entry_size: 0,
             account_index_offset: 0,

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -97,6 +97,9 @@ impl AccountMetaFlags {
     }
 }
 
+const DEFAULT_RENT_EPOCH: Epoch = u64::MAX;
+const DEFAULT_WRITE_VERSION: StoredMetaWriteVersion = u64::MAX;
+
 /// The in-memory struct for the optional fields for tiered account meta.
 ///
 /// Note that the storage representation of the optional fields might be
@@ -113,6 +116,21 @@ pub struct AccountMetaOptionalFields {
 }
 
 impl AccountMetaOptionalFields {
+    /// Create a new AccountMetaOptionalFields instance with the specified
+    /// fields.  If the value of a field equals to the default, then None
+    /// will be used in that field.
+    pub fn new_from_fields(
+        rent_epoch: Epoch,
+        account_hash: &Hash,
+        write_version: StoredMetaWriteVersion,
+    ) -> Self {
+        AccountMetaOptionalFields {
+            rent_epoch: (rent_epoch != DEFAULT_RENT_EPOCH).then_some(rent_epoch),
+            account_hash: (*account_hash != Hash::default()).then_some(*account_hash),
+            write_version: (write_version != DEFAULT_WRITE_VERSION).then_some(write_version),
+        }
+    }
+
     /// The size of the optional fields in bytes (excluding the boolean flags).
     pub fn size(&self) -> usize {
         self.rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>())

--- a/accounts-db/src/tiered_storage/writer.rs
+++ b/accounts-db/src/tiered_storage/writer.rs
@@ -2,16 +2,37 @@
 
 use {
     crate::{
-        account_storage::meta::{StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo},
+        account_storage::meta::{
+            StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredMetaWriteVersion,
+        },
         storable_accounts::StorableAccounts,
         tiered_storage::{
-            error::TieredStorageError, file::TieredStorageFile, footer::TieredStorageFooter,
+            byte_block::ByteBlockWriter,
+            error::TieredStorageError,
+            file::TieredStorageFile,
+            footer::TieredStorageFooter,
+            hot::HotAccountMeta,
+            meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
             TieredStorageFormat, TieredStorageResult,
         },
     },
     solana_sdk::{account::ReadableAccount, hash::Hash},
     std::{borrow::Borrow, path::Path},
 };
+
+const EMPTY_ACCOUNT_DATA: [u8; 0] = [0u8; 0];
+const PADDING: [u8; 8] = [0x8; 8];
+
+/// A helper function that extracts the lamports, rent epoch, and account data
+/// from the specified ReadableAccount, or returns the default of these values
+/// when the account is None (e.g. a zero-lamport account).
+fn get_account_fields<T: ReadableAccount + Sync>(account: Option<&T>) -> (u64, u64, &[u8]) {
+    if let Some(account) = account {
+        return (account.lamports(), account.rent_epoch(), account.data());
+    }
+
+    (0, u64::MAX, &EMPTY_ACCOUNT_DATA)
+}
 
 #[derive(Debug)]
 pub struct TieredStorageWriter<'format> {
@@ -30,6 +51,53 @@ impl<'format> TieredStorageWriter<'format> {
         })
     }
 
+    /// Persists a single account to a dedicated new account block and
+    /// return its stored size.
+    ///
+    /// The function currently only supports HotAccountMeta, and will
+    /// be extended to cover more TieredAccountMeta in future PRs.
+    fn write_single_account<T: TieredAccountMeta, U: ReadableAccount + Sync>(
+        &self,
+        account: Option<&U>,
+        account_hash: &Hash,
+        write_version: StoredMetaWriteVersion,
+        footer: &mut TieredStorageFooter,
+    ) -> TieredStorageResult<usize> {
+        let (lamports, rent_epoch, account_data) = get_account_fields(account);
+
+        let optional_fields =
+            AccountMetaOptionalFields::new_from_fields(rent_epoch, account_hash, write_version);
+
+        let flags = AccountMetaFlags::new_from(&optional_fields);
+        let meta = T::new()
+            .with_lamports(lamports)
+            .with_account_data_size(account_data.len() as u64)
+            .with_account_data_padding(((8 - (account_data.len() % 8)) % 8).try_into().unwrap())
+            .with_flags(&flags);
+
+        // writes the account in the following format:
+        //  +------------------+
+        //  | account meta     |
+        //  | account data     |
+        //  | padding (if any) |
+        //  | optional fields  |
+        //  +------------------+
+        let mut writer = ByteBlockWriter::new(footer.account_block_format);
+        writer.write_type(&meta)?;
+        writer.write(account_data)?;
+        if meta.account_data_padding() > 0 {
+            writer.write(&PADDING[0..meta.account_data_padding() as usize])?;
+        }
+        writer.write_optional_fields(&optional_fields)?;
+        let account_block = writer.finish()?;
+
+        self.storage.write_bytes(&account_block)?;
+
+        // For now it only supports HotAccountMeta, so the intra-block offset
+        // is always zero.
+        Ok(account_block.len())
+    }
+
     pub fn write_accounts<
         'a,
         'b,
@@ -41,7 +109,8 @@ impl<'format> TieredStorageWriter<'format> {
         accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
         skip: usize,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
-        let footer = TieredStorageFooter {
+        // TODO(yhchiang): try to make footer non mut
+        let mut footer = TieredStorageFooter {
             account_meta_format: self.format.account_meta_format,
             owners_block_format: self.format.owners_block_format,
             account_block_format: self.format.account_block_format,
@@ -54,6 +123,24 @@ impl<'format> TieredStorageWriter<'format> {
                 .expect("num accounts <= u32::MAX"),
             ..TieredStorageFooter::default()
         };
+
+        let mut cursor: usize = 0;
+        let len = accounts.accounts.len();
+        for i in skip..len {
+            let (account, _, hash, write_version) = accounts.get(i);
+
+            let stored_size = self.write_single_account::<HotAccountMeta, T>(
+                account,
+                hash,
+                write_version,
+                &mut footer,
+            )?;
+            // advance the cursor with the stored size
+            cursor += stored_size;
+        }
+
+        footer.account_index_offset = cursor as u64;
+        // TODO(yhchiang): index block will be included in a separate PR.
 
         footer.write_footer_block(&self.storage)?;
 


### PR DESCRIPTION
#### Summary of Changes
This PR further implements the write path of hot accounts and its
index block for TieredStorage::write_accounts().

#### Test Plan
New unit-tests are included in this PR.
More tests will be added once the reader and index part is implemented.

This PR depends on https://github.com/solana-labs/solana/pull/32850.