### PR TITLE
use shift for pubkey to bin calculation

### DIFF
--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -28,9 +28,10 @@ impl PubkeyBinCalculator24 {
         }
     }
 
+    #[inline]
     pub(crate) fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
         let as_ref = pubkey.as_ref();
-        ((as_ref[0] as usize * 256 + as_ref[1] as usize) * 256 + as_ref[2] as usize)
+        ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
             >> self.shift_bits
     }
 


### PR DESCRIPTION
#### Problem

pubkey to bin calculation can be done with shift in a cheaper way.


#### Summary of Changes

use shift for pubkey bin calculation


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
