### PR TITLE
Demote Arc<Bank> parameter to &Bank

### DIFF
--- a/core/src/cache_block_meta_service.rs
+++ b/core/src/cache_block_meta_service.rs
@@ -41,7 +41,7 @@ impl CacheBlockMetaService {
                     }
                     Ok(bank) => {
                         let mut cache_block_meta_timer = Measure::start("cache_block_meta_timer");
-                        Self::cache_block_meta(bank, &blockstore);
+                        Self::cache_block_meta(&bank, &blockstore);
                         cache_block_meta_timer.stop();
                         if cache_block_meta_timer.as_ms() > CACHE_BLOCK_TIME_WARNING_MS {
                             warn!(
@@ -57,7 +57,7 @@ impl CacheBlockMetaService {
         Self { thread_hdl }
     }
 
-    fn cache_block_meta(bank: Arc<Bank>, blockstore: &Blockstore) {
+    fn cache_block_meta(bank: &Bank, blockstore: &Blockstore) {
         if let Err(e) = blockstore.cache_block_time(bank.slot(), bank.clock().unix_timestamp) {
             error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
         }


### PR DESCRIPTION
#### Problem
Sub-function doesn't need an `Arc`; this is pretty inconsequential since the caller will just drop the `Arc<Bank>` shortly after, but still more proper