### PR TITLE
ci: move some fast checks to sanity

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -13,24 +13,6 @@ source ci/rust-version.sh nightly
 eval "$(ci/channel-info.sh)"
 cargoNightly="$(readlink -f "./cargo") nightly"
 
-scripts/increment-cargo-version.sh check
-
-if ! [ -v SOLANA_CI_ALLOW_STALE_CARGO_LOCK ] ; then
-# Disallow uncommitted Cargo.lock changes
-(
-  _ scripts/cargo-for-all-lock-files.sh tree >/dev/null
-  set +e
-  if ! _ git diff --exit-code; then
-    cat <<EOF 1>&2
-
-Error: Uncommitted Cargo.lock changes.
-Run './scripts/cargo-for-all-lock-files.sh tree' and commit the result.
-EOF
-    exit 1
-  fi
-)
-fi
-
 echo --- build environment
 (
   set -x

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -53,4 +53,22 @@ _ ci/check-channel-version.sh
 _ ci/nits.sh
 _ ci/check-ssh-keys.sh
 
+scripts/increment-cargo-version.sh check
+
+if ! [ -v SOLANA_CI_ALLOW_STALE_CARGO_LOCK ] ; then
+# Disallow uncommitted Cargo.lock changes
+(
+  _ scripts/cargo-for-all-lock-files.sh tree >/dev/null
+  set +e
+  if ! _ git diff --exit-code; then
+    cat <<EOF 1>&2
+
+Error: Uncommitted Cargo.lock changes.
+Run './scripts/cargo-for-all-lock-files.sh tree' and commit the result.
+EOF
+    exit 1
+  fi
+)
+fi
+
 echo --- ok


### PR DESCRIPTION
#### Problem

there are a couple tests in `test-checks.sh` that are fast and invasive to local iteration

#### Summary of Changes

move them to `test-sanity.sh`