### PR TITLE
v1.14: ci: fix reqwest to 0.11.11

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ humantime = "2.0.1"
 log = "0.4.17"
 num-traits = "0.2"
 pretty-hex = "0.3.0"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.10"
 serde = "1.0.138"
 serde_derive = "1.0.103"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,7 +32,7 @@ quinn-proto = "0.8.3"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.3"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
 semver = "1.0.10"
 serde = "1.0.138"

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 console = "0.15.0"
 indicatif = "0.16.2"
 log = "0.4.17"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-runtime = { path = "../runtime", version = "=1.14.25" }
 solana-sdk = { path = "../sdk", version = "=1.14.25" }
 

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -22,7 +22,7 @@ dirs-next = "2.0.0"
 indicatif = "0.16.2"
 lazy_static = "1.4.0"
 nix = "0.24.2"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.10"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_yaml = "0.8.26"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -14,7 +14,7 @@ crossbeam-channel = "0.5"
 gethostname = "0.2.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "=1.14.25" }
 
 [dev-dependencies]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = "1.0"
 
 [lib]

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -16,7 +16,7 @@ bs58 = "0.4.0"
 crossbeam-channel = "0.5"
 futures-util = "0.3.21"
 log = "0.4.17"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde = "1.0.138"
 serde_json = "1.0.81"
 solana-account-decoder = { path = "../account-decoder", version = "=1.14.25" }


### PR DESCRIPTION
#### Problem

https://buildkite.com/solana-labs/solana/builds/100639#018a20fc-c99a-41c6-a543-17f73499f5b6

![Screenshot 2023-08-23 at 11 17 02 PM](https://github.com/solana-labs/solana/assets/8209234/129c5f28-1ec2-41a2-bae2-709958e55ca0)

I think we can fix it to 0.11.11 which we're using atm.


#### Summary of Changes

```diff
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { version = "=0.11.11", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
```
