### PR TITLE
ci: allocate more threads for gossip tests

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -11,3 +11,11 @@ path = "junit.xml"
 [[profile.ci.overrides]]
 filter = "package(solana-zk-token-proof-program-tests) & test(/^test_batched_range_proof_u256$/)"
 threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = "package(solana-gossip) & test(/^test_star_network_push_star_200/)"
+threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = "package(solana-gossip) & test(/^test_star_network_push_ring_200/)"
+threads-required = "num-cpus"


### PR DESCRIPTION
#### Problem

these two tests 

- test_star_network_push_star_200
- test_star_network_push_ring_200

become flaky when I migrated `cargo test` to `nextest`. I guess there was a thread issue at that time, and I always forgot to send this PR 🫠. I have tested this one and seems to work in my devbox.

thanks https://discord.com/channels/428295358100013066/560503042458517505/1146486337218814022 for reminding me of this one
