### PR TITLE
Fix non-determinism in account_hash_ignore_slot on genesis

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3833,6 +3833,16 @@ impl Bank {
         // Bootstrap validator collects fees until `new_from_parent` is called.
         self.fee_rate_governor = genesis_config.fee_rate_governor.clone();
 
+        // Make sure to activate the account_hash_ignore_slot feature
+        // before calculating any account hashes.
+        if genesis_config
+            .accounts
+            .iter()
+            .any(|(pubkey, _)| pubkey == &feature_set::account_hash_ignore_slot::id())
+        {
+            self.activate_feature(&feature_set::account_hash_ignore_slot::id());
+        }
+
         for (pubkey, account) in genesis_config.accounts.iter() {
             assert!(
                 self.get_account(pubkey).is_none(),


### PR DESCRIPTION
#### Problem
See #32801

until the `account_hash_ignore_slot` feature gets activated, there is some non-determinism in testing.

#### Summary of Changes
Remove non-determinism.

Fixes #32800 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
