### PR TITLE
Add --release-with-debug option to cargo-install-all.sh

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -35,7 +35,7 @@ EOF
 
 maybeRustVersion=
 installDir=
-# buildProfileArg and buildProfile duplicate some information because cargo 
+# buildProfileArg and buildProfile duplicate some information because cargo
 # doesn't allow '--profile debug' but we still need to know that the binaries
 # will be in target/debug
 buildProfileArg='--profile release'

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -28,7 +28,7 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [+<cargo version>] [--debug] [--validator-only] [--canary] <install directory>
+usage: $0 [+<cargo version>] [--debug] [--validator-only] [--release-with-debug] <install directory>
 EOF
   exit $exitcode
 }
@@ -48,7 +48,7 @@ while [[ -n $1 ]]; do
       buildProfileArg=      # the default cargo profile is 'debug'
       buildProfile='debug'
       shift
-    elif [[ $1 = --canary ]]; then
+    elif [[ $1 = --release-with-debug ]]; then
       buildProfileArg='--profile release-with-debug'
       buildProfile='release-with-debug'
       shift

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -40,7 +40,6 @@ installDir=
 # will be in target/debug
 buildProfileArg='--profile release'
 buildProfile='release'
-maybeRustFlags=
 validatorOnly=
 
 while [[ -n $1 ]]; do
@@ -52,7 +51,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --canary ]]; then
       buildProfileArg='--profile release-with-debug'
       buildProfile='release-with-debug'
-      maybeRustFlags='-C debug-assertions'
       shift
     elif [[ $1 = --validator-only ]]; then
       validatorOnly=true
@@ -147,7 +145,7 @@ mkdir -p "$installDir/bin"
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  RUSTFLAGS=$maybeRustFlags "$cargo" $maybeRustVersion build $buildProfileArg "${binArgs[@]}"
+  "$cargo" $maybeRustVersion build $buildProfileArg "${binArgs[@]}"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then


### PR DESCRIPTION
#### Problem
Canaries use the release build, which limits debugging options

#### Summary of Changes
Add a --release-with-debug option that uses the release-with-debug profile. The canaries will use this via a corresponding change in cluster-ops scripts.

To see a sample run check out `mce1:~/build-artifacts/`