### PR TITLE
Renames AccountsHashEnum to AccountsHashKind

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -33,7 +33,7 @@ use {
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_file::{AccountsFile, AccountsFileError},
         accounts_hash::{
-            AccountsDeltaHash, AccountsHash, AccountsHashEnum, AccountsHasher,
+            AccountsDeltaHash, AccountsHash, AccountsHashKind, AccountsHasher,
             CalcAccountsHashConfig, CalculateHashIntermediate, HashStats, IncrementalAccountsHash,
             SerdeAccountsDeltaHash, SerdeAccountsHash, SerdeIncrementalAccountsHash,
             ZeroLamportAccounts,
@@ -7661,7 +7661,7 @@ impl AccountsDb {
             CalcAccountsHashFlavor::Full,
             self.full_accounts_hash_cache_path.clone(),
         )?;
-        let AccountsHashEnum::Full(accounts_hash) = accounts_hash else {
+        let AccountsHashKind::Full(accounts_hash) = accounts_hash else {
             panic!("calculate_accounts_hash_from_storages must return a FullAccountsHash");
         };
         Ok((accounts_hash, capitalization))
@@ -7689,7 +7689,7 @@ impl AccountsDb {
             CalcAccountsHashFlavor::Incremental,
             self.incremental_accounts_hash_cache_path.clone(),
         )?;
-        let AccountsHashEnum::Incremental(incremental_accounts_hash) = accounts_hash else {
+        let AccountsHashKind::Incremental(incremental_accounts_hash) = accounts_hash else {
             panic!("calculate_incremental_accounts_hash must return an IncrementalAccountsHash");
         };
         Ok((incremental_accounts_hash, capitalization))
@@ -7702,7 +7702,7 @@ impl AccountsDb {
         mut stats: HashStats,
         flavor: CalcAccountsHashFlavor,
         accounts_hash_cache_path: PathBuf,
-    ) -> Result<(AccountsHashEnum, u64), AccountsHashVerificationError> {
+    ) -> Result<(AccountsHashKind, u64), AccountsHashVerificationError> {
         let total_time = Measure::start("");
         let _guard = self.active_stats.activate(ActiveStatItem::Hash);
         stats.oldest_root = storages.range().start;
@@ -7758,9 +7758,9 @@ impl AccountsDb {
             let (accounts_hash, capitalization) =
                 accounts_hasher.rest_of_hash_calculation(&cache_hash_intermediates, &mut stats);
             let accounts_hash = match flavor {
-                CalcAccountsHashFlavor::Full => AccountsHashEnum::Full(AccountsHash(accounts_hash)),
+                CalcAccountsHashFlavor::Full => AccountsHashKind::Full(AccountsHash(accounts_hash)),
                 CalcAccountsHashFlavor::Incremental => {
-                    AccountsHashEnum::Incremental(IncrementalAccountsHash(accounts_hash))
+                    AccountsHashKind::Incremental(IncrementalAccountsHash(accounts_hash))
                 }
             };
             info!("calculate_accounts_hash_from_storages: slot: {slot}, {accounts_hash:?}, capitalization: {capitalization}");

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1138,26 +1138,26 @@ pub enum ZeroLamportAccounts {
 
 /// Hash of accounts
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AccountsHashEnum {
+pub enum AccountsHashKind {
     Full(AccountsHash),
     Incremental(IncrementalAccountsHash),
 }
-impl AccountsHashEnum {
+impl AccountsHashKind {
     pub fn as_hash(&self) -> &Hash {
         match self {
-            AccountsHashEnum::Full(AccountsHash(hash))
-            | AccountsHashEnum::Incremental(IncrementalAccountsHash(hash)) => hash,
+            AccountsHashKind::Full(AccountsHash(hash))
+            | AccountsHashKind::Incremental(IncrementalAccountsHash(hash)) => hash,
         }
     }
 }
-impl From<AccountsHash> for AccountsHashEnum {
+impl From<AccountsHash> for AccountsHashKind {
     fn from(accounts_hash: AccountsHash) -> Self {
-        AccountsHashEnum::Full(accounts_hash)
+        AccountsHashKind::Full(accounts_hash)
     }
 }
-impl From<IncrementalAccountsHash> for AccountsHashEnum {
+impl From<IncrementalAccountsHash> for AccountsHashKind {
     fn from(incremental_accounts_hash: IncrementalAccountsHash) -> Self {
-        AccountsHashEnum::Incremental(incremental_accounts_hash)
+        AccountsHashKind::Incremental(incremental_accounts_hash)
     }
 }
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -8,7 +8,7 @@ use {
     solana_accounts_db::{
         accounts_db::CalcAccountsHashFlavor,
         accounts_hash::{
-            AccountsHash, AccountsHashEnum, CalcAccountsHashConfig, HashStats,
+            AccountsHash, AccountsHashKind, CalcAccountsHashConfig, HashStats,
             IncrementalAccountsHash,
         },
         sorted_storages::SortedStorages,
@@ -273,7 +273,7 @@ impl AccountsHashVerifier {
     fn calculate_and_verify_accounts_hash(
         accounts_package: &AccountsPackage,
         snapshot_config: &SnapshotConfig,
-    ) -> AccountsHashEnum {
+    ) -> AccountsHashKind {
         let accounts_hash_calculation_flavor = match accounts_package.package_type {
             AccountsPackageType::AccountsHashVerifier => CalcAccountsHashFlavor::Full,
             AccountsPackageType::EpochAccountsHash => CalcAccountsHashFlavor::Full,
@@ -290,7 +290,7 @@ impl AccountsHashVerifier {
         };
 
         let (
-            accounts_hash_enum,
+            accounts_hash_kind,
             accounts_hash_for_reserialize,
             bank_incremental_snapshot_persistence,
         ) = match accounts_hash_calculation_flavor {
@@ -371,7 +371,7 @@ impl AccountsHashVerifier {
             );
         }
 
-        accounts_hash_enum
+        accounts_hash_kind
     }
 
     fn _calculate_full_accounts_hash(
@@ -503,10 +503,10 @@ impl AccountsHashVerifier {
 
     fn save_epoch_accounts_hash(
         accounts_package: &AccountsPackage,
-        accounts_hash: AccountsHashEnum,
+        accounts_hash: AccountsHashKind,
     ) {
         if accounts_package.package_type == AccountsPackageType::EpochAccountsHash {
-            let AccountsHashEnum::Full(accounts_hash) = accounts_hash else {
+            let AccountsHashKind::Full(accounts_hash) = accounts_hash else {
                 panic!("EAH requires a full accounts hash!");
             };
             info!(
@@ -525,7 +525,7 @@ impl AccountsHashVerifier {
         accounts_package: &AccountsPackage,
         cluster_info: &ClusterInfo,
         hashes: &mut Vec<(Slot, Hash)>,
-        accounts_hash: AccountsHashEnum,
+        accounts_hash: AccountsHashKind,
         accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
     ) {
         let hash = accounts_hash_fault_injector
@@ -542,7 +542,7 @@ impl AccountsHashVerifier {
         accounts_package: AccountsPackage,
         snapshot_package_sender: Option<&Sender<SnapshotPackage>>,
         snapshot_config: &SnapshotConfig,
-        accounts_hash: AccountsHashEnum,
+        accounts_hash: AccountsHashKind,
         exit: &AtomicBool,
     ) {
         if !snapshot_config.should_generate_snapshots()

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1142,7 +1142,7 @@ pub fn package_and_archive_incremental_snapshot(
         None,
     );
 
-    let (accounts_hash_enum, accounts_hash_for_reserialize, bank_incremental_snapshot_persistence) =
+    let (accounts_hash_kind, accounts_hash_for_reserialize, bank_incremental_snapshot_persistence) =
         if bank
             .feature_set
             .is_active(&feature_set::incremental_snapshot_only_incremental_hash_calculation::id())
@@ -1185,7 +1185,7 @@ pub fn package_and_archive_incremental_snapshot(
         bank_incremental_snapshot_persistence.as_ref(),
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash_enum);
+    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash_kind);
     archive_snapshot_package(
         &snapshot_package,
         full_snapshot_archives_dir,

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -1,6 +1,6 @@
 //! Helper types and functions for handling and dealing with snapshot hashes.
 use {
-    solana_accounts_db::{accounts_hash::AccountsHashEnum, epoch_accounts_hash::EpochAccountsHash},
+    solana_accounts_db::{accounts_hash::AccountsHashKind, epoch_accounts_hash::EpochAccountsHash},
     solana_sdk::{
         clock::Slot,
         hash::{Hash, Hasher},
@@ -35,7 +35,7 @@ impl SnapshotHash {
     /// Make a snapshot hash from an accounts hash and epoch accounts hash
     #[must_use]
     pub fn new(
-        accounts_hash: &AccountsHashEnum,
+        accounts_hash: &AccountsHashKind,
         epoch_accounts_hash: Option<&EpochAccountsHash>,
     ) -> Self {
         let snapshot_hash = match epoch_accounts_hash {

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -9,7 +9,7 @@ use {
     solana_accounts_db::{
         accounts::Accounts,
         accounts_db::{AccountStorageEntry, IncludeSlotInHash, INCLUDE_SLOT_IN_HASH_TESTS},
-        accounts_hash::{AccountsHash, AccountsHashEnum},
+        accounts_hash::{AccountsHash, AccountsHashKind},
         epoch_accounts_hash::EpochAccountsHash,
         rent_collector::RentCollector,
     },
@@ -248,7 +248,7 @@ pub struct SnapshotPackage {
 }
 
 impl SnapshotPackage {
-    pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHashEnum) -> Self {
+    pub fn new(accounts_package: AccountsPackage, accounts_hash: AccountsHashKind) -> Self {
         let AccountsPackageType::Snapshot(snapshot_kind) = accounts_package.package_type else {
             panic!(
                 "The AccountsPackage must be of type Snapshot in order to make a SnapshotPackage!"


### PR DESCRIPTION
#### Problem

When creating an enum to select some underlying *kind* of a thing, we sometimes append `Enum` or `Type` for the name of the type. I think both of these are bad, but not life ending.

Obviously the variants are not *types* in the Rust sense of the word. And the type is already an enum, so adding `Enum` feels redundant.

In the Rust std lib, they have this problem for errors. They've solved this with [`ErrorKind`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html). 

(Some non-Rust projects have also used `Flavor` too, which I like, but not as much as `Kind`.)

`AccountsHashEnum` has this naming problem.

#### Summary of Changes

Rename `AccountsHashEnum` to `AccountsHashKind`.