### PR TITLE
ci: update aws cli image

### DIFF
--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -34,7 +34,7 @@ upload-s3-artifact() {
     fi
     args+=(
       amazon/aws-cli:2.13.11
-      s3 cp "$1" "$2"
+      s3 cp "$1" "$2" --acl public-read
     )
     set -x
     docker run "${args[@]}"

--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -33,8 +33,8 @@ upload-s3-artifact() {
       )
     fi
     args+=(
-      eremite/aws-cli:2018.12.18
-      /usr/bin/s3cmd --acl-public put "$1" "$2"
+      amazon/aws-cli:2.13.11
+      s3 cp "$1" "$2"
     )
     set -x
     docker run "${args[@]}"


### PR DESCRIPTION
#### Problem

the old one doesn't exist anymore 😢 it's the time to change it to official one! 

#### Summary of Changes

use `amazon/aws-cli` image. (I don't use the `latest` tag cuz they said: _There are no backwards compatibility guarantees in relying on the latest tag_)
