### PR TITLE
round two preliminaries for bumping nightly to 2023-08-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,6 +6023,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version 0.4.0",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1003,7 +1003,8 @@ pub fn keypair_from_path(
     keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
-    let keypair = encodable_key_from_path(matches, path, keypair_name)?;
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let keypair = encodable_key_from_path(path, keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&keypair, "pubkey");
     }
@@ -1050,7 +1051,8 @@ pub fn elgamal_keypair_from_path(
     elgamal_keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<ElGamalKeypair, Box<dyn error::Error>> {
-    let elgamal_keypair = encodable_key_from_path(matches, path, elgamal_keypair_name)?;
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let elgamal_keypair = encodable_key_from_path(path, elgamal_keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&elgamal_keypair, "ElGamal pubkey");
     }
@@ -1104,13 +1106,14 @@ pub fn ae_key_from_path(
     path: &str,
     key_name: &str,
 ) -> Result<AeKey, Box<dyn error::Error>> {
-    encodable_key_from_path(matches, path, key_name)
+    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    encodable_key_from_path(path, key_name, skip_validation)
 }
 
 fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
-    matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
+    skip_validation: bool,
 ) -> Result<K, Box<dyn error::Error>> {
     let SignerSource {
         kind,
@@ -1118,15 +1121,12 @@ fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
         legacy,
     } = parse_signer_source(path)?;
     match kind {
-        SignerSourceKind::Prompt => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(encodable_key_from_seed_phrase(
-                keypair_name,
-                skip_validation,
-                derivation_path,
-                legacy,
-            )?)
-        }
+        SignerSourceKind::Prompt => Ok(encodable_key_from_seed_phrase(
+            keypair_name,
+            skip_validation,
+            derivation_path,
+            legacy,
+        )?),
         SignerSourceKind::Filepath(path) => match K::read_from_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
+rustversion = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1972,6 +1972,10 @@ impl ClusterInfo {
     // Returns a predicate checking if the pull request is from a valid
     // address, and if the address have responded to a ping request. Also
     // appends ping packets for the addresses which need to be (re)verified.
+    //
+    // allow lint false positive trait bound requirement (`CryptoRng` only
+    // implemented on `&'a mut T`
+    #[rustversion::attr(since(1.73), allow(clippy::needless_pass_by_ref_mut))]
     fn check_pull_request<'a, R>(
         &'a self,
         now: Instant,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5018,6 +5018,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",


### PR DESCRIPTION
#### Problem

i left these off of #33047 since they might stir contention. the remainder of compatibility changes for bumping toolchain(s) need to go in with the bump as they reference lints that the current toolchain(s) don't know about

#### Summary of Changes

* work around nightly ice triggered by something something `const ref` in generic context
* allow `clippy::needless_pass_by_ref_mut` to avoid false-positive ignoring trait bounds