### PR TITLE
Hide wen_restart and do not take default value for now.

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1385,10 +1385,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("wen_restart")
                 .long("wen-restart")
+                .hidden(hidden_unless_forced())
                 .value_name("DIR")
                 .takes_value(true)
                 .required(false)
-                .default_value(&default_args.wen_restart_path)
                 .conflicts_with("wait_for_supermajority")
                 .help(
                     "When specified, the validator will enter Wen Restart mode which


### PR DESCRIPTION
--wen_restart not ready yet, hide it for now and do not take default value so not to break wait_for_supermajority.