### PR TITLE
Geyser notification to be sent on account deletion

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -7,7 +7,6 @@ use {
         accounts_index::{IndexKey, ScanConfig, ScanError, ScanResult, ZeroLamport},
         ancestors::Ancestors,
         nonce_info::{NonceFull, NonceInfo},
-        rent_collector::RentCollector,
         rent_debits::RentDebits,
         storable_accounts::StorableAccounts,
         transaction_results::TransactionExecutionResult,
@@ -115,6 +114,12 @@ pub type TransactionLoadResult = (Result<LoadedTransaction>, Option<NonceFull>);
 pub enum AccountAddressFilter {
     Exclude, // exclude all addresses matching the filter
     Include, // only include addresses matching the filter
+}
+
+struct CollectedAccountsData<'a> {
+    pub accounts_to_store: Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    pub transactions: Vec<Option<&'a SanitizedTransaction>>,
+    pub preexecution_account_datas: Option<Vec<Option<&'a AccountSharedData>>>,
 }
 
 impl Accounts {
@@ -655,27 +660,34 @@ impl Accounts {
         txs: &[SanitizedTransaction],
         res: &[TransactionExecutionResult],
         loaded: &mut [TransactionLoadResult],
-        rent_collector: &RentCollector,
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
+        preexection_account_data: Option<HashMap<Pubkey, AccountSharedData>>,
     ) {
-        let (accounts_to_store, transactions) = self.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            transactions,
+            preexecution_account_datas,
+        } = self.collect_accounts_to_store(
             txs,
             res,
             loaded,
-            rent_collector,
             durable_nonce,
             lamports_per_signature,
+            preexection_account_data.as_ref(),
         );
-        self.accounts_db
-            .store_cached_inline_update_index((slot, &accounts_to_store[..]), Some(&transactions));
+        self.accounts_db.store_cached_inline_update_index(
+            (slot, &accounts_to_store[..]),
+            Some(&transactions),
+            preexecution_account_datas,
+        );
     }
 
     pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
     ) {
-        self.accounts_db.store_cached(accounts, None)
+        self.accounts_db.store_cached(accounts, None, None)
     }
 
     /// Add a slot to root.  Root slots cannot be purged
@@ -689,15 +701,25 @@ impl Accounts {
         txs: &'a [SanitizedTransaction],
         execution_results: &'a [TransactionExecutionResult],
         load_results: &'a mut [TransactionLoadResult],
-        _rent_collector: &RentCollector,
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
-    ) -> (
-        Vec<(&'a Pubkey, &'a AccountSharedData)>,
-        Vec<Option<&'a SanitizedTransaction>>,
-    ) {
+        preexecution_account_map: Option<&'a HashMap<Pubkey, AccountSharedData>>,
+    ) -> CollectedAccountsData<'a> {
         let mut accounts = Vec::with_capacity(load_results.len());
         let mut transactions = Vec::with_capacity(load_results.len());
+        // to track the accounts as they change when transactions are executed
+        let collect_preexecution_account_data = preexecution_account_map.is_some();
+
+        let mut preexecution_account_datas = if collect_preexecution_account_data {
+            Vec::with_capacity(load_results.len())
+        } else {
+            // preexeution account data not required
+            vec![]
+        };
+        let mut preexecution_account_map: HashMap<Pubkey, &AccountSharedData> =
+            preexecution_account_map
+                .map(|map| map.iter().map(|(key, acc)| (*key, acc)).collect())
+                .unwrap_or_default();
         for (i, ((tx_load_result, nonce), tx)) in load_results.iter_mut().zip(txs).enumerate() {
             if tx_load_result.is_err() {
                 // Don't store any accounts if tx failed to load
@@ -748,11 +770,27 @@ impl Accounts {
                         // Add to the accounts to store
                         accounts.push((&*address, &*account));
                         transactions.push(Some(tx));
+                        // get and update old account state
+                        if collect_preexecution_account_data {
+                            let prev_acc = preexecution_account_map.insert(*address, &*account);
+                            preexecution_account_datas.push(prev_acc);
+                        }
                     }
                 }
             }
         }
-        (accounts, transactions)
+        let preexecution_account_datas =
+            collect_preexecution_account_data.then_some(preexecution_account_datas);
+        CollectedAccountsData {
+            accounts_to_store: accounts,
+            transactions,
+            preexecution_account_datas,
+        }
+    }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.accounts_db
+            .enable_preexecution_account_states_notification()
     }
 }
 
