### PR TITLE
dcou: set_accounts_hash()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7445,7 +7445,8 @@ impl AccountsDb {
     /// Set the accounts hash for `slot`
     ///
     /// returns the previous accounts hash for `slot`
-    pub fn set_accounts_hash(
+    #[cfg_attr(feature = "dev-context-only-utils", fn_qualifiers(pub))]
+    fn set_accounts_hash(
         &self,
         slot: Slot,
         accounts_hash: (AccountsHash, /*capitalization*/ u64),
@@ -9595,10 +9596,6 @@ impl AccountsDb {
 
     pub fn accounts_hashes(&self) -> &Mutex<HashMap<Slot, (AccountsHash, /*capitalization*/ u64)>> {
         &self.accounts_hashes
-    }
-
-    pub fn set_accounts_hash_for_tests(&self, slot: Slot, accounts_hash: AccountsHash) {
-        self.set_accounts_hash(slot, (accounts_hash, u64::default()));
     }
 
     pub fn assert_load_account(&self, slot: Slot, pubkey: Pubkey, expected_lamports: u64) {

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -131,10 +131,10 @@ mod tests {
         bank2.freeze();
         bank2.squash();
         bank2.force_flush_accounts_cache();
-        bank2
-            .accounts()
-            .accounts_db
-            .set_accounts_hash_for_tests(bank2.slot(), AccountsHash(Hash::new(&[0; 32])));
+        bank2.accounts().accounts_db.set_accounts_hash(
+            bank2.slot(),
+            (AccountsHash(Hash::new(&[0; 32])), u64::default()),
+        );
 
         let snapshot_storages = bank2.get_snapshot_storages(None);
         let mut buf = vec![];
@@ -164,10 +164,10 @@ mod tests {
         .unwrap();
 
         if update_accounts_hash {
-            bank2
-                .accounts()
-                .accounts_db
-                .set_accounts_hash_for_tests(bank2.slot(), AccountsHash(Hash::new(&[1; 32])));
+            bank2.accounts().accounts_db.set_accounts_hash(
+                bank2.slot(),
+                (AccountsHash(Hash::new(&[1; 32])), u64::default()),
+            );
         }
         let accounts_hash = bank2.get_accounts_hash().unwrap();
 
@@ -353,10 +353,10 @@ mod tests {
                 .accounts
                 .accounts_db
                 .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
-            bank.rc
-                .accounts
-                .accounts_db
-                .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
+            bank.rc.accounts.accounts_db.set_accounts_hash(
+                bank.slot(),
+                (AccountsHash(Hash::new_unique()), u64::default()),
+            );
 
             // Set extra fields
             bank.fee_rate_governor.lamports_per_signature = 7000;
@@ -544,10 +544,10 @@ mod tests {
             .accounts
             .accounts_db
             .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
-        bank.rc
-            .accounts
-            .accounts_db
-            .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
+        bank.rc.accounts.accounts_db.set_accounts_hash(
+            bank.slot(),
+            (AccountsHash(Hash::new_unique()), u64::default()),
+        );
 
         // Set extra fields
         bank.fee_rate_governor.lamports_per_signature = 7000;
@@ -626,10 +626,10 @@ mod tests {
                 .accounts
                 .accounts_db
                 .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
-            bank.rc
-                .accounts
-                .accounts_db
-                .set_accounts_hash_for_tests(bank.slot(), AccountsHash(Hash::new_unique()));
+            bank.rc.accounts.accounts_db.set_accounts_hash(
+                bank.slot(),
+                (AccountsHash(Hash::new_unique()), u64::default()),
+            );
             let snapshot_storages = bank.rc.accounts.accounts_db.get_snapshot_storages(..=0).0;
             // ensure there is a single snapshot storage example for ABI digesting
             assert_eq!(snapshot_storages.len(), 1);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -239,7 +239,7 @@ mod serde_snapshot_tests {
         let accounts_hash = AccountsHash(Hash::new_unique());
         accounts
             .accounts_db
-            .set_accounts_hash_for_tests(slot, accounts_hash);
+            .set_accounts_hash(slot, (accounts_hash, u64::default()));
 
         let mut writer = Cursor::new(vec![]);
         accountsdb_to_stream(


### PR DESCRIPTION
#### Problem

context: https://github.com/solana-labs/solana/pull/32748#discussion_r1286322947

This PR is a follow up #32822, which showed how to avoid creating a new function just for testing (https://github.com/solana-labs/solana/pull/32822#pullrequestreview-1575315692).

#### Summary of Changes

Conditionally make `set_accounts_hash()` public when the DCOU feature is enabled.