### PR TITLE
removes repair socket from gossip ContactInfo

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -28,6 +28,8 @@ cargo_audit_ignores=(
   # Exception is a stopgap to unblock CI
   # https://github.com/solana-labs/solana/issues/29586
   --ignore RUSTSEC-2023-0001
+
+  --ignore RUSTSEC-2022-0093
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -214,7 +214,7 @@ pub(crate) type Ping = ping_pong::Ping<[u8; REPAIR_PING_TOKEN_SIZE]>;
 
 /// Window protocol messages
 #[derive(Debug, AbiEnumVisitor, AbiExample, Deserialize, Serialize, strum_macros::Display)]
-#[frozen_abi(digest = "DPHju3YufeNw1qfr22ZWRgJdXb1TvZt8iwLqWXUTyrtW")]
+#[frozen_abi(digest = "7vZyACjc13qQYWUsqWbdidLXR3uNXpmqUZaKeV3gKuY2")]
 pub enum RepairProtocol {
     LegacyWindowIndex(LegacyContactInfo, Slot, u64),
     LegacyHighestWindowIndex(LegacyContactInfo, Slot, u64),
@@ -1912,7 +1912,6 @@ mod tests {
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
         nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
         nxt.set_tvu_quic((Ipv4Addr::LOCALHOST, 1236)).unwrap();
-        nxt.set_repair((Ipv4Addr::LOCALHOST, 1237)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
         nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();
@@ -1943,7 +1942,6 @@ mod tests {
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
         nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
         nxt.set_tvu_quic((Ipv4Addr::LOCALHOST, 1236)).unwrap();
-        nxt.set_repair((Ipv4Addr::LOCALHOST, 1237)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
         nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -448,7 +448,7 @@ fn get_target(
                     Mode::TpuForwards => {
                         Some((*node.pubkey(), node.tpu_forwards(protocol).unwrap()))
                     }
-                    Mode::Repair => Some((*node.pubkey(), node.repair().unwrap())),
+                    Mode::Repair => todo!("repair socket is not gossiped anymore!"),
                     Mode::ServeRepair => Some((*node.pubkey(), node.serve_repair().unwrap())),
                     Mode::Rpc => None,
                 };
@@ -856,6 +856,9 @@ pub mod test {
             },
         );
 
+        // TODO: Figure out how to DOS repair. Repair socket is no longer
+        // gossiped and cannot be obtained from a node's contact-info.
+        #[cfg(not(test))]
         run_dos_no_client(
             &nodes,
             1,

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -26,7 +26,6 @@ pub const SOCKET_ADDR_UNSPECIFIED: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0u16);
 
 const SOCKET_TAG_GOSSIP: u8 = 0;
-const SOCKET_TAG_REPAIR: u8 = 1;
 const SOCKET_TAG_RPC: u8 = 2;
 const SOCKET_TAG_RPC_PUBSUB: u8 = 3;
 const SOCKET_TAG_SERVE_REPAIR: u8 = 4;
@@ -223,7 +222,6 @@ impl ContactInfo {
     }
 
     get_socket!(gossip, SOCKET_TAG_GOSSIP);
-    get_socket!(repair, SOCKET_TAG_REPAIR);
     get_socket!(rpc, SOCKET_TAG_RPC);
     get_socket!(rpc_pubsub, SOCKET_TAG_RPC_PUBSUB);
     get_socket!(serve_repair, SOCKET_TAG_SERVE_REPAIR);
@@ -237,7 +235,6 @@ impl ContactInfo {
     get_socket!(tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
 
     set_socket!(set_gossip, SOCKET_TAG_GOSSIP);
-    set_socket!(set_repair, SOCKET_TAG_REPAIR);
     set_socket!(set_rpc, SOCKET_TAG_RPC);
     set_socket!(set_rpc_pubsub, SOCKET_TAG_RPC_PUBSUB);
     set_socket!(set_serve_repair, SOCKET_TAG_SERVE_REPAIR);
@@ -365,7 +362,6 @@ impl ContactInfo {
         node.set_gossip((Ipv4Addr::LOCALHOST, 8000)).unwrap();
         node.set_tvu((Ipv4Addr::LOCALHOST, 8001)).unwrap();
         node.set_tvu_quic((Ipv4Addr::LOCALHOST, 8002)).unwrap();
-        node.set_repair((Ipv4Addr::LOCALHOST, 8007)).unwrap();
         node.set_tpu((Ipv4Addr::LOCALHOST, 8003)).unwrap(); // quic: 8009
         node.set_tpu_forwards((Ipv4Addr::LOCALHOST, 8004)).unwrap(); // quic: 8010
         node.set_tpu_vote((Ipv4Addr::LOCALHOST, 8005)).unwrap();
@@ -389,7 +385,6 @@ impl ContactInfo {
         node.set_gossip((addr, port + 1)).unwrap();
         node.set_tvu((addr, port + 2)).unwrap();
         node.set_tvu_quic((addr, port + 3)).unwrap();
-        node.set_repair((addr, port + 4)).unwrap();
         node.set_tpu((addr, port)).unwrap(); // quic: port + 6
         node.set_tpu_forwards((addr, port + 5)).unwrap(); // quic: port + 11
         node.set_tpu_vote((addr, port + 7)).unwrap();
@@ -732,7 +727,6 @@ mod tests {
                 }
             }
             assert_eq!(node.gossip().ok().as_ref(), sockets.get(&SOCKET_TAG_GOSSIP));
-            assert_eq!(node.repair().ok().as_ref(), sockets.get(&SOCKET_TAG_REPAIR));
             assert_eq!(node.rpc().ok().as_ref(), sockets.get(&SOCKET_TAG_RPC));
             assert_eq!(
                 node.rpc_pubsub().ok().as_ref(),
@@ -817,7 +811,6 @@ mod tests {
     fn cross_verify_with_legacy(node: &ContactInfo) {
         let old = LegacyContactInfo::try_from(node).unwrap();
         assert_eq!(old.gossip().unwrap(), node.gossip().unwrap());
-        assert_eq!(old.repair().unwrap(), node.repair().unwrap());
         assert_eq!(old.rpc().unwrap(), node.rpc().unwrap());
         assert_eq!(old.rpc_pubsub().unwrap(), node.rpc_pubsub().unwrap());
         assert_eq!(old.serve_repair().unwrap(), node.serve_repair().unwrap());

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -27,8 +27,7 @@ pub struct LegacyContactInfo {
     tvu: SocketAddr,
     /// TVU over QUIC protocol.
     tvu_quic: SocketAddr,
-    /// address to send repair responses to
-    repair: SocketAddr,
+    unused: SocketAddr,
     /// transactions address
     tpu: SocketAddr,
     /// address to forward unprocessed transactions to
@@ -124,7 +123,7 @@ impl Default for LegacyContactInfo {
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
             tvu_quic: socketaddr_any!(),
-            repair: socketaddr_any!(),
+            unused: socketaddr_any!(),
             tpu: socketaddr_any!(),
             tpu_forwards: socketaddr_any!(),
             tpu_vote: socketaddr_any!(),
@@ -144,7 +143,7 @@ impl LegacyContactInfo {
             gossip: socketaddr!(Ipv4Addr::LOCALHOST, 1234),
             tvu: socketaddr!(Ipv4Addr::LOCALHOST, 1235),
             tvu_quic: socketaddr!(Ipv4Addr::LOCALHOST, 1236),
-            repair: socketaddr!(Ipv4Addr::LOCALHOST, 1237),
+            unused: socketaddr!(Ipv4Addr::LOCALHOST, 1237),
             tpu: socketaddr!(Ipv4Addr::LOCALHOST, 1238),
             tpu_forwards: socketaddr!(Ipv4Addr::LOCALHOST, 1239),
             tpu_vote: socketaddr!(Ipv4Addr::LOCALHOST, 1240),
@@ -206,7 +205,6 @@ impl LegacyContactInfo {
 
     get_socket!(gossip);
     get_socket!(tvu, tvu_quic);
-    get_socket!(repair);
     get_socket!(@quic tpu);
     get_socket!(@quic tpu_forwards);
     get_socket!(tpu_vote);
@@ -274,7 +272,7 @@ impl TryFrom<&ContactInfo> for LegacyContactInfo {
             gossip: unwrap_socket!(gossip),
             tvu: unwrap_socket!(tvu, Protocol::UDP),
             tvu_quic: unwrap_socket!(tvu, Protocol::QUIC),
-            repair: unwrap_socket!(repair),
+            unused: SOCKET_ADDR_UNSPECIFIED,
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
             tpu_vote: unwrap_socket!(tpu_vote),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -72,7 +72,7 @@ pub struct AdminRpcContactInfo {
     pub gossip: SocketAddr,
     pub tvu: SocketAddr,
     pub tvu_quic: SocketAddr,
-    pub repair: SocketAddr,
+    pub unused: SocketAddr,
     pub tpu: SocketAddr,
     pub tpu_forwards: SocketAddr,
     pub tpu_vote: SocketAddr,
@@ -104,7 +104,7 @@ impl From<ContactInfo> for AdminRpcContactInfo {
             gossip: unwrap_socket!(gossip),
             tvu: unwrap_socket!(tvu, Protocol::UDP),
             tvu_quic: unwrap_socket!(tvu, Protocol::QUIC),
-            repair: unwrap_socket!(repair),
+            unused: SOCKET_ADDR_UNSPECIFIED,
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
             tpu_vote: unwrap_socket!(tpu_vote),
@@ -122,7 +122,6 @@ impl Display for AdminRpcContactInfo {
         writeln!(f, "Gossip: {}", self.gossip)?;
         writeln!(f, "TVU: {}", self.tvu)?;
         writeln!(f, "TVU QUIC: {}", self.tvu_quic)?;
-        writeln!(f, "Repair: {}", self.repair)?;
         writeln!(f, "TPU: {}", self.tpu)?;
         writeln!(f, "TPU Forwards: {}", self.tpu_forwards)?;
         writeln!(f, "TPU Votes: {}", self.tpu_vote)?;


### PR DESCRIPTION

#### Problem
Repair responses are sent back to the address the repair request came from and there is no need to gossip repair socket address. https://github.com/solana-labs/solana/blob/9212ac347/core/src/repair/serve_repair.rs#L519


#### Summary of Changes
Removed repair socket from gossip `ContactInfo`.