### PR TITLE
Unhides fastboot cli arg

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1245,7 +1245,6 @@ fn main() {
     let use_snapshot_archives_at_startup =
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
-            .hidden(hidden_unless_forced())
             .takes_value(true)
             .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
             .default_value(use_snapshot_archives_at_startup::cli::default_value())

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -305,7 +305,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
                 .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
-                .hidden(hidden_unless_forced())
                 .takes_value(true)
                 .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
                 .default_value(use_snapshot_archives_at_startup::cli::default_value())


### PR DESCRIPTION
#### Problem

The fastboot CLI arg, `--use-snapshot-archives-at-startup`, is currently hidden. It should be stable enough for node operators to start experimenting with.


#### Summary of Changes

Unhide the CLI arg for both ledger-tool and validator.