### PR TITLE
uses typed Pubkey instead of opaque [u8; 32]

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -92,17 +92,11 @@ mod test {
         .unwrap();
         packet.meta_mut().flags |= PacketFlags::REPAIR;
 
-        let leader_slots = [(slot, keypair.pubkey().to_bytes())]
-            .iter()
-            .cloned()
-            .collect();
+        let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
         assert!(verify_shred_cpu(&packet, &leader_slots));
 
         let wrong_keypair = Keypair::new();
-        let leader_slots = [(slot, wrong_keypair.pubkey().to_bytes())]
-            .iter()
-            .cloned()
-            .collect();
+        let leader_slots = HashMap::from([(slot, wrong_keypair.pubkey())]);
         assert!(!verify_shred_cpu(&packet, &leader_slots));
 
         let leader_slots = HashMap::new();


### PR DESCRIPTION
#### Problem
Unnecessary use of `[u8; 32]` instead of `Pubkey` type.

#### Summary of Changes
Use typed `Pubkey` instead of opaque `[u8; 32]`.