### PR TITLE
dump final startup index stats only after startup is complete

### DIFF
--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -226,7 +226,7 @@ impl BucketMapHolderStats {
         // sum of elapsed time in each thread
         let mut thread_time_elapsed_ms = elapsed_ms * storage.threads as u64;
         if disk.is_some() {
-            if startup || was_startup {
+            if was_startup {
                 // these stats only apply at startup
                 datapoint_info!(
                     "accounts_index_startup",

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -369,16 +369,15 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                         items.len().saturating_sub(duplicates.len()) as u64,
                         Ordering::Relaxed,
                     );
-                    self.index.stats.startup.entries_reused.fetch_add(
+                    let stats = &self.index.stats.startup;
+                    stats.entries_reused.fetch_add(
                         items
                             .len()
                             .saturating_sub(duplicates.len())
                             .saturating_sub(entries_created_on_disk) as u64,
                         Ordering::Relaxed,
                     );
-                    self.index
-                        .stats
-                        .startup
+                    stats
                         .entries_created
                         .fetch_add(entries_created_on_disk as u64, Ordering::Relaxed);
                     return duplicates;


### PR DESCRIPTION
#### Problem
Working on speeding up startup and generate index.

#### Summary of Changes
Only dump some startup index stats after all of startup has completed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
