### PR TITLE
Fix lamport calculation and transfer for loader-v4 program upgrade

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -429,8 +429,8 @@ pub fn process_instruction_deploy(
     load_program_metrics.submit_datapoint(&mut invoke_context.timings);
     if let Some(mut source_program) = source_program {
         let rent = invoke_context.get_sysvar_cache().get_rent()?;
-        let required_lamports = rent.minimum_balance(program.get_data().len());
-        let transfer_lamports = program.get_lamports().saturating_sub(required_lamports);
+        let required_lamports = rent.minimum_balance(source_program.get_data().len());
+        let transfer_lamports = required_lamports.saturating_sub(program.get_lamports());
         program.set_data_from_slice(source_program.get_data())?;
         source_program.set_data_length(0)?;
         source_program.checked_sub_lamports(transfer_lamports)?;


### PR DESCRIPTION
#### Problem
The upgrade/redeployment using temporary buffer fails for loader-v4 programs when the new program is larger than the current program.

#### Summary of Changes
As part of program upgrade, the loader transfers necessary lamports from the temporary buffer account to the program account. The calculation of the required lamports, and transferred lamports is incorrect. That resulted into transfer of 0 lamports the the program account resulting in underflow of account balance.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
