### PR TITLE
program: move array-bytes to dev-dependencies

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5235,7 +5235,6 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "array-bytes",
  "base64 0.21.4",
  "bincode",
  "bitflags 2.3.3",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -51,7 +51,6 @@ ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
-array-bytes = { workspace = true }
 bitflags = { workspace = true }
 base64 = { workspace = true, features = ["alloc", "std"] }
 curve25519-dalek = { workspace = true, features = ["serde"] }
@@ -79,6 +78,7 @@ parking_lot = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+array-bytes = { workspace = true }
 assert_matches = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }


### PR DESCRIPTION
For solana-program, array-bytes is only used in the tests