### PR TITLE
rpc api to configure ancestor hashes sample size

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -78,3 +78,6 @@ signal-hook = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev_extensions = []

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -61,7 +61,7 @@ const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
 const MINIMUM_TICKS_PER_SLOT: u64 = 2;
 
 pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
-    return App::new(crate_name!()).about(crate_description!())
+    let app = App::new(crate_name!()).about(crate_description!())
         .version(version)
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::InferSubcommands)
@@ -1626,8 +1626,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 )
                 .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")
-        ).
-        subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("set-public-address")
                 .about("Specify addresses to advertise in gossip")
                 .arg(
@@ -1654,6 +1654,22 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 )
                 .after_help("Note: At least one arg must be used. Using multiple is ok"),
         );
+    #[cfg(feature = "dev_extensions")]
+    let app = app.subcommand(
+        SubCommand::with_name("set-ancestor-hashes")
+            .about("Configure validator ancestor hashes parameters")
+            .arg(
+                Arg::with_name("sample_size")
+                    .long("sample-size")
+                    .value_name("NUMBER")
+                    .takes_value(true)
+                    .help("Set the validator ancestor hashes sample size"),
+            )
+            .after_help(
+                "Note: the new value only applies to the currently running validator instance",
+            ),
+    );
+    app
 }
 
 /// Deprecated argument description should be moved into the [`deprecated_arguments()`] function,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -877,6 +877,24 @@ pub fn main() {
             );
             return;
         }
+        #[cfg(feature = "dev_extensions")]
+        ("set-ancestor-hashes", Some(subcommand_matches)) => {
+            let sample_size: u32 =
+                value_t_or_exit!(subcommand_matches, "sample_size", std::num::NonZeroU32).into();
+            let admin_client = admin_rpc_service::dev_extensions::connect(&ledger_path);
+            admin_rpc_service::runtime()
+                .block_on(async move {
+                    admin_client
+                        .await?
+                        .set_ancestor_hashes_sample_size(sample_size)
+                        .await
+                })
+                .unwrap_or_else(|err| {
+                    println!("set ancestor hashes sample size failed: {err}");
+                    exit(1);
+                });
+            return;
+        }
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
#### Problem
Ancestor hashes sample size should be configurable for development scenarios.

#### Summary of Changes
Make ancestor hash sample size configurable via rpc when `dev_extensions` feature is enabled.

build using `cargo build --features dev_extensions`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
