### PR TITLE
add PartialEq and Debug to bucket map

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -88,7 +88,7 @@ struct DataFileEntryToFree {
 }
 
 // >= 2 instances of BucketStorage per 'bucket' in the bucket map. 1 for index, >= 1 for data
-pub struct Bucket<T: Copy + 'static> {
+pub struct Bucket<T: Copy + PartialEq + 'static> {
     drives: Arc<Vec<PathBuf>>,
     /// index
     pub index: BucketStorage<IndexBucket<T>>,
@@ -109,7 +109,7 @@ pub struct Bucket<T: Copy + 'static> {
     at_least_one_entry_deleted: bool,
 }
 
-impl<'b, T: Clone + Copy + 'static> Bucket<T> {
+impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
     pub fn new(
         drives: Arc<Vec<PathBuf>>,
         max_search: MaxSearch,

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -16,7 +16,7 @@ use {
 
 type LockedBucket<T> = RwLock<Option<Bucket<T>>>;
 
-pub struct BucketApi<T: Clone + Copy + 'static> {
+pub struct BucketApi<T: Clone + Copy + PartialEq + 'static> {
     drives: Arc<Vec<PathBuf>>,
     max_search: MaxSearch,
     pub stats: Arc<BucketMapStats>,
@@ -25,7 +25,7 @@ pub struct BucketApi<T: Clone + Copy + 'static> {
     count: Arc<AtomicU64>,
 }
 
-impl<T: Clone + Copy> BucketApi<T> {
+impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     pub fn new(
         drives: Arc<Vec<PathBuf>>,
         max_search: MaxSearch,

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -25,7 +25,7 @@ impl BucketMapConfig {
     }
 }
 
-pub struct BucketMap<T: Clone + Copy + Debug + 'static> {
+pub struct BucketMap<T: Clone + Copy + Debug + PartialEq + 'static> {
     buckets: Vec<Arc<BucketApi<T>>>,
     drives: Arc<Vec<PathBuf>>,
     max_buckets_pow2: u8,
@@ -33,7 +33,7 @@ pub struct BucketMap<T: Clone + Copy + Debug + 'static> {
     pub temp_dir: Option<TempDir>,
 }
 
-impl<T: Clone + Copy + Debug> Drop for BucketMap<T> {
+impl<T: Clone + Copy + Debug + PartialEq> Drop for BucketMap<T> {
     fn drop(&mut self) {
         if self.temp_dir.is_none() {
             BucketMap::<T>::erase_previous_drives(&self.drives);
@@ -41,7 +41,7 @@ impl<T: Clone + Copy + Debug> Drop for BucketMap<T> {
     }
 }
 
-impl<T: Clone + Copy + Debug> std::fmt::Debug for BucketMap<T> {
+impl<T: Clone + Copy + Debug + PartialEq> Debug for BucketMap<T> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
@@ -59,7 +59,7 @@ pub enum BucketMapError {
     IndexNoSpace(u64),
 }
 
-impl<T: Clone + Copy + Debug> BucketMap<T> {
+impl<T: Clone + Copy + Debug + PartialEq> BucketMap<T> {
     pub fn new(config: BucketMapConfig) -> Self {
         assert_ne!(
             config.max_buckets, 0,

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -71,7 +71,7 @@ impl BucketOccupied for BucketWithHeader {
 
 /// allocated in `contents` in a BucketStorage
 #[derive(Debug)]
-pub struct IndexBucketUsingBitVecBits<T: 'static> {
+pub struct IndexBucketUsingBitVecBits<T: PartialEq + 'static> {
     /// 2 bits per entry that represent a 4 state enum tag
     pub enum_tag: BitVec,
     /// number of elements allocated
@@ -79,7 +79,7 @@ pub struct IndexBucketUsingBitVecBits<T: 'static> {
     _phantom: PhantomData<&'static T>,
 }
 
-impl<T: Copy + 'static> IndexBucketUsingBitVecBits<T> {
+impl<T: Copy + PartialEq + 'static> IndexBucketUsingBitVecBits<T> {
     /// set the 2 bits (first and second) in `enum_tag`
     fn set_bits(&mut self, ix: u64, first: bool, second: bool) {
         self.enum_tag.set(ix * 2, first);
@@ -102,7 +102,7 @@ impl<T: Copy + 'static> IndexBucketUsingBitVecBits<T> {
     }
 }
 
-impl<T: Copy + 'static> BucketOccupied for IndexBucketUsingBitVecBits<T> {
+impl<T: Copy + PartialEq + 'static> BucketOccupied for IndexBucketUsingBitVecBits<T> {
     fn occupy(&mut self, element: &mut [u8], ix: usize) {
         assert!(self.is_free(element, ix));
         self.set_enum_tag(ix as u64, OccupiedEnumTag::ZeroSlots);
@@ -140,7 +140,7 @@ impl<T: Copy + 'static> BucketOccupied for IndexBucketUsingBitVecBits<T> {
     }
 }
 
-impl<T> BucketCapacity for IndexBucketUsingBitVecBits<T> {
+impl<T: PartialEq> BucketCapacity for IndexBucketUsingBitVecBits<T> {
     fn capacity(&self) -> u64 {
         self.capacity
     }
@@ -312,7 +312,7 @@ struct PackedStorage {
     offset: B56,
 }
 
-impl<T: Copy + 'static> IndexEntryPlaceInBucket<T> {
+impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
     pub(crate) fn get_slot_count_enum<'a>(
         &self,
         index_bucket: &'a BucketStorage<IndexBucket<T>>,


### PR DESCRIPTION
#### Problem
Improving startup performance.

#### Summary of Changes
The value of a bucket map on disk needs to have PartialEq and Debug for work that is coming soon.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
