### PR TITLE
ci: bump the hardcoded Rust version for crate publishing

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
-export RUST_STABLE_VERSION=1.65.0
+export RUST_STABLE_VERSION=1.67.0
 source ci/rust-version.sh stable
 
 cargo="$(readlink -f ./cargo)"


### PR DESCRIPTION
#### Problem

our crate's publishing failed for v1.14.23 and v1.14.24. the reason:

![Screenshot 2023-08-23 at 11 37 12 PM](https://github.com/solana-labs/solana/assets/8209234/77e29ed5-4d8a-44c3-9330-5fdf441ca75d)

#### Summary of Changes

use the same solution as #31687, bumping the hardcoded Rust version for crate publishing. 
