### PR TITLE
storage-proto: change rerun line format

### DIFF
--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut protos = Vec::new();
     for proto_file in &proto_files {
         let proto = proto_base_path.join(proto_file);
-        println!("cargo::rerun-if-changed={}", proto.display());
+        println!("cargo:rerun-if-changed={}", proto.display());
         protos.push(proto);
     }
 


### PR DESCRIPTION
#### Problem

Not possible to build 1.16 crates with rust 1.73 due to the changed `rerun` line in `build.rs`

#### Summary of Changes

Change `rerun` format
