### PR TITLE
rework hash_dedup algo

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1050,9 +1050,10 @@ impl<'a> AccountsHasher<'a> {
                     let mut offset = first_pubkey_in_bin;
 
                     while let Some(k) = key {
-                        if !working_set.contains_key(&k) {
+                        if let std::collections::btree_map::Entry::Vacant(e) = working_set.entry(k)
+                        {
                             // found a new key, insert into working_set
-                            working_set.insert(k, (i, offset));
+                            e.insert((i, offset));
                             break;
                         } else {
                             // key already exist in working_set, find next key.

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -843,7 +843,7 @@ impl<'a> AccountsHasher<'a> {
         key: &Pubkey,
     ) -> (
         &'b CalculateHashIntermediate,
-        Option<(Pubkey, usize, usize)>,
+        Option<(&'b Pubkey, usize, usize)>,
     ) {
         let division_data = &sorted_data_by_pubkey[division_index];
         let mut index = offset;
@@ -867,7 +867,7 @@ impl<'a> AccountsHasher<'a> {
             }
 
             // point to the next pubkey > key
-            next = Some((*next_key, division_index, index));
+            next = Some((next_key, division_index, index));
             break;
         }
 
@@ -1046,7 +1046,7 @@ impl<'a> AccountsHasher<'a> {
                     Self::find_first_pubkey_in_bin(hash_data, pubkey_bin, bins, &binner, stats);
 
                 if let Some(first_pubkey_in_bin) = first_pubkey_in_bin {
-                    let mut key = Some(hash_data[first_pubkey_in_bin].pubkey);
+                    let mut key = Some(&hash_data[first_pubkey_in_bin].pubkey);
                     let mut offset = first_pubkey_in_bin;
 
                     while let Some(k) = key {


### PR DESCRIPTION
#### Problem

Original hash_dedup algo is not efficient. Bookkeeping with arrays, scanning arrays for lowest item, and removing from arrays are not efficient.


#### Summary of Changes

Rework hash_dedup algo.

Basically, we keep the lowest item for the slot groups in a BTree, pops out the smallest element from the working_set to process, add new lowest items,  until the working_set is empty.

- base (master) 

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages a | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  4408444i
pubkey_bin_search_us                10830942i
```

- this pr (first version)
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  3381527i
pubkey_bin_search_us                15508835i
```

- this pr with (process new directly)
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  2633002i
pubkey_bin_search_us                11021416i
```


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
