### PR TITLE
Adds default info to cli arg for --accounts-hash-cache-path

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1150,10 +1150,7 @@ fn main() {
         .long("accounts-hash-cache-path")
         .value_name("PATH")
         .takes_value(true)
-        .help("Use PATH as accounts hash cache location")
-        .long_help(
-            "Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]",
-        );
+        .help("Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]");
     let accounts_index_path_arg = Arg::with_name("accounts_index_path")
         .long("accounts-index-path")
         .value_name("PATH")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -293,8 +293,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("accounts-hash-cache-path")
                 .value_name("PATH")
                 .takes_value(true)
-                .help("Use PATH as accounts hash cache location")
-                .long_help("Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]"),
+                .help("Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]"),
         )
         .arg(
             Arg::with_name("snapshots")


### PR DESCRIPTION
#### Problem

The accounts hash cache path CLI arg does not inform the user what it's default value is.


#### Summary of Changes

Add default info.

Note, this PR is simple/minimal on purpose for ease of backporting. I'll do a subsequent PR to better generate the default string using `AccountsDb::DEFAULT_ACCOUNTS_HASH_CACHE_DIR`. (See https://github.com/solana-labs/solana/pull/33117#discussion_r1313713591 for more context.)