### PR TITLE
set approx store count at generate index time

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9508,6 +9508,9 @@ impl AccountsDb {
                 );
                 store.count_and_status.write().unwrap().0 = entry.count;
                 store.alive_bytes.store(entry.stored_size, Ordering::SeqCst);
+                store
+                    .approx_store_count
+                    .store(entry.count, Ordering::Relaxed);
             } else {
                 trace!("id: {} clearing count", id);
                 store.count_and_status.write().unwrap().0 = 0;


### PR DESCRIPTION
#### Problem
Speeding up accounts hash calculation.

#### Summary of Changes
approx count of an append vec is not set at load time. This is a problem because some algorithms need to know how many entries are in a storage as opposed to how many "alive" items are in an append vec.
For example, when scanning append vecs for hash calculation, if we know the upper bound of how many accounts are in an append vec, then we can plan ahead better.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
