### PR TITLE
[clap-v3-utils] Deprecate signer validation and update parsing for clap-v3

### DIFF
--- a/clap-v3-utils/src/fee_payer.rs
+++ b/clap-v3-utils/src/fee_payer.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{input_validators, ArgConstant},
+    crate::{input_parsers::signer::SignerSourceParserBuilder, ArgConstant},
     clap::Arg,
 };
 
@@ -16,6 +16,6 @@ pub fn fee_payer_arg<'a>() -> Arg<'a> {
         .long(FEE_PAYER_ARG.long)
         .takes_value(true)
         .value_name("KEYPAIR")
-        .validator(|s| input_validators::is_valid_signer(s))
+        .value_parser(SignerSourceParserBuilder::default().build())
         .help(FEE_PAYER_ARG.help)
 }

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -411,8 +411,7 @@ mod tests {
     use {
         super::*,
         clap::{Arg, Command},
-        solana_sdk::signature::write_keypair_file,
-        solana_sdk::{hash::Hash, pubkey::Pubkey},
+        solana_sdk::{hash::Hash, pubkey::Pubkey, signature::write_keypair_file},
         std::fs,
     };
 

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -2,8 +2,8 @@ use {
     crate::{
         input_validators::normalize_to_url_if_moniker,
         keypair::{
-            keypair_from_seed_phrase, pubkey_from_path, signer_from_path, ASK_KEYWORD,
-            SKIP_SEED_PHRASE_VALIDATION_ARG,
+            keypair_from_seed_phrase, pubkey_from_path, resolve_signer_from_path, signer_from_path,
+            ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
         },
     },
     chrono::DateTime,
@@ -386,6 +386,23 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, 
             })
             .collect()
     })
+}
+
+#[deprecated(
+    since = "1.17.0",
+    note = "Please use `SignerSource::try_resolve` instead"
+)]
+pub fn resolve_signer(
+    matches: &ArgMatches,
+    name: &str,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    resolve_signer_from_path(
+        matches,
+        matches.try_get_one::<String>(name)?.unwrap(),
+        name,
+        wallet_manager,
+    )
 }
 
 #[cfg(test)]

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -246,6 +246,10 @@ pub fn parse_derived_address_seed(arg: &str) -> Result<String, String> {
 }
 
 // Return the keypair for an argument with filename `name` or None if not present.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSource::try_get_keypair` instead"
