### PR TITLE
Cleanup select_vote_and_reset_forks()

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3441,10 +3441,11 @@ impl ReplayStage {
         //    switch_threshold succeeds
         let mut failure_reasons = vec![];
         struct CandidateVoteAndResetBanks<'a> {
-            // A bank that the validator will consider voting on given it passes all
+            // A bank that the validator will vote on given it passes all
             // remaining vote checks
             candidate_vote_bank: Option<&'a Arc<Bank>>,
-            // A bank that the validator will reset its PoH to
+            // A bank that the validator will reset its PoH to regardless
+            // of voting behavior
             reset_bank: Option<&'a Arc<Bank>>,
             switch_fork_decision: SwitchForkDecision,
         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3441,7 +3441,10 @@ impl ReplayStage {
         //    switch_threshold succeeds
         let mut failure_reasons = vec![];
         struct CandidateVoteAndResetBanks<'a> {
+            // A bank that the validator will consider voting on given it passes all
+            // remaining vote checks
             candidate_vote_bank: Option<&'a Arc<Bank>>,
+            // A bank that the validator will reset its PoH to
             reset_bank: Option<&'a Arc<Bank>>,
             switch_fork_decision: SwitchForkDecision,
         }
@@ -3479,7 +3482,7 @@ impl ReplayStage {
                     };
                     CandidateVoteAndResetBanks {
                         candidate_vote_bank,
-                        reset_bank: candidate_vote_bank,
+                        reset_bank: heaviest_bank_on_same_voted_fork,
                         switch_fork_decision: final_switch_fork_decision,
                     }
                 }
@@ -3615,7 +3618,7 @@ impl ReplayStage {
             } else {
                 SelectVoteAndResetForkResult {
                     vote_bank: None,
-                    reset_bank: Some(candidate_vote_bank.clone()),
+                    reset_bank: reset_bank.cloned(),
                     heaviest_fork_failures: failure_reasons,
                 }
             }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3464,9 +3464,8 @@ impl ReplayStage {
 
             match switch_fork_decision {
                 SwitchForkDecision::FailedSwitchThreshold(switch_proof_stake, total_stake) => {
-                    let candidate_vote_bank = heaviest_bank_on_same_voted_fork;
                     let final_switch_fork_decision = Self::select_forks_failed_switch_threshold(
-                        candidate_vote_bank.map(|bank| bank.as_ref()),
+                        heaviest_bank_on_same_voted_fork.map(|bank| bank.as_ref()),
                         progress,
                         tower,
                         heaviest_bank.slot(),
@@ -3476,11 +3475,11 @@ impl ReplayStage {
                         switch_fork_decision,
                     );
                     let candidate_vote_bank = if final_switch_fork_decision.can_vote() {
-                        candidate_vote_bank
-                    } else {
                         // The only time we would still vote despite `!switch_fork_decision.can_vote()`
                         // is if we switched the vote candidate to `heaviest_bank_on_same_voted_fork`
                         // because we needed to refresh the vote to the tip of our last voted fork.
+                        heaviest_bank_on_same_voted_fork
+                    } else {
                         // Otherwise,  we should just return the original vote candidate, the heaviest bank
                         // for logging purposes, namely to check if there are any additional voting failures
                         // besides the switch threshold
@@ -8194,7 +8193,10 @@ pub(crate) mod tests {
         assert_eq!(reset_fork, Some(6));
         assert_eq!(
             failures,
-            vec![HeaviestForkFailures::FailedSwitchThreshold(4, 0, 30000),]
+            vec![
+                HeaviestForkFailures::FailedSwitchThreshold(4, 0, 30000),
+                HeaviestForkFailures::LockedOut(4)
+            ]
         );
 
         let (vote_fork, reset_fork, failures) = run_compute_and_select_forks(
@@ -8210,7 +8212,10 @@ pub(crate) mod tests {
         assert_eq!(reset_fork, Some(6));
         assert_eq!(
             failures,
-            vec![HeaviestForkFailures::FailedSwitchThreshold(4, 0, 30000),]
+            vec![
+                HeaviestForkFailures::FailedSwitchThreshold(4, 0, 30000),
+                HeaviestForkFailures::LockedOut(4)
+            ]
         );
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3478,7 +3478,13 @@ impl ReplayStage {
                     let candidate_vote_bank = if final_switch_fork_decision.can_vote() {
                         candidate_vote_bank
                     } else {
-                        None
+                        // The only time we would still vote despite `!switch_fork_decision.can_vote()`
+                        // is if we switched the vote candidate to `heaviest_bank_on_same_voted_fork`
+                        // because we needed to refresh the vote to the tip of our last voted fork.
+                        // Otherwise,  we should just return the original vote candidate, the heaviest bank
+                        // for logging purposes, namely to check if there are any additional voting failures
+                        // besides the switch threshold
+                        Some(heaviest_bank)
                     };
                     CandidateVoteAndResetBanks {
                         candidate_vote_bank,


### PR DESCRIPTION
#### Problem
select_vote_and_reset_forks() logic is too complicated because the results of the switching threshold check are hard too interpret

#### Summary of Changes
Make switching threshold check result more explicit 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
