### PR TITLE
perf(sdk): Make Poseidon module optional to reduce default build times

### DIFF
--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 
 [dependencies]
 array-bytes = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, features = ["poseidon"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,8 +34,10 @@ full = [
     "libsecp256k1",
     "sha3",
     "digest",
+    "poseidon"
 ]
 dev-context-only-utils = []
+poseidon = ["solana-program/poseidon"]
 
 [dependencies]
 assert_matches = { workspace = true, optional = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -57,7 +57,7 @@ curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 libc = { workspace = true, features = ["extra_traits"] }
 libsecp256k1 = { workspace = true }
-light-poseidon = { workspace = true }
+light-poseidon = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
 tiny-bip39 = { workspace = true }
@@ -96,4 +96,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
+poseidon = ["light-poseidon"]
+
 default = []

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -507,6 +507,7 @@ pub mod log;
 pub mod message;
 pub mod native_token;
 pub mod nonce;
+#[cfg(feature = "poseidon")]
 pub mod poseidon;
 pub mod program;
 pub mod program_error;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,6 +42,8 @@ pub use signer::signers;
 // confusing duplication in the docs due to a rustdoc bug. #26211
 #[allow(deprecated)]
 pub use solana_program::address_lookup_table_account;
+#[cfg(feature = "poseidon")]
+pub use solana_program::poseidon;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 pub use solana_program::{
@@ -50,11 +52,11 @@ pub use solana_program::{
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
     decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
     incinerator, instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction,
-    loader_v4, loader_v4_instruction, message, msg, native_token, nonce, poseidon, program,
-    program_error, program_memory, program_option, program_pack, rent, sanitize, sdk_ids,
-    secp256k1_program, secp256k1_recover, serde_varint, serialize_utils, short_vec, slot_hashes,
-    slot_history, stable_layout, stake, stake_history, syscalls, system_instruction,
-    system_program, sysvar, unchecked_div_by_const, vote, wasm_bindgen,
+    loader_v4, loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
+    program_memory, program_option, program_pack, rent, sanitize, sdk_ids, secp256k1_program,
+    secp256k1_recover, serde_varint, serialize_utils, short_vec, slot_hashes, slot_history,
+    stable_layout, stake, stake_history, syscalls, system_instruction, system_program, sysvar,
+    unchecked_div_by_const, vote, wasm_bindgen,
 };
 
 pub mod account;


### PR DESCRIPTION
People report increased build times of Solana SDK (Lightprotocol/light-poseidon#31) after Poseidon syscall was merged (#32680).

Not every Solana developer is going to need the Poseidon syscall. It's mostly meant fot ZK-related applications and protocols, so the SDK functionality related to Poseidon can be optionally enabled there.

Therefore, hide the Poseidon functionality behind the `poseidon` feature flag.