### PR TITLE
Fix - missing delay visibility feature triggering cache flush

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8069,6 +8069,7 @@ impl Bank {
             feature_set::enable_partitioned_epoch_reward::id(),
             feature_set::disable_deploy_of_alloc_free_syscall::id(),
             feature_set::last_restart_slot_sysvar::id(),
+            feature_set::delay_visibility_of_program_deployment::id(),
         ];
         if !only_apply_transitions_for_new_features
             || FEATURES_AFFECTING_RBPF


### PR DESCRIPTION
#### Problem
The feature `delay_visibility_of_program_deployment` should also trigger a flush of the `LoadedPrograms` cache.

#### Summary of Changes
Adds `delay_visibility_of_program_deployment` to `FEATURES_AFFECTING_RBPF` in `Bank::apply_builtin_program_feature_transitions()`.