### PR TITLE
assert approx_stored_count is initially 0

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9482,6 +9482,7 @@ impl AccountsDb {
             let id = store.append_vec_id();
             // Should be default at this point
             assert_eq!(store.alive_bytes(), 0);
+            assert_eq!(store.approx_stored_count(), 0);
             if let Some(entry) = stored_sizes_and_counts.get(&id) {
                 trace!(
                     "id: {} setting count: {} cur: {}",


### PR DESCRIPTION
#### Problem
Working on speeding up generate index/startup.
assert that approx_stored_count is 0 to start with.
This will be depended on by accounts hash calculation.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
