### PR TITLE
Add #[repr(C)] for more future-proof byte mangling

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12561,13 +12561,15 @@ pub mod tests {
 
     #[test]
     fn test_hash_stored_account() {
-        // This test uses some UNSAFE tricks to detect most of account's field
-        // addition and deletion without changing the hash code
+        // This test uses some UNSAFE tricks to detect most of hashing algo changes, resulting from
+        // account's field additions and deletions of StoredAccountMeta and AccountSharedData and
+        // hashing-order changes.
 
         const ACCOUNT_DATA_LEN: usize = 3;
-        // the type of InputTuple elements must not contain references;
+        // the type of InputFields elements must not contain references;
         // they should be simple scalars or data blobs
-        type InputTuple = (
+        #[repr(C)]
+        struct InputFields(
             Slot,
             StoredMeta,
             AccountMeta,
@@ -12575,19 +12577,22 @@ pub mod tests {
             usize, // for StoredAccountMeta::offset
             Hash,
         );
-        const INPUT_LEN: usize = std::mem::size_of::<InputTuple>();
+        const INPUT_LEN: usize = std::mem::size_of::<InputFields>();
         type InputBlob = [u8; INPUT_LEN];
         let mut blob: InputBlob = [0u8; INPUT_LEN];
 
-        // spray memory with decreasing counts so that, data layout can be detected.
+        // spray memory with decreasing integers so that, data layout change and/or hashing
+        // reordering can be detected.
         for (i, byte) in blob.iter_mut().enumerate() {
             *byte = (INPUT_LEN - i) as u8;
         }
 
-        //UNSAFE: forcibly cast the special byte pattern to actual account fields.
-        let (slot, meta, account_meta, data, offset, hash): InputTuple =
-            unsafe { std::mem::transmute::<InputBlob, InputTuple>(blob) };
+        //UNSAFE: forcibly slice off actual fields from the special byte pattern.
+        let InputFields(slot, meta, account_meta, data, offset, hash) =
+            unsafe { std::mem::transmute::<InputBlob, InputFields>(blob) };
 
+        // When adding a field to AppendVecStoredAccountMeta, make sure this is sourced from
+        // InputFields as well after adding new corresponding one to it.
         let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
@@ -12599,9 +12604,9 @@ pub mod tests {
         let account = stored_account.to_account_shared_data();
 
         let expected_account_hash = if cfg!(debug_assertions) {
-            Hash::from_str("6qtBXmRrLdTdAV5bK6bZZJxQA4fPSUBxzQGq2BQSat25").unwrap()
+            Hash::from_str("8GiQSN2VvWASKPUuZgFkH4v66ihEanrDVXAkMFvLwEa8").unwrap()
         } else {
-            Hash::from_str("5HL9MtsQmxZQ8XSgcAhSkqnrayQFXUY8FT1JsHjDNKbi").unwrap()
+            Hash::from_str("9MYASra3mm8oXzMapYUonB6TcRsKFPtjhNXVgY3MPPUX").unwrap()
         };
 
         assert_eq!(


### PR DESCRIPTION
#### Problem

the setup part of the test introduced at https://github.com/solana-labs/solana/pull/7415#discussion_r1311294502 is fragile against rustc's abi-related changes.

For example, hashing change is needed due to updating rustc to 1.72: https://github.com/solana-labs/solana/pull/32961#discussion_r1311296564 

#### Summary of Changes

Use `repr(C)` to make test byte pattern generation more resilient to any abi changes.

i confirmed locally the updated hash in this pr is emitted now with both rust 1.69 and 1.72.

also some comment clarification is done for future me and others. :)