### PR TITLE
Fix CLI help text for `solana stake-account`

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -710,7 +710,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("csv")
                         .long("csv")
                         .takes_value(false)
-                        .help("Format stake account data in csv")
+                        .help("Format stake rewards data in csv")
                 )
                 .arg(
                     Arg::with_name("num_rewards_epochs")


### PR DESCRIPTION
#### Problem

Help text is wrong for --csv option.

#### Summary of Changes

Change accounts -> rewards.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
