### PR TITLE
v1.16: Add warning about deprecated snapshot archive formats

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1509,8 +1509,19 @@ pub fn main() {
 
     let archive_format = {
         let archive_format_str = value_t_or_exit!(matches, "snapshot_archive_format", String);
-        ArchiveFormat::from_cli_arg(&archive_format_str)
-            .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"))
+        let archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
+            .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"));
+        match archive_format {
+            ArchiveFormat::TarBzip2 | ArchiveFormat::TarGzip | ArchiveFormat::Tar => {
+                warn!(
+                    "The specified --snapshot-archive-format is deprecated. Update to use either \
+                    lz4 or zstd, or do not pass --snapshot-archive-format argument at all to use \
+                    the default value of zstd. Deprecated value: {archive_format_str}"
+                );
+            }
+            ArchiveFormat::TarZstd | ArchiveFormat::TarLz4 => {}
+        }
+        archive_format
     };
 
     let snapshot_version =

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1515,7 +1515,7 @@ pub fn main() {
             ArchiveFormat::TarBzip2 | ArchiveFormat::TarGzip | ArchiveFormat::Tar => {
                 warn!(
                     "The specified --snapshot-archive-format is deprecated. Update to use either \
-                    lz4 or zstd, or do not pass --snapshot-archive-format argument at all to use \
+                    zstd or lz4, or do not pass --snapshot-archive-format argument at all to use \
                     the default value of zstd. Deprecated value: {archive_format_str}"
                 );
             }


### PR DESCRIPTION
#### Summary of Changes
These values are not deprecated in v1.16, but they are deprecated in v1.17. So, give a warning in v1.16 to operators who are running the soon-to-be deprecated values.

Tested locally and confirmed the warning shows as expected (newlines inserted here for readability):
```
[2023-10-10T22:33:40.704581671Z WARN  solana_validator] The specified --snapshot-archive-format is deprecated.
Update to use either lz4 or zstd, or do not pass --snapshot-archive-format argument at all to use the default
value of zstd. Deprecated value: none
```