### PR TITLE
Separate vote cost

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -737,7 +737,7 @@ mod tests {
             unprocessed_transaction_storage::ThreadType,
         },
         crossbeam_channel::{unbounded, Receiver},
-        solana_cost_model::cost_model::CostModel,
+        solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
         solana_entry::entry::{next_entry, next_versioned_entry},
         solana_ledger::{
             blockstore::{entries_to_test_shreds, Blockstore},
@@ -1264,7 +1264,9 @@ mod tests {
                 };
 
                 let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
-                cost.bpf_execution_cost = actual_bpf_execution_cost;
+                if let TransactionCost::Transaction(ref mut usage_cost) = cost {
+                    usage_cost.bpf_execution_cost = actual_bpf_execution_cost;
+                }
 
                 block_cost + cost.sum()
             } else {

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -318,25 +318,25 @@ impl QosService {
             Ok(cost) => {
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_signature_cost,
-                    cost.signature_cost
+                    cost.signature_cost()
                 );
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_write_lock_cost,
-                    cost.write_lock_cost
+                    cost.write_lock_cost()
                 );
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_data_bytes_cost,
-                    cost.data_bytes_cost
+                    cost.data_bytes_cost()
                 );
                 saturating_add_assign!(
                     batched_transaction_details
                         .costs
                         .batched_builtins_execute_cost,
-                    cost.builtins_execution_cost
+                    cost.builtins_execution_cost()
                 );
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_bpf_execute_cost,
-                    cost.bpf_execution_cost
+                    cost.bpf_execution_cost()
                 );
             }
             Err(transaction_error) => match transaction_error {

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -589,6 +589,7 @@ mod tests {
     use {
         super::*,
         itertools::Itertools,
+        solana_cost_model::transaction_cost::UsageCostDetails,
         solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_sdk::{
             hash::Hash,
@@ -734,7 +735,7 @@ mod tests {
             let commited_status: Vec<CommitTransactionDetails> = qos_cost_results
                 .iter()
                 .map(|tx_cost| CommitTransactionDetails::Committed {
-                    compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost
+                    compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost()
                         + execute_units_adjustment,
                 })
                 .collect();
@@ -861,7 +862,7 @@ mod tests {
                         CommitTransactionDetails::NotCommitted
                     } else {
                         CommitTransactionDetails::Committed {
-                            compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost
+                            compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost()
                                 + execute_units_adjustment,
                         }
                     }
@@ -904,14 +905,14 @@ mod tests {
         let tx_cost_results: Vec<_> = (0..num_txs)
             .map(|n| {
                 if n % 2 == 0 {
-                    Ok(TransactionCost {
+                    Ok(TransactionCost::Transaction(UsageCostDetails {
                         signature_cost,
                         write_lock_cost,
                         data_bytes_cost,
                         builtins_execution_cost,
                         bpf_execution_cost,
-                        ..TransactionCost::default()
-                    })
+                        ..UsageCostDetails::default()
+                    }))
                 } else {
                     Err(TransactionError::WouldExceedMaxBlockCostLimit)
                 }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -37,7 +37,7 @@ impl CostModel {
         feature_set: &FeatureSet,
     ) -> TransactionCost {
         if transaction.is_simple_vote_transaction() {
-            TransactionCost::Vote {
+            TransactionCost::SimpleVote {
                 writable_accounts: Self::get_writable_accounts(transaction),
             }
         } else {

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -520,11 +520,11 @@ mod tests {
         );
 
         let tx_cost = CostModel::calculate_cost(&tx, &FeatureSet::all_enabled());
-        assert_eq!(2 + 2, tx_cost.writable_accounts.len());
-        assert_eq!(signer1.pubkey(), tx_cost.writable_accounts[0]);
-        assert_eq!(signer2.pubkey(), tx_cost.writable_accounts[1]);
-        assert_eq!(key1, tx_cost.writable_accounts[2]);
-        assert_eq!(key2, tx_cost.writable_accounts[3]);
+        assert_eq!(2 + 2, tx_cost.writable_accounts().len());
+        assert_eq!(signer1.pubkey(), tx_cost.writable_accounts()[0]);
+        assert_eq!(signer2.pubkey(), tx_cost.writable_accounts()[1]);
+        assert_eq!(key1, tx_cost.writable_accounts()[2]);
+        assert_eq!(key2, tx_cost.writable_accounts()[3]);
     }
 
     #[test]
@@ -550,12 +550,12 @@ mod tests {
                 * DEFAULT_PAGE_COST;
 
         let tx_cost = CostModel::calculate_cost(&tx, &FeatureSet::all_enabled());
-        assert_eq!(expected_account_cost, tx_cost.write_lock_cost);
-        assert_eq!(*expected_execution_cost, tx_cost.builtins_execution_cost);
-        assert_eq!(2, tx_cost.writable_accounts.len());
+        assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
+        assert_eq!(*expected_execution_cost, tx_cost.builtins_execution_cost());
+        assert_eq!(2, tx_cost.writable_accounts().len());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
-            tx_cost.loaded_accounts_data_size_cost
+            tx_cost.loaded_accounts_data_size_cost()
         );
     }
 
@@ -579,12 +579,12 @@ mod tests {
         let expected_loaded_accounts_data_size_cost = 0;
 
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
-        assert_eq!(expected_account_cost, tx_cost.write_lock_cost);
-        assert_eq!(*expected_execution_cost, tx_cost.builtins_execution_cost);
-        assert_eq!(2, tx_cost.writable_accounts.len());
+        assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
+        assert_eq!(*expected_execution_cost, tx_cost.builtins_execution_cost());
+        assert_eq!(2, tx_cost.writable_accounts().len());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
-            tx_cost.loaded_accounts_data_size_cost
+            tx_cost.loaded_accounts_data_size_cost()
         );
     }
 
@@ -618,12 +618,12 @@ mod tests {
         let expected_loaded_accounts_data_size_cost = (data_limit as u64) / (32 * 1024) * 8;
 
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
-        assert_eq!(expected_account_cost, tx_cost.write_lock_cost);
-        assert_eq!(expected_execution_cost, tx_cost.builtins_execution_cost);
-        assert_eq!(2, tx_cost.writable_accounts.len());
+        assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
+        assert_eq!(expected_execution_cost, tx_cost.builtins_execution_cost());
+        assert_eq!(2, tx_cost.writable_accounts().len());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
-            tx_cost.loaded_accounts_data_size_cost
+            tx_cost.loaded_accounts_data_size_cost()
         );
     }
 
@@ -651,12 +651,12 @@ mod tests {
         let expected_loaded_accounts_data_size_cost = 0;
 
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
-        assert_eq!(expected_account_cost, tx_cost.write_lock_cost);
-        assert_eq!(expected_execution_cost, tx_cost.builtins_execution_cost);
-        assert_eq!(2, tx_cost.writable_accounts.len());
+        assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
+        assert_eq!(expected_execution_cost, tx_cost.builtins_execution_cost());
+        assert_eq!(2, tx_cost.writable_accounts().len());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
-            tx_cost.loaded_accounts_data_size_cost
+            tx_cost.loaded_accounts_data_size_cost()
         );
     }
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -47,7 +47,6 @@ impl CostModel {
             Self::get_write_lock_cost(&mut tx_cost, transaction);
             Self::get_transaction_cost(&mut tx_cost, transaction, feature_set);
             tx_cost.account_data_size = Self::calculate_account_data_size(transaction);
-            tx_cost.is_simple_vote = transaction.is_simple_vote_transaction();
 
             debug!("transaction {:?} has cost {:?}", transaction, tx_cost);
             TransactionCost::Transaction(tx_cost)

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -365,7 +365,7 @@ mod tests {
         let writable_accounts = vec![mint_keypair.pubkey()];
         (
             vote_transaction,
-            TransactionCost::Vote { writable_accounts },
+            TransactionCost::SimpleVote { writable_accounts },
         )
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -186,11 +186,9 @@ impl CostTracker {
             if self.vote_cost.saturating_add(cost) > self.vote_cost_limit {
                 return Err(CostTrackerError::WouldExceedVoteMaxLimit);
             }
-        } else {
+        } else if self.block_cost.saturating_add(cost) > self.block_cost_limit {
             // check against the total package cost
-            if self.block_cost.saturating_add(cost) > self.block_cost_limit {
-                return Err(CostTrackerError::WouldExceedBlockMaxLimit);
-            }
+            return Err(CostTrackerError::WouldExceedBlockMaxLimit);
         }
 
         // check if the transaction itself is more costly than the account_cost_limit

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -106,7 +106,6 @@ pub struct UsageCostDetails {
     pub bpf_execution_cost: u64,
     pub loaded_accounts_data_size_cost: u64,
     pub account_data_size: u64,
-    pub is_simple_vote: bool,
 }
 
 impl Default for UsageCostDetails {
@@ -120,7 +119,6 @@ impl Default for UsageCostDetails {
             bpf_execution_cost: 0u64,
             loaded_accounts_data_size_cost: 0u64,
             account_data_size: 0u64,
-            is_simple_vote: false,
         }
     }
 }
@@ -139,7 +137,6 @@ impl PartialEq for UsageCostDetails {
             && self.bpf_execution_cost == other.bpf_execution_cost
             && self.loaded_accounts_data_size_cost == other.loaded_accounts_data_size_cost
             && self.account_data_size == other.account_data_size
-            && self.is_simple_vote == other.is_simple_vote
             && to_hash_set(&self.writable_accounts) == to_hash_set(&other.writable_accounts)
     }
 }

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -93,7 +93,7 @@ impl TransactionCost {
 
     pub fn writable_accounts(&self) -> &[Pubkey] {
         match self {
-            Self::Vote { writable_accounts } => &writable_accounts,
+            Self::Vote { writable_accounts } => writable_accounts,
             Self::Transaction(usage_cost) => &usage_cost.writable_accounts,
         }
     }

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -220,8 +220,8 @@ mod tests {
         )
         .unwrap();
 
-        // expected vote tx cost: 2 write locks, 2 sig, 1 vite ix, and 11 CU tx data cost
-        let expected_vote_cost = 4151;
+        // expected vote tx cost: 2 write locks, 2 sig, 1 vite ix,
+        let expected_vote_cost = 4140;
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
         let expected_none_vote_cost = 20535;
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -141,6 +141,7 @@ impl PartialEq for UsageCostDetails {
 impl Eq for UsageCostDetails {}
 
 impl UsageCostDetails {
+    #[cfg(test)]
     pub fn new_with_capacity(capacity: usize) -> Self {
         Self {
             writable_accounts: Vec::with_capacity(capacity),
@@ -210,7 +211,7 @@ mod tests {
         )
         .unwrap();
 
-        // expected vote tx cost: 2 write locks, 2 sig, 1 vite ix,
+        // expected vote tx cost: 2 write locks, 2 sig, 1 vote ix,
         let expected_vote_cost = 4140;
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
         let expected_none_vote_cost = 20535;

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -166,6 +166,7 @@ impl UsageCostDetails {
 #[cfg(test)]
 mod tests {
     use {
+        super::*,
         crate::cost_model::CostModel,
         solana_sdk::{
             feature_set::FeatureSet,
@@ -211,8 +212,8 @@ mod tests {
         )
         .unwrap();
 
-        // expected vote tx cost: 2 write locks, 2 sig, 1 vote ix,
-        let expected_vote_cost = 4140;
+        // expected vote tx cost: 2 write locks, 1 sig, 1 vote ix, 8cu of loaded accounts size,
+        let expected_vote_cost = SIMPLE_VOTE_USAGE_COST;
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
         let expected_none_vote_cost = 20535;
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -163,19 +163,12 @@ impl UsageCostDetails {
     }
 
     pub fn sum(&self) -> u64 {
-        if self.is_simple_vote {
-            self.signature_cost
-                .saturating_add(self.write_lock_cost)
-                .saturating_add(self.data_bytes_cost)
-                .saturating_add(self.builtins_execution_cost)
-        } else {
-            self.signature_cost
-                .saturating_add(self.write_lock_cost)
-                .saturating_add(self.data_bytes_cost)
-                .saturating_add(self.builtins_execution_cost)
-                .saturating_add(self.bpf_execution_cost)
-                .saturating_add(self.loaded_accounts_data_size_cost)
-        }
+        self.signature_cost
+            .saturating_add(self.write_lock_cost)
+            .saturating_add(self.data_bytes_cost)
+            .saturating_add(self.builtins_execution_cost)
+            .saturating_add(self.bpf_execution_cost)
+            .saturating_add(self.loaded_accounts_data_size_cost)
     }
 }
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -5,18 +5,18 @@ use {crate::block_cost_limits, solana_sdk::pubkey::Pubkey};
 /// Resources required to process a regular transaction often include
 /// an array of variables, such as execution cost, loaded bytes, write
 /// lock and read lock etc.
-/// Vote has a simpler and pre-determined format, it's cost structure
+/// SimpleVote has a simpler and pre-determined format, it's cost structure
 /// can be simpler, calculation quicker.
 #[derive(Debug)]
 pub enum TransactionCost {
-    Vote { writable_accounts: Vec<Pubkey> },
+    SimpleVote { writable_accounts: Vec<Pubkey> },
     Transaction(UsageCostDetails),
 }
 
 impl TransactionCost {
     pub fn sum(&self) -> u64 {
         match self {
-            Self::Vote { writable_accounts } => {
+            Self::SimpleVote { writable_accounts } => {
                 let num_of_signatures = writable_accounts.len() as u64;
 
                 solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS
@@ -33,42 +33,42 @@ impl TransactionCost {
 
     pub fn bpf_execution_cost(&self) -> u64 {
         match self {
-            Self::Vote { .. } => 0,
+            Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost.bpf_execution_cost,
         }
     }
 
     pub fn is_simple_vote(&self) -> bool {
         match self {
-            Self::Vote { .. } => true,
+            Self::SimpleVote { .. } => true,
             Self::Transaction(_) => false,
         }
     }
 
     pub fn data_bytes_cost(&self) -> u64 {
         match self {
-            Self::Vote { .. } => 0,
+            Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost.data_bytes_cost,
         }
     }
 
     pub fn account_data_size(&self) -> u64 {
         match self {
-            Self::Vote { .. } => 0,
+            Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost.account_data_size,
         }
     }
 
     pub fn loaded_accounts_data_size_cost(&self) -> u64 {
         match self {
-            Self::Vote { .. } => 0,
+            Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost.loaded_accounts_data_size_cost,
         }
     }
 
     pub fn signature_cost(&self) -> u64 {
         match self {
-            Self::Vote { writable_accounts } => {
+            Self::SimpleVote { writable_accounts } => {
                 block_cost_limits::SIGNATURE_COST.saturating_mul(writable_accounts.len() as u64)
             }
             Self::Transaction(usage_cost) => usage_cost.signature_cost,
@@ -77,7 +77,7 @@ impl TransactionCost {
 
     pub fn write_lock_cost(&self) -> u64 {
         match self {
-            Self::Vote { writable_accounts } => {
+            Self::SimpleVote { writable_accounts } => {
                 block_cost_limits::WRITE_LOCK_UNITS.saturating_mul(writable_accounts.len() as u64)
             }
             Self::Transaction(usage_cost) => usage_cost.write_lock_cost,
@@ -86,14 +86,14 @@ impl TransactionCost {
 
     pub fn builtins_execution_cost(&self) -> u64 {
         match self {
-            Self::Vote { .. } => solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
+            Self::SimpleVote { .. } => solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
             Self::Transaction(usage_cost) => usage_cost.builtins_execution_cost,
         }
     }
 
     pub fn writable_accounts(&self) -> &[Pubkey] {
         match self {
-            Self::Vote { writable_accounts } => writable_accounts,
+            Self::SimpleVote { writable_accounts } => writable_accounts,
             Self::Transaction(usage_cost) => &usage_cost.writable_accounts,
         }
     }


### PR DESCRIPTION
#### Problem
Usage cost of simple-vote transaction is static (#33269), due to restrictions of being a "simple vote transaction".
 
Assigning a static usage cost to simple-vote, instead of going to calculation that applies to normal transaction, would simplify code. Also preparing for enhancing normal transaction's usage cost categorization and calculation, without having to worry about accidentally changing vote's cost. Another side benefit is to slightly improve vote cost calculation performance. 

#### Summary of Changes
- Add `enum` cost type for `Vote` and `Transaction`.
- Sets simple-vote cost to be statically 3428 CUs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
