### PR TITLE
Feature - Epoch boundary recompilation phase

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -552,7 +552,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .clone(),
     );
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key, false));
+        loaded_programs.replenish(key, bank.load_program(&key, false, None));
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -465,6 +465,8 @@ pub struct LoadedPrograms<FG: ForkGraph> {
     /// More precisely, it starts with the recompilation phase a few hundred slots before the epoch boundary,
     /// and it ends with the first rerooting after the epoch boundary.
     pub upcoming_environments: Option<ProgramRuntimeEnvironments>,
+    /// List of loaded programs which should be recompiled before the next epoch (but don't have to).
+    pub programs_to_recompile: Vec<(Pubkey, Arc<LoadedProgram>)>,
     pub stats: Stats,
     pub fork_graph: Option<Arc<RwLock<FG>>>,
 }
@@ -488,6 +490,7 @@ impl<FG: ForkGraph> Default for LoadedPrograms<FG> {
             latest_root_epoch: 0,
             environments: ProgramRuntimeEnvironments::default(),
             upcoming_environments: None,
+            programs_to_recompile: Vec::default(),
             stats: Stats::default(),
             fork_graph: None,
         }
@@ -670,6 +673,7 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
             if let Some(upcoming_environments) = self.upcoming_environments.take() {
                 recompilation_phase_ends = true;
                 self.environments = upcoming_environments;
+                self.programs_to_recompile.clear();
             }
         }
         for second_level in self.entries.values_mut() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8238,7 +8238,6 @@ impl Bank {
                 );
             loaded_programs_cache.environments.program_runtime_v2 =
                 Arc::new(program_runtime_environment_v2);
-            loaded_programs_cache.prune_feature_set_transition();
         }
         for builtin in BUILTINS.iter() {
             if let Some(feature_id) = builtin.feature_id {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8251,45 +8251,6 @@ impl Bank {
         only_apply_transitions_for_new_features: bool,
         new_feature_activations: &HashSet<Pubkey>,
     ) {
-        const FEATURES_AFFECTING_RBPF: &[Pubkey] = &[
-            feature_set::error_on_syscall_bpf_function_hash_collisions::id(),
-            feature_set::reject_callx_r10::id(),
-            feature_set::switch_to_new_elf_parser::id(),
-            feature_set::bpf_account_data_direct_mapping::id(),
-            feature_set::enable_alt_bn128_syscall::id(),
-            feature_set::enable_alt_bn128_compression_syscall::id(),
-            feature_set::enable_big_mod_exp_syscall::id(),
-            feature_set::blake3_syscall_enabled::id(),
-            feature_set::curve25519_syscall_enabled::id(),
-            feature_set::disable_fees_sysvar::id(),
-            feature_set::enable_partitioned_epoch_reward::id(),
-            feature_set::disable_deploy_of_alloc_free_syscall::id(),
-            feature_set::last_restart_slot_sysvar::id(),
-            feature_set::remaining_compute_units_syscall_enabled::id(),
-        ];
-        if !only_apply_transitions_for_new_features
-            || FEATURES_AFFECTING_RBPF
-                .iter()
-                .any(|key| new_feature_activations.contains(key))
-        {
-            let program_runtime_environment_v1 = create_program_runtime_environment_v1(
-                &self.feature_set,
-                &self.runtime_config.compute_budget.unwrap_or_default(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap();
-            let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
-            loaded_programs_cache.environments.program_runtime_v1 =
-                Arc::new(program_runtime_environment_v1);
-            let program_runtime_environment_v2 =
-                solana_loader_v4_program::create_program_runtime_environment_v2(
-                    &self.runtime_config.compute_budget.unwrap_or_default(),
-                    false, /* debugging_features */
-                );
-            loaded_programs_cache.environments.program_runtime_v2 =
-                Arc::new(program_runtime_environment_v2);
-        }
         for builtin in BUILTINS.iter() {
             if let Some(feature_id) = builtin.feature_id {
                 let should_apply_action_for_feature_transition =

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6877,6 +6877,24 @@ impl Bank {
             }
         }
 
+        let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
+        loaded_programs_cache.latest_root_slot = self.slot();
+        loaded_programs_cache.latest_root_epoch = self.epoch();
+        loaded_programs_cache.environments.program_runtime_v1 = Arc::new(
+            create_program_runtime_environment_v1(
+                &self.feature_set,
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap(),
+        );
+        loaded_programs_cache.environments.program_runtime_v2 =
+            Arc::new(create_program_runtime_environment_v2(
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* debugging_features */
+            ));
+
         if self
             .feature_set
             .is_active(&feature_set::cap_accounts_data_len::id())

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -39,6 +39,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) feature_set_time_us: u64,
     pub(crate) ancestors_time_us: u64,
     pub(crate) update_epoch_time_us: u64,
+    pub(crate) recompilation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
 }
@@ -144,6 +145,7 @@ pub(crate) fn report_new_bank_metrics(
         ("feature_set_us", timings.feature_set_time_us, i64),
         ("ancestors_us", timings.ancestors_time_us, i64),
         ("update_epoch_us", timings.update_epoch_time_us, i64),
+        ("recompilation_time_us", timings.recompilation_time_us, i64),
         ("update_sysvars_us", timings.update_sysvars_time_us, i64),
         (
             "fill_sysvar_cache_us",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7232,7 +7232,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1, false);
+    let program = bank.load_program(&key1, false, None);
     assert_matches!(program.program, LoadedProgramType::LegacyV1(_));
     assert_eq!(
         program.account_size,
@@ -7387,7 +7387,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(*elf.get(i).unwrap(), *byte);
     }
 
-    let loaded_program = bank.load_program(&program_keypair.pubkey(), false);
+    let loaded_program = bank.load_program(&program_keypair.pubkey(), false, None);
 
     // Invoke deployed program
     mock_process_instruction(


### PR DESCRIPTION
#### Problem
This is a different approach to the problem as #32172 was flawed. It ended the recompilation phase at the first block after the epoch boundary, but we need to wait for a rerooting to be sure that we won't replay any blocks from before the epoch boundary anymore.

#### Summary of Changes
- Adds `LoadedPrograms::upcoming_environments`: Which is `Some` during the recompilation phase, even if there is no change to any environment.
- Moves `LoadedPrograms::prune_feature_set_transition()` into `LoadedPrograms::prune()`: Delays it to happen on the first rerooting after the epoch boundary.
- Removes the manually managed `FEATURES_AFFECTING_RBPF` list: Because we can now automatically detect changes by using `BuiltinProgram::eq()`.
- Adds parameter recompile to `Bank::load_program()`: Which is `Some` when called from within the recompilation phase.
