### PR TITLE
dcou: Update qualifier_attr to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "qualifier_attr"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a696aef893ed46a96ed81163ef58856b2da620c2eb4b38623253ad215c600b1d"
+checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ prost = "0.11.9"
 prost-types = "0.11.9"
 protobuf-src = "1.1.0"
 qstring = "0.7.2"
-qualifier_attr = "0.1.6"
+qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.10.2"
 quinn-proto = "0.10.2"
 quote = "1.0"

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -19,7 +19,7 @@
 //! commit for each slot entry would be indexed.
 
 #[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::fn_qualifiers;
+use qualifier_attr::qualifiers;
 use {
     crate::{
         account_info::{AccountInfo, StorageLocation},
@@ -7476,7 +7476,7 @@ impl AccountsDb {
     /// Set the accounts hash for `slot`
     ///
     /// returns the previous accounts hash for `slot`
-    #[cfg_attr(feature = "dev-context-only-utils", fn_qualifiers(pub))]
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn set_accounts_hash(
         &self,
         slot: Slot,
@@ -7977,7 +7977,7 @@ impl AccountsDb {
     /// Set the accounts delta hash for `slot` in the `accounts_delta_hashes` map
     ///
     /// returns the previous accounts delta hash for `slot`
-    #[cfg_attr(feature = "dev-context-only-utils", fn_qualifiers(pub))]
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn set_accounts_delta_hash(
         &self,
         slot: Slot,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3633,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "qualifier_attr"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a696aef893ed46a96ed81163ef58856b2da620c2eb4b38623253ad215c600b1d"
+checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
~needs to #32829 to land first but~ (EDIT: landed) `qualifier_attr` needs to be updated. its internal impl improved quite a bit by https://github.com/JohnScience/qualifier_attr/pull/1, which is released under 0.2.x releases.

thus, the crate now needs to be `default-features = false` to exclusively switch to the newer impl according to https://crates.io/crates/qualifier_attr/0.2.2#note-on-legacy-attributes.

