### PR TITLE
rework sorting during generate_index

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -281,7 +281,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
 
     /// for each item in `items`, get the hash value when hashed with `random`.
     /// Return a vec of tuples:
-    /// (hash_value, key, value)
+    /// (hash_value, index in `items`)
     fn index_entries(items: &[(Pubkey, T)], random: u64) -> Vec<(u64, usize)> {
         let mut inserts = Vec::with_capacity(items.len());
         items.iter().enumerate().for_each(|(i, (key, _v))| {
@@ -291,8 +291,8 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         inserts
     }
 
-    /// insert all of `items` into the index.
-    /// return duplicates
+    /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
+    /// For any pubkeys that already exist, the index in `items` of the failed insertion and the existing data (previously put in the index) are returned.
     pub(crate) fn batch_insert_non_duplicates(&mut self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
         assert!(
             !self.at_least_one_entry_deleted,

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -125,7 +125,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     }
 
     /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
-    /// For any pubkeys that already exist, the failed insertion data and the existing data are returned.
+    /// For any pubkeys that already exist, the index in `items` of the failed insertion and the existing data (previously put in the index) are returned.
     pub fn batch_insert_non_duplicates(&self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
         let mut bucket = self.get_write_bucket();
         bucket.as_mut().unwrap().batch_insert_non_duplicates(items)

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -126,16 +126,9 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
 
     /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
     /// For any pubkeys that already exist, the failed insertion data and the existing data are returned.
-    pub fn batch_insert_non_duplicates(
-        &self,
-        items: impl Iterator<Item = (Pubkey, T)>,
-        count: usize,
-    ) -> Vec<(Pubkey, T, T)> {
+    pub fn batch_insert_non_duplicates(&self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
         let mut bucket = self.get_write_bucket();
-        bucket
-            .as_mut()
-            .unwrap()
-            .batch_insert_non_duplicates(items, count)
+        bucket.as_mut().unwrap().batch_insert_non_duplicates(items)
     }
 
     pub fn update<F>(&self, key: &Pubkey, updatefn: F)

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -507,13 +507,9 @@ mod tests {
                                 );
                                 duplicates += 1;
                             }
-                            let count = batch_additions.len();
                             assert_eq!(
                                 map.get_bucket_from_index(0)
-                                    .batch_insert_non_duplicates(
-                                        batch_additions.into_iter(),
-                                        count,
-                                    )
+                                    .batch_insert_non_duplicates(&batch_additions,)
                                     .len(),
                                 duplicates
                             );


### PR DESCRIPTION
#### Problem
Reducing startup time by reducing index generation time.

#### Summary of Changes
When sorting before inserting into disk index, keep index to data to insert instead of copying values (such as pubkeys) around.
This also allows us to keep the data().len() around at a higher level. When we later deal with duplicates, we will have the data length already and not have to look it up again for each duplicate account.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
