### PR TITLE
disk idx: try to reuse disk index's exisiting data on startup

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -414,10 +414,9 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         // pop one entry at a time to insert
         'outer: while let Some((ix_entry_raw, ix)) = reverse_sorted_entries.pop() {
             let (k, v) = &items[ix];
-            let ix_entry = ix_entry_raw % cap;
             // search for an empty spot starting at `ix_entry`
             for search in 0..search_end {
-                let ix_index = (ix_entry + search) % cap;
+                let ix_index = (ix_entry_raw + search) % cap;
                 let elem = IndexEntryPlaceInBucket::new(ix_index);
                 match elem.occupy_if_matches(index, v, k) {
                     OccupyIfMatches::SuccessfulInit => {}
@@ -1055,8 +1054,6 @@ mod tests {
             let cap = index.capacity();
             let ix = hashed[0].0 % cap;
 
-            // occupy the index data entry with same pubkey, different value.
-            // This causes it to be treated as a duplicate.
             let entry = IndexEntryPlaceInBucket::new(ix);
 
             // file is blank, so nothing matches, so everything returned in `hashed` to retry.
@@ -1168,8 +1165,8 @@ mod tests {
         let cap = index.capacity();
         let ix = hashed[0].0 % cap;
 
-        // occupy the index data entry with same pubkey, different value.
-        // This causes it to be treated as a duplicate.
+        // occupy the index data entry with a different pubkey
+        // This causes it to be skipped.
         let entry = IndexEntryPlaceInBucket::new(ix);
         entry.init(&mut index, &(other.0));
         let entry = IndexEntryPlaceInBucket::new(ix + 1);
@@ -1221,8 +1218,8 @@ mod tests {
         let cap = index.capacity();
         let ix = hashed[0].0 % cap;
 
-        // occupy the index data entry with same pubkey, different value.
-        // This causes it to be treated as a duplicate.
+        // occupy the index data entry with a different pubkey
+        // This causes it to be skipped.
         let entry = IndexEntryPlaceInBucket::new(ix);
         entry.init(&mut index, &(other.0));
         let entry = IndexEntryPlaceInBucket::new(ix + 1);

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -1003,7 +1003,9 @@ mod tests {
                     );
                     assert_eq!(entries_created, hashed_raw.len());
                 } else if reuse_type == 2 {
-                    // just overwrite all data instead of trying to reuse it
+                    // call the higher level fn
+                    // That fn will call batch_insert_non_duplicates_reusing_file.
+                    // The inner fn should insert everything, reusing data, so there should be no entries created.
                     let mut entries_created = 0;
                     _ = Bucket::<u64>::batch_insert_non_duplicates_internal(
                         &mut index,

--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -1,5 +1,4 @@
 //! Persistent info of disk index files to allow files to be reused on restart.
-#![allow(dead_code)]
 use {
     crate::bucket_map::{BucketMapConfig, MAX_SEARCH_DEFAULT},
     bytemuck::{Pod, Zeroable},


### PR DESCRIPTION
#### Problem
Speeding up startup.
Re-using index files on startup.

#### Summary of Changes
Now that we can re-use an individual file. Try to re-use the data already in the file while generating the index. This means instead of writing new data (over data initialized to 0), we look for data in the file to see if it already matches what we would write. 99.9% of the time it will match and we can just re-use the existing file contents.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
