### PR TITLE
ci: move solana-client-test to nextest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5650,6 +5650,7 @@ name = "solana-client-test"
 version = "1.17.0"
 dependencies = [
  "futures-util",
+ "rand 0.8.5",
  "serde_json",
  "solana-client",
  "solana-ledger",

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -31,7 +31,6 @@ if [ ! "$LIMIT" -gt "$INDEX" ]; then
 fi
 
 DONT_USE_NEXTEST_PACKAGES=(
-  solana-client-test
   solana-cargo-build-sbf
   solana-core
 )

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 
 [dependencies]
 futures-util = { workspace = true }
+rand = { workspace = true }
 serde_json = { workspace = true }
 solana-client = { workspace = true }
 solana-ledger = { workspace = true }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -1,5 +1,6 @@
 use {
     futures_util::StreamExt,
+    rand::Rng,
     serde_json::{json, Value},
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
     solana_pubsub_client::{nonblocking, pubsub_client::PubsubClient},
@@ -28,7 +29,6 @@ use {
         commitment_config::{CommitmentConfig, CommitmentLevel},
         native_token::sol_to_lamports,
         pubkey::Pubkey,
-        rpc_port,
         signature::{Keypair, Signer},
         system_program, system_transaction,
     },
@@ -41,7 +41,7 @@ use {
         collections::HashSet,
         net::{IpAddr, SocketAddr},
         sync::{
-            atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
+            atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, RwLock,
         },
         thread::sleep,
@@ -51,12 +51,10 @@ use {
     tungstenite::connect,
 };
 
-static NEXT_RPC_PUBSUB_PORT: AtomicU16 = AtomicU16::new(rpc_port::DEFAULT_RPC_PUBSUB_PORT);
-
 fn pubsub_addr() -> SocketAddr {
     SocketAddr::new(
         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        NEXT_RPC_PUBSUB_PORT.fetch_add(1, Ordering::Relaxed),
+        rand::thread_rng().gen_range(1024..65535),
     )
 }
 


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/33102

nextest runs tests individually. using a static variable in solana-client-test will make these tests failed.

#### Summary of Changes

use random ports to test. (for now I guess it will be fine. if we have hundreds of tests here, I think we need to use another solution to avoid port number collision)

(there was a discussion about pre-defined const port numbers https://github.com/solana-labs/solana/pull/29255/commits/2436fe10bdfef7bc2586a8bf7699c631aa540d76)
