### PR TITLE
use bytemuck for disk bucket restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5417,6 +5417,7 @@ name = "solana-bucket-map"
 version = "1.17.0"
 dependencies = [
  "bv",
+ "bytemuck",
  "fs_extra",
  "log",
  "memmap2",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
+bytemuck = { workspace = true, features = ["derive"] }
 log = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4643,6 +4643,7 @@ name = "solana-bucket-map"
 version = "1.17.0"
 dependencies = [
  "bv",
+ "bytemuck",
  "log",
  "memmap2",
  "modular-bitfield",


### PR DESCRIPTION
#### Problem
Speeding up restart.
Reusing disk index files on start.

#### Summary of Changes
Use bytemuck for manipulations.
Improve test.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
