### PR TITLE
Fix failure in updating GIT index of cargo registry server

### DIFF
--- a/cargo-registry/src/dummy_git_index.rs
+++ b/cargo-registry/src/dummy_git_index.rs
@@ -70,7 +70,11 @@ impl DummyGitIndex {
         if empty || config_written || new_symlink || new_git_symlink {
             let mut index = repository.index().expect("cannot get the Index file");
             index
-                .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
+                .add_all(
+                    ["config.json", "index"].iter(),
+                    IndexAddOption::DEFAULT,
+                    None,
+                )
                 .expect("Failed to add modified files to git index");
             index.write().expect("Failed to update the git index");
 


### PR DESCRIPTION
#### Problem
The cargo registry server fails to start if the index configuration changes (e.g. due to change in port or IP address)

```
thread 'main' panicked at cargo-registry/src/dummy_git_index.rs:80:18:
Failed to get tree: Error { code: -1, klass: 14, message: "failed to insert entry: invalid object specified - git" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#### Summary of Changes
The config change requires a new commit to the GIT index. The staging of the commit was adding all the files, including `.git` folder. That was causing the issue. This PR adds only the required files to the stage/commit.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
