### PR TITLE
stop padding new append vecs to page size

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9909,7 +9909,7 @@ pub mod test_utils {
             // allocate an append vec for this slot that can hold all the test accounts. This prevents us from creating more than 1 append vec for this slot.
             _ = accounts.accounts_db.create_and_insert_store(
                 slot,
-                bytes_required as u64,
+                AccountsDb::page_align(bytes_required as u64),
                 "create_test_accounts",
             );
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5733,11 +5733,7 @@ impl AccountsDb {
             .create_store_count
             .fetch_add(1, Ordering::Relaxed);
         let path_index = thread_rng().gen_range(0..paths.len());
-        let store = Arc::new(self.new_storage_entry(
-            slot,
-            Path::new(&paths[path_index]),
-            Self::page_align(size),
-        ));
+        let store = Arc::new(self.new_storage_entry(slot, Path::new(&paths[path_index]), size));
 
         debug!(
             "creating store: {} slot: {} len: {} size: {} from: {} path: {:?}",

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -17387,17 +17387,14 @@ pub mod tests {
                                     assert_eq!(shrink_collect.aligned_total_bytes, 0);
                                     assert_eq!(shrink_collect.alive_total_bytes, 0);
                                 }
-                                // these constants are multiples of page size (4096).
-                                // They are determined by what size append vec gets created when the write cache is flushed to an append vec.
-                                // Thus, they are dependent on the # of accounts that are written. They were identified by hitting the asserts and noting the value
-                                // for shrink_collect.original_bytes at each account_count and then encoding it here.
-                                let expected_capacity = if account_count >= 100 {
-                                    16384
-                                } else if account_count >= 50 {
-                                    8192
-                                } else {
-                                    4096
-                                };
+                                // expected_capacity is determined by what size append vec gets created when the write cache is flushed to an append vec.
+                                let mut expected_capacity =
+                                    (account_count * aligned_stored_size(space)) as u64;
+                                if append_opposite_zero_lamport_account && space != 0 {
+                                    // zero lamport accounts always write space = 0
+                                    expected_capacity -= space as u64;
+                                }
+
                                 assert_eq!(shrink_collect.capacity, expected_capacity);
                                 assert_eq!(shrink_collect.total_starting_accounts, account_count);
                                 let mut expected_all_are_zero_lamports = lamports == 0;


### PR DESCRIPTION
#### Problem
We no longer 'append' to append vecs. We know the full size when we are ready to write to them. So, it is no longer necessary to pad them to the next full page size. This makes 100% of the data in the file required and the used length equal to the allocated length.

This pr was attempted as #33607 but reverted as #33634.
There were 2 conflicting prs. There was a failing test. That test has now been fixed.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
