### PR TITLE
Takes inner HashSet when dropping CacheHashData

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -226,12 +226,12 @@ impl CacheHashData {
         result
     }
     fn delete_old_cache_files(&self) {
-        let pre_existing_cache_files = self.pre_existing_cache_files.lock().unwrap();
-        if !pre_existing_cache_files.is_empty() {
+        let old_cache_files = std::mem::take(&mut *self.pre_existing_cache_files.lock().unwrap());
+        if !old_cache_files.is_empty() {
             self.stats
                 .unused_cache_files
-                .fetch_add(pre_existing_cache_files.len(), Ordering::Relaxed);
-            for file_name in pre_existing_cache_files.iter() {
+                .fetch_add(old_cache_files.len(), Ordering::Relaxed);
+            for file_name in old_cache_files.iter() {
                 let result = self.cache_dir.join(file_name);
                 let _ = fs::remove_file(result);
             }


### PR DESCRIPTION
#### Problem

When dropping CacheHashData, we lock the mutex holding the unused preexisting cache files for the duration of the function. Since this field can be shared, this may block others that are holding the same Arc, slowing down their `drop`.

Another potential issue, since we delete these preexisting files *but do not remove them* from the HashSet, another instance that shares the HashSet would still have PathBufs to the now-deleted files.

#### Summary of Changes

Take the inner HashMap of preexisting files at the beginning of `drop` and immediately release the mutex.