### PR TITLE
Make program owners a const array instead of Vec<_>

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -648,7 +648,7 @@ impl Accounts {
         ancestors: &Ancestors,
         txs: &[SanitizedTransaction],
         lock_results: &mut [TransactionCheckResult],
-        program_owners: &[&'a Pubkey],
+        program_owners: &'a [Pubkey],
         hash_queue: &BlockhashQueue,
     ) -> HashMap<Pubkey, (&'a Pubkey, u64)> {
         let mut result: HashMap<Pubkey, (&'a Pubkey, u64)> = HashMap::new();
@@ -678,7 +678,7 @@ impl Accounts {
                                 ) {
                                     program_owners
                                         .get(index)
-                                        .map(|owner| entry.insert((*owner, 1)));
+                                        .map(|owner| entry.insert((owner, 1)));
                                 }
                             }
                         });
@@ -2090,11 +2090,12 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
+        let owners = &[program1_pubkey, program2_pubkey];
         let programs = accounts.filter_executable_program_accounts(
             &ancestors,
             &[sanitized_tx1, sanitized_tx2],
             &mut [(Ok(()), None), (Ok(()), None)],
-            &[&program1_pubkey, &program2_pubkey],
+            owners,
             &hash_queue,
         );
 
@@ -2198,12 +2199,13 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
+        let owners = &[program1_pubkey, program2_pubkey];
         let mut lock_results = vec![(Ok(()), None), (Ok(()), None)];
         let programs = accounts.filter_executable_program_accounts(
             &ancestors,
             &[sanitized_tx1, sanitized_tx2],
             &mut lock_results,
-            &[&program1_pubkey, &program2_pubkey],
+            owners,
             &hash_queue,
         );
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -865,7 +865,7 @@ impl<'a> LoadedAccountAccessor<'a> {
         }
     }
 
-    fn account_matches_owners(&self, owners: &[&Pubkey]) -> Result<usize, MatchAccountOwnerError> {
+    fn account_matches_owners(&self, owners: &[Pubkey]) -> Result<usize, MatchAccountOwnerError> {
         match self {
             LoadedAccountAccessor::Cached(cached_account) => cached_account
                 .as_ref()
@@ -875,7 +875,7 @@ impl<'a> LoadedAccountAccessor<'a> {
                     } else {
                         owners
                             .iter()
-                            .position(|entry| &cached_account.account.owner() == entry)
+                            .position(|entry| cached_account.account.owner() == entry)
                     }
                 })
                 .ok_or(MatchAccountOwnerError::NoMatch),
@@ -5074,7 +5074,7 @@ impl AccountsDb {
         &self,
         ancestors: &Ancestors,
         account: &Pubkey,
-        owners: &[&Pubkey],
+        owners: &[Pubkey],
     ) -> Result<usize, MatchAccountOwnerError> {
         let (slot, storage_location, _maybe_account_accesor) = self
             .read_index_for_accessor_or_load_slow(ancestors, account, None, false)
@@ -5088,7 +5088,7 @@ impl AccountsDb {
                 } else {
                     owners
                         .iter()
-                        .position(|entry| &account.owner() == entry)
+                        .position(|entry| account.owner() == entry)
                         .ok_or(MatchAccountOwnerError::NoMatch)
                 };
             }
@@ -14092,7 +14092,6 @@ pub mod tests {
         ));
 
         let owners: Vec<Pubkey> = (0..2).map(|_| Pubkey::new_unique()).collect();
-        let owners_refs: Vec<&Pubkey> = owners.iter().collect();
 
         let account1_key = Pubkey::new_unique();
         let account1 = AccountSharedData::new(321, 10, &owners[0]);
@@ -14122,23 +14121,23 @@ pub mod tests {
         db.clean_accounts_for_tests();
 
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account1_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account1_key, &owners),
             Ok(0)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account2_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account2_key, &owners),
             Ok(1)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account3_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account3_key, &owners),
             Err(MatchAccountOwnerError::NoMatch)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account4_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account4_key, &owners),
             Err(MatchAccountOwnerError::NoMatch)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &Pubkey::new_unique(), &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &Pubkey::new_unique(), &owners),
             Err(MatchAccountOwnerError::UnableToLoad)
         );
 
@@ -14156,23 +14155,23 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account1_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account1_key, &owners),
             Ok(0)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account2_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account2_key, &owners),
             Ok(1)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account3_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account3_key, &owners),
             Err(MatchAccountOwnerError::NoMatch)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &account4_key, &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &account4_key, &owners),
             Err(MatchAccountOwnerError::NoMatch)
         );
         assert_eq!(
-            db.account_matches_owners(&Ancestors::default(), &Pubkey::new_unique(), &owners_refs),
+            db.account_matches_owners(&Ancestors::default(), &Pubkey::new_unique(), &owners),
             Err(MatchAccountOwnerError::UnableToLoad)
         );
     }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -116,7 +116,7 @@ impl AccountsFile {
     pub fn account_matches_owners(
         &self,
         offset: usize,
-        owners: &[&Pubkey],
+        owners: &[Pubkey],
     ) -> std::result::Result<usize, MatchAccountOwnerError> {
         match self {
             Self::AppendVec(av) => av.account_matches_owners(offset, owners),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5116,18 +5116,17 @@ impl Bank {
         );
         check_time.stop();
 
-        let program_owners: Vec<Pubkey> = vec![
-            bpf_loader_upgradeable::id(),
-            bpf_loader::id(),
-            bpf_loader_deprecated::id(),
-            loader_v4::id(),
+        const PROGRAM_OWNERS: &[&Pubkey] = &[
+            &bpf_loader_upgradeable::id(),
+            &bpf_loader::id(),
+            &bpf_loader_deprecated::id(),
+            &loader_v4::id(),
         ];
-        let program_owners_refs: Vec<&Pubkey> = program_owners.iter().collect();
         let mut program_accounts_map = self.rc.accounts.filter_executable_program_accounts(
             &self.ancestors,
             sanitized_txs,
             &mut check_results,
-            &program_owners_refs,
+            PROGRAM_OWNERS,
             &self.blockhash_queue.read().unwrap(),
         );
         let native_loader = native_loader::id();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5116,11 +5116,11 @@ impl Bank {
         );
         check_time.stop();
 
-        const PROGRAM_OWNERS: &[&Pubkey] = &[
-            &bpf_loader_upgradeable::id(),
-            &bpf_loader::id(),
-            &bpf_loader_deprecated::id(),
-            &loader_v4::id(),
+        const PROGRAM_OWNERS: &[Pubkey] = &[
+            bpf_loader_upgradeable::id(),
+            bpf_loader::id(),
+            bpf_loader_deprecated::id(),
+            loader_v4::id(),
         ];
         let mut program_accounts_map = self.rc.accounts.filter_executable_program_accounts(
             &self.ancestors,


### PR DESCRIPTION
#### Problem
The program owners pubkeys are constant, no need to reconstruct the Vec<Pubkey> and Vec<&Pubkey> each time this function runs (every time we execute transactions).

#### Summary of Changes
Make a const array and remove an unnecessary layer of indirection by changing `&[&Pubkey]` (slice of pubkey references) to `&[Pubkey]` (slice of pupkeys).
