### PR TITLE
TransactionScheduler: TransactionStateContainer

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -2,5 +2,5 @@
 mod thread_aware_account_locks;
 
 #[allow(dead_code)]
-mod transaction_packet_container;
+mod transaction_state_container;
 mod transaction_priority_id;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -2,6 +2,7 @@
 mod thread_aware_account_locks;
 
 mod transaction_priority_id;
+#[allow(dead_code)]
 mod transaction_state;
 #[allow(dead_code)]
 mod transaction_state_container;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,6 +1,7 @@
 #[allow(dead_code)]
 mod thread_aware_account_locks;
 
+mod transaction_priority_id;
+mod transaction_state;
 #[allow(dead_code)]
 mod transaction_state_container;
-mod transaction_priority_id;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,2 +1,6 @@
 #[allow(dead_code)]
 mod thread_aware_account_locks;
+
+#[allow(dead_code)]
+mod transaction_packet_container;
+mod transaction_priority_id;

--- a/core/src/banking_stage/transaction_scheduler/transaction_packet_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_packet_container.rs
@@ -1,0 +1,324 @@
+use {
+    super::transaction_priority_id::TransactionPriorityId,
+    crate::banking_stage::{
+        immutable_deserialized_packet::ImmutableDeserializedPacket,
+        scheduler_messages::TransactionId, unprocessed_packet_batches::DeserializedPacket,
+    },
+    min_max_heap::MinMaxHeap,
+    solana_sdk::{slot_history::Slot, transaction::SanitizedTransaction},
+    std::collections::HashMap,
+};
+
+/// Simple wrapper to tie a `SanitizedTransaction` with the maximum slot
+/// it can be processed at without re-sanitization.
+pub(crate) struct SanitizedTransactionTTL {
+    pub(crate) transaction: SanitizedTransaction,
+    pub(crate) max_age_slot: Slot,
+}
+
+pub(crate) struct TransactionPacketContainer {
+    /// Unscheduled unique identifiers ordered by priority
+    priority_queue: MinMaxHeap<TransactionPriorityId>,
+    /// Map from `TransactionId` to `SanitizedTransactionTTL`.
+    /// Contains transactions that have not yet been scheduled for consuming.
+    id_to_transaction_ttl: HashMap<TransactionId, SanitizedTransactionTTL>,
+    /// Map from `TransactionId` to `DeserializedPacket`.
+    /// Contains packets for the entire lifetime of packet/transaction.
+    /// These will only be removed once a transaction has finished processing,
+    /// or if the packets are forwarded without holding.
+    id_to_packet: HashMap<TransactionId, DeserializedPacket>,
+}
+
+impl TransactionPacketContainer {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            priority_queue: MinMaxHeap::with_capacity(capacity),
+            id_to_transaction_ttl: HashMap::with_capacity(capacity),
+            id_to_packet: HashMap::with_capacity(capacity),
+        }
+    }
+
+    /// Returns true if the queue is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.priority_queue.is_empty()
+    }
+
+    /// Returns the remaining capacity of the queue
+    pub(crate) fn remaining_queue_capacity(&self) -> usize {
+        self.priority_queue.capacity() - self.priority_queue.len()
+    }
+
+    /// Get a non-consuming iterator over the top `n` transactions in the queue.
+    pub(crate) fn take_top_n(
+        &mut self,
+        n: usize,
+    ) -> impl Iterator<Item = TransactionPriorityId> + '_ {
+        (0..n).map_while(|_| self.priority_queue.pop_max())
+    }
+
+    /// Get packet by id.
+    pub(crate) fn get_packet(&self, id: &TransactionId) -> Option<&DeserializedPacket> {
+        self.id_to_packet.get(id)
+    }
+
+    /// Get mutable packet by id.
+    pub(crate) fn get_mut_packet(&mut self, id: &TransactionId) -> Option<&mut DeserializedPacket> {
+        self.id_to_packet.get_mut(id)
+    }
+
+    /// Get transaction by id.
+    /// Panics if the transaction does not exist.
+    pub(crate) fn get_transaction(&self, id: &TransactionId) -> &SanitizedTransactionTTL {
+        self.id_to_transaction_ttl
+            .get(id)
+            .expect("transaction must exist")
+    }
+
+    /// Take transaction by id.
+    /// Panics if the transaction does not exist.
+    pub(crate) fn take_transaction(&mut self, id: &TransactionId) -> SanitizedTransactionTTL {
+        self.id_to_transaction_ttl
+            .remove(id)
+            .expect("transaction must exist")
+    }
+
+    /// Insert a new transaction into the container's queues and maps.
+    pub(crate) fn insert_new_transaction(
+        &mut self,
+        transaction_id: TransactionId,
+        packet: ImmutableDeserializedPacket,
+        transaction_ttl: SanitizedTransactionTTL,
+    ) {
+        let priority_id = TransactionPriorityId::new(packet.priority(), transaction_id);
+        if self.push_id_into_queue(priority_id) {
+            self.id_to_packet.insert(
+                transaction_id,
+                DeserializedPacket::from_immutable_section(packet),
+            );
+            self.id_to_transaction_ttl
+                .insert(transaction_id, transaction_ttl);
+        }
+    }
+
+    /// Retries a transaction - inserts transaction back into map (but not packet).
+    pub(crate) fn retry_transaction(
+        &mut self,
+        transaction_id: TransactionId,
+        transaction: SanitizedTransaction,
+        max_age_slot: Slot,
+    ) {
+        let priority = self
+            .id_to_packet
+            .get(&transaction_id)
+            .unwrap()
+            .immutable_section()
+            .priority();
+        let priority_id = TransactionPriorityId::new(priority, transaction_id);
+        if self.push_id_into_queue(priority_id) {
+            self.id_to_transaction_ttl.insert(
+                transaction_id,
+                SanitizedTransactionTTL {
+                    transaction,
+                    max_age_slot,
+                },
+            );
+        }
+    }
+
+    /// Pushes a transaction id into the priority queue, without inserting the packet or transaction.
+    /// Returns true if the id was successfully pushed into the priority queue
+    pub(crate) fn push_id_into_queue(&mut self, priority_id: TransactionPriorityId) -> bool {
+        if self.priority_queue.len() == self.priority_queue.capacity() {
+            let popped_id = self.priority_queue.push_pop_min(priority_id);
+            if popped_id == priority_id {
+                return false;
+            } else {
+                self.remove_by_id(&popped_id.id);
+            }
+        } else {
+            self.priority_queue.push(priority_id);
+        }
+
+        true
+    }
+
+    /// Remove packet and transaction by id.
+    pub(crate) fn remove_by_id(&mut self, id: &TransactionId) {
+        self.id_to_packet.remove(id);
+        self.id_to_transaction_ttl.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_perf::packet::Packet,
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
+            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
+        },
+    };
+
+    fn test_packet_and_transaction(
+        priority: u64,
+    ) -> (ImmutableDeserializedPacket, SanitizedTransactionTTL) {
+        let from_keypair = Keypair::new();
+        let ixs = vec![
+            system_instruction::transfer(
+                &from_keypair.pubkey(),
+                &solana_sdk::pubkey::new_rand(),
+                1,
+            ),
+            ComputeBudgetInstruction::set_compute_unit_price(priority),
+        ];
+        let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
+        let tx = Transaction::new(&[&from_keypair], message, Hash::default());
+
+        let packet = Packet::from_data(None, tx.clone()).unwrap();
+        let packet = ImmutableDeserializedPacket::new(packet).unwrap();
+
+        let transaction_ttl = SanitizedTransactionTTL {
+            transaction: SanitizedTransaction::from_transaction_for_tests(tx),
+            max_age_slot: Slot::MAX,
+        };
+        (packet, transaction_ttl)
+    }
+
+    fn push_to_container(container: &mut TransactionPacketContainer, num: usize) {
+        for id in 0..num as u64 {
+            let priority = id;
+            let (packet, transaction_ttl) = test_packet_and_transaction(priority);
+            container.insert_new_transaction(TransactionId::new(id), packet, transaction_ttl);
+        }
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut container = TransactionPacketContainer::with_capacity(1);
+        assert!(container.is_empty());
+
+        push_to_container(&mut container, 1);
+        assert!(!container.is_empty());
+    }
+
+    #[test]
+    fn test_priority_queue_capacity() {
+        let mut container = TransactionPacketContainer::with_capacity(1);
+        push_to_container(&mut container, 5);
+
+        assert_eq!(container.priority_queue.len(), 1);
+        assert_eq!(container.id_to_packet.len(), 1);
+        assert_eq!(container.id_to_transaction_ttl.len(), 1);
+        assert_eq!(
+            container
+                .id_to_packet
+                .iter()
+                .map(|p| p.1.immutable_section().priority())
+                .next()
+                .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn test_take_top_n() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        let taken = container.take_top_n(3).collect::<Vec<_>>();
+        assert_eq!(
+            taken,
+            vec![
+                TransactionPriorityId::new(4, TransactionId::new(4)),
+                TransactionPriorityId::new(3, TransactionId::new(3)),
+                TransactionPriorityId::new(2, TransactionId::new(2)),
+            ]
+        );
+        assert_eq!(container.priority_queue.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_by_id() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        container.remove_by_id(&TransactionId::new(3));
+        assert_eq!(container.priority_queue.len(), 5); // remove_by_id does not remove from priority queue
+        assert_eq!(container.id_to_packet.len(), 4);
+        assert_eq!(container.id_to_transaction_ttl.len(), 4);
+
+        container.remove_by_id(&TransactionId::new(7));
+        assert_eq!(container.id_to_packet.len(), 4);
+        assert_eq!(container.id_to_transaction_ttl.len(), 4);
+    }
+
+    #[test]
+    fn test_push_id_into_queue() {
+        let mut container = TransactionPacketContainer::with_capacity(1);
+        assert!(container.push_id_into_queue(TransactionPriorityId::new(1, TransactionId::new(0))));
+        assert_eq!(container.priority_queue.len(), 1);
+        assert_eq!(container.id_to_packet.len(), 0);
+        assert_eq!(container.id_to_transaction_ttl.len(), 0);
+
+        assert!(container.push_id_into_queue(TransactionPriorityId::new(1, TransactionId::new(1))));
+        assert_eq!(container.priority_queue.len(), 1);
+        // should be dropped due to capacity
+        assert!(!container.push_id_into_queue(TransactionPriorityId::new(0, TransactionId::new(2))));
+        assert_eq!(container.priority_queue.len(), 1);
+    }
+
+    #[test]
+    fn test_get_packet_entry_missing() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+        assert!(container.get_packet(&TransactionId::new(7)).is_none());
+    }
+
+    #[test]
+    fn test_get_packet_entry() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+        assert!(container.get_packet(&TransactionId::new(3)).is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction must exist")]
+    fn test_get_transaction_panic() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        let _ = container.get_transaction(&TransactionId::new(7));
+    }
+
+    #[test]
+    fn test_get_transaction() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        let transaction_id = TransactionId::new(3);
+        let _ = container.get_transaction(&transaction_id);
+        let _ = container.get_transaction(&transaction_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction must exist")]
+    fn test_take_transaction_panic() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        let _ = container.take_transaction(&TransactionId::new(7));
+    }
+
+    #[test]
+    fn test_take_transaction() {
+        let mut container = TransactionPacketContainer::with_capacity(5);
+        push_to_container(&mut container, 5);
+
+        let transaction_id = TransactionId::new(3);
+        let _ = container.take_transaction(&transaction_id);
+        assert!(!container
+            .id_to_transaction_ttl
+            .contains_key(&transaction_id));
+    }
+}

