### PR TITLE
ci: fix audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -30,6 +30,10 @@ cargo_audit_ignores=(
   --ignore RUSTSEC-2023-0001
 
   --ignore RUSTSEC-2022-0093
+
+  # webpki: CPU denial of service in certificate path building
+  # No fixed upgrade is available!
+  --ignore RUSTSEC-2023-0052
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4102,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
#### Summary of Changes

- bump rustl-webpki to 0.101.4
- ignore RUSTSEC-2023-0052 temporarily