### PR TITLE
cli: Don't skip preflight when closing a program

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1562,7 +1562,6 @@ fn close(
         &tx,
         config.commitment,
         RpcSendTransactionConfig {
-            skip_preflight: true,
             preflight_commitment: Some(config.commitment.commitment),
             ..RpcSendTransactionConfig::default()
         },


### PR DESCRIPTION
#### Problem

When closing a program, the CLI skips preflight checks on the transaction, so if there's an error, the CLI can't report a nice error.

#### Summary of Changes

Don't skip preflight checks when closing a program. If there's a good reason for the current behavior, I'll happily close the PR, but it didn't make a ton of sense to me.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
