### PR TITLE
test validator write stake account to JSON

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -838,6 +838,14 @@ impl TestValidator {
             ledger_path.join("validator-keypair.json").to_str().unwrap(),
         )?;
 
+        write_keypair_file(
+            &validator_stake_account,
+            ledger_path
+                .join("stake-account-keypair.json")
+                .to_str()
+                .unwrap(),
+        )?;
+
         // `ledger_exists` should fail until the vote account keypair is written
         assert!(!TestValidatorGenesis::ledger_exists(&ledger_path));
 


### PR DESCRIPTION
#### Problem
The test validator writes its validator **identity** and **vote account** to JSON files on startup, but it doesn't do this for its **stake account**. 

#### Summary of Changes
Write the stake account to JSON on startup.
