### PR TITLE
Store pubkey bin offsets in hash cache file

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7258,7 +7258,7 @@ impl AccountsDb {
                 // so, build a file name:
                 let hash = hasher.finish();
                 let file_name = format!(
-                    "{}.{}.{}.{}.{:016x}",
+                    "new.{}.{}.{}.{}.{:016x}",
                     range_this_chunk.start,
                     range_this_chunk.end,
                     bin_range.start,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -57,7 +57,9 @@ use {
             aligned_stored_size, AppendVec, MatchAccountOwnerError, APPEND_VEC_MMAPPED_FILES_OPEN,
             STORE_META_OVERHEAD,
         },
-        cache_hash_data::{CacheHashData, CacheHashDataFileReference},
+        cache_hash_data::{
+            CacheHashData, CacheHashDataFileReference, ACCOUNT_HASHES_CACHE_FILE_VERSION,
+        },
         contains::Contains,
         epoch_accounts_hash::EpochAccountsHashManager,
         in_mem_accounts_index::StartupStats,
@@ -7258,12 +7260,13 @@ impl AccountsDb {
                 // so, build a file name:
                 let hash = hasher.finish();
                 let file_name = format!(
-                    "new.{}.{}.{}.{}.{:016x}",
+                    "{}.{}.{}.{}.{:016x}.{}",
                     range_this_chunk.start,
                     range_this_chunk.end,
                     bin_range.start,
                     bin_range.end,
-                    hash
+                    hash,
+                    ACCOUNT_HASHES_CACHE_FILE_VERSION,
                 );
                 if load_from_cache {
                     if let Ok(mapped_file) =

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -24,7 +24,7 @@ pub(crate) const ACCOUNT_HASHES_CACHE_FILE_VERSION: u64 = 1;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
-pub struct Header {
+struct Header {
     /// count of accounts' hashes in the file
     count: usize,
 
@@ -59,7 +59,7 @@ pub(crate) struct CacheHashDataFile {
 }
 
 impl CacheHashDataFileReference {
-    /// convert the open file refrence to a mmapped file that can be returned as a slice
+    /// convert the open file reference to a mmapped file that can be returned as a slice
     pub(crate) fn map(&self) -> Result<CacheHashDataFile, std::io::Error> {
         let file_len = self.file_len;
         let mut m1 = Measure::start("read_file");

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -19,6 +19,9 @@ pub type EntryType = CalculateHashIntermediate;
 pub type SavedType = Vec<Vec<EntryType>>;
 pub type SavedTypeSlice = [Vec<EntryType>];
 
+/// Account hashes file version
+pub(crate) const ACCOUNT_HASHES_CACHE_FILE_VERSION: u64 = 1;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct Header {
@@ -27,7 +30,7 @@ pub struct Header {
 
     /// offset for the first pubkey in each bin
     /// For `N` bins, there will be `N+1` offsets. The boundaries for each bin `i` are from offsets[i] to offsets[i+1].
-    /// The one extra element in offsets help to avoid the need to special case i=0 for offset look up by `bin`, which makes the lookup code faster.
+    /// The one extra element in offsets helps to avoid the need to special case i=0 for offset lookups by `bin`, which makes the lookup code faster.
     number_offsets: usize,
 }
 


### PR DESCRIPTION
#### Problem

Storing pubkey bin offsets in hash cache file to avoid recomputing them when deduping. 

65K * 8 * 300K = 156G data

master 
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d0 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us|^sort_us|hash_total|total_us"
total_us                            9190042i
eliminate_zeros_us                  4677618i
sort_us                             674877i
hash_total                          338924320i
pubkey_bin_search_us                12422676i
```

this PR
```
sol@dev-equinix-washington-23:~$ grep calculate_accounts_hash_from_storages d2 | tail -n1 | awk '{for(i=1; i<=NF; i++) if (0 != index($i, "=")) {print($i)}}' | column -ts "=" | grep -E "pubkey_bin_search_us|eliminate_zeros_us|min_pk_scan_us|hash_writes_us|skip_duplicates_us|^sort_us|hash_total|total_us"
total_us                            7825945i
eliminate_zeros_us                  3338763i
sort_us                             678038i
hash_total                          338924320i
pubkey_bin_search_us                0i
```

Cut down de-dup by 1.3s. 

Dedup timing on mainnet

![image](https://github.com/solana-labs/solana/assets/219428/64f6d55f-30e0-41e2-b189-79d9cc28a28d)

Red: master; blue: this PR.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
