### PR TITLE
Increase loaded accounts data size when padding program is used

### DIFF
--- a/bench-tps/src/keypairs.rs
+++ b/bench-tps/src/keypairs.rs
@@ -16,6 +16,7 @@ pub fn get_keypairs<T>(
     num_lamports_per_account: u64,
     client_ids_and_stake_file: &str,
     read_from_client_file: bool,
+    enable_padding: bool,
 ) -> Vec<Keypair>
 where
     T: 'static + BenchTpsClient + Send + Sync + ?Sized,
@@ -56,6 +57,7 @@ where
             &keypairs,
             keypairs.len().saturating_sub(keypair_count) as u64,
             last_balance,
+            enable_padding,
         )
         .unwrap_or_else(|e| {
             eprintln!("Error could not fund keys: {e:?}");
@@ -63,10 +65,16 @@ where
         });
         keypairs
     } else {
-        generate_and_fund_keypairs(client, id, keypair_count, num_lamports_per_account)
-            .unwrap_or_else(|e| {
-                eprintln!("Error could not fund keys: {e:?}");
-                exit(1);
-            })
+        generate_and_fund_keypairs(
+            client,
+            id,
+            keypair_count,
+            num_lamports_per_account,
+            enable_padding,
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Error could not fund keys: {e:?}");
+            exit(1);
+        })
     }
 }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -345,6 +345,7 @@ fn main() {
         *num_lamports_per_account,
         client_ids_and_stake_file,
         *read_from_client_file,
+        instruction_padding_config.is_some(),
     );
 
     let nonce_keypairs = if *use_durable_nonce {

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -95,6 +95,7 @@ fn test_bench_tps_local_cluster(config: Config) {
         &config.id,
         keypair_count,
         lamports_per_account,
+        false,
     )
     .unwrap();
 
@@ -140,6 +141,7 @@ fn test_bench_tps_test_validator(config: Config) {
         &config.id,
         keypair_count,
         lamports_per_account,
+        false,
     )
     .unwrap();
     let nonce_keypairs = if config.use_durable_nonce {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -550,12 +550,17 @@ fn create_payers<T: 'static + BenchTpsClient + Send + Sync>(
         // transactions are built to be invalid so the the amount here is arbitrary
         let funding_key = Keypair::new();
         let funding_key = Arc::new(funding_key);
-        let res =
-            generate_and_fund_keypairs(client.unwrap().clone(), &funding_key, size, 1_000_000)
-                .unwrap_or_else(|e| {
-                    eprintln!("Error could not fund keys: {e:?}");
-                    exit(1);
-                });
+        let res = generate_and_fund_keypairs(
+            client.unwrap().clone(),
+            &funding_key,
+            size,
+            1_000_000,
+            false,
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Error could not fund keys: {e:?}");
+            exit(1);
+        });
         res.into_iter().map(Some).collect()
     } else {
         std::iter::repeat_with(|| None).take(size).collect()


### PR DESCRIPTION
#### Problem

When padding program is used the current default limit of 30KB is insufficient because program itself takes 28KB.

#### Summary of Changes

This PR increases loaded accounts data size limit when used with padding program.
