### PR TITLE
Fix vote credits accounting so that a credit is not added for a new r…

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -687,6 +687,10 @@ pub mod reduce_stake_warmup_cooldown {
     }
 }
 
+pub mod new_root_vote_credits_fix {
+    solana_sdk::declare_id!("3DW824DEYqeLDAGZa3ri6HQSNkVG33QWnEiPdDPde7HR");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -851,6 +855,7 @@ lazy_static! {
         (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
         (reduce_stake_warmup_cooldown::id(), "reduce stake warmup cooldown from 25% to 9%"),
+        (new_root_vote_credits_fix::id(), "fix vote credit erroneously added for a new root in VoteStateUpdate regardless of whether that slot was voted on or not"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
…oot slot

which was not voted on.  Fixes issue #32889.

#### Problem

VoteStateUpdate processing was adding 1 vote credit for a VoteStateUpdate which set a new root, even if that new root was not voted on in the prior VoteState.


#### Summary of Changes

Only add a vote credit for the new root if it was a voted-on slot in the prior VoteState.  In addition, added a test case which demonstrates the ways in which prior implementations (based on feature) were incorrect, and verifying that with the fix, the credits accounting is correct.


Fixes #32889