### PR TITLE
Assert acount hash mmap file capacity > 0

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -97,6 +97,7 @@ impl AccountHashesFile {
             // Theoretical performance optimization: write a zero to the end of
             // the file so that we won't have to resize it later, which may be
             // expensive.
+            assert!(self.capacity > 0);
             data.seek(SeekFrom::Start((self.capacity - 1) as u64))
                 .unwrap();
             data.write_all(&[0]).unwrap();


### PR DESCRIPTION
#### Problem

We are seeing a memory allocation failure when writing 0 to the end of
account's hash file.

It seems that it could be caused by self.capacity = 0. When we estimate the
capacity, it is possible that self.capacity = 0.

However, if `write()` is called, self.capacity must be greater than 0.


#### Summary of Changes

To rule out the possiblity, add an "assert" for capacity must be greater than
0.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
