### PR TITLE
remove redis setup from net.sh

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -806,7 +806,6 @@ $(
     install-earlyoom.sh \
     install-iftop.sh \
     install-libssl-compatability.sh \
-    install-redis.sh \
     install-rsync.sh \
     install-perf.sh \
     localtime.sh \


### PR DESCRIPTION
#### Problem

system performance tests failed recently.

it seems that this line is the culprit
https://github.com/solana-labs/solana/blob/452fd5d384e344377c4d14ab4373f9ad129f36d2/net/scripts/install-redis.sh#L7

If I don't miss anything, we don't really use redis in our performance tests.

#### Summary of Changes

remove the redis setup from the net.sh