### PR TITLE
Add early return to Blockstore::find_address_signatures methods

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2474,8 +2474,10 @@ impl Blockstore {
         end_slot: Slot,
     ) -> Result<Vec<(Slot, Signature)>> {
         let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
-
         let mut signatures: Vec<(Slot, Signature)> = vec![];
+        if end_slot < lowest_available_slot {
+            return Ok(signatures);
+        }
         for transaction_status_cf_primary_index in 0..=1 {
             let index_iterator = self.address_signatures_cf.iter(IteratorMode::From(
                 (
@@ -2511,12 +2513,15 @@ impl Blockstore {
     ) -> Result<Vec<(Slot, Signature)>> {
         let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
         let mut signatures: Vec<(Slot, Signature)> = vec![];
+        if slot < lowest_available_slot {
+            return Ok(signatures);
+        }
         for transaction_status_cf_primary_index in 0..=1 {
             let index_iterator = self.address_signatures_cf.iter(IteratorMode::From(
                 (
                     transaction_status_cf_primary_index,
                     pubkey,
-                    slot.max(lowest_available_slot),
+                    slot,
                     Signature::default(),
                 ),
                 IteratorDirection::Forward,


### PR DESCRIPTION
#### Problem
Spin off from #33419. In the case of both `find_address_signatures_for_slot` and `find_address_signatures`, there is no reason to read from Blockstore when the slot in question (or range of slots in question, respectively) has already been purged from the ledger.

#### Summary of Changes
Add early return to `find_address_signatures_for_slot` and `find_address_signatures` based on `lowest_available_slot`
