### PR TITLE
Renames SnapshotRequestType to SnapshotRequestKind

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -35,7 +35,7 @@ use {
     solana_program_runtime::timings::{ExecuteTimingType, ExecuteTimings, ThreadExecuteTimings},
     solana_rayon_threadlimit::{get_max_thread_count, get_thread_count},
     solana_runtime::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequestType},
+        accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
         bank::{Bank, TransactionBalancesSet},
         bank_forks::BankForks,
         bank_utils,
@@ -657,7 +657,7 @@ pub fn test_process_blockstore(
                 snapshot_request_receiver
                     .try_iter()
                     .filter(|snapshot_request| {
-                        snapshot_request.request_type == SnapshotRequestType::EpochAccountsHash
+                        snapshot_request.request_kind == SnapshotRequestKind::EpochAccountsHash
                     })
                     .for_each(|snapshot_request| {
                         snapshot_request

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -17,7 +17,7 @@ use {
         loaded_programs::LoadedProgram, stable_log, timings::ExecuteTimings,
     },
     solana_runtime::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequestType},
+        accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
         bank::Bank,
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
@@ -1137,7 +1137,7 @@ impl ProgramTestContext {
         snapshot_request_receiver
             .try_iter()
             .filter(|snapshot_request| {
-                snapshot_request.request_type == SnapshotRequestType::EpochAccountsHash
+                snapshot_request.request_kind == SnapshotRequestKind::EpochAccountsHash
             })
             .for_each(|snapshot_request| {
                 snapshot_request

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestType},
+        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestKind},
         bank::{epoch_accounts_hash_utils, Bank, SquashTiming},
         snapshot_config::SnapshotConfig,
     },
@@ -319,7 +319,7 @@ impl BankForks {
                 .send_snapshot_request(SnapshotRequest {
                     snapshot_root_bank: Arc::clone(eah_bank),
                     status_cache_slot_deltas: Vec::default(),
-                    request_type: SnapshotRequestType::EpochAccountsHash,
+                    request_kind: SnapshotRequestKind::EpochAccountsHash,
                     enqueued: Instant::now(),
                 })
                 .expect("send epoch accounts hash request");
@@ -355,7 +355,7 @@ impl BankForks {
                         accounts_background_request_sender.send_snapshot_request(SnapshotRequest {
                             snapshot_root_bank: Arc::clone(bank),
                             status_cache_slot_deltas,
-                            request_type: SnapshotRequestType::Snapshot,
+                            request_kind: SnapshotRequestKind::Snapshot,
                             enqueued: Instant::now(),
                         })
                     {
@@ -801,7 +801,7 @@ mod tests {
                     snapshot_request_receiver
                         .try_iter()
                         .filter(|snapshot_request| {
-                            snapshot_request.request_type == SnapshotRequestType::EpochAccountsHash
+                            snapshot_request.request_kind == SnapshotRequestKind::EpochAccountsHash
                         })
                         .for_each(|snapshot_request| {
                             snapshot_request


### PR DESCRIPTION
#### Problem

When creating an enum to select some underlying *kind* of a thing, we sometimes append `Enum` or `Type` for the name of the type. I think both of these are bad, but not life ending.

Obviously the variants are not *types* in the Rust sense of the word. And the type is already an enum, so adding `Enum` feels redundant.

In the Rust std lib, they have this problem for errors. They've solved this with [`ErrorKind`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html). 

(Some non-Rust projects have also used `Flavor` too, which I like, but not as much as `Kind`.)

`SnapshotRequestType` has this naming problem.

#### Summary of Changes

Rename `SnapshotRequestType` to `SnapshotRequestKind`.