### PR TITLE
fix clippy error

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -181,7 +181,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
 
     /// delete the backing file on disk
     fn delete(&self) {
-         _ = remove_file(&self.path);
+        _ = remove_file(&self.path);
     }
 
     pub fn max_search(&self) -> u64 {

--- a/vote/src/lib.rs
+++ b/vote/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 pub mod vote_account;
 pub mod vote_parser;


### PR DESCRIPTION
#### Problem
https://buildkite.com/solana-labs/solana/builds/101939#018aaf88-dadc-4ea1-a104-633b04ee26d1

```


error: lint `clippy::integer_arithmetic` has been renamed to `clippy::arithmetic_side_effects`
--
  | --> vote/src/lib.rs:2:10
  | \|
  | 2 \| #![allow(clippy::integer_arithmetic)]
  | \|          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::arithmetic_side_effects`
```

#### Summary of Changes
change clippy allow

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
