### PR TITLE
docs: updating systemd command

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -374,7 +374,7 @@ the validator as expected. Don't forget to mark it executable with `chmod +x /ho
 Start the service with:
 
 ```bash
-$ sudo systemctl enable --now sol
+sudo systemctl enable --now sol
 ```
 
 ### Logging


### PR DESCRIPTION
#### Problem

There's a `$` in the `systemctl enable` command. When copying the command from [here](https://docs.solana.com/running-validator/validator-start#systemd-unit), it's not pasteable in the terminal as the `$` gets copied.

#### Summary of Changes

Remove the `$` out of the command
