### PR TITLE
Remove From<LogCollector> for Vec<String>

### DIFF
--- a/program-runtime/src/log_collector.rs
+++ b/program-runtime/src/log_collector.rs
@@ -54,11 +54,9 @@ impl LogCollector {
             ..Self::default()
         }))
     }
-}
 
-impl From<LogCollector> for Vec<String> {
-    fn from(log_collector: LogCollector) -> Self {
-        log_collector.messages
+    pub fn into_messages(self) -> Vec<String> {
+        self.messages
     }
 }
 
@@ -114,7 +112,7 @@ pub(crate) mod tests {
             lc.log("x");
         }
 
-        let logs: Vec<_> = lc.into();
+        let logs: Vec<_> = lc.into_messages();
         assert_eq!(logs.len(), LOG_MESSAGES_BYTES_LIMIT);
         for log in logs.iter().take(LOG_MESSAGES_BYTES_LIMIT - 1) {
             assert_eq!(*log, "x".to_string());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4895,7 +4895,7 @@ impl Bank {
         let log_messages: Option<TransactionLogMessages> =
             log_collector.and_then(|log_collector| {
                 Rc::try_unwrap(log_collector)
-                    .map(|log_collector| log_collector.into_inner().into())
+                    .map(|log_collector| log_collector.into_inner().into_messages())
                     .ok()
             });
 


### PR DESCRIPTION
#### Problem

imo, this use of trait `From` isn't strictly needed semantically. it's actually not like a cast, rather a finalization of some stateful builder object.

also (my personal main reason), traits doesn't work nicely for rust-analyzer's call-hierarchy...

#### Summary of Changes

seems this was intentionally changed to use the `Into` (ie. the mirror of `From`) trait at https://github.com/solana-labs/solana/pull/10528#discussion_r1306439150

but, this pr just convert back to the original plain old inherent method taking ownership.