### PR TITLE
removes outdated check for merkle shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -893,7 +893,6 @@ pub fn should_discard_shred(
     root: Slot,
     max_slot: Slot,
     shred_version: u16,
-    should_drop_merkle_shreds: impl Fn(Slot) -> bool,
     stats: &mut ShredFetchStats,
 ) -> bool {
     debug_assert!(root < max_slot);
@@ -970,15 +969,9 @@ pub fn should_discard_shred(
     match shred_variant {
         ShredVariant::LegacyCode | ShredVariant::LegacyData => (),
         ShredVariant::MerkleCode(_) => {
-            if should_drop_merkle_shreds(slot) {
-                return true;
-            }
             stats.num_shreds_merkle_code = stats.num_shreds_merkle_code.saturating_add(1);
         }
         ShredVariant::MerkleData(_) => {
-            if should_drop_merkle_shreds(slot) {
-                return true;
-            }
             stats.num_shreds_merkle_data = stats.num_shreds_merkle_data.saturating_add(1);
         }
     }
@@ -1178,7 +1171,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats, ShredFetchStats::default());
@@ -1189,7 +1181,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats.index_overrun, 1);
@@ -1200,7 +1191,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats.index_overrun, 2);
@@ -1211,7 +1201,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats.index_overrun, 3);
@@ -1222,7 +1211,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats.index_overrun, 4);
@@ -1233,7 +1221,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(stats.bad_parent_offset, 1);
@@ -1254,7 +1241,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
 
@@ -1274,7 +1260,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(1, stats.index_out_of_bounds);
@@ -1295,7 +1280,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         packet.buffer_mut()[OFFSET_OF_SHRED_VARIANT] = u8::MAX;
@@ -1305,7 +1289,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(1, stats.bad_shred_type);
@@ -1317,7 +1300,6 @@ mod tests {
             root,
             max_slot,
             shred_version,
-            |_| false, // should_drop_merkle_shreds
             &mut stats
         ));
         assert_eq!(1, stats.bad_shred_type);

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -573,14 +573,6 @@ pub mod disable_turbine_fanout_experiments {
     solana_sdk::declare_id!("Gz1aLrbeQ4Q6PTSafCZcGWZXz91yVRi7ASFzFEr1U4sa");
 }
 
-pub mod drop_merkle_shreds {
-    solana_sdk::declare_id!("84zy5N23Q9vTZuLc9h1HWUtyM9yCFV2SCmyP9W9C3yHZ");
-}
-
-pub mod keep_merkle_shreds {
-    solana_sdk::declare_id!("HyNQzc7TMNmRhpVHXqDGjpsHzeQie82mDQXSF9hj7nAH");
-}
-
 pub mod move_serialized_len_ptr_in_cpi {
     solana_sdk::declare_id!("74CoWuBmt3rUVUrCb2JiSTvh6nXyBWUsK4SaMj3CtE3T");
 }
@@ -833,8 +825,6 @@ lazy_static! {
         (commission_updates_only_allowed_in_first_half_of_epoch::id(), "validator commission updates are only allowed in the first half of an epoch #29362"),
         (enable_turbine_fanout_experiments::id(), "enable turbine fanout experiments #29393"),
         (disable_turbine_fanout_experiments::id(), "disable turbine fanout experiments #29393"),
-        (drop_merkle_shreds::id(), "drop merkle shreds #29711"),
-        (keep_merkle_shreds::id(), "keep merkle shreds #29711"),
         (move_serialized_len_ptr_in_cpi::id(), "cpi ignore serialized_len_ptr #29592"),
         (update_hashes_per_tick::id(), "Update desired hashes per tick on epoch boundary"),
         (enable_big_mod_exp_syscall::id(), "add big_mod_exp syscall #28503"),

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -513,7 +513,7 @@ fn enable_turbine_fanout_experiments(shred_slot: Slot, root_bank: &Bank) -> bool
 
 // Returns true if the feature is effective for the shred slot.
 #[must_use]
-pub fn check_feature_activation(feature: &Pubkey, shred_slot: Slot, root_bank: &Bank) -> bool {
+fn check_feature_activation(feature: &Pubkey, shred_slot: Slot, root_bank: &Bank) -> bool {
     match root_bank.feature_set.activated_slot(feature) {
         None => false,
         Some(feature_slot) => {


### PR DESCRIPTION
#### Problem
No longer need to check and filter out Merkle shreds.

#### Summary of Changes
Removed outdated check for feature activation.