@@ -813,10 +851,7 @@ fn prepare_if_nonce_account(
 mod tests {
     use {
         super::*,
-        crate::{
-            rent_collector::RentCollector,
-            transaction_results::{DurableNonceFee, TransactionExecutionDetails},
-        },
+        crate::transaction_results::{DurableNonceFee, TransactionExecutionDetails},
         assert_matches::assert_matches,
         solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
         solana_sdk::{
@@ -1508,13 +1543,13 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let pubkey = solana_sdk::pubkey::new_rand();
+        let preexec_account = AccountSharedData::new(0, 0, &Pubkey::default());
         let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
         let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
         let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
 
-        let rent_collector = RentCollector::default();
-
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
         let message = Message::new_with_compiled_instructions(
             1,
             0,
@@ -1523,6 +1558,9 @@ mod tests {
             Hash::default(),
             instructions,
         );
+
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
         let transaction_accounts0 = vec![
             (message.account_keys[0], account0),
             (message.account_keys[1], account2.clone()),
@@ -1538,6 +1576,9 @@ mod tests {
             Hash::default(),
             instructions,
         );
+
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
         let transaction_accounts1 = vec![
             (message.account_keys[0], account1),
             (message.account_keys[1], account2),
@@ -1577,25 +1618,34 @@ mod tests {
         }
         let txs = vec![tx0.clone(), tx1.clone()];
         let execution_results = vec![new_execution_result(Ok(()), None); 2];
-        let (collected_accounts, transactions) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            transactions,
+            preexecution_account_datas,
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &DurableNonce::default(),
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 2);
-        assert!(collected_accounts
+        assert_eq!(accounts_to_store.len(), 2);
+        assert!(accounts_to_store
             .iter()
             .any(|(pubkey, _account)| *pubkey == &keypair0.pubkey()));
-        assert!(collected_accounts
+        assert!(accounts_to_store
             .iter()
             .any(|(pubkey, _account)| *pubkey == &keypair1.pubkey()));
 
         assert_eq!(transactions.len(), 2);
         assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx0)));
         assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx1)));
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 2);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
+        assert_eq!(preexecution_account_datas[1], Some(&preexec_account));
 
         // Ensure readonly_lock reflects lock
         assert_eq!(
@@ -1884,8 +1934,6 @@ mod tests {
 
     #[test]
     fn test_nonced_failure_accounts_rollback_from_pays() {
-        let rent_collector = RentCollector::default();
-
         let nonce_address = Pubkey::new_unique();
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -1899,6 +1947,7 @@ mod tests {
         )));
         let nonce_account_post =
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
+        let preexec_account = AccountSharedData::new(1000, 0, &Pubkey::default());
         let from_account_post = AccountSharedData::new(4199, 0, &Pubkey::default());
         let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
         let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
@@ -1917,6 +1966,14 @@ mod tests {
             (message.account_keys[3], to_account),
             (message.account_keys[4], recent_blockhashes_sysvar_account),
         ];
+
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[2], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[3], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[4], preexec_account.clone());
+
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
@@ -1958,17 +2015,21 @@ mod tests {
             )),
             nonce.as_ref(),
         )];
