### PR TITLE
ci: install protobuf-compiler to docker image

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -24,6 +24,7 @@ RUN set -x \
       golang \
       unzip \
       lld \
+      protobuf-compiler \
       \
  && apt remove -y libcurl4-openssl-dev \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
#### Problem

install dependencies for #32947

(the docker images has uploaded)

#### Summary of Changes

- install protobuf-compiler 