### PR TITLE
rekey stake_redelegate_instruction feature

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -282,7 +282,7 @@ pub mod stake_deactivate_delinquent_instruction {
 }
 
 pub mod stake_redelegate_instruction {
-    solana_sdk::declare_id!("3EPmAX94PvVJCjMeFfRFvj4avqCPL8vv3TGsZQg7ydMx");
+    solana_sdk::declare_id!("GUrp5BKMyDazsAp9mBoVD6orE5ihXNRPC3jkBRfx6Lq7");
 }
 
 pub mod vote_withdraw_authority_may_change_authorized_voter {


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/26765

devnet has this feature activated already without the fixes from #32606
unfortunately. Fortunately, testnet it's now having this feature disabled
thanks to the 1.14/1.16 restart. 

In order to turn off this feature from devnet during the next devnent upgrade,
we will need to rekey this feature. 

#### Summary of Changes

Rekey stake_redelegate_instruction feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
