### PR TITLE
Feature - Enable Program-Runtime-v2 and Loader-v4

### DIFF
--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -101,4 +101,10 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
         name: "zk_token_proof_program",
         entrypoint: solana_zk_token_proof_program::process_instruction,
     },
+    BuiltinPrototype {
+        feature_id: Some(feature_set::enable_program_runtime_v2_and_loader_v4::id()),
+        program_id: solana_sdk::loader_v4::id(),
+        name: "loader_v4",
+        entrypoint: solana_loader_v4_program::process_instruction,
+    },
 ];

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -685,6 +685,10 @@ pub mod remaining_compute_units_syscall_enabled {
     solana_sdk::declare_id!("5TuppMutoyzhUSfuYdhgzD47F92GL1g89KpCZQKqedxP");
 }
 
+pub mod enable_program_runtime_v2_and_loader_v4 {
+    solana_sdk::declare_id!("8oBxsYqnCvUTGzgEpxPcnVf7MLbWWPYddE33PftFeBBd");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -851,6 +855,7 @@ lazy_static! {
         (enable_poseidon_syscall::id(), "Enable Poseidon syscall"),
         (timely_vote_credits::id(), "use timeliness of votes in determining credits to award"),
         (remaining_compute_units_syscall_enabled::id(), "enable the remaining_compute_units syscall"),
+        (enable_program_runtime_v2_and_loader_v4::id(), "Enable Program-Runtime-v2 and Loader-v4 #33293"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The loader-v4 is currently unreachable outside of unit tests. So, a feature gate for local testing should be introduced.

#### Summary of Changes
- Adds a new feature `enable_program_runtime_v2_and_loader_v4`.
- Adds a feature gated `BuiltinPrototype` for the `solana_loader_v4_program`.

Feature Gate Issue: #33293
