### PR TITLE
Adds docs to non_vote_transaction_count_since_restart()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6920,6 +6920,10 @@ impl Bank {
         self.transaction_count.load(Relaxed)
     }
 
+    /// Returns the number of non-vote transactions processed without error
+    /// since the most recent boot from snapshot or genesis.
+    /// This value is not shared though the network, nor retained
+    /// within snapshots, but is preserved in `Bank::new_from_parent`.
     pub fn non_vote_transaction_count_since_restart(&self) -> u64 {
         self.non_vote_transaction_count_since_restart.load(Relaxed)
     }


### PR DESCRIPTION
#### Problem

An audit of the bank code identified fns missing doc comments.

Original context: https://github.com/solana-labs/solana/pull/32709


#### Summary of Changes

Add documentation to `non_vote_transaction_count_since_restart()`.