### PR TITLE
Set loader-v4 program deployment slot at actual deployment

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -341,7 +341,7 @@ pub fn process_instruction_truncate(
         )?;
         if is_initialization {
             let state = get_state_mut(program.get_data_mut()?)?;
-            state.slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
+            state.slot = 0;
             state.status = LoaderV4Status::Retracted;
             state.authority_address = *authority_address;
         }


### PR DESCRIPTION
#### Problem
The program deployment fails when using loader-v4.

#### Summary of Changes
The truncate instruction sets the deployment slot for the program to the current slot when the buffer is being initialized. The deploy instruction checks if `DEPLOYMENT_COOLDOWN_IN_SLOTS` have elapsed since the last deployment. `DEPLOYMENT_COOLDOWN_IN_SLOTS` is set to 750, so the deployment fails (since the CLI sends truncate and deploy instructions in quick succession).

Taking a step back, the truncate instruction should not be setting the deployment slot when the buffer is being initialized. It should only be set at the time of program deployment.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
