### PR TITLE
Add check for CHANGELOG.md change when changelog label applied to PR

### DIFF
--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -uo pipefail
+
+CHANGELOG_FILE="CHANGELOG.md"
+echo "Checking: git diff --exit-code origin/${BASE_REF} -- ${CHANGELOG_FILE}"
+
+if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+    >&2 echo "Error: this pull request requires an entry in $CHANGELOG_FILE, but no entry was found"
+    exit 1
+fi

--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -1,0 +1,20 @@
+name: Require changelog entry
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-changelog:
+    if: contains(github.event.pull_request.labels.*.name, 'changelog')
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Check if changes to CHANGELOG.md
+      shell: bash
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: .github/scripts/check-changelog.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release channels have their own copy of this changelog:
 <a name="edge-channel"></a>
 ## [1.18.0] - Unreleased
 * Changes
+  * Added a github check to support `changelog` label
 * Upgrade Notes
 
 ## [1.17.0]


### PR DESCRIPTION
Testing:

| Commit | changelog Label | Expected | Actual same as expected? | 
| ------ | --------------- | -------- | ------ |
| e98c0bc7 (no CHANGELOG.md entry) | Yes        | Check fails   | OK |
| e98c0bc7 | No         | Check skipped | OK |
| 73cfe1a4 (with CHANGELOG.md entry) | Yes        | Check passes  |  OK |
| 73cfe1a4 | No         | Check skipped | OK |