### PR TITLE
Refactor - LoadedPrograms part 2

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -933,6 +933,10 @@ impl WorkingSlot for Bank {
         self.slot
     }
 
+    fn current_epoch(&self) -> Epoch {
+        self.epoch
+    }
+
     fn is_ancestor(&self, other: Slot) -> bool {
         self.ancestors.contains_key(&other)
     }
@@ -4675,12 +4679,8 @@ impl Bank {
     }
 
     pub fn load_program(&self, pubkey: &Pubkey, reload: bool) -> Arc<LoadedProgram> {
-        let environments = self
-            .loaded_programs_cache
-            .read()
-            .unwrap()
-            .environments
-            .clone();
+        let loaded_programs_cache = self.loaded_programs_cache.read().unwrap();
+        let environments = loaded_programs_cache.get_environments_for_epoch(self.epoch);
 
         let mut load_program_metrics = LoadProgramMetrics {
             program_id: pubkey.to_string(),
@@ -4773,20 +4773,22 @@ impl Bank {
                     })
                     .unwrap_or(LoadedProgram::new_tombstone(
                         self.slot,
-                        LoadedProgramType::FailedVerification(environments.program_runtime_v2),
+                        LoadedProgramType::FailedVerification(
+                            environments.program_runtime_v2.clone(),
+                        ),
                     ));
                 Ok(loaded_program)
             }
 
             ProgramAccountLoadResult::InvalidV4Program => Ok(LoadedProgram::new_tombstone(
                 self.slot,
-                LoadedProgramType::FailedVerification(environments.program_runtime_v2),
+                LoadedProgramType::FailedVerification(environments.program_runtime_v2.clone()),
             )),
         }
         .unwrap_or_else(|_| {
             LoadedProgram::new_tombstone(
                 self.slot,
-                LoadedProgramType::FailedVerification(environments.program_runtime_v1),
+                LoadedProgramType::FailedVerification(environments.program_runtime_v1.clone()),
             )
         });
 


### PR DESCRIPTION
#### Problem
General fixes split off from #33477, continuation of #33482.

#### Summary of Changes
- Uses one mock environment across all entries generated in each `LoadedProgram` test.
- Adds `LoadedProgramType::get_environment()`.
- Adjusts `test_runtime_feature_enable_with_program_cache()`.
- Filter out entries of different environments in `LoadedPrograms::extract()`.
- Adds `LoadedPrograms::get_environments_for_epoch()`.