### PR TITLE
diskidx: stats for created vs reused

### DIFF
--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -226,6 +226,34 @@ impl BucketMapHolderStats {
         // sum of elapsed time in each thread
         let mut thread_time_elapsed_ms = elapsed_ms * storage.threads as u64;
         if disk.is_some() {
+            if startup || was_startup {
+                // these stats only apply at startup
+                datapoint_info!(
+                    "accounts_index_startup",
+                    (
+                        "entries_created",
+                        disk.map(|disk| disk
+                            .stats
+                            .index
+                            .startup
+                            .entries_created
+                            .swap(0, Ordering::Relaxed))
+                            .unwrap_or_default(),
+                        i64
+                    ),
+                    (
+                        "entries_reused",
+                        disk.map(|disk| disk
+                            .stats
+                            .index
+                            .startup
+                            .entries_reused
+                            .swap(0, Ordering::Relaxed))
+                            .unwrap_or_default(),
+                        i64
+                    ),
+                );
+            }
             datapoint_info!(
                 if startup || was_startup {
                     thread_time_elapsed_ms *= 2; // more threads are allocated during startup

--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -4,6 +4,12 @@ use std::sync::{
 };
 
 #[derive(Debug, Default)]
+pub struct StartupBucketStats {
+    pub entries_created: AtomicU64,
+    pub entries_reused: AtomicU64,
+}
+
+#[derive(Debug, Default)]
 pub struct BucketStats {
     pub resizes: AtomicU64,
     pub failed_resizes: AtomicU64,
@@ -15,6 +21,7 @@ pub struct BucketStats {
     pub find_index_entry_mut_us: AtomicU64,
     pub file_count: AtomicU64,
     pub total_file_size: AtomicU64,
+    pub startup: StartupBucketStats,
 }
 
 impl BucketStats {


### PR DESCRIPTION
#### Problem
Speeding up startup.
Re-using index files on startup.

#### Summary of Changes
Add stats for how many startup index entries were re-used vs created.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
