### PR TITLE
rpc-client: Encapsulate `set_message_for_confirmed_transactions`

### DIFF
--- a/rpc-client/src/spinner.rs
+++ b/rpc-client/src/spinner.rs
@@ -14,8 +14,29 @@ pub fn new_progress_bar() -> ProgressBar {
     progress_bar.set_style(
         ProgressStyle::default_spinner()
             .template("{spinner:.green} {wide_msg}")
-            .expect("ProgresStyle::template direct input to be correct"),
+            .expect("ProgressStyle::template direct input to be correct"),
     );
     progress_bar.enable_steady_tick(Duration::from_millis(100));
     progress_bar
+}
+
+#[derive(Debug, Default)]
+pub struct SendTransactionProgress {
+    pub confirmed_transactions: usize,
+    pub total_transactions: usize,
+    pub block_height: u64,
+    pub last_valid_block_height: u64,
+}
+
+impl SendTransactionProgress {
+    pub fn set_message_for_confirmed_transactions(&self, progress_bar: &ProgressBar, status: &str) {
+        progress_bar.set_message(format!(
+            "{:>5.1}% | {:<40} [block height {}; re-sign in {} blocks]",
+            self.confirmed_transactions as f64 * 100. / self.total_transactions as f64,
+            status,
+            self.block_height,
+            self.last_valid_block_height
+                .saturating_sub(self.block_height),
+        ));
+    }
 }


### PR DESCRIPTION
#### Problem

While working on an alternative for sending multiple transactions quickly, the solution had me passing around many fields that could be encapsulated just to print out the progress.

#### Summary of Changes

Rather than pass around so many fields, let's encapsulate everything needed by `set_message_for_confirmed_transactions` into a struct, and call it properly!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
