### PR TITLE
ci: remove unstable options for stable tests

### DIFF
--- a/ci/stable/run-all.sh
+++ b/ci/stable/run-all.sh
@@ -12,8 +12,4 @@ source "$here"/../common/limit-threads.sh
 #shellcheck source=ci/stable/common.sh
 source "$here"/common.sh
 
-if need_to_generate_test_result; then
-  _ cargo test --jobs "$JOBS" --workspace --tests --verbose -- -Z unstable-options --format json --report-time | tee results.json
-else
-  _ ci/intercept.sh cargo test --jobs "$JOBS" --workspace --tests --verbose -- --nocapture
-fi
+_ ci/intercept.sh cargo test --jobs "$JOBS" --workspace --tests --verbose -- --nocapture

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -46,11 +46,7 @@ if [ "$INDEX" -eq "$((LIMIT - 1))" ]; then
     ARGS+=(-p "$package")
   done
 
-  if need_to_generate_test_result; then
-    _ cargo test "${ARGS[@]}" --verbose -- -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ cargo test "${ARGS[@]}"
-  fi
+  _ cargo test "${ARGS[@]}"
 else
   ARGS=(
     --profile ci

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -33,11 +33,7 @@ source ci/common/shared-functions.sh
 echo "Executing $testName"
 case $testName in
 test-stable)
-  if need_to_upload_test_result; then
-    _ cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-  fi
+  _ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   ;;
 test-stable-sbf)
   # Clear the C dependency files, if dependency moves these files are not regenerated
@@ -73,15 +69,9 @@ test-stable-sbf)
 
   # SBF C program system tests
   _ make -C programs/sbf/c tests
-  if need_to_upload_test_result; then
-    _ cargo test \
-      --manifest-path programs/sbf/Cargo.toml \
-      --no-default-features --features=sbf_c,sbf_rust -- -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ cargo test \
-      --manifest-path programs/sbf/Cargo.toml \
-      --no-default-features --features=sbf_c,sbf_rust -- --nocapture
-  fi
+  _ cargo test \
+    --manifest-path programs/sbf/Cargo.toml \
+    --no-default-features --features=sbf_c,sbf_rust -- --nocapture
 
   # SBF Rust program unit tests
   for sbf_test in programs/sbf/rust/*; do
@@ -114,18 +104,10 @@ test-stable-sbf)
 
   # SBF program instruction count assertion
   sbf_target_path=programs/sbf/target
-  if need_to_upload_test_result; then
-    _ cargo test \
-      --manifest-path programs/sbf/Cargo.toml \
-      --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
-      -- -Z unstable-options --format json --report-time |& tee results.json
-    awk '!/{ "type": .* }/' results.json >"${sbf_target_path}"/deploy/instuction_counts.txt
-  else
-    _ cargo test \
-      --manifest-path programs/sbf/Cargo.toml \
-      --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
-      -- --nocapture &> "${sbf_target_path}"/deploy/instuction_counts.txt
-  fi
+  _ cargo test \
+    --manifest-path programs/sbf/Cargo.toml \
+    --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
+    -- --nocapture &> "${sbf_target_path}"/deploy/instuction_counts.txt
 
   sbf_dump_archive="sbf-dumps.tar.bz2"
   rm -f "$sbf_dump_archive"
@@ -150,47 +132,27 @@ test-stable-perf)
   fi
 
   _ cargo build --bins ${V:+--verbose}
-  if need_to_upload_test_result; then
-    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
-  fi
+  _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
   _ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
   ;;
 test-local-cluster)
   _ cargo build --release --bins ${V:+--verbose}
-  if need_to_upload_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
-  fi
+  _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster ${V:+--verbose} -- --nocapture --test-threads=1
   exit 0
   ;;
 test-local-cluster-flakey)
   _ cargo build --release --bins ${V:+--verbose}
-  if need_to_upload_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
-  fi
+  _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_flakey ${V:+--verbose} -- --nocapture --test-threads=1
   exit 0
   ;;
 test-local-cluster-slow-1)
   _ cargo build --release --bins ${V:+--verbose}
-  if need_to_upload_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
-  fi
+  _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_slow_1 ${V:+--verbose} -- --nocapture --test-threads=1
   exit 0
   ;;
 test-local-cluster-slow-2)
   _ cargo build --release --bins ${V:+--verbose}
-  if need_to_upload_test_result; then
-    _ cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --test-threads=1 -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
-  fi
+  _ ci/intercept.sh cargo test --release --package solana-local-cluster --test local_cluster_slow_2 ${V:+--verbose} -- --nocapture --test-threads=1
   exit 0
   ;;
 test-wasm)
@@ -207,11 +169,7 @@ test-wasm)
   exit 0
   ;;
 test-docs)
-  if need_to_upload_test_result; then
-    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- -Z unstable-options --format json --report-time | tee results.json
-  else
-    _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-  fi
+  _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   exit 0
   ;;
 *)


### PR DESCRIPTION
#### Problem

`-Zunstable-options` can't be used since 1.70.0 (https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#enforced-stability-in-the-test-cli)

a possible solution, `--timings=json`, is still unstable atm 😢 

#### Summary of Changes

remove unstable options for stable tests atm. we will lose some test report. For unblocking our master CI, I still would like to have this stopgap first.

I will try to finish https://github.com/solana-labs/solana/issues/33102 soon!
