### PR TITLE
tower: when syncing from vote state, update last_vote

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -745,18 +745,18 @@ pub fn process_vote(
 }
 
 /// "unchecked" functions used by tests and Tower
-pub fn process_vote_unchecked(vote_state: &mut VoteState, vote: Vote) {
+pub fn process_vote_unchecked(vote_state: &mut VoteState, vote: Vote) -> Result<(), VoteError> {
     if vote.slots.is_empty() {
-        return;
+        return Err(VoteError::EmptySlots);
     }
     let slot_hashes: Vec<_> = vote.slots.iter().rev().map(|x| (*x, vote.hash)).collect();
-    let _ignored = process_vote_unfiltered(
+    process_vote_unfiltered(
         vote_state,
         &vote.slots,
         &vote,
         &slot_hashes,
         vote_state.current_epoch(),
-    );
+    )
 }
 
 #[cfg(test)]
@@ -767,7 +767,7 @@ pub fn process_slot_votes_unchecked(vote_state: &mut VoteState, slots: &[Slot]) 
 }
 
 pub fn process_slot_vote_unchecked(vote_state: &mut VoteState, slot: Slot) {
-    process_vote_unchecked(vote_state, Vote::new(vec![slot], Hash::default()));
+    let _ = process_vote_unchecked(vote_state, Vote::new(vec![slot], Hash::default()));
 }
 
 /// Authorize the given pubkey to withdraw or sign votes. This may be called multiple times,
@@ -1684,7 +1684,8 @@ mod tests {
                     hash: Hash::new_unique(),
                     timestamp: None,
                 },
-            );
+            )
+            .unwrap();
 
             // Now use the resulting new vote state to perform a vote state update on vote_state
             assert_eq!(

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -708,7 +708,7 @@ pub fn process_new_vote_state(
     Ok(())
 }
 
-fn process_vote_unfiltered(
+pub fn process_vote_unfiltered(
     vote_state: &mut VoteState,
     vote_slots: &[Slot],
     vote: &Vote,


### PR DESCRIPTION
#### Problem
On replay, if validators observe a newer vote state from a frozen bank, they will adopt that vote state in favor of their local tower. This is to avoid an outdated local tower from sending out slashable votes, or in case of large divergences, having to wait forever for lockout to expire. 

However when we adopt vote state, we do not update the tower's `last_vote` field. This causes problems in situations where our fork choice does not agree with the on chain vote state. 
Consider the following:

```
[...] - 115 - 124 - 125 - 126 - 127
         \
          - 120 - 121 - 122 - 123
```
Previously our validator had voted on slots `124` and `126` which landed in block `127`. Currently, our validator has replayed only up to `115` and has most recently voted on `115`.

Next it receives the remaining blocks up to `127` to replay. Upon replay of `127` it realizes it has voted on slots `124` and `126` in the past, and updates the tower vote state to reflect that.
https://github.com/solana-labs/solana/blob/14d0759af0663c7739ffd0c6e94c3c57f1ebcff1/core/src/replay_stage.rs#L3029-L3031

Suppose that previously, our validator did not get a chance to observe the `120` fork which is why it voted on `124`. However in our current run, fork choice rates `123` as the best slot. When it comes time to select forks, we select `123` as the heaviest slot *and* `123` as the heaviest slot descended from our last vote:
https://github.com/solana-labs/solana/blob/14d0759af0663c7739ffd0c6e94c3c57f1ebcff1/core/src/consensus/heaviest_subtree_fork_choice.rs#L1015-L1017
Because we have not updated our last vote, we think that the heaviest slot descends from our last vote, and incorrectly `SwitchForkDecision::SameFork` 
https://github.com/solana-labs/solana/blob/14d0759af0663c7739ffd0c6e94c3c57f1ebcff1/core/src/consensus.rs#L872-L875

At this point we vote on `123`, however because we adopted the vote state from `127` which contains votes for `124` and `126`, this vote will fail. Unfortunately we use `process_vote_unchecked` which silently ignores this error. We think that the vote has succeeded, and construct our new `last_vote` from the tower. This `last_vote` is garbage, it contains slot `126`, but has a `vote_hash` for slot `123`.
https://github.com/solana-labs/solana/blob/14d0759af0663c7739ffd0c6e94c3c57f1ebcff1/core/src/consensus.rs#L569-L578
Any further operations involving the tower + fork choice will now panic, as the last vote in the tower does not exist in fork choice (invalid `SlotHashKey`). 

#### Summary of Changes
- When adopting on chain vote state, update `tower.last_vote` as well.
- `tower.record_bank_vote...` variants should use `process_vote_unfiltered`. Although it is unlikely we can recover in case this vote fails, we can log the error to make debugging such situations possible. 

Fixes #32880 
This is the proper fix for #32894 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->