### PR TITLE
Uses `IntSet` for `RootsTracker::uncleaned_roots`

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -20,6 +20,7 @@ use {
         ThreadPool,
     },
     solana_measure::measure::Measure,
+    solana_nohash_hasher::IntSet,
     solana_sdk::{
         account::ReadableAccount,
         clock::{BankId, Slot},
@@ -457,7 +458,7 @@ pub struct RootsTracker {
     /// Updated every time we add a new root or clean/shrink an append vec into irrelevancy.
     /// Range is approximately the last N slots where N is # slots per epoch.
     pub alive_roots: RollingBitField,
-    uncleaned_roots: HashSet<Slot>,
+    uncleaned_roots: IntSet<Slot>,
 }
 
 impl Default for RootsTracker {
@@ -473,7 +474,7 @@ impl RootsTracker {
     pub fn new(max_width: u64) -> Self {
         Self {
             alive_roots: RollingBitField::new(max_width),
-            uncleaned_roots: HashSet::new(),
+            uncleaned_roots: IntSet::default(),
         }
     }
 
@@ -1994,7 +1995,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         tracker.alive_roots.get_all()
     }
 
-    pub fn clone_uncleaned_roots(&self) -> HashSet<Slot> {
+    pub fn clone_uncleaned_roots(&self) -> IntSet<Slot> {
         self.roots_tracker.read().unwrap().uncleaned_roots.clone()
     }
 


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/33521 added `solana-nohash-hasher`. `RootsTracker::uncleaned_roots` is a list of slots, and doesn't need to be cryptographically secure. This will make inserting/looking up roots to clean faster.


#### Summary of Changes

Uses `IntSet` for `RootsTracker::uncleaned_roots`

