### PR TITLE
ShrinkCandidates only holds slot

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1347,10 +1347,7 @@ pub mod tests {
                         let storage = db.storage.get_slot_storage_entry(slot);
                         assert!(storage.is_some());
                         if in_shrink_candidate_slots {
-                            db.shrink_candidate_slots
-                                .lock()
-                                .unwrap()
-                                .insert(slot, storage.unwrap());
+                            db.shrink_candidate_slots.lock().unwrap().insert(slot);
                         }
                     });
 
@@ -1379,11 +1376,7 @@ pub mod tests {
                     );
 
                     slots.clone().for_each(|slot| {
-                        assert!(!db
-                            .shrink_candidate_slots
-                            .lock()
-                            .unwrap()
-                            .contains_key(&slot));
+                        assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&slot));
                     });
 
                     let roots_after = db


### PR DESCRIPTION
#### Problem
Improving startup time.
Now that we only have 1 storage per slot, it is more efficient to not hold an `Arc` to the append vec in the shrink list.
During index generation, especially with incremental snapshots, we can end up with say 60M duplicate pubkeys across all 432k slots. This results in a lot of record keeping and inefficient `HashMap` stuffing of almost every `(Slot, Arc<AppendVec>)`. Getting the append vecs is not fast. They can be looked up in the bg thread by shrink itself. A slot is sufficient to request a shrink.

#### Summary of Changes
Just hold a `HashSet<Slot>` instead of a `HashMap<Slot, Arc<AppendVec>>`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
