### PR TITLE
Add SIMD field to feature gate issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-gate.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-gate.yml
@@ -24,6 +24,14 @@ body:
         `solana_sdk::declare_id!()` within the module. Additionally, add an entry to `FEATURE_NAMES` map.
 
         3. Add desired logic to check for and switch on feature availability.
+  - type: input
+    id: simd
+    attributes:
+      label: SIMD
+      description: Solana IMprovement Document (SIMD)
+      placeholder: Link to the https://github.com/solana-foundation/solana-improvement-documents document for this feature
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
We want to encourage all consesus-breaking changes to first have a SIMD. Update the feature gate issue template to request a link to its SIMD as a _gentle_ nudge in this direction