### PR TITLE
Do not do send in cache warmer -- just establish connections

### DIFF
--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -54,7 +54,7 @@ impl WarmQuicCacheService {
                                 .lookup_contact_info(&leader_pubkey, |node| node.tpu(Protocol::QUIC))
                             {
                                 let conn = connection_cache.get_connection(&addr);
-                                if let Err(err) = conn.send_data(&[0u8]) {
+                                if let Err(err) = conn.send_data(&[]) {
                                     warn!(
                                         "Failed to warmup QUIC connection to the leader {:?}, Error {:?}",
                                         leader_pubkey, err

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -384,6 +384,11 @@ impl QuicClient {
                 .acks
                 .update_stat(&self.stats.acks, new_stats.frame_tx.acks);
 
+            if data.len() == 0 {
+                // no need to send packet as it is only for warming connections
+                return Ok(connection);
+            }
+
             last_connection_id = connection.stable_id();
             match Self::_send_buffer_using_conn(data, &connection).await {
                 Ok(()) => {

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -384,7 +384,7 @@ impl QuicClient {
                 .acks
                 .update_stat(&self.stats.acks, new_stats.frame_tx.acks);
 
-            if data.len() == 0 {
+            if data.is_empty() {
                 // no need to send packet as it is only for warming connections
                 return Ok(connection);
             }


### PR DESCRIPTION
#### Problem

The cache warmer is unnecessarily sending 1 bytes long packets. The connection can be established without this. This help reduce noise and unnecessary computations through the whole network.
#### Summary of Changes
Instead of sending one byte long message, send 0 length message. The quic-client will establish the connection without a send.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
