### PR TITLE
Enable the banking trace by default

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1134,11 +1134,11 @@ impl Validator {
             .map_err(|err| format!("{} [{:?}]", &err, &err))?;
         if banking_tracer.is_enabled() {
             info!(
-                "Enabled banking tracer (dir_byte_limit: {})",
+                "Enabled banking trace (dir_byte_limit: {})",
                 config.banking_trace_dir_byte_limit
             );
         } else {
-            info!("Disabled banking tracer");
+            info!("Disabled banking trace");
         }
 
         let entry_notification_sender = entry_notifier_service

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1351,9 +1351,17 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 // explicitly given, similar to --limit-ledger-size.
                 // see configure_banking_trace_dir_byte_limit() for this.
                 .default_value(&default_args.banking_trace_dir_byte_limit)
-                .help("Write trace files for simulate-leader-blocks, retaining \
-                       up to the default or specified total bytes in the \
-                       ledger")
+                .help("Enables the banking trace explicitly, which is enabled by default and \
+                       writes trace files for simulate-leader-blocks, retaining up to the default \
+                       or specified total bytes in the ledger. This flag can be used to override \
+                       its byte limit.")
+        )
+        .arg(
+            Arg::with_name("disable_banking_trace")
+                .long("disable-banking-trace")
+                .conflicts_with("banking_trace_dir_byte_limit")
+                .takes_value(false)
+                .help("Disables the banking trace")
         )
         .arg(
             Arg::with_name("block_verification_method")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -448,15 +448,16 @@ fn configure_banking_trace_dir_byte_limit(
     validator_config: &mut ValidatorConfig,
     matches: &ArgMatches,
 ) {
-    validator_config.banking_trace_dir_byte_limit =
-        if matches.occurrences_of("banking_trace_dir_byte_limit") == 0 {
-            // disable with no explicit flag; then, this effectively becomes `opt-in` even if we're
-            // specifying a default value in clap configuration.
-            DISABLED_BAKING_TRACE_DIR
-        } else {
-            // BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT or user-supplied override value
-            value_t_or_exit!(matches, "banking_trace_dir_byte_limit", u64)
-        };
+    validator_config.banking_trace_dir_byte_limit = if matches.is_present("disable_banking_trace") {
+        // disable with an explicit flag; This effectively becomes `opt-out` by reseting to
+        // DISABLED_BAKING_TRACE_DIR, while allowing us to specify a default sensible limit in clap
+        // configuration for cli help.
+        DISABLED_BAKING_TRACE_DIR
+    } else {
+        // a default value in clap configuration (BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT) or
+        // explicit user-supplied override value
+        value_t_or_exit!(matches, "banking_trace_dir_byte_limit", u64)
+    };
 }
 
 pub fn main() {


### PR DESCRIPTION
#### Problem

The banking trace disabled code path is running fine with mb & v1.16.

Let's bake the banking trace with v1.17 rel train to enable it on mb by default eventually.

I'm procrastinator.. missed v1.17 branching a day.

#### Summary of Changes

Enable it by default.

CLI:

```
--enable-banking-trace <BYTES>
    Enables the banking trace explicitly, which is enabled by default and writes trace files for simulate-
    leader-blocks, retaining up to the default or specified total bytes in the ledger. This flag can be
    used to override its byte limit. [default: 15032385536]

--disable-banking-trace                   
    Disables the banking trace
```

