### PR TITLE
sdk: make `sysvar::ALL_IDS` private

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -591,7 +591,7 @@ pub mod sdk_ids {
                 #[allow(deprecated)]
                 stake::config::id(),
             ];
-            sdk_ids.extend(sysvar::ALL_IDS.iter());
+            sysvar::extend_with_sysvar_ids(&mut sdk_ids);
             sdk_ids
         };
     }

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -53,7 +53,7 @@ lazy_static! {
     pub static ref MAYBE_BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
         let mut temp_table: [bool; 256] = [false; 256];
         BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
-        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
+        sysvar::for_each_sysvar_id(|key| temp_table[key.0[0] as usize] = true);
         temp_table
     };
 }

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -100,7 +100,7 @@ pub mod slot_history;
 pub mod stake_history;
 
 lazy_static! {
-    pub static ref ALL_IDS: Vec<Pubkey> = vec![
+    static ref ALL_IDS: Vec<Pubkey> = vec![
         clock::id(),
         epoch_schedule::id(),
         #[allow(deprecated)]
@@ -121,6 +121,17 @@ lazy_static! {
 /// Returns `true` of the given `Pubkey` is a sysvar account.
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     ALL_IDS.iter().any(|key| key == id)
+}
+
+pub fn extend_with_sysvar_ids(pubkeys: &mut Vec<Pubkey>) {
+    pubkeys.extend(ALL_IDS.iter())
+}
+
+pub fn for_each_sysvar_id<F>(f: F)
+where
+    F: FnMut(&Pubkey),
+{
+    ALL_IDS.iter().for_each(f)
 }
 
 /// Declares an ID that implements [`SysvarId`].


### PR DESCRIPTION
#### Problem

`sysvar::ALL_IDS` needs to be modified by runtime, but is treated as constant for a given sdk version

#### Summary of Changes

revoke its pubness