### PR TITLE
Implement CLI front-end for loader-v4 commands

### DIFF
--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
         address_lookup_table::AddressLookupTableSubCommands, cli::*, cluster_query::*, feature::*,
-        inflation::*, nonce::*, program::*, stake::*, validator_info::*, vote::*, wallet::*,
+        inflation::*, nonce::*, program::*, program_v4::ProgramV4SubCommands, stake::*,
+        validator_info::*, vote::*, wallet::*,
     },
     clap::{App, AppSettings, Arg, ArgGroup, SubCommand},
     solana_clap_utils::{self, hidden_unless_forced, input_validators::*, keypair::*},
@@ -143,6 +144,7 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
         .inflation_subcommands()
         .nonce_subcommands()
         .program_subcommands()
+        .program_v4_subcommands()
         .address_lookup_table_subcommands()
         .stake_subcommands()
         .validator_info_subcommands()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         address_lookup_table::*, clap_app::*, cluster_query::*, feature::*, inflation::*, nonce::*,
-        program::*, spend_utils::*, stake::*, validator_info::*, vote::*, wallet::*,
+        program::*, program_v4::*, spend_utils::*, stake::*, validator_info::*, vote::*, wallet::*,
     },
     clap::{crate_description, crate_name, value_t_or_exit, ArgMatches, Shell},
     log::*,
@@ -175,6 +175,7 @@ pub enum CliCommand {
     // Program Deployment
     Deploy,
     Program(ProgramCliCommand),
+    ProgramV4(ProgramV4CliCommand),
     // Stake Commands
     CreateStakeAccount {
         stake_account: SignerIndex,
@@ -687,6 +688,9 @@ pub fn parse_command(
         ("program", Some(matches)) => {
             parse_program_subcommand(matches, default_signer, wallet_manager)
         }
+        ("program-v4", Some(matches)) => {
+            parse_program_v4_subcommand(matches, default_signer, wallet_manager)
+        }
         ("address-lookup-table", Some(matches)) => {
             parse_address_lookup_table_subcommand(matches, default_signer, wallet_manager)
         }
@@ -1101,6 +1105,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Deploy a custom program to the chain
         CliCommand::Program(program_subcommand) => {
             process_program_subcommand(rpc_client, config, program_subcommand)
+        }
+
+        // Deploy a custom program v4 to the chain
+        CliCommand::ProgramV4(program_subcommand) => {
+            process_program_v4_subcommand(rpc_client, config, program_subcommand)
         }
 
         // Stake Commands

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -408,7 +408,6 @@ pub fn process_program_v4_subcommand(
 // * Redeploy a program using a buffer account
 //   - buffer_signer argument must contain the temporary buffer account information
 //     (program_address must contain program ID and must NOT be same as buffer_signer.pubkey())
-#[allow(dead_code)]
 fn process_deploy_program(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -509,7 +508,6 @@ fn process_deploy_program(
     Ok(config.output_format.formatted_string(&program_id))
 }
 
-#[allow(dead_code)]
 fn process_undeploy_program(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -573,7 +571,6 @@ fn process_undeploy_program(
     Ok(config.output_format.formatted_string(&program_id))
 }
 
-#[allow(dead_code)]
 fn process_finalize_program(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -610,7 +607,6 @@ fn process_finalize_program(
     Ok(config.output_format.formatted_string(&program_id))
 }
 
-#[allow(dead_code)]
 fn check_payer(
     rpc_client: &RpcClient,
     config: &CliConfig,
@@ -642,7 +638,6 @@ fn check_payer(
     Ok(())
 }
 
-#[allow(dead_code)]
 fn send_messages(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -761,7 +756,6 @@ fn send_messages(
     Ok(())
 }
 
-#[allow(dead_code)]
 fn build_create_buffer_message(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -930,7 +924,6 @@ fn build_retract_and_deploy_messages(
     Ok(messages)
 }
 
-#[allow(dead_code)]
 fn build_retract_instruction(
     account: &Account,
     buffer_address: &Pubkey,
@@ -962,7 +955,6 @@ fn build_retract_instruction(
     }
 }
 
-#[allow(dead_code)]
 fn build_truncate_instructions(
     rpc_client: Arc<RpcClient>,
     payer: &Pubkey,


### PR DESCRIPTION
#### Problem
We need a loader-v4 CLI command front-end for testing PRv2 until we have a cargo registry interface which speaks the cargo "sparse" protocol so that people can use `cargo publish` directly.

#### Summary of Changes
Add the CLI subcommands, description and integrate to the processors for loader-v4.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
