### PR TITLE
client: Speed up send-and-confirm-parallel

### DIFF
--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -53,6 +53,7 @@ pub struct SendAndConfirmConfig {
     pub resign_txs_count: Option<usize>,
 }
 
+/// Sends and confirms transactions concurrently in a sync context
 pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
     rpc_client: Arc<BlockingRpcClient>,
     tpu_client: Option<QuicTpuClient>,
@@ -344,9 +345,11 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
     }
 }
 
-/// This is a new method which will be able to send and confirm a large amount of transactions
+/// Sends and confirms transactions concurrently
+///
 /// The sending and confirmation of transactions is done in parallel tasks
-/// The signer sign the transaction just before sending so that blockhash is not expired
+/// The method signs transactions just before sending so that blockhash does not
+/// expire.
 pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     rpc_client: Arc<RpcClient>,
     tpu_client: Option<QuicTpuClient>,

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -181,7 +181,7 @@ fn progress_from_context_and_block_height(
 
 async fn sign_all_messages_and_send<T: Signers + ?Sized>(
     progress_bar: &Option<indicatif::ProgressBar>,
-    rpc_client: Arc<RpcClient>,
+    rpc_client: &RpcClient,
     tpu_client: &Option<QuicTpuClient>,
     messages_with_index: Vec<(usize, Message)>,
     signers: &T,
@@ -439,7 +439,7 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
 
         sign_all_messages_and_send(
             &progress_bar,
-            rpc_client.clone(),
+            &rpc_client,
             &tpu_client,
             messages_with_index,
             signers,

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -312,7 +312,6 @@ fn timeout_future<'a, Fut: Future<Output = TransportResult<()>> + 'a>(
 ) -> impl Future<Output = TransportResult<()>> + 'a {
     timeout(timeout_duration, future)
         .unwrap_or_else(|_| Err(TransportError::Custom("Timed out".to_string())))
-        .boxed_local()
 }
 
 #[cfg(feature = "spinner")]
@@ -331,7 +330,6 @@ async fn sleep_and_set_message(
     Ok(())
 }
 
-#[cfg(feature = "spinner")]
 async fn sleep_and_send_wire_transaction_to_addr<P, M, C>(
     sleep_duration: Duration,
     connection_cache: &ConnectionCache<P, M, C>,
@@ -343,8 +341,7 @@ where
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
 {
     sleep(sleep_duration).await;
-    let conn = connection_cache.get_nonblocking_connection(&addr);
-    conn.send_data(&wire_transaction).await
+    send_wire_transaction_to_addr(connection_cache, &addr, wire_transaction).await
 }
 
 async fn send_wire_transaction_to_addr<P, M, C>(


### PR DESCRIPTION
#### Problem

The new deployment method is awesome, but it still blocks on every send, making it go very slowly.

#### Summary of Changes

Await all sends at the same time to not get slowed down by one bad send.

Please go through the commits linearly, since there's some refactoring and cleaning up involved too. a7e309489f2b41365c06aed38adf8226b6f3f065 is pretty unrelated, but was bothering me.

With this PR, 100 txs take roughly 5s, and without it takes 17-25s. For 1000 txs, the difference is huge, but I got frustrated waiting for the old version to finish it, so I didn't even test it. The new version takes roughly 13s for 1000 txs though.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
