### PR TITLE
finalize prioritization_fee_cache after oc-ed bank is frozen

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -181,6 +181,7 @@ impl OptimisticallyConfirmedBankTracker {
         last_notified_confirmed_slot: &mut Slot,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
+        prioritization_fee_cache: &PrioritizationFeeCache,
     ) {
         if bank.is_frozen() {
             if bank.slot() > *last_notified_confirmed_slot {
@@ -194,6 +195,9 @@ impl OptimisticallyConfirmedBankTracker {
                     slot_notification_subscribers,
                     SlotNotification::OptimisticallyConfirmed(bank.slot()),
                 );
+
+                // finalize block's minimum prioritization fee cache for this bank
+                prioritization_fee_cache.finalize_priority_fee(bank.slot());
             }
         } else if bank.slot() > bank_forks.read().unwrap().root() {
             pending_optimistically_confirmed_banks.insert(bank.slot());
@@ -209,6 +213,7 @@ impl OptimisticallyConfirmedBankTracker {
         last_notified_confirmed_slot: &mut Slot,
         pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
+        prioritization_fee_cache: &PrioritizationFeeCache,
     ) {
         for confirmed_bank in bank.parents_inclusive().iter().rev() {
             if confirmed_bank.slot() > slot_threshold {
@@ -223,6 +228,7 @@ impl OptimisticallyConfirmedBankTracker {
                     last_notified_confirmed_slot,
                     pending_optimistically_confirmed_banks,
                     slot_notification_subscribers,
+                    prioritization_fee_cache,
                 );
             }
         }
@@ -291,6 +297,7 @@ impl OptimisticallyConfirmedBankTracker {
                             last_notified_confirmed_slot,
                             pending_optimistically_confirmed_banks,
                             slot_notification_subscribers,
+                            prioritization_fee_cache,
                         );
 
                         *highest_confirmed_slot = slot;
@@ -307,9 +314,6 @@ impl OptimisticallyConfirmedBankTracker {
                     slot,
                     timestamp: timestamp(),
                 });
-
-                // finalize block's minimum prioritization fee cache for this bank
-                prioritization_fee_cache.finalize_priority_fee(slot);
             }
             BankNotification::Frozen(bank) => {
                 let frozen_slot = bank.slot();
@@ -348,6 +352,7 @@ impl OptimisticallyConfirmedBankTracker {
                         last_notified_confirmed_slot,
                         pending_optimistically_confirmed_banks,
                         slot_notification_subscribers,
+                        prioritization_fee_cache,
                     );
 
                     let mut w_optimistically_confirmed_bank =


### PR DESCRIPTION
#### Problem
[Comment](https://github.com/solana-labs/solana/pull/33062#discussion_r1309490595) points out prioritization_fee_Cache should be finalized when oc-ed bank is frozen. 

#### Summary of Changes
- move `finalize_priority_fee()` to when bank is frozen.

related to #32692 