### PR TITLE
wip: clear out unused data when recycling an append vec

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -58,6 +58,12 @@ impl AccountsFile {
         Ok((Self::AppendVec(av), num_accounts))
     }
 
+    pub(crate) fn clear_left_over_data_beyond_this_offset(&self, offset: usize) {
+        match self {
+            Self::AppendVec(av) => av.clear_left_over_data_beyond_this_offset(offset),
+        }
+    }
+
     pub fn flush(&self) -> Result<()> {
         match self {
             Self::AppendVec(av) => av.flush(),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -292,6 +292,19 @@ impl AppendVec {
         }
     }
 
+    /// When recycling a mmapped file, there may be garbage left over at the end of the file.
+    /// This clears out all data after `offset`.
+    pub(crate) fn clear_left_over_data_beyond_this_offset(&self, offset: usize) {
+        unsafe {
+            // this is ugly... clean it up
+            let r = &self.map[offset..];
+            let const_ptr = r as *const [u8];
+            let mut_ptr = const_ptr as *mut [u8];
+            let m2 = &mut *mut_ptr;
+            m2.iter_mut().for_each(|x| *x = 0);
+        }
+    }
+
     fn sanitize_len_and_size(current_len: usize, file_size: usize) -> Result<()> {
         if file_size == 0 {
             Err(AccountsFileError::AppendVecError(


### PR DESCRIPTION
#### Problem
Trying to not leave garbage behind when we recycle an append vec.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
