### PR TITLE
Adds docs to get_all_accounts()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6850,7 +6850,8 @@ impl Bank {
         self.rc.accounts.account_indexes_include_key(key)
     }
 
-    pub fn get_all_accounts_with_modified_slots(&self) -> ScanResult<Vec<PubkeyAccountSlot>> {
+    /// Returns all the accounts this bank can load
+    pub fn get_all_accounts(&self) -> ScanResult<Vec<PubkeyAccountSlot>> {
         self.rc.accounts.load_all(&self.ancestors, self.bank_id)
     }
 
@@ -8150,7 +8151,7 @@ impl Bank {
 
     /// Get all the accounts for this bank and calculate stats
     pub fn get_total_accounts_stats(&self) -> ScanResult<TotalAccountsStats> {
-        let accounts = self.get_all_accounts_with_modified_slots()?;
+        let accounts = self.get_all_accounts()?;
         Ok(self.calculate_total_accounts_stats(
             accounts
                 .iter()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4479,7 +4479,7 @@ fn test_bank_get_program_accounts() {
     let parent = Arc::new(Bank::new_for_tests(&genesis_config));
     parent.restore_old_behavior_for_fragile_tests();
 
-    let genesis_accounts: Vec<_> = parent.get_all_accounts_with_modified_slots().unwrap();
+    let genesis_accounts: Vec<_> = parent.get_all_accounts().unwrap();
     assert!(
         genesis_accounts
             .iter()


### PR DESCRIPTION
#### Problem

An audit of the bank code identified fns missing doc comments.

Original context: https://github.com/solana-labs/solana/pull/32709


#### Summary of Changes

Renames `get_all_accounts_with_modified_slots()` to `get_all_accounts()` and adds documentation.