### PR TITLE
Manually add lookup table addresses instead of sanitizing

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1024,13 +1024,14 @@ fn get_latest_optimistic_slots(
 /// Finds the accounts needed to replay slots `snapshot_slot` to `ending_slot`.
 /// Removes all other accounts from accounts_db, and updates the accounts hash
 /// and capitalization. This is used by the --minimize option in create-snapshot
+/// Returns true if the minimized snapshot may be incomplete.
 fn minimize_bank_for_snapshot(
     blockstore: &Blockstore,
     bank: &Bank,
     snapshot_slot: Slot,
     ending_slot: Slot,
-) {
-    let (transaction_account_set, transaction_accounts_measure) = measure!(
+) -> bool {
+    let ((transaction_account_set, possibly_incomplete), transaction_accounts_measure) = measure!(
         blockstore.get_accounts_used_in_range(bank, snapshot_slot, ending_slot),
         "get transaction accounts"
     );
@@ -1038,6 +1039,7 @@ fn minimize_bank_for_snapshot(
     info!("Added {total_accounts_len} accounts from transactions. {transaction_accounts_measure}");
 
     SnapshotMinimizer::minimize(bank, snapshot_slot, ending_slot, transaction_account_set);
+    possibly_incomplete
 }
 
 fn assert_capitalization(bank: &Bank) {
@@ -3158,14 +3160,16 @@ fn main() {
                             bank
                         };
 
-                        if is_minimized {
+                        let minimize_snapshot_possibly_incomplete = if is_minimized {
                             minimize_bank_for_snapshot(
                                 &blockstore,
                                 &bank,
                                 snapshot_slot,
                                 ending_slot.unwrap(),
-                            );
-                        }
+                            )
+                        } else {
+                            false
+                        };
 
                         println!(
                             "Creating a version {} {}snapshot of slot {}",
@@ -3244,6 +3248,10 @@ fn main() {
                                 if starting_epoch != ending_epoch {
                                     warn!("Minimized snapshot range crosses epoch boundary ({} to {}). Bank hashes after {} will not match replays from a full snapshot",
                                         starting_epoch, ending_epoch, bank.epoch_schedule().get_last_slot_in_epoch(starting_epoch));
+                                }
+
+                                if minimize_snapshot_possibly_incomplete {
+                                    warn!("Minimized snapshot may be incomplete due to missing accounts from CPI'd address lookup table extensions. This may lead to replay failures");
                                 }
                             }
                         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3251,7 +3251,7 @@ fn main() {
                                 }
 
                                 if minimize_snapshot_possibly_incomplete {
-                                    warn!("Minimized snapshot may be incomplete due to missing accounts from CPI'd address lookup table extensions. This may lead to replay failures");
+                                    warn!("Minimized snapshot may be incomplete due to missing accounts from CPI'd address lookup table extensions. This may lead to mismatched bank hashes while replaying.");
                                 }
                             }
                         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2984,7 +2984,7 @@ impl Blockstore {
             }
         });
 
-        (result, possible_cpi_alt_extend.load(Ordering::Relaxed))
+        (result, possible_cpi_alt_extend.into_inner())
     }
 
     fn get_completed_ranges(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -21,7 +21,7 @@ use {
             Shred, ShredData, ShredId, ShredType, Shredder,
         },
         slot_stats::{ShredSource, SlotsStats},
-        transaction_address_lookup_table_scanner::{scan_transaction, ScanResult},
+        transaction_address_lookup_table_scanner::scan_transaction,
     },
     assert_matches::debug_assert_matches,
     bincode::{deserialize, serialize},
@@ -2958,14 +2958,10 @@ impl Blockstore {
                                 let tx = SanitizedVersionedTransaction::try_from(tx)
                                     .expect("transaction failed to sanitize");
 
-                                let alt_scan_result = scan_transaction(&tx);
-                                match alt_scan_result {
-                                    ScanResult::NotFound => {}
-                                    ScanResult::NativeUsed(keys) => add_to_set(&result, &keys),
-                                    ScanResult::NonNativeUsed(keys) => {
-                                        add_to_set(&result, &keys);
-                                        possible_cpi_alt_extend.store(true, Ordering::Relaxed);
-                                    }
+                                let alt_scan_extensions = scan_transaction(&tx);
+                                add_to_set(&result, &alt_scan_extensions.accounts);
+                                if alt_scan_extensions.possibly_incomplete {
+                                    possible_cpi_alt_extend.store(true, Ordering::Relaxed);
                                 }
                             }
                         });

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2953,7 +2953,8 @@ impl Blockstore {
                 return;
             };
 
