### PR TITLE
Fix off-by-one bug in Blockstore::purge_exact()

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1105,7 +1105,9 @@ pub mod tests {
             index0_max_slot,
             index1_max_slot,
         );
-        blockstore.run_purge(0, index0_max_slot - 1, PurgeType::Exact).unwrap();
+        blockstore
+            .run_purge(0, index0_max_slot - 1, PurgeType::Exact)
+            .unwrap();
         assert_eq!(
             blockstore
                 .transaction_status_index_cf

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -354,8 +354,7 @@ impl Blockstore {
     ) -> Result<()> {
         let mut index0 = self.transaction_status_index_cf.get(0)?.unwrap_or_default();
         let mut index1 = self.transaction_status_index_cf.get(1)?.unwrap_or_default();
-        let to_slot = to_slot.saturating_add(1);
-        for slot in from_slot..to_slot {
+        for slot in from_slot..to_slot.saturating_add(1) {
             let slot_entries = self.get_any_valid_slot_entries(slot, 0);
             let transactions = slot_entries
                 .into_iter()

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -354,7 +354,7 @@ impl Blockstore {
     ) -> Result<()> {
         let mut index0 = self.transaction_status_index_cf.get(0)?.unwrap_or_default();
         let mut index1 = self.transaction_status_index_cf.get(1)?.unwrap_or_default();
-        for slot in from_slot..to_slot.saturating_add(1) {
+        for slot in from_slot..=to_slot {
             let slot_entries = self.get_any_valid_slot_entries(slot, 0);
             let transactions = slot_entries
                 .into_iter()

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1100,6 +1100,25 @@ pub mod tests {
         assert_eq!(entry.0, 2); // Buffer entry, no index 1 entries remaining
         drop(status_entry_iterator);
 
+        // Purge up to but not including index0_max_slot
+        clear_and_repopulate_transaction_statuses_for_test(
+            &blockstore,
+            index0_max_slot,
+            index1_max_slot,
+        );
+        blockstore.run_purge(0, index0_max_slot - 1, PurgeType::Exact).unwrap();
+        assert_eq!(
+            blockstore
+                .transaction_status_index_cf
+                .get(0)
+                .unwrap()
+                .unwrap(),
+            TransactionStatusIndexMeta {
+                max_slot: index0_max_slot,
+                frozen: true,
+            }
+        );
+
         // Test purge all
         clear_and_repopulate_transaction_statuses_for_test(
             &blockstore,


### PR DESCRIPTION
#### Problem
`to_slot` is incremented by one in order to make the loop run for `[from_slot, to_slot]`. However, this value is then used with a `<=` later on; we need the original (non-incremented) value for the comparison to be correct.

#### Summary of Changes
Use the incremented value in the loop bounds only instead of updating `to_slot`.

This could also be done with `from_slot..=to_slot`; I'm guessing `saturating_add(1)` was used to try to make the inclusivity more obvious. I could go either way on using `..=` vs `.saturating_add(1)`