### PR TITLE
ci: fix cargo files changes doens't trigger doc tests

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -151,6 +151,8 @@ all_test_steps() {
   # Docs tests
   if affects \
              .rs$ \
+             Cargo.lock$ \
+             Cargo.toml$ \
              ^ci/rust-version.sh \
              ^ci/test-docs.sh \
       ; then


### PR DESCRIPTION
#### Problem

#33437 doesn't catch doc test error 😢 

#### Summary of Changes

build doc tests when either Cargo.lock or Cargo.toml is modified