### PR TITLE
Refactor - `LoadedPrograms`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -26,7 +26,8 @@ use {
     },
 };
 
-const MAX_LOADED_ENTRY_COUNT: usize = 256;
+pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static>>>;
+pub const MAX_LOADED_ENTRY_COUNT: usize = 256;
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
 /// Relationship between two fork IDs
@@ -62,17 +63,17 @@ pub trait WorkingSlot {
 #[derive(Default)]
 pub enum LoadedProgramType {
     /// Tombstone for undeployed, closed or unloadable programs
-    FailedVerification(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    FailedVerification(ProgramRuntimeEnvironment),
     #[default]
     Closed,
     DelayVisibility,
     /// Successfully verified but not currently compiled, used to track usage statistics when a compiled program is evicted from memory.
-    Unloaded(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    Unloaded(ProgramRuntimeEnvironment),
     LegacyV0(Executable<InvokeContext<'static>>),
     LegacyV1(Executable<InvokeContext<'static>>),
     Typed(Executable<InvokeContext<'static>>),
     #[cfg(test)]
-    TestLoaded(Arc<BuiltinProgram<InvokeContext<'static>>>),
+    TestLoaded(ProgramRuntimeEnvironment),
     Builtin(BuiltinProgram<InvokeContext<'static>>),
 }
 
@@ -221,7 +222,7 @@ impl LoadedProgram {
     /// Creates a new user program
     pub fn new(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
         effective_slot: Slot,
         maybe_expiration_slot: Option<Slot>,
@@ -407,10 +408,10 @@ impl LoadedProgram {
 
 #[derive(Clone, Debug)]
 pub struct ProgramRuntimeEnvironments {
-    /// Globally shared RBPF config and syscall registry
-    pub program_runtime_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    /// Globally shared RBPF config and syscall registry for runtime V1
+    pub program_runtime_v1: ProgramRuntimeEnvironment,
     /// Globally shared RBPF config and syscall registry for runtime V2
-    pub program_runtime_v2: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    pub program_runtime_v2: ProgramRuntimeEnvironment,
 }
 
 impl Default for ProgramRuntimeEnvironments {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -638,7 +638,7 @@ impl LoadedPrograms {
         self.remove_programs_with_no_entries();
     }
 
-    /// Before rerooting the blockstore this removes all superflous entries
+    /// Before rerooting the blockstore this removes all superfluous entries
     pub fn prune<F: ForkGraph>(
         &mut self,
         fork_graph: &F,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -419,7 +419,7 @@ impl BankForks {
             .loaded_programs_cache
             .write()
             .unwrap()
-            .prune(self, root);
+            .prune(self, root, root_bank.epoch());
         let set_root_start = Instant::now();
         let (removed_banks, set_root_metrics) = self.do_set_root_return_metrics(
             root,


### PR DESCRIPTION
#### Problem
Preparation for #33477.

#### Summary of Changes
- Adds type `ProgramRuntimeEnvironment`: For slightly improved code readability.
- Moves `LoadedPrograms::remove_expired_entries()` into `LoadedPrograms::prune()`: As an optimization as we don't need to `retain` / `collect` the secondary index level twice.
- Adds `Stats::prunes_environment` and renames `Stats::prunes_orphan` and `Stats::prunes_expired`: So that all three reasons for pruning entries on rerooting have the same naming scheme.
- Adds `LoadedPrograms::latest_root_epoch`: To detect the first rerooting after an epoch boundary, ending the recompilation phase.
