### PR TITLE
purge duplicated bank prioritization fee from cache

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -197,7 +197,7 @@ impl OptimisticallyConfirmedBankTracker {
                 );
 
                 // finalize block's minimum prioritization fee cache for this bank
-                prioritization_fee_cache.finalize_priority_fee(bank.slot());
+                prioritization_fee_cache.finalize_priority_fee(bank.slot(), bank.bank_id());
             }
         } else if bank.slot() > bank_forks.read().unwrap().root() {
             pending_optimistically_confirmed_banks.insert(bank.slot());
@@ -282,7 +282,6 @@ impl OptimisticallyConfirmedBankTracker {
                 if let Some(bank) = bank {
                     let mut w_optimistically_confirmed_bank =
                         optimistically_confirmed_bank.write().unwrap();
-                    let bank_id = bank.bank_id();
 
                     if bank.slot() > w_optimistically_confirmed_bank.bank.slot() && bank.is_frozen()
                     {
@@ -304,9 +303,6 @@ impl OptimisticallyConfirmedBankTracker {
                         *highest_confirmed_slot = slot;
                     }
                     drop(w_optimistically_confirmed_bank);
-
-                    // finalize block's minimum prioritization fee cache for this bank
-                    prioritization_fee_cache.finalize_priority_fee(slot, bank_id);
                 } else if slot > bank_forks.read().unwrap().root() {
                     pending_optimistically_confirmed_banks.insert(slot);
                 } else {
@@ -321,7 +317,6 @@ impl OptimisticallyConfirmedBankTracker {
             }
             BankNotification::Frozen(bank) => {
                 let frozen_slot = bank.slot();
-                let frozen_bank_id = bank.bank_id();
                 if let Some(parent) = bank.parent() {
                     let num_successful_transactions = bank
                         .transaction_count()
@@ -366,9 +361,6 @@ impl OptimisticallyConfirmedBankTracker {
                         w_optimistically_confirmed_bank.bank = bank;
                     }
                     drop(w_optimistically_confirmed_bank);
-
-                    // finalize block's minimum prioritization fee cache for this bank
-                    prioritization_fee_cache.finalize_priority_fee(frozen_slot, frozen_bank_id);
                 }
             }
             BankNotification::NewRootBank(bank) => {

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -282,6 +282,7 @@ impl OptimisticallyConfirmedBankTracker {
                 if let Some(bank) = bank {
                     let mut w_optimistically_confirmed_bank =
                         optimistically_confirmed_bank.write().unwrap();
+                    let bank_id = bank.bank_id();
 
                     if bank.slot() > w_optimistically_confirmed_bank.bank.slot() && bank.is_frozen()
                     {
@@ -303,6 +304,9 @@ impl OptimisticallyConfirmedBankTracker {
                         *highest_confirmed_slot = slot;
                     }
                     drop(w_optimistically_confirmed_bank);
+
+                    // finalize block's minimum prioritization fee cache for this bank
+                    prioritization_fee_cache.finalize_priority_fee(slot, bank_id);
                 } else if slot > bank_forks.read().unwrap().root() {
                     pending_optimistically_confirmed_banks.insert(slot);
                 } else {
@@ -317,6 +321,7 @@ impl OptimisticallyConfirmedBankTracker {
             }
             BankNotification::Frozen(bank) => {
                 let frozen_slot = bank.slot();
+                let frozen_bank_id = bank.bank_id();
                 if let Some(parent) = bank.parent() {
                     let num_successful_transactions = bank
                         .transaction_count()
@@ -361,6 +366,9 @@ impl OptimisticallyConfirmedBankTracker {
                         w_optimistically_confirmed_bank.bank = bank;
                     }
                     drop(w_optimistically_confirmed_bank);
+
+                    // finalize block's minimum prioritization fee cache for this bank
+                    prioritization_fee_cache.finalize_priority_fee(frozen_slot, frozen_bank_id);
                 }
             }
             BankNotification::NewRootBank(bank) => {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8658,6 +8658,7 @@ pub mod tests {
             0
         );
         let slot0 = rpc.working_bank().slot();
+        let bank0_id = rpc.working_bank().bank_id();
         let account0 = Pubkey::new_unique();
         let account1 = Pubkey::new_unique();
         let account2 = Pubkey::new_unique();
@@ -8677,7 +8678,7 @@ pub mod tests {
         ];
         rpc.update_prioritization_fee_cache(transactions);
         let cache = rpc.get_prioritization_fee_cache();
-        cache.finalize_priority_fee(slot0);
+        cache.finalize_priority_fee(slot0, bank0_id);
         wait_for_cache_blocks(cache, 1);
 
         let request = create_test_request("getRecentPrioritizationFees", None);
@@ -8721,6 +8722,7 @@ pub mod tests {
 
         rpc.advance_bank_to_confirmed_slot(1);
         let slot1 = rpc.working_bank().slot();
+        let bank1_id = rpc.working_bank().bank_id();
         let price1 = 11;
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
@@ -8737,7 +8739,7 @@ pub mod tests {
         ];
         rpc.update_prioritization_fee_cache(transactions);
         let cache = rpc.get_prioritization_fee_cache();
-        cache.finalize_priority_fee(slot1);
+        cache.finalize_priority_fee(slot1, bank1_id);
         wait_for_cache_blocks(cache, 2);
 
         let request = create_test_request("getRecentPrioritizationFees", None);

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -19,6 +19,9 @@ struct PrioritizationFeeMetrics {
     // Count of transactions that have zero prioritization fee.
     non_prioritized_transactions_count: u64,
 
+    // Count of attempted update on finalized PrioritizationFee
+    attempted_update_on_finalized_fee_count: u64,
+
     // Total prioritization fees included in this slot.
     total_prioritization_fee: u64,
 
@@ -39,6 +42,10 @@ impl PrioritizationFeeMetrics {
 
     fn accumulate_total_update_elapsed_us(&mut self, val: u64) {
         saturating_add_assign!(self.total_update_elapsed_us, val);
+    }
+
+    fn increment_attempted_update_on_finalized_fee_count(&mut self, val: u64) {
+        saturating_add_assign!(self.attempted_update_on_finalized_fee_count, val);
     }
 
     fn update_prioritization_fee(&mut self, fee: u64) {
@@ -80,6 +87,11 @@ impl PrioritizationFeeMetrics {
             (
                 "non_prioritized_transactions_count",
                 self.non_prioritized_transactions_count as i64,
+                i64
+            ),
+            (
+                "attempted_update_on_finalized_fee_count",
+                self.attempted_update_on_finalized_fee_count as i64,
                 i64
             ),
             (
@@ -159,22 +171,27 @@ impl PrioritizationFee {
     ) -> Result<(), PrioritizationFeeError> {
         let (_, update_time) = measure!(
             {
-                if transaction_fee < self.min_transaction_fee {
-                    self.min_transaction_fee = transaction_fee;
-                }
+                if !self.is_finalized {
+                    if transaction_fee < self.min_transaction_fee {
+                        self.min_transaction_fee = transaction_fee;
+                    }
 
-                for write_account in writable_accounts.iter() {
-                    self.min_writable_account_fees
-                        .entry(*write_account)
-                        .and_modify(|write_lock_fee| {
-                            *write_lock_fee = std::cmp::min(*write_lock_fee, transaction_fee)
-                        })
-                        .or_insert(transaction_fee);
-                }
+                    for write_account in writable_accounts.iter() {
+                        self.min_writable_account_fees
+                            .entry(*write_account)
+                            .and_modify(|write_lock_fee| {
+                                *write_lock_fee = std::cmp::min(*write_lock_fee, transaction_fee)
+                            })
+                            .or_insert(transaction_fee);
+                    }
 
-                self.metrics
-                    .accumulate_total_prioritization_fee(transaction_fee);
-                self.metrics.update_prioritization_fee(transaction_fee);
+                    self.metrics
+                        .accumulate_total_prioritization_fee(transaction_fee);
+                    self.metrics.update_prioritization_fee(transaction_fee);
+                } else {
+                    self.metrics
+                        .increment_attempted_update_on_finalized_fee_count(1);
+                }
             },
             "update_time",
         );

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -118,6 +118,7 @@ impl PrioritizationFeeMetrics {
     }
 }
 
+#[derive(Debug)]
 pub enum PrioritizationFeeError {
     // Not able to get account locks from sanitized transaction, which is required to update block
     // minimum fees.

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -467,7 +467,12 @@ mod tests {
         bank: Arc<Bank>,
         txs: impl Iterator<Item = &'a SanitizedTransaction> + ExactSizeIterator,
     ) {
-        let expected_update_count = txs.len() as u64;
+        let expected_update_count = prioritization_fee_cache
+            .metrics
+            .successful_transaction_update_count
+            .load(Ordering::Relaxed)
+            .saturating_add(txs.len() as u64);
+
         prioritization_fee_cache.update(&bank, txs);
 
         // wait till expected number of transaction updates have occurred...

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -129,7 +129,7 @@ enum CacheServiceUpdate {
         transaction_fee: u64,
         writable_accounts: Arc<Vec<Pubkey>>,
     },
-    BankFrozen {
+    BankFinalized {
         slot: Slot,
         bank_id: BankId,
     },
@@ -277,7 +277,7 @@ impl PrioritizationFeeCache {
     /// by pruning irrelevant accounts to save space, and marking its availability for queries.
     pub fn finalize_priority_fee(&self, slot: Slot, bank_id: BankId) {
         self.sender
-            .send(CacheServiceUpdate::BankFrozen { slot, bank_id })
+            .send(CacheServiceUpdate::BankFinalized { slot, bank_id })
             .unwrap_or_else(|err| {
                 warn!(
                     "prioritization fee cache signalling bank frozen failed: {:?}",
@@ -369,7 +369,7 @@ impl PrioritizationFeeCache {
                     writable_accounts,
                     metrics.clone(),
                 ),
-                CacheServiceUpdate::BankFrozen { slot, bank_id } => {
+                CacheServiceUpdate::BankFinalized { slot, bank_id } => {
                     Self::finalize_slot(cache.clone(), &slot, &bank_id, metrics.clone());
 
                     metrics.report(slot);


### PR DESCRIPTION
#### Problem

Duplicated banks can add inconsistent data to prioritization_fee_cache.

#### Summary of Changes
- purge duplicated bank's priority_fee from cache during finalization
- add test for the described scenario
- add metrics counts to monitor such occurrences 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
