### PR TITLE
Use update_accounts_hash() in AccountsHashVerifier

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -125,7 +125,7 @@ fn main() {
                 .update_accounts_hash_for_tests(0, &ancestors, false, false);
             time.stop();
             let mut time_store = Measure::start("hash using store");
-            let results_store = accounts.accounts_db.update_accounts_hash(
+            let results_store = accounts.accounts_db.update_accounts_hash_with_verify(
                 CalcAccountsHashDataSource::Storages,
                 false,
                 solana_sdk::clock::Slot::default(),

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -396,24 +396,17 @@ impl AccountsHashVerifier {
             include_slot_in_hash: accounts_package.include_slot_in_hash,
         };
 
+        let slot = accounts_package.slot;
         let ((accounts_hash, lamports), measure_hash_us) = measure_us!(accounts_package
             .accounts
             .accounts_db
-            .calculate_accounts_hash_from_storages(
+            .update_accounts_hash(
                 &calculate_accounts_hash_config,
                 &sorted_storages,
+                slot,
                 timings,
             )
             .unwrap()); // unwrap here will never fail since check_hash = false
-
-        let slot = accounts_package.slot;
-        let old_accounts_hash = accounts_package
-            .accounts
-            .accounts_db
-            .set_accounts_hash(slot, (accounts_hash, lamports));
-        if let Some(old_accounts_hash) = old_accounts_hash {
-            warn!("Accounts hash was already set for slot {slot}! old: {old_accounts_hash:?}, new: {accounts_hash:?}");
-        }
 
         if accounts_package.expected_capitalization != lamports {
             // before we assert, run the hash calc again. This helps track down whether it could have been a failure in a race condition possibly with shrink.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7279,7 +7279,7 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .update_accounts_hash(
+            .update_accounts_hash_with_verify(
                 // we have to use the index since the slot could be in the write cache still
                 CalcAccountsHashDataSource::IndexForTests,
                 debug_verify,
@@ -7385,17 +7385,21 @@ impl Bank {
         mut debug_verify: bool,
         is_startup: bool,
     ) -> AccountsHash {
-        let (accounts_hash, total_lamports) = self.rc.accounts.accounts_db.update_accounts_hash(
-            data_source,
-            debug_verify,
-            self.slot(),
-            &self.ancestors,
-            Some(self.capitalization()),
-            self.epoch_schedule(),
-            &self.rent_collector,
-            is_startup,
-            self.include_slot_in_hash(),
-        );
+        let (accounts_hash, total_lamports) = self
+            .rc
+            .accounts
+            .accounts_db
+            .update_accounts_hash_with_verify(
+                data_source,
+                debug_verify,
+                self.slot(),
+                &self.ancestors,
+                Some(self.capitalization()),
+                self.epoch_schedule(),
+                &self.rent_collector,
+                is_startup,
+                self.include_slot_in_hash(),
+            );
         if total_lamports != self.capitalization() {
             datapoint_info!(
                 "capitalization_mismatch",
@@ -7408,17 +7412,20 @@ impl Bank {
                 // cap mismatch detected. It has been logged to metrics above.
                 // Run both versions of the calculation to attempt to get more info.
                 debug_verify = true;
-                self.rc.accounts.accounts_db.update_accounts_hash(
-                    data_source,
-                    debug_verify,
-                    self.slot(),
-                    &self.ancestors,
-                    Some(self.capitalization()),
-                    self.epoch_schedule(),
-                    &self.rent_collector,
-                    is_startup,
-                    self.include_slot_in_hash(),
-                );
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .update_accounts_hash_with_verify(
+                        data_source,
+                        debug_verify,
+                        self.slot(),
+                        &self.ancestors,
+                        Some(self.capitalization()),
+                        self.epoch_schedule(),
+                        &self.rent_collector,
+                        is_startup,
+                        self.include_slot_in_hash(),
+                    );
             }
 
             panic!(


### PR DESCRIPTION
#### Problem

AccountsHashVerifier calculates the accounts hash when handling snapshot requests. It also updates AccountsDb after the calculation is complete. For full snapshot requests, we currently call `calculate` then `set`. For incremental snapshots, we call `update`, which performs both `calculate` and `set` steps.

In order to make `AccountsDb::set_accounts_hash()` private (for https://github.com/solana-labs/solana/pull/32829), we need to *not* call `set_accounts_hash()` from AHV.



#### Summary of Changes
 
* AHV calls `update_accounts_hash` instead of `calculate` and `set`
* Add a new `update_accounts_hash` function to AccountsDb, and rename the old one to `update_accounts_hash_with_verify`