### PR TITLE
Async connection creation in connection cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,6 +5700,7 @@ version = "1.17.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "crossbeam-channel",
  "futures-util",
  "indexmap 2.0.0",
  "indicatif",

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -1,7 +1,9 @@
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_client::tpu_client::TpuClient,
-    solana_connection_cache::connection_cache::{ConnectionManager, ConnectionPool},
+    solana_connection_cache::connection_cache::{
+        ConnectionManager, ConnectionPool, NewConnectionConfig,
+    },
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
         message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
@@ -12,6 +14,7 @@ impl<P, M, C> BenchTpsClient for TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
         let signature = transaction.signatures[0];

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -5,6 +5,7 @@ use {
         client_connection::ClientConnection,
         connection_cache::{
             BaseClientConnection, ConnectionCache as BackendConnectionCache, ConnectionPool,
+            NewConnectionConfig,
         },
     },
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},

--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -3,6 +3,7 @@ use {
     crate::{connection_cache::ConnectionCache, tpu_client::TpuClientConfig},
     solana_connection_cache::connection_cache::{
         ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
+        NewConnectionConfig,
     },
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
@@ -30,6 +31,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
@@ -99,6 +101,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Create a new client that disconnects when dropped
     pub async fn new_with_connection_cache(

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -2,6 +2,7 @@ use {
     crate::connection_cache::ConnectionCache,
     solana_connection_cache::connection_cache::{
         ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
+        NewConnectionConfig,
     },
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::rpc_client::RpcClient,
@@ -34,6 +35,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
@@ -90,6 +92,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Create a new client that disconnects when dropped
     pub fn new_with_connection_cache(

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
+crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true, optional = true }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -6,6 +6,7 @@ use {
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     indexmap::map::IndexMap,
+    log::*,
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
     solana_sdk::timing::AtomicInterval,
@@ -196,8 +197,9 @@ where
                             let conn = pool.get(idx);
                             if let Ok(conn) = conn {
                                 drop(map);
-                                let conn = conn.new_nonblocking_connection(addr, stats.clone());
-                                let _ = conn.send_data(&[]);
+                                let conn = conn.new_blocking_connection(addr, stats.clone());
+                                let rslt = conn.send_data(&[]);
+                                info!("Create async connection result {rslt:?}");
                             }
                         }
                     }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -361,7 +361,7 @@ pub trait NewConnectionConfig: Sized + Send + Sync + 'static {
     fn new() -> Result<Self, ClientError>;
 }
 
-pub trait ConnectionPool: Send + Sync {
+pub trait ConnectionPool: Send + Sync + 'static {
     type NewConnectionConfig: NewConnectionConfig;
     type BaseClientConnection: BaseClientConnection;
 

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -97,7 +97,7 @@ where
             name,
             map,
             stats,
-            connection_manager: connection_manager,
+            connection_manager,
             last_stats: AtomicInterval::default(),
             connection_pool_size,
             connection_config: config,
@@ -179,7 +179,7 @@ where
                 self.connection_config.clone(),
                 self.connection_manager.clone(),
                 &mut map,
-                &addr,
+                addr,
                 self.connection_pool_size,
                 Some(self.sender.clone()),
             );

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -288,7 +288,7 @@ where
         let mut hit_cache = false;
         map.entry(*addr)
             .and_modify(|pool| {
-                if pool.need_new_connection(connection_pool_size).1 {
+                if pool.need_new_connection(connection_pool_size).0 {
                     pool.add_connection(&config, addr);
                     async_connection_sender.map(|sender| {
                         info!("Sending async connection creation {} for {addr}", pool.num_connections() - 1);

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -147,7 +147,7 @@ where
                                 drop(map);
                                 let conn = conn.new_blocking_connection(addr, stats.clone());
                                 let rslt = conn.send_data(&[]);
-                                info!("Create async connection result {rslt:?}");
+                                debug!("Create async connection result {rslt:?} for {addr}");
                             }
                         }
                     }
@@ -191,7 +191,7 @@ where
 
         if need_new_connection && !should_create_connection {
             // trigger an async connection create
-            info!("Triggering async connection for {addr:?}");
+            debug!("Triggering async connection for {addr:?}");
             Self::create_connection_internal(
                 self.connection_config.clone(),
                 self.connection_manager.clone(),
@@ -246,7 +246,7 @@ where
                 if pool.need_new_connection(connection_pool_size).0 {
                     pool.add_connection(&config, addr);
                     async_connection_sender.map(|sender| {
-                        info!(
+                        debug!(
                             "Sending async connection creation {} for {addr}",
                             pool.num_connections() - 1
                         );
@@ -300,7 +300,7 @@ where
                 } else {
                     let connection = pool.borrow_connection();
                     if need_connection {
-                        info!("Creating connection async for {addr}");
+                        debug!("Creating connection async for {addr}");
                         drop(map);
                         let mut map = self.map.write().unwrap();
                         Self::create_connection_internal(

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -246,6 +246,7 @@ where
 
         if need_new_connection && !should_create_connection {
             // trigger an async connection create
+            info!("Triggering async connection for {addr:?}");
             self.sender.send(addr.clone()).unwrap();
         }
 
@@ -290,6 +291,7 @@ where
                 if pool.need_new_connection(connection_pool_size).1 {
                     pool.add_connection(&config, addr);
                     async_connection_sender.map(|sender| {
+                        info!("Sending async connection creation {} for {addr}", pool.num_connections() - 1);
                         sender.send((pool.num_connections() - 1, *addr)).unwrap();
                     });
                 } else {
@@ -340,6 +342,7 @@ where
                 } else {
                     let connection = pool.borrow_connection();
                     if need_connection {
+                        info!("Creating connection async for {addr}");
                         self.sender.send(addr.clone()).unwrap();
                     }
                     CreateConnectionResult {

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -576,7 +576,7 @@ mod tests {
         }
     }
 
-    impl MockUdpConfig {
+    impl NewConnectionConfig for MockUdpConfig {
         fn new() -> Result<Self, ClientError> {
             Ok(Self {
                 udp_socket: Arc::new(

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -228,13 +228,13 @@ where
             .and_modify(|pool| {
                 if pool.need_new_connection(connection_pool_size).0 {
                     pool.add_connection(&config, addr);
-                    async_connection_sender.map(|sender| {
+                    if let Some(sender) = async_connection_sender {
                         debug!(
                             "Sending async connection creation {} for {addr}",
                             pool.num_connections() - 1
                         );
                         sender.send((pool.num_connections() - 1, *addr)).unwrap();
-                    });
+                    };
                 } else {
                     hit_cache = true;
                 }
@@ -290,7 +290,7 @@ where
                             self.connection_config.clone(),
                             self.connection_manager.clone(),
                             &mut map,
-                            &addr,
+                            addr,
                             self.connection_pool_size,
                             Some(self.sender.clone()),
                         );

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4765,6 +4765,7 @@ version = "1.17.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "crossbeam-channel",
  "futures-util",
  "indexmap 2.0.0",
  "log",

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -110,22 +110,6 @@ impl NewConnectionConfig for QuicConfig {
 }
 
 impl QuicConfig {
-    pub fn new() -> Result<Self, ClientError> {
-        let (cert, priv_key) =
-            new_self_signed_tls_certificate(&Keypair::new(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))?;
-        Ok(Self {
-            client_certificate: Arc::new(QuicClientCertificate {
-                certificate: cert,
-                key: priv_key,
-            }),
-            maybe_staked_nodes: None,
-            maybe_client_pubkey: None,
-            client_endpoint: None,
-        })
-    }
-}
-
-impl QuicConfig {
     fn create_endpoint(&self) -> QuicLazyInitializedEndpoint {
         QuicLazyInitializedEndpoint::new(
             self.client_certificate.clone(),

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -53,9 +53,11 @@ impl ConnectionPool for QuicPool {
     type BaseClientConnection = Quic;
     type NewConnectionConfig = QuicConfig;
 
-    fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr) {
+    fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr) -> usize {
         let connection = self.create_pool_entry(config, addr);
+        let idx = self.connections.len();
         self.connections.push(connection);
+        idx
     }
 
     fn num_connections(&self) -> usize {

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -19,7 +19,7 @@ use {
     solana_connection_cache::{
         connection_cache::{
             BaseClientConnection, ClientError, ConnectionCache, ConnectionManager, ConnectionPool,
-            ConnectionPoolError, Protocol,
+            ConnectionPoolError, NewConnectionConfig, Protocol,
         },
         connection_cache_stats::ConnectionCacheStats,
     },
@@ -91,6 +91,22 @@ pub struct QuicConfig {
     // The optional specified endpoint for the quic based client connections
     // If not specified, the connection cache will create as needed.
     client_endpoint: Option<Endpoint>,
+}
+
+impl NewConnectionConfig for QuicConfig {
+    fn new() -> Result<Self, ClientError> {
+        let (cert, priv_key) =
+            new_self_signed_tls_certificate(&Keypair::new(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))?;
+        Ok(Self {
+            client_certificate: Arc::new(QuicClientCertificate {
+                certificate: cert,
+                key: priv_key,
+            }),
+            maybe_staked_nodes: None,
+            maybe_client_pubkey: None,
+            client_endpoint: None,
+        })
+    }
 }
 
 impl QuicConfig {

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -340,16 +340,18 @@ impl QuicClient {
                             Ok(conn) => {
                                 *conn_guard = Some(conn.clone());
                                 info!(
-                                    "Made connection to {} id {} try_count {}",
+                                    "Made connection to {} id {} try_count {}, from connection cache warming?: {}",
                                     self.addr,
                                     conn.connection.stable_id(),
-                                    connection_try_count
+                                    connection_try_count,
+                                    data.is_empty(),
                                 );
                                 connection_try_count += 1;
                                 conn.connection.clone()
                             }
                             Err(err) => {
-                                info!("Cannot make connection to {}, error {:}", self.addr, err);
+                                info!("Cannot make connection to {}, error {:}, from connection cache warming?: {}",
+                                    self.addr, err, data.is_empty());
                                 return Err(err);
                             }
                         }

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                        return Err(A::Error::custom("Invalid Sequence"));
-                    };
+                                return Err(A::Error::custom("Invalid Sequence"));
+                            };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                        return Err(A::Error::custom("Invalid Sequence"));
-                    };
+                                                return Err(A::Error::custom("Invalid Sequence"));
+                                            };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                                                return Err(A::Error::custom("Invalid Sequence"));
-                                            };
+                        return Err(A::Error::custom("Invalid Sequence"));
+                    };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                                                return Err(A::Error::custom("Invalid Sequence"));
-                                            };
+                                return Err(A::Error::custom("Invalid Sequence"));
+                            };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/sdk/program/src/serde_varint.rs
+++ b/sdk/program/src/serde_varint.rs
@@ -74,8 +74,8 @@ macro_rules! impl_var_int {
                 let mut shift = 0u32;
                 while shift < <$type>::BITS {
                     let Some(byte) = seq.next_element::<u8>()? else {
-                                return Err(A::Error::custom("Invalid Sequence"));
-                            };
+                                                return Err(A::Error::custom("Invalid Sequence"));
+                                            };
                     out |= ((byte & 0x7F) as Self) << shift;
                     if byte & 0x80 == 0 {
                         // Last byte should not have been truncated when it was

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -8,7 +8,9 @@ use {
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     solana_connection_cache::{
         client_connection::ClientConnection,
-        connection_cache::{ConnectionCache, ConnectionManager, ConnectionPool},
+        connection_cache::{
+            ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig,
+        },
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{config::RpcProgramAccountsConfig, response::Response},
@@ -124,6 +126,7 @@ impl<P, M, C> ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Create a new ThinClient that will interface with the Rpc at `rpc_addr` using TCP
     /// and the Tpu at `tpu_addr` over `transactions_socket` using Quic or UDP
@@ -324,6 +327,7 @@ impl<P, M, C> Client for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     fn tpu_addr(&self) -> String {
         self.tpu_addr().to_string()
@@ -334,6 +338,7 @@ impl<P, M, C> SyncClient for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     fn send_and_confirm_message<T: Signers + ?Sized>(
         &self,
@@ -618,6 +623,7 @@ impl<P, M, C> AsyncClient for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     fn async_send_versioned_transaction(
         &self,

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -9,7 +9,7 @@ use {
     log::*,
     solana_connection_cache::{
         connection_cache::{
-            ConnectionCache, ConnectionManager, ConnectionPool, Protocol,
+            ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig, Protocol,
             DEFAULT_CONNECTION_POOL_SIZE,
         },
         nonblocking::client_connection::ClientConnection,
@@ -268,6 +268,7 @@ fn send_wire_transaction_futures<'a, P, M, C>(
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     const SEND_TIMEOUT_INTERVAL: Duration = Duration::from_secs(5);
     let sleep_duration = SEND_TRANSACTION_INTERVAL.saturating_mul(index as u32);
@@ -339,6 +340,7 @@ async fn sleep_and_send_wire_transaction_to_addr<P, M, C>(
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     sleep(sleep_duration).await;
     send_wire_transaction_to_addr(connection_cache, &addr, wire_transaction).await
@@ -352,6 +354,7 @@ async fn send_wire_transaction_to_addr<P, M, C>(
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     let conn = connection_cache.get_nonblocking_connection(addr);
     conn.send_data(&wire_transaction).await
@@ -365,6 +368,7 @@ async fn send_wire_transaction_batch_to_addr<P, M, C>(
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     let conn = connection_cache.get_nonblocking_connection(addr);
     conn.send_data_batch(wire_transactions).await
@@ -374,6 +378,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -3,7 +3,7 @@ use {
     crate::nonblocking::tpu_client::TpuClient as NonblockingTpuClient,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     solana_connection_cache::connection_cache::{
-        ConnectionCache, ConnectionManager, ConnectionPool,
+        ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig,
     },
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{clock::Slot, transaction::Transaction, transport::Result as TransportResult},
@@ -71,6 +71,7 @@ impl<P, M, C> TpuClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+    C: NewConnectionConfig,
 {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -11,7 +11,7 @@ use {
     solana_connection_cache::{
         connection_cache::{
             BaseClientConnection, ClientError, ConnectionManager, ConnectionPool,
-            ConnectionPoolError, Protocol,
+            ConnectionPoolError, NewConnectionConfig, Protocol,
         },
         connection_cache_stats::ConnectionCacheStats,
     },
@@ -55,6 +55,16 @@ impl ConnectionPool for UdpPool {
 
 pub struct UdpConfig {
     udp_socket: Arc<UdpSocket>,
+}
+
+impl NewConnectionConfig for UdpConfig {
+    fn new() -> Result<Self, ClientError> {
+        let socket = solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+            .map_err(Into::<ClientError>::into)?;
+        Ok(Self {
+            udp_socket: Arc::new(socket),
+        })
+    }
 }
 
 impl UdpConfig {

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -67,16 +67,6 @@ impl NewConnectionConfig for UdpConfig {
     }
 }
 
-impl UdpConfig {
-    fn new() -> Result<Self, ClientError> {
-        let socket = solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-            .map_err(Into::<ClientError>::into)?;
-        Ok(Self {
-            udp_socket: Arc::new(socket),
-        })
-    }
-}
-
 pub struct Udp(Arc<UdpSocket>);
 impl BaseClientConnection for Udp {
     type BlockingClientConnection = BlockingUdpConnection;

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -28,9 +28,11 @@ impl ConnectionPool for UdpPool {
     type BaseClientConnection = Udp;
     type NewConnectionConfig = UdpConfig;
 
-    fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr) {
+    fn add_connection(&mut self, config: &Self::NewConnectionConfig, addr: &SocketAddr) -> usize {
         let connection = self.create_pool_entry(config, addr);
+        let idx = self.connections.len();
         self.connections.push(connection);
+        idx
     }
 
     fn num_connections(&self) -> usize {


### PR DESCRIPTION
#### Problem
There is connection warmer creating connection in the background, and we have connection pooling in the connection cache. The default is 4. This results in we create new connection until the pool size is satisfied even when there is a connection in the cache.

#### Summary of Changes
If there is a connection in the cache available, use it and create the additional connection asynchronously.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
