### PR TITLE
Add LoaderV4State layout assertions

### DIFF
--- a/sdk/program/src/loader_v4.rs
+++ b/sdk/program/src/loader_v4.rs
@@ -1,4 +1,4 @@
-//! The v3 built-in loader program.
+//! The v4 built-in loader program.
 //!
 //! This is the loader of the program runtime v2.
 
@@ -27,5 +27,60 @@ impl LoaderV4State {
     /// Size of a serialized program account.
     pub const fn program_data_offset() -> usize {
         std::mem::size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, memoffset::offset_of};
+
+    #[test]
+    fn test_state_layout() {
+        assert_eq!(std::mem::size_of::<LoaderV4State>(), 0x30);
+        assert_eq!(LoaderV4State::program_data_offset(), 0x30);
+        assert_eq!(offset_of!(LoaderV4State, slot), 0x00);
+        assert_eq!(offset_of!(LoaderV4State, is_deployed), 0x08);
+        assert_eq!(offset_of!(LoaderV4State, authority_address), 0x09);
+    }
+
+    #[test]
+    fn test_transmute() {
+        // Ensure transmute behaves correctly on complex types.
+        let mut state = LoaderV4State {
+            slot: 0,
+            is_deployed: true,
+            authority_address: Some(super::id()),
+        };
+
+        let raw: &mut [u8; std::mem::size_of::<LoaderV4State>()];
+        unsafe {
+            raw = std::mem::transmute(&mut state);
+        }
+
+        // Layout assertion
+        assert_eq!(
+            &raw[0x09..0x2a],
+            &[
+                0x01, // Option discriminant
+                0x05, 0x12, 0xb4, 0x11, 0x51, 0x51, 0xe3, 0x7a, // 0x08
+                0xad, 0x0a, 0x8b, 0xc5, 0xd3, 0x88, 0x2e, 0x7b, // 0x10
+                0x7f, 0xda, 0x4c, 0xf3, 0xd2, 0xc0, 0x28, 0xc8, // 0x18
+                0xcf, 0x83, 0x36, 0x18, 0x00, 0x00, 0x00, 0x00, // 0x20
+            ]
+        );
+
+        // Ensure that changing the option disciminant properly
+        // sanitizes the previously set value.
+        state.authority_address = None;
+        assert_eq!(
+            &raw[0x09..0x2a],
+            &[
+                0x00, // Option discriminant
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0x08
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0x10
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0x18
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0x20
+            ]
+        );
     }
 }


### PR DESCRIPTION
#### Problem

LoaderV4State is "unsafely" (in Rust's definition of the term) transmuted to a byte array in the Loader V4 native program.
However, the struct definition lacks layout assertions.

#### Summary of Changes

- Adds LoaderV4State layout assertions
- Adds regression test verifying that changing a C-representation complex option type to `None` also memsets the (ignored) value field to zero. ~~(Undocumented behavior, as no such promise appears in the "repr(C)" documentation of the Rustonomicon)~~ EDIT: Option<T> is an enum type, thus well-defined in repr(C)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
