### PR TITLE
Refactors out `unsafe` from MmapAccountHashesFile::read()

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -42,12 +42,9 @@ impl MmapAccountHashesFile {
     /// return a slice of account hashes starting at 'index'
     fn read(&self, index: usize) -> &[Hash] {
         let start = std::mem::size_of::<Hash>() * index;
-        let item_slice: &[u8] = &self.mmap[start..self.count * std::mem::size_of::<Hash>()];
-        let remaining_elements = item_slice.len() / std::mem::size_of::<Hash>();
-        unsafe {
-            let item = item_slice.as_ptr() as *const Hash;
-            std::slice::from_raw_parts(item, remaining_elements)
-        }
+        let end = std::mem::size_of::<Hash>() * self.count;
+        let bytes = &self.mmap[start..end];
+        bytemuck::cast_slice(bytes)
     }
 
     /// write a hash to the end of mmap file.


### PR DESCRIPTION
#### Problem

We use `unsafe` blocks to read/write data in the various accounts hash files. That's not always needed.

`MmapAccountHashesFile::read()` is one of those.


#### Summary of Changes

Since `Hash` is `Pod`, we can use `bytemuck::cast_slice()` instead of `unsafe`.
