### PR TITLE
[docs] clarified `jsonParsed` fallback encoding for `simulateTransaction`

### DIFF
--- a/docs/src/api/methods/_simulateTransaction.mdx
+++ b/docs/src/api/methods/_simulateTransaction.mdx
@@ -88,8 +88,8 @@ encoding for returned Account data
 
 - `jsonParsed` encoding attempts to use program-specific state
   parsers to return more human-readable and explicit account state data.
-- If `jsonParsed` is requested but a parser cannot be found, the field falls
-  back to binary encoding, detectable when the `data` field is type `string`.
+- If `jsonParsed` is requested but a [parser cannot be found](https://github.com/solana-labs/solana/blob/cfd0a00ae2ba85a6d76757df8b4fa38ed242d185/account-decoder/src/parse_account_data.rs#L98-L100), the field falls
+  back to `base64` encoding, detectable when the returned `accounts.data` field is type `string`.
 
 </details>
 


### PR DESCRIPTION
#### Problem

The `simulateTransaction` rpc method docs are unclear about which accounts encoding will be the fallback for `jsonParsed`

#### Summary of Changes

Corrected docs to state the correct fallback encoding of `base64` as the [fallback encoding](https://github.com/solana-labs/solana/blob/cfd0a00ae2ba85a6d76757df8b4fa38ed242d185/rpc/src/rpc.rs#L3763-L3765) when [no json parser was found](https://github.com/solana-labs/solana/blob/cfd0a00ae2ba85a6d76757df8b4fa38ed242d185/account-decoder/src/parse_account_data.rs#L98-L100).

Fixes #32964
