### PR TITLE
ci: Re-enable spl-stake-pool downstream job

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -128,7 +128,7 @@ jobs:
           - [governance/addin-mock/program, governance/program]
           - [memo/program]
           - [name-service/program]
-          # - [stake-pool/program]
+          - [stake-pool/program]
           - [single-pool/program]
 
     steps:


### PR DESCRIPTION
#### Problem

During the work to make the rent-exemption consistent during stake split https://github.com/solana-labs/solana/pull/33295, we needed to disable the downstream spl-stake-pool job because the program was designed around the old behavior.

#### Summary of Changes

Now that we've got all the following done:

* https://github.com/solana-labs/solana-program-library/pull/5334
* https://github.com/solana-labs/solana-program-library/pull/5288
* https://github.com/solana-labs/solana-program-library/pull/5285
* https://github.com/solana-labs/solana-program-library/pull/5322
 
The stake pool program handles the new behavior properly, so re-enable the downstream job!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->