### PR TITLE
transaction-status: Remove conversions between spl re-exports and local sdk

### DIFF
--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -102,14 +102,10 @@ mod test {
             },
             solana_program::{
                 instruction::CompiledInstruction as SplAssociatedTokenCompiledInstruction,
-                message::Message, pubkey::Pubkey as SplAssociatedTokenPubkey, sysvar,
+                message::Message, sysvar,
             },
         },
     };
-
-    fn convert_pubkey(pubkey: Pubkey) -> SplAssociatedTokenPubkey {
-        SplAssociatedTokenPubkey::new_from_array(pubkey.to_bytes())
-    }
 
     fn convert_compiled_instruction(
         instruction: &SplAssociatedTokenCompiledInstruction,
@@ -126,14 +122,9 @@ mod test {
         let funder = Pubkey::new_unique();
         let wallet_address = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-        let associated_account_address =
-            get_associated_token_address(&convert_pubkey(wallet_address), &convert_pubkey(mint));
+        let associated_account_address = get_associated_token_address(&wallet_address, &mint);
         #[allow(deprecated)]
-        let create_ix = create_associated_token_account_deprecated(
-            &convert_pubkey(funder),
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(mint),
-        );
+        let create_ix = create_associated_token_account_deprecated(&funder, &wallet_address, &mint);
         let message = Message::new(&[create_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         let expected_parsed_ix = ParsedInstructionEnum {
@@ -187,17 +178,10 @@ mod test {
         let wallet_address = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let token_program_id = Pubkey::new_unique();
-        let associated_account_address = get_associated_token_address_with_program_id(
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(mint),
-            &convert_pubkey(token_program_id),
-        );
-        let create_ix = create_associated_token_account(
-            &convert_pubkey(funder),
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(mint),
-            &convert_pubkey(token_program_id),
-        );
+        let associated_account_address =
+            get_associated_token_address_with_program_id(&wallet_address, &mint, &token_program_id);
+        let create_ix =
+            create_associated_token_account(&funder, &wallet_address, &mint, &token_program_id);
         let message = Message::new(&[create_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -232,16 +216,13 @@ mod test {
         let wallet_address = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let token_program_id = Pubkey::new_unique();
-        let associated_account_address = get_associated_token_address_with_program_id(
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(mint),
-            &convert_pubkey(token_program_id),
-        );
+        let associated_account_address =
+            get_associated_token_address_with_program_id(&wallet_address, &mint, &token_program_id);
         let create_ix = create_associated_token_account_idempotent(
-            &convert_pubkey(funder),
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(mint),
-            &convert_pubkey(token_program_id),
+            &funder,
+            &wallet_address,
+            &mint,
+            &token_program_id,
         );
         let message = Message::new(&[create_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
@@ -278,25 +259,25 @@ mod test {
         let nested_mint = Pubkey::new_unique();
         let token_program_id = Pubkey::new_unique();
         let owner_associated_account_address = get_associated_token_address_with_program_id(
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(owner_mint),
-            &convert_pubkey(token_program_id),
+            &wallet_address,
+            &owner_mint,
+            &token_program_id,
         );
         let nested_associated_account_address = get_associated_token_address_with_program_id(
             &owner_associated_account_address,
-            &convert_pubkey(nested_mint),
-            &convert_pubkey(token_program_id),
+            &nested_mint,
+            &token_program_id,
         );
         let destination_associated_account_address = get_associated_token_address_with_program_id(
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(nested_mint),
-            &convert_pubkey(token_program_id),
+            &wallet_address,
+            &nested_mint,
+            &token_program_id,
         );
         let recover_ix = recover_nested(
-            &convert_pubkey(wallet_address),
-            &convert_pubkey(owner_mint),
-            &convert_pubkey(nested_mint),
-            &convert_pubkey(token_program_id),
+            &wallet_address,
+            &owner_mint,
+            &nested_mint,
+            &token_program_id,
         );
         let message = Message::new(&[recover_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -100,22 +100,9 @@ mod test {
                 create_associated_token_account, create_associated_token_account_idempotent,
                 recover_nested,
             },
-            solana_program::{
-                instruction::CompiledInstruction as SplAssociatedTokenCompiledInstruction,
-                message::Message, sysvar,
-            },
+            solana_program::{message::Message, sysvar},
         },
     };
-
-    fn convert_compiled_instruction(
-        instruction: &SplAssociatedTokenCompiledInstruction,
-    ) -> CompiledInstruction {
-        CompiledInstruction {
-            program_id_index: instruction.program_id_index,
-            accounts: instruction.accounts.clone(),
-            data: instruction.data.clone(),
-        }
-    }
 
     #[test]
     fn test_parse_create_deprecated() {
@@ -125,8 +112,8 @@ mod test {
         let associated_account_address = get_associated_token_address(&wallet_address, &mint);
         #[allow(deprecated)]
         let create_ix = create_associated_token_account_deprecated(&funder, &wallet_address, &mint);
-        let message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[create_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         let expected_parsed_ix = ParsedInstructionEnum {
             instruction_type: "create".to_string(),
             info: json!({
@@ -182,8 +169,8 @@ mod test {
             get_associated_token_address_with_program_id(&wallet_address, &mint, &token_program_id);
         let create_ix =
             create_associated_token_account(&funder, &wallet_address, &mint, &token_program_id);
-        let message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[create_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
@@ -224,8 +211,8 @@ mod test {
             &mint,
             &token_program_id,
         );
-        let message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[create_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
@@ -279,8 +266,8 @@ mod test {
             &nested_mint,
             &token_program_id,
         );
-        let message = Message::new(&[recover_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[recover_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -94,13 +94,13 @@ mod test {
     use spl_associated_token_account::create_associated_token_account as create_associated_token_account_deprecated;
     use {
         super::*,
+        solana_sdk::{message::Message, sysvar},
         spl_associated_token_account::{
             get_associated_token_address, get_associated_token_address_with_program_id,
             instruction::{
                 create_associated_token_account, create_associated_token_account_idempotent,
                 recover_nested,
             },
-            solana_program::{message::Message, sysvar},
         },
     };
 
@@ -113,7 +113,7 @@ mod test {
         #[allow(deprecated)]
         let create_ix = create_associated_token_account_deprecated(&funder, &wallet_address, &mint);
         let mut message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
+        let compiled_instruction = &mut message.instructions[0];
         let expected_parsed_ix = ParsedInstructionEnum {
             instruction_type: "create".to_string(),
             info: json!({
@@ -127,7 +127,7 @@ mod test {
         };
         assert_eq!(
             parse_associated_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -143,7 +143,7 @@ mod test {
         compiled_instruction.accounts.remove(rent_account_index);
         assert_eq!(
             parse_associated_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -153,7 +153,7 @@ mod test {
         // after popping another account, parsing should fail
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
-            &compiled_instruction,
+            compiled_instruction,
             &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
@@ -170,10 +170,10 @@ mod test {
         let create_ix =
             create_associated_token_account(&funder, &wallet_address, &mint, &token_program_id);
         let mut message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -191,7 +191,7 @@ mod test {
         );
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
-            &compiled_instruction,
+            compiled_instruction,
             &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
@@ -212,10 +212,10 @@ mod test {
             &token_program_id,
         );
         let mut message = Message::new(&[create_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -233,7 +233,7 @@ mod test {
         );
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
-            &compiled_instruction,
+            compiled_instruction,
             &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());
@@ -267,10 +267,10 @@ mod test {
             &token_program_id,
         );
         let mut message = Message::new(&[recover_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_associated_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -289,7 +289,7 @@ mod test {
         );
         compiled_instruction.accounts.pop();
         assert!(parse_associated_token(
-            &compiled_instruction,
+            compiled_instruction,
             &AccountKeys::new(&message.account_keys, None)
         )
         .is_err());

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -817,12 +817,8 @@ mod test {
                 pubkey::Pubkey as SplTokenPubkey,
             },
         },
-        std::{iter::repeat_with, str::FromStr},
+        std::iter::repeat_with,
     };
-
-    pub(super) fn convert_pubkey(pubkey: Pubkey) -> SplTokenPubkey {
-        SplTokenPubkey::from_str(&pubkey.to_string()).unwrap()
-    }
 
     pub(super) fn convert_compiled_instruction(
         instruction: &SplTokenCompiledInstruction,
@@ -843,9 +839,9 @@ mod test {
         // Test InitializeMint variations
         let initialize_mint_ix = initialize_mint(
             program_id,
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(mint_authority),
-            Some(&convert_pubkey(freeze_authority)),
+            &mint_pubkey,
+            &mint_authority,
+            Some(&freeze_authority),
             2,
         )
         .unwrap();
@@ -869,14 +865,8 @@ mod test {
             }
         );
 
-        let initialize_mint_ix = initialize_mint(
-            program_id,
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(mint_authority),
-            None,
-            2,
-        )
-        .unwrap();
+        let initialize_mint_ix =
+            initialize_mint(program_id, &mint_pubkey, &mint_authority, None, 2).unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -899,9 +889,9 @@ mod test {
         // Test InitializeMint2
         let initialize_mint_ix = initialize_mint2(
             program_id,
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(mint_authority),
-            Some(&convert_pubkey(freeze_authority)),
+            &mint_pubkey,
+            &mint_authority,
+            Some(&freeze_authority),
             2,
         )
         .unwrap();
@@ -927,13 +917,8 @@ mod test {
         // Test InitializeAccount
         let account_pubkey = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
-        let initialize_account_ix = initialize_account(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(owner),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -954,13 +939,8 @@ mod test {
         );
 
         // Test InitializeAccount2
-        let initialize_account_ix = initialize_account2(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(owner),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account2(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -981,13 +961,8 @@ mod test {
         );
 
         // Test InitializeAccount3
-        let initialize_account_ix = initialize_account3(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(owner),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account3(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1013,12 +988,8 @@ mod test {
         let multisig_signer2 = Pubkey::new_unique();
         let initialize_multisig_ix = initialize_multisig(
             program_id,
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-                &convert_pubkey(multisig_signer2),
-            ],
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1, &multisig_signer2],
             2,
         )
         .unwrap();
@@ -1048,12 +1019,8 @@ mod test {
         // Test InitializeMultisig2
         let initialize_multisig_ix = initialize_multisig2(
             program_id,
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-                &convert_pubkey(multisig_signer2),
-            ],
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1, &multisig_signer2],
             2,
         )
         .unwrap();
@@ -1082,15 +1049,8 @@ mod test {
         // Test Transfer, incl multisig
         let recipient = Pubkey::new_unique();
         #[allow(deprecated)]
-        let transfer_ix = transfer(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
-            &[],
-            42,
-        )
-        .unwrap();
+        let transfer_ix =
+            transfer(program_id, &account_pubkey, &recipient, &owner, &[], 42).unwrap();
         let message = Message::new(&[transfer_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1113,13 +1073,10 @@ mod test {
         #[allow(deprecated)]
         let transfer_ix = transfer(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             42,
         )
         .unwrap();
@@ -1147,15 +1104,7 @@ mod test {
         );
 
         // Test Approve, incl multisig
-        let approve_ix = approve(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
-            &[],
-            42,
-        )
-        .unwrap();
+        let approve_ix = approve(program_id, &account_pubkey, &recipient, &owner, &[], 42).unwrap();
         let message = Message::new(&[approve_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1177,13 +1126,10 @@ mod test {
 
         let approve_ix = approve(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             42,
         )
         .unwrap();
@@ -1211,13 +1157,7 @@ mod test {
         );
 
         // Test Revoke
-        let revoke_ix = revoke(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(owner),
-            &[],
-        )
-        .unwrap();
+        let revoke_ix = revoke(program_id, &account_pubkey, &owner, &[]).unwrap();
         let message = Message::new(&[revoke_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1239,10 +1179,10 @@ mod test {
         let new_freeze_authority = Pubkey::new_unique();
         let set_authority_ix = set_authority(
             program_id,
-            &convert_pubkey(mint_pubkey),
-            Some(&convert_pubkey(new_freeze_authority)),
+            &mint_pubkey,
+            Some(&new_freeze_authority),
             AuthorityType::FreezeAccount,
-            &convert_pubkey(freeze_authority),
+            &freeze_authority,
             &[],
         )
         .unwrap();
@@ -1267,10 +1207,10 @@ mod test {
 
         let set_authority_ix = set_authority(
             program_id,
-            &convert_pubkey(account_pubkey),
+            &account_pubkey,
             None,
             AuthorityType::CloseAccount,
-            &convert_pubkey(owner),
+            &owner,
             &[],
         )
         .unwrap();
@@ -1297,9 +1237,9 @@ mod test {
         // Test MintTo
         let mint_to_ix = mint_to(
             program_id,
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_authority),
+            &mint_pubkey,
+            &account_pubkey,
+            &mint_authority,
             &[],
             42,
         )
@@ -1324,15 +1264,7 @@ mod test {
         );
 
         // Test Burn
-        let burn_ix = burn(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(owner),
-            &[],
-            42,
-        )
-        .unwrap();
+        let burn_ix = burn(program_id, &account_pubkey, &mint_pubkey, &owner, &[], 42).unwrap();
         let message = Message::new(&[burn_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1353,14 +1285,8 @@ mod test {
         );
 
         // Test CloseAccount
-        let close_account_ix = close_account(
-            program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
-            &[],
-        )
-        .unwrap();
+        let close_account_ix =
+            close_account(program_id, &account_pubkey, &recipient, &owner, &[]).unwrap();
         let message = Message::new(&[close_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1382,9 +1308,9 @@ mod test {
         // Test FreezeAccount
         let freeze_account_ix = freeze_account(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(freeze_authority),
+            &account_pubkey,
+            &mint_pubkey,
+            &freeze_authority,
             &[],
         )
         .unwrap();
@@ -1409,9 +1335,9 @@ mod test {
         // Test ThawAccount
         let thaw_account_ix = thaw_account(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(freeze_authority),
+            &account_pubkey,
+            &mint_pubkey,
+            &freeze_authority,
             &[],
         )
         .unwrap();
@@ -1436,10 +1362,10 @@ mod test {
         // Test TransferChecked, incl multisig
         let transfer_ix = transfer_checked(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &owner,
             &[],
             42,
             2,
@@ -1472,14 +1398,11 @@ mod test {
 
         let transfer_ix = transfer_checked(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             42,
             2,
         )
@@ -1516,10 +1439,10 @@ mod test {
         // Test ApproveChecked, incl multisig
         let approve_ix = approve_checked(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &owner,
             &[],
             42,
             2,
@@ -1552,14 +1475,11 @@ mod test {
 
         let approve_ix = approve_checked(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             42,
             2,
         )
@@ -1596,9 +1516,9 @@ mod test {
         // Test MintToChecked
         let mint_to_ix = mint_to_checked(
             program_id,
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_authority),
+            &mint_pubkey,
+            &account_pubkey,
+            &mint_authority,
             &[],
             42,
             2,
@@ -1631,9 +1551,9 @@ mod test {
         // Test BurnChecked
         let burn_ix = burn_checked(
             program_id,
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(owner),
+            &account_pubkey,
+            &mint_pubkey,
+            &owner,
             &[],
             42,
             2,
@@ -1664,7 +1584,7 @@ mod test {
         );
 
         // Test SyncNative
-        let sync_native_ix = sync_native(program_id, &convert_pubkey(account_pubkey)).unwrap();
+        let sync_native_ix = sync_native(program_id, &account_pubkey).unwrap();
         let message = Message::new(&[sync_native_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1683,7 +1603,7 @@ mod test {
 
         // Test InitializeImmutableOwner
         let init_immutable_owner_ix =
-            initialize_immutable_owner(program_id, &convert_pubkey(account_pubkey)).unwrap();
+            initialize_immutable_owner(program_id, &account_pubkey).unwrap();
         let message = Message::new(&[init_immutable_owner_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1703,7 +1623,7 @@ mod test {
         // Test GetAccountDataSize
         let get_account_data_size_ix = get_account_data_size(
             program_id,
-            &convert_pubkey(mint_pubkey),
+            &mint_pubkey,
             &[], // This emulates the packed data of spl_token::instruction::get_account_data_size
         )
         .unwrap();
@@ -1725,7 +1645,7 @@ mod test {
 
         let get_account_data_size_ix = get_account_data_size(
             program_id,
-            &convert_pubkey(mint_pubkey),
+            &mint_pubkey,
             &[ExtensionType::ImmutableOwner, ExtensionType::MemoTransfer],
         )
         .unwrap();
@@ -1750,8 +1670,7 @@ mod test {
         );
 
         // Test AmountToUiAmount
-        let amount_to_ui_amount_ix =
-            amount_to_ui_amount(program_id, &convert_pubkey(mint_pubkey), 4242).unwrap();
+        let amount_to_ui_amount_ix = amount_to_ui_amount(program_id, &mint_pubkey, 4242).unwrap();
         let message = Message::new(&[amount_to_ui_amount_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1771,7 +1690,7 @@ mod test {
 
         // Test UiAmountToAmount
         let ui_amount_to_amount_ix =
-            ui_amount_to_amount(program_id, &convert_pubkey(mint_pubkey), "42.42").unwrap();
+            ui_amount_to_amount(program_id, &mint_pubkey, "42.42").unwrap();
         let message = Message::new(&[ui_amount_to_amount_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1803,8 +1722,7 @@ mod test {
     #[test]
     fn test_create_native_mint() {
         let payer = Pubkey::new_unique();
-        let create_native_mint_ix =
-            create_native_mint(&spl_token_2022::id(), &convert_pubkey(payer)).unwrap();
+        let create_native_mint_ix = create_native_mint(&spl_token_2022::id(), &payer).unwrap();
         let message = Message::new(&[create_native_mint_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -1828,14 +1746,8 @@ mod test {
         let keys: Vec<Pubkey> = repeat_with(solana_sdk::pubkey::new_rand).take(10).collect();
 
         // Test InitializeMint variations
-        let initialize_mint_ix = initialize_mint(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            Some(&convert_pubkey(keys[2])),
-            2,
-        )
-        .unwrap();
+        let initialize_mint_ix =
+            initialize_mint(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
@@ -1843,14 +1755,7 @@ mod test {
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
-        let initialize_mint_ix = initialize_mint(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            None,
-            2,
-        )
-        .unwrap();
+        let initialize_mint_ix = initialize_mint(program_id, &keys[0], &keys[1], None, 2).unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
@@ -1859,14 +1764,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMint2
-        let initialize_mint_ix = initialize_mint2(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            Some(&convert_pubkey(keys[2])),
-            2,
-        )
-        .unwrap();
+        let initialize_mint_ix =
+            initialize_mint2(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..0], None)).is_err());
@@ -1875,13 +1774,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount
-        let initialize_account_ix = initialize_account(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
@@ -1890,13 +1784,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount2
-        let initialize_account_ix = initialize_account2(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[3]),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account2(program_id, &keys[0], &keys[1], &keys[3]).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -1905,13 +1794,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount3
-        let initialize_account_ix = initialize_account3(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-        )
-        .unwrap();
+        let initialize_account_ix =
+            initialize_account3(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
@@ -1920,17 +1804,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMultisig
-        let initialize_multisig_ix = initialize_multisig(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &[
-                &convert_pubkey(keys[1]),
-                &convert_pubkey(keys[2]),
-                &convert_pubkey(keys[3]),
-            ],
-            2,
-        )
-        .unwrap();
+        let initialize_multisig_ix =
+            initialize_multisig(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
         let message = Message::new(&[initialize_multisig_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
@@ -1939,17 +1814,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMultisig2
-        let initialize_multisig_ix = initialize_multisig2(
-            program_id,
-            &convert_pubkey(keys[0]),
-            &[
-                &convert_pubkey(keys[1]),
-                &convert_pubkey(keys[2]),
-                &convert_pubkey(keys[3]),
-            ],
-            2,
-        )
-        .unwrap();
+        let initialize_multisig_ix =
+            initialize_multisig2(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
         let message = Message::new(&[initialize_multisig_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
@@ -1959,15 +1825,7 @@ mod test {
 
         // Test Transfer, incl multisig
         #[allow(deprecated)]
-        let transfer_ix = transfer(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-        )
-        .unwrap();
+        let transfer_ix = transfer(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let message = Message::new(&[transfer_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -1978,10 +1836,10 @@ mod test {
         #[allow(deprecated)]
         let transfer_ix = transfer(
             program_id,
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[4]),
-            &[&convert_pubkey(keys[0]), &convert_pubkey(keys[1])],
+            &keys[2],
+            &keys[3],
+            &keys[4],
+            &[&keys[0], &keys[1]],
             42,
         )
         .unwrap();
@@ -1993,15 +1851,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Approve, incl multisig
-        let approve_ix = approve(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-        )
-        .unwrap();
+        let approve_ix = approve(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let message = Message::new(&[approve_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2011,10 +1861,10 @@ mod test {
 
         let approve_ix = approve(
             program_id,
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[4]),
-            &[&convert_pubkey(keys[0]), &convert_pubkey(keys[1])],
+            &keys[2],
+            &keys[3],
+            &keys[4],
+            &[&keys[0], &keys[1]],
             42,
         )
         .unwrap();
@@ -2026,13 +1876,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Revoke
-        let revoke_ix = revoke(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[0]),
-            &[],
-        )
-        .unwrap();
+        let revoke_ix = revoke(program_id, &keys[1], &keys[0], &[]).unwrap();
         let message = Message::new(&[revoke_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
@@ -2043,10 +1887,10 @@ mod test {
         // Test SetAuthority
         let set_authority_ix = set_authority(
             program_id,
-            &convert_pubkey(keys[1]),
-            Some(&convert_pubkey(keys[2])),
+            &keys[1],
+            Some(&keys[2]),
             AuthorityType::FreezeAccount,
-            &convert_pubkey(keys[0]),
+            &keys[0],
             &[],
         )
         .unwrap();
@@ -2058,15 +1902,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test MintTo
-        let mint_to_ix = mint_to(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-        )
-        .unwrap();
+        let mint_to_ix = mint_to(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let message = Message::new(&[mint_to_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2075,15 +1911,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Burn
-        let burn_ix = burn(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-        )
-        .unwrap();
+        let burn_ix = burn(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let message = Message::new(&[burn_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2092,14 +1920,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test CloseAccount
-        let close_account_ix = close_account(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-        )
-        .unwrap();
+        let close_account_ix =
+            close_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let message = Message::new(&[close_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2108,14 +1930,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test FreezeAccount
-        let freeze_account_ix = freeze_account(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-        )
-        .unwrap();
+        let freeze_account_ix =
+            freeze_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let message = Message::new(&[freeze_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2124,14 +1940,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test ThawAccount
-        let thaw_account_ix = thaw_account(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-        )
-        .unwrap();
+        let thaw_account_ix = thaw_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let message = Message::new(&[thaw_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2142,10 +1951,10 @@ mod test {
         // Test TransferChecked, incl multisig
         let transfer_ix = transfer_checked(
             program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[0]),
+            &keys[1],
+            &keys[2],
+            &keys[3],
+            &keys[0],
             &[],
             42,
             2,
@@ -2160,11 +1969,11 @@ mod test {
 
         let transfer_ix = transfer_checked(
             program_id,
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[4]),
-            &convert_pubkey(keys[5]),
-            &[&convert_pubkey(keys[0]), &convert_pubkey(keys[1])],
+            &keys[2],
+            &keys[3],
+            &keys[4],
+            &keys[5],
+            &[&keys[0], &keys[1]],
             42,
             2,
         )
@@ -2179,10 +1988,10 @@ mod test {
         // Test ApproveChecked, incl multisig
         let approve_ix = approve_checked(
             program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[0]),
+            &keys[1],
+            &keys[2],
+            &keys[3],
+            &keys[0],
             &[],
             42,
             2,
@@ -2197,11 +2006,11 @@ mod test {
 
         let approve_ix = approve_checked(
             program_id,
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[3]),
-            &convert_pubkey(keys[4]),
-            &convert_pubkey(keys[5]),
-            &[&convert_pubkey(keys[0]), &convert_pubkey(keys[1])],
+            &keys[2],
+            &keys[3],
+            &keys[4],
+            &keys[5],
+            &[&keys[0], &keys[1]],
             42,
             2,
         )
@@ -2214,16 +2023,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test MintToChecked
-        let mint_to_ix = mint_to_checked(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-            2,
-        )
-        .unwrap();
+        let mint_to_ix =
+            mint_to_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
         let message = Message::new(&[mint_to_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2232,16 +2033,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test BurnChecked
-        let burn_ix = burn_checked(
-            program_id,
-            &convert_pubkey(keys[1]),
-            &convert_pubkey(keys[2]),
-            &convert_pubkey(keys[0]),
-            &[],
-            42,
-            2,
-        )
-        .unwrap();
+        let burn_ix = burn_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
         let message = Message::new(&[burn_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
@@ -2250,7 +2042,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test SyncNative
-        let sync_native_ix = sync_native(program_id, &convert_pubkey(keys[0])).unwrap();
+        let sync_native_ix = sync_native(program_id, &keys[0]).unwrap();
         let message = Message::new(&[sync_native_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
@@ -2259,8 +2051,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeImmutableOwner
-        let init_immutable_owner_ix =
-            initialize_immutable_owner(program_id, &convert_pubkey(keys[0])).unwrap();
+        let init_immutable_owner_ix = initialize_immutable_owner(program_id, &keys[0]).unwrap();
         let message = Message::new(&[init_immutable_owner_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
@@ -2269,8 +2060,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test GetAccountDataSize
-        let get_account_data_size_ix =
-            get_account_data_size(program_id, &convert_pubkey(keys[0]), &[]).unwrap();
+        let get_account_data_size_ix = get_account_data_size(program_id, &keys[0], &[]).unwrap();
         let message = Message::new(&[get_account_data_size_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
@@ -2279,8 +2069,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test AmountToUiAmount
-        let amount_to_ui_amount_ix =
-            amount_to_ui_amount(program_id, &convert_pubkey(keys[0]), 4242).unwrap();
+        let amount_to_ui_amount_ix = amount_to_ui_amount(program_id, &keys[0], 4242).unwrap();
         let message = Message::new(&[amount_to_ui_amount_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
@@ -2289,8 +2078,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test UiAmountToAmount
-        let ui_amount_to_amount_ix =
-            ui_amount_to_amount(program_id, &convert_pubkey(keys[0]), "42.42").unwrap();
+        let ui_amount_to_amount_ix = ui_amount_to_amount(program_id, &keys[0], "42.42").unwrap();
         let message = Message::new(&[ui_amount_to_amount_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -813,22 +813,12 @@ mod test {
         spl_token_2022::{
             instruction::*,
             solana_program::{
-                instruction::CompiledInstruction as SplTokenCompiledInstruction, message::Message,
+                message::Message,
                 pubkey::Pubkey as SplTokenPubkey,
             },
         },
         std::iter::repeat_with,
     };
-
-    pub(super) fn convert_compiled_instruction(
-        instruction: &SplTokenCompiledInstruction,
-    ) -> CompiledInstruction {
-        CompiledInstruction {
-            program_id_index: instruction.program_id_index,
-            accounts: instruction.accounts.clone(),
-            data: instruction.data.clone(),
-        }
-    }
 
     fn test_parse_token(program_id: &SplTokenPubkey) {
         let mint_pubkey = Pubkey::new_unique();
@@ -846,7 +836,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -868,7 +858,7 @@ mod test {
         let initialize_mint_ix =
             initialize_mint(program_id, &mint_pubkey, &mint_authority, None, 2).unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -896,7 +886,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[initialize_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -920,7 +910,7 @@ mod test {
         let initialize_account_ix =
             initialize_account(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -942,7 +932,7 @@ mod test {
         let initialize_account_ix =
             initialize_account2(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -964,7 +954,7 @@ mod test {
         let initialize_account_ix =
             initialize_account3(program_id, &account_pubkey, &mint_pubkey, &owner).unwrap();
         let message = Message::new(&[initialize_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -994,7 +984,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[initialize_multisig_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1025,7 +1015,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[initialize_multisig_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1052,7 +1042,7 @@ mod test {
         let transfer_ix =
             transfer(program_id, &account_pubkey, &recipient, &owner, &[], 42).unwrap();
         let message = Message::new(&[transfer_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1081,7 +1071,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[transfer_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1106,7 +1096,7 @@ mod test {
         // Test Approve, incl multisig
         let approve_ix = approve(program_id, &account_pubkey, &recipient, &owner, &[], 42).unwrap();
         let message = Message::new(&[approve_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1134,7 +1124,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[approve_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1159,7 +1149,7 @@ mod test {
         // Test Revoke
         let revoke_ix = revoke(program_id, &account_pubkey, &owner, &[]).unwrap();
         let message = Message::new(&[revoke_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1187,7 +1177,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[set_authority_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1215,7 +1205,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[set_authority_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         let new_authority: Option<String> = None;
         assert_eq!(
             parse_token(
@@ -1245,7 +1235,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[mint_to_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1266,7 +1256,7 @@ mod test {
         // Test Burn
         let burn_ix = burn(program_id, &account_pubkey, &mint_pubkey, &owner, &[], 42).unwrap();
         let message = Message::new(&[burn_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1288,7 +1278,7 @@ mod test {
         let close_account_ix =
             close_account(program_id, &account_pubkey, &recipient, &owner, &[]).unwrap();
         let message = Message::new(&[close_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1315,7 +1305,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[freeze_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1342,7 +1332,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[thaw_account_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1372,7 +1362,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[transfer_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1408,7 +1398,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[transfer_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1449,7 +1439,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[approve_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1485,7 +1475,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[approve_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1525,7 +1515,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[mint_to_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1560,7 +1550,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[burn_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1586,7 +1576,7 @@ mod test {
         // Test SyncNative
         let sync_native_ix = sync_native(program_id, &account_pubkey).unwrap();
         let message = Message::new(&[sync_native_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1605,7 +1595,7 @@ mod test {
         let init_immutable_owner_ix =
             initialize_immutable_owner(program_id, &account_pubkey).unwrap();
         let message = Message::new(&[init_immutable_owner_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1628,7 +1618,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[get_account_data_size_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1650,7 +1640,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[get_account_data_size_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1672,7 +1662,7 @@ mod test {
         // Test AmountToUiAmount
         let amount_to_ui_amount_ix = amount_to_ui_amount(program_id, &mint_pubkey, 4242).unwrap();
         let message = Message::new(&[amount_to_ui_amount_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1692,7 +1682,7 @@ mod test {
         let ui_amount_to_amount_ix =
             ui_amount_to_amount(program_id, &mint_pubkey, "42.42").unwrap();
         let message = Message::new(&[ui_amount_to_amount_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1724,7 +1714,7 @@ mod test {
         let payer = Pubkey::new_unique();
         let create_native_mint_ix = create_native_mint(&spl_token_2022::id(), &payer).unwrap();
         let message = Message::new(&[create_native_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -1748,16 +1738,16 @@ mod test {
         // Test InitializeMint variations
         let initialize_mint_ix =
             initialize_mint(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
-        let message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_mint_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let initialize_mint_ix = initialize_mint(program_id, &keys[0], &keys[1], None, 2).unwrap();
-        let message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_mint_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1766,8 +1756,8 @@ mod test {
         // Test InitializeMint2
         let initialize_mint_ix =
             initialize_mint2(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
-        let message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_mint_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..0], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1776,8 +1766,8 @@ mod test {
         // Test InitializeAccount
         let initialize_account_ix =
             initialize_account(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
-        let message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1786,8 +1776,8 @@ mod test {
         // Test InitializeAccount2
         let initialize_account_ix =
             initialize_account2(program_id, &keys[0], &keys[1], &keys[3]).unwrap();
-        let message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1796,8 +1786,8 @@ mod test {
         // Test InitializeAccount3
         let initialize_account_ix =
             initialize_account3(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
-        let message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1806,8 +1796,8 @@ mod test {
         // Test InitializeMultisig
         let initialize_multisig_ix =
             initialize_multisig(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
-        let message = Message::new(&[initialize_multisig_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_multisig_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -1816,8 +1806,8 @@ mod test {
         // Test InitializeMultisig2
         let initialize_multisig_ix =
             initialize_multisig2(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
-        let message = Message::new(&[initialize_multisig_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[initialize_multisig_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -1826,8 +1816,8 @@ mod test {
         // Test Transfer, incl multisig
         #[allow(deprecated)]
         let transfer_ix = transfer(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
-        let message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[transfer_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1843,8 +1833,8 @@ mod test {
             42,
         )
         .unwrap();
-        let message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[transfer_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -1852,8 +1842,8 @@ mod test {
 
         // Test Approve, incl multisig
         let approve_ix = approve(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
-        let message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[approve_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1868,8 +1858,8 @@ mod test {
             42,
         )
         .unwrap();
-        let message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[approve_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -1877,8 +1867,8 @@ mod test {
 
         // Test Revoke
         let revoke_ix = revoke(program_id, &keys[1], &keys[0], &[]).unwrap();
-        let message = Message::new(&[revoke_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[revoke_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1894,8 +1884,8 @@ mod test {
             &[],
         )
         .unwrap();
-        let message = Message::new(&[set_authority_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[set_authority_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1903,8 +1893,8 @@ mod test {
 
         // Test MintTo
         let mint_to_ix = mint_to(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
-        let message = Message::new(&[mint_to_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[mint_to_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1912,8 +1902,8 @@ mod test {
 
         // Test Burn
         let burn_ix = burn(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
-        let message = Message::new(&[burn_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[burn_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1922,8 +1912,8 @@ mod test {
         // Test CloseAccount
         let close_account_ix =
             close_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
-        let message = Message::new(&[close_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[close_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1932,8 +1922,8 @@ mod test {
         // Test FreezeAccount
         let freeze_account_ix =
             freeze_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
-        let message = Message::new(&[freeze_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[freeze_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1941,8 +1931,8 @@ mod test {
 
         // Test ThawAccount
         let thaw_account_ix = thaw_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
-        let message = Message::new(&[thaw_account_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[thaw_account_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1960,8 +1950,8 @@ mod test {
             2,
         )
         .unwrap();
-        let message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[transfer_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -1978,8 +1968,8 @@ mod test {
             2,
         )
         .unwrap();
-        let message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[transfer_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -1997,8 +1987,8 @@ mod test {
             2,
         )
         .unwrap();
-        let message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[approve_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2015,8 +2005,8 @@ mod test {
             2,
         )
         .unwrap();
-        let message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[approve_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
@@ -2025,8 +2015,8 @@ mod test {
         // Test MintToChecked
         let mint_to_ix =
             mint_to_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
-        let message = Message::new(&[mint_to_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[mint_to_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2034,8 +2024,8 @@ mod test {
 
         // Test BurnChecked
         let burn_ix = burn_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
-        let message = Message::new(&[burn_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[burn_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2043,8 +2033,8 @@ mod test {
 
         // Test SyncNative
         let sync_native_ix = sync_native(program_id, &keys[0]).unwrap();
-        let message = Message::new(&[sync_native_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[sync_native_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2052,8 +2042,8 @@ mod test {
 
         // Test InitializeImmutableOwner
         let init_immutable_owner_ix = initialize_immutable_owner(program_id, &keys[0]).unwrap();
-        let message = Message::new(&[init_immutable_owner_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[init_immutable_owner_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2061,8 +2051,8 @@ mod test {
 
         // Test GetAccountDataSize
         let get_account_data_size_ix = get_account_data_size(program_id, &keys[0], &[]).unwrap();
-        let message = Message::new(&[get_account_data_size_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[get_account_data_size_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2070,8 +2060,8 @@ mod test {
 
         // Test AmountToUiAmount
         let amount_to_ui_amount_ix = amount_to_ui_amount(program_id, &keys[0], 4242).unwrap();
-        let message = Message::new(&[amount_to_ui_amount_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[amount_to_ui_amount_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
@@ -2079,8 +2069,8 @@ mod test {
 
         // Test UiAmountToAmount
         let ui_amount_to_amount_ix = ui_amount_to_amount(program_id, &keys[0], "42.42").unwrap();
-        let message = Message::new(&[ui_amount_to_amount_ix], None);
-        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[ui_amount_to_amount_ix], None);
+        let mut compiled_instruction = &mut message.instructions[0];
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -809,18 +809,12 @@ fn map_coption_pubkey(pubkey: COption<Pubkey>) -> Option<String> {
 mod test {
     use {
         super::*,
-        solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey},
-        spl_token_2022::{
-            instruction::*,
-            solana_program::{
-                message::Message,
-                pubkey::Pubkey as SplTokenPubkey,
-            },
-        },
+        solana_sdk::{message::Message, pubkey::Pubkey},
+        spl_token_2022::instruction::*,
         std::iter::repeat_with,
     };
 
-    fn test_parse_token(program_id: &SplTokenPubkey) {
+    fn test_parse_token(program_id: &Pubkey) {
         let mint_pubkey = Pubkey::new_unique();
         let mint_authority = Pubkey::new_unique();
         let freeze_authority = Pubkey::new_unique();
@@ -839,7 +833,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -861,7 +855,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -889,7 +883,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -913,7 +907,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -935,7 +929,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -957,7 +951,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -987,7 +981,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1018,7 +1012,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1045,7 +1039,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1074,7 +1068,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1099,7 +1093,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1127,7 +1121,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1152,7 +1146,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1180,7 +1174,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1209,7 +1203,7 @@ mod test {
         let new_authority: Option<String> = None;
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1238,7 +1232,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1259,7 +1253,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1281,7 +1275,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1308,7 +1302,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1335,7 +1329,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1365,7 +1359,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1401,7 +1395,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1442,7 +1436,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1478,7 +1472,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1518,7 +1512,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1553,7 +1547,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1579,7 +1573,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1598,7 +1592,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1621,7 +1615,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1643,7 +1637,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1665,7 +1659,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1685,7 +1679,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1717,7 +1711,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -1732,96 +1726,96 @@ mod test {
         );
     }
 
-    fn test_token_ix_not_enough_keys(program_id: &SplTokenPubkey) {
+    fn test_token_ix_not_enough_keys(program_id: &Pubkey) {
         let keys: Vec<Pubkey> = repeat_with(solana_sdk::pubkey::new_rand).take(10).collect();
 
         // Test InitializeMint variations
         let initialize_mint_ix =
             initialize_mint(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
         let mut message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let initialize_mint_ix = initialize_mint(program_id, &keys[0], &keys[1], None, 2).unwrap();
         let mut message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMint2
         let initialize_mint_ix =
             initialize_mint2(program_id, &keys[0], &keys[1], Some(&keys[2]), 2).unwrap();
         let mut message = Message::new(&[initialize_mint_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..0], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..0], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount
         let initialize_account_ix =
             initialize_account(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
         let mut message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount2
         let initialize_account_ix =
             initialize_account2(program_id, &keys[0], &keys[1], &keys[3]).unwrap();
         let mut message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeAccount3
         let initialize_account_ix =
             initialize_account3(program_id, &keys[0], &keys[1], &keys[2]).unwrap();
         let mut message = Message::new(&[initialize_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMultisig
         let initialize_multisig_ix =
             initialize_multisig(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
         let mut message = Message::new(&[initialize_multisig_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeMultisig2
         let initialize_multisig_ix =
             initialize_multisig2(program_id, &keys[0], &[&keys[1], &keys[2], &keys[3]], 2).unwrap();
         let mut message = Message::new(&[initialize_multisig_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Transfer, incl multisig
         #[allow(deprecated)]
         let transfer_ix = transfer(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let mut message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         #[allow(deprecated)]
         let transfer_ix = transfer(
@@ -1834,20 +1828,20 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Approve, incl multisig
         let approve_ix = approve(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let mut message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let approve_ix = approve(
             program_id,
@@ -1859,20 +1853,20 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Revoke
         let revoke_ix = revoke(program_id, &keys[1], &keys[0], &[]).unwrap();
         let mut message = Message::new(&[revoke_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test SetAuthority
         let set_authority_ix = set_authority(
@@ -1885,58 +1879,58 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[set_authority_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test MintTo
         let mint_to_ix = mint_to(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let mut message = Message::new(&[mint_to_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test Burn
         let burn_ix = burn(program_id, &keys[1], &keys[2], &keys[0], &[], 42).unwrap();
         let mut message = Message::new(&[burn_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test CloseAccount
         let close_account_ix =
             close_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let mut message = Message::new(&[close_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test FreezeAccount
         let freeze_account_ix =
             freeze_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let mut message = Message::new(&[freeze_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test ThawAccount
         let thaw_account_ix = thaw_account(program_id, &keys[1], &keys[2], &keys[0], &[]).unwrap();
         let mut message = Message::new(&[thaw_account_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test TransferChecked, incl multisig
         let transfer_ix = transfer_checked(
@@ -1951,11 +1945,11 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let transfer_ix = transfer_checked(
             program_id,
@@ -1969,11 +1963,11 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[transfer_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test ApproveChecked, incl multisig
         let approve_ix = approve_checked(
@@ -1988,11 +1982,11 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let approve_ix = approve_checked(
             program_id,
@@ -2006,75 +2000,75 @@ mod test {
         )
         .unwrap();
         let mut message = Message::new(&[approve_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 3].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test MintToChecked
         let mint_to_ix =
             mint_to_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
         let mut message = Message::new(&[mint_to_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test BurnChecked
         let burn_ix = burn_checked(program_id, &keys[1], &keys[2], &keys[0], &[], 42, 2).unwrap();
         let mut message = Message::new(&[burn_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test SyncNative
         let sync_native_ix = sync_native(program_id, &keys[0]).unwrap();
         let mut message = Message::new(&[sync_native_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test InitializeImmutableOwner
         let init_immutable_owner_ix = initialize_immutable_owner(program_id, &keys[0]).unwrap();
         let mut message = Message::new(&[init_immutable_owner_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test GetAccountDataSize
         let get_account_data_size_ix = get_account_data_size(program_id, &keys[0], &[]).unwrap();
         let mut message = Message::new(&[get_account_data_size_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test AmountToUiAmount
         let amount_to_ui_amount_ix = amount_to_ui_amount(program_id, &keys[0], 4242).unwrap();
         let mut message = Message::new(&[amount_to_ui_amount_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test UiAmountToAmount
         let ui_amount_to_amount_ix = ui_amount_to_amount(program_id, &keys[0], "42.42").unwrap();
         let mut message = Message::new(&[ui_amount_to_amount_ix], None);
-        let mut compiled_instruction = &mut message.instructions[0];
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
+        let compiled_instruction = &mut message.instructions[0];
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
             compiled_instruction.accounts[0..compiled_instruction.accounts.len() - 1].to_vec();
-        assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
+        assert!(parse_token(compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -54,13 +54,8 @@ mod test {
 
         // Enable, single owner
         let owner_pubkey = Pubkey::new_unique();
-        let enable_cpi_guard_ix = enable_cpi_guard(
-            &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(owner_pubkey),
-            &[],
-        )
-        .unwrap();
+        let enable_cpi_guard_ix =
+            enable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -84,12 +79,9 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let enable_cpi_guard_ix = enable_cpi_guard(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
         )
         .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
@@ -114,13 +106,8 @@ mod test {
         );
 
         // Disable, single owner
-        let enable_cpi_guard_ix = disable_cpi_guard(
-            &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(owner_pubkey),
-            &[],
-        )
-        .unwrap();
+        let enable_cpi_guard_ix =
+            disable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
@@ -144,12 +131,9 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let enable_cpi_guard_ix = disable_cpi_guard(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
         )
         .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -40,7 +40,6 @@ pub(in crate::parse_token) fn parse_cpi_guard_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{
             extension::cpi_guard::instruction::{disable_cpi_guard, enable_cpi_guard},
@@ -60,7 +59,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -88,7 +87,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -112,7 +111,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -140,7 +139,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -57,7 +57,7 @@ mod test {
         let enable_cpi_guard_ix =
             enable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -85,7 +85,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -109,7 +109,7 @@ mod test {
         let enable_cpi_guard_ix =
             disable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -137,7 +137,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -74,7 +74,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[init_default_account_state_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -101,7 +101,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[update_default_account_state_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -131,7 +131,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[update_default_account_state_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -69,7 +69,7 @@ mod test {
         let mint_pubkey = Pubkey::new_unique();
         let init_default_account_state_ix = initialize_default_account_state(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
+            &mint_pubkey,
             &AccountState::Frozen,
         )
         .unwrap();
@@ -94,8 +94,8 @@ mod test {
         let mint_freeze_authority = Pubkey::new_unique();
         let update_default_account_state_ix = update_default_account_state(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(mint_freeze_authority),
+            &mint_pubkey,
+            &mint_freeze_authority,
             &[],
             &AccountState::Initialized,
         )
@@ -124,12 +124,9 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let update_default_account_state_ix = update_default_account_state(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &mint_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             &AccountState::Initialized,
         )
         .unwrap();

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -53,7 +53,6 @@ pub(in crate::parse_token) fn parse_default_account_state_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{
             extension::default_account_state::instruction::{
@@ -77,7 +76,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -104,7 +103,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -134,7 +133,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -58,8 +58,8 @@ mod test {
         let owner_pubkey = Pubkey::new_unique();
         let enable_memo_transfers_ix = enable_required_transfer_memos(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(owner_pubkey),
+            &account_pubkey,
+            &owner_pubkey,
             &[],
         )
         .unwrap();
@@ -86,12 +86,9 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let enable_memo_transfers_ix = enable_required_transfer_memos(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);
@@ -118,8 +115,8 @@ mod test {
         // Disable, single owner
         let enable_memo_transfers_ix = disable_required_transfer_memos(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(owner_pubkey),
+            &account_pubkey,
+            &owner_pubkey,
             &[],
         )
         .unwrap();
@@ -146,12 +143,9 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let enable_memo_transfers_ix = disable_required_transfer_memos(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -40,7 +40,6 @@ pub(in crate::parse_token) fn parse_memo_transfer_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{
             extension::memo_transfer::instruction::{
@@ -67,7 +66,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -95,7 +94,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -124,7 +123,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -152,7 +151,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -64,7 +64,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -92,7 +92,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -121,7 +121,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -149,7 +149,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[enable_memo_transfers_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/metadata_pointer.rs
+++ b/transaction-status/src/parse_token/extension/metadata_pointer.rs
@@ -94,7 +94,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -113,7 +113,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -138,7 +138,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -168,7 +168,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/metadata_pointer.rs
+++ b/transaction-status/src/parse_token/extension/metadata_pointer.rs
@@ -74,10 +74,7 @@ pub(in crate::parse_token) fn parse_metadata_pointer_instruction(
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*, crate::parse_token::test::*, solana_sdk::pubkey::Pubkey,
-        spl_token_2022::solana_program::message::Message,
-    };
+    use {super::*, solana_sdk::pubkey::Pubkey, spl_token_2022::solana_program::message::Message};
 
     #[test]
     fn test_parse_metadata_pointer_instruction() {
@@ -93,8 +90,8 @@ mod test {
             Some(metadata_address),
         )
         .unwrap();
-        let message = Message::new(&[init_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[init_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -112,8 +109,8 @@ mod test {
         );
 
         let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
-        let message = Message::new(&[init_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[init_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -137,8 +134,8 @@ mod test {
             Some(metadata_address),
         )
         .unwrap();
-        let message = Message::new(&[update_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[update_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -167,8 +164,8 @@ mod test {
             Some(metadata_address),
         )
         .unwrap();
-        let message = Message::new(&[update_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[update_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -39,7 +39,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[mint_close_authority_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -58,7 +58,7 @@ mod test {
         let mint_close_authority_ix =
             initialize_mint_close_authority(&spl_token_2022::id(), &mint_pubkey, None).unwrap();
         let message = Message::new(&[mint_close_authority_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -22,7 +22,6 @@ pub(in crate::parse_token) fn parse_initialize_mint_close_authority_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         serde_json::Value,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{instruction::*, solana_program::message::Message},
@@ -42,7 +41,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -61,7 +60,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -34,8 +34,8 @@ mod test {
         let close_authority = Pubkey::new_unique();
         let mint_close_authority_ix = initialize_mint_close_authority(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            Some(&convert_pubkey(close_authority)),
+            &mint_pubkey,
+            Some(&close_authority),
         )
         .unwrap();
         let message = Message::new(&[mint_close_authority_ix], None);
@@ -55,12 +55,8 @@ mod test {
             }
         );
 
-        let mint_close_authority_ix = initialize_mint_close_authority(
-            &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            None,
-        )
-        .unwrap();
+        let mint_close_authority_ix =
+            initialize_mint_close_authority(&spl_token_2022::id(), &mint_pubkey, None).unwrap();
         let message = Message::new(&[mint_close_authority_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -28,12 +28,8 @@ mod test {
     fn test_parse_initialize_permanent_delegate_instruction() {
         let mint_pubkey = Pubkey::new_unique();
         let delegate = Pubkey::new_unique();
-        let permanent_delegate_ix = initialize_permanent_delegate(
-            &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(delegate),
-        )
-        .unwrap();
+        let permanent_delegate_ix =
+            initialize_permanent_delegate(&spl_token_2022::id(), &mint_pubkey, &delegate).unwrap();
         let message = Message::new(&[permanent_delegate_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -19,7 +19,6 @@ pub(in crate::parse_token) fn parse_initialize_permanent_delegate_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{instruction::*, solana_program::message::Message},
     };
@@ -34,7 +33,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -31,7 +31,7 @@ mod test {
         let permanent_delegate_ix =
             initialize_permanent_delegate(&spl_token_2022::id(), &mint_pubkey, &delegate).unwrap();
         let message = Message::new(&[permanent_delegate_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -58,7 +58,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[reallocate_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -91,7 +91,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[reallocate_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -31,7 +31,6 @@ pub(in crate::parse_token) fn parse_reallocate_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{instruction::reallocate, solana_program::message::Message},
     };
@@ -61,7 +60,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -94,7 +93,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -50,9 +50,9 @@ mod test {
         let owner_pubkey = Pubkey::new_unique();
         let reallocate_ix = reallocate(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(payer_pubkey),
-            &convert_pubkey(owner_pubkey),
+            &account_pubkey,
+            &payer_pubkey,
+            &owner_pubkey,
             &[],
             &extension_types,
         )
@@ -83,13 +83,10 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let reallocate_ix = reallocate(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(payer_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &payer_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             &extension_types,
         )
         .unwrap();

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -184,7 +184,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[init_transfer_fee_config_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -213,7 +213,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[init_transfer_fee_config_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -250,7 +250,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[transfer_checked_with_fee_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -297,7 +297,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[transfer_checked_with_fee_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -341,7 +341,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -368,7 +368,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -402,7 +402,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -434,7 +434,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -467,7 +467,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[harvest_withheld_tokens_to_mint_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -497,7 +497,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[set_transfer_fee_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -526,7 +526,7 @@ mod test {
         )
         .unwrap();
         let message = Message::new(&[set_transfer_fee_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -176,9 +176,9 @@ mod test {
         // InitializeTransferFeeConfig variations
         let init_transfer_fee_config_ix = initialize_transfer_fee_config(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            Some(&convert_pubkey(transfer_fee_config_authority)),
-            Some(&convert_pubkey(withdraw_withheld_authority)),
+            &mint_pubkey,
+            Some(&transfer_fee_config_authority),
+            Some(&withdraw_withheld_authority),
             transfer_fee_basis_points,
             maximum_fee,
         )
@@ -205,7 +205,7 @@ mod test {
 
         let init_transfer_fee_config_ix = initialize_transfer_fee_config(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
+            &mint_pubkey,
             None,
             None,
             transfer_fee_basis_points,
@@ -239,10 +239,10 @@ mod test {
         let fee = 5;
         let transfer_checked_with_fee_ix = transfer_checked_with_fee(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(owner),
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &owner,
             &[],
             amount,
             decimals,
@@ -286,14 +286,11 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let transfer_checked_with_fee_ix = transfer_checked_with_fee(
             &spl_token_2022::id(),
-            &convert_pubkey(account_pubkey),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &account_pubkey,
+            &mint_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             amount,
             decimals,
             fee,
@@ -337,9 +334,9 @@ mod test {
         // Single authority WithdrawWithheldTokensFromMint
         let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(withdraw_withheld_authority),
+            &mint_pubkey,
+            &recipient,
+            &withdraw_withheld_authority,
             &[],
         )
         .unwrap();
@@ -364,13 +361,10 @@ mod test {
         // Multisig WithdrawWithheldTokensFromMint
         let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &mint_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_mint_ix], None);
@@ -400,11 +394,11 @@ mod test {
         let fee_account1 = Pubkey::new_unique();
         let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(withdraw_withheld_authority),
+            &mint_pubkey,
+            &recipient,
+            &withdraw_withheld_authority,
             &[],
-            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+            &[&fee_account0, &fee_account1],
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
@@ -432,14 +426,11 @@ mod test {
         // Multisig WithdrawWithheldTokensFromAccounts
         let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(recipient),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
-            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+            &mint_pubkey,
+            &recipient,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
+            &[&fee_account0, &fee_account1],
         )
         .unwrap();
         let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
@@ -471,8 +462,8 @@ mod test {
         // HarvestWithheldTokensToMint
         let harvest_withheld_tokens_to_mint_ix = harvest_withheld_tokens_to_mint(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+            &mint_pubkey,
+            &[&fee_account0, &fee_account1],
         )
         .unwrap();
         let message = Message::new(&[harvest_withheld_tokens_to_mint_ix], None);
@@ -498,8 +489,8 @@ mod test {
         // Single authority SetTransferFee
         let set_transfer_fee_ix = set_transfer_fee(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(transfer_fee_config_authority),
+            &mint_pubkey,
+            &transfer_fee_config_authority,
             &[],
             transfer_fee_basis_points,
             maximum_fee,
@@ -527,12 +518,9 @@ mod test {
         // Multisig WithdrawWithheldTokensFromMint
         let set_transfer_fee_ix = set_transfer_fee(
             &spl_token_2022::id(),
-            &convert_pubkey(mint_pubkey),
-            &convert_pubkey(multisig_pubkey),
-            &[
-                &convert_pubkey(multisig_signer0),
-                &convert_pubkey(multisig_signer1),
-            ],
+            &mint_pubkey,
+            &multisig_pubkey,
+            &[&multisig_signer0, &multisig_signer1],
             transfer_fee_basis_points,
             maximum_fee,
         )

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -158,7 +158,6 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
 mod test {
     use {
         super::*,
-        crate::parse_token::test::*,
         solana_sdk::pubkey::Pubkey,
         spl_token_2022::{
             extension::transfer_fee::instruction::*, solana_program::message::Message,
@@ -187,7 +186,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -216,7 +215,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -253,7 +252,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -300,7 +299,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -344,7 +343,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -371,7 +370,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -405,7 +404,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -437,7 +436,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -470,7 +469,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -500,7 +499,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -529,7 +528,7 @@ mod test {
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/transfer_hook.rs
+++ b/transaction-status/src/parse_token/extension/transfer_hook.rs
@@ -88,7 +88,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -107,7 +107,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -132,7 +132,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),
@@ -162,7 +162,7 @@ mod test {
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
-                &compiled_instruction,
+                compiled_instruction,
                 &AccountKeys::new(&message.account_keys, None)
             )
             .unwrap(),

--- a/transaction-status/src/parse_token/extension/transfer_hook.rs
+++ b/transaction-status/src/parse_token/extension/transfer_hook.rs
@@ -68,10 +68,7 @@ pub(in crate::parse_token) fn parse_transfer_hook_instruction(
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*, crate::parse_token::test::*, solana_sdk::pubkey::Pubkey,
-        spl_token_2022::solana_program::message::Message,
-    };
+    use {super::*, solana_sdk::pubkey::Pubkey, spl_token_2022::solana_program::message::Message};
 
     #[test]
     fn test_parse_transfer_hook_instruction() {
@@ -87,8 +84,8 @@ mod test {
             Some(program_id),
         )
         .unwrap();
-        let message = Message::new(&[init_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[init_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -106,8 +103,8 @@ mod test {
         );
 
         let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
-        let message = Message::new(&[init_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[init_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -131,8 +128,8 @@ mod test {
             Some(program_id),
         )
         .unwrap();
-        let message = Message::new(&[update_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[update_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,
@@ -161,8 +158,8 @@ mod test {
             Some(program_id),
         )
         .unwrap();
-        let message = Message::new(&[update_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut message = Message::new(&[update_ix], None);
+        let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
             parse_token(
                 &compiled_instruction,


### PR DESCRIPTION
#### Problem

While working on #33453, I noticed that helpers like `convert_pubkey` were still being used, even though #31607 removed the additional sdk crates that were pulled in through the SPL crates.

#### Summary of Changes

Remove all of the helpers! Essentially, I just ran a few commands to remove the functions and their usages:

```
git g -l convert_pubkey | xargs sed -i'' -re 's/convert_pubkey\(([^)]+)\)/\1/g'
```

And

```
git g -l convert_compiled_instruction | xargs sed -i'' -re 's/convert_compiled_instruction\(([^)]+)\)/\1/g'
```

And then cleaned up the build and clippy errors. Note that this only impacts tests, and nothing else.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
