### PR TITLE
Disallow partial towers with missing vote for conf count 1

### DIFF
--- a/sdk/program/src/vote/error.rs
+++ b/sdk/program/src/vote/error.rs
@@ -69,6 +69,9 @@ pub enum VoteError {
 
     #[error("Cannot update commission at this point in the epoch")]
     CommissionUpdateTooLate,
+
+    #[error("Proposed state is a partial tower, unreachable from previous state")]
+    PartialTower,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -704,6 +704,10 @@ pub mod programify_feature_gate_program {
     solana_sdk::declare_id!("8GdovDzVwWU5edz2G697bbB7GZjrUc6aQZLWyNNAtHdg");
 }
 
+pub mod disallow_partial_towers {
+    solana_sdk::declare_id!("5ma5Su5wKxgQj66YnFVpnuxgqzTPfqJrTFa3rfoE7Fet");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -875,6 +879,7 @@ lazy_static! {
         (better_error_codes_for_tx_lamport_check::id(), "better error codes for tx lamport check #33353"),
         (enable_alt_bn128_compression_syscall::id(), "add alt_bn128 compression syscalls"),
         (programify_feature_gate_program::id(), "move feature gate activation logic to an on-chain program #32783"),
+        (disallow_partial_towers::id(), "disallow partial towers in vote program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Voters can submit partial towers. Strange behavior from `4zDJfqwyQ5bf6oVfzeyFH5cHQ3nix3sgaDfSqkAF7v4k` for example

```
Slot        | Vote state update [root]
------------------------------------
222480169:  |  111 (31)   112 (30)   113 (29)   114 (28)   115 (27)   116 (26)   117 (25)   118 (24) [222480110]
222480176:  |  124 (31) [222480119]
222480176:  |  124 (31)   125 (30) [222480119]
222480178:  |  127 (31) [222480126]
222480184:  |  133 (31) [222480132]
222480186:  |  135 (31) [222480134]
222480188:  |  137 (31) [222480136]
222480190:  |  139 (31) [222480138]
222480192:  |  141 (31) [222480140]
222480194:  |  143 (31) [222480142]
```

I'm of the opinion that tvc will get rid of this behavior, but since it's been pushed back to 1.18 might be nice to make this change.


#### Summary of Changes
Disallow towers without a slot with conf count 1 at the top. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
