### PR TITLE
rpc: turn off getStakeActivation epoch parameter

### DIFF
--- a/docs/src/api/methods/_getStakeActivation.mdx
+++ b/docs/src/api/methods/_getStakeActivation.mdx
@@ -41,6 +41,7 @@ Configuration object containing the following fields:
 <Field name="epoch" type="u64" optional={true}>
   epoch for which to calculate activation details. If parameter not provided,
   defaults to current epoch.
+  **DEPRECATED**, inputs other than the current epoch return an error.
 </Field>
 
 </Parameter>

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1719,14 +1719,10 @@ impl JsonRpcRequestProcessor {
             min_context_slot: config.min_context_slot,
         })?;
         let epoch = config.epoch.unwrap_or_else(|| bank.epoch());
-        if bank.epoch().saturating_sub(epoch) > solana_sdk::stake_history::MAX_ENTRIES as u64 {
+        if epoch != bank.epoch() {
             return Err(Error::invalid_params(format!(
-                "Invalid param: epoch {epoch:?} is too far in the past"
-            )));
-        }
-        if epoch > bank.epoch() {
-            return Err(Error::invalid_params(format!(
-                "Invalid param: epoch {epoch:?} has not yet started"
+                "Invalid param: epoch {epoch:?}. Only the current epoch ({:?}) is supported",
+                bank.epoch()
             )));
         }
 


### PR DESCRIPTION
#### Problem
`getStakeActivation` returns incorrect data for previous epochs because it depends on a stake account's *current* Delegation, which may include past rewards, splits, or merges.

#### Summary of Changes
Return an error when a submitted `epoch` parameter is not the current epoch. Users should just remove the 
I updated the docs to notate the config-parameter field as "deprecated", but open to better ways to document the change.

Fixes #26622
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
