### PR TITLE
Create runtime-transaction crate to host transaction type for runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6897,6 +6897,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-runtime-transaction"
+version = "1.17.0"
+dependencies = [
+ "bincode",
+ "log",
+ "rand 0.8.5",
+ "rustc_version 0.4.0",
+ "solana-program-runtime",
+ "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
 name = "solana-sdk"
 version = "1.17.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ members = [
     "rpc-client-nonce-utils",
     "rpc-test",
     "runtime",
+    "runtime-transaction",
     "runtime/store-tool",
     "sdk",
     "sdk/cargo-build-bpf",
@@ -353,6 +354,7 @@ solana-rpc-client = { path = "rpc-client", version = "=1.17.0", default-features
 solana-rpc-client-api = { path = "rpc-client-api", version = "=1.17.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=1.17.0" }
 solana-runtime = { path = "runtime", version = "=1.17.0" }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=1.17.0" }
 solana-sdk = { path = "sdk", version = "=1.17.0" }
 solana-sdk-macro = { path = "sdk/macro", version = "=1.17.0" }
 solana-send-transaction-service = { path = "send-transaction-service", version = "=1.17.0" }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solana-runtime-transaction"
+description = "Solana runtime-transaction"
+documentation = "https://docs.rs/solana-runtime-transaction"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+log = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-sdk = { workspace = true }
+thiserror = { workspace = true }
+
+[lib]
+crate-type = ["lib"]
+name = "solana_runtime_transaction"
+
+[dev-dependencies]
+bincode = { workspace = true }
+rand = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+rustc_version = { workspace = true }
+
+[features]
+dev-context-only-utils = []

--- a/runtime-transaction/build.rs
+++ b/runtime-transaction/build.rs
@@ -1,0 +1,27 @@
+extern crate rustc_version;
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Copied and adapted from
+    // https://github.com/Kimundi/rustc-version-rs/blob/1d692a965f4e48a8cb72e82cda953107c0d22f47/README.md#example
+    // Licensed under Apache-2.0 + MIT
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+            // See https://github.com/solana-labs/solana/issues/11055
+            // We may be running the custom `rust-bpf-builder` toolchain,
+            // which currently needs `#![feature(proc_macro_hygiene)]` to
+            // be applied.
+            println!("cargo:rustc-cfg=RUSTC_NEEDS_PROC_MACRO_HYGIENE");
+        }
+    }
+}

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#![allow(clippy::arithmetic_side_effects)]
+
+pub mod runtime_transaction;
+pub(crate) mod simple_vote_transaction_checker;
+pub mod transaction_meta;

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -1,0 +1,72 @@
+use {
+    crate::{
+        simple_vote_transaction_checker::is_simple_vote_transaction, transaction_meta::TransactionMeta,
+    },
+    solana_sdk::{
+        hash::Hash,
+        message::{
+            v0::{self},
+            AddressLoader, LegacyMessage, SanitizedMessage, SanitizedVersionedMessage,
+            VersionedMessage,
+        },
+        signature::Signature,
+        transaction::{MessageHash, Result, SanitizedVersionedTransaction},
+    },
+};
+
+/// RuntimeTransaction is runtime face representation of transaction, as
+/// SanitizedTransaction is client facing rep.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RuntimeTransaction {
+    message: SanitizedMessage,
+    message_hash: Hash,
+    signatures: Vec<Signature>,
+    transaction_meta: TransactionMeta,
+}
+
+impl RuntimeTransaction {
+    /// Create a runtime transaction from a sanitized versioend transaction,
+    /// then load account addresses from address-lookup-table if apply, and
+    /// populate transaction metadata.
+    pub fn try_new(
+        // Note: transaction sanitization is a function of `sdk` that is shared
+        // by both runtime and client.
+        sanitized_versioned_tx: SanitizedVersionedTransaction,
+        message_hash: impl Into<MessageHash>,
+        is_simple_vote_tx: Option<bool>,
+        address_loader: impl AddressLoader,
+    ) -> Result<Self> {
+        // metadata can be lazily updated alone transaction's execution path
+        let mut transaction_meta = TransactionMeta::default();
+        transaction_meta.set_is_simple_vote_tx(is_simple_vote_tx.unwrap_or_else(|| {
+            is_simple_vote_transaction(&sanitized_versioned_tx)
+        }));
+
+        let signatures = sanitized_versioned_tx.signatures;
+
+        let SanitizedVersionedMessage { message } = sanitized_versioned_tx.message;
+
+        let message_hash = match message_hash.into() {
+            MessageHash::Compute => message.hash(),
+            MessageHash::Precomputed(hash) => hash,
+        };
+
+        let message = match message {
+            VersionedMessage::Legacy(message) => {
+                SanitizedMessage::Legacy(LegacyMessage::new(message))
+            }
+            VersionedMessage::V0(message) => {
+                let loaded_addresses =
+                    address_loader.load_addresses(&message.address_table_lookups)?;
+                SanitizedMessage::V0(v0::LoadedMessage::new(message, loaded_addresses))
+            }
+        };
+
+        Ok(Self {
+            message,
+            message_hash,
+            signatures,
+            transaction_meta,
+        })
+    }
+}

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -5,68 +5,160 @@ use {
     solana_sdk::{
         hash::Hash,
         message::{
-            v0::{self},
-            AddressLoader, LegacyMessage, SanitizedMessage, SanitizedVersionedMessage,
-            VersionedMessage,
+            AddressLoader, SanitizedMessage, SanitizedVersionedMessage,
         },
         signature::Signature,
-        transaction::{MessageHash, Result, SanitizedVersionedTransaction},
+        transaction::{Result, SanitizedVersionedTransaction},
     },
 };
 
 /// RuntimeTransaction is runtime face representation of transaction, as
 /// SanitizedTransaction is client facing rep.
