### PR TITLE
Memory-optimize merkle root finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6353,6 +6353,8 @@ version = "1.17.0"
 dependencies = [
  "fast-math",
  "hex",
+ "rand 0.8.5",
+ "solana-logger",
  "solana-program",
 ]
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -231,12 +231,19 @@ pub fn hash_transactions(transactions: &[VersionedTransaction]) -> Hash {
         .iter()
         .flat_map(|tx| tx.signatures.iter())
         .collect();
-    let merkle_tree = MerkleTree::new(&signatures);
+
+    if !signatures.is_empty() {
+        MerkleTree::merkle_root(&signatures)
+    }
+    else {
+        Hash::default()
+    }
+    /*let merkle_tree = MerkleTree::new(&signatures);
     if let Some(root_hash) = merkle_tree.get_root() {
         *root_hash
     } else {
         Hash::default()
-    }
+    }*/
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the transaction contains

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -232,11 +232,7 @@ pub fn hash_transactions(transactions: &[VersionedTransaction]) -> Hash {
         .flat_map(|tx| tx.signatures.iter())
         .collect();
 
-    if let Some(root) = MerkleTree::merkle_root(&signatures) {
-        root
-    } else {
-        Hash::default()
-    }
+    MerkleTree::merkle_root(&signatures).unwrap_or_default()
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the transaction contains

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -232,18 +232,11 @@ pub fn hash_transactions(transactions: &[VersionedTransaction]) -> Hash {
         .flat_map(|tx| tx.signatures.iter())
         .collect();
 
-    if !signatures.is_empty() {
-        MerkleTree::merkle_root(&signatures)
-    }
-    else {
-        Hash::default()
-    }
-    /*let merkle_tree = MerkleTree::new(&signatures);
-    if let Some(root_hash) = merkle_tree.get_root() {
-        *root_hash
+    if let Some(root) = MerkleTree::merkle_root(&signatures) {
+        root
     } else {
         Hash::default()
-    }*/
+    }
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the transaction contains

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 [dependencies]
 fast-math = { workspace = true }
 solana-program = { workspace = true }
+rand = { workspace = true }
+solana-logger = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -281,7 +281,7 @@ mod tests {
 
     fn gen_bytes(num: usize) -> Vec<Vec<u8>> {
         (0..num).map(|_| {
-            let num_bytes = thread_rng().gen_range(1..1024);
+            let num_bytes = thread_rng().gen_range(1..1025);
             (0..num_bytes).map(|_| thread_rng().gen()).collect::<Vec<u8>>()
         }).collect()
     }
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn fuzz_merkle_root() {
         solana_logger::setup();
-        for num_data in 1..1024 {
+        for num_data in 1..1025 {
             let data = gen_bytes(num_data);
 
             let hash1 = MerkleTree::merkle_root(&data).unwrap();

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -1,4 +1,4 @@
-use solana_program::hash::{hashv, Hash};
+use {std::fmt::Debug, solana_program::hash::{hashv, Hash}};
 
 // We need to discern between leaf and intermediate nodes to prevent trivial second
 // pre-image attacks.
@@ -194,7 +194,7 @@ impl MerkleTree {
     }
 
     #[allow(clippy::uninit_vec)]
-    pub fn merkle_root<T: AsRef<[u8]>>(items: &[T]) -> Option<Hash> {
+    pub fn merkle_root<T: AsRef<[u8]> + Debug>(items: &[T]) -> Option<Hash> {
         if items.is_empty() {
             return None;
         }
@@ -213,7 +213,15 @@ impl MerkleTree {
         let mut leaf_count = 0;
         leaf_count = Self::append_nodes(&mut nodes, leaf_count, hashes);
 
-        Some(Self::commit_finish(&mut nodes, leaf_count))
+        let res = Self::commit_finish(&mut nodes, leaf_count);
+
+        let temp: Hash = "11111111111111111111111111111111".parse().unwrap();
+
+        if res == Hash::default() || res == temp {
+            panic!("Bad hash, data: {:?}", items);
+        }
+
+        Some(res)
     }
 
     pub fn find_path(&self, index: usize) -> Option<Proof> {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -183,17 +183,16 @@ impl MerkleTree {
             let mut tmp = self.nodes[layer];
 
             while layer_count > 1 {
-                if (layer_count & 1) != 0 {
+                tmp = if (layer_count & 1) != 0 {
                     let arg1 = &tmp;
                     let arg2 = &tmp;
-                    let hash = hash_intermediate!(arg1, arg2);
-                    tmp = hash;
+                    hash_intermediate!(arg1, arg2)
                 }
                 else {
-                    let arg1 = &self.nodes[layer];
-                    let hash = hash_intermediate!(tmp, arg1);
-                    tmp = hash;
-                }
+                    let arg1 = &tmp;
+                    let arg2 = &self.nodes[layer];
+                    hash_intermediate!(arg1, arg2)
+                };
                 layer+=1; 
                 layer_count = (layer_count+1) >> 1;
             }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -139,26 +139,22 @@ impl MerkleTree {
         self.nodes.iter().last()
     }
 
-    fn private_merge(a: &mut Hash, b: &Hash) {
-        //todo: verify and implement jump's fancy avx implementation
-        let hash = hash_intermediate!(a, b);
-        *a = hash;
-    }
-
     fn append_nodes(&mut self, nodes: Vec<Hash>,) {
         let mut leaf_count = self.leaf_count;
         for mut node in nodes {
-            let tmp = &mut node;
             let mut layer: usize = 0;
             leaf_count += 1;
             let mut cursor = leaf_count;
             while (cursor & 1) == 0 {
-                Self::private_merge(tmp, &self.nodes[layer]);
+                let arg1 = &node;
+                let arg2 = &self.nodes[layer];
+                //todo: verify and implement jump's fancy avx implementation
+                node = hash_intermediate!(arg1, arg2);
                 layer += 1;
                 cursor >>= 1;
             }
         
-            self.nodes[layer] = *tmp;
+            self.nodes[layer] = node;
             
         }
         self.leaf_count = leaf_count;

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -215,12 +215,17 @@ impl MerkleTree {
 
         let res = Self::commit_finish(&mut nodes, leaf_count);
 
-        let temp: Hash = "11111111111111111111111111111111".parse().unwrap();
+        /*let temp: Hash = "11111111111111111111111111111111".parse().unwrap();
 
         if res == Hash::default() || res == temp {
             panic!("Bad hash, data: {:?}", items);
-        }
+        }*/
 
+        let tree = Self::new(items);
+        let res2 = *tree.get_root().unwrap();
+        if res != res2 {
+            panic!("Bad hash, data: {:?}", items);
+        }
         Some(res)
     }
 


### PR DESCRIPTION
#### Problem
Jump has developed a more a method of calculating the merkle root without building up the full merkle tree. This allows the root to be calculated using O(logn) memory, allowing for memory savings. Preliminary testing on Testnet has found about a ~10-15% overall memory savings.

#### Summary of Changes
Implements Jump's merkle root calculation method.

Fixes #
#32622 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
