### PR TITLE
Boot solana-test-validator without enable_partitioned_epoch_reward feature

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -19,6 +19,7 @@ use {
         account::AccountSharedData,
         clock::Slot,
         epoch_schedule::EpochSchedule,
+        feature_set,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
         rent::Rent,
@@ -348,7 +349,9 @@ fn main() {
         exit(1);
     });
 
-    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
+    let mut features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
+    // Remove this when client support is ready for the enable_partitioned_epoch_reward feature
+    features_to_deactivate.push(feature_set::enable_partitioned_epoch_reward::id());
 
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/32174 broke the `getInflationReward` RPC endpoint on solana-test-validator because TestValidator features are always on by default, and the `enable_partitioned_epoch_reward` feature moves the location of stake rewards without updating RPC to figure out where they are. This would be a problem on a real cluster as well, but only if the feature is activated before RPC/client support is implemented

#### Summary of Changes
Because client support for partitioned epoch rewards isn't yet designed (as per https://github.com/solana-foundation/solana-improvement-documents/pull/15#issuecomment-1570321524), slap a bandaid on solana-test-validator that deactivates the feature in genesis.


Fixes #33098
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
