### PR TITLE
remove unused return value from reset_uncleaned_roots

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1934,7 +1934,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.roots_tracker.read().unwrap().min_alive_root()
     }
 
-    pub fn reset_uncleaned_roots(&self, max_clean_root: Option<Slot>) -> HashSet<Slot> {
+    pub(crate) fn reset_uncleaned_roots(&self, max_clean_root: Option<Slot>) {
         let mut cleaned_roots = HashSet::new();
         let mut w_roots_tracker = self.roots_tracker.write().unwrap();
         w_roots_tracker.uncleaned_roots.retain(|root| {
@@ -1947,7 +1947,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             // Only keep the slots that have yet to be cleaned
             !is_cleaned
         });
-        std::mem::replace(&mut w_roots_tracker.previous_uncleaned_roots, cleaned_roots)
+        w_roots_tracker.previous_uncleaned_roots = cleaned_roots;
     }
 
     #[cfg(test)]


### PR DESCRIPTION
#### Problem
improving startup time performance
Return value from `reset_uncleaned_roots` is never used by any callers.

#### Summary of Changes
Remove the return value.
This will simplify understanding the uses of `uncleaned_roots` and perhaps facilitate removing it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
