### PR TITLE
Remove dummy entries in Blockstore special columns

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2131,17 +2131,19 @@ impl Blockstore {
         // If present, delete dummy entries inserted by old software
         // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);
-        if let Some(_) = self
+        if self
             .transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>(transaction_status_dummy_key)?
+            .is_some()
         {
             self.transaction_status_cf
                 .delete(transaction_status_dummy_key)?;
         };
         let address_signatures_dummy_key = cf::AddressSignatures::as_index(2);
-        if let Some(_) = self
+        if self
             .address_signatures_cf
             .get(address_signatures_dummy_key)?
+            .is_some()
         {
             self.address_signatures_cf
                 .delete(address_signatures_dummy_key)?;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7682,8 +7682,6 @@ pub mod tests {
     fn test_get_transaction_status() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        // TransactionStatus column opens initialized with one entry at index 2
         let transaction_status_cf = &blockstore.transaction_status_cf;
 
         let pre_balances_vec = vec![1, 2, 3];
@@ -7876,8 +7874,6 @@ pub mod tests {
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        // TransactionStatus column opens initialized with one entry at index 2
         let transaction_status_cf = &blockstore.transaction_status_cf;
 
         let pre_balances_vec = vec![1, 2, 3];

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7862,13 +7862,13 @@ pub mod tests {
             .get_transaction_status_with_counter(signature7, &[].into())
             .unwrap();
         assert_eq!(status, None);
-        assert_eq!(counter, 2);
+        assert_eq!(counter, 1);
 
         let (status, counter) = blockstore
             .get_transaction_status_with_counter(signature7, &[3].into())
             .unwrap();
         assert_eq!(status, None);
-        assert_eq!(counter, 2);
+        assert_eq!(counter, 1);
     }
 
     fn do_test_lowest_cleanup_slot_and_special_cfs(simulate_ledger_cleanup_service: bool) {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -649,9 +649,6 @@ pub mod tests {
                 IteratorDirection::Forward,
             ))
             .unwrap();
-        let padding_entry = status_entry_iterator.next().unwrap().0;
-        assert_eq!(padding_entry.0, 2);
-        assert_eq!(padding_entry.2, 0);
         assert!(status_entry_iterator.next().is_none());
         let mut address_transactions_iterator = blockstore
             .db
@@ -660,10 +657,8 @@ pub mod tests {
                 IteratorDirection::Forward,
             ))
             .unwrap();
-        let padding_entry = address_transactions_iterator.next().unwrap().0;
-        assert_eq!(padding_entry.0, 2);
-        assert_eq!(padding_entry.2, 0);
         assert!(address_transactions_iterator.next().is_none());
+
         assert_eq!(
             transaction_status_index_cf.get(0).unwrap().unwrap(),
             TransactionStatusIndexMeta {
@@ -1095,8 +1090,6 @@ pub mod tests {
                 frozen: false,
             }
         );
-        let entry = status_entry_iterator.next().unwrap().0;
-        assert_eq!(entry.0, 2); // Buffer entry, no index 1 entries remaining
         drop(status_entry_iterator);
 
         // Purge up to but not including index0_max_slot
@@ -1135,6 +1128,8 @@ pub mod tests {
                 IteratorDirection::Forward,
             ))
             .unwrap();
+        assert!(status_entry_iterator.next().is_none());
+
         assert_eq!(
             blockstore
                 .transaction_status_index_cf
@@ -1157,8 +1152,6 @@ pub mod tests {
                 frozen: false,
             }
         );
-        let entry = status_entry_iterator.next().unwrap().0;
-        assert_eq!(entry.0, 2); // Buffer entry, no index 0 or index 1 entries remaining
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
These entries were found to improve compaction performance when
LedgerCleanupService was performing direct compactions on each primary
index. Cleaning by primary index has been deprecated for a while, and
as such, these dummy entries are no longer needed and can be removed.

#### Summary of Changes
Remove the dummy entries + a few comments that will no longer be correct

This is broken out from https://github.com/solana-labs/solana/pull/33370