### PR TITLE
remove unused stats

### DIFF
--- a/accounts-db/src/cache_hash_data_stats.rs
+++ b/accounts-db/src/cache_hash_data_stats.rs
@@ -14,7 +14,6 @@ pub struct CacheHashDataStats {
     pub create_save_us: AtomicU64,
     pub load_us: AtomicU64,
     pub read_us: AtomicU64,
-    pub merge_us: AtomicU64,
     pub unused_cache_files: AtomicUsize,
 }
 


### PR DESCRIPTION
#### Problem

merge_us is not used.


#### Summary of Changes

get rid of `merge_us`


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
