### PR TITLE
Add error messages for BlockstoreError

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -110,21 +110,21 @@ pub enum BlockstoreError {
     ShredForIndexExists,
     #[error("invalid shred data")]
     InvalidShredData(Box<bincode::ErrorKind>),
-    #[error("RocksDB error, error: {0}")]
+    #[error("RocksDB error: {0}")]
     RocksDb(#[from] rocksdb::Error),
     #[error("slot is not rooted")]
     SlotNotRooted,
     #[error("dead slot")]
     DeadSlot,
-    #[error("io error, error: {0}")]
+    #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("serialization error, error: {0}")]
+    #[error("serialization error: {0}")]
     Serialize(#[from] Box<bincode::ErrorKind>),
-    #[error("fs extra error, error: {0}")]
+    #[error("fs extra error: {0}")]
     FsExtraError(#[from] fs_extra::error::Error),
     #[error("slot cleaned up")]
     SlotCleanedUp,
-    #[error("unpack error, error: {0}")]
+    #[error("unpack error: {0}")]
     UnpackError(#[from] UnpackError),
     #[error("unable to set open file description limit")]
     UnableToSetOpenFileDescriptorLimit,
@@ -134,9 +134,9 @@ pub enum BlockstoreError {
     EmptyEpochStakes,
     #[error("no vote timestamps in range")]
     NoVoteTimestampsInRange,
-    #[error("protobuf encode error, error: {0}")]
+    #[error("protobuf encode error: {0}")]
     ProtobufEncodeError(#[from] prost::EncodeError),
-    #[error("protobuf decode error, error: {0}")]
+    #[error("protobuf decode error: {0}")]
     ProtobufDecodeError(#[from] prost::DecodeError),
     #[error("parent entries unavailable")]
     ParentEntriesUnavailable,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -126,9 +126,9 @@ pub enum BlockstoreError {
     SlotCleanedUp,
     #[error("unpack error: {0}")]
     UnpackError(#[from] UnpackError),
-    #[error("unable to set open file description limit")]
+    #[error("unable to set open file descriptor limit")]
     UnableToSetOpenFileDescriptorLimit,
-    #[error("trnasaction status slot mismatch")]
+    #[error("transaction status slot mismatch")]
     TransactionStatusSlotMismatch,
     #[error("empty epoch stakes")]
     EmptyEpochStakes,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -106,34 +106,48 @@ const OPTIMISTIC_SLOTS_CF: &str = "optimistic_slots";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
+    #[error("shred for index exists")]
     ShredForIndexExists,
+    #[error("invalid shred data")]
     InvalidShredData(Box<bincode::ErrorKind>),
+    #[error("RocksDB error")]
     RocksDb(#[from] rocksdb::Error),
+    #[error("slot is not rooted")]
     SlotNotRooted,
+    #[error("dead slot")]
     DeadSlot,
+    #[error("io error")]
     Io(#[from] std::io::Error),
+    #[error("serialization error")]
     Serialize(#[from] Box<bincode::ErrorKind>),
+    #[error("fs extra error")]
     FsExtraError(#[from] fs_extra::error::Error),
+    #[error("slot cleaned up")]
     SlotCleanedUp,
+    #[error("unpack error")]
     UnpackError(#[from] UnpackError),
+    #[error("unable to set open file description limit")]
     UnableToSetOpenFileDescriptorLimit,
+    #[error("trnasaction status slot mismatch")]
     TransactionStatusSlotMismatch,
+    #[error("empty epoch stakes")]
     EmptyEpochStakes,
+    #[error("no vote timestamps in range")]
     NoVoteTimestampsInRange,
+    #[error("protobuf encode error")]
     ProtobufEncodeError(#[from] prost::EncodeError),
+    #[error("protobuf decode error")]
     ProtobufDecodeError(#[from] prost::DecodeError),
+    #[error("parent entries unavailable")]
     ParentEntriesUnavailable,
+    #[error("slot unavailable")]
     SlotUnavailable,
+    #[error("unsupported transaction version")]
     UnsupportedTransactionVersion,
+    #[error("missing transaction metadata")]
     MissingTransactionMetadata,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
-
-impl std::fmt::Display for BlockstoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "blockstore error")
-    }
-}
 
 pub enum IteratorMode<Index> {
     Start,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -110,21 +110,21 @@ pub enum BlockstoreError {
     ShredForIndexExists,
     #[error("invalid shred data")]
     InvalidShredData(Box<bincode::ErrorKind>),
-    #[error("RocksDB error")]
+    #[error("RocksDB error, error: {0}")]
     RocksDb(#[from] rocksdb::Error),
     #[error("slot is not rooted")]
     SlotNotRooted,
     #[error("dead slot")]
     DeadSlot,
-    #[error("io error")]
+    #[error("io error, error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("serialization error")]
+    #[error("serialization error, error: {0}")]
     Serialize(#[from] Box<bincode::ErrorKind>),
-    #[error("fs extra error")]
+    #[error("fs extra error, error: {0}")]
     FsExtraError(#[from] fs_extra::error::Error),
     #[error("slot cleaned up")]
     SlotCleanedUp,
-    #[error("unpack error")]
+    #[error("unpack error, error: {0}")]
     UnpackError(#[from] UnpackError),
     #[error("unable to set open file description limit")]
     UnableToSetOpenFileDescriptorLimit,
@@ -134,9 +134,9 @@ pub enum BlockstoreError {
     EmptyEpochStakes,
     #[error("no vote timestamps in range")]
     NoVoteTimestampsInRange,
-    #[error("protobuf encode error")]
+    #[error("protobuf encode error, error: {0}")]
     ProtobufEncodeError(#[from] prost::EncodeError),
-    #[error("protobuf decode error")]
+    #[error("protobuf decode error, error: {0}")]
     ProtobufDecodeError(#[from] prost::DecodeError),
     #[error("parent entries unavailable")]
     ParentEntriesUnavailable,


### PR DESCRIPTION
#### Problem

When `BlockstoreError` is logged, it is impossible to see the value of the particular variant of the enum.

#### Summary of Changes


