### PR TITLE
ci: allow retrying mac publishing steps

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -37,9 +37,15 @@ steps:
     command: "ci/publish-tarball.sh"
     agents:
       queue: "release-build-aarch64-apple-darwin"
+    retry:
+      manual:
+        permit_on_passed: true
     timeout_in_minutes: 60
   - name: "publish tarball (x86_64-apple-darwin)"
     command: "ci/publish-tarball.sh"
     agents:
       queue: "release-build-x86_64-apple-darwin"
+    retry:
+      manual:
+        permit_on_passed: true
     timeout_in_minutes: 60


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1142219875071303740

the x86_64 mac seems to upload something wrong.

#### Summary of Changes

allow retrying the step for easier debugging

