### PR TITLE
Check loader-v4::id() as a valid program owner

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5079,6 +5079,7 @@ impl Bank {
             bpf_loader_upgradeable::id(),
             bpf_loader::id(),
             bpf_loader_deprecated::id(),
+            loader_v4::id(),
         ];
         let program_owners_refs: Vec<&Pubkey> = program_owners.iter().collect();
         let mut program_accounts_map = self.rc.accounts.filter_executable_program_accounts(


### PR DESCRIPTION
#### Problem
The filtering of valid programs does not include programs owned by loader-v4.

#### Summary of Changes
Include the loader_v4 to the list of valid program owners.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