+)]
 pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
     if let Some(value) = matches.value_of(name) {
         if value == ASK_KEYWORD {
@@ -259,6 +263,10 @@ pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
     }
 }
 
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSource::try_get_keypairs` instead"
+)]
 pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
     matches.values_of(name).map(|values| {
         values

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,7 +1,10 @@
 use {
-    crate::keypair::{
-        keypair_from_source, pubkey_from_source, resolve_signer_from_path, signer_from_source,
-        ASK_KEYWORD,
+    crate::{
+        input_parsers::STDOUT_OUTFILE_TOKEN,
+        keypair::{
+            keypair_from_source, pubkey_from_source, resolve_signer_from_source,
+            signer_from_source, ASK_KEYWORD,
+        },
     },
     clap::{builder::ValueParser, ArgMatches},
     solana_remote_wallet::{
@@ -182,6 +185,19 @@ impl SignerSource {
         }
     }
 
+    pub fn try_resolve(
+        matches: &ArgMatches,
+        name: &str,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+    ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        let source = matches.try_get_one::<Self>(name)?;
+        if let Some(source) = source {
+            resolve_signer_from_source(matches, source, name, wallet_manager)
+        } else {
+            Ok(None)
+        }
+    }
+
     pub(crate) fn parse<S: AsRef<str>>(source: S) -> Result<SignerSource, SignerSourceError> {
         let source = source.as_ref();
         let source = {
@@ -333,19 +349,6 @@ impl SignerSourceParserBuilder {
             },
         )
     }
-}
-
-pub fn resolve_signer(
-    matches: &ArgMatches,
-    name: &str,
-    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    resolve_signer_from_path(
-        matches,
-        matches.try_get_one::<String>(name)?.unwrap(),
-        name,
-        wallet_manager,
-    )
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,19 +1,161 @@
 use {
     crate::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, pubkeys_of},
-        keypair::{
-            parse_signer_source, pubkey_from_path, resolve_signer_from_path, signer_from_path,
-            SignerSource, SignerSourceError, SignerSourceKind,
-        },
+        keypair::{pubkey_from_path, resolve_signer_from_path, signer_from_path, ASK_KEYWORD},
     },
     clap::{builder::ValueParser, ArgMatches},
-    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_remote_wallet::{
+        locator::{Locator as RemoteWalletLocator, LocatorError as RemoteWalletLocatorError},
+        remote_wallet::RemoteWalletManager,
+    },
     solana_sdk::{
+        derivation_path::{DerivationPath, DerivationPathError},
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
     },
     std::{error, rc::Rc, str::FromStr},
+    thiserror::Error,
 };
+
+const SIGNER_SOURCE_PROMPT: &str = "prompt";
+const SIGNER_SOURCE_FILEPATH: &str = "file";
+const SIGNER_SOURCE_USB: &str = "usb";
+const SIGNER_SOURCE_STDIN: &str = "stdin";
+const SIGNER_SOURCE_PUBKEY: &str = "pubkey";
+
+#[derive(Debug, Error)]
+pub enum SignerSourceError {
+    #[error("unrecognized signer source")]
+    UnrecognizedSource,
+    #[error(transparent)]
+    RemoteWalletLocatorError(#[from] RemoteWalletLocatorError),
+    #[error(transparent)]
+    DerivationPathError(#[from] DerivationPathError),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("unsupported source")]
+    UnsupportedSource,
+}
+
+#[derive(Clone)]
+pub enum SignerSourceKind {
+    Prompt,
+    Filepath(String),
+    Usb(RemoteWalletLocator),
+    Stdin,
+    Pubkey(Pubkey),
+}
+
+impl AsRef<str> for SignerSourceKind {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Prompt => SIGNER_SOURCE_PROMPT,
+            Self::Filepath(_) => SIGNER_SOURCE_FILEPATH,
+            Self::Usb(_) => SIGNER_SOURCE_USB,
+            Self::Stdin => SIGNER_SOURCE_STDIN,
+            Self::Pubkey(_) => SIGNER_SOURCE_PUBKEY,
+        }
+    }
+}
+
+impl std::fmt::Debug for SignerSourceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s: &str = self.as_ref();
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SignerSource {
+    pub kind: SignerSourceKind,
+    pub derivation_path: Option<DerivationPath>,
+    pub legacy: bool,
+}
+
+impl SignerSource {
+    fn new(kind: SignerSourceKind) -> Self {
+        Self {
+            kind,
+            derivation_path: None,
+            legacy: false,
+        }
+    }
+
+    fn new_legacy(kind: SignerSourceKind) -> Self {
+        Self {
+            kind,
+            derivation_path: None,
+            legacy: true,
+        }
+    }
+}
+
+pub fn parse_signer_source<S: AsRef<str>>(source: S) -> Result<SignerSource, SignerSourceError> {
+    let source = source.as_ref();
+    let source = {
+        #[cfg(target_family = "windows")]
+        {
+            // trim matched single-quotes since cmd.exe won't
+            let mut source = source;
+            while let Some(trimmed) = source.strip_prefix('\'') {
+                source = if let Some(trimmed) = trimmed.strip_suffix('\'') {
+                    trimmed
+                } else {
+                    break;
+                }
+            }
+            source.replace('\\', "/")
+        }
+        #[cfg(not(target_family = "windows"))]
+        {
+            source.to_string()
+        }
+    };
+    match uriparse::URIReference::try_from(source.as_str()) {
+        Err(_) => Err(SignerSourceError::UnrecognizedSource),
+        Ok(uri) => {
+            if let Some(scheme) = uri.scheme() {
+                let scheme = scheme.as_str().to_ascii_lowercase();
+                match scheme.as_str() {
+                    SIGNER_SOURCE_PROMPT => Ok(SignerSource {
+                        kind: SignerSourceKind::Prompt,
+                        derivation_path: DerivationPath::from_uri_any_query(&uri)?,
+                        legacy: false,
+                    }),
+                    SIGNER_SOURCE_FILEPATH => Ok(SignerSource::new(SignerSourceKind::Filepath(
+                        uri.path().to_string(),
+                    ))),
+                    SIGNER_SOURCE_USB => Ok(SignerSource {
+                        kind: SignerSourceKind::Usb(RemoteWalletLocator::new_from_uri(&uri)?),
+                        derivation_path: DerivationPath::from_uri_key_query(&uri)?,
+                        legacy: false,
+                    }),
+                    SIGNER_SOURCE_STDIN => Ok(SignerSource::new(SignerSourceKind::Stdin)),
+                    _ => {
+                        #[cfg(target_family = "windows")]
+                        // On Windows, an absolute path's drive letter will be parsed as the URI
+                        // scheme. Assume a filepath source in case of a single character shceme.
+                        if scheme.len() == 1 {
+                            return Ok(SignerSource::new(SignerSourceKind::Filepath(source)));
+                        }
+                        Err(SignerSourceError::UnrecognizedSource)
+                    }
+                }
+            } else {
+                match source.as_str() {
+                    STDOUT_OUTFILE_TOKEN => Ok(SignerSource::new(SignerSourceKind::Stdin)),
+                    ASK_KEYWORD => Ok(SignerSource::new_legacy(SignerSourceKind::Prompt)),
+                    _ => match Pubkey::from_str(source.as_str()) {
+                        Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
+                        Err(_) => std::fs::metadata(source.as_str())
+                            .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
+                            .map_err(|err| err.into()),
+                    },
+                }
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct SignerSourceParserBuilder {

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -579,4 +579,65 @@ mod tests {
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }
+
+    #[test]
+    fn test_parse_pubkey_or_keypair_signer_source() {
+        let command = Command::new("test").arg(
+            Arg::new("signer")
+                .long("signer")
+                .takes_value(true)
+                .value_parser(
+                    SignerSourceParserBuilder::new()
+                        .allow_pubkey()
+                        .allow_file_path()
+                        .build(),
+                ),
+        );
+
+        // success cases
+        let pubkey = Pubkey::new_unique();
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--signer", &pubkey.to_string()])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("signer").unwrap();
+        assert!(matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Pubkey(p),
+                derivation_path: None,
+                legacy: false,
+            }
+            if *p == pubkey));
+
+        let file0 = NamedTempFile::new().unwrap();
+        let path = file0.path();
+        let path_str = path.to_str().unwrap();
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--signer", path_str])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("signer").unwrap();
+        assert!(matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            }
+            if p == path_str));
+
+        // faile cases
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--signer", "-"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--signer", "usb::/ledger"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+    }
 }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -252,6 +252,7 @@ impl FromStr for PubkeySignature {
 mod tests {
     use {
         super::*,
+        assert_matches::assert_matches,
         clap::{Arg, Command},
         solana_sdk::signature::write_keypair_file,
         std::fs,
@@ -429,6 +430,100 @@ mod tests {
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_parse_keypair_or_ask_keyword_source() {
+        // allow `ASK` keyword
+        let command = Command::new("test").arg(
+            Arg::new("keypair")
+                .long("keypair")
+                .takes_value(true)
+                .value_parser(
+                    SignerSourceParserBuilder::new()
+                        .allow_file_path()
+                        .allow_prompt()
+                        .build(),
+                ),
+        );
+
+        // success cases
+        let file0 = NamedTempFile::new().unwrap();
+        let path = file0.path();
+        let path_str = path.to_str().unwrap();
+
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", path_str])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+        assert!(matches!(signer_source, SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            }
+            if p == path_str));
+
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "ASK"])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+        assert_matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: true,
+            }
+        );
+
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "prompt:"])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+        assert_matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: false,
+            }
+        );
+
+        // faile cases
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "-"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+
+        // disallow `ASK` keyword
+        let command = Command::new("test").arg(
+            Arg::new("keypair")
+                .long("keypair")
+                .takes_value(true)
+                .value_parser(
+                    SignerSourceParserBuilder::new()
+                        .allow_file_path()
+                        .allow_prompt()
+                        .disallow_legacy()
+                        .build(),
+                ),
+        );
+
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "ASK"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -255,6 +255,7 @@ mod tests {
         clap::{Arg, Command},
         solana_sdk::signature::write_keypair_file,
         std::fs,
+        tempfile::NamedTempFile,
     };
 
     fn app<'ab>() -> Command<'ab> {
@@ -386,6 +387,48 @@ mod tests {
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--pubkeysig", "this_is_an_invalid_arg"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_parse_keypair_source() {
+        let command = Command::new("test").arg(
+            Arg::new("keypair")
+                .long("keypair")
+                .takes_value(true)
+                .value_parser(SignerSourceParserBuilder::new().allow_file_path().build()),
+        );
+
+        // success case
+        let file0 = NamedTempFile::new().unwrap();
+        let path = file0.path();
+        let path_str = path.to_str().unwrap();
+
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", path_str])
+            .unwrap();
+
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+
+        assert!(matches!(signer_source, SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            }
+            if p == path_str));
+
+        // faile cases
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "-"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -527,4 +527,56 @@ mod tests {
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }
+
+    #[test]
+    fn test_parse_prompt_signer_source() {
+        let command = Command::new("test").arg(
+            Arg::new("keypair")
+                .long("keypair")
+                .takes_value(true)
+                .value_parser(SignerSourceParserBuilder::new().allow_prompt().build()),
+        );
+
+        // success case
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "ASK"])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+        assert_matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: true,
+            }
+        );
+
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "prompt:"])
+            .unwrap();
+        let signer_source = matches.get_one::<SignerSource>("keypair").unwrap();
+        assert_matches!(
+            signer_source,
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: false,
+            }
+        );
+
+        // faile cases
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "-"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+    }
 }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,9 +1,12 @@
 use {
     crate::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, pubkeys_of},
-        keypair::{pubkey_from_path, resolve_signer_from_path, signer_from_path},
+        keypair::{
+            parse_signer_source, pubkey_from_path, resolve_signer_from_path, signer_from_path,
+            SignerSource, SignerSourceError, SignerSourceKind,
+        },
     },
-    clap::ArgMatches,
+    clap::{builder::ValueParser, ArgMatches},
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_sdk::{
         pubkey::Pubkey,
@@ -11,6 +14,91 @@ use {
     },
     std::{error, rc::Rc, str::FromStr},
 };
+
+#[derive(Debug)]
+pub struct SignerSourceParserBuilder {
+    prompt: bool,
+    file_path: bool,
+    usb: bool,
+    stdin: bool,
+    pubkey: bool,
+    allow_legacy: bool,
+}
+
+impl Default for SignerSourceParserBuilder {
+    fn default() -> Self {
+        Self {
+            prompt: true,
+            file_path: true,
+            usb: true,
+            stdin: true,
+            pubkey: true,
+            allow_legacy: true,
+        }
+    }
+}
+
+impl SignerSourceParserBuilder {
+    pub fn new() -> Self {
+        Self {
+            prompt: false,
+            file_path: false,
+            usb: false,
+            stdin: false,
+            pubkey: false,
+            allow_legacy: true,
+        }
+    }
+
+    pub fn allow_prompt(mut self) -> Self {
+        self.prompt = true;
+        self
+    }
+
+    pub fn allow_file_path(mut self) -> Self {
+        self.file_path = true;
+        self
+    }
+
+    pub fn allow_usb(mut self) -> Self {
+        self.usb = true;
+        self
+    }
+
+    pub fn allow_stdin(mut self) -> Self {
+        self.stdin = true;
+        self
+    }
+
+    pub fn allow_pubkey(mut self) -> Self {
+        self.pubkey = true;
+        self
+    }
+
+    pub fn disallow_legacy(mut self) -> Self {
+        self.allow_legacy = false;
+        self
+    }
+
+    pub fn build(self) -> ValueParser {
+        ValueParser::from(
+            move |arg: &str| -> Result<SignerSource, SignerSourceError> {
+                let signer_source = parse_signer_source(arg)?;
+                if !self.allow_legacy && signer_source.legacy {
+                    return Err(SignerSourceError::UnsupportedSource);
+                }
+                match signer_source.kind {
+                    SignerSourceKind::Prompt if self.prompt => Ok(signer_source),
+                    SignerSourceKind::Filepath(_) if self.file_path => Ok(signer_source),
+                    SignerSourceKind::Usb(_) if self.usb => Ok(signer_source),
+                    SignerSourceKind::Stdin if self.stdin => Ok(signer_source),
+                    SignerSourceKind::Pubkey(_) if self.pubkey => Ok(signer_source),
+                    _ => Err(SignerSourceError::UnsupportedSource),
+                }
+            },
+        )
+    }
+}
 
 // Sentinel value used to indicate to write to screen instead of file
 pub const STDOUT_OUTFILE_TOKEN: &str = "-";

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -335,33 +335,6 @@ impl SignerSourceParserBuilder {
     }
 }
 
-// Sentinel value used to indicate to write to screen instead of file
-pub const STDOUT_OUTFILE_TOKEN: &str = "-";
-
-// Return pubkey/signature pairs for a string of the form pubkey=signature
-pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, Signature)>> {
-    matches.values_of(name).map(|values| {
-        values
-            .map(|pubkey_signer_string| {
-                let mut signer = pubkey_signer_string.split('=');
-                let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
-                let sig = Signature::from_str(signer.next().unwrap()).unwrap();
-                (key, sig)
-            })
-            .collect()
-    })
-}
-
-// Return pubkey/signature pairs for a string of the form pubkey=signature wrapped inside `Result`
-#[allow(clippy::type_complexity)]
-pub fn try_pubkeys_sigs_of(
-    matches: &ArgMatches,
-    name: &str,
-) -> Result<Option<Vec<(Pubkey, Signature)>>, Box<dyn error::Error>> {
-    matches.try_contains_id(name)?;
-    Ok(pubkeys_sigs_of(matches, name))
-}
-
 pub fn resolve_signer(
     matches: &ArgMatches,
     name: &str,
@@ -377,8 +350,8 @@ pub fn resolve_signer(
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PubkeySignature {
-    pubkey: Pubkey,
-    signature: Signature,
+    pub pubkey: Pubkey,
+    pub signature: Signature,
 }
 impl FromStr for PubkeySignature {
     type Err = String;

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -90,6 +90,10 @@ where
 }
 
 // Return an error if a keypair file cannot be parsed
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_file_path().allow_prompt().build()` instead"
+)]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -107,6 +107,10 @@ where
 }
 
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_prompt().build()` instead"
+)]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
         return Ok(());

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -59,6 +59,10 @@ where
 }
 
 // Return an error if a pubkey cannot be parsed.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `clap::value_parser!(Pubkey)` instead"
+)]
 pub fn is_pubkey(string: &str) -> Result<(), String> {
     is_parsable_generic::<Pubkey, _>(string)
 }

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -127,6 +127,10 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 }
 
 // Return an error if string cannot be parsed as pubkey string or keypair file location
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -136,6 +140,10 @@ where
 
 // Return an error if string cannot be parsed as a pubkey string, or a valid Signer that can
 // produce a pubkey()
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -157,6 +165,10 @@ where
 // when paired with an offline `--signer` argument to provide a Presigner (pubkey + signature).
 // Clap validators can't check multiple fields at once, so the verification that a `--signer` is
 // also provided and correct happens in parsing, not in validation.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().build()` instead"
