### PR TITLE
Blockstore special columns: minimize deletes in PurgeType::Exact

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1256,6 +1256,8 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let index0_max_slot = 9;
         let index1_max_slot = 19;
+        // includes slot 0, and slot 9 has 2 transactions
+        let num_total_transactions = index1_max_slot + 2;
 
         clear_and_repopulate_transaction_statuses_for_test(
             &blockstore,
@@ -1293,7 +1295,7 @@ pub mod tests {
             assert!(slot >= oldest_slot);
             count += 1;
         }
-        assert_eq!(count, index1_max_slot - (oldest_slot - 1));
+        assert_eq!(count, num_total_transactions - oldest_slot);
 
         clear_and_repopulate_transaction_statuses_for_test(
             &blockstore,
@@ -1331,6 +1333,6 @@ pub mod tests {
             assert!(slot >= oldest_slot);
             count += 1;
         }
-        assert_eq!(count, index1_max_slot - (oldest_slot - 1));
+        assert_eq!(count, num_total_transactions - oldest_slot - 1); // Extra transaction in slot 9
     }
 }


### PR DESCRIPTION
#### Problem
Currently, `Blockstore::purge_columns_exact()` gets called on cluster restarts and takes quite a while to complete. However, we can halve the number of special-column deletes in the write batch in half for nodes running with `--enable-rpc-transaction-history` (ie RPC nodes), and eliminate them altogether for nodes without this flag (the majority of staked validators).

#### Summary of Changes
We already read both values from the `transaction_status_index_cf`, so use this data in memory to determine which (if any) primary_index contains the slot in question.

This is a reworking of functionality that is in #33370, but done in a way that works better with #33419
