### PR TITLE
bump nightly to 2023-08-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6021,6 +6021,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version 0.4.0",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -694,6 +694,7 @@ pub mod tests {
         fn set_data_len_unsafe(&self, new_data_len: u64) {
             // UNSAFE: cast away & (= const ref) to &mut to force to mutate append-only (=read-only) AppendVec
             unsafe {
+                #[allow(invalid_reference_casting)]
                 std::ptr::write(
                     std::mem::transmute::<*const u64, *mut u64>(&self.meta.data_len),
                     new_data_len,
@@ -711,6 +712,7 @@ pub mod tests {
         fn set_executable_as_byte(&self, new_executable_byte: u8) {
             // UNSAFE: Force to interpret mmap-backed &bool as &u8 to write some crafted value;
             unsafe {
+                #[allow(invalid_reference_casting)]
                 std::ptr::write(
                     std::mem::transmute::<*const bool, *mut u8>(&self.account_meta.executable),
                     new_executable_byte,

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2023-04-19
+  nightly_version=2023-08-25
 fi
 
 

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -76,6 +76,7 @@ _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" clippy --workspace -
   --deny=clippy::integer_arithmetic \
   --deny=clippy::manual_let_else \
   --deny=clippy::used_underscore_binding \
+  --allow=clippy::items-after-test-module \
   "${nightly_clippy_allows[@]}"
 
 # temporarily run stable clippy as well to scan the codebase for
@@ -89,6 +90,7 @@ _ scripts/cargo-for-all-lock-files.sh -- clippy --workspace  --tests --bins --ex
   --deny=clippy::default_trait_access \
   --deny=clippy::integer_arithmetic \
   --deny=clippy::manual_let_else \
+  --allow=clippy::items-after-test-module \
   --deny=clippy::used_underscore_binding
 
 if [[ -n $CI ]]; then

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1003,7 +1003,8 @@ pub fn keypair_from_path(
     keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
-    let keypair = encodable_key_from_path(matches, path, keypair_name)?;
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let keypair = encodable_key_from_path(path, keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&keypair, "pubkey");
     }
@@ -1050,7 +1051,8 @@ pub fn elgamal_keypair_from_path(
     elgamal_keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<ElGamalKeypair, Box<dyn error::Error>> {
-    let elgamal_keypair = encodable_key_from_path(matches, path, elgamal_keypair_name)?;
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let elgamal_keypair = encodable_key_from_path(path, elgamal_keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&elgamal_keypair, "ElGamal pubkey");
     }
@@ -1104,13 +1106,14 @@ pub fn ae_key_from_path(
     path: &str,
     key_name: &str,
 ) -> Result<AeKey, Box<dyn error::Error>> {
-    encodable_key_from_path(matches, path, key_name)
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    encodable_key_from_path(path, key_name, skip_validation)
 }
 
 fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
-    matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
+    skip_validation: bool,
 ) -> Result<K, Box<dyn error::Error>> {
     let SignerSource {
         kind,
@@ -1118,15 +1121,12 @@ fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
         legacy,
     } = parse_signer_source(path)?;
     match kind {
-        SignerSourceKind::Prompt => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(encodable_key_from_seed_phrase(
-                keypair_name,
-                skip_validation,
-                derivation_path,
-                legacy,
-            )?)
-        }
+        SignerSourceKind::Prompt => Ok(encodable_key_from_seed_phrase(
+            keypair_name,
+            skip_validation,
+            derivation_path,
+            legacy,
+        )?),
         SignerSourceKind::Filepath(path) => match K::read_from_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
+rustversion = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1972,6 +1972,10 @@ impl ClusterInfo {
     // Returns a predicate checking if the pull request is from a valid
     // address, and if the address have responded to a ping request. Also
     // appends ping packets for the addresses which need to be (re)verified.
+    //
+    // allow lint false positive trait bound requirement (`CryptoRng` only
+    // implemented on `&'a mut T`
+    #[rustversion::attr(since(1.73), allow(clippy::needless_pass_by_ref_mut))]
     fn check_pull_request<'a, R>(
         &'a self,
         now: Instant,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5018,6 +5018,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -185,6 +185,7 @@ impl<'a> AccountInfo<'a> {
     pub fn assign(&self, new_owner: &Pubkey) {
         // Set the non-mut owner field
         unsafe {
+            #[allow(invalid_reference_casting)]
             std::ptr::write_volatile(
                 self.owner as *const Pubkey as *mut [u8; 32],
                 new_owner.to_bytes(),


### PR DESCRIPTION
#### Problem

ci is targeting a _four_ month old nightly toolchain. as a result, [bumping stable to 1.72](https://github.com/solana-labs/solana/pull/32961) leads to nightly incremental builds failing on unstable symbols in build artifacts that have since stabilized :upside_down_face: 

there are still a couple controversial lints/workarounds to debate here, hence draft. we'll pop them out to separate PR(s) as resolved

#### Summary of Changes

bump nightly toolchain to 2023-08-25

_**REQUIRES:**_ https://github.com/solana-labs/solana/pull/33047