### PR TITLE
[zk-token-sdk] Limit max seed length for key derivations

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -50,6 +50,8 @@ pub enum AuthenticatedEncryptionError {
     DerivationMethodNotSupported,
     #[error("seed length too short for derivation")]
     SeedLengthTooShort,
+    #[error("seed length too long for derivation")]
+    SeedLengthTooLarge,
 }
 
 struct AuthenticatedEncryption;
@@ -172,9 +174,13 @@ impl EncodableKey for AeKey {
 impl SeedDerivable for AeKey {
     fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
         const MINIMUM_SEED_LEN: usize = AE_KEY_LEN;
+        const MAXIMUM_SEED_LEN: usize = 65535;
 
         if seed.len() < MINIMUM_SEED_LEN {
             return Err(AuthenticatedEncryptionError::SeedLengthTooShort.into());
+        }
+        if seed.len() > MAXIMUM_SEED_LEN {
+            return Err(AuthenticatedEncryptionError::SeedLengthTooLarge.into());
         }
 
         let mut hasher = Sha3_512::new();
@@ -277,5 +283,17 @@ mod tests {
 
         let null_signer = NullSigner::new(&Pubkey::default());
         assert!(AeKey::new_from_signer(&null_signer, Pubkey::default().as_ref()).is_err());
+    }
+
+    #[test]
+    fn test_aes_key_from_seed() {
+        let good_seed = vec![0; 32];
+        assert!(AeKey::from_seed(&good_seed).is_ok());
+
+        let too_short_seed = vec![0; 15];
+        assert!(AeKey::from_seed(&too_short_seed).is_err());
+
+        let too_long_seed = vec![0; 65536];
+        assert!(AeKey::from_seed(&too_long_seed).is_err());
     }
 }

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -51,7 +51,7 @@ pub enum AuthenticatedEncryptionError {
     #[error("seed length too short for derivation")]
     SeedLengthTooShort,
     #[error("seed length too long for derivation")]
-    SeedLengthTooLarge,
+    SeedLengthTooLong,
 }
 
 struct AuthenticatedEncryption;

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -180,7 +180,7 @@ impl SeedDerivable for AeKey {
             return Err(AuthenticatedEncryptionError::SeedLengthTooShort.into());
         }
         if seed.len() > MAXIMUM_SEED_LEN {
-            return Err(AuthenticatedEncryptionError::SeedLengthTooLarge.into());
+            return Err(AuthenticatedEncryptionError::SeedLengthTooLong.into());
         }
 
         let mut hasher = Sha3_512::new();

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -457,7 +457,7 @@ impl ElGamalSecretKey {
             return Err(ElGamalError::SeedLengthTooShort);
         }
         if seed.len() > MAXIMUM_SEED_LEN {
-            return Err(ElGamalError::SeedLengthTooLarge);
+            return Err(ElGamalError::SeedLengthTooLong);
         }
         Ok(ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(seed)))
     }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -77,7 +77,7 @@ pub enum ElGamalError {
     #[error("seed length too short for derivation")]
     SeedLengthTooShort,
     #[error("seed length too long for derivation")]
-    SeedLengthTooLarge,
+    SeedLengthTooLong,
 }
 
 /// Algorithm handle for the twisted ElGamal encryption scheme

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -76,6 +76,8 @@ pub enum ElGamalError {
     DerivationMethodNotSupported,
     #[error("seed length too short for derivation")]
     SeedLengthTooShort,
+    #[error("seed length too long for derivation")]
+    SeedLengthTooLarge,
 }
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
@@ -449,9 +451,13 @@ impl ElGamalSecretKey {
     /// Derive an ElGamal secret key from an entropy seed.
     pub fn from_seed(seed: &[u8]) -> Result<Self, ElGamalError> {
         const MINIMUM_SEED_LEN: usize = ELGAMAL_SECRET_KEY_LEN;
+        const MAXIMUM_SEED_LEN: usize = 65535;
 
         if seed.len() < MINIMUM_SEED_LEN {
             return Err(ElGamalError::SeedLengthTooShort);
+        }
+        if seed.len() > MAXIMUM_SEED_LEN {
+            return Err(ElGamalError::SeedLengthTooLarge);
         }
         Ok(ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(seed)))
     }
@@ -1026,6 +1032,9 @@ mod tests {
 
         let too_short_seed = vec![0; 31];
         assert!(ElGamalKeypair::from_seed(&too_short_seed).is_err());
+
+        let too_long_seed = vec![0; 65536];
+        assert!(ElGamalKeypair::from_seed(&too_long_seed).is_err());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/33508

#### Summary of Changes
Add a maximum length (2^16 bytes, which should be plenty for any practical usecase) check on the maximum seed length for ElGamal and AES keypairs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
