### PR TITLE
data bucket holds RestartableBucket

### DIFF
--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -97,6 +97,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
                 self.max_search,
                 Arc::clone(&self.stats),
                 Arc::clone(&self.count),
+                self.restartable_bucket.clone(),
             ));
         }
     }


### PR DESCRIPTION
#### Problem
Working on speeding up startup.
Making generate index re-use disk index files on restart.

#### Summary of Changes
each index bucket holds onto a RestartableBucket, which helps it keep track of which file is in use.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
