### PR TITLE
Adds docs to scan_all_accounts()

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3332,8 +3332,7 @@ fn main() {
                     }
                 };
                 let mut measure = Measure::start("scanning accounts");
-                bank.scan_all_accounts_with_modified_slots(scan_func)
-                    .unwrap();
+                bank.scan_all_accounts(scan_func).unwrap();
                 measure.stop();
                 info!("{}", measure);
                 if let Some(json_serializer) = json_serializer {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6854,7 +6854,8 @@ impl Bank {
         self.rc.accounts.load_all(&self.ancestors, self.bank_id)
     }
 
-    pub fn scan_all_accounts_with_modified_slots<F>(&self, scan_func: F) -> ScanResult<()>
+    // Scans all the accounts this bank can load, applying `scan_func`
+    pub fn scan_all_accounts<F>(&self, scan_func: F) -> ScanResult<()>
     where
         F: FnMut(Option<(&Pubkey, AccountSharedData, Slot)>),
     {


### PR DESCRIPTION
#### Problem

An audit of the bank code identified fns missing doc comments.

Original context: https://github.com/solana-labs/solana/pull/32709


#### Summary of Changes

Renames `scan_all_accounts_with_modified_slots()` to `scan_all_accounts()` and adds documentation.

Please refer to https://github.com/solana-labs/solana/pull/32887#discussion_r1298546704 for comments regarding the rename.

Similarly, this function is only called from ledger-tool.