### PR TITLE
hash dedup mmap

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -111,6 +111,40 @@ impl AccountHashesFile {
         );
         count_and_writer.0 += 1;
     }
+
+    pub fn init(&mut self) {
+        if self.count_and_writer.is_none() {
+            // we have hashes to write but no file yet, so create a file that will auto-delete on drop
+            self.count_and_writer = Some((
+                0,
+                BufWriter::new(
+                    tempfile_in(&self.dir_for_temp_cache_files).unwrap_or_else(|err| {
+                        panic!(
+                            "Unable to create file within {}: {err}",
+                            self.dir_for_temp_cache_files.display()
+                        )
+                    }),
+                ),
+            ));
+        }
+    }
+
+    pub fn write2(&mut self, hash: &Hash) {
+        let count_and_writer = self.count_and_writer.as_mut().unwrap();
+        assert_eq!(
+            std::mem::size_of::<Hash>(),
+            count_and_writer
+                .1
+                .write(hash.as_ref())
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "Unable to write file within {}: {err}",
+                        self.dir_for_temp_cache_files.display()
+                    )
+                })
+        );
+        count_and_writer.0 += 1;
+    }
 }
 
 /// parameters to calculate accounts hash
@@ -1037,6 +1071,8 @@ impl<'a> AccountsHasher<'a> {
             count_and_writer: None,
             dir_for_temp_cache_files: self.dir_for_temp_cache_files.clone(),
         };
+        hashes.init();
+
         // initialize 'first_items', which holds the current lowest item in each slot group
         sorted_data_by_pubkey
             .iter()
@@ -1098,7 +1134,7 @@ impl<'a> AccountsHasher<'a> {
                     overall_sum = Self::checked_cast_for_capitalization(
                         item.lamports as u128 + overall_sum as u128,
                     );
-                    hashes.write(&item.hash);
+                    hashes.write2(&item.hash);
                 }
             } else {
                 // if lamports == 0, check if they should be included
@@ -1107,7 +1143,7 @@ impl<'a> AccountsHasher<'a> {
                     // the hash of its pubkey
                     let hash = blake3::hash(bytemuck::bytes_of(&item.pubkey));
                     let hash = Hash::new_from_array(hash.into());
-                    hashes.write(&hash);
+                    hashes.write2(&hash);
                 }
             }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -834,11 +834,55 @@ impl<'a> AccountsHasher<'a> {
         (hashes, lamports_total)
     }
 
+    fn get_item2<'b>(
+        min_index: usize,
+        bin: usize,
+        sorted_data_by_pubkey: &[&'b [CalculateHashIntermediate]],
+        first_items: &mut Vec<(usize, usize, &'b Pubkey)>,
+        binner: &PubkeyBinCalculator24,
+    ) -> &'b CalculateHashIntermediate {
+        let (division_index, mut index, key) = first_items[min_index];
+        let division_data = &sorted_data_by_pubkey[division_index];
+        index += 1;
+        let mut end;
+        loop {
+            end = index >= division_data.len();
+            if end {
+                break;
+            }
+            // still more items where we found the previous key, so just increment the index for that slot group, skipping all pubkeys that are equal
+            let next_key = &division_data[index].pubkey;
+            if next_key == key {
+                index += 1;
+                continue; // duplicate entries of same pubkey, so keep skipping
+            }
+
+            if binner.bin_from_pubkey(next_key) > bin {
+                // the next pubkey is not in our bin
+                end = true;
+                break;
+            }
+
+            // point to the next pubkey > key
+            first_items[min_index] = (division_index, index, next_key);
+            break;
+        }
+        if end {
+            // stop looking in this vector - we exhausted it
+            first_items.remove(min_index);
+        }
+
+        // this is the previous first item that was requested
+        &division_data[index - 1]
+    }
+
     /// returns the item referenced by `min_index`
     ///   updates `indexes` to skip over the pubkey and its duplicates
     ///   updates `first_items` to point to the next pubkey
     /// or removes the entire pubkey division entries (for `min_index`) if the referenced pubkey is the last entry in the same `bin`
     ///     removed from: `first_items`, `indexes`, and `first_item_pubkey_division`
+    ///
+    #[allow(dead_code)]
     fn get_item<'b>(
         min_index: usize,
         bin: usize,
