### PR TITLE
add occupy_if_matches to bucket map

### DIFF
--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -36,6 +36,16 @@ struct DataBucketRefCountOccupiedHeader {
     packed_ref_count: PackedRefCount,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum OccupyIfMatches {
+    /// this entry is occupied and contains a pubkey with a different value, so this entry could not be updated
+    FoundDuplicate,
+    /// this entry was free and contains this pubkey and either value matched or the value was written to match
+    SuccessfulInit,
+    /// this entry had a different pubkey
+    PubkeyMismatch,
+}
+
 /// allocated in `contents` in a BucketStorage
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -279,7 +289,7 @@ pub(crate) union SingleElementOrMultipleSlots<T: Clone + Copy> {
 
 /// just the values for `OccupiedEnum`
 /// This excludes the contents of any enum value.
-#[derive(PartialEq, FromPrimitive)]
+#[derive(PartialEq, FromPrimitive, Debug)]
 #[repr(u8)]
 enum OccupiedEnumTag {
     #[default]
@@ -375,6 +385,39 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
         self.set_slot_count_enum_value(index_bucket, OccupiedEnum::ZeroSlots);
         let index_entry = index_bucket.get_mut::<IndexEntry<T>>(self.ix);
         index_entry.key = *pubkey;
+    }
+
+    /// If the entry matches the pubkey and is unoccupied, then store `data` here and occupy the entry.
+    pub(crate) fn occupy_if_matches(
+        &self,
+        index_bucket: &mut BucketStorage<IndexBucket<T>>,
+        data: &T,
+        k: &Pubkey,
+    ) -> OccupyIfMatches {
+        let index_entry = index_bucket.get::<IndexEntry<T>>(self.ix);
+        if &index_entry.key == k {
+            let enum_tag = index_bucket.contents.get_enum_tag(self.ix);
+            if unsafe { &index_entry.contents.single_element } == data {
+                assert_eq!(
+                    enum_tag,
+                    OccupiedEnumTag::Free,
+                    "index asked to insert the same data twice"
+                );
+                index_bucket
+                    .contents
+                    .set_enum_tag(self.ix, OccupiedEnumTag::OneSlotInIndex);
+                OccupyIfMatches::SuccessfulInit
+            } else if enum_tag == OccupiedEnumTag::Free {
+                // pubkey is same, but value is different, so update value
+                self.set_slot_count_enum_value(index_bucket, OccupiedEnum::OneSlotInIndex(data));
+                OccupyIfMatches::SuccessfulInit
+            } else {
+                // found occupied duplicate of this pubkey
+                OccupyIfMatches::FoundDuplicate
+            }
+        } else {
+            OccupyIfMatches::PubkeyMismatch
+        }
     }
 
     pub(crate) fn read_value<'a>(


### PR DESCRIPTION
#### Problem
working on speeding up startup & generate index.
we want to reuse existing disk index files.

#### Summary of Changes
`add occupy_if_matches()` will be used to inspect disk index file data and occupy the entry if disk already matches. This will be used shortly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
