### PR TITLE
[clap-v3-utils] Add replace deprecated `value_of` and `is_present` with `get_one` and `contains_id`

### DIFF
--- a/clap-v3-utils/src/input_parsers.rs
+++ b/clap-v3-utils/src/input_parsers.rs
@@ -14,7 +14,7 @@ use {
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair, Signature, Signer},
     },
-    std::{rc::Rc, str::FromStr},
+    std::{error, rc::Rc, str::FromStr},
 };
 
 // Sentinel value used to indicate to write to screen instead of file
@@ -69,6 +69,15 @@ pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
     }
 }
 
+// Return the keypair for an argument with filename `name` or `None` if not present wrapped inside `Result`.
+pub fn try_keypair_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<Keypair>, Box<dyn error::Error>> {
+    matches.try_contains_id(name)?;
+    Ok(keypair_of(matches, name))
+}
+
 pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
     matches.values_of(name).map(|values| {
         values
@@ -84,10 +93,28 @@ pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
     })
 }
 
+pub fn try_keypairs_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<Vec<Keypair>>, Box<dyn error::Error>> {
+    matches.try_contains_id(name)?;
+    Ok(keypairs_of(matches, name))
+}
+
 // Return a pubkey for an argument that can itself be parsed into a pubkey,
 // or is a filename that can be read as a keypair
 pub fn pubkey_of(matches: &ArgMatches, name: &str) -> Option<Pubkey> {
     value_of(matches, name).or_else(|| keypair_of(matches, name).map(|keypair| keypair.pubkey()))
+}
+
+// Return a `Result` wrapped pubkey for an argument that can itself be parsed into a pubkey,
+// or is a filename that can be read as a keypair
+pub fn try_pubkey_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<Pubkey>, Box<dyn error::Error>> {
+    matches.try_contains_id(name)?;
+    Ok(pubkey_of(matches, name))
 }
 
 pub fn pubkeys_of(matches: &ArgMatches, name: &str) -> Option<Vec<Pubkey>> {
@@ -104,6 +131,14 @@ pub fn pubkeys_of(matches: &ArgMatches, name: &str) -> Option<Vec<Pubkey>> {
     })
 }
 
+pub fn try_pubkeys_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<Vec<Pubkey>>, Box<dyn error::Error>> {
+    matches.try_contains_id(name)?;
+    Ok(pubkeys_of(matches, name))
+}
+
 // Return pubkey/signature pairs for a string of the form pubkey=signature
 pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, Signature)>> {
     matches.values_of(name).map(|values| {
@@ -116,6 +151,16 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, 
             })
             .collect()
     })
+}
+
+// Return pubkey/signature pairs for a string of the form pubkey=signature wrapped inside `Result`
+#[allow(clippy::type_complexity)]
+pub fn try_pubkeys_sigs_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<Vec<(Pubkey, Signature)>>, Box<dyn error::Error>> {
+    matches.try_contains_id(name)?;
+    Ok(pubkeys_sigs_of(matches, name))
 }
 
 // Return a signer from matches at `name`

