### PR TITLE
v1.14: ci: use llvm 15 for Windows build

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -54,6 +54,7 @@ jobs:
           echo "::set-output name=tag::$CI_TAG"
           eval "$(ci/channel-info.sh)"
           echo "::set-output name=channel::$CHANNEL"
+          choco install llvm --version=15.0.7 --force
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files


### PR DESCRIPTION
#### Problem

our Windows build failed on v1.14 branch

(https://github.com/solana-labs/solana/actions/runs/6123962073/job/16622993534)

#### Summary of Changes

the default llvm version is 16 in the window image atm. reinstall it with 15.