### PR TITLE
Drops the shrink_candidate_slots lock after done inserting

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8229,6 +8229,7 @@ impl AccountsDb {
         for slot in new_shrink_candidates {
             shrink_candidate_slots.insert(slot);
         }
+        drop(shrink_candidate_slots);
         measure.stop();
         self.clean_accounts_stats
             .remove_dead_accounts_shrink_us


### PR DESCRIPTION
#### Problem

Please read through https://github.com/solana-labs/solana/pull/33458 first. Here's the snippet from the end:

> Note that the code in https://github.com/solana-labs/solana/pull/29117 has another subtle change here. The old version with the `if` block drops the lock on `shrink_candidate_slots`, but now we don't drop until the function exits. I'll fix that in a subsequent PR.


#### Summary of Changes

Explicitly drop the lock.