### PR TITLE
Warn if vaildator appears to be repairing excessively

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -436,7 +436,12 @@ fn main() {
         let cluster_info = {
             let keypair = Arc::new(Keypair::new());
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
-            ClusterInfo::new(node.info, keypair, SocketAddrSpace::Unspecified)
+            ClusterInfo::new(
+                node.info,
+                keypair,
+                SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
+            )
         };
         let cluster_info = Arc::new(cluster_info);
         let tpu_disable_quic = matches.is_present("tpu_disable_quic");

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -288,7 +288,12 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         let cluster_info = {
             let keypair = Arc::new(Keypair::new());
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
-            ClusterInfo::new(node.info, keypair, SocketAddrSpace::Unspecified)
+            ClusterInfo::new(
+                node.info,
+                keypair,
+                SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
+            )
         };
         let cluster_info = Arc::new(cluster_info);
         let (s, _r) = unbounded();

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -601,7 +601,12 @@ mod tests {
     fn new_test_cluster_info() -> ClusterInfo {
         let keypair = Arc::new(Keypair::new());
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
-        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            contact_info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     }
 
     #[test]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -655,8 +655,12 @@ mod tests {
     pub(crate) fn new_test_cluster_info(keypair: Option<Arc<Keypair>>) -> (Node, ClusterInfo) {
         let keypair = keypair.unwrap_or_else(|| Arc::new(Keypair::new()));
         let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
-        let cluster_info =
-            ClusterInfo::new(node.info.clone(), keypair, SocketAddrSpace::Unspecified);
+        let cluster_info = ClusterInfo::new(
+            node.info.clone(),
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        );
         (node, cluster_info)
     }
 

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -192,7 +192,12 @@ mod test {
         let keypair = Arc::new(Keypair::new());
         let pubkey = keypair.pubkey();
         let node_info = Node::new_localhost_with_pubkey(&pubkey);
-        let cluster_info = ClusterInfo::new(node_info.info, keypair, SocketAddrSpace::Unspecified);
+        let cluster_info = ClusterInfo::new(
+            node_info.info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        );
         ClusterSlotsService::update_lowest_slot(5, &cluster_info);
         cluster_info.flush_push_queue();
         let lowest = {

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1256,6 +1256,7 @@ mod test {
                 responder_node.info.clone(),
                 Arc::new(keypair),
                 SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
             );
             let responder_serve_repair = ServeRepair::new(
                 Arc::new(cluster_info),
@@ -1350,6 +1351,7 @@ mod test {
                 Node::new_localhost_with_pubkey(&keypair.pubkey()).info,
                 Arc::new(keypair),
                 SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
             ));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::default()));
             let requester_serve_repair = ServeRepair::new(

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -879,7 +879,12 @@ mod test {
     fn new_test_cluster_info() -> ClusterInfo {
         let keypair = Arc::new(Keypair::new());
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
-        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            contact_info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     }
 
     #[test]

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1969,7 +1969,12 @@ mod tests {
     fn new_test_cluster_info() -> ClusterInfo {
         let keypair = Arc::new(Keypair::new());
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
-        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            contact_info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     }
 
     #[test]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4162,6 +4162,7 @@ pub(crate) mod tests {
             Node::new_localhost_with_pubkey(&my_pubkey).info,
             Arc::new(my_keypairs.node_keypair.insecure_clone()),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
         assert_eq!(my_pubkey, cluster_info.id());
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -409,8 +409,12 @@ pub mod tests {
         let (repair_quic_endpoint_sender, _repair_quic_endpoint_receiver) =
             tokio::sync::mpsc::channel(/*buffer:*/ 128);
         //start cluster_info1
-        let cluster_info1 =
-            ClusterInfo::new(target1.info.clone(), keypair, SocketAddrSpace::Unspecified);
+        let cluster_info1 = ClusterInfo::new(
+            target1.info.clone(),
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        );
         cluster_info1.insert_info(leader.info);
         let cref1 = Arc::new(cluster_info1);
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -728,6 +728,7 @@ impl Validator {
             node.info.clone(),
             identity_keypair.clone(),
             socket_addr_space,
+            config.known_validators.clone(),
         );
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);
@@ -974,7 +975,6 @@ impl Validator {
                 ledger_path,
                 config.validator_exit.clone(),
                 exit.clone(),
-                config.known_validators.clone(),
                 rpc_override_health_check.clone(),
                 startup_verification_complete,
                 optimistically_confirmed_bank.clone(),
@@ -2610,6 +2610,7 @@ mod tests {
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -361,7 +361,7 @@ impl WindowService {
         let (duplicate_sender, duplicate_receiver) = unbounded();
 
         let t_check_duplicate = Self::start_check_duplicate_thread(
-            cluster_info,
+            cluster_info.clone(),
             exit.clone(),
             blockstore.clone(),
             duplicate_receiver,
@@ -442,6 +442,7 @@ impl WindowService {
                 };
                 let mut metrics = BlockstoreInsertionMetrics::default();
                 let mut ws_metrics = WindowServiceMetrics::default();
+
                 let mut last_print = Instant::now();
                 while !exit.load(Ordering::Relaxed) {
                     if let Err(e) = run_insert(
@@ -581,6 +582,7 @@ mod test {
             contact_info,
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
         run_check_duplicate(
             &cluster_info,
@@ -615,6 +617,7 @@ mod test {
             contact_info,
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         ));
 
         // Start duplicate thread receiving and inserting duplicates

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -130,6 +130,7 @@ impl TestEnvironment {
             ContactInfo::new_localhost(&node_id.pubkey(), timestamp()),
             Arc::clone(&node_id),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         ));
 
         let pruned_banks_receiver =

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -505,7 +505,12 @@ fn test_concurrent_snapshot_packaging(
             timestamp(), // wallclock
             0u16,        // shred_version
         );
-        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            contact_info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     });
 
     let (snapshot_package_sender, snapshot_package_receiver) = crossbeam_channel::unbounded();
@@ -955,6 +960,7 @@ fn test_snapshots_with_background_services(
         ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
         node_keypair,
         SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
     ));
 
     let (pruned_banks_sender, pruned_banks_receiver) = unbounded();

--- a/gossip/src/duplicate_shred_listener.rs
+++ b/gossip/src/duplicate_shred_listener.rs
@@ -105,6 +105,7 @@ mod tests {
             node.info,
             host1_key,
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         ));
         let exit = Arc::new(AtomicBool::new(false));
         let count = Arc::new(AtomicU32::new(0));

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -311,7 +311,12 @@ pub fn make_gossip_node(
     } else {
         ClusterInfo::spy_node(keypair.pubkey(), shred_version)
     };
-    let cluster_info = ClusterInfo::new(node, Arc::new(keypair), socket_addr_space);
+    let cluster_info = ClusterInfo::new(
+        node,
+        Arc::new(keypair),
+        socket_addr_space,
+        /*known_validators*/ None,
+    );
     if let Some(entrypoint) = entrypoint {
         cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(entrypoint));
     }
@@ -349,6 +354,7 @@ mod tests {
             tn.info.clone(),
             Arc::new(Keypair::new()),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
         let c = Arc::new(cluster_info);
         let d = GossipService::new(
@@ -377,6 +383,7 @@ mod tests {
             contact_info,
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
         cluster_info.insert_info(peer0_info.clone());
         cluster_info.insert_info(peer1_info);

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -42,6 +42,7 @@ fn test_node(exit: Arc<AtomicBool>) -> (Arc<ClusterInfo>, GossipService, UdpSock
         test_node.info.clone(),
         keypair,
         SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
     ));
     let gossip_service = GossipService::new(
         &cluster_info,
@@ -70,6 +71,7 @@ fn test_node_with_bank(
         test_node.info.clone(),
         node_keypair,
         SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
     ));
     let gossip_service = GossipService::new(
         &cluster_info,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -262,6 +262,7 @@ pub fn load_and_process_ledger(
         ContactInfo::new_localhost(&node_id.pubkey(), timestamp()),
         Arc::clone(&node_id),
         SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
     ));
     let (accounts_package_sender, accounts_package_receiver) = crossbeam_channel::unbounded();
     let accounts_hash_verifier = AccountsHashVerifier::new(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1055,6 +1055,7 @@ impl Blockstore {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_shreds_handle_duplicate<F>(
         &self,
         shreds: Vec<Shred>,

--- a/ledger/src/slot_stats.rs
+++ b/ledger/src/slot_stats.rs
@@ -1,5 +1,5 @@
 use {
-    crate::blockstore_meta::SlotMeta,
+    crate::{blockstore_meta::SlotMeta, blockstore_metrics::ExcessiveRepairContext},
     bitflags::bitflags,
     lru::LruCache,
     solana_sdk::clock::Slot,
@@ -96,6 +96,7 @@ impl SlotsStats {
         fec_set_index: u32,
         source: ShredSource,
         slot_meta: Option<&SlotMeta>,
+        excessive_repair_context: &mut ExcessiveRepairContext,
     ) {
         let mut slot_full_reporting_info = None;
         let mut stats = self.stats.lock().unwrap();
@@ -118,6 +119,8 @@ impl SlotsStats {
                     slot_full_reporting_info =
                         Some((slot_stats.num_repaired, slot_stats.num_recovered));
                 }
+                excessive_repair_context
+                    .record_slot(slot_stats.last_index, slot_stats.num_repaired);
             }
         }
         drop(stats);

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -165,6 +165,7 @@ mod test {
                 ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
                 node_keypair,
                 SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
             ));
 
             let validator0_socket = (

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -355,7 +355,12 @@ impl JsonRpcRequestProcessor {
                 &keypair.pubkey(),
                 solana_sdk::timing::timestamp(), // wallclock
             );
-            ClusterInfo::new(contact_info, keypair, socket_addr_space)
+            ClusterInfo::new(
+                contact_info,
+                keypair,
+                socket_addr_space,
+                /*known_validators*/ None,
+            )
         });
         let tpu_address = cluster_info
             .my_contact_info()
@@ -387,7 +392,6 @@ impl JsonRpcRequestProcessor {
             validator_exit: create_validator_exit(exit.clone()),
             health: Arc::new(RpcHealth::new(
                 cluster_info.clone(),
-                None,
                 0,
                 exit,
                 Arc::clone(bank.get_startup_verification_complete()),
@@ -4704,7 +4708,12 @@ pub mod tests {
             &keypair.pubkey(),
             solana_sdk::timing::timestamp(), // wallclock
         );
-        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            contact_info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     }
 
     fn create_test_request(method: &str, params: Option<serde_json::Value>) -> serde_json::Value {
@@ -6411,7 +6420,12 @@ pub mod tests {
                 &keypair.pubkey(),
                 &socketaddr!(Ipv4Addr::LOCALHOST, 1234),
             );
-            ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+            ClusterInfo::new(
+                contact_info,
+                keypair,
+                SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
+            )
         });
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         let tpu_address = cluster_info

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -45,6 +45,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
         leader_info.info,
         leader_keypair,
         SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
     );
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);

--- a/turbine/benches/retransmit_stage.rs
+++ b/turbine/benches/retransmit_stage.rs
@@ -53,7 +53,12 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     let cluster_info = {
         let keypair = Arc::new(Keypair::new());
         let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
-        ClusterInfo::new(node.info, keypair, SocketAddrSpace::Unspecified)
+        ClusterInfo::new(
+            node.info,
+            keypair,
+            SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
+        )
     };
     const NUM_PEERS: usize = 4;
     let peer_sockets: Vec<_> = repeat_with(|| {

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -660,6 +660,7 @@ pub mod test {
             leader_info.info.clone(),
             leader_keypair,
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         );
         cluster_info.insert_info(broadcast_buddy.info);
         let cluster_info = Arc::new(cluster_info);

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -173,7 +173,12 @@ mod tests {
         let cluster = {
             let keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
-            ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+            ClusterInfo::new(
+                contact_info,
+                keypair,
+                SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
+            )
         };
         for k in 1..5 {
             cluster.insert_info(ContactInfo::new_with_socketaddr(

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -538,6 +538,7 @@ mod test {
             leader_info.info,
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         ));
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let mut genesis_config = create_genesis_config(10_000).genesis_config;

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -459,7 +459,12 @@ pub fn make_test_cluster<R: Rng>(
         .collect();
     // Add some staked nodes with no contact-info.
     stakes.extend(repeat_with(|| (Pubkey::new_unique(), rng.gen_range(0..20))).take(100));
-    let cluster_info = ClusterInfo::new(this_node, keypair, SocketAddrSpace::Unspecified);
+    let cluster_info = ClusterInfo::new(
+        this_node,
+        keypair,
+        SocketAddrSpace::Unspecified,
+        /*known_validators*/ None,
+    );
     let nodes: Vec<_> = nodes
         .iter()
         .map(LegacyContactInfo::try_from)

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -867,6 +867,7 @@ mod tests {
                 ),
                 keypair,
                 SocketAddrSpace::Unspecified,
+                /*known_validators*/ None,
             ));
             let exit = Arc::new(AtomicBool::new(false));
             let validator_exit = create_validator_exit(exit);

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -155,7 +155,12 @@ fn start_gossip_node(
         *gossip_addr,
         expected_shred_version.unwrap_or(0),
     );
-    let mut cluster_info = ClusterInfo::new(contact_info, identity_keypair, socket_addr_space);
+    let mut cluster_info = ClusterInfo::new(
+        contact_info,
+        identity_keypair,
+        socket_addr_space,
+        /*known_validators*/ None,
+    );
     cluster_info.set_entrypoints(cluster_entrypoints.to_vec());
     cluster_info.restore_contact_info(ledger_path, 0);
     let cluster_info = Arc::new(cluster_info);

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -91,6 +91,7 @@ mod tests {
             },
             node_keypair,
             SocketAddrSpace::Unspecified,
+            /*known_validators*/ None,
         ));
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let mut wen_restart_proto_path = ledger_path.path().to_path_buf();


### PR DESCRIPTION
#### Problem
It is possible for validators to stay in sync with a cluster solely using repair. This is substantially less efficient than receiving data using turbine and most likely indicates network related misconfiguration. Misconfigured nodes generating substantial repair traffic skews metric data.

#### Summary of Changes
Maintain slot repair history and generate warnings if a node appears to be excessively repairing slots while indicating that it is "caught up" with the cluster.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
