### PR TITLE
ledger-tool: Consolidate ledger-tool specific directories

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,4 +1,5 @@
 use {
+    crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, values_t_or_exit, ArgMatches},
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, FillerAccountsConfig},
@@ -41,7 +42,9 @@ pub fn get_accounts_db_config(
             .map(PathBuf::from)
             .collect()
     } else {
-        vec![ledger_path.join("ledger-tool").join("accounts_index")]
+        vec![ledger_path
+            .join(LEDGER_TOOL_DIRECTORY)
+            .join("accounts_index")]
     };
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -41,7 +41,7 @@ pub fn get_accounts_db_config(
             .map(PathBuf::from)
             .collect()
     } else {
-        vec![ledger_path.join("accounts_index.ledger-tool")]
+        vec![ledger_path.join("ledger-tool").join("accounts_index")]
     };
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,

--- a/ledger-tool/src/ledger_path.rs
+++ b/ledger-tool/src/ledger_path.rs
@@ -4,6 +4,8 @@ use std::{
     process::exit,
 };
 
+pub const LEDGER_TOOL_DIRECTORY: &str = "ledger_tool";
+
 // Canonicalize ledger path to avoid issues with symlink creation
 pub fn canonicalize_ledger_path(ledger_path: &Path) -> PathBuf {
     fs::canonicalize(ledger_path).unwrap_or_else(|err| {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,4 +1,5 @@
 use {
+    crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, value_t_or_exit, values_t_or_exit, ArgMatches},
     crossbeam_channel::unbounded,
     log::*,
@@ -76,7 +77,7 @@ pub fn load_and_process_ledger(
     } else {
         blockstore
             .ledger_path()
-            .join("ledger-tool")
+            .join(LEDGER_TOOL_DIRECTORY)
             .join("snapshot")
     };
 
@@ -168,7 +169,7 @@ pub fn load_and_process_ledger(
     } else {
         let non_primary_accounts_path = blockstore
             .ledger_path()
-            .join("ledger-tool")
+            .join(LEDGER_TOOL_DIRECTORY)
             .join("accounts");
         info!(
             "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -71,13 +71,14 @@ pub fn load_and_process_ledger(
     snapshot_archive_path: Option<PathBuf>,
     incremental_snapshot_archive_path: Option<PathBuf>,
 ) -> Result<(Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>), BlockstoreProcessorError> {
-    let bank_snapshots_dir = blockstore
-        .ledger_path()
-        .join(if blockstore.is_primary_access() {
-            "snapshot"
-        } else {
-            "snapshot.ledger-tool"
-        });
+    let bank_snapshots_dir = if blockstore.is_primary_access() {
+        blockstore.ledger_path().join("snapshot")
+    } else {
+        blockstore
+            .ledger_path()
+            .join("ledger-tool")
+            .join("snapshot")
+    };
 
     let mut starting_slot = 0; // default start check with genesis
     let snapshot_config = if arg_matches.is_present("no_snapshot") {
@@ -165,7 +166,10 @@ pub fn load_and_process_ledger(
     } else if blockstore.is_primary_access() {
         vec![blockstore.ledger_path().join("accounts")]
     } else {
-        let non_primary_accounts_path = blockstore.ledger_path().join("accounts.ledger-tool");
+        let non_primary_accounts_path = blockstore
+            .ledger_path()
+            .join("ledger-tool")
+            .join("accounts");
         info!(
             "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
             non_primary_accounts_path


### PR DESCRIPTION
#### Problem
    When ledger-tool runs, it may create secondary directories for things
    like accounts, accounts-index, etc as not to potentially interfere with
    solana-validator's directories. These would show as multiple directories
    with ".ledger-tool" appended to the typical directory name.
    
#### Summary of Changes
    To more clearly group these items, make the default directories for
    snapshots, accounts and accounts-index all within a common "ledger-tool"
    directory. This eases cleaning of ledger-tool files easier too.
    
This should not interfere would fast-boot at all, as fast-boot will currently run with primary access.