### PR TITLE
Ag31 test just adta len 5

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8981,6 +8981,7 @@ impl AccountsDb {
                     StorageLocation::AppendVec(store_id, stored_account.offset()), // will never be cached
                     stored_account.lamports(),
                 ),
+                stored_account.data_len(),
             )
         });
 
@@ -8993,7 +8994,7 @@ impl AccountsDb {
             // Some were not inserted. This means some info like stored data is off.
             duplicates_this_slot
                 .into_iter()
-                .for_each(|(pubkey, (_slot, info))| {
+                .for_each(|(pubkey, (_slot, info), _data_len)| {
                     let duplicate = storage.accounts.get_account(info.offset()).unwrap().0;
                     assert_eq!(&pubkey, duplicate.pubkey());
                     stored_size_alive = stored_size_alive.saturating_sub(duplicate.stored_size());

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -126,7 +126,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
 
     /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
     /// For any pubkeys that already exist, the index in `items` of the failed insertion and the existing data (previously put in the index) are returned.
-    pub fn batch_insert_non_duplicates(&self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
+    pub fn batch_insert_non_duplicates(&self, items: &[(Pubkey, T, u64)]) -> Vec<(usize, T)> {
         let mut bucket = self.get_write_bucket();
         bucket.as_mut().unwrap().batch_insert_non_duplicates(items)
     }

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -441,6 +441,7 @@ mod tests {
                 initial *= 3;
             }
 
+            let data_len = 0;
             // do random operations: insert, update, delete, add/unref in random order
             // verify consistency between hashmap and all bucket maps
             for i in 0..10000 {
@@ -473,11 +474,11 @@ mod tests {
                                     }
                                 }
                             }
-                            (k, v)
+                            (k, v, data_len)
                         })
                         .collect::<Vec<_>>();
 
-                    additions.clone().into_iter().for_each(|(k, v)| {
+                    additions.clone().into_iter().for_each(|(k, v, _data_len)| {
                         hash_map.write().unwrap().insert(k, v);
                         return_key(k);
                     });
@@ -492,7 +493,7 @@ mod tests {
                             let mut batch_additions = additions
                                 .clone()
                                 .into_iter()
-                                .map(|(k, mut v)| (k, v.0.pop().unwrap()))
+                                .map(|(k, mut v, data_len)| (k, v.0.pop().unwrap(), data_len))
                                 .collect::<Vec<_>>();
                             let mut duplicates = 0;
                             if batch_additions.len() > 1 && thread_rng().gen_range(0..2) == 0 {
@@ -514,7 +515,7 @@ mod tests {
                                 duplicates
                             );
                         } else {
-                            additions.clone().into_iter().for_each(|(k, v)| {
+                            additions.clone().into_iter().for_each(|(k, v, _data_len)| {
                                 if insert {
                                     map.insert(&k, (&v.0, v.1))
                                 } else {


### PR DESCRIPTION
#### Problem
speeding up generate index/startup.
there are many duplicate accounts at startup.
Instead of looking duplicate accounts up again once they are discovered, we keep the data_len around of all accounts we add. This avoids a later lookup at the background point of insertion. This also allows an efficient clean to take place during generating the index instead of delaying this until later.

#### Summary of Changes
Pass data_len of the account's data in through index generation to prepare for future improvements.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
