### PR TITLE
Add test for compaction filter purge

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1287,6 +1287,11 @@ impl Database {
     pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
         self.backend.live_files_metadata()
     }
+
+    pub fn compact_range_cf<C: Column + ColumnName>(&self, from: &[u8], to: &[u8]) {
+        let cf = self.cf_handle::<C>();
+        self.backend.db.compact_range_cf(cf, Some(from), Some(to));
+    }
 }
 
 impl<C> LedgerColumn<C>


### PR DESCRIPTION
#### Problem
I'm exploring removing the primary-index from the Blockstore "special column" keys. But it's difficult to tell if I might be breaking current purge functionality, because there is no test of CompactionFilter-type purge.

#### Summary of Changes
Add test of compaction-filter purge.
I also exposed `compact_range_cf` functionality as a method on `Database` -- I need it for the test, but thought it might be useful for purging the special columns in other contexts. But I could lock it down within `mod tests` if preferred.
