### PR TITLE
Get slot info along tpu leader

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -381,6 +381,14 @@ impl PohRecorder {
             .slot_leader_at(current_slot + slots, None)
     }
 
+    /// Return the leader and slot pair after `slots` slots.
+    pub fn leader_and_slot_after_n_slots(&self, slots: u64) -> Option<(Pubkey, Slot)> {
+        let current_slot = self.slot_for_tick_height(self.tick_height);
+        self.leader_schedule_cache
+            .slot_leader_at(current_slot + slots, None)
+            .map(|leader| (leader, current_slot + slots))
+    }
+
     pub fn next_slot_leader(&self) -> Option<Pubkey> {
         self.leader_after_n_slots(1)
     }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -382,11 +382,13 @@ impl PohRecorder {
     }
 
     /// Return the leader and slot pair after `slots` slots.
-    pub fn leader_and_slot_after_n_slots(&self, slots: u64) -> Option<(Pubkey, Slot)> {
-        let current_slot = self.slot_for_tick_height(self.tick_height);
+    pub fn leader_and_slot_after_n_slots(&self, slots_in_the_future: u64) -> Option<(Pubkey, Slot)> {
+        let target_slot = self
+            .slot_for_tick_height(self.tick_height)
+            .checked_add(slots_in_the_future)?;
         self.leader_schedule_cache
-            .slot_leader_at(current_slot + slots, None)
-            .map(|leader| (leader, current_slot + slots))
+            .slot_leader_at(target_slot, None)
+            .map(|leader| (leader, target_slot))
     }
 
     pub fn next_slot_leader(&self) -> Option<Pubkey> {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -381,8 +381,11 @@ impl PohRecorder {
             .slot_leader_at(current_slot + slots, None)
     }
 
-    /// Return the leader and slot pair after `slots` slots.
-    pub fn leader_and_slot_after_n_slots(&self, slots_in_the_future: u64) -> Option<(Pubkey, Slot)> {
+    /// Return the leader and slot pair after `slots_in_the_future` slots.
+    pub fn leader_and_slot_after_n_slots(
+        &self,
+        slots_in_the_future: u64,
+    ) -> Option<(Pubkey, Slot)> {
         let target_slot = self
             .slot_for_tick_height(self.tick_height)
             .checked_add(slots_in_the_future)?;

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -1,7 +1,10 @@
 use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS}, pubkey::Pubkey},
+    solana_sdk::{
+        clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+        pubkey::Pubkey,
+    },
     solana_send_transaction_service::tpu_info::TpuInfo,
     std::{
         collections::HashMap,
@@ -65,7 +68,11 @@ impl TpuInfo for ClusterTpuInfo {
         unique_leaders
     }
 
-    fn get_leader_tpus_with_slots(&self, max_count: u64, protocol: Protocol) -> Vec<(&SocketAddr, Slot)> {
+    fn get_leader_tpus_with_slots(
+        &self,
+        max_count: u64,
+        protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)> {
         let recorder = self.poh_recorder.read().unwrap();
         let leaders: Vec<_> = (0..max_count)
             .filter_map(|i| {

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -96,7 +96,7 @@ impl TpuInfo for ClusterTpuInfo {
                     })
             })
             .collect::<HashMap<_, _>>();
-        let mut unique_leaders = addrs_to_slots.into_iter().collect::<Vec<_>>();
+        let mut unique_leaders = Vec::from_iter(addrs_to_slots);
         unique_leaders.sort_by_key(|(_addr, slot)| *slot);
         unique_leaders
     }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -789,17 +789,12 @@ impl SendTransactionService {
         config: &'a Config,
         protocol: Protocol,
     ) -> Vec<(&'a SocketAddr, Slot)> {
-        let addresses = leader_info.as_ref().map(|leader_info| {
-            leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol)
-        });
-        addresses
-            .map(|address_list| {
-                if address_list.is_empty() {
-                    vec![(tpu_address, 0)]
-                } else {
-                    address_list
-                }
+        leader_info
+            .as_ref()
+            .map(|leader_info| {
+                leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol)
             })
+            .filter(|addresses| !addresses.is_empty())
             .unwrap_or_else(|| vec![(tpu_address, 0)])
     }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -10,8 +10,8 @@ use {
     solana_metrics::datapoint_warn,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
-        clock::Slot, hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign, signature::Signature,
-        timing::AtomicInterval, transport::TransportError,
+        clock::Slot, hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign,
+        signature::Signature, timing::AtomicInterval, transport::TransportError,
     },
     std::{
         collections::{
@@ -577,8 +577,7 @@ impl SendTransactionService {
             .map(|(_, transaction_info)| {
                 debug!(
                     "Sending transacation {} to (address, slot): {:?}",
-                    transaction_info.signature,
-                    addresses,
+                    transaction_info.signature, addresses,
                 );
                 transaction_info.wire_transaction.as_ref()
             })
@@ -790,9 +789,9 @@ impl SendTransactionService {
         config: &'a Config,
         protocol: Protocol,
     ) -> Vec<(&'a SocketAddr, Slot)> {
-        let addresses = leader_info
-            .as_ref()
-            .map(|leader_info| leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol));
+        let addresses = leader_info.as_ref().map(|leader_info| {
+            leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol)
+        });
         addresses
             .map(|address_list| {
                 if address_list.is_empty() {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -10,7 +10,7 @@ use {
     solana_metrics::datapoint_warn,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
-        hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign, signature::Signature,
+        clock::Slot, hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign, signature::Signature,
         timing::AtomicInterval, transport::TransportError,
     },
     std::{
@@ -565,7 +565,7 @@ impl SendTransactionService {
         stats: &SendTransactionServiceStats,
     ) {
         // Processing the transactions in batch
-        let addresses = Self::get_tpu_addresses(
+        let addresses = Self::get_tpu_addresses_with_slots(
             tpu_address,
             leader_info,
             config,
@@ -574,11 +574,18 @@ impl SendTransactionService {
 
         let wire_transactions = transactions
             .iter()
-            .map(|(_, transaction_info)| transaction_info.wire_transaction.as_ref())
+            .map(|(_, transaction_info)| {
+                debug!(
+                    "Sending transacation {} to (address, slot): {:?}",
+                    transaction_info.signature,
+                    addresses,
+                );
+                transaction_info.wire_transaction.as_ref()
+            })
             .collect::<Vec<&[u8]>>();
 
         for address in &addresses {
-            Self::send_transactions(address, &wire_transactions, connection_cache, stats);
+            Self::send_transactions(address.0, &wire_transactions, connection_cache, stats);
         }
     }
 
@@ -775,6 +782,26 @@ impl SendTransactionService {
                 }
             })
             .unwrap_or_else(|| vec![tpu_address])
+    }
+
+    fn get_tpu_addresses_with_slots<'a, T: TpuInfo>(
+        tpu_address: &'a SocketAddr,
+        leader_info: Option<&'a T>,
+        config: &'a Config,
+        protocol: Protocol,
+    ) -> Vec<(&'a SocketAddr, Slot)> {
+        let addresses = leader_info
+            .as_ref()
+            .map(|leader_info| leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol));
+        addresses
+            .map(|address_list| {
+                if address_list.is_empty() {
+                    vec![(tpu_address, 0)]
+                } else {
+                    address_list
+                }
+            })
+            .unwrap_or_else(|| vec![(tpu_address, 0)])
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,8 +1,10 @@
-use {solana_client::connection_cache::Protocol, std::net::SocketAddr};
+use {solana_client::connection_cache::Protocol, solana_sdk::clock::Slot, std::net::SocketAddr};
 
 pub trait TpuInfo {
     fn refresh_recent_peers(&mut self);
     fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
+    /// In addition to the the tpu address, also return the leader slot
+    fn get_leader_tpus_with_slots(&self, max_count: u64, protocol: Protocol) -> Vec<(&SocketAddr, Slot)>;
 }
 
 #[derive(Clone)]
@@ -11,6 +13,9 @@ pub struct NullTpuInfo;
 impl TpuInfo for NullTpuInfo {
     fn refresh_recent_peers(&mut self) {}
     fn get_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
+        vec![]
+    }
+    fn get_leader_tpus_with_slots(&self, _max_count: u64, _protocol: Protocol) -> Vec<(&SocketAddr, Slot)> {
         vec![]
     }
 }

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -4,7 +4,11 @@ pub trait TpuInfo {
     fn refresh_recent_peers(&mut self);
     fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
     /// In addition to the the tpu address, also return the leader slot
-    fn get_leader_tpus_with_slots(&self, max_count: u64, protocol: Protocol) -> Vec<(&SocketAddr, Slot)>;
+    fn get_leader_tpus_with_slots(
+        &self,
+        max_count: u64,
+        protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)>;
 }
 
 #[derive(Clone)]
@@ -15,7 +19,11 @@ impl TpuInfo for NullTpuInfo {
     fn get_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
         vec![]
     }
-    fn get_leader_tpus_with_slots(&self, _max_count: u64, _protocol: Protocol) -> Vec<(&SocketAddr, Slot)> {
+    fn get_leader_tpus_with_slots(
+        &self,
+        _max_count: u64,
+        _protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)> {
         vec![]
     }
 }


### PR DESCRIPTION
#### Problem

In send_transaction_service we only have tpu leader address. This made it hard to understand if the leader obtained and used for sending transactions are up-to-date to the real leader where the transaction is really landed.

#### Summary of Changes
Created an overload of get_leader_tpus: get_leader_tpus_with_slots to get the tpu address along with the slot. And put that information into the debug log. This information can be compared with where the the transaction confirmed to measure leader accuracy. This help us better understand the txn latency.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
