### PR TITLE
pass RestartableBucket through disk index

### DIFF
--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bucket::Bucket, bucket_item::BucketItem, bucket_map::BucketMapError,
-        bucket_stats::BucketMapStats, MaxSearch, RefCount,
+        bucket_stats::BucketMapStats, restart::RestartableBucket, MaxSearch, RefCount,
     },
     solana_sdk::pubkey::Pubkey,
     std::{
@@ -23,6 +23,11 @@ pub struct BucketApi<T: Clone + Copy + PartialEq + 'static> {
 
     bucket: LockedBucket<T>,
     count: Arc<AtomicU64>,
+
+    /// keeps track of which index file this bucket is currently using
+    /// or at startup, which bucket file this bucket should initially use
+    #[allow(dead_code)]
+    restartable_bucket: RestartableBucket,
 }
 
 impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
@@ -30,6 +35,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
         drives: Arc<Vec<PathBuf>>,
         max_search: MaxSearch,
         stats: Arc<BucketMapStats>,
+        restartable_bucket: RestartableBucket,
     ) -> Self {
         Self {
             drives,
@@ -37,6 +43,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
             stats,
             bucket: RwLock::default(),
             count: Arc::default(),
+            restartable_bucket,
         }
     }
 


### PR DESCRIPTION
#### Problem
working on speeding up startup
Reusing disk index files on restart.

#### Summary of Changes
Staging to prepare for each disk bucket to know the `RestartableBucket` we are keeping track of at runtime and we will reuse at startup.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
