### PR TITLE
ci: move solana-cargo-build-sbf to nextest

### DIFF
--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -15,7 +15,7 @@ partitions=$(
   "command": ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/stable/run-partition.sh",
   "timeout_in_minutes": 30,
   "agent": "$agent",
-  "parallelism": 3,
+  "parallelism": 2,
   "retry": 3
 }
 EOF

--- a/nextest.toml
+++ b/nextest.toml
@@ -23,3 +23,7 @@ threads-required = "num-cpus"
 [[profile.ci.overrides]]
 filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external_ip_test_random/)"
 threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = "package(solana-cargo-build-sbf)"
+threads-required = "num-cpus"


### PR DESCRIPTION
#### Summary of Changes

move solana-cargo-build-sbf to nextest for

- easier managing
- get the test result

(we finally get rid of the `DONT_USE_NEXTEST_PACKAGES` list 🎉 )