### PR TITLE
Blockstore::get_sigs_for_addr2: ensure lowest_slot >= first_available_block

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2325,14 +2325,15 @@ impl Blockstore {
         confirmed_unrooted_slots: &HashSet<Slot>,
     ) -> Result<(Option<(Slot, TransactionStatusMeta)>, u64)> {
         let mut counter = 0;
-        let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
+        let (lock, _) = self.ensure_lowest_cleanup_slot();
+        let first_available_block = self.get_first_available_block()?;
 
         for transaction_status_cf_primary_index in 0..=1 {
             let index_iterator = self.transaction_status_cf.iter(IteratorMode::From(
                 (
                     transaction_status_cf_primary_index,
                     signature,
-                    lowest_available_slot,
+                    first_available_block,
                 ),
                 IteratorDirection::Forward,
             ))?;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8012,6 +8012,7 @@ pub mod tests {
 
         if simulate_ledger_cleanup_service {
             *blockstore.lowest_cleanup_slot.write().unwrap() = lowest_cleanup_slot;
+            blockstore.purge_slots(0, lowest_cleanup_slot, PurgeType::CompactionFilter);
         }
 
         let are_missing = check_for_missing();


### PR DESCRIPTION
#### Problem
As pointed out [here](https://github.com/solana-labs/solana/pull/33419#discussion_r1346837089), `Blockstore::get_confirmed_signatures_for_address2()` does more iterating than it needs to.

#### Summary of Changes
Ensure lowest_slot >= first_available_block:
- Update `get_transaction_status` to only return data from `first_available_block` and onward (this is the expected behavior from the perspective of rpc already)
- When a transaction status is not found, set `lowest_slot` to `first_available_block`
