### PR TITLE
moves new_warmup_cooldown_rate_epoch outside iterators and for loops

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -481,7 +481,7 @@ mod tests {
             account_utils::StateMut,
             clock::{Epoch, UnixTimestamp},
             epoch_schedule::EpochSchedule,
-            feature_set::{reduce_stake_warmup_cooldown::NewWarmupCooldownRateEpoch, FeatureSet},
+            feature_set::FeatureSet,
             instruction::{AccountMeta, Instruction},
             pubkey::Pubkey,
             rent::Rent,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -14,10 +14,7 @@ use {
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,
         clock::{Clock, Epoch},
-        feature_set::{
-            self, reduce_stake_warmup_cooldown::NewWarmupCooldownRateEpoch,
-            stake_merge_with_unmatched_credits_observed, FeatureSet,
-        },
+        feature_set::{self, stake_merge_with_unmatched_credits_observed, FeatureSet},
         instruction::{checked_add, InstructionError},
         pubkey::Pubkey,
         rent::Rent,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -20,6 +20,7 @@
 
 use {
     lazy_static::lazy_static,
+    solana_program::{epoch_schedule::EpochSchedule, stake_history::Epoch},
     solana_sdk::{
         clock::Slot,
         hash::{Hash, Hasher},
@@ -665,18 +666,7 @@ pub mod last_restart_slot_sysvar {
 }
 
 pub mod reduce_stake_warmup_cooldown {
-    use solana_program::{epoch_schedule::EpochSchedule, stake_history::Epoch};
     solana_sdk::declare_id!("GwtDQBghCTBgmX2cpEGNPxTEBUTQRaDMGTr5qychdGMj");
-
-    pub trait NewWarmupCooldownRateEpoch {
-        fn new_warmup_cooldown_rate_epoch(&self, epoch_schedule: &EpochSchedule) -> Option<Epoch>;
-    }
-    impl NewWarmupCooldownRateEpoch for super::FeatureSet {
-        fn new_warmup_cooldown_rate_epoch(&self, epoch_schedule: &EpochSchedule) -> Option<Epoch> {
-            self.activated_slot(&id())
-                .map(|slot| epoch_schedule.get_epoch(slot))
-        }
-    }
 }
 
 pub mod revise_turbine_epoch_stakes {
@@ -959,6 +949,11 @@ impl FeatureSet {
     pub fn deactivate(&mut self, feature_id: &Pubkey) {
         self.active.remove(feature_id);
         self.inactive.insert(*feature_id);
+    }
+
+    pub fn new_warmup_cooldown_rate_epoch(&self, epoch_schedule: &EpochSchedule) -> Option<Epoch> {
+        self.activated_slot(&reduce_stake_warmup_cooldown::id())
+            .map(|slot| epoch_schedule.get_epoch(slot))
     }
 }
 


### PR DESCRIPTION
#### Problem
`new_warmup_cooldown_rate_epoch` is wastefully recomputed once for each of ~600k stake accounts at epoch boundary. 


#### Summary of Changes
* moved `new_warmup_cooldown_rate_epoch` outside iterators and for loops.
* also removed `NewWarmupCooldownRateEpoch` trait which is unnecessary and verbose.
