### PR TITLE
Fix blockstore-purge delete_files_in_range_us metric

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -50,7 +50,7 @@ impl Blockstore {
             ("write_batch_us", purge_stats.write_batch as i64, i64),
             (
                 "delete_files_in_range_us",
-                purge_stats.write_batch as i64,
+                purge_stats.delete_files_in_range as i64,
                 i64
             )
         );


### PR DESCRIPTION
#### Problem
This field was being filled with the wrong value