### PR TITLE
Allow to create HTTP Sender with custom Client

### DIFF
--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -47,6 +47,31 @@ impl HttpSender {
     ///
     /// The URL is an HTTP URL, usually for port 8899.
     pub fn new_with_timeout<U: ToString>(url: U, timeout: Duration) -> Self {
+        Self::new_with_client(
+            url,
+            reqwest::Client::builder()
+                .default_headers(Self::default_headers())
+                .timeout(timeout)
+                .pool_idle_timeout(timeout)
+                .build()
+                .expect("build rpc client"),
+        )
+    }
+
+    /// Create an HTTP RPC sender.
+    ///
+    /// Most flexiable way to create sender. Accept created `reqwest::Client`.
+    pub fn new_with_client<U: ToString>(url: U, client: reqwest::Client) -> Self {
+        Self {
+            client: Arc::new(client),
+            url: url.to_string(),
+            request_id: AtomicU64::new(0),
+            stats: RwLock::new(RpcTransportStats::default()),
+        }
+    }
+
+    /// Create default headers used by HTTP Sender.
+    pub fn default_headers() -> header::HeaderMap {
         let mut default_headers = header::HeaderMap::new();
         default_headers.append(
             header::HeaderName::from_static("solana-client"),
@@ -55,22 +80,7 @@ impl HttpSender {
             )
             .unwrap(),
         );
-
-        let client = Arc::new(
-            reqwest::Client::builder()
-                .default_headers(default_headers)
-                .timeout(timeout)
-                .pool_idle_timeout(timeout)
-                .build()
-                .expect("build rpc client"),
-        );
-
-        Self {
-            client,
-            url: url.to_string(),
-            request_id: AtomicU64::new(0),
-            stats: RwLock::new(RpcTransportStats::default()),
-        }
+        default_headers
     }
 }
 

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -60,7 +60,7 @@ impl HttpSender {
 
     /// Create an HTTP RPC sender.
     ///
-    /// Most flexiable way to create sender. Accept created `reqwest::Client`.
+    /// Most flexible way to create a sender. Pass a created `reqwest::Client`.
     pub fn new_with_client<U: ToString>(url: U, client: reqwest::Client) -> Self {
         Self {
             client: Arc::new(client),


### PR DESCRIPTION
#### Problem

In [Triton](https://triton.one/) sometimes we use custom headers in RPC Client but it's hard to create `HttpSender` outside of solana crate so we need to use a slightly patched version. With `HttpSender::new_with_client` it would be possible to create a sender with completely controlled created `reqwest::Client`.

#### Summary of Changes

- Add `HttpSender::new_with_client`
- Move default headers to `HttpSender::default_headers`