### PR TITLE
Uses hex for the hash in accounts hash cache file names

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7246,22 +7246,6 @@ impl AccountsDb {
                         {
                             return Some(mapped_file);
                         }
-
-                        // if we didn't find the cache file, try again one more time
-                        // with the old file name format
-                        let old_file_name = format!(
-                            "{}.{}.{}.{}.{}",
-                            range_this_chunk.start,
-                            range_this_chunk.end,
-                            bin_range.start,
-                            bin_range.end,
-                            hash
-                        );
-                        if let Ok(mapped_file) =
-                            cache_hash_data.get_file_reference_to_map_later(&old_file_name)
-                        {
-                            return Some(mapped_file);
-                        }
                     }
 
                     // fall through and load normally - we failed to load from a cache file


### PR DESCRIPTION
#### Problem

The hash part of the file name for accounts hash cache paths could be more aesthetically pleasing.


#### Summary of Changes

Use hex for the hash in the file name for an accounts hash cache path.


Note, since #33164 has merged, any validator will rebuild their accounts hash cache already, so now's the perfect time to rename the hash files.

Further, any mnb/testnet/devnet node running a v1.16 release will (should) see the backport of #33164 and the backport of this PR in the same future release, which solidifies the above point as well.