### PR TITLE
ci: remove --ignore RUSTSEC-2022-0093

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -30,10 +30,6 @@ cargo_audit_ignores=(
   --ignore RUSTSEC-2023-0001
 
   --ignore RUSTSEC-2022-0093
-
-  # webpki: CPU denial of service in certificate path building
-  # No fixed upgrade is available!
-  --ignore RUSTSEC-2023-0052
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

We have removed `webpki` from our repo 🎉 

#### Summary of Changes

remove `--ignore RUSTSEC-2022-0093`

close #32933 