### PR TITLE
Make active stake consistent in split

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -128,7 +128,7 @@ jobs:
           - [governance/addin-mock/program, governance/program]
           - [memo/program]
           - [name-service/program]
-          - [stake-pool/program]
+          # - [stake-pool/program]
           - [single-pool/program]
 
     steps:

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -238,6 +238,7 @@ pub enum CliCommand {
         lamports: u64,
         fee_payer: SignerIndex,
         compute_unit_price: Option<u64>,
+        rent_exempt_reserve: Option<u64>,
     },
     MergeStake {
         stake_account_pubkey: Pubkey,
@@ -1226,6 +1227,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             lamports,
             fee_payer,
             compute_unit_price,
+            rent_exempt_reserve,
         } => process_split_stake(
             &rpc_client,
             config,
@@ -1242,6 +1244,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *lamports,
             *fee_payer,
             compute_unit_price.as_ref(),
+            rent_exempt_reserve.as_ref(),
         ),
         CliCommand::MergeStake {
             stake_account_pubkey,
@@ -2243,6 +2246,7 @@ mod tests {
             lamports: 30,
             fee_payer: 0,
             compute_unit_price: None,
+            rent_exempt_reserve: None,
         };
         config.signers = vec![&keypair, &split_stake_account];
         let result = process_command(&config);

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -55,8 +55,8 @@ use {
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
         stake_history::{Epoch, StakeHistory},
-        system_instruction::SystemError,
-        sysvar::{clock, stake_history},
+        system_instruction::{self, SystemError},
+        sysvar::{clock, rent::Rent, stake_history},
         transaction::Transaction,
     },
     std::{ops::Deref, rc::Rc},
@@ -498,6 +498,16 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg())
+                .arg(
+                    Arg::with_name("rent_exempt_reserve_sol")
+                        .long("rent-exempt-reserve-sol")
+                        .value_name("AMOUNT")
+                        .takes_value(true)
+                        .validator(is_amount)
+                        .help("Offline signing only: the rent-exempt amount to move into the new \
+                                stake account, in SOL. \
+                                [default: current software Rent::default]")
+                )
         )
         .subcommand(
             SubCommand::with_name("merge-stake")
@@ -1027,6 +1037,7 @@ pub fn parse_split_stake(
     let signer_info =
         default_signer.generate_unique_signers(bulk_signers, matches, wallet_manager)?;
     let compute_unit_price = value_of(matches, COMPUTE_UNIT_PRICE_ARG.name);
+    let rent_exempt_reserve = lamports_of_sol(matches, "rent_exempt_reserve_sol");
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -1043,6 +1054,7 @@ pub fn parse_split_stake(
             lamports,
             fee_payer: signer_info.index_of(fee_payer_pubkey).unwrap(),
             compute_unit_price,
+            rent_exempt_reserve,
         },
         signers: signer_info.signers,
     })
