### PR TITLE
optimize hash cache data file writes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10661,10 +10661,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[0].push(raw_expected[1].clone());
-        expected[bins - 1].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected[3].clone());
+        expected[0].push(raw_expected[0]);
+        expected[0].push(raw_expected[1]);
+        expected[bins - 1].push(raw_expected[2]);
+        expected[bins - 1].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 0, bins);
 
         let bins = 4;
@@ -10683,10 +10683,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[1].push(raw_expected[1].clone());
-        expected[2].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected[3].clone());
+        expected[0].push(raw_expected[0]);
+        expected[1].push(raw_expected[1]);
+        expected[2].push(raw_expected[2]);
+        expected[bins - 1].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 0, bins);
 
         let bins = 256;
@@ -10705,10 +10705,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[127].push(raw_expected[1].clone());
-        expected[128].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected.last().unwrap().clone());
+        expected[0].push(raw_expected[0]);
+        expected[127].push(raw_expected[1]);
+        expected[128].push(raw_expected[2]);
+        expected[bins - 1].push(*raw_expected.last().unwrap());
         assert_scan(result, vec![expected], bins, 0, bins);
     }
 
@@ -10767,8 +10767,8 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); half_bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[0].push(raw_expected[1].clone());
+        expected[0].push(raw_expected[0]);
+        expected[0].push(raw_expected[1]);
         assert_scan(result, vec![expected], bins, 0, half_bins);
 
         // just the second bin of 2
@@ -10789,8 +10789,8 @@ pub mod tests {
 
         let mut expected = vec![Vec::new(); half_bins];
         let starting_bin_index = 0;
-        expected[starting_bin_index].push(raw_expected[2].clone());
-        expected[starting_bin_index].push(raw_expected[3].clone());
+        expected[starting_bin_index].push(raw_expected[2]);
+        expected[starting_bin_index].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 1, bins - 1);
 
         // 1 bin at a time of 4
@@ -10812,7 +10812,7 @@ pub mod tests {
                 )
                 .unwrap();
             let mut expected = vec![Vec::new(); 1];
-            expected[0].push(expected_item.clone());
+            expected[0].push(*expected_item);
             assert_scan(result, vec![expected], bins, bin, 1);
         }
 
@@ -10837,7 +10837,7 @@ pub mod tests {
             let mut expected = vec![];
             if let Some(index) = bin_locations.iter().position(|&r| r == bin) {
                 expected = vec![Vec::new(); range];
-                expected[0].push(raw_expected[index].clone());
+                expected[0].push(raw_expected[index]);
             }
             let mut result2 = (0..range).map(|_| Vec::default()).collect::<Vec<_>>();
             if let Some(m) = result.get(0) {
@@ -10882,7 +10882,7 @@ pub mod tests {
             .unwrap();
         assert_eq!(result.len(), 1); // 2 chunks, but 1 is empty so not included
         let mut expected = vec![Vec::new(); range];
-        expected[0].push(raw_expected[1].clone());
+        expected[0].push(raw_expected[1]);
         let mut result2 = (0..range).map(|_| Vec::default()).collect::<Vec<_>>();
         result[0].load_all(&mut result2, 0, &PubkeyBinCalculator24::new(range));
         assert_eq!(result2.len(), 1);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -6,6 +6,7 @@ use {
         pubkey_bins::PubkeyBinCalculator24,
         rent_collector::RentCollector,
     },
+    bytemuck::{Pod, Zeroable},
     log::*,
     memmap2::MmapMut,
     rayon::prelude::*,
@@ -268,7 +269,7 @@ impl HashStats {
 /// Note this can be saved/loaded during hash calculation to a memory mapped file whose contents are
 /// [CalculateHashIntermediate]
 #[repr(C)]
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy, Pod, Zeroable)]
 pub struct CalculateHashIntermediate {
     pub hash: Hash,
     pub lamports: u64,

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1749,7 +1749,7 @@ pub mod tests {
         let hash = Hash::new_unique();
         let mut account_maps = Vec::new();
         let val = CalculateHashIntermediate::new(hash, 1, key);
-        account_maps.push(val.clone());
+        account_maps.push(val);
 
         let vecs = vec![account_maps.to_vec()];
         let slice = convert_to_slice(&vecs);

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -123,7 +123,7 @@ impl CacheHashDataFile {
                 "{pubkey_to_bin_index}, {start_bin_index}"
             ); // this would indicate we put a pubkey in too high of a bin
             pubkey_to_bin_index -= start_bin_index;
-            accumulator[pubkey_to_bin_index].push(d.clone()); // may want to avoid clone here
+            accumulator[pubkey_to_bin_index].push(*d); // may want to avoid clone here
         }
 
         m2.stop();

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -6,11 +6,10 @@ use {
     bytemuck::{Pod, Zeroable},
     memmap2::MmapMut,
     solana_measure::measure::Measure,
-    std::io::BufWriter,
     std::{
         collections::HashSet,
         fs::{self, remove_file, File, OpenOptions},
-        io::Write,
+        io::{BufWriter, Write},
         path::{Path, PathBuf},
         sync::{atomic::Ordering, Arc, Mutex},
     },

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -326,8 +326,7 @@ impl CacheHashData {
         let mut m2 = Measure::start("write_to_mmap");
         let mut i = 0;
         for x in data {
-            let size = x.len() * std::mem::size_of::<EntryType>();
-            let slice = unsafe { std::slice::from_raw_parts(x.as_ptr() as *const u8, size) };
+            let slice = bytemuck::cast_slice(x.as_slice());
             fw.write_all(slice)?;
             i += x.len();
         }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -6,6 +6,7 @@
 use {
     crate::{sanitize::Sanitize, wasm_bindgen},
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    bytemuck::{Pod, Zeroable},
     sha2::{Digest, Sha256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
@@ -41,6 +42,8 @@ const MAX_BASE58_LEN: usize = 44;
     Ord,
     PartialOrd,
     Hash,
+    Pod,
+    Zeroable,
     AbiExample,
 )]
 #[repr(transparent)]


### PR DESCRIPTION
#### Problem

mmap the `whole` hash cache data file into memory to write, then `unmmap` the data file is not efficient. It increases the TLB pressure (more page table entries) and leads to higher dirty page ratio, which puts stress on the memory paging table.

Since writing out the hash cache data is sequential, a buffered file writer will put less stress on memory paging table resources and lead to better performance. 


- master (mmap, element by element writes)

```
sol@dev-equinix-washington-23:~$ grep cache_hash_data_stats  d1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "write_to_mmap_us"
write_to_mmap_us           28268583i
write_to_mmap_us           288182i
```

- mmap, slice writes
```
sol@dev-equinix-washington-23:~$ grep cache_hash_data_stats  d1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "write_to_mmap_us"
write_to_mmap_us           31239824i
write_to_mmap_us           305127i
```

It is slower to copy the slice (probably due to the fact that faster write lead to higher dirty page ratio and puts more pressure on memory paging).

- FileBufWriter

```
sol@dev-equinix-washington-23:~$ grep cache_hash_data_stats  d1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "write_to_mmap_us"                                                                            
write_to_mmap_us           22873415i
write_to_mmap_us           262826i
```

FileBufWriter saves 6s for writing out cached hash data into file. 

#### Summary of Changes

Use BufWriter to write out cached hash data file. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
