### PR TITLE
Bump solana_rbpf to v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,9 +7607,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08e812351a5c726e51fa6aaae8687c661acfeb9a8b651bd58fc413a58701a58"
+checksum = "103318aa365ff7caa8cf534f2246b5eb7e5b34668736d52b1266b143f7a21196"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ siphasher = "0.3.11"
 smpl_jwt = "0.7.1"
 socket2 = "0.5.4"
 soketto = "0.7"
-solana_rbpf = "=0.7.1"
+solana_rbpf = "=0.7.2"
 solana-account-decoder = { path = "account-decoder", version = "=1.17.0" }
 solana-accounts-db = { path = "accounts-db", version = "=1.17.0" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.17.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6537,9 +6537,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08e812351a5c726e51fa6aaae8687c661acfeb9a8b651bd58fc413a58701a58"
+checksum = "103318aa365ff7caa8cf534f2246b5eb7e5b34668736d52b1266b143f7a21196"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.8"
 rustversion = "1.0.14"
 serde = "1.0.112"
 serde_json = "1.0.56"
-solana_rbpf = "=0.7.1"
+solana_rbpf = "=0.7.2"
 solana-account-decoder = { path = "../../account-decoder", version = "=1.17.0" }
 solana-accounts-db = { path = "../../accounts-db", version = "=1.17.0" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.17.0" }


### PR DESCRIPTION
[solana_rbpf v0.7.2](https://github.com/solana-labs/rbpf/releases/tag/v0.7.2) was released.