### PR TITLE
Fixup duplicate shred proof plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6133,6 +6133,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "static_assertions",
+ "test-case",
  "thiserror",
 ]
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -214,7 +214,7 @@ impl Tvu {
                 leader_schedule_cache.clone(),
                 verified_vote_receiver,
                 completed_data_sets_sender,
-                duplicate_slots_sender,
+                duplicate_slots_sender.clone(),
                 ancestor_hashes_replay_update_receiver,
                 dumped_slots_receiver,
                 popular_pruned_forks_sender,
@@ -322,6 +322,7 @@ impl Tvu {
                 blockstore,
                 leader_schedule_cache.clone(),
                 bank_forks.clone(),
+                duplicate_slots_sender,
             ),
         );
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -19,7 +19,7 @@ use {
     rayon::{prelude::*, ThreadPool},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
-        blockstore::{Blockstore, BlockstoreInsertionMetrics},
+        blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{self, Nonce, ReedSolomonCache, Shred},
     },
@@ -138,23 +138,41 @@ impl WindowServiceMetrics {
 fn run_check_duplicate(
     cluster_info: &ClusterInfo,
     blockstore: &Blockstore,
-    shred_receiver: &Receiver<Shred>,
+    shred_receiver: &Receiver<PossibleDuplicateShred>,
     duplicate_slots_sender: &DuplicateSlotSender,
 ) -> Result<()> {
-    let check_duplicate = |shred: Shred| -> Result<()> {
+    let check_duplicate = |shred: PossibleDuplicateShred| -> Result<()> {
         let shred_slot = shred.slot();
-        if !blockstore.has_duplicate_shreds_in_slot(shred_slot) {
-            if let Some(existing_shred_payload) = blockstore.is_shred_duplicate(&shred) {
-                cluster_info.push_duplicate_shred(&shred, &existing_shred_payload)?;
-                blockstore.store_duplicate_slot(
-                    shred_slot,
-                    existing_shred_payload,
-                    shred.into_payload(),
-                )?;
-
-                duplicate_slots_sender.send(shred_slot)?;
+        let (shred1, shred2) = match shred {
+            PossibleDuplicateShred::LastIndexConflict(shred, conflict) => (shred, conflict),
+            PossibleDuplicateShred::ErasureConflict(shred, conflict) => (shred, conflict),
+            PossibleDuplicateShred::Exists(shred) => {
+                // Unlike the other cases we have to wait until here to decide to handle the duplicate and store
+                // in blockstore. This is because the duplicate could have been part of the same insert batch,
+                // so we wait until the batch has been written.
+                if !blockstore.has_duplicate_shreds_in_slot(shred_slot) {
+                    if let Some(existing_shred_payload) = blockstore.is_shred_duplicate(&shred) {
+                        blockstore.store_duplicate_slot(
+                            shred_slot,
+                            existing_shred_payload.clone(),
+                            shred.clone().into_payload(),
+                        )?;
+                        (shred, existing_shred_payload)
+                    } else {
+                        // Shred is not duplicate
+                        return Ok(());
+                    }
+                } else {
+                    // Shred has already been handled
+                    return Ok(());
+                }
             }
-        }
+        };
+
+        // Propagate duplicate proof through gossip
+        cluster_info.push_duplicate_shred(&shred1, &shred2)?;
+        // Notify duplicate consensus state machine
+        duplicate_slots_sender.send(shred_slot)?;
 
         Ok(())
     };
@@ -226,7 +244,7 @@ fn run_insert<F>(
     reed_solomon_cache: &ReedSolomonCache,
 ) -> Result<()>
 where
-    F: Fn(Shred),
+    F: Fn(PossibleDuplicateShred),
 {
     const RECV_TIMEOUT: Duration = Duration::from_millis(200);
     let mut shred_receiver_elapsed = Measure::start("shred_receiver_elapsed");
@@ -370,7 +388,7 @@ impl WindowService {
         cluster_info: Arc<ClusterInfo>,
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
-        duplicate_receiver: Receiver<Shred>,
+        duplicate_receiver: Receiver<PossibleDuplicateShred>,
         duplicate_slots_sender: DuplicateSlotSender,
     ) -> JoinHandle<()> {
         let handle_error = || {
@@ -400,7 +418,7 @@ impl WindowService {
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         verified_receiver: Receiver<Vec<PacketBatch>>,
-        check_duplicate_sender: Sender<Shred>,
+        check_duplicate_sender: Sender<PossibleDuplicateShred>,
         completed_data_sets_sender: CompletedDataSetsSender,
         retransmit_sender: Sender<Vec<ShredPayload>>,
         outstanding_requests: Arc<RwLock<OutstandingShredRepairs>>,
@@ -417,8 +435,8 @@ impl WindowService {
         Builder::new()
             .name("solWinInsert".to_string())
             .spawn(move || {
-                let handle_duplicate = |shred| {
-                    let _ = check_duplicate_sender.send(shred);
+                let handle_duplicate = |possible_duplicate_shred| {
+                    let _ = check_duplicate_sender.send(possible_duplicate_shred);
                 };
                 let mut metrics = BlockstoreInsertionMetrics::default();
                 let mut ws_metrics = WindowServiceMetrics::default();
@@ -551,7 +569,9 @@ mod test {
         };
         assert_eq!(duplicate_shred.slot(), shreds[0].slot());
         let duplicate_shred_slot = duplicate_shred.slot();
-        sender.send(duplicate_shred.clone()).unwrap();
+        sender
+            .send(PossibleDuplicateShred::Exists(duplicate_shred.clone()))
+            .unwrap();
         assert!(!blockstore.has_duplicate_shreds_in_slot(duplicate_shred_slot));
         let keypair = Keypair::new();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -53,6 +53,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -149,7 +149,7 @@ impl CrdsGossip {
         let now = timestamp();
         for entry in entries {
             if let Err(err) = crds.insert(entry, now, GossipRoute::LocalMessage) {
-                error!("push_duplicate_shred faild: {:?}", err);
+                error!("push_duplicate_shred failed: {:?}", err);
             }
         }
         Ok(())

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -135,9 +135,26 @@ impl std::fmt::Display for InsertDataShredError {
     }
 }
 
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum PossibleDuplicateShred {
+    Exists(Shred), // Blockstore has another shred in its spot
+    LastIndexConflict(/* original */ Shred, /* conflict */ Vec<u8>), // The index of this shred conflicts with `slot_meta.last_index`
+    ErasureConflict(/* original */ Shred, /* conflict */ Vec<u8>), // The coding shred has a conflict in the erasure_meta
+}
+
+impl PossibleDuplicateShred {
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Exists(shred) => shred.slot(),
+            Self::LastIndexConflict(shred, _) => shred.slot(),
+            Self::ErasureConflict(shred, _) => shred.slot(),
+        }
+    }
+}
+
 pub struct InsertResults {
     completed_data_set_infos: Vec<CompletedDataSetInfo>,
-    duplicate_shreds: Vec<Shred>,
+    duplicate_shreds: Vec<PossibleDuplicateShred>,
 }
 
 /// A "complete data set" is a range of [`Shred`]s that combined in sequence carry a single
@@ -1047,7 +1064,7 @@ impl Blockstore {
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<Vec<CompletedDataSetInfo>>
     where
-        F: Fn(Shred),
+        F: Fn(PossibleDuplicateShred),
     {
         let InsertResults {
             completed_data_set_infos,
@@ -1165,7 +1182,7 @@ impl Blockstore {
         write_batch: &mut WriteBatch,
         just_received_shreds: &mut HashMap<ShredId, Shred>,
         index_meta_time_us: &mut u64,
-        duplicate_shreds: &mut Vec<Shred>,
+        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
         is_trusted: bool,
         shred_source: ShredSource,
         metrics: &mut BlockstoreInsertionMetrics,
@@ -1184,7 +1201,7 @@ impl Blockstore {
         if !is_trusted {
             if index_meta.coding().contains(shred_index) {
                 metrics.num_coding_shreds_exists += 1;
-                duplicate_shreds.push(shred);
+                duplicate_shreds.push(PossibleDuplicateShred::Exists(shred));
                 return false;
             }
 
@@ -1201,8 +1218,6 @@ impl Blockstore {
                 .unwrap_or_else(|| ErasureMeta::from_coding_shred(&shred).unwrap())
         });
 
-        // TODO: handle_duplicate is not invoked and so duplicate shreds are
-        // not gossiped to the rest of cluster.
         if !erasure_meta.check_coding_shred(&shred) {
             metrics.num_coding_shreds_invalid_erasure_config += 1;
             let conflicting_shred = self.find_conflicting_coding_shred(
@@ -1212,15 +1227,22 @@ impl Blockstore {
                 just_received_shreds,
             );
             if let Some(conflicting_shred) = conflicting_shred {
-                if self
-                    .store_duplicate_if_not_existing(
-                        slot,
+                if !self.has_duplicate_shreds_in_slot(slot) {
+                    if self
+                        .store_duplicate_slot(
+                            slot,
+                            conflicting_shred.clone(),
+                            shred.payload().clone(),
+                        )
+                        .is_err()
+                    {
+                        warn!("bad duplicate store..");
+                    }
+
+                    duplicate_shreds.push(PossibleDuplicateShred::ErasureConflict(
+                        shred.clone(),
                         conflicting_shred,
-                        shred.payload().clone(),
-                    )
-                    .is_err()
-                {
-                    warn!("bad duplicate store..");
+                    ));
                 }
             } else {
                 datapoint_info!("bad-conflict-shred", ("slot", slot, i64));
@@ -1338,7 +1360,7 @@ impl Blockstore {
         just_inserted_shreds: &mut HashMap<ShredId, Shred>,
         index_meta_time_us: &mut u64,
         is_trusted: bool,
-        duplicate_shreds: &mut Vec<Shred>,
+        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
         leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
     ) -> std::result::Result<Vec<CompletedDataSetInfo>, InsertDataShredError> {
@@ -1360,7 +1382,7 @@ impl Blockstore {
 
         if !is_trusted {
             if Self::is_data_shred_present(&shred, slot_meta, index_meta.data()) {
-                duplicate_shreds.push(shred);
+                duplicate_shreds.push(PossibleDuplicateShred::Exists(shred));
                 return Err(InsertDataShredError::Exists);
             }
 
@@ -1385,6 +1407,7 @@ impl Blockstore {
                 &self.last_root,
                 leader_schedule,
                 shred_source,
+                duplicate_shreds,
             ) {
                 return Err(InsertDataShredError::InvalidShred);
             }
@@ -1466,6 +1489,7 @@ impl Blockstore {
         last_root: &RwLock<u64>,
         leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
+        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
         let shred_index = u64::from(shred.index());
         let slot = shred.slot();
@@ -1483,21 +1507,25 @@ impl Blockstore {
             let leader_pubkey = leader_schedule
                 .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
 
-            let ending_shred: Cow<Vec<u8>> = self.get_data_shred_from_just_inserted_or_db(
-                just_inserted_shreds,
-                slot,
-                last_index.unwrap(),
-            );
+            if !self.has_duplicate_shreds_in_slot(slot) {
+                let ending_shred: Vec<u8> = self
+                    .get_data_shred_from_just_inserted_or_db(
+                        just_inserted_shreds,
+                        slot,
+                        last_index.unwrap(),
+                    )
+                    .into_owned();
 
-            if self
-                .store_duplicate_if_not_existing(
-                    slot,
-                    ending_shred.into_owned(),
-                    shred.payload().clone(),
-                )
-                .is_err()
-            {
-                warn!("store duplicate error");
+                if self
+                    .store_duplicate_slot(slot, ending_shred.clone(), shred.payload().clone())
+                    .is_err()
+                {
+                    warn!("store duplicate error");
+                }
+                duplicate_shreds.push(PossibleDuplicateShred::LastIndexConflict(
+                    shred.clone(),
+                    ending_shred,
+                ));
             }
 
             datapoint_error!(
@@ -1518,21 +1546,25 @@ impl Blockstore {
             let leader_pubkey = leader_schedule
                 .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
 
-            let ending_shred: Cow<Vec<u8>> = self.get_data_shred_from_just_inserted_or_db(
-                just_inserted_shreds,
-                slot,
-                slot_meta.received - 1,
-            );
+            if !self.has_duplicate_shreds_in_slot(slot) {
+                let ending_shred: Vec<u8> = self
+                    .get_data_shred_from_just_inserted_or_db(
+                        just_inserted_shreds,
+                        slot,
+                        slot_meta.received - 1,
+                    )
+                    .into_owned();
 
-            if self
-                .store_duplicate_if_not_existing(
-                    slot,
-                    ending_shred.into_owned(),
-                    shred.payload().clone(),
-                )
-                .is_err()
-            {
-                warn!("store duplicate error");
+                if self
+                    .store_duplicate_slot(slot, ending_shred.clone(), shred.payload().clone())
+                    .is_err()
+                {
+                    warn!("store duplicate error");
+                }
+                duplicate_shreds.push(PossibleDuplicateShred::LastIndexConflict(
+                    shred.clone(),
+                    ending_shred,
+                ));
             }
 
             datapoint_error!(
@@ -3222,19 +3254,6 @@ impl Blockstore {
 
     pub fn remove_slot_duplicate_proof(&self, slot: Slot) -> Result<()> {
         self.duplicate_slots_cf.delete(slot)
-    }
-
-    pub fn store_duplicate_if_not_existing(
-        &self,
-        slot: Slot,
-        shred1: Vec<u8>,
-        shred2: Vec<u8>,
-    ) -> Result<()> {
-        if !self.has_duplicate_shreds_in_slot(slot) {
-            self.store_duplicate_slot(slot, shred1, shred2)
-        } else {
-            Ok(())
-        }
     }
 
     pub fn get_first_duplicate_proof(&self) -> Option<(Slot, DuplicateSlotProof)> {
@@ -6571,6 +6590,7 @@ pub mod tests {
             &last_root,
             None,
             ShredSource::Repaired,
+            &mut Vec::new(),
         ));
         // Trying to insert another "is_last" shred with index < the received index should fail
         // skip over shred 7
@@ -6587,6 +6607,7 @@ pub mod tests {
                 panic!("Shred in unexpected format")
             }
         };
+        let mut duplicate_shreds = vec![];
         assert!(!blockstore.should_insert_data_shred(
             &shred7,
             &slot_meta,
@@ -6594,8 +6615,15 @@ pub mod tests {
             &last_root,
             None,
             ShredSource::Repaired,
+            &mut duplicate_shreds,
         ));
         assert!(blockstore.has_duplicate_shreds_in_slot(0));
+        assert_eq!(duplicate_shreds.len(), 1);
+        matches!(
+            duplicate_shreds[0],
+            PossibleDuplicateShred::LastIndexConflict(_, _)
+        );
+        assert_eq!(duplicate_shreds[0].slot(), 0);
 
         // Insert all pending shreds
         let mut shred8 = shreds[8].clone();
@@ -6604,18 +6632,30 @@ pub mod tests {
 
         // Trying to insert a shred with index > the "is_last" shred should fail
         if shred8.is_data() {
-            shred8.set_slot(slot_meta.last_index.unwrap() + 1);
+            shred8.set_index((slot_meta.last_index.unwrap() + 1) as u32);
         } else {
             panic!("Shred in unexpected format")
         }
+        duplicate_shreds.clear();
+        blockstore.duplicate_slots_cf.delete(0).unwrap();
+        assert!(!blockstore.has_duplicate_shreds_in_slot(0));
         assert!(!blockstore.should_insert_data_shred(
-            &shred7,
+            &shred8,
             &slot_meta,
             &HashMap::new(),
             &last_root,
             None,
             ShredSource::Repaired,
+            &mut duplicate_shreds,
         ));
+
+        assert_eq!(duplicate_shreds.len(), 1);
+        matches!(
+            duplicate_shreds[0],
+            PossibleDuplicateShred::LastIndexConflict(_, _)
+        );
+        assert_eq!(duplicate_shreds[0].slot(), 0);
+        assert!(blockstore.has_duplicate_shreds_in_slot(0));
     }
 
     #[test]
@@ -6701,7 +6741,10 @@ pub mod tests {
             ShredSource::Turbine,
             &mut BlockstoreInsertionMetrics::default(),
         ));
-        assert_eq!(duplicate_shreds, vec![coding_shred]);
+        assert_eq!(
+            duplicate_shreds,
+            vec![PossibleDuplicateShred::Exists(coding_shred)]
+        );
     }
 
     #[test]

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -322,7 +322,7 @@ impl SlotMeta {
 }
 
 impl ErasureMeta {
-    pub(crate) fn from_coding_shred(shred: &Shred) -> Option<Self> {
+    pub fn from_coding_shred(shred: &Shred) -> Option<Self> {
         match shred.shred_type() {
             ShredType::Data => None,
             ShredType::Code => {
@@ -344,7 +344,7 @@ impl ErasureMeta {
 
     // Returns true if the erasure fields on the shred
     // are consistent with the erasure-meta.
-    pub(crate) fn check_coding_shred(&self, shred: &Shred) -> bool {
+    pub fn check_coding_shred(&self, shred: &Shred) -> bool {
         let Some(mut other) = Self::from_coding_shred(shred) else {
             return false;
         };


### PR DESCRIPTION
#### Problem
Duplicate shreds detected due to invalid `LAST_SHRED_IN_SLOT` flags, or erasure metas are stored in blockstore but never forwarded to the cluster or the state machine.

Similarly duplicate shreds received through gossip are never forwarded to the state machine.

Also on replay from ledger, we do not do anything with the blockstore cf indicating duplicate proof, this should be sent to the state machine. 

#### Summary of Changes
Fix the plumbing. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
