### PR TITLE
TransactionScheduler: Pipe BlockProductionMethod

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -450,7 +450,7 @@ fn main() {
                 DEFAULT_TPU_CONNECTION_POOL_SIZE,
             ),
         };
-        let banking_stage = BankingStage::new_num_threads(
+        let banking_stage = BankingStage::new_thread_local_multi_iterator(
             &cluster_info,
             &poh_recorder,
             non_vote_receiver,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![feature(test)]
 
+use solana_core::validator::BlockProductionMethod;
+
 extern crate test;
 
 use {
@@ -291,6 +293,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         let cluster_info = Arc::new(cluster_info);
         let (s, _r) = unbounded();
         let _banking_stage = BankingStage::new(
+            BlockProductionMethod::ThreadLocalMultiIterator,
             &cluster_info,
             &poh_recorder,
             non_vote_receiver,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -15,7 +15,7 @@ use {
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
         tpu_entry_notifier::TpuEntryNotifier,
-        validator::GeneratorConfig,
+        validator::{BlockProductionMethod, GeneratorConfig},
     },
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver},
@@ -112,6 +112,7 @@ impl Tpu {
         tracer_thread_hdl: TracerThread,
         tpu_enable_udp: bool,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        block_production_method: BlockProductionMethod,
         _generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */
     ) -> Self {
         let TpuSockets {
@@ -221,6 +222,7 @@ impl Tpu {
         );
 
         let banking_stage = BankingStage::new(
+            block_production_method,
             cluster_info,
             poh_recorder,
             non_vote_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1254,6 +1254,7 @@ impl Validator {
             tracer_thread,
             tpu_enable_udp,
             &prioritization_fee_cache,
+            config.block_production_method.clone(),
             config.generator_config.clone(),
         );
 


### PR DESCRIPTION
#### Problem
Will need a way to switch between block production modes.
Currently only one variant, so no effect.

#### Summary of Changes
- Pass `BlockProductionMethod` into `BankingStage::new` and `BankingStage::new_num_threads`
- Pipe the config from `Validator -> Tpu -> BankingStage`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
