### PR TITLE
use rolling bit field for slots to shrink

### DIFF
--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -4,7 +4,7 @@
 
 use {bv::BitVec, solana_sdk::clock::Slot, std::collections::HashSet};
 
-#[derive(Debug, Default, AbiExample, Clone)]
+#[derive(Debug, AbiExample, Clone)]
 pub struct RollingBitField {
     max_width: u64,
     min: u64,
@@ -53,6 +53,10 @@ impl RollingBitField {
 
     // find the array index
     fn get_address(&self, key: &u64) -> u64 {
+        if self.max_width == 0 {
+            log::error!("max width 0");
+            panic!("");
+        }
         key % self.max_width
     }
 


### PR DESCRIPTION
#### Problem
`HashSet<Slot>` does not perform well when we know we have a range of 432k slots (mostly). We already moved ancestors to a RollingBitField.

#### Summary of Changes
Move shrink slots to a rolling bit field. clean slots is next.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
