### PR TITLE
Uses stable `u64::next_multiple_of()`

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -529,7 +529,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
         // Based on the EAH start and snapshot interval, pick a slot to mass-root all the banks in
         // this range such that an EAH request will be sent and also a snapshot request.
         let eah_start_slot = epoch_accounts_hash_utils::calculation_start(&bank);
-        let set_root_slot = next_multiple_of(eah_start_slot, FULL_SNAPSHOT_INTERVAL);
+        let set_root_slot = eah_start_slot.next_multiple_of(FULL_SNAPSHOT_INTERVAL);
 
         if bank.block_height() == set_root_slot {
             info!("Calling set_root() on bank {}...", bank.slot());
@@ -660,17 +660,4 @@ fn test_epoch_accounts_hash_and_warping() {
         .epoch_accounts_hash_manager
         .wait_get_epoch_accounts_hash();
     info!("Waiting for epoch accounts hash... DONE");
-}
-
-// Copy the impl of `next_multiple_of` since it is nightly-only experimental.
-// https://doc.rust-lang.org/std/primitive.u64.html#method.next_multiple_of
-// https://github.com/rust-lang/rust/issues/88581
-// https://github.com/rust-lang/rust/pull/88582
-// https://github.com/jhpratt/rust/blob/727a4fc7e3f836938dfeb4a2ab237cfca612222d/library/core/src/num/uint_macros.rs#L1811-L1837
-const fn next_multiple_of(lhs: u64, rhs: u64) -> u64 {
-    #![allow(clippy::arithmetic_side_effects)]
-    match lhs % rhs {
-        0 => lhs,
-        r => lhs + (rhs - r),
-    }
 }


### PR DESCRIPTION
#### Problem

We copied the impl of `next_multiple_of` into our codebase because it was not stable yet. With [Rust 1.73.0, that has changed](https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html#stabilized-apis)! We can use the stable version of [`next_multiple_of`](https://doc.rust-lang.org/stable/std/primitive.u64.html#method.next_multiple_of) from `std` instead.


#### Summary of Changes

Use the stable version, and removes ours.