+/// The lifetime of RuntimeTransaction within banking_stage is roughly this: 
+/// 1. Receive `packet` from sigverify, deserialize it into i`solana_sdk::VersioedTransaction`
+/// 2. sanitize into `solana_sdk::SanitizedVersionedTransaction`
+/// 3. create `RuntimeTransaction` from it, which does:
+///    3.1 sets `RuntimeMessage` to `StaticallyLoaded` state
+///    3.2 extracts static meta: message hash, simple vote flag, compute budget limits, payer account etc
+///        Perhaps evencalculates transaction cost at this point (need upgrade cost-model a bit)
+/// 4. banking_stage/scheduler process `RuntimeTransaction` with its static metadata, untill when
+///    it becomes necessary to call `load_addresses(...)` load accounts address from on-chain ALT
+///    4.1 `RuntimeMessage` transits to `DynamicallyLoaded` state
+///    4.2 extracts dynamic metadata, such as nonce account etc
+/// 5. `RuntimeTransaction` is ready for "load_and_execute"
+///
+
+/// runtime message has two stats:
+/// 1. Initial state when message
+/// is created from solana_sdk::SanitizedVersionedTransaction,
+/// which is a super-light-wieghted op; During this state,
+/// static metadata (eg those solely based on message itself)
+/// can be cheaply resolved and used.
+/// 2. DynamicallyLoaded state is when account addresses loaded from on-chain
+/// address-lookup-table, a operation involves loading accounts from
+/// accounts db, deserialize accounts' data. During this state,
+/// accounts related metadata can be resolved, such as Nonce account,
+/// transaction costs, and transaction (base) fee
+///
+/// Following events can transit runtime message from Initial state to DynamicallyLoaded state:
+/// 1. `pub fn load_addresses(address_loader)` is called, or
+///
+/// New Error:
+/// If Getter of account-based metadata is called while in Initial state,
+/// a new Error shall return to indicate RuntimeTransaction is not
+/// furnished with necessary data yet.
+///
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub enum RuntimeMessage {
+    #[default]
+    Uninitialized,
+    StaticallyLoaded(SanitizedVersionedMessage),
+    DynamicallyLoaded(SanitizedMessage),
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RuntimeTransaction {
-    message: SanitizedMessage,
-    message_hash: Hash,
+    // sanitized signatures
     signatures: Vec<Signature>,
-    transaction_meta: TransactionMeta,
+
+    // sanitized message that can be in static/dynamic state
+    message: RuntimeMessage,
+
+    // transaction meta is a collection of fields, it is updated
+    // during message state transition
+    meta: TransactionMeta,
+}
+
+impl Default for RuntimeTransaction {
+    fn default() -> Self {
+        Self {
+            signatures: vec![],
+            message: RuntimeMessage::Uninitialized,
+            meta: TransactionMeta::default(),
+        }
+    }
 }
 
 impl RuntimeTransaction {
-    /// Create a runtime transaction from a sanitized versioend transaction,
-    /// then load account addresses from address-lookup-table if apply, and
-    /// populate transaction metadata.
-    pub fn try_new(
-        // Note: transaction sanitization is a function of `sdk` that is shared
-        // by both runtime and client.
+    pub fn try_from(
         sanitized_versioned_tx: SanitizedVersionedTransaction,
-        message_hash: impl Into<MessageHash>,
+        message_hash: Option<Hash>,
         is_simple_vote_tx: Option<bool>,
-        address_loader: impl AddressLoader,
     ) -> Result<Self> {
-        // metadata can be lazily updated alone transaction's execution path
-        let mut transaction_meta = TransactionMeta::default();
-        transaction_meta.set_is_simple_vote_tx(is_simple_vote_tx.unwrap_or_else(|| {
+        let mut tx = RuntimeTransaction::default();
+        tx.to_statically_loaded(sanitized_versioned_tx, message_hash, is_simple_vote_tx)?;
+        Ok(tx)
+    }
+
+    // transit from Uninitialized to StaticallyLoaded state, where static metadata are available
+    pub fn to_statically_loaded(
+        &mut self,
+        sanitized_versioned_tx: SanitizedVersionedTransaction,
+        message_hash: Option<Hash>,
+        is_simple_vote_tx: Option<bool>,
+    ) -> Result<()> {
+        if let RuntimeMessage::Uninitialized = self.message {
+            self.load_static_metadata(&sanitized_versioned_tx, message_hash, is_simple_vote_tx)?;
+            self.signatures = sanitized_versioned_tx.signatures;
+            self.message = RuntimeMessage::StaticallyLoaded(sanitized_versioned_tx.message);
+        } else {
+            todo!();
+        }
+        Ok(())
+    }
+    
+    pub fn to_dynamically_loaded(
+        &mut self,
+        address_loader: impl AddressLoader,
+    ) -> Result<()> {
+        let message = std::mem::take(&mut self.message);
+        if let RuntimeMessage::StaticallyLoaded(sanitized_versioned_message) = message {
+            // load dynamic address accounts
+            let sanitized_message = SanitizedMessage::try_new(sanitized_versioned_message, address_loader)?;
+            let _ = std::mem::replace(&mut self.message, RuntimeMessage::DynamicallyLoaded(sanitized_message));
+            self.load_dynamic_metadata()?;
+        } else {
+            todo!();
+        }
+        Ok(())
+    }
+
+    // Getter
+    pub fn get_message_hash(&self) -> &Hash {
+        if let RuntimeMessage::Uninitialized = self.message {
+            panic!("Runtime transaction is uninitialized");
+        }
+        &self.meta.message_hash
+    }
+
+    pub fn get_is_simple_vote_tx(&self) -> bool {
+        if let RuntimeMessage::Uninitialized = self.message {
+            panic!("Runtime transaction is uninitialized");
+        }
+        self.meta.is_simple_vote_tx
+    }
+
+
+    // private helpers
+    fn load_static_metadata(
+        &mut self,
+        sanitized_versioned_tx: &SanitizedVersionedTransaction,
+        message_hash: Option<Hash>,
+        is_simple_vote_tx: Option<bool>,
+    ) ->Result<()> {
+        self.meta.set_is_simple_vote_tx(is_simple_vote_tx.unwrap_or_else(|| {
             is_simple_vote_transaction(&sanitized_versioned_tx)
         }));
+        self.meta.set_message_hash(message_hash.unwrap_or_else(|| {
+            sanitized_versioned_tx.message.message.hash()
+        }));
 
-        let signatures = sanitized_versioned_tx.signatures;
+        Ok(())
+    }
 
-        let SanitizedVersionedMessage { message } = sanitized_versioned_tx.message;
-
-        let message_hash = match message_hash.into() {
-            MessageHash::Compute => message.hash(),
-            MessageHash::Precomputed(hash) => hash,
-        };
-
-        let message = match message {
-            VersionedMessage::Legacy(message) => {
-                SanitizedMessage::Legacy(LegacyMessage::new(message))
-            }
-            VersionedMessage::V0(message) => {
-                let loaded_addresses =
-                    address_loader.load_addresses(&message.address_table_lookups)?;
-                SanitizedMessage::V0(v0::LoadedMessage::new(message, loaded_addresses))
-            }
-        };
-
-        Ok(Self {
-            message,
-            message_hash,
-            signatures,
-            transaction_meta,
-        })
+    fn load_dynamic_metadata(
+        &mut self,
+    ) -> Result<()> {
+        Ok(())
     }
 }

--- a/runtime-transaction/src/simple_vote_transaction_checker.rs
+++ b/runtime-transaction/src/simple_vote_transaction_checker.rs
@@ -1,0 +1,26 @@
+use solana_sdk::{message::VersionedMessage, transaction::SanitizedVersionedTransaction};
+
+/// Simple vote transaction meets these conditions:
+/// 1. has 1 or 2 signatures;
+/// 2. is legacy message;
+/// 3. has only one instruction;
+/// 4. which must be Vote insutrction;
+pub(crate) fn is_simple_vote_transaction(
+    sanitized_versioned_transaction: &SanitizedVersionedTransaction,
+) -> bool {
+    let signatures_count = sanitized_versioned_transaction.signatures.len();
+    let is_legacy_message = matches!(
+        sanitized_versioned_transaction.message.message,
+        VersionedMessage::Legacy(_)
+    );
+    let mut instructions = sanitized_versioned_transaction
+        .message
+        .program_instructions_iter();
+    signatures_count < 3
+        && is_legacy_message
+        && instructions
+            .next()
+            .xor(instructions.next())
+            .map(|(program_id, _ix)| program_id == &solana_sdk::vote::program::id())
+            .unwrap_or(false)
+}

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -1,0 +1,17 @@
+//! Transaction Meta contains data that follows a transaction through the
+//! execution pipeline in runtime. Metadata can include limits specified by
+//! compute-budget instructions, simple-vote flag, transactino costs,
+//! durable nonce account etc; Metadata can be lazily populated as
+//! transaction goes through execution path.
+//!
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransactionMeta {
+    pub is_simple_vote_tx: bool,
+}
+
+impl TransactionMeta {
+    pub fn set_is_simple_vote_tx(&mut self, is_simple_vote_tx: bool) {
+        self.is_simple_vote_tx = is_simple_vote_tx;
+    }
+}

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -5,12 +5,21 @@
 //! transaction goes through execution path.
 //!
 
+use {
+    solana_sdk::hash::Hash,
+};
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TransactionMeta {
+    pub message_hash: Hash,
     pub is_simple_vote_tx: bool,
 }
 
 impl TransactionMeta {
+    pub fn set_message_hash(&mut self, message_hash: Hash) {
+        self.message_hash = message_hash;
+    }
+
     pub fn set_is_simple_vote_tx(&mut self, is_simple_vote_tx: bool) {
         self.is_simple_vote_tx = is_simple_vote_tx;
     }

--- a/sdk/src/transaction/versioned/sanitized.rs
+++ b/sdk/src/transaction/versioned/sanitized.rs
@@ -8,9 +8,9 @@ use {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SanitizedVersionedTransaction {
     /// List of signatures
-    pub(crate) signatures: Vec<Signature>,
+    pub signatures: Vec<Signature>,
     /// Message to sign.
-    pub(crate) message: SanitizedVersionedMessage,
+    pub message: SanitizedVersionedMessage,
 }
 
 impl TryFrom<VersionedTransaction> for SanitizedVersionedTransaction {


### PR DESCRIPTION
#### Problem

Add a transaction type for runtime that contains encapsulated internal metadata, which can be accessed/updated as sanitized transaction goes through execution pipeline.

#### Summary of Changes
- create a crate for runtime-transaction type to reduce dependencies
- add `RuntimeTransaction` struct that can be built from `sdk::SanitizedVersionedTransaction`
- add `TransactionMeta` currently only has `is_simple_vote_tx` flag to match `sdk::SanitizedTransaction`. Will be expanded later (see comment)
- add helper function `is_simple_vote_transaction(...)` 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
