### PR TITLE
zeroize: Allow versions newer than 1.3 for `curve25519-dalek`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,8 +1463,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=c14774464c4d38de553c6ef2f48a10982c1b4801#c14774464c4d38de553c6ef2f48a10982c1b4801"
 dependencies = [
  "byteorder",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,3 +491,36 @@ solana-zk-token-sdk = { path = "zk-token-sdk" }
 [patch.crates-io.aes-gcm-siv]
 git = "https://github.com/RustCrypto/AEADs"
 rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
+
+# Our dependency tree has `curve25519-dalek` v3.2.1.  They have removed the
+# constrain in the next major release.  Commit that removes `zeroize` constrain
+# was added to multiple release branches.  Bot not to the 3.2 branch.
+#
+# `curve25519-dalek` maintainers are saying they do not want to invest any more
+# time in the 3.2 release:
+#
+# https://github.com/dalek-cryptography/curve25519-dalek/issues/452#issuecomment-1749809428
+#
+# So we have to fork and create our own release, based on v3.2.1.  Commit that
+# removed `zeroize` constrain on the `main` branch cherry picked on top of the
+# v3.2.1 release.
+#
+# `curve25519-dalek` v3.2.1 release:
+#
+# https://github.com/dalek-cryptography/curve25519-dalek/releases/tag/3.2.1
+#
+# Corresponds to commit
+#
+# https://github.com/dalek-cryptography/curve25519-dalek/commit/29e5c29b0e5c6821e4586af58b0d0891dd2ec639
+#
+# Comparison with `c14774464c4d38de553c6ef2f48a10982c1b4801`:
+#
+# https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:c14774464c4d38de553c6ef2f48a10982c1b4801
+#
+# Or, using the branch name instead of the hash:
+#
+# https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:3.2.1-unpin-zeroize
+#
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/solana-labs/curve25519-dalek.git"
+rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"


### PR DESCRIPTION
#### Problem
`curve25519-dalek` v3.2.1 has a constraint on the maximum `zeroize` version to be no more than 1.3.

At the same time, `cargo` does not want to construct a dependency graph with duplicate instances of a crate, when the first non-zero version of those instances are the same.  That is, it refuses to build a workspace with both 1.3 and 1.4 versions of `zeroize`.

`zeroize` is actually backward compatible, and `curve25519-dalek` restriction is overly pessimistic.  This package lifted this restriction in newer versions, but we still depend on older version and can not immediately update.

#### Summary of Changes
Use a patched version based on v3.2.1 that also removes the unnecessary constraint.