### PR TITLE
hash dedup vec

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -436,7 +436,7 @@ pub struct AccountsHasher<'a> {
 }
 
 /// Pointer to a specific item in chunked accounts hash slices.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct SlotGroupPointer {
     /// slot group index
     slot_group_index: usize,
@@ -1037,7 +1037,7 @@ impl<'a> AccountsHasher<'a> {
                     [*current_min_offset]
                     .pubkey;
                 if *key < current_min_key {
-                    working_set.push(pointer.clone());
+                    working_set.push(*pointer);
                     break;
                 }
             }
@@ -1052,7 +1052,7 @@ impl<'a> AccountsHasher<'a> {
                     // found a new new key, insert into the working_set. This is O(n/2) on
                     // average. Theoretically, this operation could be expensive and may be further
                     // optimized in future.
-                    working_set.insert(index, pointer.clone());
+                    working_set.insert(index, *pointer);
                     break;
                 }
                 Ok(index) => {
@@ -1066,7 +1066,7 @@ impl<'a> AccountsHasher<'a> {
                             binner,
                             &ItemLocation {
                                 key,
-                                pointer: pointer.clone(),
+                                pointer: *pointer,
                             },
                         );
                         *next = new_next;
@@ -1078,10 +1078,10 @@ impl<'a> AccountsHasher<'a> {
                             binner,
                             &ItemLocation {
                                 key,
-                                pointer: found.clone(),
+                                pointer: *found,
                             },
                         );
-                        *found = pointer.clone();
+                        *found = *pointer;
                         *next = new_next;
                     }
                 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -813,30 +813,24 @@ impl<'a> AccountsHasher<'a> {
         (hashes, lamports_total)
     }
 
-    /// returns the item referenced by `min_index`
-    ///   updates `indexes` to skip over the pubkey and its duplicates
-    ///   updates `first_items` to point to the next pubkey
-    /// or removes the entire pubkey division entries (for `min_index`) if the referenced pubkey is the last entry in the same `bin`
-    ///     removed from: `first_items`, `indexes`, and `first_item_pubkey_division`
     fn get_item<'b>(
