### PR TITLE
Fix - Superfluous `if` condition for overwriting `environments` in feature activation code

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8086,23 +8086,15 @@ impl Bank {
             )
             .unwrap();
             let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
-            if *loaded_programs_cache.environments.program_runtime_v1
-                != program_runtime_environment_v1
-            {
-                loaded_programs_cache.environments.program_runtime_v1 =
-                    Arc::new(program_runtime_environment_v1);
-            }
+            loaded_programs_cache.environments.program_runtime_v1 =
+                Arc::new(program_runtime_environment_v1);
             let program_runtime_environment_v2 =
                 solana_loader_v4_program::create_program_runtime_environment_v2(
                     &self.runtime_config.compute_budget.unwrap_or_default(),
                     false, /* debugging_features */
                 );
-            if *loaded_programs_cache.environments.program_runtime_v2
-                != program_runtime_environment_v2
-            {
-                loaded_programs_cache.environments.program_runtime_v2 =
-                    Arc::new(program_runtime_environment_v2);
-            }
+            loaded_programs_cache.environments.program_runtime_v2 =
+                Arc::new(program_runtime_environment_v2);
             loaded_programs_cache.prune_feature_set_transition();
         }
         for builtin in BUILTINS.iter() {


### PR DESCRIPTION
#### Problem
There was a bug in RBPF v0.6.0 which caused the `BuiltinProgram::eq()` to always return `false`. Thus, the behavior we stabilized implicitly in v1.16 is that the `if` condition is always `true`.

#### Summary of Changes
Removes the `if` block around the overwriting of the `environments`.