### PR TITLE
Reduce ConnectionPool size used by send-transaction-service

### DIFF
--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -22,7 +22,7 @@ use {
 const MAX_CONNECTIONS: usize = 1024;
 
 /// Default connection pool size per remote address
-pub const DEFAULT_CONNECTION_POOL_SIZE: usize = 4;
+pub const DEFAULT_CONNECTION_POOL_SIZE: usize = 2;
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub enum Protocol {

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -81,6 +81,7 @@ where
         connection_config: C,
         connection_manager: M,
     ) -> Self {
+        info!("Creating ConnectionCache {name}, pool size: {connection_pool_size}");
         let (sender, receiver) = crossbeam_channel::unbounded();
 
         let map = Arc::new(RwLock::new(IndexMap::with_capacity(MAX_CONNECTIONS)));


### PR DESCRIPTION
#### Problem
Reduce pool size for ConnectionCache used by send-transaction-service

#### Summary of Changes

Reduce pool size for ConnectionCache used by send-transaction-service to 2 from 4. No significant slow down of performance from bench-tps testing using rpc-client which is used by send-transaction-service. This will reduce active connections maintained both on the server and client. This will enable us to cache connections for more nodes. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
