### PR TITLE
check source_path before delete it

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -247,8 +247,10 @@ fn install_if_missing(
         let source_base = config.sbf_sdk.join("dependencies");
         if source_base.exists() {
             let source_path = source_base.join(package);
-            debug!("Remove file {:?}", source_path);
-            fs::remove_file(source_path).map_err(|err| err.to_string())?;
+            if source_path.exists() {
+                debug!("Remove file {:?}", source_path);
+                fs::remove_file(source_path).map_err(|err| err.to_string())?;
+            }
         }
     }
     // Check whether the target path is an empty directory. This can


### PR DESCRIPTION
#### Problem

when I tried to migrate tests in `solana-cargo-build-sbf` to nextest. I found that we don't check the proper path before actually removing it

#### Summary of Changes

check `source_path` before removing it.