### PR TITLE
gen idx: refactor StorageSizeAndCount population

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -71,6 +71,12 @@ pub type SlotSlice<'s, T> = &'s [(Slot, T)];
 pub type RefCount = u64;
 pub type AccountMap<T, U> = Arc<InMemAccountsIndex<T, U>>;
 
+#[derive(Default, Debug, PartialEq, Eq)]
+pub(crate) struct GenerateIndexCount {
+    /// number of accounts inserted in the index
+    pub count: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// how accounts index 'upsert' should handle reclaims
 pub enum UpsertReclaim {
@@ -1586,13 +1592,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     // Can save time when inserting lots of new keys.
     // But, does NOT update secondary index
     // This is designed to be called at startup time.
+    // returns (dirty_pubkeys, insertion_time_us, GenerateIndexCount)
     #[allow(clippy::needless_collect)]
     pub(crate) fn insert_new_if_missing_into_primary_index(
         &self,
         slot: Slot,
         item_len: usize,
         items: impl Iterator<Item = (Pubkey, T)>,
-    ) -> (Vec<Pubkey>, u64) {
+    ) -> (Vec<Pubkey>, u64, GenerateIndexCount) {
         // big enough so not likely to re-allocate, small enough to not over-allocate by too much
         // this assumes the largest bin contains twice the expected amount of the average size per bin
         let bins = self.bins();
@@ -1612,6 +1619,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 (pubkey_bin, Vec::with_capacity(expected_items_per_bin))
             })
             .collect::<Vec<_>>();
+        let mut count = 0;
         let mut dirty_pubkeys = items
             .filter_map(|(pubkey, account_info)| {
                 let pubkey_bin = self.bin_calculator.bin_from_pubkey(&pubkey);
@@ -1631,6 +1639,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         binned.into_iter().for_each(|(pubkey_bin, items)| {
             let r_account_maps = &self.account_maps[pubkey_bin];
             let mut insert_time = Measure::start("insert_into_primary_index");
+            count += items.len();
             if use_disk {
                 r_account_maps.startup_insert_only(items.into_iter());
             } else {
@@ -1660,7 +1669,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             insertion_time.fetch_add(insert_time.as_us(), Ordering::Relaxed);
         });
 
-        (dirty_pubkeys, insertion_time.load(Ordering::Relaxed))
+        (
+            dirty_pubkeys,
+            insertion_time.load(Ordering::Relaxed),
+            GenerateIndexCount { count },
+        )
     }
 
     /// use Vec<> because the internal vecs are already allocated per bin
@@ -2195,7 +2208,10 @@ pub mod tests {
         let account_info = true;
         let items = vec![(*pubkey, account_info)];
         index.set_startup(Startup::Startup);
-        index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
+        let expected_len = items.len();
+        let (_, _, result) =
+            index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
+        assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
         let mut ancestors = Ancestors::default();
@@ -2230,7 +2246,10 @@ pub mod tests {
         let account_info = false;
         let items = vec![(*pubkey, account_info)];
         index.set_startup(Startup::Startup);
-        index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
+        let expected_len = items.len();
+        let (_, _, result) =
+            index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
+        assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
         let mut ancestors = Ancestors::default();
@@ -2337,7 +2356,10 @@ pub mod tests {
 
         index.set_startup(Startup::Startup);
         let items = vec![(key0, account_infos[0]), (key1, account_infos[1])];
-        index.insert_new_if_missing_into_primary_index(slot0, items.len(), items.into_iter());
+        let expected_len = items.len();
+        let (_, _, result) =
+            index.insert_new_if_missing_into_primary_index(slot0, items.len(), items.into_iter());
+        assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
         for (i, key) in [key0, key1].iter().enumerate() {
@@ -2388,7 +2410,13 @@ pub mod tests {
         } else {
             let items = vec![(key, account_infos[0])];
             index.set_startup(Startup::Startup);
-            index.insert_new_if_missing_into_primary_index(slot0, items.len(), items.into_iter());
+            let expected_len = items.len();
+            let (_, _, result) = index.insert_new_if_missing_into_primary_index(
+                slot0,
+                items.len(),
+                items.into_iter(),
+            );
+            assert_eq!(result.count, expected_len);
             index.set_startup(Startup::Normal);
         }
         assert!(gc.is_empty());
@@ -2433,7 +2461,13 @@ pub mod tests {
 
             let items = vec![(key, account_infos[1])];
             index.set_startup(Startup::Startup);
-            index.insert_new_if_missing_into_primary_index(slot1, items.len(), items.into_iter());
+            let expected_len = items.len();
+            let (_, _, result) = index.insert_new_if_missing_into_primary_index(
+                slot1,
+                items.len(),
+                items.into_iter(),
+            );
+            assert_eq!(result.count, expected_len);
             index.set_startup(Startup::Normal);
         }
         assert!(gc.is_empty());


### PR DESCRIPTION
#### Problem
Speeding up index generation at startup.
`StorageSizeAndCount` is undercounting and ignoring dead accounts of several varieties. Also, further optimizations will change how we iterate the accounts in an append vec. It is better to populate storage size and count further downstream than it is currently calculated.

#### Summary of Changes
Populate `StorageSizeAndCount` further downstream.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
