### PR TITLE
CreateAncientStorage packs by default

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -161,9 +161,9 @@ pub enum IncludeSlotInHash {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum CreateAncientStorage {
     /// ancient storages are created by appending
-    #[default]
     Append,
     /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats
+    #[default]
     Pack,
 }
 


### PR DESCRIPTION
#### Problem
When no argument is passed to validators, we want the ancient append vec algorithm to pack instead of appending.

#### Summary of Changes
Change enum's default.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
