### PR TITLE
InvalidFeePayerFilter

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -463,6 +463,7 @@ fn main() {
             Arc::new(connection_cache),
             bank_forks.clone(),
             &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::default(),
         );
 
         // This is so that the signal_receiver does not go out of scope after the closure.

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -109,7 +109,13 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         );
         let (s, _r) = unbounded();
         let committer = Committer::new(None, s, Arc::new(PrioritizationFeeCache::new(0u64)));
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(
+            Arc::default(),
+            committer,
+            recorder,
+            QosService::new(1),
+            None,
+        );
         // This tests the performance of buffering packets.
         // If the packet buffers are copied, performance will be poor.
         bencher.iter(move || {
@@ -305,6 +311,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             Arc::new(ConnectionCache::new("connection_cache_test")),
             bank_forks,
             &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::default(),
         );
 
         let chunk_len = verified.len() / CHUNKS;

--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -80,7 +80,13 @@ fn create_consumer(poh_recorder: &RwLock<PohRecorder>) -> Consumer {
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let committer = Committer::new(None, replay_vote_sender, Arc::default());
     let transaction_recorder = poh_recorder.read().unwrap().new_recorder();
-    Consumer::new(committer, transaction_recorder, QosService::new(0), None)
+    Consumer::new(
+        Arc::default(),
+        committer,
+        transaction_recorder,
+        QosService::new(0),
+        None,
+    )
 }
 
 struct BenchFrame {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -430,11 +430,13 @@ impl BankingStage {
                     ),
                 };
 
-                let mut packet_receiver =
-                    PacketReceiver::new(id, packet_receiver, bank_forks.clone());
+                let mut packet_receiver = PacketReceiver::new(
+                    id,
+                    packet_receiver,
+                    bank_forks.clone(),
+                    invalid_fee_payer_filter.clone(),
+                );
                 let poh_recorder = poh_recorder.clone();
-                let invalid_fee_payer_filter = invalid_fee_payer_filter.clone();
-
                 let committer = Committer::new(
                     transaction_status_sender.clone(),
                     replay_vote_sender.clone(),
@@ -450,7 +452,7 @@ impl BankingStage {
                     invalid_fee_payer_filter.clone(),
                 );
                 let consumer = Consumer::new(
-                    invalid_fee_payer_filter,
+                    invalid_fee_payer_filter.clone(),
                     committer,
                     poh_recorder.read().unwrap().new_recorder(),
                     QosService::new(id),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -16,8 +16,8 @@ use {
         unprocessed_transaction_storage::{ThreadType, UnprocessedTransactionStorage},
     },
     crate::{
-        banking_trace::BankingPacketReceiver, tracer_packet_stats::TracerPacketStats,
-        validator::BlockProductionMethod,
+        banking_trace::BankingPacketReceiver, invalid_fee_payer_filter::InvalidFeePayerFilter,
+        tracer_packet_stats::TracerPacketStats, validator::BlockProductionMethod,
     },
     crossbeam_channel::RecvTimeoutError,
     histogram::Histogram,
@@ -320,6 +320,7 @@ impl BankingStage {
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        invalid_fee_payer_filter: Arc<InvalidFeePayerFilter>,
     ) -> Self {
         Self::new_num_threads(
             block_production_method,
@@ -335,6 +336,7 @@ impl BankingStage {
             connection_cache,
             bank_forks,
             prioritization_fee_cache,
+            invalid_fee_payer_filter,
         )
     }
 
@@ -353,6 +355,7 @@ impl BankingStage {
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        invalid_fee_payer_filter: Arc<InvalidFeePayerFilter>,
     ) -> Self {
         match block_production_method {
             BlockProductionMethod::ThreadLocalMultiIterator => {
@@ -369,6 +372,7 @@ impl BankingStage {
                     connection_cache,
                     bank_forks,
                     prioritization_fee_cache,
+                    invalid_fee_payer_filter,
                 )
             }
         }
@@ -388,6 +392,7 @@ impl BankingStage {
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        invalid_fee_payer_filter: Arc<InvalidFeePayerFilter>,
     ) -> Self {
         assert!(num_threads >= MIN_TOTAL_THREADS);
         // Single thread to generate entries from many banks.
@@ -428,6 +433,7 @@ impl BankingStage {
                 let mut packet_receiver =
                     PacketReceiver::new(id, packet_receiver, bank_forks.clone());
                 let poh_recorder = poh_recorder.clone();
+                let invalid_fee_payer_filter = invalid_fee_payer_filter.clone();
 
                 let committer = Committer::new(
                     transaction_status_sender.clone(),
@@ -443,6 +449,7 @@ impl BankingStage {
                     data_budget.clone(),
                 );
                 let consumer = Consumer::new(
+                    invalid_fee_payer_filter,
                     committer,
                     poh_recorder.read().unwrap().new_recorder(),
                     QosService::new(id),
@@ -695,6 +702,7 @@ mod tests {
                 Arc::new(ConnectionCache::new("connection_cache_test")),
                 bank_forks,
                 &Arc::new(PrioritizationFeeCache::new(0u64)),
+                Arc::default(),
             );
             drop(non_vote_sender);
             drop(tpu_vote_sender);
@@ -752,6 +760,7 @@ mod tests {
                 Arc::new(ConnectionCache::new("connection_cache_test")),
                 bank_forks,
                 &Arc::new(PrioritizationFeeCache::new(0u64)),
+                Arc::default(),
             );
             trace!("sending bank");
             drop(non_vote_sender);
@@ -834,6 +843,7 @@ mod tests {
                 Arc::new(ConnectionCache::new("connection_cache_test")),
                 bank_forks,
                 &Arc::new(PrioritizationFeeCache::new(0u64)),
+                Arc::default(),
             );
 
             // fund another account so we can send 2 good transactions in a single batch.
@@ -996,6 +1006,7 @@ mod tests {
                     Arc::new(ConnectionCache::new("connection_cache_test")),
                     bank_forks,
                     &Arc::new(PrioritizationFeeCache::new(0u64)),
+                    Arc::default(),
                 );
 
                 // wait for banking_stage to eat the packets
@@ -1187,6 +1198,7 @@ mod tests {
                 Arc::new(ConnectionCache::new("connection_cache_test")),
                 bank_forks,
                 &Arc::new(PrioritizationFeeCache::new(0u64)),
+                Arc::default(),
             );
 
             let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -447,6 +447,7 @@ impl BankingStage {
                     cluster_info.clone(),
                     connection_cache.clone(),
                     data_budget.clone(),
+                    invalid_fee_payer_filter.clone(),
                 );
                 let consumer = Consumer::new(
                     invalid_fee_payer_filter,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -430,6 +430,7 @@ impl BankingStage {
                     ),
                 };
 
+                let invalid_fee_payer_filter = invalid_fee_payer_filter.clone();
                 let mut packet_receiver = PacketReceiver::new(
                     id,
                     packet_receiver,
@@ -467,6 +468,7 @@ impl BankingStage {
                             &decision_maker,
                             &forwarder,
                             &consumer,
+                            &invalid_fee_payer_filter,
                             id,
                             unprocessed_transaction_storage,
                         );
@@ -548,6 +550,7 @@ impl BankingStage {
         decision_maker: &DecisionMaker,
         forwarder: &Forwarder,
         consumer: &Consumer,
+        invalid_fee_payer_filter: &InvalidFeePayerFilter,
         id: u32,
         mut unprocessed_transaction_storage: UnprocessedTransactionStorage,
     ) {
@@ -590,6 +593,7 @@ impl BankingStage {
                 Err(RecvTimeoutError::Disconnected) => break,
             }
             banking_stage_stats.report(1000);
+            invalid_fee_payer_filter.reset_on_interval();
         }
     }
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -202,7 +202,13 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(
+            Arc::default(),
+            committer,
+            recorder,
+            QosService::new(1),
+            None,
+        );
 
         let (consume_sender, consume_receiver) = unbounded();
         let (consumed_sender, consumed_receiver) = unbounded();

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -659,7 +659,8 @@ impl Consumer {
             .iter()
             .zip(batch.sanitized_transactions())
         {
-            if let Err(TransactionError::InsufficientFundsForFee) = result {
+            // This fee-payer submitted an unexecutable, non-fee paying transaction. Reject them.
+            if result.is_err() {
                 self.invalid_fee_payer_filter.add(*tx.message().fee_payer());
             }
         }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -659,31 +659,11 @@ impl Consumer {
             .iter()
             .zip(batch.sanitized_transactions())
         {
-            // If this fee-payer submitted an unexecutable, non-fee paying transaction. Reject them.
             if let Err(err) = result {
                 match err {
-                    TransactionError::AccountLoadedTwice
-                    | TransactionError::AccountNotFound
-                    | TransactionError::ProgramAccountNotFound
+                    TransactionError::AccountNotFound
                     | TransactionError::InsufficientFundsForFee
-                    | TransactionError::InvalidAccountForFee
-                    | TransactionError::MissingSignatureForFee
-                    | TransactionError::InvalidAccountIndex
-                    | TransactionError::SignatureFailure
-                    | TransactionError::InvalidProgramForExecution
-                    | TransactionError::SanitizeFailure
-                    | TransactionError::UnsupportedVersion
-                    | TransactionError::InvalidWritableAccount
-                    | TransactionError::TooManyAccountLocks
-                    | TransactionError::AddressLookupTableNotFound
-                    | TransactionError::InvalidAddressLookupTableOwner
-                    | TransactionError::InvalidAddressLookupTableData
-                    | TransactionError::InvalidAddressLookupTableIndex
-                    | TransactionError::InvalidRentPayingAccount
-                    | TransactionError::DuplicateInstruction(_)
-                    | TransactionError::InsufficientFundsForRent { .. }
-                    | TransactionError::MaxLoadedAccountsDataSizeExceeded
-                    | TransactionError::InvalidLoadedAccountsDataSizeLimit => {
+                    | TransactionError::InvalidAccountForFee => {
                         self.invalid_fee_payer_filter.add(*tx.message().fee_payer());
                     }
                     _ => {}

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -660,8 +660,7 @@ impl Consumer {
             .zip(batch.sanitized_transactions())
         {
             if let Err(TransactionError::InsufficientFundsForFee) = result {
-                self.invalid_fee_payer_filter
-                    .add(tx.message().account_keys()[0]);
+                self.invalid_fee_payer_filter.add(*tx.message().fee_payer());
             }
         }
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -659,9 +659,35 @@ impl Consumer {
             .iter()
             .zip(batch.sanitized_transactions())
         {
-            // This fee-payer submitted an unexecutable, non-fee paying transaction. Reject them.
-            if result.is_err() {
-                self.invalid_fee_payer_filter.add(*tx.message().fee_payer());
+            // If this fee-payer submitted an unexecutable, non-fee paying transaction. Reject them.
+            if let Err(err) = result {
+                match err {
+                    TransactionError::AccountLoadedTwice
+                    | TransactionError::AccountNotFound
+                    | TransactionError::ProgramAccountNotFound
+                    | TransactionError::InsufficientFundsForFee
+                    | TransactionError::InvalidAccountForFee
+                    | TransactionError::MissingSignatureForFee
+                    | TransactionError::InvalidAccountIndex
+                    | TransactionError::SignatureFailure
+                    | TransactionError::InvalidProgramForExecution
+                    | TransactionError::SanitizeFailure
+                    | TransactionError::UnsupportedVersion
+                    | TransactionError::InvalidWritableAccount
+                    | TransactionError::TooManyAccountLocks
+                    | TransactionError::AddressLookupTableNotFound
+                    | TransactionError::InvalidAddressLookupTableOwner
+                    | TransactionError::InvalidAddressLookupTableData
+                    | TransactionError::InvalidAddressLookupTableIndex
+                    | TransactionError::InvalidRentPayingAccount
+                    | TransactionError::DuplicateInstruction(_)
+                    | TransactionError::InsufficientFundsForRent { .. }
+                    | TransactionError::MaxLoadedAccountsDataSizeExceeded
+                    | TransactionError::InvalidLoadedAccountsDataSizeLimit => {
+                        self.invalid_fee_payer_filter.add(*tx.message().fee_payer());
+                    }
+                    _ => {}
+                }
             }
         }
 

--- a/core/src/banking_stage/forward_worker.rs
+++ b/core/src/banking_stage/forward_worker.rs
@@ -158,6 +158,7 @@ mod tests {
             cluster_info,
             Arc::new(ConnectionCache::new("test")),
             Arc::default(),
+            Arc::default(),
         );
 
         let (forward_sender, forward_receiver) = unbounded();

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -122,7 +122,7 @@ impl PacketReceiver {
         let mut dropped_packets_count = 0;
         let mut newly_buffered_packets_count = 0;
         let (deserialized_packets, num_filter_dropped_packets) =
-            Self::filter_packets(&self.invalid_fee_payer_filter, deserialized_packets);
+            Self::filter_invalid_fee_payers(&self.invalid_fee_payer_filter, deserialized_packets);
         dropped_packets_count += num_filter_dropped_packets;
 
         Self::push_unprocessed(
@@ -149,7 +149,7 @@ impl PacketReceiver {
             .swap(unprocessed_transaction_storage.len(), Ordering::Relaxed);
     }
 
-    fn filter_packets(
+    fn filter_invalid_fee_payers(
         invalid_fee_payer_filter: &InvalidFeePayerFilter,
         deserialized_packets: Vec<ImmutableDeserializedPacket>,
     ) -> (Vec<ImmutableDeserializedPacket>, usize) {

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -56,7 +56,7 @@ impl PacketReceiver {
                     recv_timeout,
                     unprocessed_transaction_storage.max_receive_size(),
                 )
-                // Consumes results if Ok, otherwise we keep the Err)
+                // Consumes results if Ok, otherwise we keep the Err
                 .map(|receive_packet_results| {
                     self.buffer_packets(
                         receive_packet_results,

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -768,7 +768,7 @@ impl ThreadLocalUnprocessedPackets {
 
     /// Checks sanitized transactions against bank, returns valid transaction indexes
     fn filter_invalid_transactions(
-        transactions: &[SanitizedTransction],
+        transactions: &[SanitizedTransaction],
         invalid_fee_payer_filter: &InvalidFeePayerFilter,
         bank: &Bank,
         total_dropped_packets: &mut usize,

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -143,11 +143,11 @@ pub struct ConsumeScannerPayload<'a> {
 }
 
 fn consume_scan_should_process_packet(
-    invalid_fee_payer_filter: &InvalidFeePayerFilter,
     bank: &Bank,
     banking_stage_stats: &BankingStageStats,
     packet: &ImmutableDeserializedPacket,
     payload: &mut ConsumeScannerPayload,
+    invalid_fee_payer_filter: &InvalidFeePayerFilter,
 ) -> ProcessingDecision {
     // If end of the slot, return should process (quick loop after reached end of slot)
     if payload.reached_end_of_slot {
@@ -475,11 +475,11 @@ impl VoteStorage {
         let should_process_packet =
             |packet: &Arc<ImmutableDeserializedPacket>, payload: &mut ConsumeScannerPayload| {
                 consume_scan_should_process_packet(
-                    invalid_fee_payer_filter,
                     &bank,
                     banking_stage_stats,
                     packet,
                     payload,
+                    invalid_fee_payer_filter,
                 )
             };
 
@@ -910,11 +910,11 @@ impl ThreadLocalUnprocessedPackets {
         let should_process_packet =
             |packet: &Arc<ImmutableDeserializedPacket>, payload: &mut ConsumeScannerPayload| {
                 consume_scan_should_process_packet(
-                    invalid_fee_payer_filter,
                     bank,
                     banking_stage_stats,
                     packet,
                     payload,
+                    invalid_fee_payer_filter,
                 )
             };
         let mut scanner = create_consume_multi_iterator(

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -768,7 +768,7 @@ impl ThreadLocalUnprocessedPackets {
 
     /// Checks sanitized transactions against bank, returns valid transaction indexes
     fn filter_invalid_transactions(
-        transactions: &[SanitizedTransaction],
+        transactions: &[SanitizedTransction],
         invalid_fee_payer_filter: &InvalidFeePayerFilter,
         bank: &Bank,
         total_dropped_packets: &mut usize,
@@ -777,7 +777,10 @@ impl ThreadLocalUnprocessedPackets {
             .iter()
             .map(|tx| {
                 if invalid_fee_payer_filter.should_reject(&tx.message().account_keys()[0]) {
-                    Err(TransactionError::InsufficientFundsForFee)
+                    // Actual error variant is not used - Result is only used to skip additional
+                    // checks in `check_transactions_with_forwarding_delay`, since this will not
+                    // be forwarded.
+                    Err(TransactionError::InvalidAccountForFee)
                 } else {
                     Ok(())
                 }

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -3,11 +3,23 @@
 //! in any block, much earlier in the transaction pipeline.
 //!
 
-use {dashmap::DashSet, solana_sdk::pubkey::Pubkey};
+use {
+    dashmap::DashSet,
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+        thread::{sleep, Builder, JoinHandle},
+        time::Duration,
+    },
+};
 
 #[derive(Default)]
 pub struct InvalidFeePayerFilter {
     recent_invalid_fee_payers: DashSet<Pubkey>,
+    reject_count: Arc<AtomicUsize>,
 }
 
 impl InvalidFeePayerFilter {
@@ -23,6 +35,53 @@ impl InvalidFeePayerFilter {
 
     /// Check if a pubkey is in the filter.
     pub fn should_reject(&self, pubkey: &Pubkey) -> bool {
-        self.recent_invalid_fee_payers.contains(pubkey)
+        let should_reject = self.recent_invalid_fee_payers.contains(pubkey);
+        if should_reject {
+            self.reject_count.fetch_add(1, Ordering::Relaxed);
+        }
+        should_reject
+    }
+}
+
+/// Simple wrapper thread that periodically resets the filter.
+pub struct InvalidFeePayerFilterThread {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl InvalidFeePayerFilterThread {
+    pub fn new(exit: Arc<AtomicBool>) -> (Self, Arc<InvalidFeePayerFilter>) {
+        let invalid_fee_payer_filter = Arc::new(InvalidFeePayerFilter::default());
+        let reject_count = invalid_fee_payer_filter.reject_count.clone();
+
+        let thread_hdl = Builder::new()
+            .name("solInvFeePay".to_string())
+            .spawn({
+                let invalid_fee_payer_filter = invalid_fee_payer_filter.clone();
+                move || {
+                    const RESET_INTERVAL: Duration = Duration::from_secs(120);
+                    while !exit.load(Ordering::Relaxed) {
+                        let num_rejects = reject_count.swap(0, Ordering::Relaxed);
+                        let num_invalid_fee_payers =
+                            invalid_fee_payer_filter.recent_invalid_fee_payers.len();
+
+                        if num_rejects > 0 {
+                            datapoint_info!(
+                                "invalid_fee_payer_filter",
+                                ("invalid_fee_payers", num_invalid_fee_payers, i64),
+                                ("rejects", num_rejects, i64),
+                            );
+                        }
+
+                        invalid_fee_payer_filter.reset();
+                        sleep(RESET_INTERVAL);
+                    }
+                }
+            })
+            .unwrap();
+        (Self { thread_hdl }, invalid_fee_payer_filter)
+    }
+
+    pub fn join(self) -> std::thread::Result<()> {
+        self.thread_hdl.join()
     }
 }

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -1,0 +1,28 @@
+//! Manages a set of recent invalid fee payers.
+//! This is used to filter out transactions that are unlikely to be included
+//! in any block, much earlier in the transaction pipeline.
+//!
+
+use {dashmap::DashSet, solana_sdk::pubkey::Pubkey};
+
+#[derive(Default)]
+pub struct InvalidFeePayerFilter {
+    recent_invalid_fee_payers: DashSet<Pubkey>,
+}
+
+impl InvalidFeePayerFilter {
+    /// Reset the filter - this should be called periodically.
+    pub fn reset(&self) {
+        self.recent_invalid_fee_payers.clear();
+    }
+
+    /// Add a pubkey to the filter.
+    pub fn add(&self, pubkey: Pubkey) {
+        self.recent_invalid_fee_payers.insert(pubkey);
+    }
+
+    /// Check if a pubkey is in the filter.
+    pub fn should_reject(&self, pubkey: &Pubkey) -> bool {
+        self.recent_invalid_fee_payers.contains(pubkey)
+    }
+}

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -58,7 +58,7 @@ impl InvalidFeePayerFilterThread {
             .spawn({
                 let invalid_fee_payer_filter = invalid_fee_payer_filter.clone();
                 move || {
-                    const RESET_INTERVAL: Duration = Duration::from_secs(120);
+                    const RESET_INTERVAL: Duration = Duration::from_secs(2);
                     while !exit.load(Ordering::Relaxed) {
                         let num_rejects = reject_count.swap(0, Ordering::Relaxed);
                         let num_invalid_fee_payers =

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -85,3 +85,24 @@ impl InvalidFeePayerFilterThread {
         self.thread_hdl.join()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_sdk::pubkey::Pubkey};
+
+    #[test]
+    fn test_invalid_fee_payer_filter() {
+        let invalid_fee_payer_filter = Arc::new(InvalidFeePayerFilter::default());
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        assert!(!invalid_fee_payer_filter.should_reject(&pubkey1));
+        assert!(!invalid_fee_payer_filter.should_reject(&pubkey2));
+        invalid_fee_payer_filter.add(pubkey1);
+        assert!(invalid_fee_payer_filter.should_reject(&pubkey1));
+        assert!(!invalid_fee_payer_filter.should_reject(&pubkey2));
+
+        invalid_fee_payer_filter.reset();
+        assert!(!invalid_fee_payer_filter.should_reject(&pubkey1));
+        assert!(!invalid_fee_payer_filter.should_reject(&pubkey2));
+    }
+}

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -18,8 +18,16 @@ pub struct InvalidFeePayerFilter {
 
 impl Default for InvalidFeePayerFilter {
     fn default() -> Self {
+        // Upper-bound on the number of invalid fee payers to track, to avoid
+        // unbounded memory growth.
+        // Number chosen so it is large enough to track a large number of
+        // invalid fee payers, but small enough to not use too much memory.
+        // Typically, unique invalid fee paying is rare so this is probably
+        // overkill.
+        const INVALID_FEE_PAYER_CAPACITY: usize = 16 * 1024;
+
         Self {
-            capacity: 16 * 1024,
+            capacity: INVALID_FEE_PAYER_CAPACITY,
             recent_invalid_fee_payers: DashSet::new(),
             stats: InvalidFeePayerFilterStats::default(),
             interval: AtomicInterval::default(),

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -39,7 +39,12 @@ impl InvalidFeePayerFilter {
         self.recent_invalid_fee_payers.insert(pubkey);
 
         if self.recent_invalid_fee_payers.len() > self.capacity {
-            if let Some(key) = self.recent_invalid_fee_payers.iter().next().map(|k| *k.key()) {
+            if let Some(key) = self
+                .recent_invalid_fee_payers
+                .iter()
+                .next()
+                .map(|k| *k.key())
+            {
                 self.recent_invalid_fee_payers.remove(&key);
             }
         }

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -29,8 +29,12 @@ impl InvalidFeePayerFilter {
     /// Reset the filter if enough time has passed since last reset.
     pub fn reset_on_interval(&self) {
         if self.stats.try_report() {
-            self.recent_invalid_fee_payers.clear();
+            self.reset();
         }
+    }
+
+    fn reset(&self) {
+        self.recent_invalid_fee_payers.clear();
     }
 
     /// Add a pubkey to the filter.
@@ -103,7 +107,7 @@ mod tests {
         assert!(invalid_fee_payer_filter.should_reject(&pubkey1));
         assert!(!invalid_fee_payer_filter.should_reject(&pubkey2));
 
-        invalid_fee_payer_filter.reset_on_interval();
+        invalid_fee_payer_filter.reset();
         assert!(!invalid_fee_payer_filter.should_reject(&pubkey1));
         assert!(!invalid_fee_payer_filter.should_reject(&pubkey2));
     }

--- a/core/src/invalid_fee_payer_filter.rs
+++ b/core/src/invalid_fee_payer_filter.rs
@@ -13,6 +13,7 @@ pub struct InvalidFeePayerFilter {
     capacity: usize,
     recent_invalid_fee_payers: DashSet<Pubkey>,
     stats: InvalidFeePayerFilterStats,
+    interval: AtomicInterval,
 }
 
 impl Default for InvalidFeePayerFilter {
@@ -21,15 +22,19 @@ impl Default for InvalidFeePayerFilter {
             capacity: 16 * 1024,
             recent_invalid_fee_payers: DashSet::new(),
             stats: InvalidFeePayerFilterStats::default(),
+            interval: AtomicInterval::default(),
         }
     }
 }
 
 impl InvalidFeePayerFilter {
     /// Reset the filter if enough time has passed since last reset.
+    /// If reset, also report stats.
     pub fn reset_on_interval(&self) {
-        if self.stats.try_report() {
+        const RESET_INTERVAL_MS: u64 = 2000;
+        if self.interval.should_update(RESET_INTERVAL_MS) {
             self.reset();
+            self.stats.report();
         }
     }
 
@@ -66,28 +71,21 @@ impl InvalidFeePayerFilter {
 
 #[derive(Default)]
 struct InvalidFeePayerFilterStats {
-    interval: AtomicInterval,
     num_added: AtomicUsize,
     num_rejects: AtomicUsize,
 }
 
 impl InvalidFeePayerFilterStats {
-    fn try_report(&self) -> bool {
-        const REPORT_INTERVAL_MS: u64 = 2000;
-
-        if self.interval.should_update(REPORT_INTERVAL_MS) {
-            let num_added = self.num_added.swap(0, Ordering::Relaxed);
-            if num_added > 0 {
-                let num_rejects = self.num_rejects.swap(0, Ordering::Relaxed);
-                datapoint_info!(
-                    "invalid_fee_payer_filter_stats",
-                    ("added", num_added, i64),
-                    ("rejects", num_rejects, i64),
-                );
-            }
-            true
-        } else {
-            false
+    /// Report metrics since last report, if any invalid fee-payers have been detected.
+    fn report(&self) {
+        let num_added = self.num_added.swap(0, Ordering::Relaxed);
+        if num_added > 0 {
+            let num_rejects = self.num_rejects.swap(0, Ordering::Relaxed);
+            datapoint_info!(
+                "invalid_fee_payer_filter_stats",
+                ("added", num_added, i64),
+                ("rejects", num_rejects, i64),
+            );
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod cost_update_service;
 pub mod drop_bank_service;
 pub mod fetch_stage;
 pub mod gen_keys;
+mod invalid_fee_payer_filter;
 pub mod ledger_cleanup_service;
 pub mod ledger_metric_report_service;
 pub mod next_leader;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -11,6 +11,7 @@ use {
             GossipVerifiedVoteHashSender, VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
+        invalid_fee_payer_filter::InvalidFeePayerFilter,
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -188,6 +189,8 @@ impl Tpu {
         )
         .unwrap();
 
+        let invalid_fee_payer_filter = Arc::new(InvalidFeePayerFilter::default());
+
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::new(non_vote_sender);
             SigVerifyStage::new(packet_receiver, verifier, "tpu-verifier")
@@ -231,6 +234,7 @@ impl Tpu {
             connection_cache.clone(),
             bank_forks.clone(),
             prioritization_fee_cache,
+            invalid_fee_payer_filter,
         );
 
         let (entry_receiver, tpu_entry_notifier) =

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -11,7 +11,7 @@ use {
             GossipVerifiedVoteHashSender, VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
-        invalid_fee_payer_filter::InvalidFeePayerFilter,
+        invalid_fee_payer_filter::InvalidFeePayerFilterThread,
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -74,6 +74,7 @@ pub struct Tpu {
     tpu_entry_notifier: Option<TpuEntryNotifier>,
     staked_nodes_updater_service: StakedNodesUpdaterService,
     tracer_thread_hdl: TracerThread,
+    invalid_fee_payer_thread: InvalidFeePayerFilterThread,
 }
 
 impl Tpu {
@@ -189,7 +190,8 @@ impl Tpu {
         )
         .unwrap();
 
-        let invalid_fee_payer_filter = Arc::new(InvalidFeePayerFilter::default());
+        let (invalid_fee_payer_thread, invalid_fee_payer_filter) =
+            InvalidFeePayerFilterThread::new(exit.clone());
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::new(non_vote_sender);
@@ -275,6 +277,7 @@ impl Tpu {
             tpu_entry_notifier,
             staked_nodes_updater_service,
             tracer_thread_hdl,
+            invalid_fee_payer_thread,
         }
     }
 
@@ -288,6 +291,7 @@ impl Tpu {
             self.staked_nodes_updater_service.join(),
             self.tpu_quic_t.join(),
             self.tpu_forwards_quic_t.join(),
+            self.invalid_fee_payer_thread.join(),
         ];
         let broadcast_result = self.broadcast_stage.join();
         for result in results {


### PR DESCRIPTION
#### Problem
Some transactions that cannot pay fees make it into banking stage, often with repeat offenders. These transactions take time to process which can cause fewer valid transactions to make it into the block.

#### Summary of Changes
- Add an `InvalidFeePayerFilter`
  - Wrapper of DashMap for now, but potentially switch to a bloom filter in future (?)
- Upon seeing a transaction without sufficient funds for fees, add the fee-payer to the `InvalidFeePayerFilter`
- Multi-Iterator checks `InvalidFeePayerFilter` during batch selection
  - this let's more quickly rule these out
- Checks `InvalidFeePayerFilter` before forwarding
  - no need to forward these transactions to the next leader
- `BankingStage` checks `InvalidFeePayerFilter` when receiving packets from `SigVerify`
  - this means these transactions cannot take up the limited buffer space
- `BankingStage` will periodically clear the filter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