--- a/core/src/banking_stage/transaction_scheduler/transaction_packet_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_packet_container.rs
@@ -1,40 +1,144 @@
 use {
     super::transaction_priority_id::TransactionPriorityId,
-    crate::banking_stage::{
-        immutable_deserialized_packet::ImmutableDeserializedPacket,
-        scheduler_messages::TransactionId, unprocessed_packet_batches::DeserializedPacket,
-    },
+    crate::banking_stage::scheduler_messages::TransactionId,
     min_max_heap::MinMaxHeap,
+    solana_runtime::transaction_priority_details::TransactionPriorityDetails,
     solana_sdk::{slot_history::Slot, transaction::SanitizedTransaction},
     std::collections::HashMap,
 };
 
-/// Simple wrapper to tie a `SanitizedTransaction` with the maximum slot
-/// it can be processed at without re-sanitization.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum TransactionState {
+    Unprocessed {
+        transaction_ttl: SanitizedTransactionTTL,
+        transaction_priority_details: TransactionPriorityDetails,
+        forwarded: bool,
+    },
+    Pending {
+        transaction_priority_details: TransactionPriorityDetails,
+        forwarded: bool,
+    },
+}
+
+impl TransactionState {
+    fn new(
+        transaction_ttl: SanitizedTransactionTTL,
+        transaction_priority_details: TransactionPriorityDetails,
+        forwarded: bool,
+    ) -> Self {
+        Self::Unprocessed {
+            transaction_ttl,
+            transaction_priority_details,
+            forwarded,
+        }
+    }
+
+    pub(crate) fn transaction_priority_details(&self) -> &TransactionPriorityDetails {
+        match self {
+            Self::Unprocessed {
+                transaction_priority_details,
+                ..
+            } => transaction_priority_details,
+            Self::Pending {
+                transaction_priority_details,
+                ..
+            } => transaction_priority_details,
+        }
+    }
+
+    pub(crate) fn priority(&self) -> u64 {
+        self.transaction_priority_details().priority
+    }
+
+    pub(crate) fn forwarded(&self) -> bool {
+        match self {
+            Self::Unprocessed { forwarded, .. } => *forwarded,
+            Self::Pending { forwarded, .. } => *forwarded,
+        }
+    }
+
+    pub(crate) fn set_forwarded(&mut self) {
+        match self {
+            Self::Unprocessed { forwarded, .. } => *forwarded = true,
+            Self::Pending { forwarded, .. } => *forwarded = true,
+        }
+    }
+
+    fn transition_to_pending(&mut self) -> SanitizedTransactionTTL {
+        match self.take() {
+            TransactionState::Unprocessed {
+                transaction_ttl,
+                transaction_priority_details,
+                forwarded,
+            } => {
+                *self = TransactionState::Pending {
+                    transaction_priority_details,
+                    forwarded,
+                };
+                transaction_ttl
+            }
+            TransactionState::Pending { .. } => {
+                panic!("transaction already pending");
+            }
+        }
+    }
+
+    fn transition_to_unprocessed(&mut self, transaction_ttl: SanitizedTransactionTTL) {
+        match self.take() {
+            TransactionState::Unprocessed { .. } => panic!("already unprocessed"),
+            TransactionState::Pending {
+                transaction_priority_details,
+                forwarded,
+            } => {
+                *self = Self::Unprocessed {
+                    transaction_ttl,
+                    transaction_priority_details,
+                    forwarded,
+                }
+            }
+        }
+    }
+
+    pub(crate) fn transaction_ttl(&self) -> &SanitizedTransactionTTL {
+        match self {
+            Self::Unprocessed {
+                transaction_ttl, ..
+            } => transaction_ttl,
+            Self::Pending { .. } => panic!("transaction is pending"),
+        }
+    }
+
+    /// Internal helper to transitioning between states.
+    /// Replaces `self` with a dummy state that will immediately be overwritten in transition.
+    fn take(&mut self) -> Self {
+        core::mem::replace(
+            self,
+            Self::Pending {
+                transaction_priority_details: TransactionPriorityDetails {
+                    priority: 0,
+                    compute_unit_limit: 0,
+                },
+                forwarded: false,
+            },
+        )
+    }
+}
+
 pub(crate) struct SanitizedTransactionTTL {
     pub(crate) transaction: SanitizedTransaction,
     pub(crate) max_age_slot: Slot,
 }
 
 pub(crate) struct TransactionPacketContainer {
-    /// Unscheduled unique identifiers ordered by priority
     priority_queue: MinMaxHeap<TransactionPriorityId>,
-    /// Map from `TransactionId` to `SanitizedTransactionTTL`.
-    /// Contains transactions that have not yet been scheduled for consuming.
-    id_to_transaction_ttl: HashMap<TransactionId, SanitizedTransactionTTL>,
-    /// Map from `TransactionId` to `DeserializedPacket`.
-    /// Contains packets for the entire lifetime of packet/transaction.
-    /// These will only be removed once a transaction has finished processing,
-    /// or if the packets are forwarded without holding.
-    id_to_packet: HashMap<TransactionId, DeserializedPacket>,
+    id_to_transaction_state: HashMap<TransactionId, TransactionState>,
 }
 
 impl TransactionPacketContainer {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             priority_queue: MinMaxHeap::with_capacity(capacity),
-            id_to_transaction_ttl: HashMap::with_capacity(capacity),
-            id_to_packet: HashMap::with_capacity(capacity),
+            id_to_transaction_state: HashMap::with_capacity(capacity),
         }
     }
 
