### PR TITLE
Use `write_all` for binned account hash file writes 

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -97,18 +97,16 @@ impl AccountHashesFile {
             ));
         }
         let count_and_writer = self.count_and_writer.as_mut().unwrap();
-        assert_eq!(
-            std::mem::size_of::<Hash>(),
-            count_and_writer
-                .1
-                .write(hash.as_ref())
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "Unable to write file within {}: {err}",
-                        self.dir_for_temp_cache_files.display()
-                    )
-                })
-        );
+        count_and_writer
+            .1
+            .write_all(hash.as_ref())
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to write file within {}: {err}",
+                    self.dir_for_temp_cache_files.display()
+                )
+            });
+
         count_and_writer.0 += 1;
     }
 }


### PR DESCRIPTION
#### Problem

https://doc.rust-lang.org/std/io/struct.BufWriter.html#impl-Write-for-BufWriter%3CW%3E


> fn write(&mut self, buf: &[u8]) -> Result<usize>
> Write a buffer into this writer, returning how many bytes were written. Read more
> 

write() api may do partial write of `hash` and hit the assert and crash.


#### Summary of Changes

Use write_all instead


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
