### PR TITLE
Revert "stop padding new append vecs to page size (#33607)"

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5733,7 +5733,11 @@ impl AccountsDb {
             .create_store_count
             .fetch_add(1, Ordering::Relaxed);
         let path_index = thread_rng().gen_range(0..paths.len());
-        let store = Arc::new(self.new_storage_entry(slot, Path::new(&paths[path_index]), size));
+        let store = Arc::new(self.new_storage_entry(
+            slot,
+            Path::new(&paths[path_index]),
+            Self::page_align(size),
+        ));
 
         debug!(
             "creating store: {} slot: {} len: {} size: {} from: {} path: {:?}",
@@ -9909,7 +9913,7 @@ pub mod test_utils {
             // allocate an append vec for this slot that can hold all the test accounts. This prevents us from creating more than 1 append vec for this slot.
             _ = accounts.accounts_db.create_and_insert_store(
                 slot,
-                AccountsDb::page_align(bytes_required as u64),
+                bytes_required as u64,
                 "create_test_accounts",
             );
         }


### PR DESCRIPTION
This reverts commit b7962a3610b9beec2bfe660622a31fc8e34c1cd3.

#### Problem
https://github.com/solana-labs/solana/pull/33607 and https://github.com/solana-labs/solana/pull/33608 have broken CI for the tip of master
```
running 1 test
test accounts_db::tests::test_shrink_collect_simple ... FAILED

failures:

---- accounts_db::tests::test_shrink_collect_simple stdout ----
thread 'accounts_db::tests::test_shrink_collect_simple' panicked at accounts-db/src/accounts_db.rs:17401:33:
assertion `left == right` failed
  left: 272
 right: 4096
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
These two commits were introduced in parallel, which means CI never previously ran with only one of the commits. Each individual commit on top of master passes CI, but the combination of the two fails

#### Summary of Changes
Revert https://github.com/solana-labs/solana/pull/33607 
