### PR TITLE
Remove dummy entries in Blockstore special columns (part 2)

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -325,12 +325,6 @@ impl Blockstore {
             .unwrap_or(0);
         let last_root = RwLock::new(max_root);
 
-        // Initialize transaction status index if entries are not present
-        let initialize_transaction_status_index = db
-            .iter::<cf::TransactionStatusIndex>(IteratorMode::Start)?
-            .next()
-            .is_none();
-
         measure.stop();
         info!("{:?} {}", blockstore_path, measure);
         let blockstore = Blockstore {
@@ -364,9 +358,8 @@ impl Blockstore {
             lowest_cleanup_slot: RwLock::<Slot>::default(),
             slots_stats: SlotsStats::default(),
         };
-        if initialize_transaction_status_index {
-            blockstore.initialize_transaction_status_index()?;
-        }
+        blockstore.initialize_transaction_status_index()?;
+
         Ok(blockstore)
     }
 
@@ -2114,6 +2107,9 @@ impl Blockstore {
     /// AddressSignatures columns. At any given time, one primary index is active (ie. new records
     /// are stored under this index), the other is frozen.
     fn initialize_transaction_status_index(&self) -> Result<()> {
+        if !self.is_primary_access() {
+            return Ok(());
+        }
         // If present, delete dummy entries inserted by old software
         // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -358,7 +358,7 @@ impl Blockstore {
             lowest_cleanup_slot: RwLock::<Slot>::default(),
             slots_stats: SlotsStats::default(),
         };
-        blockstore.initialize_transaction_status_index()?;
+        blockstore.cleanup_old_entries()?;
 
         Ok(blockstore)
     }
@@ -2102,11 +2102,7 @@ impl Blockstore {
             .collect()
     }
 
-    /// Initializes the TransactionStatusIndex column family with two records, `0` and `1`,
-    /// which are used as the primary index for entries in the TransactionStatus and
-    /// AddressSignatures columns. At any given time, one primary index is active (ie. new records
-    /// are stored under this index), the other is frozen.
-    fn initialize_transaction_status_index(&self) -> Result<()> {
+    fn cleanup_old_entries(&self) -> Result<()> {
         if !self.is_primary_access() {
             return Ok(());
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2114,11 +2114,6 @@ impl Blockstore {
     /// AddressSignatures columns. At any given time, one primary index is active (ie. new records
     /// are stored under this index), the other is frozen.
     fn initialize_transaction_status_index(&self) -> Result<()> {
-        self.transaction_status_index_cf
-            .put(0, &TransactionStatusIndexMeta::default())?;
-        self.transaction_status_index_cf
-            .put(1, &TransactionStatusIndexMeta::default())?;
-
         // If present, delete dummy entries inserted by old software
         // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -761,7 +761,7 @@ pub mod tests {
             .transaction_status_index_cf
             .get(0)
             .unwrap()
-            .unwrap();
+            .unwrap_or_default();
         index0.frozen = true;
         index0.max_slot = 4;
         blockstore
@@ -772,7 +772,7 @@ pub mod tests {
             .transaction_status_index_cf
             .get(1)
             .unwrap()
-            .unwrap();
+            .unwrap_or_default();
         index1.frozen = false;
         index1.max_slot = 9;
         blockstore


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/33511 previously attempted to make `Blockstore::open()` code remove dummy entries to enable the special case check that https://github.com/solana-labs/solana/pull/33534 added. However, this change was flawed:
- The lines to remove the dummy entries was added to `Blockstore::initialize_transaction_status_index()`
- `Blockstore::initialize_transaction_status_index()` would only get called if the `TransactionStatusIndex` entries are not populated
- The previous code populated the `TransactionStatusIndex` entries and the special columns dummy entries at the same time

Thus, the logic to cleanup the dummy entries would only get called if `TransactionStatusIndex` entries are absent. But, the case where we need to clean up dummy entries is the case where TransactionStatusIndex` entries are present.

#### Summary of Changes
- Rename the initialization function and ensure it is always called at open
- Stop populating `TransactionStatusIndex` entries
    - These are now unused, and if the ledger is opened with an old software version that uses these entries, it will re-populate them
    - For now, I left any existing `TransactionStatusIndex` entries untouched as @CriesofCarrots previously expressed an idea to me of being able to use values in these entries to detect when the ledger is fully cleaned of old-key formats