### PR TITLE
wip: linked list for hash calc dedup

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1208,7 +1208,7 @@ impl<'a> AccountsHasher<'a> {
                         head = Some(current);
                         break;
                     }
-                    if h_pubkey == &key {
+                    if h_pubkey == key {
                         // replace the current head with current, then skip over the prior head's entry
                         if h.slot_group_index < current.slot_group_index {
                             std::mem::swap(&mut h.slot_group_index, &mut current.slot_group_index);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -890,7 +890,7 @@ impl<'a> AccountsHasher<'a> {
         key: &Pubkey,
     ) -> (
         &'b CalculateHashIntermediate,
-        Option<(Pubkey, usize, usize)>,
+        Option<(&'b Pubkey, usize, usize)>,
     ) {
         let division_data = &sorted_data_by_pubkey[division_index];
         let mut index = offset;
@@ -914,7 +914,7 @@ impl<'a> AccountsHasher<'a> {
             }
 
             // point to the next pubkey > key
-            next = Some((*next_key, division_index, index));
+            next = Some((next_key, division_index, index));
             break;
         }
 
@@ -1089,7 +1089,7 @@ impl<'a> AccountsHasher<'a> {
                     Self::find_first_pubkey_in_bin(hash_data, pubkey_bin, bins, &binner, stats);
 
                 if let Some(first_pubkey_in_bin) = first_pubkey_in_bin {
-                    let mut key = Some(hash_data[first_pubkey_in_bin].pubkey);
+                    let mut key = Some(&hash_data[first_pubkey_in_bin].pubkey);
                     let mut offset = first_pubkey_in_bin;
 
                     while let Some(k) = key {


### PR DESCRIPTION
#### Problem
improve perf of hash calc dedup by using a linked list
O(chunks / 2) vs. O(chunks)
Chunks is ~150 on mnb, up to 140k on pop sim (which is also a problem)

#### Summary of Changes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
