### PR TITLE
Bump solana_rbpf to v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7173,9 +7173,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3082ec3a1d4ef7879eb5b84916d5acde057abd59733eec3647e0ab8885283ef"
+checksum = "17d4ba1e58947346e360fabde0697029d36ba83c42f669199b16a8931313cf29"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ signal-hook = "0.3.15"
 smpl_jwt = "0.7.1"
 socket2 = "0.4.9"
 soketto = "0.7"
-solana_rbpf = "=0.6.0"
+solana_rbpf = "=0.6.1"
 solana-account-decoder = { path = "account-decoder", version = "=1.16.14" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.16.14" }
 solana-banks-client = { path = "banks-client", version = "=1.16.14" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6278,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3082ec3a1d4ef7879eb5b84916d5acde057abd59733eec3647e0ab8885283ef"
+checksum = "17d4ba1e58947346e360fabde0697029d36ba83c42f669199b16a8931313cf29"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 rand = "0.7"
 serde = "1.0.112"
 serde_json = "1.0.56"
-solana_rbpf = "=0.6.0"
+solana_rbpf = "=0.6.1"
 solana-account-decoder = { path = "../../account-decoder", version = "=1.16.14" }
 solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.16.14" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.16.14" }


### PR DESCRIPTION
#### Problem
The JIT in RBPF can create misaligned stack frames, which on its own is fine.
However, once it calls into Rust code which for example runs SIMD code it needs the stack to be 16 byte aligned again.

#### Summary of Changes
See: https://github.com/solana-labs/rbpf/releases/tag/v0.6.1

Fixes #32940