--- a/clap-v3-utils/src/input_parsers.rs
+++ b/clap-v3-utils/src/input_parsers.rs
@@ -170,7 +170,7 @@ pub fn signer_of(
     name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<(Option<Box<dyn Signer>>, Option<Pubkey>), Box<dyn std::error::Error>> {
-    if let Some(location) = matches.value_of(name) {
+    if let Some(location) = matches.try_get_one::<String>(name)? {
         let signer = signer_from_path(matches, location, name, wallet_manager)?;
         let signer_pubkey = signer.pubkey();
         Ok((Some(signer), Some(signer_pubkey)))
@@ -184,7 +184,7 @@ pub fn pubkey_of_signer(
     name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Pubkey>, Box<dyn std::error::Error>> {
-    if let Some(location) = matches.value_of(name) {
+    if let Some(location) = matches.try_get_one::<String>(name)? {
         Ok(Some(pubkey_from_path(
             matches,
             location,
@@ -201,7 +201,7 @@ pub fn pubkeys_of_multiple_signers(
     name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<Vec<Pubkey>>, Box<dyn std::error::Error>> {
-    if let Some(pubkey_matches) = matches.values_of(name) {
+    if let Some(pubkey_matches) = matches.try_get_many::<String>(name)? {
         let mut pubkeys: Vec<Pubkey> = vec![];
         for signer in pubkey_matches {
             pubkeys.push(pubkey_from_path(matches, signer, name, wallet_manager)?);
@@ -219,7 +219,7 @@ pub fn resolve_signer(
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     resolve_signer_from_path(
         matches,
-        matches.value_of(name).unwrap(),
+        matches.try_get_one::<String>(name)?.unwrap(),
         name,
         wallet_manager,
     )

--- a/clap-v3-utils/src/keygen/derivation_path.rs
+++ b/clap-v3-utils/src/keygen/derivation_path.rs
@@ -22,10 +22,11 @@ pub fn derivation_path_arg<'a>() -> Arg<'a> {
 pub fn acquire_derivation_path(
     matches: &ArgMatches,
 ) -> Result<Option<DerivationPath>, Box<dyn error::Error>> {
-    if matches.is_present("derivation_path") {
+    if matches.try_contains_id("derivation_path")? {
         Ok(Some(DerivationPath::from_absolute_path_str(
             matches
-                .value_of("derivation_path")
+                .try_get_one::<String>("derivation_path")?
+                .map(|path| path.as_str())
                 .unwrap_or(DEFAULT_DERIVATION_PATH),
         )?))
     } else {

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -62,7 +62,11 @@ pub fn no_passphrase_arg<'a>() -> Arg<'a> {
 }
 
 pub fn acquire_language(matches: &ArgMatches) -> Language {
-    match matches.value_of(LANGUAGE_ARG.name).unwrap() {
+    match matches
+        .get_one::<String>(LANGUAGE_ARG.name)
+        .unwrap()
+        .as_str()
+    {
         "english" => Language::English,
         "chinese-simplified" => Language::ChineseSimplified,
         "chinese-traditional" => Language::ChineseTraditional,
@@ -82,7 +86,7 @@ pub fn no_passphrase_and_message() -> (String, String) {
 pub fn acquire_passphrase_and_message(
     matches: &ArgMatches,
 ) -> Result<(String, String), Box<dyn error::Error>> {
-    if matches.is_present(NO_PASSPHRASE_ARG.name) {
+    if matches.try_contains_id(NO_PASSPHRASE_ARG.name)? {
         Ok(no_passphrase_and_message())
     } else {
         match prompt_passphrase(

--- a/clap-v3-utils/src/keygen/mod.rs
+++ b/clap-v3-utils/src/keygen/mod.rs
@@ -38,7 +38,7 @@ pub fn check_for_overwrite(
     outfile: &str,
     matches: &ArgMatches,
 ) -> Result<(), Box<dyn error::Error>> {
-    let force = matches.is_present("force");
+    let force = matches.try_contains_id("force")?;
     if !force && Path::new(outfile).exists() {
         let err_msg = format!("Refusing to overwrite {outfile} without --force flag");
         return Err(err_msg.into());

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -765,7 +765,7 @@ pub fn signer_from_path_with_config(
     } = parse_signer_source(path)?;
     match kind {
         SignerSourceKind::Prompt => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+            let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
             Ok(Box::new(keypair_from_seed_phrase(
                 keypair_name,
                 skip_validation,
@@ -809,7 +809,7 @@ pub fn signer_from_path_with_config(
                 .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
-            } else if config.allow_null_signer || matches.is_present(SIGN_ONLY_ARG.name) {
+            } else if config.allow_null_signer || matches.try_contains_id(SIGN_ONLY_ARG.name)? {
                 Ok(Box::new(NullSigner::new(&pubkey)))
             } else {
                 Err(std::io::Error::new(
@@ -885,7 +885,7 @@ pub fn resolve_signer_from_path(
     } = parse_signer_source(path)?;
     match kind {
         SignerSourceKind::Prompt => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+            let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
             // This method validates the seed phrase, but returns `None` because there is no path
             // on disk or to a device
             keypair_from_seed_phrase(
@@ -1004,7 +1004,7 @@ pub fn keypair_from_path(
     keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
-    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
     let keypair = encodable_key_from_path(path, keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&keypair, "pubkey");
@@ -1052,7 +1052,7 @@ pub fn elgamal_keypair_from_path(
     elgamal_keypair_name: &str,
     confirm_pubkey: bool,
 ) -> Result<ElGamalKeypair, Box<dyn error::Error>> {
-    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
     let elgamal_keypair = encodable_key_from_path(path, elgamal_keypair_name, skip_validation)?;
     if confirm_pubkey {
         confirm_encodable_keypair_pubkey(&elgamal_keypair, "ElGamal pubkey");
@@ -1107,7 +1107,7 @@ pub fn ae_key_from_path(
     path: &str,
     key_name: &str,
 ) -> Result<AeKey, Box<dyn error::Error>> {
-    let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+    let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
     encodable_key_from_path(path, key_name, skip_validation)
 }
 


### PR DESCRIPTION
#### Problem
The behavior of clap `ArgMatches::value_of` and `ArgMatches::is_present` in clap v2 and v3 are different making it hard to upgrade existing Solana cli tools (in particular the token-cli) from using clap v2 to clap v3.

The behavior of `ArgMatches::value_of` differs in clap v2 and v3 as follows:
- In v2, if `ArgMatches::value_of` succeeds in retrieving the argument say `arg`, then it returns `Some(arg)`. If it fails in any other way, it returns `None`.
- In v3, if `ArgMatches::value_of` succeeds in retrieving the argument, then it returns `Some(arg)`. If the queried argument id is valid (it was declared with `Arg::new(...)` when defining the command), but it was not provided by the user, the it returns `None`. If the argument id is not valid, then it panics.

The `ArgMatches::is_present` has the analogous behavior:
- In v2, if an argument say `arg` was provided by the user, then `is_present(arg)` returns `true`. In all other cases, it returns `false`.
- In v3, if the argument was provided by the user, it returns `true`. If `arg` is valid, but was not provided by the user, then it returns `false`. If `arg` is not valid, then it panics.

So if we try to upgrade a cli tools from using `solana-clap-v2-utils` to `solana-clap-v3-utils`, the tests fails due to the panicking behavior introduced with v3.

Also, `value_of` and `is_present` are technically deprecated functions, but they are still used in `clap-v3-utils`, `solana-keygen`, and `solana-zk-keygen`. They should really be replaced with `ArgMatches::get_one`/`Argmatches::try_get_one` and `ArgMatches::contains_id`/`ArgMatches::try_contains_id`. In particular, the `try_get_one` and `try_contains_id` returns an `Option<_>` type wrapped inside another `Result<_,_>` type.
- If an argument is valid and was provided by the user:
  - `try_get_one` and `try_contains_id` returns `Ok(Some(arg_val))` and `Ok(true)` respectively
- If an argument is valid, but was not provided by the user:
  - `try_get_one` and `try_contains_id` returns `Ok(None)` and `Ok(false)` respectively.
- If an argument is invalid,
  - `try_get_one` and `try_contains_id` both returns `MatchesError::UnknownArgument`.

It would be nice to just replace `value_of` and `is_present` with `get_one` and `contains_id` in `clap-v3-utils`, but unfortunately, the deprecated functions and the newer functions behave differently in a non-trivial way, which would break existing cli tools that rely on `clap-v3-utils`.

#### Summary of Changes
- For key-related input parser functions, I added the `try_...` variants that use `try_get_one` or `try_contains_id` to return a suitable error when an argument is not valid.
- For functions that return a general error type `Box<dyn error::Error>`, I replaced the use of `value_of` and `is_present` with `try_get_one` and `contains_id`. This does not alter the behavior of the functions other than potentially returning a suitable error when it would otherwise panic.

This will unblock cli tools from upgrading to using clap-v3 without introducing breaking changes. On a follow-up PR, I will make some additional updates to `clap-v3-utils` to replace some deprecated functions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