+)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -76,6 +76,10 @@ where
 }
 
 // Return an error if a keypair file cannot be parsed.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_file_path().build()` instead"
+)]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -138,6 +138,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     since = "1.17.0",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -151,6 +152,7 @@ where
     since = "1.17.0",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -176,6 +178,7 @@ where
     since = "1.17.0",
     note = "please use `SignerSourceParseBuilder::new().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        input_parsers::signer::{parse_signer_source, SignerSourceKind},
+        input_parsers::signer::{SignerSource, SignerSourceKind},
         keypair::ASK_KEYWORD,
     },
     chrono::DateTime,
@@ -122,7 +122,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
         return Ok(());
     }
-    match parse_signer_source(string)
+    match SignerSource::parse(string)
         .map_err(|err| format!("{err}"))?
         .kind
     {
@@ -155,7 +155,7 @@ pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match parse_signer_source(string.as_ref())
+    match SignerSource::parse(string.as_ref())
         .map_err(|err| format!("{err}"))?
         .kind
     {

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -1,5 +1,8 @@
 use {
-    crate::keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
+    crate::{
+        input_parsers::signer::{parse_signer_source, SignerSourceKind},
+        keypair::ASK_KEYWORD,
+    },
     chrono::DateTime,
     solana_sdk::{
         clock::{Epoch, Slot},

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -440,6 +440,8 @@ pub(crate) enum SignerSourceError {
     DerivationPathError(#[from] DerivationPathError),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error("unsupported source")]
+    UnsupportedSource,
 }
 
 pub(crate) fn parse_signer_source<S: AsRef<str>>(

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -371,7 +371,7 @@ impl DefaultSigner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct SignerSource {
     pub kind: SignerSourceKind,
     pub derivation_path: Option<DerivationPath>,
@@ -402,6 +402,7 @@ const SIGNER_SOURCE_USB: &str = "usb";
 const SIGNER_SOURCE_STDIN: &str = "stdin";
 const SIGNER_SOURCE_PUBKEY: &str = "pubkey";
 
+#[derive(Clone)]
 pub(crate) enum SignerSourceKind {
     Prompt,
     Filepath(String),

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1220,8 +1220,7 @@ mod tests {
         crate::{input_parsers::signer::SignerSourceParserBuilder, offline::OfflineArgs},
         clap::{Arg, Command},
         solana_remote_wallet::remote_wallet::initialize_wallet_manager,
-        solana_sdk::signature::write_keypair_file,
-        solana_sdk::system_instruction,
+        solana_sdk::{signature::write_keypair_file, system_instruction},
         tempfile::TempDir,
     };
 

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -747,10 +747,19 @@ pub fn pubkey_from_path(
     keypair_name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Pubkey, Box<dyn error::Error>> {
-    let SignerSource { kind, .. } = SignerSource::parse(path)?;
-    match kind {
+    let source = SignerSource::parse(path)?;
+    pubkey_from_source(matches, &source, keypair_name, wallet_manager)
+}
+
+pub fn pubkey_from_source(
+    matches: &ArgMatches,
+    source: &SignerSource,
+    keypair_name: &str,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+) -> Result<Pubkey, Box<dyn error::Error>> {
+    match source.kind {
         SignerSourceKind::Pubkey(pubkey) => Ok(pubkey),
-        _ => Ok(signer_from_path(matches, path, keypair_name, wallet_manager)?.pubkey()),
+        _ => Ok(signer_from_source(matches, source, keypair_name, wallet_manager)?.pubkey()),
     }
 }
 

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -13,7 +13,7 @@ use {
     crate::{
         input_parsers::{
             pubkeys_sigs_of,
-            signer::{parse_signer_source, SignerSource, SignerSourceKind},
+            signer::{SignerSource, SignerSourceKind},
         },
         offline::{SIGNER_ARG, SIGN_ONLY_ARG},
         ArgConstant,
@@ -165,7 +165,7 @@ impl DefaultSigner {
 
     fn path(&self) -> Result<&str, Box<dyn std::error::Error>> {
         if !self.is_path_checked.borrow().deref() {
-            parse_signer_source(&self.path)
+            SignerSource::parse(&self.path)
                 .and_then(|s| {
                     if let SignerSourceKind::Filepath(path) = &s.kind {
                         std::fs::metadata(path).map(|_| ()).map_err(|e| e.into())
@@ -622,7 +622,7 @@ pub fn signer_from_path_with_config(
         kind,
         derivation_path,
         legacy,
-    } = parse_signer_source(path)?;
+    } = SignerSource::parse(path)?;
     match kind {
         SignerSourceKind::Prompt => {
             let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
@@ -725,7 +725,7 @@ pub fn pubkey_from_path(
     keypair_name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Pubkey, Box<dyn error::Error>> {
-    let SignerSource { kind, .. } = parse_signer_source(path)?;
+    let SignerSource { kind, .. } = SignerSource::parse(path)?;
     match kind {
         SignerSourceKind::Pubkey(pubkey) => Ok(pubkey),
         _ => Ok(signer_from_path(matches, path, keypair_name, wallet_manager)?.pubkey()),
@@ -742,7 +742,7 @@ pub fn resolve_signer_from_path(
         kind,
         derivation_path,
         legacy,
-    } = parse_signer_source(path)?;
+    } = SignerSource::parse(path)?;
     match kind {
         SignerSourceKind::Prompt => {
             let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
@@ -980,7 +980,7 @@ fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
         kind,
         derivation_path,
         legacy,
-    } = parse_signer_source(path)?;
+    } = SignerSource::parse(path)?;
     match kind {
         SignerSourceKind::Prompt => Ok(encodable_key_from_seed_phrase(
             keypair_name,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1293,7 +1293,7 @@ mod tests {
 
         let signer = signer_from_source(
             &clap_matches,
-            &keypair_source,
+            keypair_source,
             "signer",
             &mut Some(wallet_manager),
         )?;

--- a/clap-v3-utils/src/nonce.rs
+++ b/clap-v3-utils/src/nonce.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{input_validators::*, ArgConstant},
+    crate::{input_parsers::signer::SignerSourceParserBuilder, ArgConstant},
     clap::{Arg, Command},
 };
 
@@ -23,7 +23,12 @@ fn nonce_arg<'a>() -> Arg<'a> {
         .long(NONCE_ARG.long)
         .takes_value(true)
         .value_name("PUBKEY")
-        .validator(|s| is_valid_pubkey(s))
+        .value_parser(
+            SignerSourceParserBuilder::new()
+                .allow_pubkey()
+                .allow_file_path()
+                .build(),
+        )
         .help(NONCE_ARG.help)
 }
 
@@ -32,7 +37,7 @@ pub fn nonce_authority_arg<'a>() -> Arg<'a> {
         .long(NONCE_AUTHORITY_ARG.long)
         .takes_value(true)
         .value_name("KEYPAIR")
-        .validator(|s| is_valid_signer(s))
+        .value_parser(SignerSourceParserBuilder::default().build())
         .help(NONCE_AUTHORITY_ARG.help)
 }
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::arithmetic_side_effects, deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -87,7 +87,7 @@ impl From<Infallible> for LocatorError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Locator {
     pub manufacturer: Manufacturer,
     pub pubkey: Option<Pubkey>,

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},


### PR DESCRIPTION
#### Problem
In clap-v3, the `Arg::validator` is deprecated and replaced with `Arg::value_parser`. The idea is that when we validate an argument input, we generally parse the input, so dividing validation and parsing in separate steps forces you to parse input twice.

A previous PR https://github.com/solana-labs/solana/pull/33276 deprecated most of the validation functions in clap-v3-utils and replaced them with parsing functions. This PR is a follow-up that deprecates validation functions related to the signer.

#### Summary of Changes
Sorry this follow-up PR took such a long time. I actually had this PR open for a couple weeks, but I never asked for a review.

To make clap-v3-utils implement clap parsers idiomatically, I made some non-trivial amount of changes including making the `SignerSource` a public type. I am very open to the reviewers' opinions and am happy to revert any of the changes I made in this PR, so please let me know what you think.

- [703c5a5](https://github.com/solana-labs/solana/pull/33478/commits/703c5a5c5427fec5f9c407a64b33634536964574): The most idiomatic way to define a parser for signer related arguments was to make `SignerSource` be a public type and let applications call `matches.get_one::<SignerSource>(...)` to validate and parse the signer source. To define a parser for `SignerSource` (to call `clap::builder::ValueParser::from(...)` on the `SignerSource` type), the `SignerSource` has to implement `Clone`. I thought adding `Clone` to `SignerSource` was okay since sensitive information is not actually parsed with `SignerSource`, but later when we call `signer_from_path` or `keypair_from_path`. Please let me know otherwise.
- [bf4e1f7](https://github.com/solana-labs/solana/pull/33478/commits/bf4e1f7a71f3c20db3d7ad91c4339ed714b4d51a): I thought this was an appropriate place to use a builder pattern to build a `SignerSource` parser, so I added it.
- [7fb9565](https://github.com/solana-labs/solana/pull/33478/commits/7fb9565bc9422630cfea378633676a07f8ae3e6b), [36f5f20](https://github.com/solana-labs/solana/pull/33478/commits/36f5f20c79dae95e83001abaa456fc72535269d2), [4fb271f](https://github.com/solana-labs/solana/pull/33478/commits/4fb271f6b8f9c813a535d5f1e7110f9e42623753), [11500e7](https://github.com/solana-labs/solana/pull/33478/commits/11500e7fa583333bee59d0498ef2882259812395), [089c97b](https://github.com/solana-labs/solana/pull/33478/commits/089c97b1ee0d5cf880d0208d8147c6606fb53258): I deprecated validation functions related to keypairs. These functions were refactored into `parser::signer` from the previous PR. Since they are deprecated anyway, I moved them back to their original place (as suggested https://github.com/solana-labs/solana/pull/33276#discussion_r1338018139 previously). I should have put them back in the previous PR 🙏 ...
- [cb698b8](https://github.com/solana-labs/solana/pull/33478/commits/cb698b8649e7e1cd16a375dcc635e4b7be354d59), [76d5f62](https://github.com/solana-labs/solana/pull/33478/commits/76d5f627aabb0758cd61702209fd5c6466c931b4): I refactored `SignerSource` into `parser::signer` and made it into a public type. 
- [81ca157](https://github.com/solana-labs/solana/pull/33478/commits/81ca15773226d1c9e68f18139745d3468adbde50), [27518c1](https://github.com/solana-labs/solana/pull/33478/commits/27518c1190f4f60225c73f7e53fe9afe5229e980), [22561e1](https://github.com/solana-labs/solana/pull/33478/commits/22561e195a4b34a51ed961b1a24c5f7f06aff96e), [370c43f](https://github.com/solana-labs/solana/pull/33478/commits/370c43f336d91f66a111645388cd9076c46f895a), [7f09abc](https://github.com/solana-labs/solana/pull/33478/commits/7f09abc6451cd3f98d658661b86be175b425640e): I deprecated some of the signer related functions and replace them with associated functions to `SignerSource`. I also returned these deprecated functions back to its original place... sorry for the mess.
- [01f5656](https://github.com/solana-labs/solana/pull/33478/commits/01f5656eb7c831497f2e68b5c720504758aa6f06): I added `#[allow(deprecated)]` in `solana-keygen` and `solana-zk-keygen`. These two crates will be addressed on follow-up to remove deprecated functions. I also either removed deprecated functions in `clap-v3-utils` or added `#[allow(deprecated)]` to already deprecated functions for the CI.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
