### PR TITLE
Derives Pod for CalculateHashIntermediate

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10667,10 +10667,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[0].push(raw_expected[1].clone());
-        expected[bins - 1].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected[3].clone());
+        expected[0].push(raw_expected[0]);
+        expected[0].push(raw_expected[1]);
+        expected[bins - 1].push(raw_expected[2]);
+        expected[bins - 1].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 0, bins);
 
         let bins = 4;
@@ -10689,10 +10689,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[1].push(raw_expected[1].clone());
-        expected[2].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected[3].clone());
+        expected[0].push(raw_expected[0]);
+        expected[1].push(raw_expected[1]);
+        expected[2].push(raw_expected[2]);
+        expected[bins - 1].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 0, bins);
 
         let bins = 256;
@@ -10711,10 +10711,10 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[127].push(raw_expected[1].clone());
-        expected[128].push(raw_expected[2].clone());
-        expected[bins - 1].push(raw_expected.last().unwrap().clone());
+        expected[0].push(raw_expected[0]);
+        expected[127].push(raw_expected[1]);
+        expected[128].push(raw_expected[2]);
+        expected[bins - 1].push(*raw_expected.last().unwrap());
         assert_scan(result, vec![expected], bins, 0, bins);
     }
 
@@ -10773,8 +10773,8 @@ pub mod tests {
             )
             .unwrap();
         let mut expected = vec![Vec::new(); half_bins];
-        expected[0].push(raw_expected[0].clone());
-        expected[0].push(raw_expected[1].clone());
+        expected[0].push(raw_expected[0]);
+        expected[0].push(raw_expected[1]);
         assert_scan(result, vec![expected], bins, 0, half_bins);
 
         // just the second bin of 2
@@ -10795,8 +10795,8 @@ pub mod tests {
 
         let mut expected = vec![Vec::new(); half_bins];
         let starting_bin_index = 0;
-        expected[starting_bin_index].push(raw_expected[2].clone());
-        expected[starting_bin_index].push(raw_expected[3].clone());
+        expected[starting_bin_index].push(raw_expected[2]);
+        expected[starting_bin_index].push(raw_expected[3]);
         assert_scan(result, vec![expected], bins, 1, bins - 1);
 
         // 1 bin at a time of 4
@@ -10818,7 +10818,7 @@ pub mod tests {
                 )
                 .unwrap();
             let mut expected = vec![Vec::new(); 1];
-            expected[0].push(expected_item.clone());
+            expected[0].push(*expected_item);
             assert_scan(result, vec![expected], bins, bin, 1);
         }
 
@@ -10843,7 +10843,7 @@ pub mod tests {
             let mut expected = vec![];
             if let Some(index) = bin_locations.iter().position(|&r| r == bin) {
                 expected = vec![Vec::new(); range];
-                expected[0].push(raw_expected[index].clone());
+                expected[0].push(raw_expected[index]);
             }
             let mut result2 = (0..range).map(|_| Vec::default()).collect::<Vec<_>>();
             if let Some(m) = result.get(0) {
@@ -10888,7 +10888,7 @@ pub mod tests {
             .unwrap();
         assert_eq!(result.len(), 1); // 2 chunks, but 1 is empty so not included
         let mut expected = vec![Vec::new(); range];
-        expected[0].push(raw_expected[1].clone());
+        expected[0].push(raw_expected[1]);
         let mut result2 = (0..range).map(|_| Vec::default()).collect::<Vec<_>>();
         result[0].load_all(&mut result2, 0, &PubkeyBinCalculator24::new(range));
         assert_eq!(result2.len(), 1);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1819,7 +1819,7 @@ mod tests {
             lamports: 1,
             pubkey,
         };
-        account_maps.push(val.clone());
+        account_maps.push(val);
 
         let vecs = vec![account_maps.to_vec()];
         let slice = convert_to_slice(&vecs);
@@ -1857,19 +1857,19 @@ mod tests {
                 lamports: 1,
                 pubkey: key,
             };
-            account_maps.push(val.clone());
+            account_maps.push(val);
             let val2 = CalculateHashIntermediate {
                 hash,
                 lamports: 2,
                 pubkey: key2,
             };
-            account_maps.push(val2.clone());
+            account_maps.push(val2);
             let val3 = CalculateHashIntermediate {
                 hash,
                 lamports: 3,
                 pubkey: key2,
             };
-            account_maps2.push(val3.clone());
+            account_maps2.push(val3);
 
             let mut vecs = vec![account_maps.to_vec(), account_maps2.to_vec()];
             if reverse {
@@ -1907,19 +1907,19 @@ mod tests {
                 lamports: 2,
                 pubkey: key2,
             };
-            account_maps.push(val2.clone());
+            account_maps.push(val2);
             let val = CalculateHashIntermediate {
                 hash,
                 lamports: 1,
                 pubkey: key,
             };
-            account_maps.push(val.clone());
+            account_maps.push(val);
             let val3 = CalculateHashIntermediate {
                 hash,
                 lamports: 3,
                 pubkey: key2,
             };
-            account_maps2.push(val3.clone());
+            account_maps2.push(val3);
 
             let mut vecs = vec![account_maps.to_vec(), account_maps2.to_vec()];
             if reverse {

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -120,7 +120,7 @@ impl CacheHashDataFile {
                 "{pubkey_to_bin_index}, {start_bin_index}"
             ); // this would indicate we put a pubkey in too high of a bin
             pubkey_to_bin_index -= start_bin_index;
-            accumulator[pubkey_to_bin_index].push(d.clone()); // may want to avoid clone here
+            accumulator[pubkey_to_bin_index].push(*d); // may want to avoid copy here
         }
 
         m2.stop();
@@ -348,7 +348,7 @@ impl CacheHashData {
             x.iter().for_each(|item| {
                 let d = cache_file.get_mut(i as u64);
                 i += 1;
-                *d = item.clone();
+                *d = *item;
             })
         });
         assert_eq!(i, entries);


### PR DESCRIPTION
#### Problem

We use `unsafe` blocks to read/write data in the various accounts hash files. That's not always needed.

The `CalculateHashIntermediate` type is used as the type to read/write from these files. By marking it with `Pod`, we can rewrite `unsafe` blocks without unsafe.


#### Summary of Changes

Derive `Pod` for `CalculateHashIntermediate`.

Note that `Pod` requires `Copy` too. So the second commit is clippy fixes for replacing `clone` with copies.
