### PR TITLE
Add test for small loader v4 header

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1593,4 +1593,34 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
         );
     }
+
+    #[test]
+    fn test_small_header() {
+        let program_address = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            // The program data account
+            (
+                program_address,
+                AccountSharedData::new(
+                    1,
+                    LoaderV4State::program_data_offset() - 1,
+                    &loader_v4::id(),
+                ),
+            ),
+            // The program authority
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(10000, 0, &Pubkey::default()),
+            ),
+        ];
+
+        // Trigger check_program_account
+        process_instruction(
+            vec![],
+            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
+            transaction_accounts,
+            &[(0, false, true), (1, true, false)],
+            Err(InstructionError::AccountDataTooSmall),
+        );
+    }
 }


### PR DESCRIPTION
#### Problem

Adds an instruction processing test for a check that was missing test coverage in loader v4

#### Summary of Changes

Tests `check_program_account` with too small account

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
