### PR TITLE
Make goto_end_of_slot() take Arc<Bank>

### DIFF
--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -184,7 +184,7 @@ fn bench_bank_async_process_native_loader_transactions(bencher: &mut Bencher) {
 fn bench_bank_update_recent_blockhashes(bencher: &mut Bencher) {
     let (genesis_config, _mint_keypair) = create_genesis_config(100);
     let mut bank = Arc::new(Bank::new_for_benches(&genesis_config));
-    goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+    goto_end_of_slot(bank.clone());
     let genesis_hash = bank.last_blockhash();
     // Prime blockhash_queue
     for i in 0..(MAX_RECENT_BLOCKHASHES + 1) {
@@ -193,7 +193,7 @@ fn bench_bank_update_recent_blockhashes(bencher: &mut Bencher) {
             &Pubkey::default(),
             (i + 1) as u64,
         ));
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
     }
     // Verify blockhash_queue is full (genesis hash has been kicked out)
     assert!(!bank.is_hash_valid_for_age(&genesis_hash, MAX_RECENT_BLOCKHASHES));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8486,8 +8486,9 @@ pub mod test_utils {
         super::Bank,
         solana_sdk::{hash::hashv, pubkey::Pubkey},
         solana_vote_program::vote_state::{self, BlockTimestamp, VoteStateVersions},
+        std::sync::Arc,
     };
-    pub fn goto_end_of_slot(bank: &Bank) {
+    pub fn goto_end_of_slot(bank: Arc<Bank>) {
         let mut tick_hash = bank.last_blockhash();
         loop {
             tick_hash = hashv(&[tick_hash.as_ref(), &[42]]);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2725,7 +2725,7 @@ fn test_bank_tx_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
     let capitalization = bank.capitalization();
 
@@ -2746,7 +2746,7 @@ fn test_bank_tx_fee() {
     );
 
     assert_eq!(bank.get_balance(&leader), initial_balance);
-    goto_end_of_slot(&bank);
+    goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
         bank.get_balance(&leader),
@@ -2774,7 +2774,7 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
+    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2786,7 +2786,7 @@ fn test_bank_tx_fee() {
         bank.get_balance(&mint_keypair.pubkey()),
         mint - arbitrary_transfer_amount - 2 * expected_fee_paid
     ); // mint_keypair still pays a fee
-    goto_end_of_slot(&bank);
+    goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
 
     // Profit! 2 transaction signatures processed at 3 lamports each
@@ -2838,7 +2838,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
     let capitalization = bank.capitalization();
 
@@ -2858,7 +2858,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     assert_eq!(bank.get_balance(&leader), initial_balance);
-    goto_end_of_slot(&bank);
+    goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
         bank.get_balance(&leader),
@@ -2886,7 +2886,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
+    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2898,7 +2898,7 @@ fn test_bank_tx_compute_unit_fee() {
         bank.get_balance(&mint_keypair.pubkey()),
         mint - arbitrary_transfer_amount - 2 * expected_fee_paid
     ); // mint_keypair still pays a fee
-    goto_end_of_slot(&bank);
+    goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
 
     // Profit! 2 transaction signatures processed at 3 lamports each
@@ -2936,19 +2936,19 @@ fn test_bank_blockhash_fee_structure() {
         .target_lamports_per_signature = 5000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
 
-    let bank = Bank::new_for_tests(&genesis_config);
-    goto_end_of_slot(&bank);
+    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
-    goto_end_of_slot(&bank);
+    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
+    goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 2);
+    let bank = Bank::new_from_parent(bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -2988,19 +2988,19 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
         .target_lamports_per_signature = 1000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
 
-    let bank = Bank::new_for_tests(&genesis_config);
-    goto_end_of_slot(&bank);
+    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 1);
-    goto_end_of_slot(&bank);
+    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
+    goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent(Arc::new(bank), &leader, 2);
+    let bank = Bank::new_from_parent(bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -4885,7 +4885,7 @@ fn test_recent_blockhashes_sysvar() {
         let most_recent_hash = recent_blockhashes.iter().next().unwrap().blockhash;
         // Check order
         assert!(bank.is_hash_valid_for_age(&most_recent_hash, 0));
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 }
@@ -4893,8 +4893,8 @@ fn test_recent_blockhashes_sysvar() {
 #[allow(deprecated)]
 #[test]
 fn test_blockhash_queue_sysvar_consistency() {
-    let mut bank = create_simple_test_arc_bank(100_000);
-    goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+    let bank = create_simple_test_arc_bank(100_000);
+    goto_end_of_slot(bank.clone());
 
     let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
     let recent_blockhashes =
@@ -5053,7 +5053,7 @@ where
     // Banks 0 and 1 have no fees, wait two blocks before
     // initializing our nonce accounts
     for _ in 0..2 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5067,7 +5067,7 @@ where
 
     // The setup nonce is not valid to be used until the next bank
     // so wait one more block
-    goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+    goto_end_of_slot(bank.clone());
     bank = Arc::new(new_from_parent(bank));
 
     Ok((bank, mint_keypair, custodian_keypair, nonce_keypair))
@@ -5322,7 +5322,7 @@ fn test_nonce_transaction() {
 
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5391,7 +5391,7 @@ fn test_nonce_transaction() {
 
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5449,7 +5449,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
 
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5518,7 +5518,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
 
     /* Kick nonce hash off the blockhash_queue */
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5586,7 +5586,7 @@ fn test_nonce_authority() {
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5644,7 +5644,7 @@ fn test_nonce_payer() {
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5709,7 +5709,7 @@ fn test_nonce_payer_tx_wide_cap() {
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5777,7 +5777,7 @@ fn test_nonce_fee_calculator_updates() {
 
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5845,7 +5845,7 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
 
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
 
@@ -5925,7 +5925,7 @@ fn test_check_ro_durable_nonce_fails() {
     );
     // Kick nonce hash off the blockhash_queue
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
     }
     // Caught by the runtime because it is a nonce transaction
@@ -6546,7 +6546,7 @@ fn test_bank_hash_consistency() {
     // Check a few slots, cross an epoch boundary
     assert_eq!(bank.get_slots_in_epoch(0), 32);
     loop {
-        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+        goto_end_of_slot(bank.clone());
         if bank.slot == 0 {
             assert_eq!(
                 bank.hash().to_string(),
@@ -6617,13 +6617,13 @@ fn get_shrink_account_size() -> usize {
 
     // Set root for bank 0, with caching disabled so we can get the size
     // of the storage for this slot
-    let mut bank0 = Arc::new(Bank::new_with_config_for_tests(
+    let bank0 = Arc::new(Bank::new_with_config_for_tests(
         &genesis_config,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     ));
     bank0.restore_old_behavior_for_fragile_tests();
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
+    goto_end_of_slot(bank0.clone());
     bank0.freeze();
     bank0.squash();
     add_root_and_flush_write_cache(&bank0);
@@ -6656,7 +6656,7 @@ fn test_clean_nonrooted() {
     info!("pubkey1: {}", pubkey1);
 
     // Set root for bank 0, with caching enabled
-    let mut bank0 = Arc::new(Bank::new_with_config_for_tests(
+    let bank0 = Arc::new(Bank::new_with_config_for_tests(
         &genesis_config,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
@@ -6664,7 +6664,7 @@ fn test_clean_nonrooted() {
 
     let account_zero = AccountSharedData::new(0, 0, &Pubkey::new_unique());
 
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
+    goto_end_of_slot(bank0.clone());
     bank0.freeze();
     bank0.squash();
     // Flush now so that accounts cache cleaning doesn't clean up bank 0 when later
@@ -6673,9 +6673,9 @@ fn test_clean_nonrooted() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let mut bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
+    let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
     bank1.deposit(&pubkey0, some_lamports).unwrap();
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank1).unwrap());
+    goto_end_of_slot(bank1.clone());
     bank1.freeze();
     bank1.flush_accounts_cache_slot_for_tests();
 
@@ -6683,10 +6683,10 @@ fn test_clean_nonrooted() {
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
     // bank2's parent is bank0
-    let mut bank2 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 2));
+    let bank2 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 2));
     bank2.deposit(&pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account_zero);
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank2).unwrap());
+    goto_end_of_slot(bank2.clone());
     bank2.freeze();
     bank2.squash();
     bank2.force_flush_accounts_cache();
@@ -6698,9 +6698,9 @@ fn test_clean_nonrooted() {
     // candidate set
     bank2.clean_accounts_for_tests();
 
-    let mut bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
+    let bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
     bank3.deposit(&pubkey1, some_lamports + 1).unwrap();
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank3).unwrap());
+    goto_end_of_slot(bank3.clone());
     bank3.freeze();
     bank3.squash();
     bank3.force_flush_accounts_cache();
@@ -6731,7 +6731,7 @@ fn test_shrink_candidate_slots_cached() {
     let pubkey2 = solana_sdk::pubkey::new_rand();
 
     // Set root for bank 0, with caching enabled
-    let mut bank0 = Arc::new(Bank::new_with_config_for_tests(
+    let bank0 = Arc::new(Bank::new_with_config_for_tests(
         &genesis_config,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
@@ -6743,7 +6743,7 @@ fn test_shrink_candidate_slots_cached() {
     let account0 = AccountSharedData::new(1000, pubkey0_size, &Pubkey::new_unique());
     bank0.store_account(&pubkey0, &account0);
 
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
+    goto_end_of_slot(bank0.clone());
     bank0.freeze();
     bank0.squash();
     // Flush now so that accounts cache cleaning doesn't clean up bank 0 when later
@@ -6752,10 +6752,10 @@ fn test_shrink_candidate_slots_cached() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let mut bank1 = Arc::new(new_from_parent(bank0));
+    let bank1 = Arc::new(new_from_parent(bank0));
     bank1.deposit(&pubkey1, some_lamports).unwrap();
     bank1.deposit(&pubkey2, some_lamports).unwrap();
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank1).unwrap());
+    goto_end_of_slot(bank1.clone());
     bank1.freeze();
     bank1.squash();
     // Flush now so that accounts cache cleaning doesn't clean up bank 0 when later
@@ -6763,10 +6763,10 @@ fn test_shrink_candidate_slots_cached() {
     bank1.force_flush_accounts_cache();
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
-    let mut bank2 = Arc::new(new_from_parent(bank1));
+    let bank2 = Arc::new(new_from_parent(bank1));
     bank2.deposit(&pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account0);
-    goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank2).unwrap());
+    goto_end_of_slot(bank2.clone());
     bank2.freeze();
     bank2.squash();
     bank2.force_flush_accounts_cache();
@@ -12425,7 +12425,7 @@ fn test_runtime_feature_enable_with_program_cache() {
     genesis_config
         .accounts
         .remove(&feature_set::reject_callx_r10::id());
-    let root_bank = Bank::new_for_tests(&genesis_config);
+    let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
     // Test a basic transfer
     let amount = genesis_config.rent.minimum_balance(0);
@@ -12454,8 +12454,8 @@ fn test_runtime_feature_enable_with_program_cache() {
     let transaction1 = Transaction::new(&signers1, message1, root_bank.last_blockhash());
 
     // Advance the bank so the next transaction can be submitted.
-    goto_end_of_slot(&root_bank);
-    let mut bank = new_from_parent(Arc::new(root_bank));
+    goto_end_of_slot(root_bank.clone());
+    let mut bank = new_from_parent(root_bank);
 
     // Compose second instruction using the same program with a different block hash
     let instruction2 = Instruction::new_with_bytes(program_keypair.pubkey(), &[], Vec::new());


### PR DESCRIPTION
#### Problem

my scheduler thing needs to introduce rather invasive code changes including the `BankWithScheduler` wrapping, which touches the quite long-lived `goto_end_of_slot()` test helper function.

#### Summary of Changes

In preparation for the scheduler, adjust its argument type in advance to take `Arc<Bank>`, also clean up odd `::get_mut()` and others for consistent call-site coding styles as a bonus.

extracted from: https://github.com/solana-labs/solana/pull/33070