### PR TITLE
v1.17: skip unrecognized keys in Blockstore special-column iterators

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2310,14 +2310,16 @@ impl Blockstore {
         let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
 
         for transaction_status_cf_primary_index in 0..=1 {
-            let index_iterator = self.transaction_status_cf.iter(IteratorMode::From(
-                (
-                    transaction_status_cf_primary_index,
-                    signature,
-                    lowest_available_slot,
-                ),
-                IteratorDirection::Forward,
-            ))?;
+            let index_iterator =
+                self.transaction_status_cf
+                    .iter_current_index_filtered(IteratorMode::From(
+                        (
+                            transaction_status_cf_primary_index,
+                            signature,
+                            lowest_available_slot,
+                        ),
+                        IteratorDirection::Forward,
+                    ))?;
             for ((i, sig, slot), _data) in index_iterator {
                 counter += 1;
                 if i != transaction_status_cf_primary_index || sig != signature {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2461,15 +2461,17 @@ impl Blockstore {
 
         let mut signatures: Vec<(Slot, Signature)> = vec![];
         for transaction_status_cf_primary_index in 0..=1 {
-            let index_iterator = self.address_signatures_cf.iter(IteratorMode::From(
-                (
-                    transaction_status_cf_primary_index,
-                    pubkey,
-                    start_slot.max(lowest_available_slot),
-                    Signature::default(),
-                ),
-                IteratorDirection::Forward,
-            ))?;
+            let index_iterator =
+                self.address_signatures_cf
+                    .iter_current_index_filtered(IteratorMode::From(
+                        (
+                            transaction_status_cf_primary_index,
+                            pubkey,
+                            start_slot.max(lowest_available_slot),
+                            Signature::default(),
+                        ),
+                        IteratorDirection::Forward,
+                    ))?;
             for ((i, address, slot, signature), _) in index_iterator {
                 if i != transaction_status_cf_primary_index || slot > end_slot || address != pubkey
                 {
@@ -2496,15 +2498,17 @@ impl Blockstore {
         let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
         let mut signatures: Vec<(Slot, Signature)> = vec![];
         for transaction_status_cf_primary_index in 0..=1 {
-            let index_iterator = self.address_signatures_cf.iter(IteratorMode::From(
-                (
-                    transaction_status_cf_primary_index,
-                    pubkey,
-                    slot.max(lowest_available_slot),
-                    Signature::default(),
-                ),
-                IteratorDirection::Forward,
-            ))?;
+            let index_iterator =
+                self.address_signatures_cf
+                    .iter_current_index_filtered(IteratorMode::From(
+                        (
+                            transaction_status_cf_primary_index,
+                            pubkey,
+                            slot.max(lowest_available_slot),
+                            Signature::default(),
+                        ),
+                        IteratorDirection::Forward,
+                    ))?;
             for ((i, address, transaction_slot, signature), _) in index_iterator {
                 if i != transaction_status_cf_primary_index
                     || transaction_slot > slot

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2667,10 +2667,12 @@ impl Blockstore {
 
         let mut starting_primary_index_iter_timer = Measure::start("starting_primary_index_iter");
         if slot > next_max_slot {
-            let mut starting_iterator = self.address_signatures_cf.iter(IteratorMode::From(
-                (starting_primary_index, address, slot, Signature::default()),
-                IteratorDirection::Reverse,
-            ))?;
+            let mut starting_iterator =
+                self.address_signatures_cf
+                    .iter_current_index_filtered(IteratorMode::From(
+                        (starting_primary_index, address, slot, Signature::default()),
+                        IteratorDirection::Reverse,
+                    ))?;
 
             // Iterate through starting_iterator until limit is reached
             while address_signatures.len() < limit {
@@ -2703,10 +2705,12 @@ impl Blockstore {
 
         // Iterate through next_iterator until limit is reached
         let mut next_primary_index_iter_timer = Measure::start("next_primary_index_iter_timer");
-        let mut next_iterator = self.address_signatures_cf.iter(IteratorMode::From(
-            (next_primary_index, address, slot, Signature::default()),
-            IteratorDirection::Reverse,
-        ))?;
+        let mut next_iterator =
+            self.address_signatures_cf
+                .iter_current_index_filtered(IteratorMode::From(
+                    (next_primary_index, address, slot, Signature::default()),
+                    IteratorDirection::Reverse,
+                ))?;
         while address_signatures.len() < limit {
             if let Some(((i, key_address, slot, signature), _)) = next_iterator.next() {
                 // Skip next_max_slot, which is already included

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -730,6 +730,18 @@ impl<T: SlotColumn> Column for T {
     }
 }
 
+pub enum IndexError {
+    UnpackError,
+}
+
+/// Helper trait to transition primary indexes out from the columns that are using them. This
+/// abbreviated trait assists in iterating past data with new keys. It will be modified and
+/// expanded in a future version to support writing with the new key and reading both key types.
+pub trait ColumnIndexDeprecation: Column {
+    const CURRENT_INDEX_LEN: usize;
+    fn try_current_index(key: &[u8]) -> std::result::Result<Self::Index, IndexError>;
+}
+
 impl Column for columns::TransactionStatus {
     type Index = (u64, Signature, Slot);
 


### PR DESCRIPTION
#### Problem
In v1.18, https://github.com/solana-labs/solana/pull/33419 will deprecate the existing special-column keys, and start using new ones without the primary indexes. We want nodes to be able to upgrade and downgrade between minor releases as needed. But currently, when a node hits a key of the wrong length, it will panic.

#### Summary of Changes
Add a very abbreviated version of the ColumnIndexDeprecation trait to enable the `LedgerColumn::iter_current_index_filtered()` method
Implement ColumnIndexDeprecation for the TransactionStatus and AddressSignatures columns. (While #33419 also implements the trait for the TransactionMemo column, there isn't anywhere calling the `iter()` method against that column, so nothing that will panic on the new keys.)

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
