### PR TITLE
Derives Pod and Zeroable on Hash

### DIFF
--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -6,6 +6,7 @@
 use {
     crate::{sanitize::Sanitize, wasm_bindgen},
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    bytemuck::{Pod, Zeroable},
     sha2::{Digest, Sha256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
@@ -42,6 +43,8 @@ const MAX_BASE58_LEN: usize = 44;
     PartialOrd,
     Hash,
     AbiExample,
+    Pod,
+    Zeroable,
 )]
 #[repr(transparent)]
 pub struct Hash(pub(crate) [u8; HASH_BYTES]);


### PR DESCRIPTION
#### Problem
 
We have `unsafe` code for reading/writing `Hash`es (or other types containing hashes) to mmaps/files/disk via transmuting to byte slices. We can remove the unsafe blocks and use `bytemuck` instead [^1], if we derive a few traits.

[^1]: Here's a WIP PR that removes `unsafe` blocks: https://github.com/solana-labs/solana/pull/33258

#### Summary of Changes

Derive [`Pod`](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html) and [`Zeroable`](https://docs.rs/bytemuck/latest/bytemuck/trait.Zeroable.html) on `Hash`.

Note that `Pubkey` already does this, and it is basically the same type as `Hash`. Some discussion around this change has occurred here on Discord: https://discord.com/channels/428295358100013066/476811830145318912/1149331218006016040