### PR TITLE
PrunedBanksRequestHandler::handle_request() is only pub with dcou

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,6 +6857,7 @@ dependencies = [
  "once_cell",
  "ouroboros",
  "percentage",
+ "qualifier_attr",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5551,6 +5551,7 @@ dependencies = [
  "once_cell",
  "ouroboros",
  "percentage",
+ "qualifier_attr",
  "rand 0.8.5",
  "rayon",
  "regex",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -40,6 +40,7 @@ num_enum = { workspace = true }
 once_cell = { workspace = true }
 ouroboros = { workspace = true }
 percentage = { workspace = true }
+qualifier_attr = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -3,6 +3,8 @@
 //! This can be expensive since we have to walk the append vecs being cleaned up.
 
 mod stats;
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         bank::{Bank, BankSlotDelta, DropCallback},
@@ -501,7 +503,8 @@ pub struct PrunedBanksRequestHandler {
 }
 
 impl PrunedBanksRequestHandler {
-    pub fn handle_request(&self, bank: &Bank) -> usize {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn handle_request(&self, bank: &Bank) -> usize {
         let mut banks_to_purge: Vec<_> = self.pruned_banks_receiver.try_iter().collect();
         // We need a stable sort to ensure we purge banks—with the same slot—in the same order
         // they were sent into the channel.


### PR DESCRIPTION
#### Problem

`PrunedBanksRequestHandler::handle_request()` is only meant to be called from AccountsBackgroundService, but it is public so that bank tests can call it. Now that we have DCOU, we no longer need for this function to be pub for non-tests.


#### Summary of Changes

`PrunedBanksRequestHandler::handle_request()` is only public when in dev context.