### PR TITLE
docs: deprecated use of `cargo build-bpf`

### DIFF
--- a/docs/src/developing/on-chain-programs/developing-rust.md
+++ b/docs/src/developing/on-chain-programs/developing-rust.md
@@ -73,7 +73,7 @@ can be deployed to the cluster:
 
 ```bash
 $ cd <the program directory>
-$ cargo build-bpf
+$ cargo-build-bpf
 ```
 
 ## How to Test
@@ -380,7 +380,7 @@ To create a dump file:
 
 ```bash
 $ cd <program directory>
-$ cargo build-bpf --dump
+$ cargo-build-bpf --dump
 ```
 
 ## Examples

--- a/docs/src/getstarted/rust.md
+++ b/docs/src/getstarted/rust.md
@@ -120,12 +120,12 @@ This program above will simply [log a message](../developing/on-chain-programs/d
 Inside a terminal window, you can build your Solana Rust program by running in the root of your project (i.e. the directory with your `Cargo.toml` file):
 
 ```bash
-cargo build-bpf
+cargo-build-bpf
 ```
 
 > **NOTE:**
 > After each time you build your Solana program, the above command will output the build path of your compiled program's `.so` file and the default keyfile that will be used for the program's address.
-> `cargo build-bpf` installs the toolchain from the currently installed solana CLI tools. You may need to upgrade those tools if you encounter any version incompatibilities.
+> `cargo-build-bpf` installs the toolchain from the currently installed solana CLI tools. You may need to upgrade those tools if you encounter any version incompatibilities.
 
 ## Deploy your Solana program
 


### PR DESCRIPTION
cargo suggests to use
`cargo-build-bpf`

#### Problem
Solana get started docs [here](https://docs.solana.com/getstarted/rust#build-your-rust-program) suggest to use `cargo build-bpf` which seems to be deprecated, as seen from the output after performing the command
```
$ cargo build-bpf
Warning: cargo-build-bpf is deprecated. Please, use cargo-build-bpf
```

#### Summary of Changes
changed all `cargo build-bpf` to `cargo-build-bpf`. which include files:
- docs/src/getstarted/rust.md
- docs/src/developing/on-chain-programs/developing-rust.md

