### PR TITLE
Speedup hash dedup

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -766,10 +766,10 @@ impl<'a> AccountsHasher<'a> {
         })
     }
 
-    fn calculate_bin_map(
-        sorted_data_by_pubkey: &[&[CalculateHashIntermediate]],
+    fn calculate_bin_map<'b>(
+        sorted_data_by_pubkey: &'b [&[CalculateHashIntermediate]],
         max_bin: usize,
-    ) -> Vec<std::collections::HashMap<usize, (usize, Pubkey)>> {
+    ) -> Vec<std::collections::HashMap<usize, (usize, &'b Pubkey)>> {
         if max_bin == 0 {
             return vec![];
         }
@@ -796,7 +796,7 @@ impl<'a> AccountsHasher<'a> {
                             continue;
                         }
                     }
-                    out.entry(bin).or_insert((i, *pk));
+                    out.entry(bin).or_insert((i, pk));
                     last_bin = Some(bin)
                 }
                 out
@@ -1025,7 +1025,7 @@ impl<'a> AccountsHasher<'a> {
         sorted_data_by_pubkey: &[&[CalculateHashIntermediate]],
         pubkey_bin: usize,
         bins: usize,
-        bin_map: &Vec<std::collections::HashMap<usize, (usize, Pubkey)>>,
+        bin_map: &Vec<std::collections::HashMap<usize, (usize, &Pubkey)>>,
     ) -> (AccountHashesFile, u64) {
         let binner = PubkeyBinCalculator24::new(bins);
 
@@ -1042,7 +1042,7 @@ impl<'a> AccountsHasher<'a> {
 
         for (i, map) in bin_map.iter().enumerate() {
             if let Some((index, pubkey)) = map.get(&pubkey_bin) {
-                first_items.push(pubkey.to_owned());
+                first_items.push(*pubkey.to_owned());
                 first_item_to_pubkey_division.push(i);
                 indexes.push(index.to_owned());
             }
@@ -1394,7 +1394,7 @@ pub mod tests {
                         let expected_index = if bin == 0 { 0 } else { cumsum[bin - 1] };
                         let (index, key) = map.get(&bin).unwrap();
                         assert_eq!(*index, expected_index);
-                        assert_eq!(*key, expected_key);
+                        assert_eq!(**key, expected_key);
                     }
                 }
             }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -766,10 +766,10 @@ impl<'a> AccountsHasher<'a> {
         })
     }
 
-    fn calculate_bin_map<'b>(
-        sorted_data_by_pubkey: &'b [&[CalculateHashIntermediate]],
+    fn calculate_bin_map(
+        sorted_data_by_pubkey: &[&[CalculateHashIntermediate]],
         max_bin: usize,
-    ) -> Vec<std::collections::HashMap<usize, (usize, &'b Pubkey)>> {
+    ) -> Vec<std::collections::HashMap<usize, (usize, Pubkey)>> {
         if max_bin == 0 {
             return vec![];
         }
@@ -796,7 +796,7 @@ impl<'a> AccountsHasher<'a> {
                             continue;
                         }
                     }
-                    out.entry(bin).or_insert((i, pk));
+                    out.entry(bin).or_insert((i, *pk));
                     last_bin = Some(bin)
                 }
                 out
@@ -1025,7 +1025,7 @@ impl<'a> AccountsHasher<'a> {
         sorted_data_by_pubkey: &[&[CalculateHashIntermediate]],
         pubkey_bin: usize,
         bins: usize,
-        bin_map: &Vec<std::collections::HashMap<usize, (usize, &Pubkey)>>,
+        bin_map: &Vec<std::collections::HashMap<usize, (usize, Pubkey)>>,
     ) -> (AccountHashesFile, u64) {
         let binner = PubkeyBinCalculator24::new(bins);
 
@@ -1042,7 +1042,7 @@ impl<'a> AccountsHasher<'a> {
 
         for (i, map) in bin_map.iter().enumerate() {
             if let Some((index, pubkey)) = map.get(&pubkey_bin) {
-                first_items.push(*pubkey.to_owned());
+                first_items.push(pubkey.to_owned());
                 first_item_to_pubkey_division.push(i);
                 indexes.push(index.to_owned());
             }
@@ -1394,7 +1394,7 @@ pub mod tests {
                         let expected_index = if bin == 0 { 0 } else { cumsum[bin - 1] };
                         let (index, key) = map.get(&bin).unwrap();
                         assert_eq!(*index, expected_index);
-                        assert_eq!(**key, expected_key);
+                        assert_eq!(*key, expected_key);
                     }
                 }
             }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -780,6 +780,7 @@ impl<'a> AccountsHasher<'a> {
             .map(|hash_data| {
                 let mut out = std::collections::HashMap::new();
                 let mut last_pubkey = None;
+                let mut last_bin = None;
                 for (i, data) in hash_data.iter().enumerate() {
                     let pk = &data.pubkey;
                     if let Some(old_pk) = last_pubkey {
@@ -789,7 +790,14 @@ impl<'a> AccountsHasher<'a> {
                     }
                     last_pubkey = Some(pk);
                     let bin = binner.bin_from_pubkey(pk);
+
+                    if let Some(old_bin) = last_bin {
+                        if old_bin == bin {
+                            continue;
+                        }
+                    }
                     out.entry(bin).or_insert((i, pk));
+                    last_bin = Some(bin)
                 }
                 out
             })

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1025,7 +1025,7 @@ impl<'a> AccountsHasher<'a> {
         sorted_data_by_pubkey: &[&[CalculateHashIntermediate]],
         pubkey_bin: usize,
         bins: usize,
-        bin_map: &Vec<std::collections::HashMap<usize, (usize, &Pubkey)>>,
+        bin_map: &[std::collections::HashMap<usize, (usize, &Pubkey)>],
     ) -> (AccountHashesFile, u64) {
         let binner = PubkeyBinCalculator24::new(bins);
 
@@ -1857,7 +1857,7 @@ pub mod tests {
             account_maps,
             0,
             1,
-            &AccountsHasher::calculate_bin_map(&account_maps, 1),
+            &AccountsHasher::calculate_bin_map(account_maps, 1),
         )
     }
 


### PR DESCRIPTION
#### Problem

In `hash_dedup`, the first step is to compute the min_key index in the slot group for each pubkey bin and for each slot group. Current implementation is to iterate all the slot groups for each pubkey bin. This means scanning all slot groups for every pubkey bin.
Each slot group is read and scanned multiple times (i.e. number of pubkey bins).  This is redundant and not very good in terms of slot group locality. 

#### Summary of Changes

Scan each slot group once and compute the min_key index for all pubkey bins.

##### chunk_size = 2500
- base (master) 

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages a | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  4408444i
pubkey_bin_search_us                10830942i
```
- this pr
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages c1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  3330994i
pubkey_bin_search_us                259749i
```

##### chunk_size = 500
- base (master)
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages b | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  8506181i
pubkey_bin_search_us                18673554i
```
- this pr
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  5138410i
pubkey_bin_search_us                262960i
```


Note: pubkey_bin_search_us on master is the sum of time spent on all threads, while for this PR pubkey_bin_search_us is the wall clock time.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
