### PR TITLE
Correct num_packets stats

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -582,13 +582,14 @@ impl ClientConnection for QuicClientConnection {
 
     async fn send_data(&self, data: &[u8]) -> TransportResult<()> {
         let stats = Arc::new(ClientStats::default());
-        // When data is empty which is from cache warmer, we are not sending packets actually, do not count it in stats.
+        // When data is empty which is from cache warmer, we are not sending packets actually, do not count it in
         let num_packets = if data.is_empty() { 0 } else { 1 };
         self.client
             .send_buffer(data, &stats, self.connection_stats.clone())
             .map_ok(|v| {
                 self.connection_stats
                     .add_client_stats(&stats, num_packets, true);
+                v
             })
             .map_err(|e| {
                 warn!(

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -582,11 +582,13 @@ impl ClientConnection for QuicClientConnection {
 
     async fn send_data(&self, data: &[u8]) -> TransportResult<()> {
         let stats = Arc::new(ClientStats::default());
+        // When data is empty which is from cache warmer, we are not sending packets actually, do not count it in stats.
+        let num_packets = if data.is_empty() { 0 } else { 1 };
         self.client
             .send_buffer(data, &stats, self.connection_stats.clone())
             .map_ok(|v| {
-                self.connection_stats.add_client_stats(&stats, 1, true);
-                v
+                self.connection_stats
+                    .add_client_stats(&stats, num_packets, true);
             })
             .map_err(|e| {
                 warn!(
@@ -595,7 +597,8 @@ impl ClientConnection for QuicClientConnection {
                     e
                 );
                 datapoint_warn!("send-wire-async", ("failure", 1, i64),);
-                self.connection_stats.add_client_stats(&stats, 1, false);
+                self.connection_stats
+                    .add_client_stats(&stats, num_packets, false);
                 e.into()
             })
             .await


### PR DESCRIPTION
#### Problem

The num_packets stats are counting the empty packets which are not actually sent and hence skewing the relationship between num_packets and successful_packets

#### Summary of Changes
Do not count the empty packets from cache warmer in num_packets stats as they are not sent.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
