### PR TITLE
CI: Add back some downstream SPL jobs

### DIFF
--- a/.github/workflows/downstream-project-spl-nightly.yml
+++ b/.github/workflows/downstream-project-spl-nightly.yml
@@ -1,0 +1,24 @@
+name: Downstream Project - SPL (Nightly)
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - master
+    uses: ./.github/workflows/downstream-project-spl.yml
+    with:
+      branch: ${{ matrix.branch }}
+
+  error_reporting:
+    needs:
+      - main
+    if: failure()
+    uses: ./.github/workflows/error-reporting.yml
+    secrets:
+      WEBHOOK: ${{ secrets.SLACK_ERROR_REPORTING_WEBHOOK }}

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -33,6 +33,7 @@ env:
 
 jobs:
   check:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -53,6 +54,7 @@ jobs:
           cargo check
 
   test:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -1,0 +1,154 @@
+name: Downstream Project - SPL
+
+on:
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "cargo-build-bpf"
+      - "cargo-test-bpf"
+      - "cargo-build-sbf"
+      - "cargo-test-sbf"
+      - "ci/downstream-projects/run-spl.sh"
+      - ".github/workflows/downstream-project-spl.yml"
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+        default: "master"
+
+env:
+  SHELL: /bin/bash
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - shell: bash
+        run: |
+          .github/scripts/purge-ubuntu-runner.sh
+
+      - uses: mozilla-actions/sccache-action@v0.0.3
+
+      - shell: bash
+        run: |
+          source .github/scripts/downstream-project-spl-common.sh
+
+          sudo apt update
+          sudo apt install libudev-dev binutils-dev libunwind-dev protobuf-compiler -y
+
+          cargo check
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arrays:
+          [
+            {
+              test_paths: ["token/cli"],
+              required_programs:
+                [
+                  "token/program",
+                  "token/program-2022",
+                  "associated-token-account/program",
+                ],
+            },
+            {
+              test_paths: ["single-pool/cli"],
+              required_programs:
+                [
+                  "single-pool/program",
+                ],
+            },
+            {
+              test_paths: ["token-upgrade/cli"],
+              required_programs:
+                [
+                  "token-upgrade/program",
+                ],
+            },
+          ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - shell: bash
+        run: |
+          .github/scripts/purge-ubuntu-runner.sh
+
+      - uses: mozilla-actions/sccache-action@v0.0.3
+
+      - shell: bash
+        run: |
+          source .github/scripts/downstream-project-spl-common.sh
+
+          sudo apt update
+          sudo apt install libudev-dev binutils-dev libunwind-dev protobuf-compiler -y
+
+          programStr="${{ tojson(matrix.arrays.required_programs) }}"
+          IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
+          for program in "${programs[@]}"; do
+            $CARGO_BUILD_SBF --manifest-path "$program"/Cargo.toml
+          done
+
+          testPathsStr="${{ tojson(matrix.arrays.test_paths) }}"
+          IFS=', ' read -ra test_paths <<<"${testPathsStr//[\[\]$'\n'$'\r' ]/}"
+          for test_path in "${test_paths[@]}"; do
+            cargo test --manifest-path "$test_path"/Cargo.toml
+          done
+
+  cargo-test-sbf:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        programs:
+          - [token/program]
+          - [
+              instruction-padding/program,
+              token/program-2022,
+              token/program-2022-test,
+            ]
+          - [
+              associated-token-account/program,
+              associated-token-account/program-test,
+            ]
+          - [token-upgrade/program]
+          - [feature-proposal/program]
+          - [governance/addin-mock/program, governance/program]
+          - [memo/program]
+          - [name-service/program]
+          - [stake-pool/program]
+          - [single-pool/program]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - shell: bash
+        run: |
+          .github/scripts/purge-ubuntu-runner.sh
+
+      - uses: mozilla-actions/sccache-action@v0.0.3
+
+      - shell: bash
+        run: |
+          source .github/scripts/downstream-project-spl-common.sh
+
+          programStr="${{ tojson(matrix.programs) }}"
+          IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
+
+          for program in "${programs[@]}"; do
+            $CARGO_TEST_SBF --manifest-path "$program"/Cargo.toml
+          done


### PR DESCRIPTION
#### Problem

#32983 took a big hammer and removed all downstream SPL jobs, when only the "checks" and "tests" jobs failed during CI: https://github.com/solana-labs/solana/actions/runs/5968320899/job/16191912388?pr=32982

#### Summary of Changes

Add back all of the tests that depend on the SDK, keep the CLI tests disabled.

Since this PR reverts a commit and then disabling two sets of jobs, deleting and then reverting this PR doesn't really work anymore, so I went with `if: false` for the steps affected by the CLI changes.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
