### PR TITLE
Renamed SnapshotType to SnapshotKind

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -94,7 +94,7 @@ impl SnapshotPackagerService {
 
                         if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
                             snapshot_gossip_manager.push_snapshot_hash(
-                                snapshot_package.snapshot_type,
+                                snapshot_package.snapshot_kind,
                                 (snapshot_package.slot(), *snapshot_package.hash()),
                             );
                         }
@@ -206,7 +206,7 @@ mod tests {
             snapshot_archive_info::SnapshotArchiveInfo,
             snapshot_bank_utils,
             snapshot_hash::SnapshotHash,
-            snapshot_package::{SnapshotPackage, SnapshotType},
+            snapshot_package::{SnapshotKind, SnapshotPackage},
             snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
         },
         solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash},
@@ -296,7 +296,7 @@ mod tests {
     /// Otherwise, they should be dropped.
     #[test]
     fn test_get_next_snapshot_package() {
-        fn new(snapshot_type: SnapshotType, slot: Slot) -> SnapshotPackage {
+        fn new(snapshot_kind: SnapshotKind, slot: Slot) -> SnapshotPackage {
             SnapshotPackage {
                 snapshot_archive_info: SnapshotArchiveInfo {
                     path: PathBuf::default(),
@@ -308,15 +308,15 @@ mod tests {
                 bank_snapshot_dir: PathBuf::default(),
                 snapshot_storages: Vec::default(),
                 snapshot_version: SnapshotVersion::default(),
-                snapshot_type,
+                snapshot_kind,
                 enqueued: Instant::now(),
             }
         }
         fn new_full(slot: Slot) -> SnapshotPackage {
-            new(SnapshotType::FullSnapshot, slot)
+            new(SnapshotKind::FullSnapshot, slot)
         }
         fn new_incr(slot: Slot, base: Slot) -> SnapshotPackage {
-            new(SnapshotType::IncrementalSnapshot(base), slot)
+            new(SnapshotKind::IncrementalSnapshot(base), slot)
         }
 
         let (snapshot_package_sender, snapshot_package_receiver) = crossbeam_channel::unbounded();
@@ -350,7 +350,7 @@ mod tests {
             &snapshot_package_receiver,
         )
         .unwrap();
-        assert_eq!(snapshot_package.snapshot_type, SnapshotType::FullSnapshot,);
+        assert_eq!(snapshot_package.snapshot_kind, SnapshotKind::FullSnapshot,);
         assert_eq!(snapshot_package.slot(), 400);
         assert_eq!(num_re_enqueued_snapshot_packages, 2);
 
@@ -366,8 +366,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            snapshot_package.snapshot_type,
-            SnapshotType::IncrementalSnapshot(400),
+            snapshot_package.snapshot_kind,
+            SnapshotKind::IncrementalSnapshot(400),
         );
         assert_eq!(snapshot_package.slot(), 420);
         assert_eq!(num_re_enqueued_snapshot_packages, 0);

--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -4,7 +4,7 @@ use {
         snapshot_hash::{
             FullSnapshotHash, IncrementalSnapshotHash, SnapshotHash, StartingSnapshotHashes,
         },
-        snapshot_package::{retain_max_n_elements, SnapshotType},
+        snapshot_package::{retain_max_n_elements, SnapshotKind},
     },
     solana_sdk::{clock::Slot, hash::Hash},
     std::sync::Arc,
@@ -58,14 +58,14 @@ impl SnapshotGossipManager {
     /// Push new snapshot hash to the cluster via CRDS
     pub fn push_snapshot_hash(
         &mut self,
-        snapshot_type: SnapshotType,
+        snapshot_kind: SnapshotKind,
         snapshot_hash: (Slot, SnapshotHash),
     ) {
-        match snapshot_type {
-            SnapshotType::FullSnapshot => {
+        match snapshot_kind {
+            SnapshotKind::FullSnapshot => {
                 self.push_full_snapshot_hash(FullSnapshotHash(snapshot_hash));
             }
-            SnapshotType::IncrementalSnapshot(base_slot) => {
+            SnapshotKind::IncrementalSnapshot(base_slot) => {
                 self.push_incremental_snapshot_hash(
                     IncrementalSnapshotHash(snapshot_hash),
                     base_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -30,7 +30,7 @@ use {
         snapshot_bank_utils::{self, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL},
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
-        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotPackage, SnapshotType},
+        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self,
             SnapshotVersion::{self, V1_2_0},
@@ -244,7 +244,7 @@ fn run_bank_forks_snapshot_n<F>(
     let last_bank_snapshot_info = snapshot_utils::get_highest_bank_snapshot_pre(bank_snapshots_dir)
         .expect("no bank snapshots found in path");
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
+        AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
         &last_bank,
         &last_bank_snapshot_info,
         &snapshot_config.full_snapshot_archives_dir,
@@ -412,7 +412,7 @@ fn test_concurrent_snapshot_packaging(
         )
         .unwrap();
         let accounts_package = AccountsPackage::new_for_snapshot(
-            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
+            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
             &bank,
             &bank_snapshot_info,
             full_snapshot_archives_dir,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -5,7 +5,7 @@ use {
     log::*,
     solana_runtime::{
         snapshot_hash::SnapshotHash,
-        snapshot_package::SnapshotType,
+        snapshot_package::SnapshotKind,
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE},
@@ -256,14 +256,14 @@ pub fn download_genesis_if_missing(
     }
 }
 
-/// Download a snapshot archive from `rpc_addr`.  Use `snapshot_type` to specify downloading either
+/// Download a snapshot archive from `rpc_addr`.  Use `snapshot_kind` to specify downloading either
 /// a full snapshot or an incremental snapshot.
 pub fn download_snapshot_archive(
     rpc_addr: &SocketAddr,
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, SnapshotHash),
-    snapshot_type: SnapshotType,
+    snapshot_kind: SnapshotKind,
     maximum_full_snapshot_archives_to_retain: NonZeroUsize,
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
     use_progress_bar: bool,
@@ -277,9 +277,9 @@ pub fn download_snapshot_archive(
     );
 
     let snapshot_archives_remote_dir =
-        snapshot_utils::build_snapshot_archives_remote_dir(match snapshot_type {
-            SnapshotType::FullSnapshot => full_snapshot_archives_dir,
-            SnapshotType::IncrementalSnapshot(_) => incremental_snapshot_archives_dir,
+        snapshot_utils::build_snapshot_archives_remote_dir(match snapshot_kind {
+            SnapshotKind::FullSnapshot => full_snapshot_archives_dir,
+            SnapshotKind::IncrementalSnapshot(_) => incremental_snapshot_archives_dir,
         });
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
@@ -290,14 +290,14 @@ pub fn download_snapshot_archive(
         ArchiveFormat::TarLz4,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
-        let destination_path = match snapshot_type {
-            SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
+        let destination_path = match snapshot_kind {
+            SnapshotKind::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
                 &snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
-            SnapshotType::IncrementalSnapshot(base_slot) => {
+            SnapshotKind::IncrementalSnapshot(base_slot) => {
                 snapshot_utils::build_incremental_snapshot_archive_path(
                     &snapshot_archives_remote_dir,
                     base_slot,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -60,7 +60,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
-        snapshot_package::SnapshotType,
+        snapshot_package::SnapshotKind,
         snapshot_utils::{self},
         vote_parser,
     },
@@ -552,7 +552,7 @@ fn test_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        SnapshotType::FullSnapshot,
+        SnapshotKind::FullSnapshot,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -683,7 +683,7 @@ fn test_incremental_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        SnapshotType::FullSnapshot,
+        SnapshotKind::FullSnapshot,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -711,7 +711,7 @@ fn test_incremental_snapshot_download() {
             incremental_snapshot_archive_info.slot(),
             *incremental_snapshot_archive_info.hash(),
         ),
-        SnapshotType::IncrementalSnapshot(incremental_snapshot_archive_info.base_slot()),
+        SnapshotKind::IncrementalSnapshot(incremental_snapshot_archive_info.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -854,7 +854,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .incremental_snapshot_archives_dir
             .path(),
         (full_snapshot_archive.slot(), *full_snapshot_archive.hash()),
-        SnapshotType::FullSnapshot,
+        SnapshotKind::FullSnapshot,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -891,7 +891,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             incremental_snapshot_archive.slot(),
             *incremental_snapshot_archive.hash(),
         ),
-        SnapshotType::IncrementalSnapshot(incremental_snapshot_archive.base_slot()),
+        SnapshotKind::IncrementalSnapshot(incremental_snapshot_archive.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -9,7 +9,7 @@ use {
         bank_forks::BankForks,
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
-        snapshot_package::{self, AccountsPackage, AccountsPackageType, SnapshotType},
+        snapshot_package::{self, AccountsPackage, AccountsPackageType, SnapshotKind},
         snapshot_utils::{self, SnapshotError},
     },
     crossbeam_channel::{Receiver, SendError, Sender},
@@ -257,7 +257,7 @@ impl SnapshotRequestHandler {
                 // then handle `y` first.
                 let (snapshot_request, accounts_package_type) = if z.1
                     == AccountsPackageType::EpochAccountsHash
-                    && y.1 == AccountsPackageType::Snapshot(SnapshotType::FullSnapshot)
+                    && y.1 == AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
                     && y.0.snapshot_root_bank.slot() < z.0.snapshot_root_bank.slot()
                 {
                     // SAFETY: We know the len is > 1, so both `pop`s will return `Some`
@@ -318,7 +318,7 @@ impl SnapshotRequestHandler {
         // we should not rely on the state of this validator until startup verification is complete
         assert!(snapshot_root_bank.is_startup_verification_complete());
 
-        if accounts_package_type == AccountsPackageType::Snapshot(SnapshotType::FullSnapshot) {
+        if accounts_package_type == AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot) {
             *last_full_snapshot_slot = Some(snapshot_root_bank.slot());
         }
 
@@ -749,13 +749,13 @@ fn new_accounts_package_type(
                 block_height,
                 snapshot_config.full_snapshot_archive_interval_slots,
             ) {
-                AccountsPackageType::Snapshot(SnapshotType::FullSnapshot)
+                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
             } else if snapshot_utils::should_take_incremental_snapshot(
                 block_height,
                 snapshot_config.incremental_snapshot_archive_interval_slots,
                 last_full_snapshot_slot,
             ) {
-                AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(
+                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(
                     last_full_snapshot_slot.unwrap(),
                 ))
             } else {
@@ -945,7 +945,7 @@ mod test {
             .unwrap();
         assert_eq!(
             accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot)
+            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 240);
 
@@ -956,7 +956,7 @@ mod test {
             .unwrap();
         assert_eq!(
             accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(240))
+            AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(240))
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 300);
 
@@ -997,7 +997,7 @@ mod test {
             .unwrap();
         assert_eq!(
             accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotType::FullSnapshot)
+            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 480);
 
@@ -1017,7 +1017,7 @@ mod test {
             .unwrap();
         assert_eq!(
             accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(480))
+            AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(480))
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 540);
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -11,7 +11,7 @@ use {
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
         },
         snapshot_hash::SnapshotHash,
-        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotPackage, SnapshotType},
+        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self, archive_snapshot_package, build_storage_from_snapshot_dir,
             delete_contents_of_path, deserialize_snapshot_data_file,
@@ -1079,7 +1079,7 @@ pub fn package_and_archive_full_snapshot(
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotType::FullSnapshot),
+        AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
         bank,
         bank_snapshot_info,
         &full_snapshot_archives_dir,
@@ -1129,7 +1129,7 @@ pub fn package_and_archive_incremental_snapshot(
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<IncrementalSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotType::IncrementalSnapshot(
+        AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(
             incremental_snapshot_base_slot,
         )),
         bank,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -846,7 +846,7 @@ pub fn archive_snapshot_package(
         ),
         ("duration_ms", timer.as_ms(), i64),
         (
-            if snapshot_package.snapshot_type.is_full_snapshot() {
+            if snapshot_package.snapshot_kind.is_full_snapshot() {
                 "full-snapshot-archive-size"
             } else {
                 "incremental-snapshot-archive-size"

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -16,7 +16,7 @@ use {
     solana_metrics::datapoint_info,
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::{
-        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::SnapshotType,
+        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::SnapshotKind,
         snapshot_utils,
     },
     solana_sdk::{
@@ -1176,7 +1176,7 @@ fn download_snapshots(
             download_abort_count,
             rpc_contact_info,
             full_snapshot_hash,
-            SnapshotType::FullSnapshot,
+            SnapshotKind::FullSnapshot,
         )?;
     }
 
@@ -1208,7 +1208,7 @@ fn download_snapshots(
                     download_abort_count,
                     rpc_contact_info,
                     incremental_snapshot_hash,
-                    SnapshotType::IncrementalSnapshot(full_snapshot_hash.0),
+                    SnapshotKind::IncrementalSnapshot(full_snapshot_hash.0),
                 )?;
             }
         }
@@ -1231,7 +1231,7 @@ fn download_snapshot(
     download_abort_count: &mut u64,
     rpc_contact_info: &ContactInfo,
     desired_snapshot_hash: (Slot, Hash),
-    snapshot_type: SnapshotType,
+    snapshot_kind: SnapshotKind,
 ) -> Result<(), String> {
     let maximum_full_snapshot_archives_to_retain = validator_config
         .snapshot_config
@@ -1253,7 +1253,7 @@ fn download_snapshot(
         full_snapshot_archives_dir,
         incremental_snapshot_archives_dir,
         desired_snapshot_hash,
-        snapshot_type,
+        snapshot_kind,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
         use_progress_bar,


### PR DESCRIPTION
#### Problem

When creating an enum to select some underlying *kind* of a thing, we sometimes append `Enum` or `Type` for the name of the type. I think both of these are bad, but not life ending.

Obviously the variants are not *types* in the Rust sense of the word. And the type is already an enum, so adding `Enum` feels redundant.

In the Rust std lib, they have this problem for errors. They've solved this with [`ErrorKind`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html). 

(Some non-Rust projects have also used `Flavor` too, which I like, but not as much as `Kind`.)

`SnapshotType` has this naming problem.

#### Summary of Changes

Rename `SnapshotType` to `SnapshotKind`.