### PR TITLE
Use 256K buffer for accounts-hash dedup result file writer

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -86,7 +86,8 @@ impl AccountHashesFile {
             // we have hashes to write but no file yet, so create a file that will auto-delete on drop
             self.count_and_writer = Some((
                 0,
-                BufWriter::new(
+                BufWriter::with_capacity(
+                    256 * 1024,
                     tempfile_in(&self.dir_for_temp_cache_files).unwrap_or_else(|err| {
                         panic!(
                             "Unable to create file within {}: {err}",

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -87,7 +87,7 @@ impl AccountHashesFile {
             self.count_and_writer = Some((
                 0,
                 BufWriter::with_capacity(
-                    256 * 1024,
+                    32 * 1024,
                     tempfile_in(&self.dir_for_temp_cache_files).unwrap_or_else(|err| {
                         panic!(
                             "Unable to create file within {}: {err}",


### PR DESCRIPTION
#### Problem

By default, rust BufferedWriter use 8K buffer. Based on the size of hash files, we could increase the buffer size of 256K to improve file write performance by reducing the number of file write kernel calls. 


#### Summary of Changes

Use 256K buffer for accounts hash file writes

The following are the benchmark result with ledger-tool. The first measure is extracted from running #33009. The second measurement is extracted from running this PR and #33009.

- base (#33009) 

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  3381527i
pubkey_bin_search_us                15508835i
```

- This PR + #33009

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  2824735i
pubkey_bin_search_us                10472585i
```



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
