### PR TITLE
ci: remove -f from cargo install rustfilt

### DIFF
--- a/sdk/cargo-build-sbf/tests/crates.rs
+++ b/sdk/cargo-build-sbf/tests/crates.rs
@@ -61,7 +61,7 @@ fn test_build() {
 fn test_dump() {
     // This test requires rustfilt.
     assert_cmd::Command::new("cargo")
-        .args(["install", "-f", "rustfilt"])
+        .args(["install", "rustfilt"])
         .assert()
         .success();
     run_cargo_build("noop", &["--dump"], false);


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1148390601335779398

we can't install rustfilt with rust 1.60.0 anymore 😢 

#### Summary of Changes

remove the `-f` flag so that we can avoid installing it trickily.