### PR TITLE
Fix deployment of program-v4 in freshly started test validator

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -366,7 +366,11 @@ pub fn process_instruction_deploy(
         authority_address,
     )?;
     let current_slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
-    if state.slot.saturating_add(DEPLOYMENT_COOLDOWN_IN_SLOTS) > current_slot {
+
+    // Slot = 0 indicates that the program hasn't been deployed yet. So no need to check for the cooldown slots.
+    // (Without this check, the program deployment is failing in freshly started test validators. That's
+    //  because at startup current_slot is 0, which is < DEPLOYMENT_COOLDOWN_IN_SLOTS).
+    if state.slot != 0 && state.slot.saturating_add(DEPLOYMENT_COOLDOWN_IN_SLOTS) > current_slot {
         ic_logger_msg!(
             log_collector,
             "Program was deployed recently, cooldown still in effect"


### PR DESCRIPTION
#### Problem
Failure in deploying program-v4 in freshly started `test-validator`.

#### Summary of Changes

- The deployment slot for a program is initialized to 0 during initialization.
- The loader checks if the current slot is > deployment slot + cooldown slots. If not, it fails the deployment.
- The test-validator starts from slot 0. So if someone tries to deploy a program within `cooldown slots` after startup, the above condition fails.
- This PR skips checking the cooldown slot if the deployment slot is 0. As it indicates the program was just initialized but never deployed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
