### PR TITLE
hash dedup batch writes

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -111,6 +111,40 @@ impl AccountHashesFile {
         );
         count_and_writer.0 += 1;
     }
+
+    pub fn init(&mut self) {
+        if self.count_and_writer.is_none() {
+            // we have hashes to write but no file yet, so create a file that will auto-delete on drop
+            self.count_and_writer = Some((
+                0,
+                BufWriter::new(
+                    tempfile_in(&self.dir_for_temp_cache_files).unwrap_or_else(|err| {
+                        panic!(
+                            "Unable to create file within {}: {err}",
+                            self.dir_for_temp_cache_files.display()
+                        )
+                    }),
+                ),
+            ));
+        }
+    }
+
+    pub fn write2(&mut self, hash: &Hash) {
+        let count_and_writer = self.count_and_writer.as_mut().unwrap();
+        assert_eq!(
+            std::mem::size_of::<Hash>(),
+            count_and_writer
+                .1
+                .write(hash.as_ref())
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "Unable to write file within {}: {err}",
+                        self.dir_for_temp_cache_files.display()
+                    )
+                })
+        );
+        count_and_writer.0 += 1;
+    }
 }
 
 /// parameters to calculate accounts hash
@@ -1037,6 +1071,8 @@ impl<'a> AccountsHasher<'a> {
             count_and_writer: None,
             dir_for_temp_cache_files: self.dir_for_temp_cache_files.clone(),
         };
+        hashes.init();
+
         // initialize 'first_items', which holds the current lowest item in each slot group
         sorted_data_by_pubkey
             .iter()
@@ -1098,7 +1134,7 @@ impl<'a> AccountsHasher<'a> {
                     overall_sum = Self::checked_cast_for_capitalization(
                         item.lamports as u128 + overall_sum as u128,
                     );
-                    hashes.write(&item.hash);
+                    hashes.write2(&item.hash);
                 }
             } else {
                 // if lamports == 0, check if they should be included
@@ -1107,7 +1143,7 @@ impl<'a> AccountsHasher<'a> {
                     // the hash of its pubkey
                     let hash = blake3::hash(bytemuck::bytes_of(&item.pubkey));
                     let hash = Hash::new_from_array(hash.into());
-                    hashes.write(&hash);
+                    hashes.write2(&hash);
                 }
             }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -834,11 +834,55 @@ impl<'a> AccountsHasher<'a> {
         (hashes, lamports_total)
     }
 
+    fn get_item2<'b>(
+        min_index: usize,
+        bin: usize,
+        sorted_data_by_pubkey: &[&'b [CalculateHashIntermediate]],
+        first_items: &mut Vec<(usize, usize, &'b Pubkey)>,
+        binner: &PubkeyBinCalculator24,
+    ) -> &'b CalculateHashIntermediate {
+        let (division_index, mut index, key) = first_items[min_index];
+        let division_data = &sorted_data_by_pubkey[division_index];
+        index += 1;
+        let mut end;
+        loop {
+            end = index >= division_data.len();
+            if end {
+                break;
+            }
+            // still more items where we found the previous key, so just increment the index for that slot group, skipping all pubkeys that are equal
+            let next_key = &division_data[index].pubkey;
+            if next_key == key {
+                index += 1;
+                continue; // duplicate entries of same pubkey, so keep skipping
+            }
+
+            if binner.bin_from_pubkey(next_key) > bin {
+                // the next pubkey is not in our bin
+                end = true;
+                break;
+            }
+
+            // point to the next pubkey > key
+            first_items[min_index] = (division_index, index, next_key);
+            break;
+        }
+        if end {
+            // stop looking in this vector - we exhausted it
+            first_items.remove(min_index);
+        }
+
+        // this is the previous first item that was requested
+        &division_data[index - 1]
+    }
+
     /// returns the item referenced by `min_index`
     ///   updates `indexes` to skip over the pubkey and its duplicates
     ///   updates `first_items` to point to the next pubkey
     /// or removes the entire pubkey division entries (for `min_index`) if the referenced pubkey is the last entry in the same `bin`
     ///     removed from: `first_items`, `indexes`, and `first_item_pubkey_division`
+    ///
+    #[allow(dead_code)]
     fn get_item<'b>(
         min_index: usize,
         bin: usize,