@@ -56,47 +160,64 @@ impl TransactionPacketContainer {
         (0..n).map_while(|_| self.priority_queue.pop_max())
     }
 
-    /// Get packet by id.
-    pub(crate) fn get_packet(&self, id: &TransactionId) -> Option<&DeserializedPacket> {
-        self.id_to_packet.get(id)
+    /// Serialize entire priority queue. `hold` indicates whether the priority queue should
+    /// be drained or not.
+    pub(crate) fn priority_ordered_ids(&mut self, hold: bool) -> Vec<TransactionPriorityId> {
+        let priority_queue = if hold {
+            self.priority_queue.clone()
+        } else {
+            let capacity = self.priority_queue.capacity();
+            core::mem::replace(
+                &mut self.priority_queue,
+                MinMaxHeap::with_capacity(capacity),
+            )
+        };
+
+        priority_queue.into_vec_desc()
     }
 
-    /// Get mutable packet by id.
-    pub(crate) fn get_mut_packet(&mut self, id: &TransactionId) -> Option<&mut DeserializedPacket> {
-        self.id_to_packet.get_mut(id)
+    /// Get transaction state by id.
+    pub(crate) fn get_mut_transaction_state(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<&mut TransactionState> {
+        self.id_to_transaction_state.get_mut(id)
     }
 
-    /// Get transaction by id.
+    /// Get reference to `SanitizedTransactionTTL` by id.
     /// Panics if the transaction does not exist.
-    pub(crate) fn get_transaction(&self, id: &TransactionId) -> &SanitizedTransactionTTL {
-        self.id_to_transaction_ttl
+    pub(crate) fn get_transaction_ttl(
+        &self,
+        id: &TransactionId,
+    ) -> Option<&SanitizedTransactionTTL> {
+        self.id_to_transaction_state
             .get(id)
-            .expect("transaction must exist")
+            .map(|state| state.transaction_ttl())
     }
 
     /// Take transaction by id.
     /// Panics if the transaction does not exist.
     pub(crate) fn take_transaction(&mut self, id: &TransactionId) -> SanitizedTransactionTTL {
-        self.id_to_transaction_ttl
-            .remove(id)
+        self.id_to_transaction_state
+            .get_mut(id)
             .expect("transaction must exist")
+            .transition_to_pending()
     }
 
     /// Insert a new transaction into the container's queues and maps.
     pub(crate) fn insert_new_transaction(
         &mut self,
         transaction_id: TransactionId,
-        packet: ImmutableDeserializedPacket,
         transaction_ttl: SanitizedTransactionTTL,
+        transaction_priority_details: TransactionPriorityDetails,
     ) {
-        let priority_id = TransactionPriorityId::new(packet.priority(), transaction_id);
+        let priority_id =
+            TransactionPriorityId::new(transaction_priority_details.priority, transaction_id);
         if self.push_id_into_queue(priority_id) {
-            self.id_to_packet.insert(
+            self.id_to_transaction_state.insert(
                 transaction_id,
-                DeserializedPacket::from_immutable_section(packet),
+                TransactionState::new(transaction_ttl, transaction_priority_details, false),
             );
-            self.id_to_transaction_ttl
-                .insert(transaction_id, transaction_ttl);
         }
     }
 
@@ -104,25 +225,14 @@ impl TransactionPacketContainer {
     pub(crate) fn retry_transaction(
         &mut self,
         transaction_id: TransactionId,
-        transaction: SanitizedTransaction,
-        max_age_slot: Slot,
+        transaction_ttl: SanitizedTransactionTTL,
     ) {
-        let priority = self
-            .id_to_packet
-            .get(&transaction_id)
-            .unwrap()
-            .immutable_section()
-            .priority();
-        let priority_id = TransactionPriorityId::new(priority, transaction_id);
-        if self.push_id_into_queue(priority_id) {
-            self.id_to_transaction_ttl.insert(
-                transaction_id,
-                SanitizedTransactionTTL {
-                    transaction,
-                    max_age_slot,
-                },
-            );
-        }
+        let transaction_state = self
+            .get_mut_transaction_state(&transaction_id)
+            .expect("transaction must exist");
+        let priority_id = TransactionPriorityId::new(transaction_state.priority(), transaction_id);
+        transaction_state.transition_to_unprocessed(transaction_ttl);
+        self.push_id_into_queue(priority_id);
     }
 
     /// Pushes a transaction id into the priority queue, without inserting the packet or transaction.
@@ -144,8 +254,7 @@ impl TransactionPacketContainer {
 
     /// Remove packet and transaction by id.
     pub(crate) fn remove_by_id(&mut self, id: &TransactionId) {
-        self.id_to_packet.remove(id);
-        self.id_to_transaction_ttl.remove(id);
+        self.id_to_transaction_state.remove(id);
     }
 }
 
@@ -153,16 +262,15 @@ impl TransactionPacketContainer {
 mod tests {
     use {
         super::*,
-        solana_perf::packet::Packet,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
             signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
         },
     };
 
-    fn test_packet_and_transaction(
+    fn test_transaction(
         priority: u64,
-    ) -> (ImmutableDeserializedPacket, SanitizedTransactionTTL) {
+    ) -> (SanitizedTransactionTTL, TransactionPriorityDetails) {
         let from_keypair = Keypair::new();
         let ixs = vec![
             system_instruction::transfer(
@@ -175,21 +283,22 @@ mod tests {
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
         let tx = Transaction::new(&[&from_keypair], message, Hash::default());
 
-        let packet = Packet::from_data(None, tx.clone()).unwrap();
-        let packet = ImmutableDeserializedPacket::new(packet).unwrap();
-
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: SanitizedTransaction::from_transaction_for_tests(tx),
             max_age_slot: Slot::MAX,
         };
-        (packet, transaction_ttl)
+        (transaction_ttl, TransactionPriorityDetails { priority, compute_unit_limit: 0 })
     }
 
     fn push_to_container(container: &mut TransactionPacketContainer, num: usize) {
         for id in 0..num as u64 {
             let priority = id;
-            let (packet, transaction_ttl) = test_packet_and_transaction(priority);
-            container.insert_new_transaction(TransactionId::new(id), packet, transaction_ttl);
+            let (transaction_ttl, transaction_priority_details) = test_transaction(priority);
+            container.insert_new_transaction(
+                TransactionId::new(id),
+                transaction_ttl,
+                transaction_priority_details,
+            );
         }
     }
 
@@ -208,13 +317,12 @@ mod tests {
         push_to_container(&mut container, 5);
 
         assert_eq!(container.priority_queue.len(), 1);
-        assert_eq!(container.id_to_packet.len(), 1);
-        assert_eq!(container.id_to_transaction_ttl.len(), 1);
+        assert_eq!(container.id_to_transaction_state.len(), 1);
         assert_eq!(
             container
-                .id_to_packet
+                .id_to_transaction_state
                 .iter()
-                .map(|p| p.1.immutable_section().priority())
+                .map(|ts| ts.1.priority())
                 .next()
                 .unwrap(),
             4
@@ -245,12 +353,10 @@ mod tests {
 
         container.remove_by_id(&TransactionId::new(3));
         assert_eq!(container.priority_queue.len(), 5); // remove_by_id does not remove from priority queue
-        assert_eq!(container.id_to_packet.len(), 4);
-        assert_eq!(container.id_to_transaction_ttl.len(), 4);
+        assert_eq!(container.id_to_transaction_state.len(), 4);
 
         container.remove_by_id(&TransactionId::new(7));
-        assert_eq!(container.id_to_packet.len(), 4);
-        assert_eq!(container.id_to_transaction_ttl.len(), 4);
+        assert_eq!(container.id_to_transaction_state.len(), 4);
     }
 
     #[test]
@@ -258,8 +364,7 @@ mod tests {
         let mut container = TransactionPacketContainer::with_capacity(1);
         assert!(container.push_id_into_queue(TransactionPriorityId::new(1, TransactionId::new(0))));
         assert_eq!(container.priority_queue.len(), 1);
-        assert_eq!(container.id_to_packet.len(), 0);
-        assert_eq!(container.id_to_transaction_ttl.len(), 0);
+        assert_eq!(container.id_to_transaction_state.len(), 0);
 
         assert!(container.push_id_into_queue(TransactionPriorityId::new(1, TransactionId::new(1))));
         assert_eq!(container.priority_queue.len(), 1);
@@ -272,23 +377,18 @@ mod tests {
     fn test_get_packet_entry_missing() {
         let mut container = TransactionPacketContainer::with_capacity(5);
         push_to_container(&mut container, 5);
-        assert!(container.get_packet(&TransactionId::new(7)).is_none());
+        assert!(container
+            .get_mut_transaction_state(&TransactionId::new(7))
+            .is_none());
     }
 
     #[test]
     fn test_get_packet_entry() {
         let mut container = TransactionPacketContainer::with_capacity(5);
         push_to_container(&mut container, 5);
-        assert!(container.get_packet(&TransactionId::new(3)).is_some());
-    }
-
-    #[test]
-    #[should_panic(expected = "transaction must exist")]
-    fn test_get_transaction_panic() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
-        push_to_container(&mut container, 5);
-
-        let _ = container.get_transaction(&TransactionId::new(7));
+        assert!(container
+            .get_mut_transaction_state(&TransactionId::new(3))
+            .is_some());
     }
 
     #[test]
@@ -296,29 +396,10 @@ mod tests {
         let mut container = TransactionPacketContainer::with_capacity(5);
         push_to_container(&mut container, 5);
 
-        let transaction_id = TransactionId::new(3);
-        let _ = container.get_transaction(&transaction_id);
-        let _ = container.get_transaction(&transaction_id);
-    }
-
-    #[test]
-    #[should_panic(expected = "transaction must exist")]
-    fn test_take_transaction_panic() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
-        push_to_container(&mut container, 5);
-
-        let _ = container.take_transaction(&TransactionId::new(7));
-    }
-
-    #[test]
-    fn test_take_transaction() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
-        push_to_container(&mut container, 5);
-
-        let transaction_id = TransactionId::new(3);
-        let _ = container.take_transaction(&transaction_id);
-        assert!(!container
-            .id_to_transaction_ttl
-            .contains_key(&transaction_id));
+        let existing_id = TransactionId::new(3);
+        let non_existing_id = TransactionId::new(7);
+        assert!(container.get_mut_transaction_state(&existing_id).is_some());
+        assert!(container.get_mut_transaction_state(&existing_id).is_some());
+        assert!(container.get_mut_transaction_state(&non_existing_id).is_none());
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
@@ -1,0 +1,27 @@
+use crate::banking_stage::scheduler_messages::TransactionId;
+
+/// A unique identifier tied with priority ordering for a transaction/packet:
+///     - `id` has no effect on ordering
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TransactionPriorityId {
+    pub(crate) priority: u64,
+    pub(crate) id: TransactionId,
+}
+
+impl TransactionPriorityId {
+    pub(crate) fn new(priority: u64, id: TransactionId) -> Self {
+        Self { priority, id }
+    }
+}
+
+impl Ord for TransactionPriorityId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.priority.cmp(&other.priority)
+    }
+}
+
+impl PartialOrd for TransactionPriorityId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -204,7 +204,7 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        let transaction_ttl = transaction_state.transition_to_pending();
+        let _ = transaction_state.transition_to_pending();
         assert!(matches!(
             transaction_state,
             TransactionState::Pending { .. }
@@ -271,8 +271,7 @@ mod tests {
         ));
         assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
 
-        // ensure transaction_ttl is not lost through state transitions
-        let transaction_ttl = transaction_state.transition_to_pending();
+        let _ = transaction_state.transition_to_pending();
         assert!(matches!(
             transaction_state,
             TransactionState::Pending { .. }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,0 +1,308 @@
+use {
+    solana_runtime::transaction_priority_details::TransactionPriorityDetails,
+    solana_sdk::{slot_history::Slot, transaction::SanitizedTransaction},
+};
+
+/// Simple wrapper type to tie a sanitized transaction to max age slot.
+pub(crate) struct SanitizedTransactionTTL {
+    pub(crate) transaction: SanitizedTransaction,
+    pub(crate) max_age_slot: Slot,
+}
+
+/// TransactionState is used to track the state of a transaction in the transaction scheduler
+/// and banking stage as a whole.
+///
+/// There are two states a transaction can be in:
+///     1. `Unprocessed` - The transaction is available for scheduling.
+///     2. `Pending` - The transaction is currently scheduled or being processed.
+///
+/// Newly received transactions are initially in the `Unprocessed` state.
+/// When a transaction is scheduled, it is transitioned to the `Pending` state,
+///   using the `transition_to_pending` method.
+/// When a transaction finishes processing it may be retryable. If it is retryable,
+///   the transaction is transitioned back to the `Unprocessed` state using the
+///   `transition_to_unprocessed` method. If it is not retryable, the state should
+///   be dropped.
+///
+/// For performance, when a transaction is transitioned to the `Pending` state, the
+///   internal `SanitizedTransaction` is moved out of the `TransactionState` and sent
+///   to the appropriate thread for processing. This is done to avoid cloning the
+///  `SanitizedTransaction`.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum TransactionState {
+    /// The transaction is available for scheduling.
+    Unprocessed {
+        transaction_ttl: SanitizedTransactionTTL,
+        transaction_priority_details: TransactionPriorityDetails,
+        forwarded: bool,
+    },
+    /// The transaction is currently scheduled or being processed.
+    Pending {
+        transaction_priority_details: TransactionPriorityDetails,
+        forwarded: bool,
+    },
+}
+
+impl TransactionState {
+    /// Creates a new `TransactionState` in the `Unprocessed` state.
+    pub(crate) fn new(
+        transaction_ttl: SanitizedTransactionTTL,
+        transaction_priority_details: TransactionPriorityDetails,
+    ) -> Self {
+        Self::Unprocessed {
+            transaction_ttl,
+            transaction_priority_details,
+            forwarded: false,
+        }
+    }
+
+    /// Returns a reference to the priority details of the transaction.
+    pub(crate) fn transaction_priority_details(&self) -> &TransactionPriorityDetails {
+        match self {
+            Self::Unprocessed {
+                transaction_priority_details,
+                ..
+            } => transaction_priority_details,
+            Self::Pending {
+                transaction_priority_details,
+                ..
+            } => transaction_priority_details,
+        }
+    }
+
+    /// Returns the priority of the transaction.
+    pub(crate) fn priority(&self) -> u64 {
+        self.transaction_priority_details().priority
+    }
+
+    /// Intended to be called when a transaction is scheduled. This method will
+    /// transition the transaction from `Unprocessed` to `Pending` and return the
+    /// `SanitizedTransactionTTL` for processing.
+    ///
+    /// # Panics
+    /// This method will panic if the transaction is already in the `Pending` state,
+    ///   as this is an invalid state transition.
+    pub(crate) fn transition_to_pending(&mut self) -> SanitizedTransactionTTL {
+        match self.take() {
+            TransactionState::Unprocessed {
+                transaction_ttl,
+                transaction_priority_details,
+                forwarded,
+            } => {
+                *self = TransactionState::Pending {
+                    transaction_priority_details,
+                    forwarded,
+                };
+                transaction_ttl
+            }
+            TransactionState::Pending { .. } => {
+                panic!("transaction already pending");
+            }
+        }
+    }
+
+    /// Intended to be called when a transaction is retried. This method will
+    /// transition the transaction from `Pending` to `Unprocessed`.
+    ///
+    /// # Panics
+    /// This method will panic if the transaction is already in the `Unprocessed`
+    ///   state, as this is an invalid state transition.
+    pub(crate) fn transition_to_unprocessed(&mut self, transaction_ttl: SanitizedTransactionTTL) {
+        match self.take() {
+            TransactionState::Unprocessed { .. } => panic!("already unprocessed"),
+            TransactionState::Pending {
+                transaction_priority_details,
+                forwarded,
+            } => {
+                *self = Self::Unprocessed {
+                    transaction_ttl,
+                    transaction_priority_details,
+                    forwarded,
+                }
+            }
+        }
+    }
+
+    /// Get a reference to the `SanitizedTransactionTTL` for the transaction.
+    ///
+    /// # Panics
+    /// This method will panic if the transaction is in the `Pending` state.
+    pub(crate) fn transaction_ttl(&self) -> &SanitizedTransactionTTL {
+        match self {
+            Self::Unprocessed {
+                transaction_ttl, ..
+            } => transaction_ttl,
+            Self::Pending { .. } => panic!("transaction is pending"),
+        }
+    }
+
+    /// Internal helper to transitioning between states.
+    /// Replaces `self` with a dummy state that will immediately be overwritten in transition.
+    fn take(&mut self) -> Self {
+        core::mem::replace(
+            self,
+            Self::Pending {
+                transaction_priority_details: TransactionPriorityDetails {
+                    priority: 0,
+                    compute_unit_limit: 0,
+                },
+                forwarded: false,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
+            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
+        },
+    };
+
+    fn create_transaction_state(priority: u64) -> TransactionState {
+        let from_keypair = Keypair::new();
+        let ixs = vec![
+            system_instruction::transfer(
+                &from_keypair.pubkey(),
+                &solana_sdk::pubkey::new_rand(),
+                1,
+            ),
+            ComputeBudgetInstruction::set_compute_unit_price(priority),
+        ];
+        let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
+        let tx = Transaction::new(&[&from_keypair], message, Hash::default());
+
+        let transaction_ttl = SanitizedTransactionTTL {
+            transaction: SanitizedTransaction::from_transaction_for_tests(tx),
+            max_age_slot: Slot::MAX,
+        };
+
+        TransactionState::new(
+            transaction_ttl,
+            TransactionPriorityDetails {
+                priority,
+                compute_unit_limit: 0,
+            },
+        )
+    }
+
+    #[test]
+    #[should_panic(expected = "already pending")]
+    fn test_transition_to_pending_panic() {
+        let mut transaction_state = create_transaction_state(0);
+        transaction_state.transition_to_pending();
+        transaction_state.transition_to_pending(); // invalid transition
+    }
+
+    #[test]
+    fn test_transition_to_pending() {
+        let mut transaction_state = create_transaction_state(0);
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+        let transaction_ttl = transaction_state.transition_to_pending();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Pending { .. }
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "already unprocessed")]
+    fn test_transition_to_unprocessed_panic() {
+        let mut transaction_state = create_transaction_state(0);
+
+        // Manually clone `SanitizedTransactionTTL`
+        let SanitizedTransactionTTL {
+            transaction,
+            max_age_slot,
+        } = transaction_state.transaction_ttl();
+        let transaction_ttl = SanitizedTransactionTTL {
+            transaction: transaction.clone(),
+            max_age_slot: *max_age_slot,
+        };
+        transaction_state.transition_to_unprocessed(transaction_ttl); // invalid transition
+    }
+
+    #[test]
+    fn test_transition_to_unprocessed() {
+        let mut transaction_state = create_transaction_state(0);
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+        let transaction_ttl = transaction_state.transition_to_pending();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Pending { .. }
+        ));
+        transaction_state.transition_to_unprocessed(transaction_ttl);
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+    }
+
+    #[test]
+    fn test_transaction_priority_details() {
+        let priority = 15;
+        let mut transaction_state = create_transaction_state(priority);
+        assert_eq!(transaction_state.priority(), priority);
+
+        // ensure priority is not lost through state transitions
+        let transaction_ttl = transaction_state.transition_to_pending();
+        assert_eq!(transaction_state.priority(), priority);
+        transaction_state.transition_to_unprocessed(transaction_ttl);
+        assert_eq!(transaction_state.priority(), priority);
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction is pending")]
+    fn test_transaction_ttl_panic() {
+        let mut transaction_state = create_transaction_state(0);
+        let transaction_ttl = transaction_state.transaction_ttl();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+
+        // ensure transaction_ttl is not lost through state transitions
+        let transaction_ttl = transaction_state.transition_to_pending();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Pending { .. }
+        ));
+        let _ = transaction_state.transaction_ttl(); // pending state, the transaction ttl is not available
+    }
+
+    #[test]
+    fn test_transaction_ttl() {
+        let mut transaction_state = create_transaction_state(0);
+        let transaction_ttl = transaction_state.transaction_ttl();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+
+        // ensure transaction_ttl is not lost through state transitions
+        let transaction_ttl = transaction_state.transition_to_pending();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Pending { .. }
+        ));
+
+        transaction_state.transition_to_unprocessed(transaction_ttl);
+        let transaction_ttl = transaction_state.transaction_ttl();
+        assert!(matches!(
+            transaction_state,
+            TransactionState::Unprocessed { .. }
+        ));
+        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+    }
+}

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -75,6 +75,22 @@ impl TransactionState {
         self.transaction_priority_details().priority
     }
 
+    /// Returns whether or not the transaction has already been forwarded.
+    pub(crate) fn forwarded(&self) -> bool {
+        match self {
+            Self::Unprocessed { forwarded, .. } => *forwarded,
+            Self::Pending { forwarded, .. } => *forwarded,
+        }
+    }
+
+    /// Sets the transaction as forwarded.
+    pub(crate) fn set_forwarded(&self) {
+        match self {
+            Self::Unprocessed { forwarded, .. } => *forwarded = true,
+            Self::Pending { forwarded, .. } => *forwarded = true,
+        }
+    }
+
     /// Intended to be called when a transaction is scheduled. This method will
     /// transition the transaction from `Unprocessed` to `Pending` and return the
     /// `SanitizedTransactionTTL` for processing.

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -157,7 +157,9 @@ impl TransactionStateContainer {
 
     /// Remove transaction by id.
     pub(crate) fn remove_by_id(&mut self, id: &TransactionId) {
-        self.id_to_transaction_state.remove(id).expect("transaction must exist");
+        self.id_to_transaction_state
+            .remove(id)
+            .expect("transaction must exist");
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -129,12 +129,12 @@ pub(crate) struct SanitizedTransactionTTL {
     pub(crate) max_age_slot: Slot,
 }
 
-pub(crate) struct TransactionPacketContainer {
+pub(crate) struct TransactionStateContainer {
     priority_queue: MinMaxHeap<TransactionPriorityId>,
     id_to_transaction_state: HashMap<TransactionId, TransactionState>,
 }
 
-impl TransactionPacketContainer {
+impl TransactionStateContainer {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             priority_queue: MinMaxHeap::with_capacity(capacity),
@@ -290,7 +290,7 @@ mod tests {
         (transaction_ttl, TransactionPriorityDetails { priority, compute_unit_limit: 0 })
     }
 
-    fn push_to_container(container: &mut TransactionPacketContainer, num: usize) {
+    fn push_to_container(container: &mut TransactionStateContainer, num: usize) {
         for id in 0..num as u64 {
             let priority = id;
             let (transaction_ttl, transaction_priority_details) = test_transaction(priority);
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        let mut container = TransactionPacketContainer::with_capacity(1);
+        let mut container = TransactionStateContainer::with_capacity(1);
         assert!(container.is_empty());
 
         push_to_container(&mut container, 1);
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_priority_queue_capacity() {
-        let mut container = TransactionPacketContainer::with_capacity(1);
+        let mut container = TransactionStateContainer::with_capacity(1);
         push_to_container(&mut container, 5);
 
         assert_eq!(container.priority_queue.len(), 1);
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn test_take_top_n() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
+        let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
 
         let taken = container.take_top_n(3).collect::<Vec<_>>();
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_remove_by_id() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
+        let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
 
         container.remove_by_id(&TransactionId::new(3));
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_push_id_into_queue() {
-        let mut container = TransactionPacketContainer::with_capacity(1);
+        let mut container = TransactionStateContainer::with_capacity(1);
         assert!(container.push_id_into_queue(TransactionPriorityId::new(1, TransactionId::new(0))));
         assert_eq!(container.priority_queue.len(), 1);
         assert_eq!(container.id_to_transaction_state.len(), 0);
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_get_packet_entry_missing() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
+        let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
         assert!(container
             .get_mut_transaction_state(&TransactionId::new(7))
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_get_packet_entry() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
+        let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
         assert!(container
             .get_mut_transaction_state(&TransactionId::new(3))
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction() {
-        let mut container = TransactionPacketContainer::with_capacity(5);
+        let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
 
         let existing_id = TransactionId::new(3);

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -15,7 +15,7 @@ use {
 /// Transaction Lifetime:
 /// 1. Received from `SigVerify` by `BankingStage`
 /// 2. Inserted into `TransactionStateContainer` by `BankingStage`
-/// 3. Popped in priority-order by scheduler, and trnsitioned to `Pending` state
+/// 3. Popped in priority-order by scheduler, and transitioned to `Pending` state
 /// 4. Processed by `ConsumeWorker`
 ///   a. If consumed, remove `Pending` state from the `TransactionStateContainer`
 ///   b. If retryable, transition back to `Unprocessed` state.


### PR DESCRIPTION
#### Problem
Breaking out of #32981.

Central scheduling BankingStage needs a place to store transactions while they are pending scheduling/processing. 

#### Summary of Changes
- Add `TransactionPriorityId` - which ties together unique transaction ID and priority. This is what lives in our priority queue, rather than packets/transactions directly.
- Add `TransactionStateContainer` - responsible for priority ordering and storing of transactions (see doc comments for details on this)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
