### PR TITLE
Update ShredFetchStage::modify_packets to drop root bank quicker

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -65,10 +65,12 @@ impl ShredFetchStage {
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
                 {
-                    let bank_forks_r = bank_forks.read().unwrap();
-                    let root_bank = bank_forks_r.root_bank();
+                    let root_bank = {
+                        let bank_forks_r = bank_forks.read().unwrap();
+                        last_slot = bank_forks_r.highest_slot();
+                        bank_forks_r.root_bank()
+                    };
                     last_root = root_bank.slot();
-                    last_slot = bank_forks_r.highest_slot();
                     slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 }
                 keypair = repair_context

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -50,14 +50,15 @@ impl ShredFetchStage {
             .as_ref()
             .map(|(_, cluster_info)| cluster_info.keypair().clone());
 
-        // Only need root bank in order to check feature statuses later on;
-        // can demote to only fetching root slot once those features go away.
-        let (mut root_bank, mut last_slot) = {
+        let (mut last_root, mut last_slot, mut slots_per_epoch) = {
             let bank_forks_r = bank_forks.read().unwrap();
-            (bank_forks_r.root_bank(), bank_forks_r.highest_slot())
+            let root_bank = bank_forks_r.root_bank();
+            (
+                root_bank.slot(),
+                root_bank.get_slots_in_epoch(root_bank.epoch()),
+                bank_forks_r.highest_slot(),
+            )
         };
-        let mut last_root = root_bank.slot();
-        let mut slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
         let mut stats = ShredFetchStats::default();
 
         for mut packet_batch in recvr {
@@ -65,11 +66,11 @@ impl ShredFetchStage {
                 last_updated = Instant::now();
                 {
                     let bank_forks_r = bank_forks.read().unwrap();
-                    root_bank = bank_forks_r.root_bank();
+                    let root_bank = bank_forks_r.root_bank();
+                    last_root = root_bank.slot();
                     last_slot = bank_forks_r.highest_slot();
+                    slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 }
-                last_root = root_bank.slot();
-                slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 keypair = repair_context
                     .as_ref()
                     .map(|(_, cluster_info)| cluster_info.keypair().clone());

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -64,15 +64,13 @@ impl ShredFetchStage {
         for mut packet_batch in recvr {
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
-                {
-                    let root_bank = {
-                        let bank_forks_r = bank_forks.read().unwrap();
-                        last_slot = bank_forks_r.highest_slot();
-                        bank_forks_r.root_bank()
-                    };
-                    last_root = root_bank.slot();
-                    slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
-                }
+                let root_bank = {
+                    let bank_forks_r = bank_forks.read().unwrap();
+                    last_slot = bank_forks_r.highest_slot();
+                    bank_forks_r.root_bank()
+                };
+                last_root = root_bank.slot();
+                slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 keypair = repair_context
                     .as_ref()
                     .map(|(_, cluster_info)| cluster_info.keypair().clone());


### PR DESCRIPTION
#### Problem
This function used to contain feature gate activation checks that required access to a bank. Those checks have been cleaned up, so we no longer need access to a full Bank. Also see https://github.com/solana-labs/solana/pull/33078#issuecomment-1701081550.

#### Summary of Changes
Rather, we can momentarily get a Bank from BankForks, calculate the necessary results and then drop the Bank along with the BankForks read lock.