### PR TITLE
bump syn to 2.0.37 for test-case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7862,7 +7862,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -7874,7 +7874,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
  "test-case-core",
 ]
 


### PR DESCRIPTION
#### Problem

we missed the syn version bumping for test-case cuz they are created at the same time. (#33285 #33286 )

#### Summary of Changes

fix it