### PR TITLE
indicate that test-checks.sh requires cargo-hack

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -13,6 +13,14 @@ source ci/rust-version.sh nightly
 eval "$(ci/channel-info.sh)"
 cargoNightly="$(readlink -f "./cargo") nightly"
 
+# check that cargo-hack has been installed
+if ! $cargoNightly hack --version >/dev/null 2>&1; then
+  cat >&2 <<EOF
+ERROR: cargo hack failed.
+       install 'cargo hack' with 'cargo install cargo-hack'
+EOF
+fi
+
 echo --- build environment
 (
   set -x


### PR DESCRIPTION
#### Problem
`test-checks.sh` output for missing `cargo-hack` could be more helpful:

```
...
+ exec cargo +nightly-2023-09-20 hack --version --verbose
error: no such command: `hack`

	Did you mean `check`?
...
```

#### Summary of Changes
Add error message indicating that `cargo-hack` is a package that should be installed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
