### PR TITLE
Improves error text when snapshot intervals are incompatible

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -468,7 +468,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.full_snapshot_archive_interval_slots)
-                .help("Number of slots between generating full snapshots")
+                .help("Number of slots between generating full snapshots. \
+                    Must be a multiple of the incremental snapshot interval.")
         )
         .arg(
             Arg::with_name("maximum_full_snapshots_to_retain")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1588,17 +1588,14 @@ pub fn main() {
         validator_config.accounts_hash_interval_slots,
     ) {
         eprintln!("Invalid snapshot configuration provided: snapshot intervals are incompatible. \
-            \n\t- full snapshot interval MUST be a multiple of accounts hash interval (if enabled) \
-            \n\t- incremental snapshot interval MUST be a multiple of accounts hash interval (if enabled) \
+            \n\t- full snapshot interval MUST be a multiple of incremental snapshot interval (if enabled) \
             \n\t- full snapshot interval MUST be larger than incremental snapshot interval (if enabled) \
             \nSnapshot configuration values: \
             \n\tfull snapshot interval: {} \
-            \n\tincremental snapshot interval: {} \
-            \n\taccounts hash interval: {}",
+            \n\tincremental snapshot interval: {}",
             if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
             if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
-            validator_config.accounts_hash_interval_slots);
-
+        );
         exit(1);
     }
 


### PR DESCRIPTION
#### Problem

Starting in v1.17.0, we changed how the snapshot intervals were set. Specifically, the accounts hash interval is no longer manually set, and instead is coerced to the snapshot interval (see #31987). This effectively means that the full snapshot interval must be a multiple of the incremental snapshot interval.

That wasn't strictly required before, and a testnet validator ran into it here: https://discord.com/channels/428295358100013066/670512312339398668/1159565622074679407

The error text could be more clear about what is happening.


#### Summary of Changes

Remove mentions of the accounts hash interval, and use incremental snapshot interval instead.


new help text:
```
--full-snapshot-interval-slots <NUMBER>
            Number of slots between generating full snapshots. Must be a multiple of the incremental snapshot interval.
            [default: 25000]
```

new error text:
```
Invalid snapshot configuration provided: snapshot intervals are incompatible. 
	- full snapshot interval MUST be a multiple of incremental snapshot interval (if enabled) 
	- full snapshot interval MUST be larger than incremental snapshot interval (if enabled) 
Snapshot configuration values: 
	full snapshot interval: 25000 
	incremental snapshot interval: 420
```


Fixes: #33552