### PR TITLE
[zk-token-sdk] Allow all zero auditor pubkey in proofs

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -840,7 +840,7 @@ mod test {
 
         assert!(fee_data.verify_proof().is_ok());
 
-        // Case 4: invalid destination, auditor, or withdraw authority pubkeys
+        // Case 4: destination pubkey invalid
         let spendable_balance: u64 = 120;
         let spendable_ciphertext = source_keypair.pubkey().encrypt(spendable_balance);
 
@@ -867,48 +867,6 @@ mod test {
             (&destination_pubkey, auditor_pubkey),
             fee_parameters,
             withdraw_withheld_authority_pubkey,
-        )
-        .unwrap();
-
-        assert!(fee_data.verify_proof().is_err());
-
-        // auditor pubkey invalid
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
-
-        let auditor_pubkey = pod::ElGamalPubkey::zeroed().try_into().unwrap();
-
-        let withdraw_withheld_authority_keypair = ElGamalKeypair::new_rand();
-        let withdraw_withheld_authority_pubkey = withdraw_withheld_authority_keypair.pubkey();
-
-        let fee_data = TransferWithFeeData::new(
-            transfer_amount,
-            (spendable_balance, &spendable_ciphertext),
-            &source_keypair,
-            (destination_pubkey, &auditor_pubkey),
-            fee_parameters,
-            withdraw_withheld_authority_pubkey,
-        )
-        .unwrap();
-
-        assert!(fee_data.verify_proof().is_err());
-
-        // withdraw authority invalid
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
-
-        let auditor_keypair = ElGamalKeypair::new_rand();
-        let auditor_pubkey = auditor_keypair.pubkey();
-
-        let withdraw_withheld_authority_pubkey = pod::ElGamalPubkey::zeroed().try_into().unwrap();
-
-        let fee_data = TransferWithFeeData::new(
-            transfer_amount,
-            (spendable_balance, &spendable_ciphertext),
-            &source_keypair,
-            (destination_pubkey, auditor_pubkey),
-            fee_parameters,
-            &withdraw_withheld_authority_pubkey,
         )
         .unwrap();
 

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -524,13 +524,11 @@ mod test {
 
         assert!(transfer_data.verify_proof().is_ok());
 
-        // Case 4: invalid destination or auditor pubkey
+        // Case 4: destination pubkey is invalid
         let spendable_balance: u64 = 0;
         let spendable_ciphertext = source_keypair.pubkey().encrypt(spendable_balance);
-
         let transfer_amount: u64 = 0;
 
-        // destination pubkey invalid
         let dest_pk = pod::ElGamalPubkey::zeroed().try_into().unwrap();
         let auditor_keypair = ElGamalKeypair::new_rand();
         let auditor_pk = auditor_keypair.pubkey();
@@ -540,21 +538,6 @@ mod test {
             (spendable_balance, &spendable_ciphertext),
             &source_keypair,
             (&dest_pk, auditor_pk),
-        )
-        .unwrap();
-
-        assert!(transfer_data.verify_proof().is_err());
-
-        // auditor pubkey invalid
-        let dest_keypair = ElGamalKeypair::new_rand();
-        let dest_pk = dest_keypair.pubkey();
-        let auditor_pk = pod::ElGamalPubkey::zeroed().try_into().unwrap();
-
-        let transfer_data = TransferData::new(
-            transfer_amount,
-            (spendable_balance, &spendable_ciphertext),
-            &source_keypair,
-            (dest_pk, &auditor_pk),
         )
         .unwrap();
 

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -302,37 +302,6 @@ mod test {
             )
             .is_err());
 
-        // if auditor public key zeroed, then the proof should always reject
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
-
-        let auditor_pubkey = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
-
-        let amount: u64 = 55;
-        let (commitment, opening) = Pedersen::new(amount);
-
-        let destination_handle = destination_pubkey.decrypt_handle(&opening);
-        let auditor_handle = auditor_pubkey.decrypt_handle(&opening);
-
-        let mut prover_transcript = Transcript::new(b"Test");
-        let mut verifier_transcript = Transcript::new(b"Test");
-
-        let proof = GroupedCiphertext2HandlesValidityProof::new(
-            (destination_pubkey, &auditor_pubkey),
-            amount,
-            &opening,
-            &mut prover_transcript,
-        );
-
-        assert!(proof
-            .verify(
-                &commitment,
-                (destination_pubkey, &auditor_pubkey),
-                (&destination_handle, &auditor_handle),
-                &mut verifier_transcript,
-            )
-            .is_err());
-
         // all zeroed ciphertext should still be valid
         let destination_keypair = ElGamalKeypair::new_rand();
         let destination_pubkey = destination_keypair.pubkey();

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof.rs
@@ -134,7 +134,8 @@ impl GroupedCiphertext2HandlesValidityProof {
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
         transcript.validate_and_append_point(b"Y_1", &self.Y_1)?;
-        transcript.validate_and_append_point(b"Y_2", &self.Y_2)?;
+        // Y_2 can be an all zero point if the auditor public key is all zero
+        transcript.append_point(b"Y_2", &self.Y_2);
 
         let c = transcript.challenge_scalar(b"c");
         let w = transcript.challenge_scalar(b"w");


### PR DESCRIPTION
#### Problem
Currently, on the ciphertext validity proof, if the auditor ElGamal public key is an all-zero key, the proof is rejected even if the algebraic relation holds. This was put in for security purposes since an ElGamal public key should never really be all zero. However, for the token application, if the auditor feature is turned off, then the proof is indeed generated with respect to the all zero public key. Therefore, currently the transfer proof always fails if the auditor feature is turned off.

#### Summary of Changes
Update the verification logic so that the proof does not immediately reject if the auditor public key is all zero.

This is a security fix that will unfortunately need to be backported to 🙏 .

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
