### PR TITLE
Renames CalcAccountsHashFlavor to CalcAccountsHashKind

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7662,7 +7662,7 @@ impl AccountsDb {
             config,
             storages,
             stats,
-            CalcAccountsHashFlavor::Full,
+            CalcAccountsHashKind::Full,
             self.full_accounts_hash_cache_path.clone(),
         )?;
         let AccountsHashKind::Full(accounts_hash) = accounts_hash else {
@@ -7690,7 +7690,7 @@ impl AccountsDb {
             config,
             storages,
             stats,
-            CalcAccountsHashFlavor::Incremental,
+            CalcAccountsHashKind::Incremental,
             self.incremental_accounts_hash_cache_path.clone(),
         )?;
         let AccountsHashKind::Incremental(incremental_accounts_hash) = accounts_hash else {
@@ -7704,7 +7704,7 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
         storages: &SortedStorages<'_>,
         mut stats: HashStats,
-        flavor: CalcAccountsHashFlavor,
+        kind: CalcAccountsHashKind,
         accounts_hash_cache_path: PathBuf,
     ) -> Result<(AccountsHashKind, u64), AccountsHashVerificationError> {
         let total_time = Measure::start("");
@@ -7736,7 +7736,7 @@ impl AccountsDb {
                 } else {
                     None
                 },
-                zero_lamport_accounts: flavor.zero_lamport_accounts(),
+                zero_lamport_accounts: kind.zero_lamport_accounts(),
                 dir_for_temp_cache_files: self.transient_accounts_hash_cache_path.clone(),
                 active_stats: &self.active_stats,
             };
@@ -7774,9 +7774,9 @@ impl AccountsDb {
             // turn raw data into merkle tree hashes and sum of lamports
             let (accounts_hash, capitalization) =
                 accounts_hasher.rest_of_hash_calculation(&cache_hash_intermediates, &mut stats);
-            let accounts_hash = match flavor {
-                CalcAccountsHashFlavor::Full => AccountsHashKind::Full(AccountsHash(accounts_hash)),
-                CalcAccountsHashFlavor::Incremental => {
+            let accounts_hash = match kind {
+                CalcAccountsHashKind::Full => AccountsHashKind::Full(AccountsHash(accounts_hash)),
+                CalcAccountsHashKind::Incremental => {
                     AccountsHashKind::Incremental(IncrementalAccountsHash(accounts_hash))
                 }
             };
@@ -9583,17 +9583,17 @@ pub enum CalcAccountsHashDataSource {
 
 /// Which accounts hash calculation is being performed?
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum CalcAccountsHashFlavor {
+pub enum CalcAccountsHashKind {
     Full,
     Incremental,
 }
 
-impl CalcAccountsHashFlavor {
+impl CalcAccountsHashKind {
     /// How should zero-lamport accounts be handled by this accounts hash calculation?
     fn zero_lamport_accounts(&self) -> ZeroLamportAccounts {
         match self {
-            CalcAccountsHashFlavor::Full => ZeroLamportAccounts::Excluded,
-            CalcAccountsHashFlavor::Incremental => ZeroLamportAccounts::Included,
+            CalcAccountsHashKind::Full => ZeroLamportAccounts::Excluded,
+            CalcAccountsHashKind::Incremental => ZeroLamportAccounts::Included,
         }
     }
 }

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -6,7 +6,7 @@
 use {
     crossbeam_channel::{Receiver, Sender},
     solana_accounts_db::{
-        accounts_db::CalcAccountsHashFlavor,
+        accounts_db::CalcAccountsHashKind,
         accounts_hash::{
             AccountsHash, AccountsHashKind, CalcAccountsHashConfig, HashStats,
             IncrementalAccountsHash,
@@ -274,16 +274,16 @@ impl AccountsHashVerifier {
         accounts_package: &AccountsPackage,
         snapshot_config: &SnapshotConfig,
     ) -> AccountsHashKind {
-        let accounts_hash_calculation_flavor = match accounts_package.package_type {
-            AccountsPackageType::AccountsHashVerifier => CalcAccountsHashFlavor::Full,
-            AccountsPackageType::EpochAccountsHash => CalcAccountsHashFlavor::Full,
+        let accounts_hash_calculation_kind = match accounts_package.package_type {
+            AccountsPackageType::AccountsHashVerifier => CalcAccountsHashKind::Full,
+            AccountsPackageType::EpochAccountsHash => CalcAccountsHashKind::Full,
             AccountsPackageType::Snapshot(snapshot_kind) => match snapshot_kind {
-                SnapshotKind::FullSnapshot => CalcAccountsHashFlavor::Full,
+                SnapshotKind::FullSnapshot => CalcAccountsHashKind::Full,
                 SnapshotKind::IncrementalSnapshot(_) => {
                     if accounts_package.is_incremental_accounts_hash_feature_enabled {
-                        CalcAccountsHashFlavor::Incremental
+                        CalcAccountsHashKind::Incremental
                     } else {
-                        CalcAccountsHashFlavor::Full
+                        CalcAccountsHashKind::Full
                     }
                 }
             },
@@ -293,13 +293,13 @@ impl AccountsHashVerifier {
             accounts_hash_kind,
             accounts_hash_for_reserialize,
             bank_incremental_snapshot_persistence,
-        ) = match accounts_hash_calculation_flavor {
-            CalcAccountsHashFlavor::Full => {
+        ) = match accounts_hash_calculation_kind {
+            CalcAccountsHashKind::Full => {
                 let (accounts_hash, _capitalization) =
                     Self::_calculate_full_accounts_hash(accounts_package);
                 (accounts_hash.into(), accounts_hash, None)
             }
-            CalcAccountsHashFlavor::Incremental => {
+            CalcAccountsHashKind::Incremental => {
                 let AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(base_slot)) =
                     accounts_package.package_type
                 else {


### PR DESCRIPTION
#### Problem

When creating an enum to select some underlying *kind* of a thing, we sometimes append `Enum` or `Type` for the name of the type. I think both of these are bad, but not life ending.

Obviously the variants are not *types* in the Rust sense of the word. And the type is already an enum, so adding `Enum` feels redundant.

In the Rust std lib, they have this problem for errors. They've solved this with [`ErrorKind`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html). 

(Some non-Rust projects have also used `Flavor` too, which I like, but not as much as `Kind`.)

`CalcAccountsHashFlavor` has this naming problem—but less so. I'd like to be self-consistent.

#### Summary of Changes

Rename `CalcAccountsHashFlavor` to `CalcAccountsHashKind`.