### PR TITLE
Validator CLI can specify accounts hash cache path

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -289,6 +289,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Path to accounts shrink path which can hold a compacted account set."),
         )
         .arg(
+            Arg::with_name("accounts_hash_cache_path")
+                .long("accounts-hash-cache-path")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Use PATH as accounts hash cache location"),
+        )
+        .arg(
             Arg::with_name("snapshots")
                 .long("snapshots")
                 .value_name("DIR")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -9,7 +9,8 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
         accounts_db::{
-            AccountShrinkThreshold, AccountsDbConfig, CreateAncientStorage, FillerAccountsConfig,
+            AccountShrinkThreshold, AccountsDb, AccountsDbConfig, CreateAncientStorage,
+            FillerAccountsConfig,
         },
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
@@ -977,6 +978,18 @@ pub fn main() {
         .pop()
         .unwrap();
 
+    let accounts_hash_cache_path = matches
+        .value_of("accounts_hash_cache_path")
+        .map(Into::into)
+        .unwrap_or_else(|| ledger_path.join(AccountsDb::DEFAULT_ACCOUNTS_HASH_CACHE_DIR));
+    let accounts_hash_cache_path = create_and_canonicalize_directories(&[accounts_hash_cache_path])
+        .unwrap_or_else(|err| {
+            eprintln!("Unable to access accounts hash cache path: {err}");
+            exit(1);
+        })
+        .pop()
+        .unwrap();
+
     let debug_keys: Option<Arc<HashSet<_>>> = if matches.is_present("debug_key") {
         Some(Arc::new(
             values_t_or_exit!(matches, "debug_key", Pubkey)
@@ -1175,6 +1188,7 @@ pub fn main() {
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         base_working_path: Some(ledger_path.clone()),
+        accounts_hash_cache_path: Some(accounts_hash_cache_path),
         filler_accounts_config,
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()


### PR DESCRIPTION
#### Problem

The accounts hash cache is stored in the ledger directory, and does not have a way for a node operator to move it. Since the accounts hash cache has a decent amount of I/O, if a disk is overwhelmed, there's no way to move the accounts hash cache somewhere else.


#### Summary of Changes

Add a CLI arg, `--accounts-hash-cache-path`, to `solana-validator` to specify the accounts hash cache path.