### PR TITLE
v1.16: unpin tokio for solana client crate

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,7 +34,7 @@ solana-thin-client = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }
 solana-udp-client = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }


### PR DESCRIPTION
#### Problem

Tokio version specifier "~1.14.1" only allows patch updates and [v1.14.1](https://crates.io/crates/tokio/1.14.1) is more than a year old.

#### Summary of Changes

Change to `tokio = "1"` in the `client/` crate.

Fixes #32878