### PR TITLE
banks-server: Support versioned transactions

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -93,7 +93,7 @@ impl BanksServer {
                 // has been processed
                 let lock = bank.freeze_lock();
                 if *lock == Hash::default() {
-                    let _ = bank.try_process_transactions(transactions.iter());
+                    let _ = bank.try_process_entry_transactions(transactions);
                     // break out of inner loop and release bank freeze lock
                     break;
                 }


### PR DESCRIPTION
#### Problem

As reported in https://solana.stackexchange.com/questions/7424/why-doesnt-solana-program-test-work-with-versionedtransaction, program-test doesn't work with versioned transactions because the banks-server is trying to deserialize legacy transactions.

#### Summary of Changes

Pretty simple, call `Bank::try_process_entry_transactions` instead of `try_process_transactions` in banks-server, since the former takes in versioned transactions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
