### PR TITLE
wip: handle duplicates in index insertion better

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,3 +1,5 @@
+use crate::in_mem_accounts_index::DuplicateInsertedItem;
+
 use {
     crate::{
         accounts_index_storage::{AccountsIndexStorage, Startup},
@@ -1719,7 +1721,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// use Vec<> because the internal vecs are already allocated per bin
     pub(crate) fn populate_and_retrieve_duplicate_keys_from_startup(
         &self,
-        f: impl Fn(Vec<(Slot, Pubkey)>) + Sync + Send,
+        f: impl Fn(Vec<DuplicateInsertedItem<T>>) + Sync + Send,
     ) {
         (0..self.bins())
             .into_par_iter()


### PR DESCRIPTION
#### Problem
Working on speeding up index generation.

#### Summary of Changes
Best way to handle identifying duplicates is using the index itself to look for duplicates in the same hash. This requires some rework.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
