### PR TITLE
Retry hash file allocation

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -107,9 +107,9 @@ impl AccountHashesFile {
                 Ok(data)
             };
 
-            // Retry 5 times for allocation the AccountHashFile. The memory maybe fragmented and
-            // causes memory allocation failure. Therefore, retry after failure. Hoping that the
-            // kernel can defrag the memory and allocation retries can succeed.
+            // Retry 5 times to allocate the AccountHashesFile. The memory might be fragmented and
+            // causes memory allocation failure. Therefore, let's retry after failure. Hoping that the
+            // kernel have the chance to defrag the memory between the retires, and retries succeed.
             let mut num_retries = 0;
             let data = loop {
                 num_retries += 1;
@@ -120,7 +120,7 @@ impl AccountHashesFile {
                     }
                     Err(err) => {
                         info!(
-                            "Unable to create account hash file within {}: {}, retry counter {}",
+                            "Unable to create account hashes file within {}: {}, retry counter {}",
                             self.dir_for_temp_cache_files.display(),
                             err,
                             num_retries
@@ -128,12 +128,12 @@ impl AccountHashesFile {
 
                         if num_retries > 5 {
                             panic!(
-                                "Unable to create account hash file within {}: after {} retries",
+                                "Unable to create account hashes file within {}: after {} retries",
                                 self.dir_for_temp_cache_files.display(),
                                 num_retries
                             );
                         }
-                        datapoint_info!("account_hash_file_allocation_retry", ("retry", 1, i64),);
+                        datapoint_info!("retry_account_hashes_file_allocation", ("retry", 1, i64));
                         thread::sleep(time::Duration::from_millis(num_retries * 100));
                     }
                 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -26,6 +26,7 @@ use {
             atomic::{AtomicU64, AtomicUsize, Ordering},
             Arc,
         },
+        thread, time,
     },
     tempfile::tempfile_in,
 };
@@ -132,6 +133,7 @@ impl AccountHashesFile {
                                 num_retries
                             );
                         }
+                        thread::sleep(time::Duration::from_millis(num_retries * 100));
                     }
                 }
             };

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -133,7 +133,7 @@ impl AccountHashesFile {
                                 num_retries
                             );
                         }
-                        datapoint_info!("retry_account_hashes_file_allocation", ("retry", 1, i64));
+                        datapoint_info!("retry_account_hashes_file_allocation", ("retry", num_retries, i64));
                         thread::sleep(time::Duration::from_millis(num_retries * 100));
                     }
                 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -109,7 +109,7 @@ impl AccountHashesFile {
 
             // Retry 5 times to allocate the AccountHashesFile. The memory might be fragmented and
             // causes memory allocation failure. Therefore, let's retry after failure. Hoping that the
-            // kernel have the chance to defrag the memory between the retires, and retries succeed.
+            // kernel has the chance to defrag the memory between the retries, and retries succeed.
             let mut num_retries = 0;
             let data = loop {
                 num_retries += 1;

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -133,6 +133,7 @@ impl AccountHashesFile {
                                 num_retries
                             );
                         }
+                        datapoint_info!("account_hash_file_allocation_retry", ("retry", 1, i64),);
                         thread::sleep(time::Duration::from_millis(num_retries * 100));
                     }
                 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -133,7 +133,10 @@ impl AccountHashesFile {
                                 num_retries
                             );
                         }
-                        datapoint_info!("retry_account_hashes_file_allocation", ("retry", num_retries, i64));
+                        datapoint_info!(
+                            "retry_account_hashes_file_allocation",
+                            ("retry", num_retries, i64)
+                        );
                         thread::sleep(time::Duration::from_millis(num_retries * 100));
                     }
                 }


### PR DESCRIPTION
#### Problem

Recently, on Oct 6, 20023, we saw a validator crash on one of the canaries boxes. 

```
[2023-10-06T06:29:48.605280562Z INFO  solana_metrics::metrics] datapoint: accounts_db_active shrink=0i
[2023-10-06T06:29:48.653273411Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="solAccountsLo03" one=1i message="panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 12, kind: OutOfMemory, message: \"Cannot allocate memory\" }', accounts-db/src/accounts_hash.rs:102:34" location="accounts-db/src/accounts_hash.rs:102:34" version="1.18.0 (src:e0091d69; feat:1091887072, client:SolanaLabs)"
```

The crash happens when allocating account hash file during hash dedup. 

```
[2023-10-06T06:29:31.721389079Z INFO  solana_metrics::metrics] datapoint: memory-stats total=269907476480i swap_total=0i free_percent=3.6710358146504354 used_bytes=39749242880i avail_percent=85.27301155255498 buffers_percent=0.6657022085615106 cached_percent=79.78760422961368 swap_free_percent=0
[2023-10-06T06:29:36.744595335Z INFO  solana_metrics::metrics] datapoint: memory-stats total=269907476480i swap_total=0i free_percent=5.081942011716148 used_bytes=35619844096i avail_percent=86.80294278597377 buffers_percent=0.6663881443585271 cached_percent=79.90525739437273 swap_free_percent=0
[2023-10-06T06:29:41.745857461Z INFO  solana_metrics::metrics] datapoint: memory-stats total=269907476480i swap_total=0i free_percent=5.645556638416836 used_bytes=35985874944i avail_percent=86.66732933325522 buffers_percent=0.6665914970063151 cached_percent=79.21095985788381 swap_free_percent=0
[2023-10-06T06:29:46.768160791Z INFO  solana_metrics::metrics] datapoint: memory-stats total=269907476480i swap_total=0i free_percent=0.6511670469158839 used_bytes=37269983232i avail_percent=86.19157063818434 buffers_percent=0.6666142603624108 cached_percent=83.64288057827423 swap_free_percent=0
```

The `used` memory increase by 2G and the free memory drops to 0.65 percent. 

It appears that the box still has enough physical memory. However, the allocation fails. Probably due to memory defragmentation and multiple threads allocate mmaps at the same time. 


#### Summary of Changes

Account hash calculation is highly parallel. It seems that when all threads start allocation files to store account hashes at the same time, the system may hit OOM for some of those allocations. To mitigate that, we add retry for account hash file allocation. If a thread fails its allocation, it will sleep for some time and then retry. This will help to stagger the memory allocation from all parallel threads.

Hopefully, the kernel has time to defrag the memory in-between the retries, and the later retry for allocation will succeed. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
