### PR TITLE
Refactor - Demotes `Arc` to `Rc`.

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -14,7 +14,7 @@ use {
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair, Signature, Signer},
     },
-    std::{str::FromStr, sync::Arc},
+    std::{rc::Rc, str::FromStr},
 };
 
 // Sentinel value used to indicate to write to screen instead of file
@@ -123,7 +123,7 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 pub fn signer_of(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<(Option<Box<dyn Signer>>, Option<Pubkey>), Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         let signer = signer_from_path(matches, location, name, wallet_manager)?;
@@ -137,7 +137,7 @@ pub fn signer_of(
 pub fn pubkey_of_signer(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Pubkey>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         Ok(Some(pubkey_from_path(
@@ -154,7 +154,7 @@ pub fn pubkey_of_signer(
 pub fn pubkeys_of_multiple_signers(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Vec<Pubkey>>, Box<dyn std::error::Error>> {
     if let Some(pubkey_matches) = matches.values_of(name) {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -170,7 +170,7 @@ pub fn pubkeys_of_multiple_signers(
 pub fn resolve_signer(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     resolve_signer_from_path(
         matches,

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -41,8 +41,8 @@ use {
         io::{stdin, stdout, Write},
         ops::Deref,
         process::exit,
+        rc::Rc,
         str::FromStr,
-        sync::Arc,
     },
     thiserror::Error,
 };
@@ -242,7 +242,7 @@ impl DefaultSigner {
         &self,
         bulk_signers: Vec<Option<Box<dyn Signer>>>,
         matches: &ArgMatches<'_>,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     ) -> Result<CliSignerInfo, Box<dyn error::Error>> {
         let mut unique_signers = vec![];
 
@@ -304,7 +304,7 @@ impl DefaultSigner {
     pub fn signer_from_path(
         &self,
         matches: &ArgMatches,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
         signer_from_path(matches, self.path()?, &self.arg_name, wallet_manager)
     }
@@ -357,7 +357,7 @@ impl DefaultSigner {
     pub fn signer_from_path_with_config(
         &self,
         matches: &ArgMatches,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
         config: &SignerFromPathConfig,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
         signer_from_path_with_config(
@@ -686,7 +686,7 @@ pub fn signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let config = SignerFromPathConfig::default();
     signer_from_path_with_config(matches, path, keypair_name, wallet_manager, &config)
@@ -753,7 +753,7 @@ pub fn signer_from_path_with_config(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     config: &SignerFromPathConfig,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let SignerSource {
@@ -860,7 +860,7 @@ pub fn pubkey_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Pubkey, Box<dyn error::Error>> {
     let SignerSource { kind, .. } = parse_signer_source(path)?;
     match kind {
@@ -873,7 +873,7 @@ pub fn resolve_signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<String>, Box<dyn error::Error>> {
     let SignerSource {
         kind,

--- a/clap-v3-utils/src/input_parsers.rs
+++ b/clap-v3-utils/src/input_parsers.rs
@@ -14,7 +14,7 @@ use {
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair, Signature, Signer},
     },
-    std::{str::FromStr, sync::Arc},
+    std::{rc::Rc, str::FromStr},
 };
 
 // Sentinel value used to indicate to write to screen instead of file
@@ -123,7 +123,7 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, 
 pub fn signer_of(
     matches: &ArgMatches,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<(Option<Box<dyn Signer>>, Option<Pubkey>), Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         let signer = signer_from_path(matches, location, name, wallet_manager)?;
@@ -137,7 +137,7 @@ pub fn signer_of(
 pub fn pubkey_of_signer(
     matches: &ArgMatches,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Pubkey>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         Ok(Some(pubkey_from_path(
@@ -154,7 +154,7 @@ pub fn pubkey_of_signer(
 pub fn pubkeys_of_multiple_signers(
     matches: &ArgMatches,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Vec<Pubkey>>, Box<dyn std::error::Error>> {
     if let Some(pubkey_matches) = matches.values_of(name) {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -170,7 +170,7 @@ pub fn pubkeys_of_multiple_signers(
 pub fn resolve_signer(
     matches: &ArgMatches,
     name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     resolve_signer_from_path(
         matches,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -42,8 +42,8 @@ use {
         io::{stdin, stdout, Write},
         ops::Deref,
         process::exit,
+        rc::Rc,
         str::FromStr,
-        sync::Arc,
     },
     thiserror::Error,
 };
@@ -243,7 +243,7 @@ impl DefaultSigner {
         &self,
         bulk_signers: Vec<Option<Box<dyn Signer>>>,
         matches: &ArgMatches,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     ) -> Result<CliSignerInfo, Box<dyn error::Error>> {
         let mut unique_signers = vec![];
 
@@ -305,7 +305,7 @@ impl DefaultSigner {
     pub fn signer_from_path(
         &self,
         matches: &ArgMatches,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
         signer_from_path(matches, self.path()?, &self.arg_name, wallet_manager)
     }
@@ -358,7 +358,7 @@ impl DefaultSigner {
     pub fn signer_from_path_with_config(
         &self,
         matches: &ArgMatches,
-        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
         config: &SignerFromPathConfig,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
         signer_from_path_with_config(
@@ -687,7 +687,7 @@ pub fn signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let config = SignerFromPathConfig::default();
     signer_from_path_with_config(matches, path, keypair_name, wallet_manager, &config)
@@ -754,7 +754,7 @@ pub fn signer_from_path_with_config(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     config: &SignerFromPathConfig,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let SignerSource {
@@ -862,7 +862,7 @@ pub fn pubkey_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Pubkey, Box<dyn error::Error>> {
     let SignerSource { kind, .. } = parse_signer_source(path)?;
     match kind {
@@ -875,7 +875,7 @@ pub fn resolve_signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<String>, Box<dyn error::Error>> {
     let SignerSource {
         kind,

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -17,7 +17,7 @@ use {
         account::from_account, clock::Clock, commitment_config::CommitmentConfig, message::Message,
         pubkey::Pubkey, signer::Signer, sysvar, transaction::Transaction,
     },
-    std::sync::Arc,
+    std::{rc::Rc, sync::Arc},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -234,7 +234,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
 pub fn parse_address_lookup_table_subcommand(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (subcommand, sub_matches) = matches.subcommand();
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -33,7 +33,9 @@ use {
     },
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_vote_program::vote_state::VoteAuthorize,
-    std::{collections::HashMap, error, io::stdout, str::FromStr, sync::Arc, time::Duration},
+    std::{
+        collections::HashMap, error, io::stdout, rc::Rc, str::FromStr, sync::Arc, time::Duration,
+    },
     thiserror::Error,
 };
 
@@ -568,7 +570,7 @@ impl Default for CliConfig<'_> {
 pub fn parse_command(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, Box<dyn error::Error>> {
     let response = match matches.subcommand() {
         // Autocompletion Command

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -70,6 +70,7 @@ use {
     std::{
         collections::{BTreeMap, HashMap, VecDeque},
         fmt,
+        rc::Rc,
         str::FromStr,
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -488,7 +489,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
 
 pub fn parse_catchup(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let node_pubkey = pubkey_of_signer(matches, "node_pubkey", wallet_manager)?;
     let mut our_localhost_port = value_t!(matches, "our_localhost", u16).ok();
@@ -523,7 +524,7 @@ pub fn parse_catchup(
 pub fn parse_cluster_ping(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
     let count = if matches.is_present("count") {
@@ -630,7 +631,7 @@ pub fn parse_get_transaction_count(_matches: &ArgMatches<'_>) -> Result<CliComma
 
 pub fn parse_show_stakes(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
     let vote_account_pubkeys =
@@ -682,7 +683,7 @@ pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
 
 pub fn parse_transaction_history(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let address = pubkey_of_signer(matches, "address", wallet_manager)?.unwrap();
 
@@ -1581,7 +1582,7 @@ pub fn process_ping(
 
 pub fn parse_logs(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let address = pubkey_of_signer(matches, "address", wallet_manager)?;
     let include_votes = matches.is_present("include_votes");

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -25,7 +25,7 @@ use {
         stake_history::Epoch,
         transaction::Transaction,
     },
-    std::{cmp::Ordering, collections::HashMap, fmt, str::FromStr, sync::Arc},
+    std::{cmp::Ordering, collections::HashMap, fmt, rc::Rc, str::FromStr},
 };
 
 const DEFAULT_MAX_ACTIVE_DISPLAY_AGE_SLOTS: Slot = 15_000_000; // ~90days
@@ -478,7 +478,7 @@ fn known_feature(feature: &Pubkey) -> Result<(), CliError> {
 pub fn parse_feature_subcommand(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let response = match matches.subcommand() {
         ("activate", Some(matches)) => {

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -12,7 +12,7 @@ use {
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{clock::Epoch, pubkey::Pubkey},
-    std::sync::Arc,
+    std::rc::Rc,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -56,7 +56,7 @@ impl InflationSubCommands for App<'_, '_> {
 pub fn parse_inflation_subcommand(
     matches: &ArgMatches<'_>,
     _default_signer: &DefaultSigner,
-    _wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    _wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let command = match matches.subcommand() {
         ("rewards", Some(matches)) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,7 @@ use {
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
-    std::{collections::HashMap, error, path::PathBuf, sync::Arc, time::Duration},
+    std::{collections::HashMap, error, path::PathBuf, rc::Rc, time::Duration},
 };
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
@@ -142,7 +142,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
 
 pub fn parse_args<'a>(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<(CliConfig<'a>, CliSigners), Box<dyn error::Error>> {
     let config = if let Some(config_file) = matches.value_of("config_file") {
         Config::load(config_file).unwrap_or_default()

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -36,7 +36,7 @@ use {
         system_program,
         transaction::Transaction,
     },
-    std::sync::Arc,
+    std::rc::Rc,
 };
 
 pub trait NonceSubCommands {
@@ -197,7 +197,7 @@ impl NonceSubCommands for App<'_, '_> {
 pub fn parse_authorize_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let new_authority = pubkey_of_signer(matches, "new_authority", wallet_manager)?.unwrap();
@@ -228,7 +228,7 @@ pub fn parse_authorize_nonce_account(
 pub fn parse_nonce_create_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (nonce_account, nonce_account_pubkey) =
         signer_of(matches, "nonce_account_keypair", wallet_manager)?;
@@ -260,7 +260,7 @@ pub fn parse_nonce_create_account(
 
 pub fn parse_get_nonce(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account_pubkey =
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
@@ -274,7 +274,7 @@ pub fn parse_get_nonce(
 pub fn parse_new_nonce(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let memo = matches.value_of(MEMO_ARG.name).map(String::from);
@@ -302,7 +302,7 @@ pub fn parse_new_nonce(
 
 pub fn parse_show_nonce_account(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account_pubkey =
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
@@ -320,7 +320,7 @@ pub fn parse_show_nonce_account(
 pub fn parse_withdraw_from_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let destination_account_pubkey =

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -60,6 +60,7 @@ use {
         io::{Read, Write},
         mem::size_of,
         path::PathBuf,
+        rc::Rc,
         str::FromStr,
         sync::Arc,
     },
@@ -431,7 +432,7 @@ impl ProgramSubCommands for App<'_, '_> {
 pub fn parse_program_subcommand(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (subcommand, sub_matches) = matches.subcommand();
     let matches_skip_fee_check = matches.is_present("skip_fee_check");

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -59,7 +59,7 @@ use {
         sysvar::{clock, stake_history},
         transaction::Transaction,
     },
-    std::{ops::Deref, sync::Arc},
+    std::{ops::Deref, rc::Rc},
 };
 
 pub const STAKE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
@@ -740,7 +740,7 @@ impl StakeSubCommands for App<'_, '_> {
 pub fn parse_create_stake_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     checked: bool,
 ) -> Result<CliCommandInfo, CliError> {
     let seed = matches.value_of("seed").map(|s| s.to_string());
@@ -816,7 +816,7 @@ pub fn parse_create_stake_account(
 pub fn parse_stake_delegate_stake(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -871,7 +871,7 @@ pub fn parse_stake_delegate_stake(
 pub fn parse_stake_authorize(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     checked: bool,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
@@ -1000,7 +1000,7 @@ pub fn parse_stake_authorize(
 pub fn parse_split_stake(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -1051,7 +1051,7 @@ pub fn parse_split_stake(
 pub fn parse_merge_stake(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -1098,7 +1098,7 @@ pub fn parse_merge_stake(
 pub fn parse_stake_deactivate_stake(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -1146,7 +1146,7 @@ pub fn parse_stake_deactivate_stake(
 pub fn parse_stake_withdraw_stake(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -1201,7 +1201,7 @@ pub fn parse_stake_withdraw_stake(
 pub fn parse_stake_set_lockup(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     checked: bool,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
@@ -1269,7 +1269,7 @@ pub fn parse_stake_set_lockup(
 
 pub fn parse_show_stake_account(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -27,7 +27,7 @@ use {
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
-    std::{error, sync::Arc},
+    std::{error, rc::Rc},
 };
 
 // Return an error if a validator details are longer than the max length.
@@ -233,7 +233,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
 pub fn parse_validator_info_command(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -40,7 +40,7 @@ use {
         vote_instruction::{self, withdraw, CreateVoteAccountConfig},
         vote_state::{VoteAuthorize, VoteInit, VoteState, VoteStateVersions},
     },
-    std::sync::Arc,
+    std::rc::Rc,
 };
 
 pub trait VoteSubCommands {
@@ -421,7 +421,7 @@ impl VoteSubCommands for App<'_, '_> {
 pub fn parse_create_vote_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (vote_account, vote_account_pubkey) = signer_of(matches, "vote_account", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
@@ -490,7 +490,7 @@ pub fn parse_create_vote_account(
 pub fn parse_vote_authorize(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     vote_authorize: VoteAuthorize,
     checked: bool,
 ) -> Result<CliCommandInfo, CliError> {
@@ -551,7 +551,7 @@ pub fn parse_vote_authorize(
 pub fn parse_vote_update_validator(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -598,7 +598,7 @@ pub fn parse_vote_update_validator(
 pub fn parse_vote_update_commission(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -643,7 +643,7 @@ pub fn parse_vote_update_commission(
 
 pub fn parse_vote_get_account_command(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -666,7 +666,7 @@ pub fn parse_vote_get_account_command(
 pub fn parse_withdraw_from_vote_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -722,7 +722,7 @@ pub fn parse_withdraw_from_vote_account(
 pub fn parse_close_vote_account(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -47,7 +47,7 @@ use {
         EncodableWithMeta, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
         TransactionBinaryEncoding, UiTransactionEncoding,
     },
-    std::{fmt::Write as FmtWrite, fs::File, io::Write, str::FromStr, sync::Arc},
+    std::{fmt::Write as FmtWrite, fs::File, io::Write, rc::Rc, str::FromStr},
 };
 
 pub trait WalletSubCommands {
@@ -393,7 +393,7 @@ fn resolve_derived_address_program_id(matches: &ArgMatches<'_>, arg_name: &str) 
 
 pub fn parse_account(
     matches: &ArgMatches<'_>,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_pubkey = pubkey_of_signer(matches, "account_pubkey", wallet_manager)?.unwrap();
     let output_file = matches.value_of("output_file");
@@ -411,7 +411,7 @@ pub fn parse_account(
 pub fn parse_airdrop(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let pubkey = pubkey_of_signer(matches, "to", wallet_manager)?;
     let signers = if pubkey.is_some() {
@@ -429,7 +429,7 @@ pub fn parse_airdrop(
 pub fn parse_balance(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let pubkey = pubkey_of_signer(matches, "pubkey", wallet_manager)?;
     let signers = if pubkey.is_some() {
@@ -470,7 +470,7 @@ pub fn parse_decode_transaction(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 pub fn parse_create_address_with_seed(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let from_pubkey = pubkey_of_signer(matches, "from", wallet_manager)?;
     let signers = if from_pubkey.is_some() {
@@ -542,7 +542,7 @@ pub fn parse_find_program_derived_address(
 pub fn parse_transfer(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let amount = SpendAmount::new_from_matches(matches, "amount");
     let to = pubkey_of_signer(matches, "to", wallet_manager)?.unwrap();
@@ -598,7 +598,7 @@ pub fn parse_transfer(
 pub fn parse_sign_offchain_message(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let version: u8 = value_of(matches, "version").unwrap();
     let message_text: String = value_of(matches, "message")
@@ -615,7 +615,7 @@ pub fn parse_sign_offchain_message(
 pub fn parse_verify_offchain_signature(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let version: u8 = value_of(matches, "version").unwrap();
     let message_text: String = value_of(matches, "message")

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -34,6 +34,7 @@ use {
     std::{
         collections::HashSet,
         error,
+        rc::Rc,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc,
@@ -64,7 +65,7 @@ struct GrindMatch {
 fn get_keypair_from_matches(
     matches: &ArgMatches,
     config: Config,
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let mut path = dirs_next::home_dir().expect("home directory");
     let path = if matches.is_present("keypair") {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -199,7 +199,7 @@ pub fn create_vm<'a, 'b>(
 ) -> Result<EbpfVm<'a, InvokeContext<'b>>, Box<dyn std::error::Error>> {
     let stack_size = stack.len();
     let heap_size = heap.len();
-    let accounts = Arc::clone(invoke_context.transaction_context.accounts());
+    let accounts = Rc::clone(invoke_context.transaction_context.accounts());
     let memory_mapping = create_memory_mapping(
         program,
         stack,

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -6,7 +6,7 @@ use {
     dialoguer::{theme::ColorfulTheme, Select},
     semver::Version as FirmwareVersion,
     solana_sdk::derivation_path::DerivationPath,
-    std::{fmt, sync::Arc},
+    std::{fmt, rc::Rc},
 };
 #[cfg(feature = "hidapi")]
 use {
@@ -592,7 +592,7 @@ pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
     keypair_name: &str,
     wallet_manager: &RemoteWalletManager,
-) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
+) -> Result<Rc<LedgerWallet>, RemoteWalletError> {
     let devices = wallet_manager.list_devices();
     let mut matches = devices
         .iter()

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "hidapi")]
-use {crate::ledger::is_valid_ledger, parking_lot::Mutex};
+use {crate::ledger::is_valid_ledger, parking_lot::Mutex, std::sync::Arc};
 use {
     crate::{
         ledger::LedgerWallet,
@@ -14,7 +14,7 @@ use {
         signature::{Signature, SignerError},
     },
     std::{
-        sync::Arc,
+        rc::Rc,
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -98,8 +98,8 @@ pub struct RemoteWalletManager {
 impl RemoteWalletManager {
     /// Create a new instance.
     #[cfg(feature = "hidapi")]
-    pub fn new(usb: Arc<Mutex<hidapi::HidApi>>) -> Arc<Self> {
-        Arc::new(Self {
+    pub fn new(usb: Arc<Mutex<hidapi::HidApi>>) -> Rc<Self> {
+        Rc::new(Self {
             usb,
             devices: RwLock::new(Vec::new()),
         })
@@ -132,7 +132,7 @@ impl RemoteWalletManager {
                             detected_devices.push(Device {
                                 path,
                                 info,
-                                wallet_type: RemoteWalletType::Ledger(Arc::new(ledger)),
+                                wallet_type: RemoteWalletType::Ledger(Rc::new(ledger)),
                             })
                         }
                         Err(err) => {
@@ -172,7 +172,7 @@ impl RemoteWalletManager {
     pub fn get_ledger(
         &self,
         host_device_path: &str,
-    ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
+    ) -> Result<Rc<LedgerWallet>, RemoteWalletError> {
         self.devices
             .read()
             .iter()
@@ -261,7 +261,7 @@ pub struct Device {
 /// Remote wallet convenience enum to hold various wallet types
 #[derive(Debug)]
 pub enum RemoteWalletType {
-    Ledger(Arc<LedgerWallet>),
+    Ledger(Rc<LedgerWallet>),
 }
 
 /// Remote wallet information.
@@ -309,18 +309,18 @@ pub fn is_valid_hid_device(usage_page: u16, interface_number: i32) -> bool {
 
 /// Helper to initialize hidapi and RemoteWalletManager
 #[cfg(feature = "hidapi")]
-pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWalletError> {
+pub fn initialize_wallet_manager() -> Result<Rc<RemoteWalletManager>, RemoteWalletError> {
     let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new()?));
     Ok(RemoteWalletManager::new(hidapi))
 }
 #[cfg(not(feature = "hidapi"))]
-pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWalletError> {
+pub fn initialize_wallet_manager() -> Result<Rc<RemoteWalletManager>, RemoteWalletError> {
     Err(RemoteWalletError::Hid(
         "hidapi crate compilation disabled in solana-remote-wallet.".to_string(),
     ))
 }
 
-pub fn maybe_wallet_manager() -> Result<Option<Arc<RemoteWalletManager>>, RemoteWalletError> {
+pub fn maybe_wallet_manager() -> Result<Option<Rc<RemoteWalletManager>>, RemoteWalletError> {
     let wallet_manager = initialize_wallet_manager()?;
     let device_count = wallet_manager.update_devices()?;
     if device_count > 0 {

--- a/stake-accounts/src/args.rs
+++ b/stake-accounts/src/args.rs
@@ -7,7 +7,7 @@ use {
         pubkey::Pubkey,
         signature::Signer,
     },
-    std::{error::Error, sync::Arc},
+    std::{error::Error, rc::Rc},
 };
 
 pub(crate) struct NewArgs<P, K> {
@@ -82,7 +82,7 @@ pub(crate) struct Args<P, K> {
 }
 
 fn resolve_stake_authority(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -90,7 +90,7 @@ fn resolve_stake_authority(
 }
 
 fn resolve_withdraw_authority(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -98,7 +98,7 @@ fn resolve_withdraw_authority(
 }
 
 fn resolve_new_stake_authority(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Pubkey, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -106,7 +106,7 @@ fn resolve_new_stake_authority(
 }
 
 fn resolve_new_withdraw_authority(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Pubkey, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -114,7 +114,7 @@ fn resolve_new_withdraw_authority(
 }
 
 fn resolve_fee_payer(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -122,7 +122,7 @@ fn resolve_fee_payer(
 }
 
 fn resolve_custodian(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -130,7 +130,7 @@ fn resolve_custodian(
 }
 
 fn resolve_new_custodian(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &Option<String>,
 ) -> Result<Option<Pubkey>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -145,7 +145,7 @@ fn resolve_new_custodian(
 }
 
 fn resolve_base_pubkey(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Pubkey, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -153,7 +153,7 @@ fn resolve_base_pubkey(
 }
 
 fn resolve_new_base_keypair(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     key_url: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn Error>> {
     let matches = ArgMatches::default();
@@ -161,7 +161,7 @@ fn resolve_new_base_keypair(
 }
 
 fn resolve_authorize_args(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     args: &AuthorizeArgs<String, String>,
 ) -> Result<AuthorizeArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
     let resolved_args = AuthorizeArgs {
@@ -183,7 +183,7 @@ fn resolve_authorize_args(
 }
 
 fn resolve_set_lockup_args(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     args: &SetLockupArgs<String, String>,
 ) -> Result<SetLockupArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
     let resolved_args = SetLockupArgs {
@@ -201,7 +201,7 @@ fn resolve_set_lockup_args(
 }
 
 fn resolve_rebase_args(
-    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
     args: &RebaseArgs<String, String>,
 ) -> Result<RebaseArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
     let resolved_args = RebaseArgs {


### PR DESCRIPTION
#### Problem
Another preparation for #32961.

Future versions of clippy will complain that:
> warning: usage of an Arc that is not Send or Sync
> = note: the trait Sync is not implemented
> = note: required to implement Send and Sync
> = help: consider using an Rc instead or wrapping the inner type with a Mutex
> = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync

#### Summary of Changes
Demotes `Arc` to `Rc` around `RemoteWalletManager`, `LedgerWallet` and `TransactionAccounts`.
