### PR TITLE
Make TimedTracedEvent accessible outside banking_trace.rs

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -63,10 +63,10 @@ pub struct BankingTracer {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct TimedTracedEvent(std::time::SystemTime, TracedEvent);
+pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
 
 #[derive(Serialize, Deserialize, Debug)]
-enum TracedEvent {
+pub enum TracedEvent {
     PacketBatch(ChannelLabel, BankingPacketBatch),
     BlockAndBankHash(Slot, Hash, Hash),
 }


### PR DESCRIPTION
#### Problem
When writing my investigation utility in #32843 I came across these fields/types being private.
This makes is impossible to read a trace file outside `banking_trace.rs` and use the deserialized info.

#### Summary of Changes
- Make fields in `TimedTracedEvent` `pub`
- Make `TracedEvent` type `pub`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
