### PR TITLE
docs(contributing): fix syntax highlighting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ before the PR can be merged.  Here are the steps:
 * Under the newly-created directory, create a Cargo.toml file.  Below is an
   example template:
 
-```
+```toml
 [package]
 name = "solana-<PACKAGE_NAME>"
 version = "0.0.1"
@@ -285,7 +285,9 @@ edition = "2021"
 * All Rust code is linted with Clippy. If you'd prefer to ignore its advice, do
   so explicitly:
 
-  ```rust #[allow(clippy::too_many_arguments)] ```
+  ```rust
+  #[allow(clippy::too_many_arguments)]
+  ```
 
   Note: Clippy defaults can be overridden in the top-level file `.clippy.toml`.
 


### PR DESCRIPTION
#### Problem
The Rust and TOML syntax highlighting wasn't working before.

#### Summary of Changes
Fixes the syntax highlighting for two code blocks.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
