### PR TITLE
ci: trigger client_targets pipeline when the cargo file changes

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -12,6 +12,8 @@ on:
       - "sdk/**"
       - ".github/workflows/client-targets.yml"
       - "ci/rust-version.sh"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
#### Summary of Changes

our client_targets is failed on master now. I think we should trigger the pipieline when the cargo files changes so that we can catch errors earlier.

https://github.com/solana-labs/solana/actions/runs/6094904422