### PR TITLE
Refactor - Loader v4 deployment status

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -150,7 +150,7 @@ use {
         inflation::Inflation,
         instruction::InstructionError,
         lamports::LamportsError,
-        loader_v4::{self, LoaderV4State},
+        loader_v4::{self, LoaderV4State, LoaderV4Status},
         message::{AccountKeys, SanitizedMessage},
         native_loader,
         native_token::LAMPORTS_PER_SOL,
@@ -4621,7 +4621,9 @@ impl Bank {
         if loader_v4::check_id(program_account.owner()) {
             return solana_loader_v4_program::get_state(program_account.data())
                 .ok()
-                .and_then(|state| state.is_deployed.then_some(state.slot))
+                .and_then(|state| {
+                    (!matches!(state.status, LoaderV4Status::Retracted)).then_some(state.slot)
+                })
                 .map(|slot| ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, slot))
                 .unwrap_or(ProgramAccountLoadResult::InvalidV4Program);
         }

--- a/sdk/program/src/loader_v4.rs
+++ b/sdk/program/src/loader_v4.rs
@@ -1,4 +1,4 @@
-//! The v3 built-in loader program.
+//! The v4 built-in loader program.
 //!
 //! This is the loader of the program runtime v2.
 
@@ -9,16 +9,27 @@ crate::declare_id!("LoaderV411111111111111111111111111111111111");
 /// Cooldown before a program can be un-/redeployed again
 pub const DEPLOYMENT_COOLDOWN_IN_SLOTS: u64 = 750;
 
+#[repr(u64)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, AbiExample)]
+pub enum LoaderV4Status {
+    /// Program is in maintanance
+    Retracted,
+    /// Program is ready to be executed
+    Deployed,
+    /// Same as `Deployed`, but can not be retracted anymore
+    Finalized,
+}
+
 /// LoaderV4 account states
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, AbiExample)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, AbiExample)]
 pub struct LoaderV4State {
-    /// Slot that the program was last initialized, deployed or retracted in.
+    /// Slot in which the program was last deployed, retracted or initialized.
     pub slot: u64,
-    /// True if the program is ready to be executed, false if it is retracted for maintainance.
-    pub is_deployed: bool,
-    /// Authority address, `None` means it is finalized.
-    pub authority_address: Option<Pubkey>,
+    /// Address of signer which can send program management instructions.
+    pub authority_address: Pubkey,
+    /// Deployment status.
+    pub status: LoaderV4Status,
     // The raw program data follows this serialized structure in the
     // account's data.
 }
@@ -27,5 +38,18 @@ impl LoaderV4State {
     /// Size of a serialized program account.
     pub const fn program_data_offset() -> usize {
         std::mem::size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, memoffset::offset_of};
+
+    #[test]
+    fn test_layout() {
+        assert_eq!(offset_of!(LoaderV4State, slot), 0x00);
+        assert_eq!(offset_of!(LoaderV4State, authority_address), 0x08);
+        assert_eq!(offset_of!(LoaderV4State, status), 0x28);
+        assert_eq!(LoaderV4State::program_data_offset(), 0x30);
     }
 }

--- a/sdk/program/src/loader_v4_instruction.rs
+++ b/sdk/program/src/loader_v4_instruction.rs
@@ -1,4 +1,4 @@
-//! Instructions for the SBF loader.
+//! Instructions for the v4 built-in loader program.
 
 #[repr(u8)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
#### Problem
The current encoding of the program state leaves gaps of uninitialized / undefined memory.
See #32989, #32990 and #32991.

#### Summary of Changes
- Replaces `is_deployed` with `status`: `Retracted`, `Deployed`, `Finalized`
- Removes the `Option<>` from `authority_address`, `None` is now expressed as status `Finalized`
- Places the `status` at the end and gives it `repr(u64)` so that there is no padding
- Adds test for the layout of the program state
- Forbids finalizing retracted programs