### PR TITLE
Adds docs to get_all_accounts_modified_since_parent()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6884,6 +6884,7 @@ impl Bank {
             .get_logs_for_address(address)
     }
 
+    /// Returns all the accounts stored in this slot
     pub fn get_all_accounts_modified_since_parent(&self) -> Vec<TransactionAccount> {
         self.rc.accounts.load_by_program_slot(self.slot(), None)
     }


### PR DESCRIPTION
#### Problem

An audit of the bank code identified fns missing doc comments.

Original context: https://github.com/solana-labs/solana/pull/32709


#### Summary of Changes

Add documentation to `get_all_accounts_modified_since_parent()`.