### PR TITLE
client: Rename confrim -> confirm

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -22,7 +22,7 @@ use {
     solana_client::{
         connection_cache::ConnectionCache,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking, SendAndConfrimConfig,
+            send_and_confirm_transactions_in_parallel_blocking, SendAndConfirmConfig,
         },
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -2198,7 +2198,7 @@ fn send_deploy_messages(
                         Some(tpu_client),
                         write_messages,
                         &[payer_signer, write_signer],
-                        SendAndConfrimConfig {
+                        SendAndConfirmConfig {
                             resign_txs_count: Some(5),
                             with_spinner: true,
                         },

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -2,7 +2,7 @@ use {
     solana_client::{
         nonblocking::tpu_client::TpuClient,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking, SendAndConfrimConfig,
+            send_and_confirm_transactions_in_parallel_blocking, SendAndConfirmConfig,
         },
     },
     solana_rpc_client::rpc_client::RpcClient,
@@ -56,7 +56,7 @@ fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
         None,
         &messages,
         &[&alice],
-        SendAndConfrimConfig {
+        SendAndConfirmConfig {
             with_spinner: false,
             resign_txs_count: Some(5),
         },
@@ -114,7 +114,7 @@ fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
         Some(tpu_client),
         &messages,
         &[&alice],
-        SendAndConfrimConfig {
+        SendAndConfirmConfig {
             with_spinner: false,
             resign_txs_count: Some(5),
         },

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -51,7 +51,7 @@ struct BlockHashData {
 }
 
 #[derive(Clone, Debug, Copy)]
-pub struct SendAndConfrimConfig {
+pub struct SendAndConfirmConfig {
     pub with_spinner: bool,
     pub resign_txs_count: Option<usize>,
 }
@@ -61,7 +61,7 @@ pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
     tpu_client: Option<QuicTpuClient>,
     messages: &[Message],
     signers: &T,
-    config: SendAndConfrimConfig,
+    config: SendAndConfirmConfig,
 ) -> Result<Vec<Option<TransactionError>>> {
     let fut = send_and_confirm_transactions_in_parallel(
         rpc_client.get_inner_client().clone(),
@@ -352,7 +352,7 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     tpu_client: Option<QuicTpuClient>,
     messages: &[Message],
     signers: &T,
-    config: SendAndConfrimConfig,
+    config: SendAndConfirmConfig,
 ) -> Result<Vec<Option<TransactionError>>> {
     // get current blockhash and corresponding last valid block height
     let (blockhash, last_valid_blockheight) = rpc_client


### PR DESCRIPTION
#### Problem

While looking over changes in #32638, I noticed some typos of `confrim` in `SendAndConfrimConfig` and `send_and_confrim_transactions_in_parallel.rs`

#### Summary of Changes

Fix the typos! This can go in after #32638 since that's been approved.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
