### PR TITLE
Add comment to OptimisticallyConfirmedBankTracker

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -314,6 +314,9 @@ impl OptimisticallyConfirmedBankTracker {
                     slot,
                     timestamp: timestamp(),
                 });
+                // NOTE: replay of `slot` may or may not be complete. Therefore, most new
+                // functionality to be triggered on optimistic confirmation should go in
+                // `notify_or_defer()` under the `bank.is_frozen()` case instead of here.
             }
             BankNotification::Frozen(bank) => {
                 let frozen_slot = bank.slot();


### PR DESCRIPTION
... about where to put optimistic-confirmation functionality

#### Problem
On multiple occasions, we have added functionality to be executed on optimistic confirmation to the wrong place in OptimisticallyConfirmedBankTracker.
https://github.com/solana-labs/solana/blob/525e59f01a7dcc5905f433f1fde110db55fdb876/rpc/src/optimistically_confirmed_bank_tracker.rs#L279-L280
^ intuitively seems right; however, notifications here do not guarantee that a Slot has been replayed. Most of the time, we need to verify both that this node has seen the optimistic-confirmation threshold met by the cluster *and* that this node has finished replaying the Slot.

#### Summary of Changes
Add a comment to help forestall this mistake in the future
