### PR TITLE
gossip test update

### DIFF
--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -99,9 +99,8 @@ where
     let exit = Arc::new(AtomicBool::new(false));
     let listen: Vec<_> = (0..num).map(|_| test_node(exit.clone())).collect();
     topo(&listen);
-    let mut done = true;
+    let mut done = false;
     for i in 0..(num * 32) {
-        done = true;
         let total: usize = listen.iter().map(|v| v.0.gossip_peers().len()).sum();
         if (total + num) * 10 > num * num * 9 {
             done = true;


### PR DESCRIPTION
#### Problem
Gossip test is setting a boolean to true at the beginning of a test and then asserting the boolean is true at the end. 

#### Summary of Changes
Set initial boolean to false. and remove extra `done = true` in first step of loop. `done` should only be set to true when network has converged.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
