### PR TITLE
compute_budget heap_size does not have to be optional

### DIFF
--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -101,8 +101,8 @@ pub struct ComputeBudget {
     /// Number of compute units consumed for a multiscalar multiplication (msm) of ristretto points.
     /// The total cost is calculated as `msm_base_cost + (length - 1) * msm_incremental_cost`.
     pub curve25519_ristretto_msm_incremental_cost: u64,
-    /// Optional program heap region size, if `None` then loader default
-    pub heap_size: Option<usize>,
+    /// program heap region size, default: solana_sdk::entrypoint::HEAP_LENGTH
+    pub heap_size: usize,
     /// Number of compute units per additional 32k heap above the default (~.5
     /// us per 32k at 15 units/us rounded up)
     pub heap_cost: u64,
@@ -171,7 +171,7 @@ impl ComputeBudget {
             curve25519_ristretto_multiply_cost: 2_208,
             curve25519_ristretto_msm_base_cost: 2303,
             curve25519_ristretto_msm_incremental_cost: 788,
-            heap_size: None,
+            heap_size: solana_sdk::entrypoint::HEAP_LENGTH,
             heap_cost: 8,
             mem_op_base_cost: 10,
             alt_bn128_addition_cost: 334,
@@ -267,7 +267,7 @@ impl ComputeBudget {
                     InstructionError::InvalidInstructionData,
                 ));
             }
-            self.heap_size = Some(bytes as usize);
+            self.heap_size = bytes as usize;
         }
 
         let compute_unit_limit = updated_compute_unit_limit
@@ -467,7 +467,7 @@ mod tests {
             Ok(PrioritizationFeeDetails::default()),
             ComputeBudget {
                 compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(40 * 1024),
+                heap_size: 40 * 1024,
                 ..ComputeBudget::default()
             }
         );
@@ -512,7 +512,7 @@ mod tests {
             Ok(PrioritizationFeeDetails::default()),
             ComputeBudget {
                 compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(MAX_HEAP_FRAME_BYTES as usize),
+                heap_size: MAX_HEAP_FRAME_BYTES as usize,
                 ..ComputeBudget::default()
             }
         );
@@ -562,7 +562,7 @@ mod tests {
             )),
             ComputeBudget {
                 compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(MAX_HEAP_FRAME_BYTES as usize),
+                heap_size: MAX_HEAP_FRAME_BYTES as usize,
                 ..ComputeBudget::default()
             }
         );
@@ -580,7 +580,7 @@ mod tests {
             )),
             ComputeBudget {
                 compute_unit_limit: 1,
-                heap_size: Some(MAX_HEAP_FRAME_BYTES as usize),
+                heap_size: MAX_HEAP_FRAME_BYTES as usize,
                 ..ComputeBudget::default()
             }
         );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -262,10 +262,7 @@ macro_rules! create_vm {
     ($vm:ident, $program:expr, $regions:expr, $accounts_metadata:expr, $invoke_context:expr $(,)?) => {
         let invoke_context = &*$invoke_context;
         let stack_size = $program.get_config().stack_size();
-        let heap_size = invoke_context
-            .get_compute_budget()
-            .heap_size
-            .unwrap_or(solana_sdk::entrypoint::HEAP_LENGTH);
+        let heap_size = invoke_context.get_compute_budget().heap_size;
         let round_up_heap_size = invoke_context
             .feature_set
             .is_active(&solana_sdk::feature_set::round_up_heap_size::id());

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -18,7 +18,7 @@ use {
         vm::{BuiltinProgram, Config, ContextObject, EbpfVm, ProgramResult},
     },
     solana_sdk::{
-        entrypoint::{HEAP_LENGTH, SUCCESS},
+        entrypoint::SUCCESS,
         feature_set,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status, DEPLOYMENT_COOLDOWN_IN_SLOTS},
@@ -113,15 +113,13 @@ pub fn create_vm<'a, 'b>(
     let config = program.get_config();
     let sbpf_version = program.get_sbpf_version();
     let compute_budget = invoke_context.get_compute_budget();
-    let heap_size = compute_budget.heap_size.unwrap_or(HEAP_LENGTH);
+    let heap_size = compute_budget.heap_size;
     invoke_context.consume_checked(calculate_heap_cost(
         heap_size as u64,
         compute_budget.heap_cost,
     ))?;
     let mut stack = AlignedMemory::<{ ebpf::HOST_ALIGN }>::zero_filled(config.stack_size());
-    let mut heap = AlignedMemory::<{ ebpf::HOST_ALIGN }>::zero_filled(
-        compute_budget.heap_size.unwrap_or(HEAP_LENGTH),
-    );
+    let mut heap = AlignedMemory::<{ ebpf::HOST_ALIGN }>::zero_filled(compute_budget.heap_size);
     let stack_len = stack.len();
     let regions: Vec<MemoryRegion> = vec![
         program.get_ro_region(),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9750,7 +9750,7 @@ fn test_compute_budget_program_noop() {
             *compute_budget,
             ComputeBudget {
                 compute_unit_limit: compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(48 * 1024),
+                heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }
         );
@@ -9793,7 +9793,7 @@ fn test_compute_request_instruction() {
             *compute_budget,
             ComputeBudget {
                 compute_unit_limit: compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(48 * 1024),
+                heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }
         );
@@ -9843,7 +9843,7 @@ fn test_failed_compute_request_instruction() {
             *compute_budget,
             ComputeBudget {
                 compute_unit_limit: compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-                heap_size: Some(48 * 1024),
+                heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }
         );


### PR DESCRIPTION
#### Problem

While refactoring compute_budget, realized its `heap_size` doesn't have to be `Option` since the loader _always_  `unwrap_or(solana_sdk::entrypoint::HEAP_LENGTH)`. May as well default it to HEAP_LENGTH to streamline the logic. 

#### Summary of Changes
- Remove `Option`, using `solana_sdk::entrypoint::HEAP_LENGTH` as default.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
