### PR TITLE
log signature after successful feature activation

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -1,6 +1,9 @@
 use {
     crate::{
-        cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
+        cli::{
+            log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError,
+            ProcessResult,
+        },
         spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
     },
     clap::{value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand},
@@ -23,6 +26,7 @@ use {
         message::Message,
         pubkey::Pubkey,
         stake_history::Epoch,
+        system_instruction::SystemError,
         transaction::Transaction,
     },
     std::{cmp::Ordering, collections::HashMap, fmt, rc::Rc, str::FromStr},
@@ -957,6 +961,6 @@ fn process_activate(
         FEATURE_NAMES.get(&feature_id).unwrap(),
         feature_id
     );
-    let signature = rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
-    Ok(format!("Signature: {signature}"))
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&transaction);
+    log_instruction_custom_error::<SystemError>(result, config)
 }

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -957,6 +957,6 @@ fn process_activate(
         FEATURE_NAMES.get(&feature_id).unwrap(),
         feature_id
     );
-    rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
-    Ok("".to_string())
+    let signature = rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
+    Ok(format!("Signature: {signature}"))
 }


### PR DESCRIPTION
#### Problem
When activating a feature the transaction `Signature` is not logged in the final result.
It is only logged temporarily in the progress bar during during transaction finalization.
If it activates quickly, The user misses the signature and has to find it manually.

#### Summary of Changes
Return the signature in the `ProcessResult` which is used to print final results.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
