### PR TITLE
check plugin name on plugin_reload rpc call

### DIFF
--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -186,7 +186,7 @@ impl GeyserPluginManager {
             return Err(jsonrpc_core::Error {
                 code: ErrorCode::InvalidRequest,
                 message: format!(
-                    "There already exists a plugin named {} loaded. Did not load requested plugin",
+                    "There already exists a plugin named {} loaded, while reloading {name}. Did not load requested plugin",
                     new_plugin.name()
                 ),
                 data: None,

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -177,6 +177,22 @@ impl GeyserPluginManager {
                 data: None,
             })?;
 
+        // Then see if a plugin with this name already exists. If so, abort
+        if self
+            .plugins
+            .iter()
+            .any(|plugin| plugin.name().eq(new_plugin.name()))
+        {
+            return Err(jsonrpc_core::Error {
+                code: ErrorCode::InvalidRequest,
+                message: format!(
+                    "There already exists a plugin named {} loaded. Did not load requested plugin",
+                    new_plugin.name()
+                ),
+                data: None,
+            });
+        }
+
         // Attempt to on_load with new plugin
         match new_plugin.on_load(new_parsed_config_file) {
             // On success, push plugin and library


### PR DESCRIPTION
#### Problem

On `plugin_reload` we need to check the new plugin name, the path to the plugin can be changed in the config file, and as a result, already loaded plugin can be loaded again.

#### Summary of Changes

Add plugin name check.