### PR TITLE
Change getHealth to compare optimistically confirmed slots

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -980,7 +980,6 @@ impl Validator {
                 ledger_path,
                 config.validator_exit.clone(),
                 exit.clone(),
-                config.known_validators.clone(),
                 rpc_override_health_check.clone(),
                 startup_verification_complete,
                 optimistically_confirmed_bank.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -943,7 +943,8 @@ impl Validator {
         // (by both replay stage and banking stage)
         let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::default());
 
-        let rpc_override_health_check = Arc::new(AtomicBool::new(false));
+        let rpc_override_health_check =
+            Arc::new(AtomicBool::new(config.rpc_config.disable_health_check));
         let (
             json_rpc_service,
             pubsub_service,

--- a/docs/src/api/http.md
+++ b/docs/src/api/http.md
@@ -154,11 +154,11 @@ Some methods support providing a `filters` object to enable pre-filtering the da
 Although not a JSON RPC API, a `GET /health` at the RPC HTTP Endpoint provides a
 health-check mechanism for use by load balancers or other network
 infrastructure. This request will always return a HTTP 200 OK response with a body of
-"ok", "behind" or "unknown" based on the following conditions:
+"ok", "behind" or "unknown":
 
-1. If the node is within `HEALTH_CHECK_SLOT_DISTANCE` slots from the latest cluster confirmed slot, "ok" is returned.
-2. If the node is behind more than `HEALTH_CHECK_SLOT_DISTANCE` slots from the latest cluster confirmed slot, an error is returned that will contain more information about far behind the node is.
-3. If the node is unable to determine its' health, an error is returned.
+- `ok`: The node is within `HEALTH_CHECK_SLOT_DISTANCE` slots from the latest cluster confirmed slot
+- `behind { distance }`: The node is behind `distance` slots from the latest cluster confirmed slot where `distance > HEALTH_CHECK_SLOT_DISTANCE`
+- `unknown`: The node is unable to determine where it stands in relation to the cluster
 
 ## JSON RPC API Reference
 

--- a/docs/src/api/http.md
+++ b/docs/src/api/http.md
@@ -156,11 +156,9 @@ health-check mechanism for use by load balancers or other network
 infrastructure. This request will always return a HTTP 200 OK response with a body of
 "ok", "behind" or "unknown" based on the following conditions:
 
-1. If one or more `--known-validator` arguments are provided to `solana-validator` - "ok" is returned
-   when the node has within `HEALTH_CHECK_SLOT_DISTANCE` slots of the highest
-   known validator, otherwise "behind". "unknown" is returned when no slot
-   information from known validators is not yet available.
-2. "ok" is always returned if no known validators are provided.
+1. If the node is within `HEALTH_CHECK_SLOT_DISTANCE` slots from the latest cluster confirmed slot, "ok" is returned.
+2. If the node is behind more than `HEALTH_CHECK_SLOT_DISTANCE` slots from the latest cluster confirmed slot, an error is returned that will contain more information about far behind the node is.
+3. If the node is unable to determine its' health, an error is returned.
 
 ## JSON RPC API Reference
 

--- a/docs/src/api/methods/_getHealth.mdx
+++ b/docs/src/api/methods/_getHealth.mdx
@@ -12,13 +12,8 @@ import {
 
 ## getHealth
 
-Returns the current health of the node.
-
-:::caution
-If one or more `--known-validator` arguments are provided to `solana-validator` - "ok" is returned
-when the node has within `HEALTH_CHECK_SLOT_DISTANCE` slots of the highest known validator,
-otherwise an error is returned. "ok" is always returned if no known validators are provided.
-:::
+Returns the current health of the node. A healthy node is one that is within
+`HEALTH_CHECK_SLOT_DISTANCE` slots of the latest cluster confirmed slot.
 
 <DocSideBySide>
 <CodeParams>

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -149,12 +149,15 @@ pub struct JsonRpcConfig {
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
     pub max_request_body_size: Option<usize>,
+    /// Disable the health check, used for tests and TestValidator
+    pub disable_health_check: bool,
 }
 
 impl JsonRpcConfig {
     pub fn default_for_test() -> Self {
         Self {
             full_api: true,
+            disable_health_check: true,
             ..Self::default()
         }
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4789,6 +4789,8 @@ pub mod tests {
             // note that this means that slot 0 will always be considered complete
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(0));
             let max_complete_rewards_slot = Arc::new(AtomicU64::new(0));
+            let optimistically_confirmed_bank =
+                OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
 
             let meta = JsonRpcRequestProcessor::new(
                 config,
@@ -4797,11 +4799,11 @@ pub mod tests {
                 block_commitment_cache.clone(),
                 blockstore.clone(),
                 validator_exit,
-                RpcHealth::stub(),
+                RpcHealth::stub(optimistically_confirmed_bank.clone(), blockstore.clone()),
                 cluster_info,
                 Hash::default(),
                 None,
-                OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
+                optimistically_confirmed_bank,
                 Arc::new(RwLock::new(LargestAccountsCache::new(30))),
                 max_slots.clone(),
                 Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
@@ -6400,7 +6402,11 @@ pub mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let (bank_forks, mint_keypair, ..) = new_bank_forks();
-        let health = RpcHealth::stub();
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let health = RpcHealth::stub(optimistically_confirmed_bank.clone(), blockstore.clone());
+        // Mark the node as healthy to start
+        health.stub_set_health_status(Some(RpcHealthStatus::Ok));
 
         // Freeze bank 0 to prevent a panic in `run_transaction_simulation()`
         bank_forks.write().unwrap().get(0).unwrap().freeze();
@@ -6431,7 +6437,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
             None,
-            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
+            optimistically_confirmed_bank,
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
@@ -6692,18 +6698,20 @@ pub mod tests {
             .my_contact_info()
             .tpu(connection_cache.protocol())
             .unwrap();
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             JsonRpcConfig::default(),
             None,
             bank_forks.clone(),
             block_commitment_cache,
-            blockstore,
+            blockstore.clone(),
             validator_exit,
-            RpcHealth::stub(),
+            RpcHealth::stub(optimistically_confirmed_bank.clone(), blockstore),
             cluster_info,
             Hash::default(),
             None,
-            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
+            optimistically_confirmed_bank,
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
@@ -8329,9 +8337,9 @@ pub mod tests {
             None,
             bank_forks.clone(),
             block_commitment_cache,
-            blockstore,
+            blockstore.clone(),
             validator_exit,
-            RpcHealth::stub(),
+            RpcHealth::stub(optimistically_confirmed_bank.clone(), blockstore.clone()),
             cluster_info,
             Hash::default(),
             None,

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -52,11 +52,11 @@ impl RpcHealth {
             }
         }
 
-        if !self.startup_verification_complete.load(Ordering::Acquire) {
-            return RpcHealthStatus::Unknown;
-        }
         if self.override_health_check.load(Ordering::Relaxed) {
             return RpcHealthStatus::Ok;
+        }
+        if !self.startup_verification_complete.load(Ordering::Acquire) {
+            return RpcHealthStatus::Unknown;
         }
 
         // A node can observe votes by both replaying blocks and observing gossip.
@@ -129,5 +129,86 @@ impl RpcHealth {
     #[cfg(test)]
     pub(crate) fn stub_set_health_status(&self, stub_health_status: Option<RpcHealthStatus>) {
         *self.stub_health_status.write().unwrap() = stub_health_status;
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        solana_ledger::{
+            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            get_tmp_ledger_path_auto_delete,
+        },
+        solana_runtime::{bank::Bank, bank_forks::BankForks},
+        solana_sdk::{clock::UnixTimestamp, hash::Hash, pubkey::Pubkey},
+    };
+
+    #[test]
+    fn test_get_health() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let bank0 = bank_forks.read().unwrap().root_bank();
+        assert!(bank0.slot() == 0);
+
+        let health_check_slot_distance = 10;
+        let override_health_check = Arc::new(AtomicBool::new(true));
+        let startup_verification_complete = Arc::clone(bank0.get_startup_verification_complete());
+        let health = RpcHealth::new(
+            optimistically_confirmed_bank.clone(),
+            blockstore.clone(),
+            health_check_slot_distance,
+            override_health_check.clone(),
+            startup_verification_complete,
+        );
+
+        // Override health check set to true - status is ok
+        assert_eq!(health.check(), RpcHealthStatus::Ok);
+
+        // Remove the override - status now unknown with incomplete startup verification
+        override_health_check.store(false, Ordering::Relaxed);
+        assert_eq!(health.check(), RpcHealthStatus::Unknown);
+
+        // Mark startup verification complete - status still unknown as no slots have been
+        // optimistically confirmed yet
+        bank0.set_startup_verification_complete();
+        assert_eq!(health.check(), RpcHealthStatus::Unknown);
+
+        // Mark slot 15 as being optimistically confirmed in the Blockstore, this could
+        // happen if the cluster confirmed the slot and this node became aware through gossip,
+        // but this node has not yet replayed slot 15. The local view of the latest optimistic
+        // slot is still slot 0 so status will be behind
+        blockstore
+            .insert_optimistic_slot(15, &Hash::default(), UnixTimestamp::default())
+            .unwrap();
+        assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 15 });
+
+        // Simulate this node observing slot 4 as optimistically confirmed - status still behind
+        let bank4 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 4));
+        optimistically_confirmed_bank.write().unwrap().bank = bank4.clone();
+        assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 11 });
+
+        // Simulate this node observing slot 5 as optimistically confirmed - status now ok
+        // as distance is <= health_check_slot_distance
+        let bank5 = Arc::new(Bank::new_from_parent(bank4, &Pubkey::default(), 5));
+        optimistically_confirmed_bank.write().unwrap().bank = bank5.clone();
+        assert_eq!(health.check(), RpcHealthStatus::Ok);
+
+        // Node now up with tip of cluster
+        let bank15 = Arc::new(Bank::new_from_parent(bank5, &Pubkey::default(), 15));
+        optimistically_confirmed_bank.write().unwrap().bank = bank15.clone();
+        assert_eq!(health.check(), RpcHealthStatus::Ok);
+
+        // Node "beyond" tip of cluster - this technically isn't possible but could be
+        // observed locally due to a race between updates to Blockstore and
+        // OptimisticallyConfirmedBank. Either way, not a problem and status is ok.
+        let bank16 = Arc::new(Bank::new_from_parent(bank15, &Pubkey::default(), 16));
+        optimistically_confirmed_bank.write().unwrap().bank = bank16.clone();
+        assert_eq!(health.check(), RpcHealthStatus::Ok);
     }
 }

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -96,7 +96,7 @@ impl RpcHealth {
         };
 
         if my_latest_optimistically_confirmed_slot
-            > cluster_latest_optimistically_confirmed_slot
+            >= cluster_latest_optimistically_confirmed_slot
                 .saturating_sub(self.health_check_slot_distance)
         {
             RpcHealthStatus::Ok

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -113,11 +113,13 @@ impl RpcHealth {
     }
 
     #[cfg(test)]
-    pub(crate) fn stub() -> Arc<Self> {
-        use crate::rpc::tests::new_test_cluster_info;
+    pub(crate) fn stub(
+        optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
+        blockstore: Arc<Blockstore>,
+    ) -> Arc<Self> {
         Arc::new(Self::new(
-            Arc::new(new_test_cluster_info()),
-            None,
+            optimistically_confirmed_bank,
+            blockstore,
             42,
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(true)),

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -37,12 +37,11 @@ use {
     },
     solana_sdk::{
         exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
-        native_token::lamports_to_sol, pubkey::Pubkey,
+        native_token::lamports_to_sol,
     },
     solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
     solana_storage_bigtable::CredentialType,
     std::{
-        collections::HashSet,
         net::SocketAddr,
         path::{Path, PathBuf},
         sync::{
@@ -350,7 +349,6 @@ impl JsonRpcService {
         ledger_path: &Path,
         validator_exit: Arc<RwLock<Exit>>,
         exit: Arc<AtomicBool>,
-        known_validators: Option<HashSet<Pubkey>>,
         override_health_check: Arc<AtomicBool>,
         startup_verification_complete: Arc<AtomicBool>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
@@ -368,8 +366,8 @@ impl JsonRpcService {
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let health = Arc::new(RpcHealth::new(
-            cluster_info.clone(),
-            known_validators,
+            Arc::clone(&optimistically_confirmed_bank),
+            Arc::clone(&blockstore),
             config.health_check_slot_distance,
             override_health_check,
             startup_verification_complete,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1146,20 +1146,44 @@ impl Drop for TestValidator {
 mod test {
     use super::*;
 
+    impl TestValidator {
+        // Wait for the given slot to be observed as confirmed. Returns true if
+        // the slot (or a greater one) is observed as confirmed, false otherwise.
+        fn wait_for_confirmed_slot(&self, slot: Slot) -> bool {
+            let rpc_client =
+                RpcClient::new_with_commitment(self.rpc_url.clone(), CommitmentConfig::confirmed());
+            const MAX_TRIES: u64 = 10;
+            let mut num_tries = 0;
+            loop {
+                num_tries += 1;
+                if num_tries > MAX_TRIES {
+                    break;
+                }
+                debug!("Waiting for slot {slot} to be confirmed {num_tries}...");
+                match rpc_client.get_slot() {
+                    Ok(latest_slot) => {
+                        if latest_slot >= slot {
+                            return true;
+                        }
+                    }
+                    Err(err) => {
+                        warn!("get_slot() failed: {:?}", err);
+                        break;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
+            }
+            false
+        }
+    }
+
     #[test]
     fn get_health() {
         let (test_validator, _payer) = TestValidatorGenesis::default().start();
         test_validator.set_startup_verification_complete_for_tests();
+        assert!(test_validator.wait_for_confirmed_slot(1));
         let rpc_client = test_validator.get_rpc_client();
         rpc_client.get_health().expect("health");
-    }
-
-    #[tokio::test]
-    async fn nonblocking_get_health() {
-        let (test_validator, _payer) = TestValidatorGenesis::default().start_async().await;
-        test_validator.set_startup_verification_complete_for_tests();
-        let rpc_client = test_validator.get_async_rpc_client();
-        rpc_client.get_health().await.expect("health");
     }
 
     #[tokio::test]

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -258,11 +258,9 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("SLOT_DISTANCE")
                 .takes_value(true)
                 .default_value(&default_args.health_check_slot_distance)
-                .help("If --known-validators are specified, report this validator healthy \
-                       if its latest account hash is no further behind than this number of \
-                       slots from the latest known validator account hash. \
-                       If no --known-validators are specified, the validator will always \
-                       report itself to be healthy")
+                .help("Report this validator healthy if its latest optimistically confirmed slot \
+                       that has been replayed is no further behind than this number of slots from \
+                       the cluster latest optimistically confirmed slot")
         )
         .arg(
             Arg::with_name("rpc_faucet_addr")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1299,6 +1299,7 @@ pub fn main() {
                 "health_check_slot_distance",
                 u64
             ),
+            disable_health_check: false,
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),


### PR DESCRIPTION
#### Problem
The current `getHealth` mechanism checks a local accounts hash slot vs. those of other nodes as specified by `--known-validator`. This is a very coarse comparison given that the default for this value is 100 slots. More so, any nodes using a value larger than the default (ie `--incremental-snapshot-interval 500`) will 100% see `getHealth` return status behind at some point.

#### Summary of Changes
Change the underlying mechanism of how health is computed. Instead of using the accounts hash slots published in gossip, use the latest optimistically confirmed slot from the cluster. The cluster confirmed slot can be compared against the latest optimistically confirmed bank to determine how far behind the node is. This new comparison is much more granular than the old approach, and also has the benefit of not going haywire if a known validator has issues (no domino effect).

#### Testing
With this branch, I observed a node reporting a diminishing "slots behind" value as it caught up from a process restart. To be sure, I also added a hack to stall `ReplayStage` for 30 seconds every 1000 slots. Stalling for 30 seconds should result in my node falling behind about 60-75 slots; this hack plus passing `--health-check-slot-distance 25` allowed me to see the node fall behind (as reported by `solana-validator monitor`) immediately after the 30s sleep, but then quickly catch up and continue to report a healthy status. 

Fixes #16957
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
