### PR TITLE
Improve Blockstore error logging

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -566,7 +566,8 @@ impl Validator {
                 .map_err(|err| {
                     format!(
                         "Failed to backup and clear shreds with incorrect \
-                        shred version from blockstore: {err}"
+                        shred version from blockstore: {:?}",
+                        err
                     )
                 })?;
             }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -566,8 +566,7 @@ impl Validator {
                 .map_err(|err| {
                     format!(
                         "Failed to backup and clear shreds with incorrect \
-                        shred version from blockstore: {:?}",
-                        err
+                        shred version from blockstore: {err:?}"
                     )
                 })?;
             }


### PR DESCRIPTION
#### Problem

When Blockstore open fails, the error log didn't show the specific variant of
BlockstoreError enum.

```
[2023-08-22T02:14:24.747916442Z ERROR solana_validator] Failed to start validator: "Failed to backup and clear shreds with incorrect shred version from blockstore: blockstore error"
```


#### Summary of Changes

Use debug format for BlockstoreError logging


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
