### PR TITLE
Uses `IntSet` for `RemoveUnrootedSlotsSynchronization::slots_under_contention`

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1416,7 +1416,7 @@ impl RecycleStores {
 #[derive(Debug, Default)]
 struct RemoveUnrootedSlotsSynchronization {
     // slots being flushed from the cache or being purged
-    slots_under_contention: Mutex<HashSet<Slot>>,
+    slots_under_contention: Mutex<IntSet<Slot>>,
     signal: Condvar,
 }
 


### PR DESCRIPTION
#### Problem

Accounts DB keeps a list of slots that is shared between flush and purge. This list is behind a mutex to ensure the two background processes don't interfere with each other. This list of slots is currently a HashSet, but we don't need strong cryptographic hashing on the slot; a simple vector would be fine too. We can use an `IntSet` to use the Slot directly, bypassing the need to perform an expensive hash.


#### Summary of Changes

Use `IntSet` for `RemoveUnrootedSlotsSynchronization::slots_under_contention`.