### PR TITLE
TransactionScheduler: InFlightTracker

### DIFF
--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,7 +1,7 @@
 use {
     super::immutable_deserialized_packet::ImmutableDeserializedPacket,
     solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
-    std::sync::Arc,
+    std::{fmt::Display, sync::Arc},
 };
 
 /// A unique identifier for a transaction batch.
@@ -14,6 +14,12 @@ impl TransactionBatchId {
     }
 }
 
+impl Display for TransactionBatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A unique identifier for a transaction.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct TransactionId(u64);
@@ -21,6 +27,12 @@ pub struct TransactionId(u64);
 impl TransactionId {
     pub fn new(index: u64) -> Self {
         Self(index)
+    }
+}
+
+impl Display for TransactionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -1,0 +1,52 @@
+use {
+    super::thread_aware_account_locks::ThreadId,
+    crate::banking_stage::scheduler_messages::TransactionBatchId, std::collections::HashMap,
+};
+
+/// Tracks the number of transactions that are in flight for each thread.
+pub struct InFlightTracker {
+    num_in_flight_per_thread: Vec<usize>,
+    batch_id_to_thread_id: HashMap<TransactionBatchId, ThreadId>,
+}
+
+impl InFlightTracker {
+    pub fn new(num_threads: usize) -> Self {
+        Self {
+            num_in_flight_per_thread: vec![0; num_threads],
+            batch_id_to_thread_id: HashMap::new(),
+        }
+    }
+
+    /// Returns the number of transactions that are in flight for each thread.
+    pub fn num_in_flight_per_thread(&self) -> &[usize] {
+        &self.num_in_flight_per_thread
+    }
+
+    /// Add a new batch with given `batch_id` and `num_transactions` to the
+    /// thread with given `thread_id`.
+    pub fn track_batch(
+        &mut self,
+        batch_id: TransactionBatchId,
+        num_transactions: usize,
+        thread_id: ThreadId,
+    ) {
+        self.num_in_flight_per_thread[thread_id] += num_transactions;
+        self.batch_id_to_thread_id.insert(batch_id, thread_id);
+    }
+
+    /// Removes `num_transactions` from the thread which the batch was
+    /// assigned to.
+    pub fn complete_batch(
+        &mut self,
+        batch_id: TransactionBatchId,
+        num_transactions: usize,
+    ) -> ThreadId {
+        let thread_id = self
+            .batch_id_to_thread_id
+            .remove(&batch_id)
+            .expect("transaction batch id should exist in in-flight tracker");
+        self.num_in_flight_per_thread[thread_id] -= num_transactions;
+
+        thread_id
+    }
+}

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -6,14 +6,19 @@ use {
 /// Tracks the number of transactions that are in flight for each thread.
 pub struct InFlightTracker {
     num_in_flight_per_thread: Vec<usize>,
-    batch_id_to_thread_id: HashMap<TransactionBatchId, ThreadId>,
+    batches: HashMap<TransactionBatchId, BatchEntry>,
+}
+
+struct BatchEntry {
+    thread_id: ThreadId,
+    num_transactions: usize,
 }
 
 impl InFlightTracker {
     pub fn new(num_threads: usize) -> Self {
         Self {
             num_in_flight_per_thread: vec![0; num_threads],
-            batch_id_to_thread_id: HashMap::new(),
+            batches: HashMap::new(),
         }
     }
 
@@ -31,22 +36,84 @@ impl InFlightTracker {
         thread_id: ThreadId,
     ) {
         self.num_in_flight_per_thread[thread_id] += num_transactions;
-        self.batch_id_to_thread_id.insert(batch_id, thread_id);
+        assert!(
+            self.batches
+                .insert(
+                    batch_id,
+                    BatchEntry {
+                        thread_id,
+                        num_transactions,
+                    }
+                )
+                .is_none(),
+            "batch id {batch_id} is already being tracked"
+        );
     }
 
-    /// Removes `num_transactions` from the thread which the batch was
-    /// assigned to.
-    pub fn complete_batch(
-        &mut self,
-        batch_id: TransactionBatchId,
-        num_transactions: usize,
-    ) -> ThreadId {
-        let thread_id = self
-            .batch_id_to_thread_id
+    /// Stop tracking the batch with given `batch_id`.
+    /// Removes the number of transactions for the scheduled thread.
+    /// Returns the thread id that the batch was scheduled on.
+    ///
+    /// # Panics
+    /// Panics if the batch id does not exist in the tracker.
+    pub fn complete_batch(&mut self, batch_id: TransactionBatchId) -> ThreadId {
+        let BatchEntry {
+            thread_id,
+            num_transactions,
+        } = self
+            .batches
             .remove(&batch_id)
-            .expect("transaction batch id should exist in in-flight tracker");
+            .expect("batch id {batch} is not being tracked");
         self.num_in_flight_per_thread[thread_id] -= num_transactions;
 
         thread_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "is already being tracked")]
+    fn test_in_flight_tracker_duplicate_batch() {
+        let mut in_flight_tracker = InFlightTracker::new(2);
+
+        let batch_id = TransactionBatchId::new(0);
+        let batch_num_transactions = 2;
+
+        in_flight_tracker.track_batch(batch_id, batch_num_transactions, 0);
+        in_flight_tracker.track_batch(batch_id, batch_num_transactions, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "is not being tracked")]
+    fn test_in_flight_tracker_untracked_batch() {
+        let mut in_flight_tracker = InFlightTracker::new(2);
+        in_flight_tracker.complete_batch(TransactionBatchId::new(5));
+    }
+
+    #[test]
+    fn test_in_flight_tracker() {
+        let mut in_flight_tracker = InFlightTracker::new(2);
+
+        let batch_id_0 = TransactionBatchId::new(0);
+        let batch_id_1 = TransactionBatchId::new(1);
+
+        // Add a batch with 2 transactions to thread 0.
+        in_flight_tracker.track_batch(batch_id_0, 2, 0);
+        assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[2, 0]);
+
+        // Add a batch with 1 transaction to thread 1.
+        in_flight_tracker.track_batch(batch_id_1, 1, 1);
+        assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[2, 1]);
+
+        // Complete the batch with 2 transactions on thread 0.
+        in_flight_tracker.complete_batch(batch_id_0);
+        assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[0, 1]);
+
+        // Complete the batch with 1 transaction on thread 1.
+        in_flight_tracker.complete_batch(batch_id_1);
+        assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[0, 0]);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -37,6 +37,9 @@ impl InFlightTracker {
 
     /// Add a new batch with given `batch_id` and `num_transactions` to the
     /// thread with given `thread_id`.
+    ///
+    /// # Panics
+    /// Panics if the batch id is already being tracked.
     pub fn track_batch(
         &mut self,
         batch_id: TransactionBatchId,

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -9,6 +9,7 @@ mod transaction_state_container;
 
 #[allow(dead_code)]
 mod transaction_id_generator;
-
 #[allow(dead_code)]
 mod batch_id_generator;
+#[allow(dead_code)]
+mod in_flight_tracker;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -7,9 +7,8 @@ mod transaction_state;
 #[allow(dead_code)]
 mod transaction_state_container;
 
-#[allow(dead_code)]
-mod transaction_id_generator;
-#[allow(dead_code)]
 mod batch_id_generator;
 #[allow(dead_code)]
 mod in_flight_tracker;
+#[allow(dead_code)]
+mod transaction_id_generator;


### PR DESCRIPTION
#### Problem
For scheduling work to consume we want to perform load balancing. We ideally want to balance the number of CUs and num txs between the threads evenly.

#### Summary of Changes
- Add `InFlightTracker` which tracks batches (num_txs, num_cus) per thread.
- Implemented Display for `TransactionBatchId` and `TransactionId` for better and easier error messages

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
