### PR TITLE
Blockstore: clean/save old TransactionMemos sensibly

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2167,6 +2167,9 @@ impl Blockstore {
                 self.transaction_status_index_cf.delete(1)?;
             }
         }
+        if w_highest_primary_index_slot.is_none() {
+            self.db.set_clean_slot_0(true);
+        }
         Ok(())
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2154,6 +2154,8 @@ impl Blockstore {
         }
         if highest_primary_index_slot.is_some() {
             self.set_highest_primary_index_slot(highest_primary_index_slot);
+        } else {
+            self.db.set_clean_slot_0(true);
         }
         Ok(())
     }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -2134,6 +2134,7 @@ pub mod tests {
             is_manual_compaction: true,
         };
         let oldest_slot = OldestSlot::default();
+        oldest_slot.set_clean_slot_0(true);
 
         let mut factory = PurgedSlotFilterFactory::<ShredData> {
             oldest_slot: oldest_slot.clone(),

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1863,7 +1863,7 @@ impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
         use rocksdb::CompactionDecision::*;
 
         let slot_in_key = C::slot(C::index(key));
-        if slot_in_key >= self.oldest_slot {
+        if slot_in_key >= self.oldest_slot || (slot_in_key == 0 && !self.clean_slot_0) {
             Keep
         } else {
             Remove

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -348,7 +348,9 @@ pub mod columns {
 }
 
 #[derive(Default, Clone, Debug)]
-struct OldestSlot(Arc<AtomicU64>);
+struct OldestSlot {
+    slot: Arc<AtomicU64>,
+}
 
 impl OldestSlot {
     pub fn set(&self, oldest_slot: Slot) {
@@ -356,7 +358,7 @@ impl OldestSlot {
         // also, compaction_filters are created via its factories, creating short-lived copies of
         // this atomic value for the single job of compaction. So, Relaxed store can be justified
         // in total
-        self.0.store(oldest_slot, Ordering::Relaxed);
+        self.slot.store(oldest_slot, Ordering::Relaxed);
     }
 
     pub fn get(&self) -> Slot {
@@ -365,7 +367,7 @@ impl OldestSlot {
         // requirement at the moment
         // also eventual propagation (very Relaxed) load is Ok, because compaction by nature doesn't
         // require strictly synchronized semantics in this regard
-        self.0.load(Ordering::Relaxed)
+        self.slot.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
#### Problem
As of [this commit](https://github.com/solana-labs/solana/pull/33419/commits/2aeacd29851c509bcf164154c5124a06530660eb), the compaction-filter purge includes the TransactionMemos column. For new TransactionMemos that include Slot in the key, the filter works as expected, and purges slots older than `oldest_slot`. However, old TransactionMemos that don't include Slot in the key are currently set to *all* be purged on the first periodic cleanup. This is because `C::slot(C::index())` always returns 0 for these entries.

#### Summary of Changes
Add a field to OldestSlot to track when slot-0 entries should be cleaned
Plumb into PurgedSlotFilter
