### PR TITLE
validator: skip health check

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1453,6 +1453,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .long("skip-new-snapshot-check")
                         .help("Skip check for a new snapshot")
                 )
+                .arg(
+                    Arg::with_name("skip_health_check")
+                        .long("skip-health-check")
+                        .help("Skip health check")
+                )
         )
         .subcommand(
             SubCommand::with_name("authorized-voter")
@@ -1667,6 +1672,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     Arg::with_name("skip_new_snapshot_check")
                         .long("skip-new-snapshot-check")
                         .help("Skip check for a new snapshot")
+                )
+                .arg(
+                    Arg::with_name("skip_health_check")
+                        .long("skip-health-check")
+                        .help("Skip health check")
                 )
                 .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -162,10 +162,7 @@ fn wait_for_restart_window(
         seen_incremential_snapshot |= snapshot_slot_info_has_incremential;
 
         let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::processed())?;
-        let healthy = match skip_health_check {
-            false => Some(rpc_client.get_health().ok().is_some()),
-            true => None,
-        };
+        let healthy = skip_health_check || rpc_client.get_health().ok().is_some();
         let delinquent_stake_percentage = {
             let vote_accounts = rpc_client.get_vote_accounts()?;
             let current_stake: u64 = vote_accounts
@@ -237,7 +234,7 @@ fn wait_for_restart_window(
         }
 
         let status = {
-            if let Some(false) = healthy {
+            if !healthy {
                 style("Node is unhealthy").red().to_string()
             } else {
                 // Wait until a hole in the leader schedule before restarting the node

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -118,6 +118,7 @@ fn wait_for_restart_window(
     min_idle_time_in_minutes: usize,
     max_delinquency_percentage: u8,
     skip_new_snapshot_check: bool,
+    skip_health_check: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sleep_interval = Duration::from_secs(5);
 
@@ -161,7 +162,10 @@ fn wait_for_restart_window(
         seen_incremential_snapshot |= snapshot_slot_info_has_incremential;
 
         let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::processed())?;
-        let healthy = rpc_client.get_health().ok().is_some();
+        let healthy = match skip_health_check {
+            false => Some(rpc_client.get_health().ok().is_some()),
+            true => None,
+        };
         let delinquent_stake_percentage = {
             let vote_accounts = rpc_client.get_vote_accounts()?;
             let current_stake: u64 = vote_accounts
@@ -233,7 +237,7 @@ fn wait_for_restart_window(
         }
 
         let status = {
-            if !healthy {
+            if let Some(false) = healthy {
                 style("Node is unhealthy").red().to_string()
             } else {
                 // Wait until a hole in the leader schedule before restarting the node
@@ -649,6 +653,7 @@ pub fn main() {
             let force = subcommand_matches.is_present("force");
             let monitor = subcommand_matches.is_present("monitor");
             let skip_new_snapshot_check = subcommand_matches.is_present("skip_new_snapshot_check");
+            let skip_health_check = subcommand_matches.is_present("skip_health_check");
             let max_delinquent_stake =
                 value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
 
@@ -659,6 +664,7 @@ pub fn main() {
                     min_idle_time,
                     max_delinquent_stake,
                     skip_new_snapshot_check,
+                    skip_health_check,
                 )
                 .unwrap_or_else(|err| {
                     println!("{err}");
@@ -777,6 +783,7 @@ pub fn main() {
             let max_delinquent_stake =
                 value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
             let skip_new_snapshot_check = subcommand_matches.is_present("skip_new_snapshot_check");
+            let skip_health_check = subcommand_matches.is_present("skip_health_check");
 
             wait_for_restart_window(
                 &ledger_path,
@@ -784,6 +791,7 @@ pub fn main() {
                 min_idle_time,
                 max_delinquent_stake,
                 skip_new_snapshot_check,
+                skip_health_check,
             )
             .unwrap_or_else(|err| {
                 println!("{err}");


### PR DESCRIPTION
#### Problem

Issues with `getHealth` are known: #16957 And I believe that the issue will be fundamentally resolved.
But right now, I'm concerned about updating the validator using `wait-for-restart-window` and `exit`.
There are already a lot of messages in the chats for 1.16.
I propose this tiny change that would allow bypassing the health check.

I sincerely hope for `v1.16` and `v1.17`

#### Summary of Changes

Added the `--skip-health-check` flag for the `wait-for-restart-window` and `exit` commands 

Fixes #33553
