### PR TITLE
Support zstd genesis archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,12 +6347,14 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "test-case",
  "thiserror",
  "tokio",
  "tokio-stream",
  "trees",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,6 +5341,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -63,6 +63,7 @@ strum_macros = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+zstd = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -62,11 +62,13 @@ spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
+tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 trees = { workspace = true }
+zstd = { workspace = true }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -48,7 +48,7 @@ use {
         account::ReadableAccount,
         address_lookup_table::state::AddressLookupTable,
         clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND},
-        genesis_config::{GenesisConfig, DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE},
+        genesis_config::{GenesisConfig, DEFAULT_GENESIS_FILE, ZSTD_GENESIS_ARCHIVE},
         hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
@@ -68,7 +68,7 @@ use {
         collections::{hash_map::Entry as HashMapEntry, BTreeSet, HashMap, HashSet, VecDeque},
         convert::TryInto,
         fmt::Write,
-        fs,
+        fs::{self, File},
         io::{Error as IoError, ErrorKind},
         path::{Path, PathBuf},
         rc::Rc,
@@ -4110,32 +4110,14 @@ pub fn create_new_ledger(
     // Explicitly close the blockstore before we create the archived genesis file
     drop(blockstore);
 
-    let archive_path = ledger_path.join(DEFAULT_GENESIS_ARCHIVE);
-    let args = vec![
-        "jcfhS",
-        archive_path.to_str().unwrap(),
-        "-C",
-        ledger_path.to_str().unwrap(),
-        DEFAULT_GENESIS_FILE,
-        blockstore_dir,
-    ];
-    let output = std::process::Command::new("tar")
-        .args(args)
-        .output()
-        .unwrap();
-    if !output.status.success() {
-        use std::str::from_utf8;
-        error!("tar stdout: {}", from_utf8(&output.stdout).unwrap_or("?"));
-        error!("tar stderr: {}", from_utf8(&output.stderr).unwrap_or("?"));
-
-        return Err(BlockstoreError::Io(IoError::new(
-            ErrorKind::Other,
-            format!(
-                "Error trying to generate snapshot archive: {}",
-                output.status
-            ),
-        )));
-    }
+    let archive_path = ledger_path.join(ZSTD_GENESIS_ARCHIVE);
+    let archive_stream =
+        zstd::Encoder::auto_finish(zstd::Encoder::new(File::create(&archive_path)?, 0)?);
+    let mut archive = tar::Builder::new(archive_stream);
+    archive.append_path_with_name(ledger_path.join(DEFAULT_GENESIS_FILE), DEFAULT_GENESIS_FILE)?;
+    archive.append_dir_all("rocksdb", ledger_path.join(blockstore_dir))?;
+    archive.finish()?;
+    drop(archive);
 
     // ensure the genesis archive can be unpacked and it is under
     // max_genesis_archive_unpacked_size, immediately after creating it above.
@@ -4154,13 +4136,13 @@ pub fn create_new_ledger(
             let mut error_messages = String::new();
 
             fs::rename(
-                ledger_path.join(DEFAULT_GENESIS_ARCHIVE),
-                ledger_path.join(format!("{DEFAULT_GENESIS_ARCHIVE}.failed")),
+                &archive_path,
+                archive_path.with_file_name(format!("{ZSTD_GENESIS_ARCHIVE}.failed")),
             )
             .unwrap_or_else(|e| {
                 let _ = write!(
                     &mut error_messages,
-                    "/failed to stash problematic {DEFAULT_GENESIS_ARCHIVE}: {e}"
+                    "/failed to stash problematic {ZSTD_GENESIS_ARCHIVE}: {e}"
                 );
             });
             fs::rename(

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -36,7 +36,9 @@ use {
         snapshot_utils,
     },
     solana_sdk::{
-        exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
+        exit::Exit,
+        genesis_config::{DEFAULT_GENESIS_DOWNLOAD_PATH, ZSTD_GENESIS_DOWNLOAD_PATH},
+        hash::Hash,
         native_token::lamports_to_sol,
     },
     solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
@@ -126,7 +128,7 @@ impl RpcRequestMiddleware {
     }
 
     fn is_file_get_path(&self, path: &str) -> bool {
-        if path == DEFAULT_GENESIS_DOWNLOAD_PATH {
+        if path == DEFAULT_GENESIS_DOWNLOAD_PATH || path == ZSTD_GENESIS_DOWNLOAD_PATH {
             return true;
         }
 
@@ -194,6 +196,10 @@ impl RpcRequestMiddleware {
             match path {
                 DEFAULT_GENESIS_DOWNLOAD_PATH => {
                     inc_new_counter_info!("rpc-get_genesis", 1);
+                    self.ledger_path.join(stem)
+                }
+                ZSTD_GENESIS_DOWNLOAD_PATH => {
+                    inc_new_counter_info!("rpc-get_zstd_genesis", 1);
                     self.ledger_path.join(stem)
                 }
                 _ => {
@@ -744,6 +750,7 @@ mod tests {
         assert!(!rrm.is_file_get_path(DEFAULT_GENESIS_ARCHIVE));
         assert!(!rrm.is_file_get_path("//genesis.tar.bz2"));
         assert!(!rrm.is_file_get_path("/../genesis.tar.bz2"));
+        assert!(rrm.is_file_get_path(ZSTD_GENESIS_DOWNLOAD_PATH));
 
         // These two are redirects
         assert!(!rrm.is_file_get_path("/snapshot.tar.bz2"));

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -36,6 +36,7 @@ use {
 pub const DEFAULT_GENESIS_FILE: &str = "genesis.bin";
 pub const DEFAULT_GENESIS_ARCHIVE: &str = "genesis.tar.bz2";
 pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
+pub const ZSTD_GENESIS_ARCHIVE: &str = "genesis.tar.zst";
 
 // deprecated default that is no longer used
 pub const UNUSED_DEFAULT: u64 = 1024;

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_GENESIS_FILE: &str = "genesis.bin";
 pub const DEFAULT_GENESIS_ARCHIVE: &str = "genesis.tar.bz2";
 pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
 pub const ZSTD_GENESIS_ARCHIVE: &str = "genesis.tar.zst";
+pub const ZSTD_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.zst";
 
 // deprecated default that is no longer used
 pub const UNUSED_DEFAULT: u64 = 1024;


### PR DESCRIPTION
#### Problem

- BZip2 is deprecated in most of the Solana protocol.
  Genesis archives are one of the few places where BZip2 is still the main compression algorithm.
- `solana-test-validator` creates a tar subprocess when creating new ledgers.

#### Summary of Changes

- Allows the validator to discover and load `genesis.tar.zst` archives (continues to support `genesis.tar.bz2`)
- Uses the `tar` crate instead of a subprocess to create new genesis archives.
- Uses `genesis.tar.zst` when creating new ledgers.
- ~~Serve `/genesis.tar.zst` if exists, and redirect `/genesis.tar.bz2`~~

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
