### PR TITLE
Renames AccountsPackageType to AccountsPackageKind

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -30,7 +30,7 @@ use {
         snapshot_bank_utils::{self, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL},
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
-        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotKind, SnapshotPackage},
+        snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self,
             SnapshotVersion::{self, V1_2_0},
@@ -244,7 +244,7 @@ fn run_bank_forks_snapshot_n<F>(
     let last_bank_snapshot_info = snapshot_utils::get_highest_bank_snapshot_pre(bank_snapshots_dir)
         .expect("no bank snapshots found in path");
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+        AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
         &last_bank,
         &last_bank_snapshot_info,
         &snapshot_config.full_snapshot_archives_dir,
@@ -412,7 +412,7 @@ fn test_concurrent_snapshot_packaging(
         )
         .unwrap();
         let accounts_package = AccountsPackage::new_for_snapshot(
-            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+            AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
             &bank,
             &bank_snapshot_info,
             full_snapshot_archives_dir,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -9,7 +9,7 @@ use {
         bank_forks::BankForks,
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
-        snapshot_package::{self, AccountsPackage, AccountsPackageType, SnapshotKind},
+        snapshot_package::{self, AccountsPackage, AccountsPackageKind, SnapshotKind},
         snapshot_utils::{self, SnapshotError},
     },
     crossbeam_channel::{Receiver, SendError, Sender},
@@ -157,7 +157,7 @@ impl SnapshotRequestHandler {
     ) -> Option<Result<u64, SnapshotError>> {
         let (
             snapshot_request,
-            accounts_package_type,
+            accounts_package_kind,
             num_outstanding_requests,
             num_re_enqueued_requests,
         ) = self.get_next_snapshot_request(*last_full_snapshot_slot)?;
@@ -178,7 +178,7 @@ impl SnapshotRequestHandler {
             non_snapshot_time_us,
             last_full_snapshot_slot,
             snapshot_request,
-            accounts_package_type,
+            accounts_package_kind,
             exit,
         ))
     }
@@ -197,7 +197,7 @@ impl SnapshotRequestHandler {
         last_full_snapshot_slot: Option<Slot>,
     ) -> Option<(
         SnapshotRequest,
-        AccountsPackageType,
+        AccountsPackageKind,
         /*num outstanding snapshot requests*/ usize,
         /*num re-enqueued snapshot requests*/ usize,
     )> {
@@ -205,12 +205,12 @@ impl SnapshotRequestHandler {
             .snapshot_request_receiver
             .try_iter()
             .map(|request| {
-                let accounts_package_type = new_accounts_package_type(
+                let accounts_package_kind = new_accounts_package_kind(
                     &request,
                     &self.snapshot_config,
                     last_full_snapshot_slot,
                 );
-                (request, accounts_package_type)
+                (request, accounts_package_kind)
             })
             .collect();
         let requests_len = requests.len();
@@ -222,14 +222,14 @@ impl SnapshotRequestHandler {
             0 => None,
             1 => {
                 // SAFETY: We know the len is 1, so `pop` will return `Some`
-                let (snapshot_request, accounts_package_type) = requests.pop().unwrap();
-                Some((snapshot_request, accounts_package_type, 1, 0))
+                let (snapshot_request, accounts_package_kind) = requests.pop().unwrap();
+                Some((snapshot_request, accounts_package_kind, 1, 0))
             }
             _ => {
                 let num_eah_requests = requests
                     .iter()
-                    .filter(|(_, account_package_type)| {
-                        *account_package_type == AccountsPackageType::EpochAccountsHash
+                    .filter(|(_, account_package_kind)| {
+                        *account_package_kind == AccountsPackageKind::EpochAccountsHash
                     })
                     .count();
                 assert!(
@@ -255,9 +255,9 @@ impl SnapshotRequestHandler {
                 // be at most one EpochAccountsHash request, so `y` is the only other request we
                 // need to check.  If `y` is a FullSnapshot request *with a lower slot* than `z`,
                 // then handle `y` first.
-                let (snapshot_request, accounts_package_type) = if z.1
-                    == AccountsPackageType::EpochAccountsHash
-                    && y.1 == AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
+                let (snapshot_request, accounts_package_kind) = if z.1
+                    == AccountsPackageKind::EpochAccountsHash
+                    && y.1 == AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
                     && y.0.snapshot_root_bank.slot() < z.0.snapshot_root_bank.slot()
                 {
                     // SAFETY: We know the len is > 1, so both `pop`s will return `Some`
@@ -286,7 +286,7 @@ impl SnapshotRequestHandler {
 
                 Some((
                     snapshot_request,
-                    accounts_package_type,
+                    accounts_package_kind,
                     requests_len,
                     num_re_enqueued_requests,
                 ))
@@ -300,12 +300,12 @@ impl SnapshotRequestHandler {
         non_snapshot_time_us: u128,
         last_full_snapshot_slot: &mut Option<Slot>,
         snapshot_request: SnapshotRequest,
-        accounts_package_type: AccountsPackageType,
+        accounts_package_kind: AccountsPackageKind,
         exit: &AtomicBool,
     ) -> Result<u64, SnapshotError> {
         debug!(
             "handling snapshot request: {:?}, {:?}",
-            snapshot_request, accounts_package_type
+            snapshot_request, accounts_package_kind
         );
         let mut total_time = Measure::start("snapshot_request_receiver_total_time");
         let SnapshotRequest {
@@ -318,7 +318,7 @@ impl SnapshotRequestHandler {
         // we should not rely on the state of this validator until startup verification is complete
         assert!(snapshot_root_bank.is_startup_verification_complete());
 
-        if accounts_package_type == AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot) {
+        if accounts_package_kind == AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot) {
             *last_full_snapshot_slot = Some(snapshot_root_bank.slot());
         }
 
@@ -389,8 +389,8 @@ impl SnapshotRequestHandler {
         let mut snapshot_time = Measure::start("snapshot_time");
         let snapshot_storages = snapshot_bank_utils::get_snapshot_storages(&snapshot_root_bank);
         let accounts_package = match request_kind {
-            SnapshotRequestKind::Snapshot => match &accounts_package_type {
-                AccountsPackageType::Snapshot(_) => {
+            SnapshotRequestKind::Snapshot => match &accounts_package_kind {
+                AccountsPackageKind::Snapshot(_) => {
                     let bank_snapshot_info = snapshot_bank_utils::add_bank_snapshot(
                         &self.snapshot_config.bank_snapshots_dir,
                         &snapshot_root_bank,
@@ -399,7 +399,7 @@ impl SnapshotRequestHandler {
                         status_cache_slot_deltas,
                     )?;
                     AccountsPackage::new_for_snapshot(
-                        accounts_package_type,
+                        accounts_package_kind,
                         &snapshot_root_bank,
                         &bank_snapshot_info,
                         &self.snapshot_config.full_snapshot_archives_dir,
@@ -410,21 +410,21 @@ impl SnapshotRequestHandler {
                         accounts_hash_for_testing,
                     )
                 }
-                AccountsPackageType::AccountsHashVerifier => {
+                AccountsPackageKind::AccountsHashVerifier => {
                     // skip the bank snapshot, just make an accounts package to send to AHV
                     AccountsPackage::new_for_accounts_hash_verifier(
-                        accounts_package_type,
+                        accounts_package_kind,
                         &snapshot_root_bank,
                         snapshot_storages,
                         accounts_hash_for_testing,
                     )
                 }
-                AccountsPackageType::EpochAccountsHash => panic!("Illegal account package type: EpochAccountsHash packages must be from an EpochAccountsHash request!"),
+                AccountsPackageKind::EpochAccountsHash => panic!("Illegal account package type: EpochAccountsHash packages must be from an EpochAccountsHash request!"),
             },
             SnapshotRequestKind::EpochAccountsHash => {
                 // skip the bank snapshot, just make an accounts package to send to AHV
                 AccountsPackage::new_for_epoch_accounts_hash(
-                    accounts_package_type,
+                    accounts_package_kind,
                     &snapshot_root_bank,
                     snapshot_storages,
                     accounts_hash_for_testing,
@@ -442,8 +442,8 @@ impl SnapshotRequestHandler {
         }
         snapshot_time.stop();
         info!(
-            "Took bank snapshot. accounts package type: {:?}, slot: {}, bank hash: {}",
-            accounts_package_type,
+            "Took bank snapshot. accounts package kind: {:?}, slot: {}, bank hash: {}",
+            accounts_package_kind,
             snapshot_root_bank.slot(),
             snapshot_root_bank.hash(),
         );
@@ -734,32 +734,32 @@ impl AccountsBackgroundService {
     }
 }
 
-/// Get the AccountsPackageType from a given SnapshotRequest
+/// Get the AccountsPackageKind from a given SnapshotRequest
 #[must_use]
-fn new_accounts_package_type(
+fn new_accounts_package_kind(
     snapshot_request: &SnapshotRequest,
     snapshot_config: &SnapshotConfig,
     last_full_snapshot_slot: Option<Slot>,
-) -> AccountsPackageType {
+) -> AccountsPackageKind {
     let block_height = snapshot_request.snapshot_root_bank.block_height();
     match snapshot_request.request_kind {
-        SnapshotRequestKind::EpochAccountsHash => AccountsPackageType::EpochAccountsHash,
+        SnapshotRequestKind::EpochAccountsHash => AccountsPackageKind::EpochAccountsHash,
         _ => {
             if snapshot_utils::should_take_full_snapshot(
                 block_height,
                 snapshot_config.full_snapshot_archive_interval_slots,
             ) {
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
             } else if snapshot_utils::should_take_incremental_snapshot(
                 block_height,
                 snapshot_config.incremental_snapshot_archive_interval_slots,
                 last_full_snapshot_slot,
             ) {
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(
                     last_full_snapshot_slot.unwrap(),
                 ))
             } else {
-                AccountsPackageType::AccountsHashVerifier
+                AccountsPackageKind::AccountsHashVerifier
             }
         }
     }
@@ -773,19 +773,19 @@ fn new_accounts_package_type(
 /// - Incremental Snapshot
 /// - Accounts Hash Verifier
 ///
-/// If two requests of the same type are being compared, their bank slots are the tiebreaker.
+/// If two requests of the same kind are being compared, their bank slots are the tiebreaker.
 #[must_use]
 fn cmp_requests_by_priority(
-    a: &(SnapshotRequest, AccountsPackageType),
-    b: &(SnapshotRequest, AccountsPackageType),
+    a: &(SnapshotRequest, AccountsPackageKind),
+    b: &(SnapshotRequest, AccountsPackageKind),
 ) -> std::cmp::Ordering {
-    let (snapshot_request_a, accounts_package_type_a) = a;
-    let (snapshot_request_b, accounts_package_type_b) = b;
+    let (snapshot_request_a, accounts_package_kind_a) = a;
+    let (snapshot_request_b, accounts_package_kind_b) = b;
     let slot_a = snapshot_request_a.snapshot_root_bank.slot();
     let slot_b = snapshot_request_b.snapshot_root_bank.slot();
-    snapshot_package::cmp_accounts_package_types_by_priority(
-        accounts_package_type_a,
-        accounts_package_type_b,
+    snapshot_package::cmp_accounts_package_kinds_by_priority(
+        accounts_package_kind_a,
+        accounts_package_kind_b,
     )
     .then(slot_a.cmp(&slot_b))
 }
@@ -929,45 +929,45 @@ mod test {
         make_banks(303);
 
         // Ensure the EAH is handled 1st
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(None)
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::EpochAccountsHash
+            accounts_package_kind,
+            AccountsPackageKind::EpochAccountsHash
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 100);
 
         // Ensure the full snapshot from slot 240 is handled 2nd
         // (the older full snapshots are skipped and dropped)
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(None)
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
+            accounts_package_kind,
+            AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 240);
 
         // Ensure the incremental snapshot from slot 300 is handled 3rd
         // (the older incremental snapshots are skipped and dropped)
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(Some(240))
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(240))
+            accounts_package_kind,
+            AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(240))
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 300);
 
         // Ensure the accounts hash verifier from slot 303 is handled 4th
         // (the older accounts hash verifiers are skipped and dropped)
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(Some(240))
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::AccountsHashVerifier
+            accounts_package_kind,
+            AccountsPackageKind::AccountsHashVerifier
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 303);
 
@@ -992,42 +992,42 @@ mod test {
         make_banks(240);
 
         // Ensure the full snapshot is handled 1st
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(None)
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot)
+            accounts_package_kind,
+            AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 480);
 
         // Ensure the EAH is handled 2nd
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(Some(480))
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::EpochAccountsHash
+            accounts_package_kind,
+            AccountsPackageKind::EpochAccountsHash
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 500);
 
         // Ensure the incremental snapshot is handled 3rd
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(Some(480))
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(480))
+            accounts_package_kind,
+            AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(480))
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 540);
 
         // Ensure the accounts hash verifier is handled 4th
-        let (snapshot_request, accounts_package_type, ..) = snapshot_request_handler
+        let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
             .get_next_snapshot_request(Some(480))
             .unwrap();
         assert_eq!(
-            accounts_package_type,
-            AccountsPackageType::AccountsHashVerifier
+            accounts_package_kind,
+            AccountsPackageKind::AccountsHashVerifier
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 543);
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -11,7 +11,7 @@ use {
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
         },
         snapshot_hash::SnapshotHash,
-        snapshot_package::{AccountsPackage, AccountsPackageType, SnapshotKind, SnapshotPackage},
+        snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self, archive_snapshot_package, build_storage_from_snapshot_dir,
             delete_contents_of_path, deserialize_snapshot_data_file,
@@ -1079,7 +1079,7 @@ pub fn package_and_archive_full_snapshot(
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+        AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
         bank,
         bank_snapshot_info,
         &full_snapshot_archives_dir,
@@ -1129,7 +1129,7 @@ pub fn package_and_archive_incremental_snapshot(
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<IncrementalSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(
+        AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(
             incremental_snapshot_base_slot,
         )),
         bank,

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        AccountsPackage, AccountsPackageType, SnapshotArchiveInfoGetter, SnapshotKind,
+        AccountsPackage, AccountsPackageKind, SnapshotArchiveInfoGetter, SnapshotKind,
         SnapshotPackage,
     },
     std::cmp::Ordering::{self, Equal, Greater, Less},
@@ -15,11 +15,11 @@ pub fn cmp_snapshot_packages_by_priority(a: &SnapshotPackage, b: &SnapshotPackag
 /// Compare accounts packages by priority; first by type, then by slot
 #[must_use]
 pub fn cmp_accounts_packages_by_priority(a: &AccountsPackage, b: &AccountsPackage) -> Ordering {
-    cmp_accounts_package_types_by_priority(&a.package_type, &b.package_type)
+    cmp_accounts_package_kinds_by_priority(&a.package_kind, &b.package_kind)
         .then(a.slot.cmp(&b.slot))
 }
 
-/// Compare accounts package types by priority
+/// Compare accounts package kinds by priority
 ///
 /// Priority, from highest to lowest:
 /// - Epoch Accounts Hash
@@ -29,11 +29,11 @@ pub fn cmp_accounts_packages_by_priority(a: &AccountsPackage, b: &AccountsPackag
 ///
 /// If two `Snapshot`s are compared, their snapshot kinds are the tiebreaker.
 #[must_use]
-pub fn cmp_accounts_package_types_by_priority(
-    a: &AccountsPackageType,
-    b: &AccountsPackageType,
+pub fn cmp_accounts_package_kinds_by_priority(
+    a: &AccountsPackageKind,
+    b: &AccountsPackageKind,
 ) -> Ordering {
-    use AccountsPackageType::*;
+    use AccountsPackageKind::*;
     match (a, b) {
         // Epoch Accounts Hash packages
         (EpochAccountsHash, EpochAccountsHash) => Equal,
@@ -161,9 +161,9 @@ mod tests {
 
     #[test]
     fn test_cmp_accounts_packages_by_priority() {
-        fn new(package_type: AccountsPackageType, slot: Slot) -> AccountsPackage {
+        fn new(package_kind: AccountsPackageKind, slot: Slot) -> AccountsPackage {
             AccountsPackage {
-                package_type,
+                package_kind,
                 slot,
                 block_height: slot,
                 ..AccountsPackage::default_for_tests()
@@ -172,196 +172,196 @@ mod tests {
 
         for (accounts_package_a, accounts_package_b, expected_result) in [
             (
-                new(AccountsPackageType::EpochAccountsHash, 11),
-                new(AccountsPackageType::EpochAccountsHash, 22),
+                new(AccountsPackageKind::EpochAccountsHash, 11),
+                new(AccountsPackageKind::EpochAccountsHash, 22),
                 Less,
             ),
             (
-                new(AccountsPackageType::EpochAccountsHash, 22),
-                new(AccountsPackageType::EpochAccountsHash, 22),
+                new(AccountsPackageKind::EpochAccountsHash, 22),
+                new(AccountsPackageKind::EpochAccountsHash, 22),
                 Equal,
             ),
             (
-                new(AccountsPackageType::EpochAccountsHash, 33),
-                new(AccountsPackageType::EpochAccountsHash, 22),
+                new(AccountsPackageKind::EpochAccountsHash, 33),
+                new(AccountsPackageKind::EpochAccountsHash, 22),
                 Greater,
             ),
             (
-                new(AccountsPackageType::EpochAccountsHash, 123),
+                new(AccountsPackageKind::EpochAccountsHash, 123),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
                 ),
                 Greater,
             ),
             (
-                new(AccountsPackageType::EpochAccountsHash, 123),
+                new(AccountsPackageKind::EpochAccountsHash, 123),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
                 Greater,
             ),
             (
-                new(AccountsPackageType::EpochAccountsHash, 123),
-                new(AccountsPackageType::AccountsHashVerifier, 123),
+                new(AccountsPackageKind::EpochAccountsHash, 123),
+                new(AccountsPackageKind::AccountsHashVerifier, 123),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
                 ),
-                new(AccountsPackageType::EpochAccountsHash, 123),
+                new(AccountsPackageKind::EpochAccountsHash, 123),
                 Less,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     11,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     22,
                 ),
                 Less,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     22,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     22,
                 ),
                 Equal,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     33,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     22,
                 ),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
                 ),
-                new(AccountsPackageType::AccountsHashVerifier, 123),
+                new(AccountsPackageKind::AccountsHashVerifier, 123),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
-                new(AccountsPackageType::EpochAccountsHash, 123),
+                new(AccountsPackageKind::EpochAccountsHash, 123),
                 Less,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                Less,
-            ),
-            (
-                new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
                 ),
                 Less,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    123,
+                ),
+                new(
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
+                    123,
+                ),
+                Less,
+            ),
+            (
+                new(
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     11,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     22,
                 ),
                 Less,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     22,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     22,
                 ),
                 Equal,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     33,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     22,
                 ),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
                     123,
                 ),
                 Greater,
             ),
             (
                 new(
-                    AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
-                new(AccountsPackageType::AccountsHashVerifier, 123),
+                new(AccountsPackageKind::AccountsHashVerifier, 123),
                 Greater,
             ),
             (
-                new(AccountsPackageType::AccountsHashVerifier, 11),
-                new(AccountsPackageType::AccountsHashVerifier, 22),
+                new(AccountsPackageKind::AccountsHashVerifier, 11),
+                new(AccountsPackageKind::AccountsHashVerifier, 22),
                 Less,
             ),
             (
-                new(AccountsPackageType::AccountsHashVerifier, 22),
-                new(AccountsPackageType::AccountsHashVerifier, 22),
+                new(AccountsPackageKind::AccountsHashVerifier, 22),
+                new(AccountsPackageKind::AccountsHashVerifier, 22),
                 Equal,
             ),
             (
-                new(AccountsPackageType::AccountsHashVerifier, 33),
-                new(AccountsPackageType::AccountsHashVerifier, 22),
+                new(AccountsPackageKind::AccountsHashVerifier, 33),
+                new(AccountsPackageKind::AccountsHashVerifier, 22),
                 Greater,
             ),
         ] {
@@ -372,87 +372,87 @@ mod tests {
     }
 
     #[test]
-    fn test_cmp_accounts_package_types_by_priority() {
-        for (accounts_package_type_a, accounts_package_type_b, expected_result) in [
+    fn test_cmp_accounts_package_kinds_by_priority() {
+        for (accounts_package_kind_a, accounts_package_kind_b, expected_result) in [
             (
-                AccountsPackageType::EpochAccountsHash,
-                AccountsPackageType::EpochAccountsHash,
+                AccountsPackageKind::EpochAccountsHash,
+                AccountsPackageKind::EpochAccountsHash,
                 Equal,
             ),
             (
-                AccountsPackageType::EpochAccountsHash,
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::EpochAccountsHash,
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 Greater,
             ),
             (
-                AccountsPackageType::EpochAccountsHash,
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::EpochAccountsHash,
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                 Greater,
             ),
             (
-                AccountsPackageType::EpochAccountsHash,
-                AccountsPackageType::AccountsHashVerifier,
+                AccountsPackageKind::EpochAccountsHash,
+                AccountsPackageKind::AccountsHashVerifier,
                 Greater,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageType::EpochAccountsHash,
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::EpochAccountsHash,
                 Less,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 Equal,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                 Greater,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageType::AccountsHashVerifier,
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::AccountsHashVerifier,
                 Greater,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::EpochAccountsHash,
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::EpochAccountsHash,
                 Less,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::Snapshot(SnapshotKind::FullSnapshot),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 Less,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
                 Less,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                 Equal,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
                 Greater,
             ),
             (
-                AccountsPackageType::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageType::AccountsHashVerifier,
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
+                AccountsPackageKind::AccountsHashVerifier,
                 Greater,
             ),
             (
-                AccountsPackageType::AccountsHashVerifier,
-                AccountsPackageType::AccountsHashVerifier,
+                AccountsPackageKind::AccountsHashVerifier,
+                AccountsPackageKind::AccountsHashVerifier,
                 Equal,
             ),
         ] {
-            let actual_result = cmp_accounts_package_types_by_priority(
-                &accounts_package_type_a,
-                &accounts_package_type_b,
+            let actual_result = cmp_accounts_package_kinds_by_priority(
+                &accounts_package_kind_a,
+                &accounts_package_kind_b,
             );
             assert_eq!(expected_result, actual_result);
         }


### PR DESCRIPTION
#### Problem

When creating an enum to select some underlying *kind* of a thing, we sometimes append `Enum` or `Type` for the name of the type. I think both of these are bad, but not life ending.

Obviously the variants are not *types* in the Rust sense of the word. And the type is already an enum, so adding `Enum` feels redundant.

In the Rust std lib, they have this problem for errors. They've solved this with [`ErrorKind`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html). 

(Some non-Rust projects have also used `Flavor` too, which I like, but not as much as `Kind`.)

`AccountsPackageType` has this naming problem.

#### Summary of Changes

Rename `AccountsPackageType` to `AccountsPackageKind`.