### PR TITLE
Add release-with-debug profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+split-debuginfo = "packed"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[profile.release-with-debug]
+inherits = "release"
+debug = true
+
 [workspace]
 members = [
     "account-decoder",


### PR DESCRIPTION
#### Problem
Canaries should build the validator with debug info. Once the profile is added a separate PR to the cluster ops repo will update the canary build script to use the new profile.

@steviez anything else we should include in this profile to facilitate debugging?