-            let Ok(lookup_table) = AddressLookupTable::deserialize(lookup_table_account.data()) else {
+            let Ok(lookup_table) = AddressLookupTable::deserialize(lookup_table_account.data())
+            else {
                 return;
             };
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -28,6 +28,7 @@ pub mod sigverify_shreds;
 pub mod slot_stats;
 mod staking_utils;
 pub mod token_balances;
+mod transaction_address_lookup_table_scanner;
 pub mod use_snapshot_archives_at_startup;
 
 #[macro_use]

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -45,9 +45,8 @@ pub fn scan_transaction(transaction: &SanitizedVersionedTransaction) -> ScanResu
     let mut native_only = true;
     for (program_id, instruction) in transaction.get_message().program_instructions_iter() {
         if address_lookup_table::program::check_id(program_id) {
-            if let ProgramInstruction::ExtendLookupTable { new_addresses } =
+            if let Ok(ProgramInstruction::ExtendLookupTable { new_addresses }) =
                 deserialize::<ProgramInstruction>(&instruction.data)
-                    .expect("invalid address lookup table instruction")
             {
                 accounts.extend(new_addresses);
             }

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -29,7 +29,7 @@ pub enum ScanResult {
 }
 
 pub fn scan_transaction(transaction: &SanitizedVersionedTransaction) -> ScanResult {
-    // If the program is not present in the account keys, it was not used
+    // If the ALT program is not present in the account keys, it was not used
     if !transaction
         .get_message()
         .message

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -14,7 +14,6 @@ lazy_static! {
     static ref SDK_IDS_SET: HashSet<Pubkey> = SDK_IDS.iter().cloned().collect();
 }
 
-#[derive(Default)]
 pub struct ScannedLookupTableExtensions {
     pub possibly_incomplete: bool,
     pub accounts: Vec<Pubkey>, // empty if no extensions found
@@ -23,17 +22,6 @@ pub struct ScannedLookupTableExtensions {
 pub fn scan_transaction(
     transaction: &SanitizedVersionedTransaction,
 ) -> ScannedLookupTableExtensions {
-    // If the ALT program is not present in the account keys, it was not used
-    if !transaction
-        .get_message()
-        .message
-        .static_account_keys()
-        .iter()
-        .any(address_lookup_table::program::check_id)
-    {
-        return ScannedLookupTableExtensions::default();
-    }
-
     // Accumulate accounts from account lookup table extension instructions
     let mut accounts = Vec::new();
     let mut native_only = true;

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -1,0 +1,64 @@
+use {
+    bincode::deserialize,
+    lazy_static::lazy_static,
+    solana_sdk::{
+        address_lookup_table::{self, instruction::ProgramInstruction},
+        pubkey::Pubkey,
+        sdk_ids::SDK_IDS,
+        transaction::SanitizedVersionedTransaction,
+    },
+    std::collections::HashSet,
+};
+
+lazy_static! {
+    static ref SDK_IDS_SET: HashSet<Pubkey> = SDK_IDS.iter().cloned().collect();
+}
+
+pub enum ScanResult {
+    /// The address lookup table program was not used
+    NotFound,
+    /// The address lookup table program was present, with non-native programs.
+    /// If instructions extending an account lookup table were found, the list
+    /// of Pubkeys will be returned. However, this may be incomplete due to the
+    /// possibility of non-native ixs CPIing to extend.
+    NonNativeUsed(Vec<Pubkey>),
+    /// The address lookup table program was present, with only native programs.
+    /// If instructions extending an account lookup table were found, the list
+    /// of Pubkeys will be returned.
+    NativeUsed(Vec<Pubkey>),
+}
+
+pub fn scan_transaction(transaction: &SanitizedVersionedTransaction) -> ScanResult {
+    // If the program is not present in the account keys, it was not used
+    if !transaction
+        .get_message()
+        .message
+        .static_account_keys()
+        .iter()
+        .any(address_lookup_table::program::check_id)
+    {
+        return ScanResult::NotFound;
+    }
+
+    // Accumulate accounts from account lookup table extension instructions
+    let mut accounts = Vec::new();
+    let mut native_only = true;
+    for (program_id, instruction) in transaction.get_message().program_instructions_iter() {
+        if address_lookup_table::program::check_id(program_id) {
+            if let ProgramInstruction::ExtendLookupTable { new_addresses } =
+                deserialize::<ProgramInstruction>(&instruction.data)
+                    .expect("invalid address lookup table instruction")
+            {
+                accounts.extend(new_addresses);
+            }
+        } else {
+            native_only &= SDK_IDS_SET.contains(program_id);
+        }
+    }
+
+    if native_only {
+        ScanResult::NativeUsed(accounts)
+    } else {
+        ScanResult::NonNativeUsed(accounts)
+    }
+}

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -564,9 +564,9 @@ pub mod config {
 pub mod sdk_ids {
     use {
         crate::{
-            bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, config, ed25519_program,
-            feature, incinerator, secp256k1_program, solana_program::pubkey::Pubkey, stake,
-            system_program, sysvar, vote,
+            address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
+            config, ed25519_program, feature, incinerator, loader_v4, secp256k1_program,
+            solana_program::pubkey::Pubkey, stake, system_program, sysvar, vote,
         },
         lazy_static::lazy_static,
     };
@@ -585,6 +585,9 @@ pub mod sdk_ids {
                 vote::program::id(),
                 feature::id(),
                 bpf_loader_deprecated::id(),
+                address_lookup_table::program::id(),
+                loader_v4::id(),
+                stake::program::id(),
                 #[allow(deprecated)]
                 stake::config::id(),
             ];


### PR DESCRIPTION
#### Problem
#30165

#### Summary of Changes
Manually load and add lookup table addresses instead of using sanitize.

Fixes #30165
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
