### PR TITLE
Remove dated Blockstore PurgeType::PrimaryIndex code

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1125,7 +1125,7 @@ impl Blockstore {
             .expect("Couldn't fetch from SlotMeta column family")
         {
             // Clear all slot related information
-            self.run_purge(slot, slot, PurgeType::PrimaryIndex)
+            self.run_purge(slot, slot, PurgeType::Exact)
                 .expect("Purge database operations failed");
 
             // Clear this slot as a next slot from parent


### PR DESCRIPTION
#### Problem
Purging the blockstore with `PurgeType::PrimaryIndex` has been dated for quite a while.

#### Summary of Changes
- Update instances of `PurgeType::PrimaryIndex` to `PurgeType::Exact`
- Remove now unused functions
- Remove unused `active_transaction_status_index` field