### PR TITLE
Integrate program loader-v4 with bank

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,8 +536,10 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs =
-        LoadedProgramsForTxBatch::new(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
+    let mut loaded_programs = LoadedProgramsForTxBatch::new_from_cache(
+        bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET,
+        &bank.loaded_programs_cache.read().unwrap(),
+    );
     for key in cached_account_keys {
         loaded_programs.replenish(key, bank.load_program(&key));
         debug!("Loaded program {}", key);

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,9 +536,13 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs = LoadedProgramsForTxBatch::new_from_cache(
+    let mut loaded_programs = LoadedProgramsForTxBatch::new(
         bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET,
-        &bank.loaded_programs_cache.read().unwrap(),
+        bank.loaded_programs_cache
+            .read()
+            .unwrap()
+            .environments
+            .clone(),
     );
     for key in cached_account_keys {
         loaded_programs.replenish(key, bank.load_program(&key));

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -214,6 +214,14 @@ impl<'a> InvokeContext<'a> {
         }
     }
 
+    pub fn find_program_in_cache(&self, pubkey: &Pubkey) -> Option<Arc<LoadedProgram>> {
+        // First lookup the cache of the programs modified by the current transaction. If not found, lookup
+        // the cache of the cache of the programs that are loaded for the transaction batch.
+        self.programs_modified_by_tx
+            .find(pubkey)
+            .or_else(|| self.programs_loaded_for_tx_batch.find(pubkey))
+    }
+
     /// Push a stack frame onto the invocation stack
     pub fn push(&mut self) -> Result<(), InstructionError> {
         let instruction_context = self

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -367,13 +367,32 @@ pub struct LoadedProgramsForTxBatch {
     /// LoadedProgram is the corresponding program entry valid for the slot in which a transaction is being executed.
     entries: HashMap<Pubkey, Arc<LoadedProgram>>,
     slot: Slot,
+    /// Runtime environment reference from LoadedProgram cache
+    pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    /// RuntimeV2 environment reference from LoadedProgram cache
+    pub program_runtime_environment_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
 }
 
 impl LoadedProgramsForTxBatch {
-    pub fn new(slot: Slot) -> Self {
+    pub fn new_from_cache(slot: Slot, loaded_programs_cache: &LoadedPrograms) -> Self {
         Self {
             entries: HashMap::new(),
             slot,
+            program_runtime_environment_v1: loaded_programs_cache
+                .program_runtime_environment_v1
+                .clone(),
+            program_runtime_environment_v2: loaded_programs_cache
+                .program_runtime_environment_v2
+                .clone(),
+        }
+    }
+
+    pub fn new_from_tx_batch_cache(slot: Slot, tx_batch_cache: &LoadedProgramsForTxBatch) -> Self {
+        Self {
+            entries: HashMap::new(),
+            slot,
+            program_runtime_environment_v1: tx_batch_cache.program_runtime_environment_v1.clone(),
+            program_runtime_environment_v2: tx_batch_cache.program_runtime_environment_v2.clone(),
         }
     }
 
@@ -654,6 +673,8 @@ impl LoadedPrograms {
             LoadedProgramsForTxBatch {
                 entries: found,
                 slot: working_slot.current_slot(),
+                program_runtime_environment_v1: self.program_runtime_environment_v1.clone(),
+                program_runtime_environment_v2: self.program_runtime_environment_v2.clone(),
             },
             missing,
         )

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -350,9 +350,9 @@ impl LoadedProgram {
 #[derive(Clone, Debug, Default)]
 pub struct ProgramRuntimeEnvironments {
     /// Globally shared RBPF config and syscall registry
-    pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    pub program_runtime_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
     /// Globally shared RBPF config and syscall registry for runtime V2
-    pub program_runtime_environment_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    pub program_runtime_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
 }
 
 #[derive(Debug, Default)]
@@ -503,27 +503,22 @@ impl LoadedPrograms {
                     LoadedProgramType::LegacyV0(program) | LoadedProgramType::LegacyV1(program)
                         if Arc::ptr_eq(
                             program.get_loader(),
-                            &self.environments.program_runtime_environment_v1,
+                            &self.environments.program_runtime_v1,
                         ) =>
                     {
                         true
                     }
                     LoadedProgramType::Unloaded(environment)
                     | LoadedProgramType::FailedVerification(environment)
-                        if Arc::ptr_eq(
-                            environment,
-                            &self.environments.program_runtime_environment_v1,
-                        ) || Arc::ptr_eq(
-                            environment,
-                            &self.environments.program_runtime_environment_v2,
-                        ) =>
+                        if Arc::ptr_eq(environment, &self.environments.program_runtime_v1)
+                            || Arc::ptr_eq(environment, &self.environments.program_runtime_v2) =>
                     {
                         true
                     }
                     LoadedProgramType::Typed(program)
                         if Arc::ptr_eq(
                             program.get_loader(),
-                            &self.environments.program_runtime_environment_v2,
+                            &self.environments.program_runtime_v2,
                         ) =>
                     {
                         true

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -99,18 +99,6 @@ pub fn load_program_from_bytes(
     Ok(loaded_program)
 }
 
-fn find_program_in_cache(
-    invoke_context: &InvokeContext,
-    pubkey: &Pubkey,
-) -> Option<Arc<LoadedProgram>> {
-    // First lookup the cache of the programs modified by the current transaction. If not found, lookup
-    // the cache of the cache of the programs that are loaded for the transaction batch.
-    invoke_context
-        .programs_modified_by_tx
-        .find(pubkey)
-        .or_else(|| invoke_context.programs_loaded_for_tx_batch.find(pubkey))
-}
-
 macro_rules! deploy_program {
     ($invoke_context:expr, $program_id:expr, $loader_key:expr,
      $account_size:expr, $slot:expr, $drop:expr, $new_programdata:expr $(,)?) => {{
@@ -137,7 +125,7 @@ macro_rules! deploy_program {
             $slot,
             Arc::new(program_runtime_environment),
         )?;
-        if let Some(old_entry) = find_program_in_cache($invoke_context, &$program_id) {
+        if let Some(old_entry) = $invoke_context.find_program_in_cache(&$program_id) {
             executor.tx_usage_counter.store(
                 old_entry.tx_usage_counter.load(Ordering::Relaxed),
                 Ordering::Relaxed
@@ -507,7 +495,8 @@ fn process_instruction_inner(
     }
 
     let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
-    let executor = find_program_in_cache(invoke_context, program_account.get_key())
+    let executor = invoke_context
+        .find_program_in_cache(program_account.get_key())
         .ok_or(InstructionError::InvalidAccountData)?;
 
     if executor.is_tombstone() {

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -454,7 +454,7 @@ pub fn process_instruction_deploy(
         invoke_context
             .programs_modified_by_tx
             .environments
-            .program_runtime_environment_v2
+            .program_runtime_v2
             .clone(),
         deployment_slot,
         effective_slot,
@@ -690,7 +690,7 @@ mod tests {
                         invoke_context
                             .programs_modified_by_tx
                             .environments
-                            .program_runtime_environment_v2
+                            .program_runtime_v2
                             .clone(),
                         0,
                         0,
@@ -738,9 +738,10 @@ mod tests {
                 invoke_context
                     .programs_modified_by_tx
                     .environments
-                    .program_runtime_environment_v2 = Arc::new(
-                    create_program_runtime_environment_v2(&ComputeBudget::default(), false),
-                );
+                    .program_runtime_v2 = Arc::new(create_program_runtime_environment_v2(
+                    &ComputeBudget::default(),
+                    false,
+                ));
                 load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -453,6 +453,7 @@ pub fn process_instruction_deploy(
         &loader_v4::id(),
         invoke_context
             .programs_modified_by_tx
+            .environments
             .program_runtime_environment_v2
             .clone(),
         deployment_slot,
@@ -688,6 +689,7 @@ mod tests {
                         &loader_v4::id(),
                         invoke_context
                             .programs_modified_by_tx
+                            .environments
                             .program_runtime_environment_v2
                             .clone(),
                         0,
@@ -735,6 +737,7 @@ mod tests {
             |invoke_context| {
                 invoke_context
                     .programs_modified_by_tx
+                    .environments
                     .program_runtime_environment_v2 = Arc::new(
                     create_program_runtime_environment_v2(&ComputeBudget::default(), false),
                 );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4640,20 +4640,11 @@ impl Bank {
     }
 
     pub fn load_program(&self, pubkey: &Pubkey) -> Arc<LoadedProgram> {
-        let program_runtime_environment_v1 = self
+        let environments = self
             .loaded_programs_cache
             .read()
             .unwrap()
             .environments
-            .program_runtime_v1
-            .clone();
-
-        let program_runtime_environment_v2 = self
-            .loaded_programs_cache
-            .read()
-            .unwrap()
-            .environments
-            .program_runtime_v2
             .clone();
 
         let mut load_program_metrics = LoadProgramMetrics {
@@ -4680,7 +4671,7 @@ impl Bank {
                     program_account.owner(),
                     program_account.data().len(),
                     0,
-                    program_runtime_environment_v1.clone(),
+                    environments.program_runtime_v1.clone(),
                 )
             }
 
@@ -4704,7 +4695,7 @@ impl Bank {
                             .len()
                             .saturating_add(programdata_account.data().len()),
                         slot,
-                        program_runtime_environment_v1.clone(),
+                        environments.program_runtime_v1.clone(),
                     )
                 }),
 
@@ -4715,7 +4706,7 @@ impl Bank {
                     .and_then(|elf_bytes| {
                         LoadedProgram::new(
                             &loader_v4::id(),
-                            program_runtime_environment_v2.clone(),
+                            environments.program_runtime_v2.clone(),
                             slot,
                             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                             None,
@@ -4727,20 +4718,20 @@ impl Bank {
                     })
                     .unwrap_or(LoadedProgram::new_tombstone(
                         self.slot,
-                        LoadedProgramType::FailedVerification(program_runtime_environment_v2),
+                        LoadedProgramType::FailedVerification(environments.program_runtime_v2),
                     ));
                 Ok(loaded_program)
             }
 
             ProgramAccountLoadResult::InvalidV4Program => Ok(LoadedProgram::new_tombstone(
                 self.slot,
-                LoadedProgramType::FailedVerification(program_runtime_environment_v2),
+                LoadedProgramType::FailedVerification(environments.program_runtime_v2),
             )),
         }
         .unwrap_or_else(|_| {
             LoadedProgram::new_tombstone(
                 self.slot,
-                LoadedProgramType::FailedVerification(program_runtime_environment_v1),
+                LoadedProgramType::FailedVerification(environments.program_runtime_v1),
             )
         });
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4645,7 +4645,7 @@ impl Bank {
             .read()
             .unwrap()
             .environments
-            .program_runtime_environment_v1
+            .program_runtime_v1
             .clone();
 
         let program_runtime_environment_v2 = self
@@ -4653,7 +4653,7 @@ impl Bank {
             .read()
             .unwrap()
             .environments
-            .program_runtime_environment_v2
+            .program_runtime_v2
             .clone();
 
         let mut load_program_metrics = LoadProgramMetrics {
@@ -8065,28 +8065,22 @@ impl Bank {
             )
             .unwrap();
             let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
-            if *loaded_programs_cache
-                .environments
-                .program_runtime_environment_v1
+            if *loaded_programs_cache.environments.program_runtime_v1
                 != program_runtime_environment_v1
             {
-                loaded_programs_cache
-                    .environments
-                    .program_runtime_environment_v1 = Arc::new(program_runtime_environment_v1);
+                loaded_programs_cache.environments.program_runtime_v1 =
+                    Arc::new(program_runtime_environment_v1);
             }
             let program_runtime_environment_v2 =
                 solana_loader_v4_program::create_program_runtime_environment_v2(
                     &self.runtime_config.compute_budget.unwrap_or_default(),
                     false, /* debugging_features */
                 );
-            if *loaded_programs_cache
-                .environments
-                .program_runtime_environment_v2
+            if *loaded_programs_cache.environments.program_runtime_v2
                 != program_runtime_environment_v2
             {
-                loaded_programs_cache
-                    .environments
-                    .program_runtime_environment_v2 = Arc::new(program_runtime_environment_v2);
+                loaded_programs_cache.environments.program_runtime_v2 =
+                    Arc::new(program_runtime_environment_v2);
             }
             loaded_programs_cache.prune_feature_set_transition();
         }


### PR DESCRIPTION
#### Problem
`loader-v4` code is not yet integrated with bank. So the programs owned by this loader cannot be used.

#### Summary of Changes
Integrate the loader code with bank.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
