### PR TITLE
[feature-id] add poseidon compression syscall feature id

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -558,7 +558,7 @@ pub mod enable_alt_bn128_syscall {
     solana_sdk::declare_id!("A16q37opZdQMCbe5qJ6xpBB9usykfv8jZaMkxvZQi4GJ");
 }
 pub mod enable_alt_bn128_compression_syscall {
-    solana_sdk::declare_id!("Compression111111111111111111111111111111111");
+    solana_sdk::declare_id!("EJJewYSddEEtSZHiqugnvhQHiWyZKjkFDQASd7oKSagn");
 }
 
 pub mod enable_program_redeployment_cooldown {


### PR DESCRIPTION
#### Problem
The altbn128 compression syscalls (https://github.com/solana-labs/solana/pull/32870) are just added, but there is no feature id added yet. 

#### Summary of Changes
Added feature id.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
