### PR TITLE
Removes the "unpacked entries so far" log at startup

### DIFF
--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -103,7 +103,6 @@ where
     let mut total_count: u64 = 0;
 
     let mut total_entries = 0;
-    let mut last_log_update = Instant::now();
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?;
@@ -189,11 +188,6 @@ where
         entry_processor(entry_path);
 
         total_entries += 1;
-        let now = Instant::now();
-        if now.duration_since(last_log_update).as_secs() >= 10 {
-            info!("unpacked {} entries so far...", total_entries);
-            last_log_update = now;
-        }
     }
     info!("unpacked {} entries total", total_entries);
 


### PR DESCRIPTION
#### Problem

When starting up from a snapshot, we have logs that show the progress. There are two different logs that show related information, but we don't need them both.

* `hardened_unpack` shows the progress of extracting the archive
* `snapshot_storage_rebuilder` shows the progress of rebuilding the account storage files—these have been extracted

Note that the `hardened_unpack` logs are duplicated, since there are multiple threads doing the unpacking. 

Here's the relevant parts of the log during startup:
<details><summary>log</summary>
<p>

```
[2023-08-31T17:12:05Z INFO  solana_runtime::snapshot_utils] Loading bank from full snapshot: /home/sol/ledger/snapshot-211422701-Cg1VpUCxcRJmVizGkJT2XviN1gx6ykJjk5BDatg8m9KB.tar.zst, and incremental snapshot: None
[2023-08-31T17:12:13Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 33317/424558 slots with 74 collisions
[2023-08-31T17:12:15Z INFO  solana_runtime::hardened_unpack] unpacked 9806 entries so far...
[2023-08-31T17:12:15Z INFO  solana_runtime::hardened_unpack] unpacked 9807 entries so far...
[2023-08-31T17:12:15Z INFO  solana_runtime::hardened_unpack] unpacked 9807 entries so far...
[2023-08-31T17:12:15Z INFO  solana_runtime::hardened_unpack] unpacked 9806 entries so far...
[2023-08-31T17:12:15Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 41757/424558 slots with 74 collisions
[2023-08-31T17:12:17Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 46795/424558 slots with 74 collisions
[2023-08-31T17:12:19Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 53883/424558 slots with 74 collisions
[2023-08-31T17:12:21Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 61806/424558 slots with 74 collisions
[2023-08-31T17:12:23Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 70294/424558 slots with 74 collisions
[2023-08-31T17:12:25Z INFO  solana_runtime::hardened_unpack] unpacked 19029 entries so far...
[2023-08-31T17:12:25Z INFO  solana_runtime::hardened_unpack] unpacked 19029 entries so far...
[2023-08-31T17:12:25Z INFO  solana_runtime::hardened_unpack] unpacked 19029 entries so far...
[2023-08-31T17:12:25Z INFO  solana_runtime::hardened_unpack] unpacked 19029 entries so far...
[2023-08-31T17:12:25Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 78452/424558 slots with 74 collisions
[2023-08-31T17:12:27Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 85301/424558 slots with 74 collisions
[2023-08-31T17:12:29Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 92332/424558 slots with 74 collisions
[2023-08-31T17:12:31Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 98707/424558 slots with 74 collisions
[2023-08-31T17:12:33Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 105542/424558 slots with 74 collisions
[2023-08-31T17:12:35Z INFO  solana_runtime::hardened_unpack] unpacked 27075 entries so far...
[2023-08-31T17:12:35Z INFO  solana_runtime::hardened_unpack] unpacked 27085 entries so far...
[2023-08-31T17:12:35Z INFO  solana_runtime::hardened_unpack] unpacked 27077 entries so far...
[2023-08-31T17:12:35Z INFO  solana_runtime::hardened_unpack] unpacked 27080 entries so far...
[2023-08-31T17:12:35Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 109358/424558 slots with 74 collisions
[2023-08-31T17:12:37Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 113056/424558 slots with 74 collisions
[2023-08-31T17:12:39Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 117035/424558 slots with 74 collisions
[2023-08-31T17:12:41Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 121795/424558 slots with 74 collisions
[2023-08-31T17:12:43Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 129063/424558 slots with 74 collisions
[2023-08-31T17:12:45Z INFO  solana_runtime::hardened_unpack] unpacked 33493 entries so far...
[2023-08-31T17:12:45Z INFO  solana_runtime::hardened_unpack] unpacked 33495 entries so far...
[2023-08-31T17:12:45Z INFO  solana_runtime::hardened_unpack] unpacked 33495 entries so far...
[2023-08-31T17:12:45Z INFO  solana_runtime::hardened_unpack] unpacked 33491 entries so far...
[2023-08-31T17:12:45Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 136159/424558 slots with 74 collisions
[2023-08-31T17:12:47Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 144424/424558 slots with 74 collisions
[2023-08-31T17:12:49Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 153026/424558 slots with 74 collisions
[2023-08-31T17:12:51Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 161252/424558 slots with 74 collisions
[2023-08-31T17:12:53Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 168803/424558 slots with 74 collisions
[2023-08-31T17:12:55Z INFO  solana_runtime::hardened_unpack] unpacked 43481 entries so far...
[2023-08-31T17:12:55Z INFO  solana_runtime::hardened_unpack] unpacked 43481 entries so far...
[2023-08-31T17:12:55Z INFO  solana_runtime::hardened_unpack] unpacked 43481 entries so far...
[2023-08-31T17:12:55Z INFO  solana_runtime::hardened_unpack] unpacked 43482 entries so far...
[2023-08-31T17:12:55Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 175835/424558 slots with 74 collisions
[2023-08-31T17:12:57Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 181320/424558 slots with 74 collisions
[2023-08-31T17:12:59Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 186510/424558 slots with 74 collisions
[2023-08-31T17:13:01Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 191521/424558 slots with 74 collisions
[2023-08-31T17:13:03Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 196662/424558 slots with 74 collisions
[2023-08-31T17:13:05Z INFO  solana_runtime::hardened_unpack] unpacked 50075 entries so far...
[2023-08-31T17:13:05Z INFO  solana_runtime::hardened_unpack] unpacked 50075 entries so far...
[2023-08-31T17:13:05Z INFO  solana_runtime::hardened_unpack] unpacked 50076 entries so far...
[2023-08-31T17:13:05Z INFO  solana_runtime::hardened_unpack] unpacked 50076 entries so far...
[2023-08-31T17:13:05Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 202527/424558 slots with 74 collisions
[2023-08-31T17:13:07Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 209531/424558 slots with 74 collisions
[2023-08-31T17:13:09Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 217637/424558 slots with 74 collisions
[2023-08-31T17:13:11Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 226287/424558 slots with 74 collisions
[2023-08-31T17:13:13Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 235182/424558 slots with 74 collisions
[2023-08-31T17:13:15Z INFO  solana_runtime::hardened_unpack] unpacked 60136 entries so far...
[2023-08-31T17:13:15Z INFO  solana_runtime::hardened_unpack] unpacked 60136 entries so far...
[2023-08-31T17:13:15Z INFO  solana_runtime::hardened_unpack] unpacked 60136 entries so far...
[2023-08-31T17:13:15Z INFO  solana_runtime::hardened_unpack] unpacked 60136 entries so far...
[2023-08-31T17:13:16Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 241959/424558 slots with 74 collisions
[2023-08-31T17:13:18Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 247023/424558 slots with 74 collisions
[2023-08-31T17:13:20Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 252095/424558 slots with 74 collisions
[2023-08-31T17:13:22Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 257163/424558 slots with 74 collisions
[2023-08-31T17:13:24Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 262210/424558 slots with 74 collisions
[2023-08-31T17:13:25Z INFO  solana_runtime::hardened_unpack] unpacked 66688 entries so far...
[2023-08-31T17:13:25Z INFO  solana_runtime::hardened_unpack] unpacked 66688 entries so far...
[2023-08-31T17:13:25Z INFO  solana_runtime::hardened_unpack] unpacked 66689 entries so far...
[2023-08-31T17:13:25Z INFO  solana_runtime::hardened_unpack] unpacked 66689 entries so far...
[2023-08-31T17:13:26Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 268780/424558 slots with 74 collisions
[2023-08-31T17:13:28Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 277036/424558 slots with 74 collisions
[2023-08-31T17:13:30Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 285477/424558 slots with 74 collisions
[2023-08-31T17:13:32Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 293975/424558 slots with 74 collisions
[2023-08-31T17:13:34Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 302447/424558 slots with 74 collisions
[2023-08-31T17:13:35Z INFO  solana_runtime::hardened_unpack] unpacked 77151 entries so far...
[2023-08-31T17:13:35Z INFO  solana_runtime::hardened_unpack] unpacked 77151 entries so far...
[2023-08-31T17:13:35Z INFO  solana_runtime::hardened_unpack] unpacked 77151 entries so far...
[2023-08-31T17:13:35Z INFO  solana_runtime::hardened_unpack] unpacked 77151 entries so far...
[2023-08-31T17:13:36Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 310271/424558 slots with 74 collisions
[2023-08-31T17:13:38Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 317374/424558 slots with 74 collisions
[2023-08-31T17:13:40Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 324048/424558 slots with 74 collisions
[2023-08-31T17:13:42Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 329928/424558 slots with 74 collisions
[2023-08-31T17:13:44Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 334944/424558 slots with 74 collisions
[2023-08-31T17:13:45Z INFO  solana_runtime::hardened_unpack] unpacked 84697 entries so far...
[2023-08-31T17:13:45Z INFO  solana_runtime::hardened_unpack] unpacked 84696 entries so far...
[2023-08-31T17:13:45Z INFO  solana_runtime::hardened_unpack] unpacked 84701 entries so far...
[2023-08-31T17:13:45Z INFO  solana_runtime::hardened_unpack] unpacked 84703 entries so far...
[2023-08-31T17:13:46Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 340010/424558 slots with 74 collisions
[2023-08-31T17:13:48Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 345197/424558 slots with 74 collisions
[2023-08-31T17:13:50Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 352930/424558 slots with 74 collisions
[2023-08-31T17:13:52Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 361400/424558 slots with 74 collisions
[2023-08-31T17:13:54Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 369899/424558 slots with 74 collisions
[2023-08-31T17:13:55Z INFO  solana_runtime::hardened_unpack] unpacked 94096 entries so far...
[2023-08-31T17:13:55Z INFO  solana_runtime::hardened_unpack] unpacked 94091 entries so far...
[2023-08-31T17:13:55Z INFO  solana_runtime::hardened_unpack] unpacked 94097 entries so far...
[2023-08-31T17:13:55Z INFO  solana_runtime::hardened_unpack] unpacked 94098 entries so far...
[2023-08-31T17:13:56Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 378354/424558 slots with 74 collisions
[2023-08-31T17:13:58Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 385357/424558 slots with 74 collisions
[2023-08-31T17:14:00Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 391238/424558 slots with 74 collisions
[2023-08-31T17:14:02Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 396240/424558 slots with 74 collisions
[2023-08-31T17:14:04Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 401351/424558 slots with 74 collisions
[2023-08-31T17:14:05Z INFO  solana_runtime::hardened_unpack] unpacked 101323 entries so far...
[2023-08-31T17:14:05Z INFO  solana_runtime::hardened_unpack] unpacked 101323 entries so far...
[2023-08-31T17:14:05Z INFO  solana_runtime::hardened_unpack] unpacked 101324 entries so far...
[2023-08-31T17:14:05Z INFO  solana_runtime::hardened_unpack] unpacked 101350 entries so far...
[2023-08-31T17:14:06Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 406393/424558 slots with 74 collisions
[2023-08-31T17:14:08Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 411733/424558 slots with 74 collisions
[2023-08-31T17:14:10Z INFO  solana_runtime::snapshot_utils::snapshot_storage_rebuilder] rebuilt storages for 420204/424558 slots with 74 collisions
[2023-08-31T17:14:11Z INFO  solana_runtime::shared_buffer_reader] reading entire decompressed file took: 125767347 us, bytes: 151837897728, read_us: 125549604, waiting_for_buffer_us: 0, largest fetch: 11141120, error: Ok(0)
[2023-08-31T17:14:11Z INFO  solana_runtime::hardened_unpack] unpacked 106141 entries total
[2023-08-31T17:14:11Z INFO  solana_runtime::hardened_unpack] unpacked 106141 entries total
[2023-08-31T17:14:11Z INFO  solana_runtime::hardened_unpack] unpacked 106141 entries total
[2023-08-31T17:14:11Z INFO  solana_runtime::hardened_unpack] unpacked 106141 entries total
[2023-08-31T17:14:11Z INFO  solana_runtime::snapshot_utils] snapshot untar took 126.0s
```

</p>
</details> 

We could fix the `hardened_unpack` log, but I'd argue it's not that useful. IMO, the account storage files sufficiently indicate progress. The storage rebuilder includes the total number, so monitoring *amount/percent complete* is possible, which is not the case for the unpack. And the rebuilder is in number of slots, which is a concept validators are familiar with, so the number is in context. The number of entries to unpack is not the same.

#### Summary of Changes

Remove the `hardened_unpack` progress logs at startup.