### PR TITLE
serve coding shreds via repair

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -22,6 +22,21 @@ pub fn repair_response_packet(
         .unwrap_or(None)
 }
 
+pub fn repair_coding_response_packet(
+    blockstore: &Blockstore,
+    slot: Slot,
+    shred_index: u64,
+    dest: &SocketAddr,
+    nonce: Nonce,
+) -> Option<Packet> {
+    let shred = blockstore
+        .get_coding_shred(slot, shred_index)
+        .expect("Blockstore could not get coding shred");
+    shred
+        .map(|shred| repair_response_packet_from_bytes(shred, dest, nonce))
+        .unwrap_or(None)
+}
+
 pub fn repair_response_packet_from_bytes(
     bytes: Vec<u8>,
     dest: &SocketAddr,


### PR DESCRIPTION
#### Problem
No ability to request coding shreds for repair. With merkle shreds it should now be possible to reconstruct and serve coding shreds.

#### Summary of Changes
Add `CodingIndex` type to `RepairProtocol` to request coding shreds.
Limit support to `Development` and `Testnet` clusters. Once this support has been rolled out to testnet it will be possible to test the efficacy of using coding shreds for repair.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
