### PR TITLE
Allow libpath to be split from other plugin config

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -30,6 +30,7 @@ env:
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  RUST_BACKTRACE: "1"
 
 jobs:
   check:

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -360,7 +360,7 @@ const TESTPLUGIN2_CONFIG_PATH: &str = "/test/plugin-2/config";
 #[cfg(test)]
 const TESTPLUGIN_CONFIG: &str = "{\"libpath\": \"/test/plugin/lib\"}";
 #[cfg(test)]
-const TESTPLUGIN2_CONFIG: &str = "{\"libpath\": \"/test/plugin-2/lib\"}";
+const TESTPLUGIN2_CONFIG: &str = "{\"libpath\": \"/test/plugin-2/lib\", \"configpath\": \"/test/plugin-2/splitconfig\"}";
 
 
 
@@ -525,5 +525,16 @@ mod tests {
         let unload_result = plugin_manager_lock.unload_plugin(TESTPLUGIN_NAME);
         assert!(unload_result.is_ok());
         assert_eq!(plugin_manager_lock.plugins.len(), 0);
+    }
+
+    #[test]
+    fn test_plugin_load_with_secondary_config() {
+        // Combined config file
+        let (_, _, config_path) = load_plugin_from_config(TESTPLUGIN_CONFIG_PATH.as_ref()).unwrap();
+        assert!(config_path.eq(TESTPLUGIN_CONFIG_PATH));
+
+        // Split config file
+        let (_, _, config_path) = load_plugin_from_config(TESTPLUGIN2_CONFIG_PATH.as_ref()).unwrap();
+        assert!(config_path.eq("/test/plugin-2/splitconfig"));
     }
 }


### PR DESCRIPTION
#### Problem

The config file given on the command line when running the validator with a geyser plugin contains both the location of the library as well as any config used by the library.  When packaging the validator with a plugin (eg. in a container), the config of the plugin should ideally be configurable by the user of the package, but the user should not need to know the location of the plugin library within the package.  As such it would be helpful if the config for the plugin library location, and the config for the plugin, could reside in different places.

#### Summary of Changes

This PR adds an optional `configpath` parameter to the plugin config file specified on the command line.  The library location is always taken from the `libpath` parameter in the command line config file.  However, if the `configpath` is specified in this file then the rest of the config (excluding `libpath`) is read from the given path.  If `configpath` is not specified then all config is read from the command line config file, as it previously was.

I also refactored the code slightly so that I could add a test for the new functionality.

##### Potential Issues

1. Plugins may assume that the config file they are passed must exist and be valid (since the geyser framework has already parsed it), but this is not necessarily the case any more, so additional error checks may be needed.  Were this the case the likely result would be a crash with an unhelpful error message.

1. Existing plugins may already use the `configpath`parameter, and the new functionality would misinterpret the config file.  This is probably unlikely, but I'm not sure how to mitigate it.

1. Docs here: https://docs.solana.com/developing/plugins/geyser-plugins should probably be updated, but I couldn't see how to do this.
