### PR TITLE
Removes hash param from AccountsCache::store()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6775,7 +6775,6 @@ impl AccountsDb {
                     slot,
                     accounts_and_meta_to_store.pubkey(i),
                     account,
-                    None::<&Hash>,
                     include_slot_in_hash,
                 );
                 // hash this account in the bg


### PR DESCRIPTION
#### Problem

The `hash` parameter to `AccountsCache::store()` is always `None` in non-test code. We do not need the `hash` parameter anymore.


#### Summary of Changes

Remove the hash parameter and set the initial value to `None`.