### PR TITLE
Fixup the metrics for remove_dead_accounts_shrink_us

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8228,11 +8228,11 @@ impl AccountsDb {
         let mut shrink_candidate_slots = self.shrink_candidate_slots.lock().unwrap();
         for slot in new_shrink_candidates {
             shrink_candidate_slots.insert(slot);
-            measure.stop();
-            self.clean_accounts_stats
-                .remove_dead_accounts_shrink_us
-                .fetch_add(measure.as_us(), Ordering::Relaxed);
         }
+        measure.stop();
+        self.clean_accounts_stats
+            .remove_dead_accounts_shrink_us
+            .fetch_add(measure.as_us(), Ordering::Relaxed);
 
         dead_slots.retain(|slot| {
             if let Some(slot_store) = self.storage.get_slot_storage_entry(*slot) {


### PR DESCRIPTION
#### Problem

While investigating the v1.16 OOM on 128 GB nodes, I was looking at various `clean` metrics and came across `remove_dead_accounts_shrink_us`. It was being reported as 27 *billion* microseconds, vs 62 *million* microseconds for the *total* time to run `clean`. It's suspicious whenever a sub-metric *vastly* exceeds the `total` metric.

Here's a graph. Note the log scale:

![Screenshot 2023-09-29 at 10 53 16 AM](https://github.com/solana-labs/solana/assets/840349/bce1a18a-8992-4992-b203-3a88d985dff8)


I think this was introduced in a refactoring as part of https://github.com/solana-labs/solana/pull/29117

Note the removal of the `if self.caching_enabled` block, specifically the *closing brace*:

![Screenshot 2023-09-29 at 10 58 45 AM](https://github.com/solana-labs/solana/assets/840349/56e222f5-8e90-4108-a6cd-f6d9084ac802)

I believe the incorrect closing brace was removed, and it should've been the one on (old) line 8073.


#### Summary of Changes

Move the metrics code *outside* the for loop.

Note that the code in #29117 has another subtle change here. The old version with the `if` block drops the lock on `shrink_candidate_slots`, but now we don't drop until the function exits. I'll fix that in a subsequent PR.