@@ -982,11 +1026,10 @@ impl<'a> AccountsHasher<'a> {
         let binner = PubkeyBinCalculator24::new(bins);
 
         let len = sorted_data_by_pubkey.len();
-        let mut indexes = Vec::with_capacity(len);
+
+        // (division_index, index, &pubkey) - 32 bytes
         let mut first_items = Vec::with_capacity(len);
-        // map from index of an item in first_items[] to index of the corresponding item in sorted_data_by_pubkey[]
-        // this will change as items in sorted_data_by_pubkey[] are exhausted
-        let mut first_item_to_pubkey_division = Vec::with_capacity(len);
+
         let mut hashes = AccountHashesFile {
             count_and_writer: None,
             dir_for_temp_cache_files: self.dir_for_temp_cache_files.clone(),
@@ -999,10 +1042,8 @@ impl<'a> AccountsHasher<'a> {
                 let first_pubkey_in_bin =
                     Self::find_first_pubkey_in_bin(hash_data, pubkey_bin, bins, &binner, stats);
                 if let Some(first_pubkey_in_bin) = first_pubkey_in_bin {
-                    let k = hash_data[first_pubkey_in_bin].pubkey;
-                    first_items.push(k);
-                    first_item_to_pubkey_division.push(i);
-                    indexes.push(first_pubkey_in_bin);
+                    let k = &hash_data[first_pubkey_in_bin].pubkey;
+                    first_items.push((i, first_pubkey_in_bin, k))
                 }
             });
         let mut overall_sum = 0;
@@ -1013,14 +1054,14 @@ impl<'a> AccountsHasher<'a> {
         while !first_items.is_empty() {
             let loop_stop = { first_items.len() - 1 }; // we increment at the beginning of the loop
             let mut min_index = 0;
-            let mut min_pubkey = first_items[min_index];
+            let mut min_pubkey = first_items[min_index].2;
             let mut first_item_index = 0; // we will start iterating at item 1. +=1 is first instruction in loop
 
             // this loop iterates over each slot group to find the minimum pubkey at the maximum slot
             // it also identifies duplicate pubkey entries at lower slots and remembers those to skip them after
             while first_item_index < loop_stop {
                 first_item_index += 1;
-                let key = &first_items[first_item_index];
+                let key = &first_items[first_item_index].2;
                 let cmp = min_pubkey.cmp(key);
                 match cmp {
                     std::cmp::Ordering::Less => {
@@ -1039,13 +1080,11 @@ impl<'a> AccountsHasher<'a> {
                 min_index = first_item_index;
             }
             // get the min item, add lamports, get hash
-            let item = Self::get_item(
+            let item = Self::get_item2(
                 min_index,
                 pubkey_bin,
-                &mut first_items,
                 sorted_data_by_pubkey,
-                &mut indexes,
-                &mut first_item_to_pubkey_division,
+                &mut first_items,
                 &binner,
             );
 
@@ -1074,13 +1113,11 @@ impl<'a> AccountsHasher<'a> {
                 // reverse this list because get_item can remove first_items[*i] when *i is exhausted
                 //  and that would mess up subsequent *i values
                 duplicate_pubkey_indexes.iter().rev().for_each(|i| {
-                    Self::get_item(
+                    Self::get_item2(
                         *i,
                         pubkey_bin,
-                        &mut first_items,
                         sorted_data_by_pubkey,
-                        &mut indexes,
-                        &mut first_item_to_pubkey_division,
+                        &mut first_items,
                         &binner,
                     );
                 });

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -132,15 +132,7 @@ impl AccountHashesFile {
         let count_and_writer = self.count_and_writer.as_mut().unwrap();
 
         let hash_bytes = unsafe { std::slice::from_raw_parts(hashes.as_ptr() as *const u8, size) };
-        assert_eq!(
-            size,
-            count_and_writer.1.write(hash_bytes).unwrap_or_else(|err| {
-                panic!(
-                    "Unable to write file within {}: {err}",
-                    self.dir_for_temp_cache_files.display()
-                )
-            })
-        );
+        count_and_writer.1.write_all(hash_bytes).unwrap();
         count_and_writer.0 += n;
     }
 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -837,13 +837,20 @@ impl<'a> AccountsHasher<'a> {
                         /*lamports sum*/ 0,
                     )
                 },
-                |mut a, mut b| {
-                    a.2 =
-                        a.2.checked_add(b.2)
-                            .expect("summing capitalization cannot overflow");
-                    a.1 += b.1;
-                    a.0.append(&mut b.0);
-                    a
+                |a, b| {
+                    let (mut acc, mut x) = if a.0.len() > b.0.len() {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    };
+
+                    acc.2 = acc
+                        .2
+                        .checked_add(x.2)
+                        .expect("summing capitalization cannot overflow");
+                    acc.1 += x.1;
+                    acc.0.append(&mut x.0);
+                    acc
                 },
             );
         zeros.stop();

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -28,9 +28,10 @@ impl PubkeyBinCalculator24 {
         }
     }
 
+    #[inline]
     pub(crate) fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
         let as_ref = pubkey.as_ref();
-        ((as_ref[0] as usize * 256 + as_ref[1] as usize) * 256 + as_ref[2] as usize)
+        ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
             >> self.shift_bits
     }
 


### PR DESCRIPTION
- combine index, offset, pk into one vec
- opt bin_from_pubkey
- init write2
- Revert "init write2" -- not much improvements
- batch hash writes
- up

#### Problem

wip

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  4583291i
pubkey_bin_search_us                11193493i
```

Not much performance improvement.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
