### PR TITLE
v1.16: ci: ignore RUSTSEC-2022-0093 temporarily

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -28,6 +28,10 @@ cargo_audit_ignores=(
   # Exception is a stopgap to unblock CI
   # https://github.com/solana-labs/solana/issues/29586
   --ignore RUSTSEC-2023-0001
+
+  # ed25519-dalek
+  # https://github.com/solana-labs/solana/pull/32836
+  --ignore RUSTSEC-2022-0093
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

due to `RUSTSEC-2022-0093`, `ed25519-dalek` should upgrade to >= 2. in case everyone is blocked by this one. I choose to ignore it temporarily. we can add it back when https://github.com/solana-labs/solana/pull/32836 is ready!

