### PR TITLE
[zk-token-sdk] Check that discrete log compression batch size is greater than 0

### DIFF
--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -130,7 +130,7 @@ impl DiscreteLog {
         &mut self,
         compression_batch_size: usize,
     ) -> Result<(), DiscreteLogError> {
-        if compression_batch_size >= TWO16 as usize {
+        if compression_batch_size >= TWO16 as usize || compression_batch_size == 0 {
             return Err(DiscreteLogError::DiscreteLogBatchSize);
         }
         self.compression_batch_size = compression_batch_size;


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/33506

#### Summary of Changes
Add a check on `compression_batch_size` in the discrete logic so that the program errors gracefully.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
