### PR TITLE
Deprecate bz2/gzip/none/tar snapshot compression types

### DIFF
--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -3,7 +3,13 @@ use {
     strum::Display,
 };
 
-pub const SUPPORTED_ARCHIVE_COMPRESSION: &[&str] = &["bz2", "gzip", "zstd", "lz4", "tar", "none"];
+// SUPPORTED_ARCHIVE_COMPRESSION lists the compression types that can be
+// specified on the command line. "zstd" and "lz4" are valid whereas "gzip",
+// "bz2", "tar" and "none" have been deprecated. Thus, all newly created
+// snapshots will either use "zstd" or "lz4". By keeping the deprecated types
+// in the ArchiveFormat enum, pre-existing snapshot archives with the
+// deprecated compression types can still be read.
+pub const SUPPORTED_ARCHIVE_COMPRESSION: &[&str] = &["zstd", "lz4"];
 pub const DEFAULT_ARCHIVE_COMPRESSION: &str = "zstd";
 
 pub const TAR_BZIP2_EXTENSION: &str = "tar.bz2";
@@ -36,11 +42,8 @@ impl ArchiveFormat {
 
     pub fn from_cli_arg(archive_format_str: &str) -> Option<ArchiveFormat> {
         match archive_format_str {
-            "bz2" => Some(ArchiveFormat::TarBzip2),
-            "gzip" => Some(ArchiveFormat::TarGzip),
             "zstd" => Some(ArchiveFormat::TarZstd),
             "lz4" => Some(ArchiveFormat::TarLz4),
-            "tar" | "none" => Some(ArchiveFormat::Tar),
             _ => None,
         }
     }
@@ -158,14 +161,7 @@ mod tests {
 
     #[test]
     fn test_from_cli_arg() {
-        let golden = [
-            Some(ArchiveFormat::TarBzip2),
-            Some(ArchiveFormat::TarGzip),
-            Some(ArchiveFormat::TarZstd),
-            Some(ArchiveFormat::TarLz4),
-            Some(ArchiveFormat::Tar),
-            Some(ArchiveFormat::Tar),
-        ];
+        let golden = [Some(ArchiveFormat::TarZstd), Some(ArchiveFormat::TarLz4)];
 
         for (arg, expected) in zip(SUPPORTED_ARCHIVE_COMPRESSION.iter(), golden.into_iter()) {
             assert_eq!(ArchiveFormat::from_cli_arg(arg), expected);

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -110,7 +110,6 @@ args=(
   --enable-rpc-transaction-history
   --enable-extended-tx-metadata-storage
   --init-complete-file "$dataDir"/init-completed
-  --snapshot-compression none
   --require-tower
   --no-wait-for-vote-to-start-leader
   --no-os-network-limits-test


### PR DESCRIPTION
#### Problem
For our use cases, the compression types being removed are inferior and have caused us support burden.

#### Summary of Changes
These options are now disallowed on the command line for solana-validator and solana-ledger-tool, which effectively means no more snapshots will be created with this types in normal usecases. However, support for reading the deprecated types is still in place.

This PR is a follow-on to https://github.com/solana-labs/solana/pull/33442 (which I will be closing); that PR ripped several things out whereas this PR has a more gradual deprecation approach in mind
