### PR TITLE
ci: have new_with_external_ip_test_random use all threads

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -19,3 +19,7 @@ threads-required = "num-cpus"
 [[profile.ci.overrides]]
 filter = "package(solana-gossip) & test(/^test_star_network_push_ring_200/)"
 threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external_ip_test_random/)"
+threads-required = "num-cpus"


### PR DESCRIPTION
#### Problem

new_with_external_ip_test_random uses fixed ports

https://github.com/solana-labs/solana/blob/3da2bb39fe8efd72f22e564180ed90c3289783a1/gossip/src/cluster_info.rs#L3644-L3657

this one makes us despair because retrying might not help the situation if it is still running on the same agent.

![Screenshot 2023-09-13 at 2 38 52 PM](https://github.com/solana-labs/solana/assets/8209234/a998f346-62bd-4e3f-950b-a8ed3c8c14d6)

#### Summary of Changes

update nextest.toml