### PR TITLE
[sdk] Add a length restriction on poseidon hash input

### DIFF
--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -4,6 +4,9 @@
 
 use thiserror::Error;
 
+/// BN254 base field bytes.
+pub const BN254_FIELD_BYTES: usize = 32;
+
 /// Length of Poseidon hash result.
 pub const HASH_BYTES: usize = 32;
 
@@ -231,6 +234,10 @@ pub fn hashv(
                     } => PoseidonSyscallError::InvalidWidthCircom,
                 }
             }
+        }
+
+        if vals.iter().any(|val| val.len() > BN254_FIELD_BYTES) {
+            return Err(PoseidonSyscallError::InputLargerThanModulus);
         }
 
         let mut hasher =


### PR DESCRIPTION
#### Problem
The newly added poseidon hash syscall (https://github.com/solana-labs/solana/pull/32680) performs a length check on the number of slice inputs to the function ([here](https://github.com/solana-labs/solana/blob/master/programs/bpf_loader/src/syscalls/mod.rs#L1844)) but not on the length of the slice. The assigned compute units for the hash function is also independent of the length of the slice inputs. 

Consider invoking the poseidon hash syscall on a very long input. If the function is invoked in the `LittleEndian` setting, then this is fine since the slices will immediately fail to be converted to a valid field element ([here](https://github.com/Lightprotocol/light-poseidon/blob/main/light-poseidon/src/lib.rs#L420)).

However, if the function is invoked in the `BigEndian` setting, then the bytes are reversed ([here](https://github.com/Lightprotocol/light-poseidon/blob/main/light-poseidon/src/lib.rs#L436)) before they are converted into a field element, which takes `O(n)` time. This creates a risk for potential ddos since the compute units do not account for this linear time operation.

#### Summary of Changes
Added a length check on the input slices before the hash function is invoked.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