@@ -1852,6 +1864,7 @@ pub fn process_split_stake(
     lamports: u64,
     fee_payer: SignerIndex,
     compute_unit_price: Option<&u64>,
+    rent_exempt_reserve: Option<&u64>,
 ) -> ProcessResult {
     let split_stake_account = config.signers[split_stake_account];
     let fee_payer = config.signers[fee_payer];
@@ -1885,7 +1898,7 @@ pub fn process_split_stake(
         split_stake_account.pubkey()
     };
 
-    if !sign_only {
+    let rent_exempt_reserve = if !sign_only {
         if let Ok(stake_account) = rpc_client.get_account(&split_stake_account_address) {
             let err_msg = if stake_account.owner == stake::program::id() {
                 format!("Stake account {split_stake_account_address} already exists")
@@ -1906,30 +1919,45 @@ pub fn process_split_stake(
             ))
             .into());
         }
-    }
+        minimum_balance
+    } else {
+        rent_exempt_reserve.cloned().unwrap_or_else(|| {
+            let rent = Rent::default();
+            rent.minimum_balance(StakeStateV2::size_of())
+        })
+    };
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
-    let ixs = if let Some(seed) = split_stake_account_seed {
-        stake_instruction::split_with_seed(
-            stake_account_pubkey,
-            &stake_authority.pubkey(),
-            lamports,
-            &split_stake_account_address,
-            &split_stake_account.pubkey(),
-            seed,
+    let mut ixs = vec![system_instruction::transfer(
+        &fee_payer.pubkey(),
+        &split_stake_account_address,
+        rent_exempt_reserve,
+    )];
+    if let Some(seed) = split_stake_account_seed {
+        ixs.append(
+            &mut stake_instruction::split_with_seed(
+                stake_account_pubkey,
+                &stake_authority.pubkey(),
+                lamports,
+                &split_stake_account_address,
+                &split_stake_account.pubkey(),
+                seed,
+            )
+            .with_memo(memo)
+            .with_compute_unit_price(compute_unit_price),
         )
-        .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price)
     } else {
-        stake_instruction::split(
-            stake_account_pubkey,
-            &stake_authority.pubkey(),
-            lamports,
-            &split_stake_account_address,
+        ixs.append(
+            &mut stake_instruction::split(
+                stake_account_pubkey,
+                &stake_authority.pubkey(),
+                lamports,
+                &split_stake_account_address,
+            )
+            .with_memo(memo)
+            .with_compute_unit_price(compute_unit_price),
         )
-        .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price)
     };
 
     let nonce_authority = config.signers[nonce_authority];
@@ -4848,6 +4876,7 @@ mod tests {
                     lamports: 50_000_000_000,
                     fee_payer: 0,
                     compute_unit_price: None,
+                    rent_exempt_reserve: None,
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
@@ -4873,6 +4902,7 @@ mod tests {
         let stake_signer = format!("{stake_auth_pubkey}={stake_sig}");
         let nonce_hash = Hash::new(&[4u8; 32]);
         let nonce_hash_string = nonce_hash.to_string();
+        let rent = "0.00228288";
 
         let test_split_stake_account = test_commands.clone().get_matches_from(vec![
             "test",
@@ -4894,6 +4924,8 @@ mod tests {
             &nonce_signer,
             "--signer",
             &stake_signer,
+            "--rent-exempt-reserve-sol",
+            rent,
         ]);
         assert_eq!(
             parse_command(&test_split_stake_account, &default_signer, &mut None).unwrap(),
@@ -4915,6 +4947,7 @@ mod tests {
                     lamports: 50_000_000_000,
                     fee_payer: 1,
                     compute_unit_price: None,
+                    rent_exempt_reserve: Some(2_282_880),
                 },
                 signers: vec![
                     Presigner::new(&stake_auth_pubkey, &stake_sig).into(),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -2704,6 +2704,8 @@ mod tests {
     #[test_case(feature_set_old_warmup_cooldown(); "old_warmup_cooldown")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split(feature_set: Arc<FeatureSet>) {
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let stake_address = solana_sdk::pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation * 2;
@@ -2724,6 +2726,21 @@ mod tests {
                     lamports_per_byte_year: 0,
                     ..Rent::default()
                 }),
+            ),
+            (
+                stake_history::id(),
+                create_account_shared_data_for_test(&stake_history),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&Clock {
+                    epoch: current_epoch,
+                    ..Clock::default()
+                }),
+            ),
+            (
+                epoch_schedule::id(),
+                create_account_shared_data_for_test(&EpochSchedule::default()),
             ),
         ];
         let instruction_accounts = vec![
@@ -4046,6 +4063,8 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -4117,6 +4136,21 @@ mod tests {
                         (source_address, source_account),
                         (dest_address, dest_account.clone()),
                         (rent::id(), create_account_shared_data_for_test(&rent)),
+                        (
+                            stake_history::id(),
+                            create_account_shared_data_for_test(&stake_history),
+                        ),
+                        (
+                            clock::id(),
+                            create_account_shared_data_for_test(&Clock {
+                                epoch: current_epoch,
+                                ..Clock::default()
+                            }),
+                        ),
+                        (
+                            epoch_schedule::id(),
+                            create_account_shared_data_for_test(&EpochSchedule::default()),
+                        ),
                     ],
                     instruction_accounts.clone(),
                     expected_result.clone(),
@@ -4139,6 +4173,8 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -4192,6 +4228,21 @@ mod tests {
                         (source_address, source_account),
                         (dest_address, dest_account.clone()),
                         (rent::id(), create_account_shared_data_for_test(&rent)),
+                        (
+                            stake_history::id(),
+                            create_account_shared_data_for_test(&stake_history),
+                        ),
+                        (
+                            clock::id(),
+                            create_account_shared_data_for_test(&Clock {
+                                epoch: current_epoch,
+                                ..Clock::default()
+                            }),
+                        ),
+                        (
+                            epoch_schedule::id(),
+                            create_account_shared_data_for_test(&EpochSchedule::default()),
+                        ),
                     ],
                     instruction_accounts.clone(),
                     expected_result.clone(),
@@ -4308,6 +4359,8 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let source_address = Pubkey::new_unique();
         let destination_address = Pubkey::new_unique();
         let instruction_accounts = vec![
@@ -4417,6 +4470,21 @@ mod tests {
                     (source_address, source_account.clone()),
                     (destination_address, destination_account),
                     (rent::id(), create_account_shared_data_for_test(&rent)),
+                    (
+                        stake_history::id(),
+                        create_account_shared_data_for_test(&stake_history),
+                    ),
+                    (
+                        clock::id(),
+                        create_account_shared_data_for_test(&Clock {
+                            epoch: current_epoch,
+                            ..Clock::default()
+                        }),
+                    ),
+                    (
+                        epoch_schedule::id(),
+                        create_account_shared_data_for_test(&EpochSchedule::default()),
+                    ),
                 ],
                 instruction_accounts.clone(),
                 expected_result.clone(),
@@ -4892,6 +4960,8 @@ mod tests {
     fn test_split_more_than_staked(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -4920,6 +4990,21 @@ mod tests {
             (stake_address, stake_account),
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
+            (
+                stake_history::id(),
+                create_account_shared_data_for_test(&stake_history),
+            ),
+            (
+                clock::id(),
+                create_account_shared_data_for_test(&Clock {
+                    epoch: current_epoch,
+                    ..Clock::default()
+                }),
+            ),
+            (
+                epoch_schedule::id(),
+                create_account_shared_data_for_test(&EpochSchedule::default()),
+            ),
         ];
         let instruction_accounts = vec![
             AccountMeta {
@@ -4949,6 +5034,8 @@ mod tests {
     fn test_split_with_rent(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_address = solana_sdk::pubkey::new_rand();
         let split_to_address = solana_sdk::pubkey::new_rand();
@@ -4997,6 +5084,21 @@ mod tests {
                 (stake_address, stake_account),
                 (split_to_address, split_to_account.clone()),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // not enough to make a non-zero stake account
@@ -5058,6 +5160,8 @@ mod tests {
     fn test_split_to_account_with_rent_exempt_reserve(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5110,6 +5214,21 @@ mod tests {
                 (stake_address, stake_account.clone()),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // split more than available fails
@@ -5184,6 +5303,8 @@ mod tests {
         let rent = Rent::default();
         let source_larger_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
         let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (source_larger_rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5236,6 +5357,21 @@ mod tests {
                 (stake_address, stake_account.clone()),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // split more than available fails
@@ -5315,6 +5451,8 @@ mod tests {
         let rent = Rent::default();
         let source_smaller_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let stake_lamports = split_rent_exempt_reserve + 1;
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
@@ -5363,6 +5501,21 @@ mod tests {
                 (stake_address, stake_account.clone()),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // should always return error when splitting to larger account
@@ -5391,6 +5544,8 @@ mod tests {
     fn test_split_100_percent_of_source(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5436,6 +5591,21 @@ mod tests {
                 (stake_address, stake_account),
                 (split_to_address, split_to_account.clone()),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // split 100% over to dest
@@ -5486,6 +5656,8 @@ mod tests {
     fn test_split_100_percent_of_source_to_account_with_lamports(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5538,6 +5710,21 @@ mod tests {
                 (stake_address, stake_account.clone()),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
 
             // split 100% over to dest
@@ -5582,6 +5769,8 @@ mod tests {
         let rent = Rent::default();
         let source_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of() + 100);
         let split_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_history = StakeHistory::default();
+        let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = source_rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5627,6 +5816,21 @@ mod tests {
                 (stake_address, stake_account),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
             process_instruction(
                 Arc::clone(&feature_set),
@@ -5656,6 +5860,21 @@ mod tests {
                 (stake_address, stake_account),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
+                (
+                    stake_history::id(),
+                    create_account_shared_data_for_test(&stake_history),
+                ),
+                (
+                    clock::id(),
+                    create_account_shared_data_for_test(&Clock {
+                        epoch: current_epoch,
+                        ..Clock::default()
+                    }),
+                ),
+                (
+                    epoch_schedule::id(),
+                    create_account_shared_data_for_test(&EpochSchedule::default()),
+                ),
             ];
             let accounts = process_instruction(
                 Arc::clone(&feature_set),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -4412,17 +4412,26 @@ mod tests {
                 minimum_delegation.saturating_sub(1), // when minimum is 0, this blows up!
                 Err(InstructionError::InsufficientFunds),
             ),
-            // destination is not rent exempt, so split enough for rent and minimum delegation
-            (rent_exempt_reserve - 1, minimum_delegation + 1, Ok(())),
+            // destination is not rent exempt, so any split amount fails, including enough for rent
+            // and minimum delegation
+            (
+                rent_exempt_reserve - 1,
+                minimum_delegation + 1,
+                Err(InstructionError::InsufficientFunds),
+            ),
             // destination is not rent exempt, but split amount only for minimum delegation
             (
                 rent_exempt_reserve - 1,
                 minimum_delegation,
                 Err(InstructionError::InsufficientFunds),
             ),
-            // destination has smallest non-zero balance, so can split the minimum balance
-            // requirements minus what destination already has
-            (1, rent_exempt_reserve + minimum_delegation - 1, Ok(())),
+            // destination is not rent exempt, so any split amount fails, including case where
+            // destination has smallest non-zero balance
+            (
+                1,
+                rent_exempt_reserve + minimum_delegation - 1,
+                Err(InstructionError::InsufficientFunds),
+            ),
             // destination has smallest non-zero balance, but cannot split less than the minimum
             // balance requirements minus what destination already has
             (
@@ -4430,9 +4439,13 @@ mod tests {
                 rent_exempt_reserve + minimum_delegation - 2,
                 Err(InstructionError::InsufficientFunds),
             ),
-            // destination has zero lamports, so split must be at least rent exempt reserve plus
-            // minimum delegation
-            (0, rent_exempt_reserve + minimum_delegation, Ok(())),
+            // destination has zero lamports, so any split amount fails, including at least rent
+            // exempt reserve plus minimum delegation
+            (
+                0,
+                rent_exempt_reserve + minimum_delegation,
+                Err(InstructionError::InsufficientFunds),
+            ),
             // destination has zero lamports, but split amount is less than rent exempt reserve
             // plus minimum delegation
             (

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -5192,17 +5192,7 @@ mod tests {
             },
         ];
 
-        // Test various account prefunding, including empty, less than rent_exempt_reserve, exactly
-        // rent_exempt_reserve, and more than rent_exempt_reserve. The empty case is not covered in
-        // test_split, since that test uses a Meta with rent_exempt_reserve = 0
-        let split_lamport_balances = vec![
-            0,
-            rent_exempt_reserve - 1,
-            rent_exempt_reserve,
-            rent_exempt_reserve + minimum_delegation - 1,
-            rent_exempt_reserve + minimum_delegation,
-        ];
-        for initial_balance in split_lamport_balances {
+        let transaction_accounts = |initial_balance: u64| -> Vec<(Pubkey, AccountSharedData)> {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
                 &StakeStateV2::Uninitialized,
@@ -5210,7 +5200,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let transaction_accounts = vec![
+            vec![
                 (stake_address, stake_account.clone()),
                 (split_to_address, split_to_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
@@ -5229,7 +5219,42 @@ mod tests {
                     epoch_schedule::id(),
                     create_account_shared_data_for_test(&EpochSchedule::default()),
                 ),
-            ];
+            ]
+        };
+
+        // Test insufficient account prefunding, including empty and less than rent_exempt_reserve.
+        // The empty case is not covered in test_split, since that test uses a Meta with
+        // rent_exempt_reserve = 0
+        let split_lamport_balances = vec![0, rent_exempt_reserve - 1];
+        for initial_balance in split_lamport_balances {
+            let transaction_accounts = transaction_accounts(initial_balance);
+            // split more than available fails
+            process_instruction(
+                Arc::clone(&feature_set),
+                &serialize(&StakeInstruction::Split(stake_lamports + 1)).unwrap(),
+                transaction_accounts.clone(),
+                instruction_accounts.clone(),
+                Err(InstructionError::InsufficientFunds),
+            );
+            // split to insufficiently funded dest fails
+            process_instruction(
+                Arc::clone(&feature_set),
+                &serialize(&StakeInstruction::Split(stake_lamports / 2)).unwrap(),
+                transaction_accounts,
+                instruction_accounts.clone(),
+                Err(InstructionError::InsufficientFunds),
+            );
+        }
+
+        // Test various account prefunding, including exactly rent_exempt_reserve, and more than
+        // rent_exempt_reserve
+        let split_lamport_balances = vec![
+            rent_exempt_reserve,
+            rent_exempt_reserve + minimum_delegation - 1,
+            rent_exempt_reserve + minimum_delegation,
+        ];
+        for initial_balance in split_lamport_balances {
+            let transaction_accounts = transaction_accounts(initial_balance);
 
             // split more than available fails
             process_instruction(

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -644,7 +644,7 @@ mod tests {
         )
     }
 
-    fn get_active_stake(
+    fn get_active_stake_for_tests(
         stake_accounts: &[AccountSharedData],
         clock: &Clock,
         stake_history: &StakeHistory,
@@ -2792,7 +2792,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[stake_account.clone(), split_to_account.clone()],
                 &clock,
                 &stake_history,
@@ -2825,7 +2825,7 @@ mod tests {
             // no deactivated stake
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             assert_eq!(from(&accounts[0]).unwrap(), from(&accounts[1]).unwrap());
@@ -4153,7 +4153,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[source_account.clone(), dest_account.clone()],
                 &clock,
                 &stake_history,
@@ -4180,7 +4180,7 @@ mod tests {
             );
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
         }
     }
@@ -4251,7 +4251,7 @@ mod tests {
                     &id(),
                 )
                 .unwrap();
-                let expected_active_stake = get_active_stake(
+                let expected_active_stake = get_active_stake_for_tests(
                     &[source_account.clone(), dest_account.clone()],
                     &clock,
                     &stake_history,
@@ -4278,7 +4278,7 @@ mod tests {
                 );
                 assert_eq!(
                     expected_active_stake,
-                    get_active_stake(&accounts[0..2], &clock, &stake_history)
+                    get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
                 );
             }
         }
@@ -4513,7 +4513,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[source_account.clone(), destination_account.clone()],
                 &clock,
                 &stake_history,
@@ -4540,7 +4540,7 @@ mod tests {
             );
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
             // For the expected OK cases, when the source's StakeStateV2 is Stake, then the
             // destination's StakeStateV2 *must* also end up as Stake as well.  Additionally,
@@ -5137,7 +5137,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[stake_account.clone(), split_to_account.clone()],
                 &clock,
                 &stake_history,
@@ -5189,7 +5189,7 @@ mod tests {
             );
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             // verify no stake leakage in the case of a stake
@@ -5313,7 +5313,7 @@ mod tests {
         ];
         for initial_balance in split_lamport_balances {
             let transaction_accounts = transaction_accounts(initial_balance);
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[
                     transaction_accounts[0].1.clone(),
                     transaction_accounts[1].1.clone(),
@@ -5347,7 +5347,7 @@ mod tests {
             // no deactivated stake
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
@@ -5481,7 +5481,7 @@ mod tests {
         ];
         for initial_balance in split_lamport_balances {
             let transaction_accounts = transaction_accounts(initial_balance);
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[
                     transaction_accounts[0].1.clone(),
                     transaction_accounts[1].1.clone(),
@@ -5515,7 +5515,7 @@ mod tests {
             // no deactivated stake
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
@@ -5712,7 +5712,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[stake_account.clone(), split_to_account.clone()],
                 &clock,
                 &stake_history,
@@ -5749,7 +5749,7 @@ mod tests {
             // no deactivated stake
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             match state {
@@ -5839,7 +5839,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[stake_account.clone(), split_to_account.clone()],
                 &clock,
                 &stake_history,
@@ -5876,7 +5876,7 @@ mod tests {
             // no deactivated stake
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             if let StakeStateV2::Stake(meta, stake, stake_flags) = state {
@@ -5991,7 +5991,7 @@ mod tests {
                 &id(),
             )
             .unwrap();
-            let expected_active_stake = get_active_stake(
+            let expected_active_stake = get_active_stake_for_tests(
                 &[stake_account.clone(), split_to_account.clone()],
                 &clock,
                 &stake_history,
@@ -6026,7 +6026,7 @@ mod tests {
             assert_eq!(accounts[1].lamports(), stake_lamports);
             assert_eq!(
                 expected_active_stake,
-                get_active_stake(&accounts[0..2], &clock, &stake_history)
+                get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
             );
 
             let expected_split_meta = Meta {
@@ -6089,8 +6089,8 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let delegation_amount = 3 * minimum_delegation;
         let source_lamports = rent_exempt_reserve + delegation_amount;
-        let source_address = solana_sdk::pubkey::new_rand();
-        let destination_address = solana_sdk::pubkey::new_rand();
+        let source_address = Pubkey::new_unique();
+        let destination_address = Pubkey::new_unique();
         let meta = Meta {
             authorized: Authorized::auto(&source_address),
             rent_exempt_reserve,
@@ -6154,7 +6154,7 @@ mod tests {
                 let split_lamport_balances = vec![0, rent_exempt_reserve - 1];
                 for initial_balance in split_lamport_balances {
                     let transaction_accounts = transaction_accounts(initial_balance);
-                    let expected_active_stake = get_active_stake(
+                    let expected_active_stake = get_active_stake_for_tests(
                         &[source_account.clone(), transaction_accounts[1].1.clone()],
                         &clock,
                         &stake_history,
@@ -6167,7 +6167,7 @@ mod tests {
                         expected_result.clone(),
                     );
                     let result_active_stake =
-                        get_active_stake(&result_accounts[0..2], &clock, &stake_history);
+                        get_active_stake_for_tests(&result_accounts[0..2], &clock, &stake_history);
                     if expected_active_stake > 0 // starting stake was delegated
                         // partial split
                         && result_accounts[0].lamports() > 0
@@ -6185,7 +6185,7 @@ mod tests {
                 let split_lamport_balances = vec![rent_exempt_reserve, rent_exempt_reserve + 1];
                 for initial_balance in split_lamport_balances {
                     let transaction_accounts = transaction_accounts(initial_balance);
-                    let expected_active_stake = get_active_stake(
+                    let expected_active_stake = get_active_stake_for_tests(
                         &[source_account.clone(), transaction_accounts[1].1.clone()],
                         &clock,
                         &stake_history,
@@ -6207,7 +6207,7 @@ mod tests {
                     // no deactivated stake
                     assert_eq!(
                         expected_active_stake,
-                        get_active_stake(&accounts[0..2], &clock, &stake_history)
+                        get_active_stake_for_tests(&accounts[0..2], &clock, &stake_history)
                     );
 
                     if let StakeStateV2::Stake(meta, stake, stake_flags) = state {

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -4993,7 +4993,7 @@ mod tests {
         .unwrap();
         let split_to_address = solana_sdk::pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
-            0,
+            rent_exempt_reserve,
             &StakeStateV2::Uninitialized,
             StakeStateV2::size_of(),
             &id(),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -701,6 +701,9 @@ pub fn split(
         StakeStateV2::Stake(meta, mut stake, stake_flags) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let minimum_delegation = crate::get_minimum_delegation(&invoke_context.feature_set);
+            let clock = invoke_context.get_sysvar_cache().get_clock()?;
+            let status = get_stake_status(invoke_context, &stake, &clock)?;
+            let is_active = status.effective > 0;
             let validated_split_info = validate_split_amount(
                 invoke_context,
                 transaction_context,
@@ -710,6 +713,7 @@ pub fn split(
                 lamports,
                 &meta,
                 minimum_delegation,
+                is_active,
             )?;
 
             // split the stake, subtract rent_exempt_balance unless
@@ -776,6 +780,7 @@ pub fn split(
                 lamports,
                 &meta,
                 0, // additional_required_lamports
+                false,
             )?;
             let mut split_meta = meta;
             split_meta.rent_exempt_reserve = validated_split_info.destination_rent_exempt_reserve;
@@ -1200,6 +1205,7 @@ fn validate_split_amount(
     lamports: u64,
     source_meta: &Meta,
     additional_required_lamports: u64,
+    source_is_active: bool,
 ) -> Result<ValidatedSplitInfo, InstructionError> {
     let source_account = instruction_context
         .try_borrow_instruction_account(transaction_context, source_account_index)?;
@@ -1240,12 +1246,27 @@ fn validate_split_amount(
         // nothing to do here
     }
 
+    let rent = invoke_context.get_sysvar_cache().get_rent()?;
+    let destination_rent_exempt_reserve = rent.minimum_balance(destination_data_len);
+
+    // As of feature `require_rent_exempt_split_destination`, if the source is active stake, one of
+    // these criteria must be met:
+    // 1. the destination account must be prefunded with at least the rent-exempt reserve, or
+    // 2. the split must consume 100% of the source
+    if invoke_context
+        .feature_set
+        .is_active(&feature_set::require_rent_exempt_split_destination::id())
+        && source_is_active
+        && source_remaining_balance != 0
+        && destination_lamports < destination_rent_exempt_reserve
+    {
+        return Err(InstructionError::InsufficientFunds);
+    }
+
     // Verify the destination account meets the minimum balance requirements
     // This must handle:
     // 1. The destination account having a different rent exempt reserve due to data size changes
     // 2. The destination account being prefunded, which would lower the minimum split amount
-    let rent = invoke_context.get_sysvar_cache().get_rent()?;
-    let destination_rent_exempt_reserve = rent.minimum_balance(destination_data_len);
     let destination_minimum_balance =
         destination_rent_exempt_reserve.saturating_add(additional_required_lamports);
     let destination_balance_deficit =

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -428,15 +428,21 @@ fn test_stake_account_lifetime() {
     let split_stake_keypair = Keypair::new();
     let split_stake_pubkey = split_stake_keypair.pubkey();
 
+    bank.transfer(
+        stake_rent_exempt_reserve,
+        &mint_keypair,
+        &split_stake_pubkey,
+    )
+    .unwrap();
     let bank_client = BankClient::new_shared(bank.clone());
+
     // Test split
     let split_starting_delegation = stake_minimum_delegation + bonus_delegation;
-    let split_starting_balance = split_starting_delegation + stake_rent_exempt_reserve;
     let message = Message::new(
         &stake_instruction::split(
             &stake_pubkey,
             &stake_pubkey,
-            split_starting_balance,
+            split_starting_delegation,
             &split_stake_pubkey,
         ),
         Some(&mint_pubkey),
@@ -451,7 +457,7 @@ fn test_stake_account_lifetime() {
         get_staked(&bank, &split_stake_pubkey),
         split_starting_delegation,
     );
-    let stake_remaining_balance = balance - split_starting_balance;
+    let stake_remaining_balance = balance - split_starting_delegation;
 
     // Deactivate the split
     let message = Message::new(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -689,6 +689,10 @@ pub mod enable_program_runtime_v2_and_loader_v4 {
     solana_sdk::declare_id!("8oBxsYqnCvUTGzgEpxPcnVf7MLbWWPYddE33PftFeBBd");
 }
 
+pub mod require_rent_exempt_split_destination {
+    solana_sdk::declare_id!("D2aip4BBr8NPWtU9vLrwrBvbuaQ8w1zV38zFLxx4pfBV");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -856,6 +860,7 @@ lazy_static! {
         (timely_vote_credits::id(), "use timeliness of votes in determining credits to award"),
         (remaining_compute_units_syscall_enabled::id(), "enable the remaining_compute_units syscall"),
         (enable_program_runtime_v2_and_loader_v4::id(), "Enable Program-Runtime-v2 and Loader-v4 #33293"),
+        (require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -559,6 +559,7 @@ fn parse_distribute_stake_args(
         stake_authority,
         withdraw_authority,
         lockup_authority,
+        rent_exempt_reserve: None,
     };
     let stake_args = StakeArgs {
         unlocked_sol: sol_to_lamports(value_t_or_exit!(matches, "unlocked_sol", f64)),

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -5,6 +5,7 @@ pub struct SenderStakeArgs {
     pub stake_authority: Box<dyn Signer>,
     pub withdraw_authority: Box<dyn Signer>,
     pub lockup_authority: Option<Box<dyn Signer>>,
+    pub rent_exempt_reserve: Option<u64>,
 }
 
 pub struct StakeArgs {

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -4,4 +4,5 @@ pub mod args;
 pub mod commands;
 mod db;
 pub mod spl_token;
+pub mod stake;
 pub mod token_display;

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -2,7 +2,7 @@ use {
     solana_clap_utils::input_validators::normalize_to_url_if_moniker,
     solana_cli_config::{Config, CONFIG_FILE},
     solana_rpc_client::rpc_client::RpcClient,
-    solana_tokens::{arg_parser::parse_args, args::Command, commands, spl_token},
+    solana_tokens::{arg_parser::parse_args, args::Command, commands, spl_token, stake},
     std::{
         env,
         error::Error,
@@ -43,6 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     match command_args.command {
         Command::DistributeTokens(mut args) => {
             spl_token::update_token_args(&client, &mut args.spl_token_args)?;
+            stake::update_stake_args(&client, &mut args.stake_args)?;
             commands::process_allocations(&client, &args, exit)?;
         }
         Command::Balances(mut args) => {

--- a/tokens/src/stake.rs
+++ b/tokens/src/stake.rs
@@ -1,0 +1,15 @@
+use {
+    crate::{args::StakeArgs, commands::Error},
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_sdk::stake::state::StakeStateV2,
+};
+
+pub fn update_stake_args(client: &RpcClient, args: &mut Option<StakeArgs>) -> Result<(), Error> {
+    if let Some(stake_args) = args {
+        if let Some(sender_args) = &mut stake_args.sender_stake_args {
+            let rent = client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
+            sender_args.rent_exempt_reserve = Some(rent);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
#### Problem
Stake split still contains some brittle logic.

#### Summary of Changes
Update tests to assert that active stake is consistent across split
Add feature to make rent-exempt handling consistent
