### PR TITLE
[zk-token-proof] Add CUs to close account instruction

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -134,6 +134,11 @@ declare_process_instruction!(process_instruction, 0, |invoke_context| {
 
     match instruction {
         ProofInstruction::CloseContextState => {
+            if native_programs_consume_cu {
+                invoke_context
+                    .consume_checked(3_300)
+                    .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            }
             ic_msg!(invoke_context, "CloseContextState");
             process_close_proof_context(invoke_context)
         }


### PR DESCRIPTION
#### Problem
The close context state account instruction does not incure a fee. If the feature https://github.com/solana-labs/solana/issues/30620 is activated, then any native instruction that does not incure a fee will fail.

#### Summary of Changes
Added compute units to close account. The instruction itself performs two things:
- Check if the owner of an account (the context account) is the signer for the transaction
- Frees the account

I modeled the compute units similar to the `spl-token` close account instruction. The token close account instruction performs similar steps as the close context state account instruction here. Although the token instruction is executed as BPF, it only really performs pubkey comparison and then frees the account, so the cost should be quite similar. The token close instruction incurs about `3_300` compute units, so this amount was assigned to the close context state account instruction.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
