### PR TITLE
Removes invariant `is_serialized_with_abs` param

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -501,7 +501,7 @@ pub struct PrunedBanksRequestHandler {
 }
 
 impl PrunedBanksRequestHandler {
-    pub fn handle_request(&self, bank: &Bank, is_serialized_with_abs: bool) -> usize {
+    pub fn handle_request(&self, bank: &Bank) -> usize {
         let mut banks_to_purge: Vec<_> = self.pruned_banks_receiver.try_iter().collect();
         // We need a stable sort to ensure we purge banks—with the same slot—in the same order
         // they were sent into the channel.
@@ -518,7 +518,7 @@ impl PrunedBanksRequestHandler {
         accounts_db.thread_pool_clean.install(|| {
             grouped_banks_to_purge.into_par_iter().for_each(|group| {
                 group.iter().for_each(|(slot, bank_id)| {
-                    accounts_db.purge_slot(*slot, *bank_id, is_serialized_with_abs);
+                    accounts_db.purge_slot(*slot, *bank_id, true);
                 })
             });
         });
@@ -533,7 +533,7 @@ impl PrunedBanksRequestHandler {
         total_remove_slots_time: &mut u64,
     ) {
         let mut remove_slots_time = Measure::start("remove_slots_time");
-        *removed_slots_count += self.handle_request(bank, true);
+        *removed_slots_count += self.handle_request(bank);
         remove_slots_time.stop();
         *total_remove_slots_time += remove_slots_time.as_us();
 
@@ -1154,7 +1154,7 @@ mod test {
         drop(fork2_bank1);
         drop(fork0_bank1);
         drop(fork0_bank0);
-        let num_banks_purged = pruned_banks_request_handler.handle_request(&fork0_bank3, true);
+        let num_banks_purged = pruned_banks_request_handler.handle_request(&fork0_bank3);
         assert_eq!(num_banks_purged, 7);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8562,7 +8562,7 @@ fn test_store_scan_consistency_unrooted() {
                 current_major_fork_bank.clean_accounts_for_tests();
                 // Move purge here so that Bank::drop()->purge_slots() doesn't race
                 // with clean. Simulates the call from AccountsBackgroundService
-                pruned_banks_request_handler.handle_request(&current_major_fork_bank, true);
+                pruned_banks_request_handler.handle_request(&current_major_fork_bank);
             }
         },
         Some(Box::new(SendDroppedBankCallback::new(pruned_banks_sender))),


### PR DESCRIPTION
#### Problem

`PrunedBanksRequestHandler::handle_request()` takes a parameter, `is_serialized_with_abs`, that is always called with `true`. I can't think of a reason why—from this function—we'd want to call `AccountsDb::purge_slot()` with a different value. So having this parameter seems unnecessary at best, and error-prone at worst.


#### Summary of Changes

Remove the param.