### PR TITLE
binary search

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -974,16 +974,9 @@ impl<'a> AccountsHasher<'a> {
                     first_items.push(k);
                     first_item_to_pubkey_division.push(i);
                     indexes.push(first_pubkey_in_bin);
-                    let mut first_pubkey_in_next_bin = first_pubkey_in_bin + 1;
-                    while first_pubkey_in_next_bin < hash_data.len() {
-                        if binner.bin_from_pubkey(&hash_data[first_pubkey_in_next_bin].pubkey)
-                            != pubkey_bin
-                        {
-                            break;
-                        }
-                        first_pubkey_in_next_bin += 1;
-                    }
-                    first_pubkey_in_next_bin - first_pubkey_in_bin
+
+                    hash_data[first_pubkey_in_bin..]
+                        .partition_point(|x| binner.bin_from_pubkey(&x.pubkey) == pubkey_bin)
                 } else {
                     0
                 }


### PR DESCRIPTION
#### Problem

master
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  7060810i
pubkey_bin_search_us                16757688i
```

this pr
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d1 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us"
eliminate_zeros_us                  7225285i
pubkey_bin_search_us                15572257i
```

slower. probably due to cache eviction of binary search...

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
