### PR TITLE
drop disk index bucket files on drop by default

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -79,6 +79,8 @@ pub struct BucketStorage<O: BucketOccupied> {
     pub stats: Arc<BucketStats>,
     pub max_search: MaxSearch,
     pub contents: O,
+    /// true if when this bucket is dropped, the file should be deleted
+    pub delete_file_on_drop: bool,
 }
 
 #[derive(Debug)]
@@ -88,7 +90,9 @@ pub enum BucketStorageError {
 
 impl<O: BucketOccupied> Drop for BucketStorage<O> {
     fn drop(&mut self) {
-        self.delete();
+        if self.delete_file_on_drop {
+            self.delete();
+        }
     }
 }
 
@@ -157,6 +161,8 @@ impl<O: BucketOccupied> BucketStorage<O> {
                 stats,
                 max_search,
                 contents: O::new(capacity),
+                // by default, newly created files will get deleted when dropped
+                delete_file_on_drop: true,
             },
             file_name,
         )


### PR DESCRIPTION
#### Problem
working on speeding up startup & generate index.
we want to reuse existing disk index files.

#### Summary of Changes
Allow individual disk buckets to optionally delete on drop. Data buckets will always do this.
Resized index files will drop.
New index buckets will NOT drop once we get everything hooked up.
Bucket files loaded on restart will NOT drop once we get everything hooked up.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