@@ -982,11 +1026,10 @@ impl<'a> AccountsHasher<'a> {
         let binner = PubkeyBinCalculator24::new(bins);
 
         let len = sorted_data_by_pubkey.len();
-        let mut indexes = Vec::with_capacity(len);
+
+        // (division_index, index, &pubkey) - 32 bytes
         let mut first_items = Vec::with_capacity(len);
-        // map from index of an item in first_items[] to index of the corresponding item in sorted_data_by_pubkey[]
-        // this will change as items in sorted_data_by_pubkey[] are exhausted
-        let mut first_item_to_pubkey_division = Vec::with_capacity(len);
+
         let mut hashes = AccountHashesFile {
             count_and_writer: None,
             dir_for_temp_cache_files: self.dir_for_temp_cache_files.clone(),
@@ -999,10 +1042,8 @@ impl<'a> AccountsHasher<'a> {
                 let first_pubkey_in_bin =
                     Self::find_first_pubkey_in_bin(hash_data, pubkey_bin, bins, &binner, stats);
                 if let Some(first_pubkey_in_bin) = first_pubkey_in_bin {
-                    let k = hash_data[first_pubkey_in_bin].pubkey;
-                    first_items.push(k);
-                    first_item_to_pubkey_division.push(i);
-                    indexes.push(first_pubkey_in_bin);
+                    let k = &hash_data[first_pubkey_in_bin].pubkey;
+                    first_items.push((i, first_pubkey_in_bin, k))
                 }
             });
         let mut overall_sum = 0;
@@ -1013,14 +1054,14 @@ impl<'a> AccountsHasher<'a> {
         while !first_items.is_empty() {
             let loop_stop = { first_items.len() - 1 }; // we increment at the beginning of the loop
             let mut min_index = 0;
-            let mut min_pubkey = first_items[min_index];
+            let mut min_pubkey = first_items[min_index].2;
             let mut first_item_index = 0; // we will start iterating at item 1. +=1 is first instruction in loop
 
             // this loop iterates over each slot group to find the minimum pubkey at the maximum slot
             // it also identifies duplicate pubkey entries at lower slots and remembers those to skip them after
             while first_item_index < loop_stop {
                 first_item_index += 1;
-                let key = &first_items[first_item_index];
+                let key = &first_items[first_item_index].2;
                 let cmp = min_pubkey.cmp(key);
                 match cmp {
                     std::cmp::Ordering::Less => {
@@ -1039,13 +1080,11 @@ impl<'a> AccountsHasher<'a> {
                 min_index = first_item_index;
             }
             // get the min item, add lamports, get hash
-            let item = Self::get_item(
+            let item = Self::get_item2(
                 min_index,
                 pubkey_bin,
-                &mut first_items,
                 sorted_data_by_pubkey,
-                &mut indexes,
-                &mut first_item_to_pubkey_division,
+                &mut first_items,
                 &binner,
             );
 
@@ -1074,13 +1113,11 @@ impl<'a> AccountsHasher<'a> {
                 // reverse this list because get_item can remove first_items[*i] when *i is exhausted
                 //  and that would mess up subsequent *i values
                 duplicate_pubkey_indexes.iter().rev().for_each(|i| {
-                    Self::get_item(
+                    Self::get_item2(
                         *i,
                         pubkey_bin,
-                        &mut first_items,
                         sorted_data_by_pubkey,
-                        &mut indexes,
-                        &mut first_item_to_pubkey_division,
+                        &mut first_items,
                         &binner,
                     );
                 });

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -20,7 +20,7 @@ use {
         borrow::Borrow,
         convert::TryInto,
         fs::File,
-        io::{BufWriter, Write},
+        io::{BufWriter, Seek, Write},
         path::PathBuf,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -120,8 +120,6 @@ impl AccountHashesFile {
     }
 
     pub fn write_batch(&mut self, hashes: &[Hash]) {
-        use std::io::{Seek, SeekFrom, Write};
-
         let file = Some(
             tempfile_in(&self.dir_for_temp_cache_files).unwrap_or_else(|err| {
                 panic!(
@@ -168,7 +166,12 @@ impl AccountHashesFile {
 
         map[..size].copy_from_slice(hash_bytes);
 
-        error!("mmap_size={}, data_size={}", map.len(), size);
+        error!(
+            "mmap_size={}, data_size={}, hash_num={}",
+            map.len(),
+            size,
+            hashes.len()
+        );
 
         self.mmap_file = Some((size, MmapAccountHashesFile { mmap: map }));
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -128,7 +128,7 @@ impl AccountHashesFile {
             ));
         }
         let n = hashes.len();
-        let size = n * std::mem::size_of::<Hash>();
+        let size = std::mem::size_of_val(hashes);
         let count_and_writer = self.count_and_writer.as_mut().unwrap();
 
         let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -173,7 +173,7 @@ impl AccountHashesFile {
             hashes.len()
         );
 
-        self.mmap_file = Some((size, MmapAccountHashesFile { mmap: map }));
+        self.mmap_file = Some((hashes.len(), MmapAccountHashesFile { mmap: map }));
 
         // mut_mmap.deref_mut().write_all(data_to_write).unwrap();
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -166,7 +166,10 @@ impl AccountHashesFile {
 
         let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
 
-        (&mut map[..]).write_all(hash_bytes).unwrap();
+        map[..size].copy_from_slice(hash_bytes);
+
+        error!("mmap_size={}, data_size={}", map.len(), size);
+
         self.mmap_file = Some((size, MmapAccountHashesFile { mmap: map }));
 
         // mut_mmap.deref_mut().write_all(data_to_write).unwrap();

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -165,7 +165,12 @@ impl AccountHashesFile {
         let (_, t1) = measure_us!({
             let hash_bytes =
                 unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
-            map[..size].copy_from_slice(hash_bytes);
+            //map[..size].copy_from_slice(hash_bytes);
+            for i in 0..size {
+                unsafe {
+                    *map.get_unchecked_mut(i) = *hash_bytes.get_unchecked(i);
+                }
+            }
         });
 
         let d1 = map[size - 2];

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -162,9 +162,24 @@ impl AccountHashesFile {
             std::process::exit(1);
         });
 
-        let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
+        // let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
+        // map[..size].copy_from_slice(hash_bytes);
 
-        map[..size].copy_from_slice(hash_bytes);
+        let mut i = 0;
+        for h in hashes {
+            let start = i * std::mem::size_of::<Hash>();
+            let end = start + std::mem::size_of::<Hash>();
+
+            let slice = &map[start..end];
+
+            let p = unsafe {
+                let item = slice.as_ptr() as *mut Hash;
+                &mut *item
+            };
+
+            *p = h.clone();
+            i += 1;
+        }
 
         error!(
             "mmap_size={}, data_size={}, hash_num={}",

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -162,24 +162,31 @@ impl AccountHashesFile {
             std::process::exit(1);
         });
 
-        // let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
-        // map[..size].copy_from_slice(hash_bytes);
+        let (_, t1) = measure_us!({
+            let hash_bytes =
+                unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
+            map[..size].copy_from_slice(hash_bytes);
+        });
 
-        let mut i = 0;
-        for h in hashes {
-            let start = i * std::mem::size_of::<Hash>();
-            let end = start + std::mem::size_of::<Hash>();
+        let (_, t2) = measure_us!({
+            let mut i = 0;
+            for h in hashes {
+                let start = i * std::mem::size_of::<Hash>();
+                let end = start + std::mem::size_of::<Hash>();
 
-            let slice = &map[start..end];
+                let slice = &map[start..end];
 
-            let p = unsafe {
-                let item = slice.as_ptr() as *mut Hash;
-                &mut *item
-            };
+                let p = unsafe {
+                    let item = slice.as_ptr() as *mut Hash;
+                    &mut *item
+                };
 
-            *p = h.clone();
-            i += 1;
-        }
+                *p = h.clone();
+                i += 1;
+            }
+        });
+
+        info!("haha batch: {} {}", t1, t2);
 
         error!(
             "mmap_size={}, data_size={}, hash_num={}",

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -168,8 +168,10 @@ impl AccountHashesFile {
             map[..size].copy_from_slice(hash_bytes);
         });
 
+        let d1 = map[size - 2];
+
+        let mut i = 0;
         let (_, t2) = measure_us!({
-            let mut i = 0;
             for h in hashes {
                 let start = i * std::mem::size_of::<Hash>();
                 let end = start + std::mem::size_of::<Hash>();
@@ -186,7 +188,9 @@ impl AccountHashesFile {
             }
         });
 
-        info!("haha batch: {} {}", t1, t2);
+        let d2 = map[size - 2];
+
+        info!("haha batch: {:?}", (t1, t2, size, i * 32, d1, d2));
 
         error!(
             "mmap_size={}, data_size={}, hash_num={}",

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -28,9 +28,10 @@ impl PubkeyBinCalculator24 {
         }
     }
 
+    #[inline]
     pub(crate) fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
         let as_ref = pubkey.as_ref();
-        ((as_ref[0] as usize * 256 + as_ref[1] as usize) * 256 + as_ref[2] as usize)
+        ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
             >> self.shift_bits
     }
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -130,7 +130,7 @@ impl AccountsHashVerifier {
                         .unwrap_or(0)
                 );
                 info!("AccountsHashVerifier has stopped");
-                panic!("Done");
+                std::process::exit(0);
             })
             .unwrap();
         Self {

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -130,6 +130,7 @@ impl AccountsHashVerifier {
                         .unwrap_or(0)
                 );
                 info!("AccountsHashVerifier has stopped");
+                panic!("Done");
             })
             .unwrap();
         Self {

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -130,7 +130,6 @@ impl AccountsHashVerifier {
                         .unwrap_or(0)
                 );
                 info!("AccountsHashVerifier has stopped");
-                std::process::exit(0);
             })
             .unwrap();
         Self {


### PR DESCRIPTION
#### Problem

- base (master) 

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages a | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -e "pubkey_bin_search_us\|eliminate_zeros_us"
eliminate_zeros_us                  4,408,444i
pubkey_bin_search_us                10,830,942i
```

- this PR (slice copy)
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  25,502,659i
pubkey_bin_search_us                23,073,092i

```

mmap is much slower. :(

probably due to tlb shootdown.

- element by element copy 
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  7,096,017i
pubkey_bin_search_us                26390451i
```
element by element copy is faster. but it is still lower than bufwriter (master).


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
