### PR TITLE
Improve plugin load/reload unit tests

### DIFF
--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -432,6 +432,12 @@ mod tests {
         // Now try a (dummy) reload, replacing TestPlugin with TestPlugin2
         let reload_result = plugin_manager_lock.reload_plugin(DUMMY_NAME, TESTPLUGIN2_CONFIG);
         assert!(reload_result.is_ok());
+
+        // The plugin is now replaced with ANOTHER_DUMMY_NAME
+        let plugins = plugin_manager_lock.list_plugins().unwrap();
+        assert!(plugins.iter().any(|name| name.eq(ANOTHER_DUMMY_NAME)));
+        // DUMMY_NAME should no longer be present.
+        assert!(!plugins.iter().any(|name| name.eq(DUMMY_NAME)));
     }
 
     #[test]

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -324,6 +324,11 @@ pub(crate) fn load_plugin_from_config(
     Ok((plugin, lib, config_file))
 }
 
+#[cfg(test)]
+const TESTPLUGIN_CONFIG: &str = "TESTPLUGIN_CONFIG";
+#[cfg(test)]
+const TESTPLUGIN2_CONFIG: &str = "TESTPLUGIN2_CONFIG";
+
 // This is mocked for tests to avoid having to do IO with a dynamically linked library
 // across different architectures at test time
 //
@@ -331,15 +336,31 @@ pub(crate) fn load_plugin_from_config(
 /// (The geyser plugin interface requires a &str for the on_load method).
 #[cfg(test)]
 pub(crate) fn load_plugin_from_config(
-    _geyser_plugin_config_file: &Path,
+    geyser_plugin_config_file: &Path,
 ) -> Result<(Box<dyn GeyserPlugin>, Library, &str), GeyserPluginManagerError> {
-    Ok(tests::dummy_plugin_and_library(tests::TestPlugin))
+    if geyser_plugin_config_file.ends_with(TESTPLUGIN_CONFIG) {
+        Ok(tests::dummy_plugin_and_library(
+            tests::TestPlugin,
+            TESTPLUGIN_CONFIG,
+        ))
+    } else if geyser_plugin_config_file.ends_with(TESTPLUGIN2_CONFIG) {
+        Ok(tests::dummy_plugin_and_library(
+            tests::TestPlugin2,
+            TESTPLUGIN2_CONFIG,
+        ))
+    } else {
+        Err(GeyserPluginManagerError::CannotOpenConfigFile(
+            geyser_plugin_config_file.to_str().unwrap().to_string(),
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use {
-        crate::geyser_plugin_manager::GeyserPluginManager,
+        crate::geyser_plugin_manager::{
+            GeyserPluginManager, TESTPLUGIN2_CONFIG, TESTPLUGIN_CONFIG,
+        },
         libloading::Library,
         solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin,
         std::sync::{Arc, RwLock},
@@ -347,11 +368,12 @@ mod tests {
 
     pub(super) fn dummy_plugin_and_library<P: GeyserPlugin>(
         plugin: P,
+        config_path: &'static str,
     ) -> (Box<dyn GeyserPlugin>, Library, &'static str) {
         (
             Box::new(plugin),
             Library::from(libloading::os::unix::Library::this()),
-            DUMMY_CONFIG,
+            config_path,
         )
     }
 
@@ -391,7 +413,7 @@ mod tests {
         );
 
         // Mock having loaded plugin (TestPlugin)
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin);
+        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin, DUMMY_CONFIG);
         plugin.on_load(config).unwrap();
         plugin_manager_lock.plugins.push(plugin);
         plugin_manager_lock.libs.push(lib);
@@ -408,7 +430,7 @@ mod tests {
         );
 
         // Now try a (dummy) reload, replacing TestPlugin with TestPlugin2
-        let reload_result = plugin_manager_lock.reload_plugin(DUMMY_NAME, DUMMY_CONFIG);
+        let reload_result = plugin_manager_lock.reload_plugin(DUMMY_NAME, TESTPLUGIN2_CONFIG);
         assert!(reload_result.is_ok());
     }
 
@@ -420,12 +442,12 @@ mod tests {
 
         // Load two plugins
         // First
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin);
+        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin, TESTPLUGIN_CONFIG);
         plugin.on_load(config).unwrap();
         plugin_manager_lock.plugins.push(plugin);
         plugin_manager_lock.libs.push(lib);
         // Second
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin2);
+        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin2, TESTPLUGIN2_CONFIG);
         plugin.on_load(config).unwrap();
         plugin_manager_lock.plugins.push(plugin);
         plugin_manager_lock.libs.push(lib);
@@ -443,7 +465,7 @@ mod tests {
         let mut plugin_manager_lock = plugin_manager.write().unwrap();
 
         // Load rpc call
-        let load_result = plugin_manager_lock.load_plugin(DUMMY_CONFIG);
+        let load_result = plugin_manager_lock.load_plugin(TESTPLUGIN_CONFIG);
         assert!(load_result.is_ok());
         assert_eq!(plugin_manager_lock.plugins.len(), 1);
 

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                        return Err(A::Error::custom("Invalid Sequence"));
-                    };
+                                        return Err(A::Error::custom("Invalid Sequence"));
+                                    };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                                        return Err(A::Error::custom("Invalid Sequence"));
-                                    };
+                        return Err(A::Error::custom("Invalid Sequence"));
+                    };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was


### PR DESCRIPTION
#### Problem
Improve plugin load/reload unit tests

#### Summary of Changes
1. Test loading different plugin of the same name. TestPlugin2 replacing TestPlugin1
2. Return the real config name in the test instead of hard coded DUMMY_CONFIG.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
