### PR TITLE
Handle closing of the program in the same slot as deployment

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -471,6 +471,10 @@ impl LoadedPrograms {
                     // The old entry is tombstone and the new one is not. Let's give the new entry
                     // a chance.
                     second_level.remove(entry_index);
+                } else if !existing.is_tombstone() && entry.is_tombstone() {
+                    // The old entry is not a tombstone and the new one is a tombstone.
+                    // Remove the old entry, as the tombstone makes it obsolete.
+                    second_level.remove(entry_index);
                 } else {
                     self.stats.replacements.fetch_add(1, Ordering::Relaxed);
                     return (true, existing.clone());

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -467,13 +467,11 @@ impl LoadedPrograms {
                         Ordering::Relaxed,
                     );
                     second_level.remove(entry_index);
-                } else if existing.is_tombstone() && !entry.is_tombstone() {
-                    // The old entry is tombstone and the new one is not. Let's give the new entry
-                    // a chance.
-                    second_level.remove(entry_index);
-                } else if !existing.is_tombstone() && entry.is_tombstone() {
-                    // The old entry is not a tombstone and the new one is a tombstone.
-                    // Remove the old entry, as the tombstone makes it obsolete.
+                } else if existing.is_tombstone() != entry.is_tombstone() {
+                    // Either the old entry is tombstone and the new one is not.
+                    // (Let's give the new entry a chance).
+                    // Or, the old entry is not a tombstone and the new one is a tombstone.
+                    // (Remove the old entry, as the tombstone makes it obsolete).
                     second_level.remove(entry_index);
                 } else {
                     self.stats.replacements.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
The cache retains the deployed program even though it was closed, if the deployment and close happened in the same slot.

#### Summary of Changes
The tombstone for closed program was not getting inserted in the cache. This allowed the cached entry for the deployed program to remain active. This PR checks if the new entry is a tombstone, and inserts it in the cache.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