-        min_index: usize,
-        bin: usize,
-        first_items: &mut Vec<Pubkey>,
         sorted_data_by_pubkey: &[&'b [CalculateHashIntermediate]],
-        indexes: &mut Vec<usize>,
-        first_item_to_pubkey_division: &mut Vec<usize>,
+        bin: usize,
         binner: &PubkeyBinCalculator24,
-    ) -> &'b CalculateHashIntermediate {
-        let first_item = first_items[min_index];
-        let key = &first_item;
-        let division_index = first_item_to_pubkey_division[min_index];
+        division_index: usize,
+        offset: usize,
+        key: &Pubkey,
+    ) -> (
+        &'b CalculateHashIntermediate,
+        Option<(&'b Pubkey, usize, usize)>,
+    ) {
         let division_data = &sorted_data_by_pubkey[division_index];
-        let mut index = indexes[min_index];
+        let mut index = offset;
         index += 1;
-        let mut end;
+        let mut next = None;
+
         loop {
-            end = index >= division_data.len();
-            if end {
+            if index >= division_data.len() {
                 break;
             }
             // still more items where we found the previous key, so just increment the index for that slot group, skipping all pubkeys that are equal
@@ -848,24 +842,16 @@ impl<'a> AccountsHasher<'a> {
 
             if binner.bin_from_pubkey(next_key) > bin {
                 // the next pubkey is not in our bin
-                end = true;
                 break;
             }
 
             // point to the next pubkey > key
-            first_items[min_index] = *next_key;
-            indexes[min_index] = index;
+            next = Some((next_key, division_index, index));
             break;
-        }
-        if end {
-            // stop looking in this vector - we exhausted it
-            first_items.remove(min_index);
-            first_item_to_pubkey_division.remove(min_index);
-            indexes.remove(min_index);
         }
 
         // this is the previous first item that was requested
-        &division_data[index - 1]
+        (&division_data[index - 1], next)
     }
 
     /// `hash_data` must be sorted by `binner.bin_from_pubkey()`
@@ -960,25 +946,60 @@ impl<'a> AccountsHasher<'a> {
     ) -> (AccountHashesFile, u64) {
         let binner = PubkeyBinCalculator24::new(bins);
 
-        let len = sorted_data_by_pubkey.len();
-        let mut indexes = Vec::with_capacity(len);
-        let mut first_items = Vec::with_capacity(len);
-        // map from index of an item in first_items[] to index of the corresponding item in sorted_data_by_pubkey[]
-        // this will change as items in sorted_data_by_pubkey[] are exhausted
-        let mut first_item_to_pubkey_division = Vec::with_capacity(len);
+        // working_set hold the lowest items for each slot_group sorted by pubkey descending (min_key is the last)
+        let mut working_set: Vec<(usize, usize)> = Vec::default();
 
-        // initialize 'first_items', which holds the current lowest item in each slot group
+        // initialize 'working_set', which holds the current lowest item in each slot group
+        // working_set should be initialized in reverse order of slot_groups. Later slot_groups are
+        // processed first. For each slot_group, if the lowest item for current slot group is
+        // already in working_set (i.e. inserted by a later slot group), the next lowest items
+        // in this slot group are searched and checked until either one that is not the
+        // working_set are found, which will then be inserted, or no next lowest items are found.
         let max_inclusive_num_pubkeys = sorted_data_by_pubkey
             .iter()
             .enumerate()
+            .rev()
             .map(|(i, hash_data)| {
                 let first_pubkey_in_bin =
                     Self::find_first_pubkey_in_bin(hash_data, pubkey_bin, bins, &binner, stats);
+
                 if let Some(first_pubkey_in_bin) = first_pubkey_in_bin {
-                    let k = hash_data[first_pubkey_in_bin].pubkey;
-                    first_items.push(k);
-                    first_item_to_pubkey_division.push(i);
-                    indexes.push(first_pubkey_in_bin);
+                    let mut key = Some(&hash_data[first_pubkey_in_bin].pubkey);
+                    let mut offset = first_pubkey_in_bin;
+
+                    while let Some(k) = key {
+                        let found = working_set.binary_search_by(|(slot_group_index, offset)| {
+                            let prob = &sorted_data_by_pubkey[*slot_group_index][*offset].pubkey;
+                            k.cmp(prob)
+                        });
+
+                        match found {
+                            Err(index) => {
+                                // found a new new key, so insert into the working_set
+                                working_set.insert(index, (i, offset));
+                                // add_to_working_set = true;
+                                break;
+                            }
+                            Ok(_index) => {
+                                // key already exists in working_set, continue to find next key.
+                                let (_item, new_next) = Self::get_item(
+                                    sorted_data_by_pubkey,
+                                    pubkey_bin,
+                                    &binner,
+                                    i,
+                                    offset,
+                                    k,
+                                );
+                                if let Some((new_key, _, new_offset)) = new_next {
+                                    key = Some(new_key);
+                                    offset = new_offset;
+                                } else {
+                                    key = None;
+                                }
+                            }
+                        }
+                    }
+
                     let mut first_pubkey_in_next_bin = first_pubkey_in_bin + 1;
                     while first_pubkey_in_next_bin < hash_data.len() {
                         if binner.bin_from_pubkey(&hash_data[first_pubkey_in_next_bin].pubkey)
@@ -1001,47 +1022,27 @@ impl<'a> AccountsHasher<'a> {
         };
 
         let mut overall_sum = 0;
-        let mut duplicate_pubkey_indexes = Vec::with_capacity(len);
         let filler_accounts_enabled = self.filler_accounts_enabled();
 
-        // this loop runs once per unique pubkey contained in any slot group
-        while !first_items.is_empty() {
-            let loop_stop = { first_items.len() - 1 }; // we increment at the beginning of the loop
-            let mut min_index = 0;
-            let mut min_pubkey = first_items[min_index];
-            let mut first_item_index = 0; // we will start iterating at item 1. +=1 is first instruction in loop
+        let mut new = None;
+        while new.is_some() || !working_set.is_empty() {
+            let (slot_group_index, offset) = if new.is_some() {
+                std::mem::take(&mut new).unwrap()
+            } else {
+                // pop the lowest item from the working_set (last element)
+                working_set.pop().unwrap()
+            };
 
-            // this loop iterates over each slot group to find the minimum pubkey at the maximum slot
-            // it also identifies duplicate pubkey entries at lower slots and remembers those to skip them after
-            while first_item_index < loop_stop {
-                first_item_index += 1;
-                let key = &first_items[first_item_index];
-                let cmp = min_pubkey.cmp(key);
-                match cmp {
-                    std::cmp::Ordering::Less => {
-                        continue; // we still have the min item
-                    }
-                    std::cmp::Ordering::Equal => {
-                        // we found the same pubkey in a later slot, so remember the lower slot as a duplicate
-                        duplicate_pubkey_indexes.push(min_index);
-                    }
-                    std::cmp::Ordering::Greater => {
-                        // this is the new min pubkey
-                        min_pubkey = *key;
-                    }
-                }
-                // this is the new index of the min entry
-                min_index = first_item_index;
-            }
+            let key = &sorted_data_by_pubkey[slot_group_index][offset].pubkey;
+
             // get the min item, add lamports, get hash
-            let item = Self::get_item(
-                min_index,
-                pubkey_bin,
-                &mut first_items,
+            let (item, mut next) = Self::get_item(
                 sorted_data_by_pubkey,
-                &mut indexes,
-                &mut first_item_to_pubkey_division,
+                pubkey_bin,
                 &binner,
+                slot_group_index,
+                offset,
+                key,
             );
 
             // add lamports and get hash
@@ -1064,22 +1065,61 @@ impl<'a> AccountsHasher<'a> {
                 }
             }
 
-            if !duplicate_pubkey_indexes.is_empty() {
-                // skip past duplicate keys in earlier slots
-                // reverse this list because get_item can remove first_items[*i] when *i is exhausted
-                //  and that would mess up subsequent *i values
-                duplicate_pubkey_indexes.iter().rev().for_each(|i| {
-                    Self::get_item(
-                        *i,
-                        pubkey_bin,
-                        &mut first_items,
-                        sorted_data_by_pubkey,
-                        &mut indexes,
-                        &mut first_item_to_pubkey_division,
-                        &binner,
-                    );
+            // looping to add next item to working set
+            while let Some((key, slot_group_index, offset)) = next {
+                // if `new key` is less than the min key in the working set, continue process with `new key` directly.
+                if let Some((current_min_slot_group_index, current_min_offset)) = working_set.last()
+                {
+                    let current_min_key = &sorted_data_by_pubkey[*current_min_slot_group_index]
+                        [*current_min_offset]
+                        .pubkey;
+                    if key < current_min_key {
+                        new = Some((slot_group_index, offset));
+                        break;
+                    }
+                }
+
+                let found = working_set.binary_search_by(|(slot_group_index, offset)| {
+                    let prob = &sorted_data_by_pubkey[*slot_group_index][*offset].pubkey;
+                    key.cmp(prob)
                 });
-                duplicate_pubkey_indexes.clear();
+
+                match found {
+                    Err(index) => {
+                        // found a new new key, insert into the working_set
+                        working_set.insert(index, (slot_group_index, offset));
+                        break;
+                    }
+                    Ok(index) => {
+                        let v = &mut working_set[index];
+                        if v.0 > slot_group_index {
+                            // There is already a later slot group that contains this key in the working_set,
+                            // look up again.
+                            let (_item, new_next) = Self::get_item(
+                                sorted_data_by_pubkey,
+                                pubkey_bin,
+                                &binner,
+                                slot_group_index,
+                                offset,
+                                key,
+                            );
+                            next = new_next;
+                        } else {
+                            // A previous slot contains this key, replace it, and look for next item in the previous slot group.
+                            let (_item, new_next) = Self::get_item(
+                                sorted_data_by_pubkey,
+                                pubkey_bin,
+                                &binner,
+                                v.0,
+                                v.1,
+                                key,
+                            );
+                            v.0 = slot_group_index;
+                            v.1 = offset;
+                            next = new_next;
+                        }
+                    }
+                }
             }
         }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -436,10 +436,14 @@ pub struct AccountsHasher<'a> {
 }
 
 /// A struct for the location of an account hash item inside chunked accounts hash slices.
+#[derive(Debug)]
 struct ItemLocation<'a> {
-    key: &'a Pubkey,       // account's pubkey
-    division_index: usize, // chunk index
-    offset: usize,         // offset within a chunk
+    /// account's pubkey
+    key: &'a Pubkey,
+    /// chunk index
+    division_index: usize,
+    /// offset within a chunk
+    offset: usize,
 }
 
 impl<'a> AccountsHasher<'a> {

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1025,7 +1025,7 @@ impl<'a> AccountsHasher<'a> {
         binner: &PubkeyBinCalculator24,
     ) {
         // looping to add next item to working set
-        while let Some(ItemLocation { key, pointer }) = next {
+        while let Some(ItemLocation { key, pointer }) = std::mem::take(next) {
             // if `new key` is less than the min key in the working set, skip binary search and
             // insert item to the end vec directly
             if let Some(SlotGroupPointer {
@@ -1036,8 +1036,8 @@ impl<'a> AccountsHasher<'a> {
                 let current_min_key = &sorted_data_by_pubkey[*current_min_slot_group_index]
                     [*current_min_offset]
                     .pubkey;
-                if *key < current_min_key {
-                    working_set.push(*pointer);
+                if key < current_min_key {
+                    working_set.push(pointer);
                     break;
                 }
             }
@@ -1052,7 +1052,7 @@ impl<'a> AccountsHasher<'a> {
                     // found a new new key, insert into the working_set. This is O(n/2) on
                     // average. Theoretically, this operation could be expensive and may be further
                     // optimized in future.
-                    working_set.insert(index, *pointer);
+                    working_set.insert(index, pointer);
                     break;
                 }
                 Ok(index) => {
@@ -1064,10 +1064,7 @@ impl<'a> AccountsHasher<'a> {
                             sorted_data_by_pubkey,
                             pubkey_bin,
                             binner,
-                            &ItemLocation {
-                                key,
-                                pointer: *pointer,
-                            },
+                            &ItemLocation { key, pointer },
                         );
                         *next = new_next;
                     } else {
@@ -1081,7 +1078,7 @@ impl<'a> AccountsHasher<'a> {
                                 pointer: *found,
                             },
                         );
-                        *found = *pointer;
+                        *found = pointer;
                         *next = new_next;
                     }
                 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -960,6 +960,9 @@ impl<'a> AccountsHasher<'a> {
         // already in working_set (i.e. inserted by a later slot group), the next lowest item
         // in this slot group is searched and checked, until either one that is `not` in the
         // working_set is found, which will then be inserted, or no next lowest item is found.
+        // Iterating in reverse order of slot_group will grantee that each slot group will be
+        // scanned only once and scanned continuously. Therefore, it can achieve better data
+        // locality during the scan.
         let max_inclusive_num_pubkeys = sorted_data_by_pubkey
             .iter()
             .enumerate()


### PR DESCRIPTION
#### Problem

Deduplicate and eliminate zero lamport account in accounts hash calculation is slow. 


#### Summary of Changes

Optimize the deduplicate and eliminate zero accounts loop. 

- master

```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us|sort_us"
eliminate_zeros_us                  6466915i
pubkey_bin_search_us                14784327i
```

- linked list (https://github.com/solana-labs/solana/pull/33215)
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  5390743i
pubkey_bin_search_us                22815254i
```

- this PR 
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  5022816i
pubkey_bin_search_us                19616637i
```

We have implemented a linked list version and a vector version (this PR). Above shows the timing comparison from running master/linklist pr/this pr with ledger tool, where both LinkedList and this PR show better performance. We prefer the vector implementation since it is simpler and cleaner. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
