### PR TITLE
bank: do not remove trailing 0 bytes from return data

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4954,7 +4954,7 @@ impl Bank {
 
         let ExecutionRecord {
             accounts,
-            mut return_data,
+            return_data,
             touched_account_count,
             accounts_resize_delta,
         } = transaction_context.into();
@@ -4976,14 +4976,8 @@ impl Bank {
         saturating_add_assign!(timings.details.changed_account_count, touched_account_count);
         let accounts_data_len_delta = status.as_ref().map_or(0, |_| accounts_resize_delta);
 
-        let return_data = if enable_return_data_recording {
-            if let Some(end_index) = return_data.data.iter().rposition(|&x| x != 0) {
-                let end_index = end_index.saturating_add(1);
-                return_data.data.truncate(end_index);
-                Some(return_data)
-            } else {
-                None
-            }
+        let return_data = if enable_return_data_recording && !return_data.data.is_empty() {
+            Some(return_data)
         } else {
             None
         };

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9711,9 +9711,9 @@ fn test_tx_return_data() {
         let mut return_data = [0u8; MAX_RETURN_DATA];
         if !instruction_data.is_empty() {
             let index = usize::from_le_bytes(instruction_data.try_into().unwrap());
-            return_data[index] = 1;
+            return_data[index / 2] = 1;
             transaction_context
-                .set_return_data(mock_program_id, return_data.to_vec())
+                .set_return_data(mock_program_id, return_data[..index + 1].to_vec())
                 .unwrap();
         }
         Ok(())
@@ -9765,8 +9765,9 @@ fn test_tx_return_data() {
         if let Some(index) = index {
             let return_data = return_data.unwrap();
             assert_eq!(return_data.program_id, mock_program_id);
-            let mut expected_data = vec![0u8; index];
-            expected_data.push(1u8);
+            let mut expected_data = vec![0u8; index + 1];
+            // include some trailing zeros
+            expected_data[index / 2] = 1;
             assert_eq!(return_data.data, expected_data);
         } else {
             assert!(return_data.is_none());


### PR DESCRIPTION
This is creating havoc for Solang, as the return data is borsh encoded and therefore `u64` values like 0x100 get truncated.

#### Problem

When Solidity returns a borsh encoded return values which end in trailing zeros, then this gets mangled. For example,
a single `bool` value `false` should be a single 0 byte but this get removed. `0x100u64` has its last byte removed.


#### Summary of Changes
Do not remove trailing 0 bytes. There is no need for this.

Fixes #31391 