-        let (collected_accounts, _) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            preexecution_account_datas,
+            ..
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &durable_nonce,
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 2);
+        assert_eq!(accounts_to_store.len(), 2);
         assert_eq!(
-            collected_accounts
+            accounts_to_store
                 .iter()
                 .find(|(pubkey, _account)| *pubkey == &from_address)
                 .map(|(_pubkey, account)| *account)
@@ -1976,7 +2037,7 @@ mod tests {
                 .unwrap(),
             from_account_pre,
         );
-        let collected_nonce_account = collected_accounts
+        let collected_nonce_account = accounts_to_store
             .iter()
             .find(|(pubkey, _account)| *pubkey == &nonce_address)
             .map(|(_pubkey, account)| *account)
@@ -1986,6 +2047,11 @@ mod tests {
             collected_nonce_account.lamports(),
             nonce_account_pre.lamports(),
         );
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 2);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
+        assert_eq!(preexecution_account_datas[1], Some(&preexec_account));
         assert_matches!(
             nonce_account::verify_nonce_account(&collected_nonce_account, durable_nonce.as_hash()),
             Some(_)
@@ -1994,8 +2060,6 @@ mod tests {
 
     #[test]
     fn test_nonced_failure_accounts_rollback_nonce_pays() {
-        let rent_collector = RentCollector::default();
-
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let nonce_address = nonce_authority.pubkey();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -2013,6 +2077,7 @@ mod tests {
         let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
         let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
         let recent_blockhashes_sysvar_account = AccountSharedData::new(4, 0, &Pubkey::default());
+        let preexec_account = AccountSharedData::new(100, 0, &Pubkey::default());
 
         let instructions = vec![
             system_instruction::advance_nonce_account(&nonce_address, &nonce_authority.pubkey()),
@@ -2027,6 +2092,13 @@ mod tests {
             (message.account_keys[3], to_account),
             (message.account_keys[4], recent_blockhashes_sysvar_account),
         ];
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[2], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[3], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[4], preexec_account.clone());
+
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
@@ -2067,16 +2139,20 @@ mod tests {
             )),
             nonce.as_ref(),
         )];
-        let (collected_accounts, _) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            preexecution_account_datas,
+            ..
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &durable_nonce,
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 1);
-        let collected_nonce_account = collected_accounts
+        assert_eq!(accounts_to_store.len(), 1);
+        let collected_nonce_account = accounts_to_store
             .iter()
             .find(|(pubkey, _account)| *pubkey == &nonce_address)
             .map(|(_pubkey, account)| *account)
