### PR TITLE
Make should_panic tests compatible with 1.73+ panic format

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -352,7 +352,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.no_shrink_in_progress()")]
+    #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_get_slot_storage_entry_fail() {
         let storage = AccountStorage::default();
         storage
@@ -362,7 +362,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.no_shrink_in_progress()")]
+    #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_all_slots_fail() {
         let storage = AccountStorage::default();
         storage
@@ -372,7 +372,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.no_shrink_in_progress()")]
+    #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_initialize_fail() {
         let mut storage = AccountStorage::default();
         storage
@@ -382,9 +382,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "assertion failed: shrink_can_be_active || self.shrink_in_progress_map.is_empty()"
-    )]
+    #[should_panic(expected = "shrink_can_be_active || self.shrink_in_progress_map.is_empty()")]
     fn test_remove_fail() {
         let storage = AccountStorage::default();
         storage
@@ -394,7 +392,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.no_shrink_in_progress()")]
+    #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_iter_fail() {
         let storage = AccountStorage::default();
         storage
@@ -404,7 +402,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.no_shrink_in_progress()")]
+    #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_insert_fail() {
         let storage = AccountStorage::default();
         let sample = storage.get_test_storage();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -17764,7 +17764,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: self.storage.remove")]
+    #[should_panic(expected = "self.storage.remove")]
     fn test_handle_dropped_roots_for_ancient_assert() {
         solana_logger::setup();
         let common_store_path = Path::new("");

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -993,7 +993,7 @@ pub mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: accounts_to_combine.target_slots_sorted.len() >= packed_contents.len()"
+        expected = "accounts_to_combine.target_slots_sorted.len() >= packed_contents.len()"
     )]
     fn test_write_packed_storages_too_few_slots() {
         let (db, storages, slots, _infos) = get_sample_storages(1, None);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -730,7 +730,7 @@ pub mod tests {
     static_assertions::assert_eq_align!(u64, StoredMeta, AccountMeta);
 
     #[test]
-    #[should_panic(expected = "assertion failed: accounts.has_hash_and_write_version()")]
+    #[should_panic(expected = "accounts.has_hash_and_write_version()")]
     fn test_storable_accounts_with_hashes_and_write_versions_new() {
         let account = AccountSharedData::default();
         // for (Slot, &'a [(&'a Pubkey, &'a T)], IncludeSlotInHash)

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -765,19 +765,25 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed:")]
+    // rust 1.73+ (our as-of-writing nightly version) changed panic message. we're stuck with this
+    // short common substring until the monorepo is fully 1.73+ including stable.
+    #[should_panic(expected = "left == right")]
     fn test_storable_accounts_with_hashes_and_write_versions_new2() {
         test_mismatch(false, false);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed:")]
+    // rust 1.73+ (our as-of-writing nightly version) changed panic message. we're stuck with this
+    // short common substring until the monorepo is fully 1.73+ including stable.
+    #[should_panic(expected = "left == right")]
     fn test_storable_accounts_with_hashes_and_write_versions_new3() {
         test_mismatch(false, true);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed:")]
+    // rust 1.73+ (our as-of-writing nightly version) changed panic message. we're stuck with this
+    // short common substring until the monorepo is fully 1.73+ including stable.
+    #[should_panic(expected = "left == right")]
     fn test_storable_accounts_with_hashes_and_write_versions_new4() {
         test_mismatch(true, false);
     }

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -477,13 +477,13 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: max_width.is_power_of_two()")]
+    #[should_panic(expected = "max_width.is_power_of_two()")]
     fn test_bitfield_power_2() {
         let _ = RollingBitField::new(3);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: max_width > 0")]
+    #[should_panic(expected = "max_width > 0")]
     fn test_bitfield_0() {
         let _ = RollingBitField::new(0);
     }

--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: hashes_per_tick > 1")]
+    #[should_panic(expected = "hashes_per_tick > 1")]
     fn test_target_poh_time_hashes_per_tick() {
         let zero = Hash::default();
         let poh = Poh::new(zero, Some(0));

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3585,7 +3585,7 @@ fn test_bank_hash_internal_state_verify() {
 }
 
 #[test]
-#[should_panic(expected = "assertion failed: self.is_frozen()")]
+#[should_panic(expected = "self.is_frozen()")]
 fn test_verify_hash_unfrozen() {
     let bank = create_simple_test_bank(2_000);
     assert!(bank.verify_hash());
@@ -12459,7 +12459,7 @@ fn test_distribute_partitioned_epoch_rewards() {
 }
 
 #[test]
-#[should_panic(expected = "assertion failed: self.epoch_schedule.get_slots_in_epoch")]
+#[should_panic(expected = "self.epoch_schedule.get_slots_in_epoch")]
 fn test_distribute_partitioned_epoch_rewards_too_many_partitions() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     let mut bank = Bank::new_for_tests(&genesis_config);

--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: self.distributed_rewards.saturating_add(amount) <= self.total_rewards"
+        expected = "self.distributed_rewards.saturating_add(amount) <= self.total_rewards"
     )]
     fn test_epoch_rewards_distribute_panic() {
         let mut epoch_rewards = EpochRewards::new(100, 0, 64);


### PR DESCRIPTION
tldr: rust 1.73 changed panic message format, and some of tests depended on it. update them to work with both <1.73 and >1.73.

split off from #32961 as this isn't strictly coupled with the rust update pr.