### PR TITLE
wip: stop scanning pubkeys when rewrites are disabled

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1942,6 +1942,7 @@ fn test_collect_rent_from_accounts() {
             vec![(zero_lamport_pubkey, account, later_slot - 1)],
             None,
             PartitionIndex::default(),
+            false, // should we cycle this here?
         );
 
         let deltas = later_bank


### PR DESCRIPTION
#### Problem
when rewrites are disasbled, stop scanning pubkeys

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