@@ -2086,6 +2162,10 @@ mod tests {
             collected_nonce_account.lamports(),
             nonce_account_pre.lamports()
         );
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 1);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
         assert_matches!(
             nonce_account::verify_nonce_account(&collected_nonce_account, durable_nonce.as_hash()),
             Some(_)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6623,6 +6623,7 @@ impl AccountsDb {
         accounts_and_meta_to_store: &impl StorableAccounts<'b, T>,
         txn_iter: Box<dyn std::iter::Iterator<Item = &Option<&SanitizedTransaction>> + 'a>,
         mut write_version_producer: P,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> Vec<AccountInfo>
     where
         P: Iterator<Item = u64>,
@@ -6634,19 +6635,24 @@ impl AccountsDb {
                     .account_default_if_zero_lamport(i)
                     .map(|account| account.to_account_shared_data())
                     .unwrap_or_default();
+                let pubkey = accounts_and_meta_to_store.pubkey(i);
+                let preexecution_account_data = preexecution_account_datas
+                    .as_ref()
+                    .map(|accounts| accounts[i])
+                    .unwrap_or_default();
+
                 let account_info = AccountInfo::new(StorageLocation::Cached, account.lamports());
 
                 self.notify_account_at_accounts_update(
                     slot,
                     &account,
                     txn,
-                    accounts_and_meta_to_store.pubkey(i),
+                    pubkey,
                     &mut write_version_producer,
+                    preexecution_account_data,
                 );
 
-                let cached_account =
-                    self.accounts_cache
-                        .store(slot, accounts_and_meta_to_store.pubkey(i), account);
+                let cached_account = self.accounts_cache.store(slot, pubkey, account);
                 // hash this account in the bg
                 match &self.sender_bg_hasher {
                     Some(ref sender) => {
@@ -6672,6 +6678,7 @@ impl AccountsDb {
         mut write_version_producer: P,
         store_to: &StoreTo,
         transactions: Option<&[Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> Vec<AccountInfo> {
         let mut calc_stored_meta_time = Measure::start("calc_stored_meta");
         let slot = accounts.target_slot();
@@ -6695,7 +6702,13 @@ impl AccountsDb {
                         None => Box::new(std::iter::repeat(&None).take(accounts.len())),
                     };
 
-                self.write_accounts_to_cache(slot, accounts, txn_iter, write_version_producer)
+                self.write_accounts_to_cache(
+                    slot,
+                    accounts,
+                    txn_iter,
+                    write_version_producer,
+                    preexecution_account_datas,
+                )
             }
             StoreTo::Storage(storage) => {
                 if accounts.has_hash_and_write_version() {
@@ -8378,6 +8391,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a, T>,
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         self.store(
             accounts,
@@ -8385,6 +8399,7 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            preexecution_account_datas,
         );
     }
 
@@ -8395,6 +8410,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a, T>,
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         self.store(
             accounts,
@@ -8402,6 +8418,7 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::Inline,
+            preexecution_account_datas,
         );
     }
 
@@ -8415,6 +8432,7 @@ impl AccountsDb {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
     }
 
@@ -8425,6 +8443,7 @@ impl AccountsDb {
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         // If all transactions in a batch are errored,
         // it's possible to get a store with no accounts.
@@ -8462,6 +8481,7 @@ impl AccountsDb {
             transactions,
             reclaim,
             update_index_thread_selection,
+            preexecution_account_datas,
         );
         self.report_store_timings();
     }
@@ -8616,6 +8636,7 @@ impl AccountsDb {
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         // This path comes from a store to a non-frozen slot.
         // If a store is dead here, then a newer update for
@@ -8634,6 +8655,7 @@ impl AccountsDb {
             transactions,
             reclaim,
             update_index_thread_selection,
+            preexecution_account_datas,
         );
     }
 
@@ -8658,9 +8680,11 @@ impl AccountsDb {
             None,
             reclaim,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn store_accounts_custom<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
@@ -8671,6 +8695,7 @@ impl AccountsDb {
         transactions: Option<&[Option<&SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> StoreAccountsTiming {
         let write_version_producer: Box<dyn Iterator<Item = u64>> = write_version_producer
             .unwrap_or_else(|| {
@@ -8692,6 +8717,7 @@ impl AccountsDb {
             write_version_producer,
             store_to,
             transactions,
+            preexecution_account_datas,
         );
         store_accounts_time.stop();
         self.stats
@@ -9448,6 +9474,13 @@ impl AccountsDb {
             );
         }
     }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.accounts_update_notifier
+            .as_ref()
+            .map(|notifier| notifier.enable_preexecution_account_states_notification())
+            .unwrap_or_default()
+    }
 }
 
 /// Specify the source of the accounts data when calculating the accounts hash
@@ -9547,6 +9580,7 @@ impl AccountsDb {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
     }
 
@@ -11394,7 +11428,7 @@ pub mod tests {
         let account0 = AccountSharedData::new(1, 0, &key);
         let ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
         if is_cached {
-            db.store_cached((unrooted_slot, &[(&key, &account0)][..]), None);
+            db.store_cached((unrooted_slot, &[(&key, &account0)][..]), None, None);
         } else {
             db.store_for_tests(unrooted_slot, &[(&key, &account0)]);
         }
@@ -12536,6 +12570,7 @@ pub mod tests {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
         db.add_root(some_slot);
         let check_hash = true;
@@ -12769,6 +12804,7 @@ pub mod tests {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
         db.add_root(some_slot);
 
@@ -13542,13 +13578,13 @@ pub mod tests {
 
         let account = AccountSharedData::new(1, 16 * 4096, &Pubkey::default());
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached((0, &[(&pubkey1, &account)][..]), None);
+        accounts.store_cached((0, &[(&pubkey1, &account)][..]), None, None);
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached((0, &[(&pubkey2, &account)][..]), None);
+        accounts.store_cached((0, &[(&pubkey2, &account)][..]), None, None);
 
         let zero_account = AccountSharedData::new(0, 1, &Pubkey::default());
-        accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]), None);
+        accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]), None, None);
 
         // Add root 0 and flush separately
         accounts.calculate_accounts_delta_hash(0);
@@ -13592,7 +13628,7 @@ pub mod tests {
         for i in 0..num_accounts {
             let account = AccountSharedData::new((i + 1) as u64, size, &Pubkey::default());
             let pubkey = solana_sdk::pubkey::new_rand();
-            accounts.store_cached((0 as Slot, &[(&pubkey, &account)][..]), None);
+            accounts.store_cached((0 as Slot, &[(&pubkey, &account)][..]), None, None);
             keys.push(pubkey);
         }
         // get delta hash to feed these accounts to clean
@@ -13606,7 +13642,7 @@ pub mod tests {
         for (i, key) in keys[1..].iter().enumerate() {
             let account =
                 AccountSharedData::new((1 + i + num_accounts) as u64, size, &Pubkey::default());
-            accounts.store_cached((1 as Slot, &[(key, &account)][..]), None);
+            accounts.store_cached((1 as Slot, &[(key, &account)][..]), None, None);
         }
         accounts.calculate_accounts_delta_hash(1);
         accounts.add_root(1);
@@ -13732,7 +13768,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached((slot, &[(&key, &account0)][..]), None);
+        db.store_cached((slot, &[(&key, &account0)][..]), None, None);
 
         // Load with no ancestors and no root will return nothing
         assert!(db
@@ -13764,7 +13800,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached((slot, &[(&key, &account0)][..]), None);
+        db.store_cached((slot, &[(&key, &account0)][..]), None, None);
         db.mark_slot_frozen(slot);
 
         // No root was added yet, requires an ancestor to find
@@ -13796,9 +13832,13 @@ pub mod tests {
         let unrooted_key = solana_sdk::pubkey::new_rand();
         let key5 = solana_sdk::pubkey::new_rand();
         let key6 = solana_sdk::pubkey::new_rand();
-        db.store_cached((unrooted_slot, &[(&unrooted_key, &account0)][..]), None);
-        db.store_cached((root5, &[(&key5, &account0)][..]), None);
-        db.store_cached((root6, &[(&key6, &account0)][..]), None);
+        db.store_cached(
+            (unrooted_slot, &[(&unrooted_key, &account0)][..]),
+            None,
+            None,
+        );
+        db.store_cached((root5, &[(&key5, &account0)][..]), None, None);
+        db.store_cached((root6, &[(&key6, &account0)][..]), None, None);
         for slot in &[unrooted_slot, root5, root6] {
             db.mark_slot_frozen(*slot);
         }
@@ -13860,7 +13900,7 @@ pub mod tests {
         let num_slots = 2 * max_cache_slots();
         for i in 0..num_roots + num_unrooted {
             let key = Pubkey::new_unique();
-            db.store_cached((i as Slot, &[(&key, &account0)][..]), None);
+            db.store_cached((i as Slot, &[(&key, &account0)][..]), None, None);
             keys.push(key);
             db.mark_slot_frozen(i as Slot);
             if i < num_roots {
@@ -13913,8 +13953,12 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -13936,7 +13980,11 @@ pub mod tests {
             .unwrap();
         assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
-        db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+        db.store_cached(
+            (2, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
@@ -13964,10 +14012,10 @@ pub mod tests {
         let account4_key = Pubkey::new_unique();
         let account4 = AccountSharedData::new(0, 1, &owners[1]);
 
-        db.store_cached((0, &[(&account1_key, &account1)][..]), None);
-        db.store_cached((1, &[(&account2_key, &account2)][..]), None);
-        db.store_cached((2, &[(&account3_key, &account3)][..]), None);
-        db.store_cached((3, &[(&account4_key, &account4)][..]), None);
+        db.store_cached((0, &[(&account1_key, &account1)][..]), None, None);
+        db.store_cached((1, &[(&account2_key, &account2)][..]), None, None);
+        db.store_cached((2, &[(&account3_key, &account3)][..]), None, None);
+        db.store_cached((3, &[(&account4_key, &account4)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -14045,8 +14093,12 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -14098,10 +14150,11 @@ pub mod tests {
         db.store_cached(
             (0, &[(&zero_lamport_account_key, &slot0_account)][..]),
             None,
+            None,
         );
         // Second key keeps other lamport account entry for slot 0 alive,
         // preventing clean of the zero_lamport_account in slot 1.
-        db.store_cached((0, &[(&other_account_key, &slot0_account)][..]), None);
+        db.store_cached((0, &[(&other_account_key, &slot0_account)][..]), None, None);
         db.add_root(0);
         db.flush_accounts_cache(true, None);
         assert!(db.storage.get_slot_storage_entry(0).is_some());
@@ -14109,6 +14162,7 @@ pub mod tests {
         // Store into slot 1, a dummy slot that will be dead and purged before flush
         db.store_cached(
             (1, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
+            None,
             None,
         );
 
@@ -14120,6 +14174,7 @@ pub mod tests {
         // `zero_lamport_account_key` from slot 2
         db.store_cached(
             (2, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
+            None,
             None,
         );
         db.add_root(1);
@@ -14237,11 +14292,15 @@ pub mod tests {
                                 /        \
                               1            2 (root)
         */
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
         // Fodder for the scan so that the lock on `account_key` is not held
-        db.store_cached((1, &[(&account_key2, &slot1_account)][..]), None);
-        db.store_cached((2, &[(&account_key, &slot2_account)][..]), None);
+        db.store_cached((1, &[(&account_key2, &slot1_account)][..]), None, None);
+        db.store_cached((2, &[(&account_key, &slot2_account)][..]), None, None);
         db.calculate_accounts_delta_hash(0);
 
         let max_scan_root = 0;
@@ -14338,7 +14397,7 @@ pub mod tests {
 
         for data_size in 0..num_keys {
             let account = AccountSharedData::new(1, data_size, &Pubkey::default());
-            accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]), None);
+            accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]), None, None);
         }
 
         accounts_db.add_root(slot);
@@ -14392,6 +14451,7 @@ pub mod tests {
                     )][..],
                 ),
                 None,
+                None,
             );
         }
 
@@ -14405,6 +14465,7 @@ pub mod tests {
                         *slot,
                         &[(key, &AccountSharedData::new(1, space, &Pubkey::default()))][..],
                     ),
+                    None,
                     None,
                 );
             }
@@ -14452,6 +14513,7 @@ pub mod tests {
                     alive_slot,
                     &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))][..],
                 ),
+                None,
                 None,
             );
             accounts_db.add_root(alive_slot);
@@ -14792,7 +14854,7 @@ pub mod tests {
         }
 
         // Make account_key1 in slot 0 outdated by updating in rooted slot 1
-        db.store_cached((1, &[(&account_key1, &account1)][..]), None);
+        db.store_cached((1, &[(&account_key1, &account1)][..]), None, None);
         db.add_root(1);
         // Flushes all roots
         db.flush_accounts_cache(true, None);
@@ -14810,7 +14872,7 @@ pub mod tests {
         db.shrink_candidate_slots(&epoch_schedule);
 
         // Make slot 0 dead by updating the remaining key
-        db.store_cached((2, &[(&account_key2, &account1)][..]), None);
+        db.store_cached((2, &[(&account_key2, &account1)][..]), None, None);
         db.add_root(2);
 
         // Flushes all roots
@@ -15042,6 +15104,7 @@ pub mod tests {
                 )][..],
             ),
             None,
+            None,
         );
         db.add_root(0);
         db.flush_accounts_cache(true, None);
@@ -15060,7 +15123,7 @@ pub mod tests {
                             return;
                         }
                         account.set_lamports(slot + 1);
-                        db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]), None);
+                        db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]), None, None);
                         db.add_root(slot);
                         sleep(Duration::from_millis(RACY_SLEEP_MS));
                         db.flush_accounts_cache(true, None);
@@ -15206,7 +15269,7 @@ pub mod tests {
         let num_trials = 10;
         for _ in 0..num_trials {
             let pubkey = Pubkey::new_unique();
-            db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+            db.store_cached((slot, &[(&pubkey, &account)][..]), None, None);
             // Wait for both threads to finish
             flush_trial_start_sender.send(()).unwrap();
             remove_trial_start_sender.send(()).unwrap();
@@ -15290,7 +15353,7 @@ pub mod tests {
             let slot_to_pubkey_map: HashMap<Slot, Pubkey> = (0..num_cached_slots)
                 .map(|slot| {
                     let pubkey = Pubkey::new_unique();
-                    db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+                    db.store_cached((slot, &[(&pubkey, &account)][..]), None, None);
                     (slot, pubkey)
                 })
                 .collect();
@@ -15751,19 +15814,19 @@ pub mod tests {
 
         let slot1: Slot = 1;
         let account = AccountSharedData::new(111, space, &owner);
-        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot1);
         accounts_db.add_root_and_flush_write_cache(slot1);
 
         let slot2: Slot = 2;
         let account = AccountSharedData::new(222, space, &owner);
-        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot2);
         accounts_db.add_root_and_flush_write_cache(slot2);
 
         let slot3: Slot = 3;
         let account = AccountSharedData::new(0, space, &owner);
-        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot3);
         accounts_db.add_root_and_flush_write_cache(slot3);
 
@@ -18051,7 +18114,7 @@ pub mod tests {
                 (&accounts[2].0, &accounts[2].1),
                 (&accounts[3].0, &accounts[3].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18068,7 +18131,7 @@ pub mod tests {
                 (&accounts[1].0, &accounts[1].1),
                 (&accounts[4].0, &accounts[4].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18114,7 +18177,7 @@ pub mod tests {
                 (&accounts[5].0, &accounts[5].1),
                 (&accounts[6].0, &accounts[6].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18135,7 +18198,7 @@ pub mod tests {
                 (&accounts[5].0, &accounts[5].1),
                 (&accounts[7].0, &accounts[7].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -15,6 +15,7 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
         write_version: u64,
+        preexecution_account_data: Option<&AccountSharedData>,
     );
 
     /// Notified when the AccountsDb is initialized at start when restored
@@ -23,6 +24,8 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);
+
+    fn enable_preexecution_account_states_notification(&self) -> bool;
 }
 
 pub type AccountsUpdateNotifier = Arc<dyn AccountsUpdateNotifierInterface + Sync + Send>;

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -15,7 +15,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
     },
-    solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{hash::Hash, account::AccountSharedData, pubkey::Pubkey, saturating_add_assign},
     solana_transaction_status::{
         token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
     },
@@ -76,6 +76,7 @@ impl Committer {
         executed_transactions_count: usize,
         executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
+        preexecution_account_states: Option<HashMap<Pubkey, AccountSharedData>>,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         let executed_transactions = execution_results
             .iter()
@@ -98,6 +99,7 @@ impl Committer {
                 signature_count,
             },
             &mut execute_and_commit_timings.execute_timings,
+            preexecution_account_states,
         ));
         execute_and_commit_timings.commit_us = commit_time_us;
 

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -15,7 +15,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
     },
-    solana_sdk::{hash::Hash, account::AccountSharedData, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey, saturating_add_assign},
     solana_transaction_status::{
         token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
     },

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -589,6 +589,7 @@ impl Consumer {
             executed_with_successful_result_count,
             signature_count,
             error_counters,
+            preexecution_account_states,
             ..
         } = load_and_execute_transactions_output;
 
@@ -666,6 +667,7 @@ impl Consumer {
                 executed_transactions_count,
                 executed_non_vote_transactions_count,
                 executed_with_successful_result_count,
+                preexecution_account_states,
             )
         } else {
             (

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -99,7 +99,6 @@ impl GeyserPluginManager {
         }
         false
     }
-
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())
@@ -265,6 +264,12 @@ impl GeyserPluginManager {
         drop(current_plugin);
         drop(current_lib);
         info!("Unloaded plugin {name} at idx {idx}");
+    }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.plugins
+            .iter()
+            .any(|plugin| plugin.enable_pre_trasaction_execution_accounts_data())
     }
 }
 

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -59,7 +59,7 @@ fn test_shrink_and_clean() {
             for (pubkey, account) in alive_accounts.iter_mut() {
                 account.checked_sub_lamports(1).unwrap();
 
-                accounts.store_cached((current_slot, &[(&*pubkey, &*account)][..]), None);
+                accounts.store_cached((current_slot, &[(&*pubkey, &*account)][..]), None, None);
             }
             accounts.add_root(current_slot);
             accounts.flush_accounts_cache(true, Some(current_slot));
@@ -125,7 +125,7 @@ fn test_bad_bank_hash() {
             .iter()
             .map(|idx| (&accounts_keys[*idx].0, &accounts_keys[*idx].1))
             .collect();
-        db.store_cached((some_slot, &account_refs[..]), None);
+        db.store_cached((some_slot, &account_refs[..]), None, None);
         for pass in 0..2 {
             for (key, account) in &account_refs {
                 assert_eq!(


### PR DESCRIPTION
#### Problem
Geyser sends account delete notifications with the a wrong owner. 

In GRPC, we subscribe to account notifications with the owner. The owner can be some program id. Currently, we do not get any notification on grpc if the account has been deleted because the notification sent on geyser channel is account with the owner defaulted to 0. So GRPC cannot notify that the account was deleted because the owner has been changed.

#### Summary of Changes
Geyser can optionally return the account state before the transaction changed the account. This is called preexecution account state in this context.

A new geyser account message type was added, `ReplicaAccountInfoV4`, which will be returned instead of the previous `ReplicaAccountInfoV3` in case any plugin requires pre-execution accounts data. `ReplicaAccountInfoV4` will only be returned only if this feature is enable else it will return previous `ReplicaAccountInfoV3`.

This feature can be enabled if enable_pre_trasaction_execution_accounts_data() returns true.

The bank will save of the accounts states before the transaction batch is executed only if any of the plugins requires the data and pass them to the geyser plugin to send the notification.

This will also enable us to compare account changes other than owner etc. The geyser plugin can use Binary delta compression techniques using this feature. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
