### PR TITLE
Adds solana-nohash-hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5211,6 +5211,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-nohash-hasher",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
@@ -6404,6 +6405,12 @@ dependencies = [
  "tokio",
  "url 2.4.1",
 ]
+
+[[package]]
+name = "solana-nohash-hasher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-notifier"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,6 +338,7 @@ solana-measure = { path = "measure", version = "=1.18.0" }
 solana-merkle-tree = { path = "merkle-tree", version = "=1.18.0" }
 solana-metrics = { path = "metrics", version = "=1.18.0" }
 solana-net-utils = { path = "net-utils", version = "=1.18.0" }
+solana-nohash-hasher = "0.2.1"
 solana-notifier = { path = "notifier", version = "=1.18.0" }
 solana-perf = { path = "perf", version = "=1.18.0" }
 solana-poh = { path = "poh", version = "=1.18.0" }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -48,6 +48,7 @@ solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-nohash-hasher = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4509,6 +4509,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-measure",
  "solana-metrics",
+ "solana-nohash-hasher",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
@@ -5176,6 +5177,12 @@ dependencies = [
  "tokio",
  "url 2.4.1",
 ]
+
+[[package]]
+name = "solana-nohash-hasher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-perf"


### PR DESCRIPTION
#### Problem

In accounts-db, we make lists of slots for various tasks. We put these in HashSets/HashMaps, which perform cryptographically secure hashing of the keys. Since we (1) don't always require cryptographic security, and (2) know that slots are unique identifiers, we actually don't need to hash the slot at all, but instead can use it directly.

The [`solana-nohash-hasher`](https://crates.io/crates/solana-nohash-hasher) crate was designed for this.


#### Summary of Changes

Add solana-nohash-hasher to accounts-db.

Future PRs will *use* solana-nohash-hasher—explicitly not included in this PR.
