### PR TITLE
Bugfix: MultiIterator batch priority guard

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -172,7 +172,6 @@ impl Consumer {
         // Clear payload for next iteration
         payload.sanitized_transactions.clear();
         payload.account_locks.clear();
-        payload.batch_priority_guard.clear();
 
         let ProcessTransactionsSummary {
             reached_max_poh_height,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -172,6 +172,7 @@ impl Consumer {
         // Clear payload for next iteration
         payload.sanitized_transactions.clear();
         payload.account_locks.clear();
+        payload.batch_priority_guard.clear();
 
         let ProcessTransactionsSummary {
             reached_max_poh_height,
@@ -757,13 +758,17 @@ mod tests {
                 self,
                 state::{AddressLookupTable, LookupTableMeta},
             },
+            compute_budget,
             instruction::InstructionError,
-            message::{v0, v0::MessageAddressTableLookup, MessageHeader, VersionedMessage},
+            message::{
+                v0::{self, MessageAddressTableLookup},
+                Message, MessageHeader, VersionedMessage,
+            },
             poh_config::PohConfig,
             pubkey::Pubkey,
             signature::Keypair,
             signer::Signer,
-            system_transaction,
+            system_instruction, system_transaction,
             transaction::{MessageHash, Transaction, VersionedTransaction},
         },
         solana_transaction_status::{TransactionStatusMeta, VersionedTransactionWithStatusMeta},
@@ -862,10 +867,11 @@ mod tests {
         Arc<Bank>,
         Arc<RwLock<PohRecorder>>,
         Receiver<WorkingBankEntry>,
+        GenesisConfigInfo,
         JoinHandle<()>,
     ) {
         Blockstore::destroy(ledger_path).unwrap();
-        let genesis_config_info = create_slow_genesis_config(10_000);
+        let genesis_config_info = create_slow_genesis_config(100_000_000);
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -905,6 +911,7 @@ mod tests {
             bank,
             poh_recorder,
             entry_receiver,
+            genesis_config_info,
             poh_simulator,
         )
     }
@@ -1830,9 +1837,9 @@ mod tests {
     fn test_consume_buffered_packets() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
-            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator) =
+            let (transactions, bank, poh_recorder, _entry_receiver, _, poh_simulator) =
                 setup_conflicting_transactions(ledger_path.path());
-            let recorder = poh_recorder.read().unwrap().new_recorder();
+            let recorder: TransactionRecorder = poh_recorder.read().unwrap().new_recorder();
             let num_conflicting_transactions = transactions.len();
             let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
             assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
@@ -1903,7 +1910,7 @@ mod tests {
     fn test_consume_buffered_packets_sanitization_error() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
-            let (mut transactions, bank, poh_recorder, _entry_receiver, poh_simulator) =
+            let (mut transactions, bank, poh_recorder, _entry_receiver, _, poh_simulator) =
                 setup_conflicting_transactions(ledger_path.path());
             let duplicate_account_key = transactions[0].message.account_keys[0];
             transactions[0]
@@ -1959,7 +1966,7 @@ mod tests {
     fn test_consume_buffered_packets_retryable() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
-            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator) =
+            let (transactions, bank, poh_recorder, _entry_receiver, _, poh_simulator) =
                 setup_conflicting_transactions(ledger_path.path());
             let recorder = poh_recorder.read().unwrap().new_recorder();
             let num_conflicting_transactions = transactions.len();
@@ -2036,6 +2043,109 @@ mod tests {
             assert_eq!(
                 bank_start.working_bank.transaction_entries_count(),
                 num_conflicting_transactions as u64 - 1
+            );
+
+            poh_recorder
+                .read()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
+        }
+        Blockstore::destroy(ledger_path.path()).unwrap();
+    }
+
+    #[test]
+    fn test_consume_buffered_packets_batch_priority_guard() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        {
+            let (_, bank, poh_recorder, _entry_receiver, genesis_config_info, poh_simulator) =
+                setup_conflicting_transactions(ledger_path.path());
+            let recorder = poh_recorder.read().unwrap().new_recorder();
+
+            // Setup transactions:
+            // [(AB), (BC), (CD)]
+            // (AB) and (BC) are conflicting, and cannot go into the same batch.
+            // (AB) and (CD) are not conflict. However, (CD) should not be able to take locks needed by (BC).
+            let keypair_a = Keypair::new();
+            let keypair_b = Keypair::new();
+            let keypair_c = Keypair::new();
+            let keypair_d = Keypair::new();
+            for keypair in &[&keypair_a, &keypair_b, &keypair_c, &keypair_d] {
+                bank.transfer(5_000, &genesis_config_info.mint_keypair, &keypair.pubkey())
+                    .unwrap();
+            }
+
+            let make_prioritized_transfer =
+                |from: &Keypair, to, lamports, priority| -> Transaction {
+                    let ixs = vec![
+                        system_instruction::transfer(&from.pubkey(), to, lamports),
+                        compute_budget::ComputeBudgetInstruction::set_compute_unit_price(priority),
+                    ];
+                    let message = Message::new(&ixs, Some(&from.pubkey()));
+                    Transaction::new(&[from], message, bank.last_blockhash())
+                };
+
+            let transactions = vec![
+                make_prioritized_transfer(&keypair_a, &keypair_b.pubkey(), 1, 3),
+                make_prioritized_transfer(&keypair_b, &keypair_c.pubkey(), 1, 2),
+                make_prioritized_transfer(&keypair_c, &keypair_d.pubkey(), 1, 1),
+            ];
+
+            let num_conflicting_transactions = transactions.len();
+            let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
+            assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
+            let mut buffered_packet_batches =
+                UnprocessedTransactionStorage::new_transaction_storage(
+                    UnprocessedPacketBatches::from_iter(
+                        deserialized_packets,
+                        num_conflicting_transactions,
+                    ),
+                    ThreadType::Transactions,
+                );
+
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+            let committer = Committer::new(
+                None,
+                replay_vote_sender,
+                Arc::new(PrioritizationFeeCache::new(0u64)),
+            );
+            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+
+            // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
+            assert!(!poh_recorder.read().unwrap().has_bank());
+            assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
+            // When the working bank in poh_recorder is Some, all packets should be processed.
+            // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
+            poh_recorder.write().unwrap().set_bank(bank, false);
+            let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
+            let banking_stage_stats = BankingStageStats::default();
+            consumer.consume_buffered_packets(
+                &bank_start,
+                &mut buffered_packet_batches,
+                &banking_stage_stats,
+                &mut LeaderSlotMetricsTracker::new(0),
+            );
+
+            // Check that all packets were processed without retrying
+            assert!(buffered_packet_batches.is_empty());
+            assert_eq!(
+                banking_stage_stats
+                    .consumed_buffered_packets_count
+                    .load(Ordering::Relaxed),
+                num_conflicting_transactions
+            );
+            assert_eq!(
+                banking_stage_stats
+                    .rebuffered_packets_count
+                    .load(Ordering::Relaxed),
+                0
+            );
+            // Use bank to check the number of entries (batches)
+            assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
+            assert_eq!(
+                bank_start.working_bank.transaction_entries_count(),
+                4 + num_conflicting_transactions as u64 // 4 for funding transfers
             );
 
             poh_recorder

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -1,12 +1,9 @@
 use {
-    solana_sdk::{
-        message::{SanitizedMessage, VersionedMessage},
-        pubkey::Pubkey,
-    },
+    solana_sdk::{message::SanitizedMessage, pubkey::Pubkey},
     std::collections::HashSet,
 };
 
-/// Wrapper struct to check account locks for a batch of transactions.
+/// Wrapper struct to accumulate locks for a batch of transactions.
 #[derive(Debug, Default)]
 pub struct ReadWriteAccountSet {
     /// Set of accounts that are locked for read
@@ -16,66 +13,26 @@ pub struct ReadWriteAccountSet {
 }
 
 impl ReadWriteAccountSet {
-    /// Check static account locks for a transaction message.
-    pub fn check_static_account_locks(&self, message: &VersionedMessage) -> bool {
-        !message
-            .static_account_keys()
+    /// Add all account locks.
+    /// Returns true if all account locks were available and false otherwise.
+    pub fn take_locks(&mut self, message: &SanitizedMessage) -> bool {
+        message
+            .account_keys()
             .iter()
             .enumerate()
-            .any(|(index, pubkey)| {
-                if message.is_maybe_writable(index) {
-                    !self.can_write(pubkey)
+            .fold(true, |all_available, (index, pubkey)| {
+                if message.is_writable(index) {
+                    all_available & self.add_write(pubkey)
                 } else {
-                    !self.can_read(pubkey)
+                    all_available & self.add_read(pubkey)
                 }
             })
-    }
-
-    /// Check all account locks and if they are available, lock them.
-    /// Returns true if all account locks are available and false otherwise.
-    pub fn try_locking(&mut self, message: &SanitizedMessage) -> bool {
-        if self.check_sanitized_message_account_locks(message) {
-            self.add_sanitized_message_account_locks(message);
-            true
-        } else {
-            false
-        }
     }
 
     /// Clears the read and write sets
     pub fn clear(&mut self) {
         self.read_set.clear();
         self.write_set.clear();
-    }
-
-    /// Check if a sanitized message's account locks are available.
-    pub(crate) fn check_sanitized_message_account_locks(&self, message: &SanitizedMessage) -> bool {
-        !message
-            .account_keys()
-            .iter()
-            .enumerate()
-            .any(|(index, pubkey)| {
-                if message.is_writable(index) {
-                    !self.can_write(pubkey)
-                } else {
-                    !self.can_read(pubkey)
-                }
-            })
-    }
-
-    /// Insert the read and write locks for a sanitized message.
-    pub(crate) fn add_sanitized_message_account_locks(&mut self, message: &SanitizedMessage) {
-        message
-            .account_keys()
-            .iter()
-            .enumerate()
-            .for_each(|(index, pubkey)| {
-                if message.is_writable(index) {
-                    self.add_write(pubkey);
-                } else {
-                    self.add_read(pubkey);
-                }
-            });
     }
 
     /// Check if an account can be read-locked
@@ -89,15 +46,21 @@ impl ReadWriteAccountSet {
     }
 
     /// Add an account to the read-set.
-    /// Should only be called after `can_read()` returns true
-    fn add_read(&mut self, pubkey: &Pubkey) {
+    /// Returns true if the lock was available.
+    fn add_read(&mut self, pubkey: &Pubkey) -> bool {
+        let can_read = self.can_read(pubkey);
         self.read_set.insert(*pubkey);
+
+        can_read
     }
 
     /// Add an account to the write-set.
-    /// Should only be called after `can_write()` returns true
-    fn add_write(&mut self, pubkey: &Pubkey) {
+    /// Returns true if the lock was available.
+    fn add_write(&mut self, pubkey: &Pubkey) -> bool {
+        let can_write = self.can_write(pubkey);
         self.write_set.insert(*pubkey);
+
+        can_write
     }
 }
 
@@ -198,48 +161,6 @@ mod tests {
     }
 
     // Helper function (could potentially use test_case in future).
-    // conflict_index = 0 means write lock conflict
-    // conflict_index = 1 means read lock conflict
-    fn test_check_static_account_locks(conflict_index: usize, add_write: bool, expectation: bool) {
-        let message =
-            create_test_versioned_message(&[Pubkey::new_unique()], &[Pubkey::new_unique()], vec![]);
-
-        let mut account_locks = ReadWriteAccountSet::default();
-        assert!(account_locks.check_static_account_locks(&message));
-
-        let conflict_key = message.static_account_keys().get(conflict_index).unwrap();
-        if add_write {
-            account_locks.add_write(conflict_key);
-        } else {
-            account_locks.add_read(conflict_key);
-        }
-        assert_eq!(
-            expectation,
-            account_locks.check_static_account_locks(&message)
-        );
-    }
-
-    #[test]
-    fn test_check_static_account_locks_write_write_conflict() {
-        test_check_static_account_locks(0, true, false);
-    }
-
-    #[test]
-    fn test_check_static_account_locks_read_write_conflict() {
-        test_check_static_account_locks(0, false, false);
-    }
-
-    #[test]
-    fn test_check_static_account_locks_write_read_conflict() {
-        test_check_static_account_locks(1, true, false);
-    }
-
-    #[test]
-    fn test_check_static_account_locks_read_read_non_conflict() {
-        test_check_static_account_locks(1, false, true);
-    }
-
-    // Helper function (could potentially use test_case in future).
     // conflict_index = 0 means write lock conflict with static key
     // conflict_index = 1 means read lock conflict with static key
     // conflict_index = 2 means write lock conflict with address table key
@@ -264,7 +185,6 @@ mod tests {
         let message = tx.message();
 
         let mut account_locks = ReadWriteAccountSet::default();
-        assert!(account_locks.check_sanitized_message_account_locks(message));
 
         let conflict_key = message.account_keys().get(conflict_index).unwrap();
         if add_write {
@@ -272,10 +192,7 @@ mod tests {
         } else {
             account_locks.add_read(conflict_key);
         }
-        assert_eq!(
-            expectation,
-            account_locks.check_sanitized_message_account_locks(message)
-        );
+        assert_eq!(expectation, account_locks.take_locks(message));
     }
 
     #[test]

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -49,7 +49,7 @@ impl ReadWriteAccountSet {
     }
 
     /// Check if a sanitized message's account locks are available.
-    fn check_sanitized_message_account_locks(&self, message: &SanitizedMessage) -> bool {
+    pub(crate) fn check_sanitized_message_account_locks(&self, message: &SanitizedMessage) -> bool {
         !message
             .account_keys()
             .iter()
@@ -64,7 +64,7 @@ impl ReadWriteAccountSet {
     }
 
     /// Insert the read and write locks for a sanitized message.
-    fn add_sanitized_message_account_locks(&mut self, message: &SanitizedMessage) {
+    pub(crate) fn add_sanitized_message_account_locks(&mut self, message: &SanitizedMessage) {
         message
             .account_keys()
             .iter()

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -177,6 +177,9 @@ fn consume_scan_should_process_packet(
             return ProcessingDecision::Never;
         }
 
+        // Always take locks during batch creation.
+        // This prevents lower-priority transactions from taking locks
+        // needed by higher-priority txs that were skipped by this check.
         if !payload.account_locks.take_locks(message) {
             return ProcessingDecision::Later;
         }


### PR DESCRIPTION
#### Problem
Shortcoming with the current multi-iterator decision function.
Allows non-conflicting txs to take higher-priority locks.

- Take these transactions (internal nodes are accounts, edges indicate conflicts) for example:

```mermaid
graph LR
subgraph Tx1 - 3
Tx1_1(1)
style Tx1_1 fill:#CF0000
Tx1_2(2)
style Tx1_2 fill:#00CF00
end
subgraph Tx2 - 2
Tx2_2(2)
style Tx2_2 fill:#00CF00
Tx2_3(3)
style Tx2_3 fill:#0000CF
end
subgraph Tx3 - 2
Tx3_3(3)
style Tx3_3 fill:#0000CF
Tx3_4(4)
style Tx3_4 fill:#333333
end
Tx1_2 --> Tx2_2
Tx2_3 --> Tx3_3
```

- `Tx1` and `Tx2` conflict so they cannot be in a batch together
- `Tx2` and `Tx3` conflict so they cannot be in a batch together
- However, `Tx1` and `Tx3` do not conflict, so they could be in a batch together
- We do not want to allow `Tx3` to execute before `Tx2` though, since `Tx2` has higher-priority.

#### Summary of Changes
- Add a batch priority guard that prevents batch from taking locks on accounts that were previously seen during the inner iteration but were marked as `Later`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
