### PR TITLE
Remove entry shuffling

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -390,7 +390,6 @@ fn bench_banking_stage_multi_programs_with_voting(bencher: &mut Bencher) {
 }
 
 fn simulate_process_entries(
-    randomize_txs: bool,
     mint_keypair: &Keypair,
     mut tx_vector: Vec<VersionedTransaction>,
     genesis_config: &GenesisConfig,
@@ -423,10 +422,11 @@ fn simulate_process_entries(
         hash: next_hash(&bank.last_blockhash(), 1, &tx_vector),
         transactions: tx_vector,
     };
-    process_entries_for_tests(&bank, vec![entry], randomize_txs, None, None).unwrap();
+    process_entries_for_tests(&bank, vec![entry], None, None).unwrap();
 }
 
-fn bench_process_entries(randomize_txs: bool, bencher: &mut Bencher) {
+#[bench]
+fn bench_process_entries(bencher: &mut Bencher) {
     // entropy multiplier should be big enough to provide sufficient entropy
     // but small enough to not take too much time while executing the test.
     let entropy_multiplier: usize = 25;
@@ -446,7 +446,6 @@ fn bench_process_entries(randomize_txs: bool, bencher: &mut Bencher) {
 
     bencher.iter(|| {
         simulate_process_entries(
-            randomize_txs,
             &mint_keypair,
             tx_vector.clone(),
             &genesis_config,
@@ -455,14 +454,4 @@ fn bench_process_entries(randomize_txs: bool, bencher: &mut Bencher) {
             num_accounts,
         );
     });
-}
-
-#[bench]
-fn bench_process_entries_without_order_shuffeling(bencher: &mut Bencher) {
-    bench_process_entries(false, bencher);
-}
-
-#[bench]
-fn bench_process_entries_with_order_shuffeling(bencher: &mut Bencher) {
-    bench_process_entries(true, bencher);
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4599,7 +4599,6 @@ pub fn populate_blockstore_for_tests(
         solana_ledger::blockstore_processor::process_entries_for_tests(
             &bank,
             entries,
-            true,
             Some(
                 &solana_ledger::blockstore_processor::TransactionStatusSender {
                     sender: transaction_status_sender,


### PR DESCRIPTION
#### Problem
We currently randomly shuffle transaction order in our entries during replay.
We want to relax constraints on entries to allow for conflicting transactions within entries.
We cannot do that if we are shuffling, because it would potentially re-order conflicting transactions, and lead to non-deterministic output.

#### Summary of Changes
Remove entry transaction shuffling

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
