### PR TITLE
[TieredStorage] AccountIndex::get_account_block()

### DIFF
--- a/runtime/src/tiered_storage/footer.rs
+++ b/runtime/src/tiered_storage/footer.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        error::TieredStorageError, file::TieredStorageFile, index::AccountIndexFormat,
+        error::TieredStorageError, file::TieredStorageFile, index::AccountIndex,
         mmap_utils::get_type, TieredStorageResult as TsResult,
     },
     memmap2::Mmap,
@@ -95,7 +95,7 @@ pub struct TieredStorageFooter {
     /// The format of the owners block.
     pub owners_block_format: OwnersBlockFormat,
     /// The format of the account index block.
-    pub account_index_format: AccountIndexFormat,
+    pub account_index_format: AccountIndex,
     /// The format of the account block.
     pub account_block_format: AccountBlockFormat,
 
@@ -149,7 +149,7 @@ impl Default for TieredStorageFooter {
         Self {
             account_meta_format: AccountMetaFormat::default(),
             owners_block_format: OwnersBlockFormat::default(),
-            account_index_format: AccountIndexFormat::default(),
+            account_index_format: AccountIndex::default(),
             account_block_format: AccountBlockFormat::default(),
             account_entry_count: 0,
             account_meta_entry_size: 0,
@@ -241,7 +241,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            account_index_format: AccountIndexFormat::AddressAndOffset,
+            account_index_format: AccountIndex::AddressAndOffset,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,

--- a/runtime/src/tiered_storage/index.rs
+++ b/runtime/src/tiered_storage/index.rs
@@ -1,6 +1,8 @@
 use {
     crate::tiered_storage::{
-        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_type,
+        file::TieredStorageFile,
+        footer::TieredStorageFooter,
+        mmap_utils::{get_slice, get_type},
         TieredStorageResult,
     },
     memmap2::Mmap,
@@ -30,7 +32,7 @@ pub struct AccountIndexWriterEntry<'a> {
     num_enum::IntoPrimitive,
     num_enum::TryFromPrimitive,
 )]
-pub enum AccountIndexFormat {
+pub enum AccountIndex {
     /// This format optimizes the storage size by storing only account addresses
     /// and offsets.  It skips storing the size of account data by storing account
     /// block entries and index block entries in the same order.
@@ -38,7 +40,7 @@ pub enum AccountIndexFormat {
     AddressAndOffset = 0,
 }
 
-impl AccountIndexFormat {
+impl AccountIndex {
     /// Persists the specified index_entries to the specified file and returns
     /// the total number of bytes written.
     pub fn write_index_block(
@@ -76,23 +78,51 @@ impl AccountIndexFormat {
         Ok(address)
     }
 
-    /// Returns the offset to the account block that contains the account
-    /// associated with the specified index to the index block.
-    pub fn get_account_block_offset(
+    /// Returns the offset and size of the account block that contains
+    /// the account associated with the specified index to the index block.
+    fn get_account_block_info(
         &self,
-        map: &Mmap,
+        mmap: &Mmap,
         footer: &TieredStorageFooter,
         index: usize,
-    ) -> TieredStorageResult<u64> {
+    ) -> TieredStorageResult<(u64, usize)> {
         match self {
             Self::AddressAndOffset => {
-                let offset = footer.account_index_offset as usize
+                let index_offset = footer.account_index_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
                     + index * std::mem::size_of::<u64>();
-                let (account_block_offset, _) = get_type(map, offset)?;
-                Ok(*account_block_offset)
+                let (target_block_offset, mut index_offset) = get_type::<u64>(mmap, index_offset)?;
+                let owners_block_offset: usize = footer.owners_offset.try_into().unwrap();
+
+                let next_block_offset = loop {
+                    if index_offset >= owners_block_offset {
+                        break footer.account_index_offset as usize;
+                    }
+                    let (block_offset, next_offset) = get_type::<u64>(mmap, index_offset)?;
+                    if *target_block_offset != *block_offset {
+                        break *block_offset as usize;
+                    }
+                    index_offset = next_offset;
+                };
+                return Ok((
+                    *target_block_offset,
+                    next_block_offset - (*target_block_offset) as usize,
+                ));
             }
         }
+    }
+
+    /// Returns the account block from the specified mmap
+    pub fn get_account_block<'a>(
+        &self,
+        mmap: &'a Mmap,
+        footer: &TieredStorageFooter,
+        index: usize,
+    ) -> TieredStorageResult<&'a [u8]> {
+        let (offset, len) = self.get_account_block_info(mmap, footer, index)?;
+        let (account_block, _) = get_slice(mmap, offset as usize, len)?;
+
+        Ok(account_block)
     }
 
     /// Returns the size of one index entry.
@@ -113,45 +143,76 @@ mod tests {
     #[test]
     fn test_address_and_offset_indexer() {
         const ENTRY_COUNT: usize = 100;
-        let footer = TieredStorageFooter {
-            account_entry_count: ENTRY_COUNT as u32,
-            ..TieredStorageFooter::default()
-        };
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test_address_and_offset_indexer");
         let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(ENTRY_COUNT)
             .collect();
         let mut rng = rand::thread_rng();
+        let mut block_offset = 0;
         let index_entries: Vec<_> = addresses
             .iter()
-            .map(|address| AccountIndexWriterEntry {
-                address,
-                block_offset: rng.gen_range(128, 2048),
-                intra_block_offset: 0,
+            .map(|address| {
+                if rng.gen_bool(0.5) {
+                    block_offset += rng.gen_range(1, 128) * 8;
+                }
+                AccountIndexWriterEntry {
+                    address,
+                    block_offset,
+                    intra_block_offset: 0,
+                }
             })
             .collect();
 
+        let account_blocks_size = block_offset + rng.gen_range(1, 128) * 8;
+        let indexer = AccountIndex::AddressAndOffset;
+        let footer = TieredStorageFooter {
+            account_entry_count: ENTRY_COUNT as u32,
+            // the account index block locates right after account blocks
+            account_index_offset: account_blocks_size,
+            // the owners block locates right after the account index block
+            owners_offset: account_blocks_size + (indexer.entry_size() * ENTRY_COUNT) as u64,
+            ..TieredStorageFooter::default()
+        };
+
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
-            let indexer = AccountIndexFormat::AddressAndOffset;
+            let test_account_blocks: Vec<u8> =
+                (0..account_blocks_size).map(|i| (i % 256) as u8).collect();
+            file.write_bytes(&test_account_blocks).unwrap();
             indexer.write_index_block(&file, &index_entries).unwrap();
         }
 
-        let indexer = AccountIndexFormat::AddressAndOffset;
+        let indexer = AccountIndex::AddressAndOffset;
         let file = OpenOptions::new()
             .read(true)
             .create(false)
             .open(&path)
             .unwrap();
         let map = unsafe { MmapOptions::new().map(&file).unwrap() };
-        for (i, index_entry) in index_entries.iter().enumerate() {
+
+        let mut block_ending_offset = account_blocks_size;
+        let (last_block_offset, _) = indexer
+            .get_account_block_info(&map, &footer, ENTRY_COUNT - 1)
+            .unwrap();
+        let mut prev_block_offset = last_block_offset;
+
+        for (i, index_entry) in index_entries.iter().enumerate().rev() {
+            let (block_offset, block_size) =
+                indexer.get_account_block_info(&map, &footer, i).unwrap();
+            assert_eq!(index_entry.block_offset, block_offset,);
+            if block_offset != prev_block_offset {
+                block_ending_offset = prev_block_offset;
+                prev_block_offset = block_offset;
+            }
+            assert_eq!(block_size as u64, block_ending_offset - block_offset);
+            let account_block = indexer.get_account_block(&map, &footer, i).unwrap();
             assert_eq!(
-                index_entry.block_offset,
-                indexer.get_account_block_offset(&map, &footer, i).unwrap()
+                account_block,
+                (block_offset..block_ending_offset)
+                    .map(|i| (i % 256) as u8)
+                    .collect::<Vec<_>>()
             );
-            let address = indexer.get_account_address(&map, &footer, i).unwrap();
-            assert_eq!(index_entry.address, address);
         }
     }
 }


### PR DESCRIPTION
#### Summary of Changes
This PR implements AccountIndex::get_account_block(), a function
that allows the Index to return the account block given the index
associated with the account.

#### Test Plan
New tests are included in the PR.

