### PR TITLE
add metric for ancient can't move slots

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2014,7 +2014,7 @@ pub(crate) struct ShrinkStatsSub {
     pub(crate) store_accounts_timing: StoreAccountsTiming,
     pub(crate) rewrite_elapsed_us: u64,
     pub(crate) create_and_insert_store_elapsed_us: u64,
-    pub(crate) count_unpackable_slots: usize,
+    pub(crate) unpackable_slots_count: usize,
 }
 
 impl ShrinkStatsSub {
@@ -2026,7 +2026,7 @@ impl ShrinkStatsSub {
             self.create_and_insert_store_elapsed_us,
             other.create_and_insert_store_elapsed_us
         );
-        saturating_add_assign!(self.count_unpackable_slots, other.count_unpackable_slots);
+        saturating_add_assign!(self.unpackable_slots_count, other.unpackable_slots_count);
     }
 }
 
@@ -2042,7 +2042,7 @@ pub struct ShrinkStats {
     handle_reclaims_elapsed: AtomicU64,
     remove_old_stores_shrink_us: AtomicU64,
     rewrite_elapsed: AtomicU64,
-    count_unpackable_slots: AtomicU64,
+    unpackable_slots_count: AtomicU64,
     drop_storage_entries_elapsed: AtomicU64,
     recycle_stores_write_elapsed: AtomicU64,
     accounts_removed: AtomicUsize,
@@ -2222,9 +2222,9 @@ impl ShrinkAncientStats {
                     i64
                 ),
                 (
-                    "count_unpackable_slots",
+                    "unpackable_slots_count",
                     self.shrink_stats
-                        .count_unpackable_slots
+                        .unpackable_slots_count
                         .swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
@@ -4187,8 +4187,8 @@ impl AccountsDb {
             .rewrite_elapsed
             .fetch_add(stats_sub.rewrite_elapsed_us, Ordering::Relaxed);
         shrink_stats
-            .count_unpackable_slots
-            .fetch_add(stats_sub.count_unpackable_slots as u64, Ordering::Relaxed);
+            .unpackable_slots_count
+            .fetch_add(stats_sub.unpackable_slots_count as u64, Ordering::Relaxed);
     }
 
     /// get stores for 'slot'

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2014,7 +2014,7 @@ pub(crate) struct ShrinkStatsSub {
     pub(crate) store_accounts_timing: StoreAccountsTiming,
     pub(crate) rewrite_elapsed_us: u64,
     pub(crate) create_and_insert_store_elapsed_us: u64,
-    pub(crate) number_unpackable_slots: usize,
+    pub(crate) count_unpackable_slots: usize,
 }
 
 impl ShrinkStatsSub {
@@ -2026,7 +2026,7 @@ impl ShrinkStatsSub {
             self.create_and_insert_store_elapsed_us,
             other.create_and_insert_store_elapsed_us
         );
-        saturating_add_assign!(self.number_unpackable_slots, other.number_unpackable_slots);
+        saturating_add_assign!(self.count_unpackable_slots, other.count_unpackable_slots);
     }
 }
 
@@ -2042,7 +2042,7 @@ pub struct ShrinkStats {
     handle_reclaims_elapsed: AtomicU64,
     remove_old_stores_shrink_us: AtomicU64,
     rewrite_elapsed: AtomicU64,
-    number_unpackable_slots: AtomicU64,
+    count_unpackable_slots: AtomicU64,
     drop_storage_entries_elapsed: AtomicU64,
     recycle_stores_write_elapsed: AtomicU64,
     accounts_removed: AtomicUsize,
@@ -2222,9 +2222,9 @@ impl ShrinkAncientStats {
                     i64
                 ),
                 (
-                    "number_unpackable_slots",
+                    "count_unpackable_slots",
                     self.shrink_stats
-                        .number_unpackable_slots
+                        .count_unpackable_slots
                         .swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
@@ -4187,8 +4187,8 @@ impl AccountsDb {
             .rewrite_elapsed
             .fetch_add(stats_sub.rewrite_elapsed_us, Ordering::Relaxed);
         shrink_stats
-            .number_unpackable_slots
-            .fetch_add(stats_sub.number_unpackable_slots as u64, Ordering::Relaxed);
+            .count_unpackable_slots
+            .fetch_add(stats_sub.count_unpackable_slots as u64, Ordering::Relaxed);
     }
 
     /// get stores for 'slot'

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2014,10 +2014,10 @@ pub(crate) struct ShrinkStatsSub {
     pub(crate) store_accounts_timing: StoreAccountsTiming,
     pub(crate) rewrite_elapsed_us: u64,
     pub(crate) create_and_insert_store_elapsed_us: u64,
+    pub(crate) number_unpackable_slots: usize,
 }
 
 impl ShrinkStatsSub {
-    #[allow(dead_code)]
     pub(crate) fn accumulate(&mut self, other: &Self) {
         self.store_accounts_timing
             .accumulate(&other.store_accounts_timing);
@@ -2026,6 +2026,7 @@ impl ShrinkStatsSub {
             self.create_and_insert_store_elapsed_us,
             other.create_and_insert_store_elapsed_us
         );
+        saturating_add_assign!(self.number_unpackable_slots, other.number_unpackable_slots);
     }
 }
 
@@ -2041,6 +2042,7 @@ pub struct ShrinkStats {
     handle_reclaims_elapsed: AtomicU64,
     remove_old_stores_shrink_us: AtomicU64,
     rewrite_elapsed: AtomicU64,
+    number_unpackable_slots: AtomicU64,
     drop_storage_entries_elapsed: AtomicU64,
     recycle_stores_write_elapsed: AtomicU64,
     accounts_removed: AtomicUsize,
@@ -2217,6 +2219,13 @@ impl ShrinkAncientStats {
                 (
                     "rewrite_elapsed",
                     self.shrink_stats.rewrite_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "number_unpackable_slots",
+                    self.shrink_stats
+                        .number_unpackable_slots
+                        .swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
                 (
@@ -4177,6 +4186,9 @@ impl AccountsDb {
         shrink_stats
             .rewrite_elapsed
             .fetch_add(stats_sub.rewrite_elapsed_us, Ordering::Relaxed);
+        shrink_stats
+            .number_unpackable_slots
+            .fetch_add(stats_sub.number_unpackable_slots as u64, Ordering::Relaxed);
     }
 
     /// get stores for 'slot'

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -299,7 +299,7 @@ impl AccountsDb {
             );
 
         let accounts_to_combine = self.calc_accounts_to_combine(&accounts_per_storage);
-        metrics.number_unpackable_slots += accounts_to_combine.number_unpackable_slots;
+        metrics.count_unpackable_slots += accounts_to_combine.number_unpackable_slots;
 
         // pack the accounts with 1 ref
         let pack = PackedAncientStorage::pack(
@@ -386,7 +386,7 @@ impl AccountsDb {
             store_accounts_timing,
             rewrite_elapsed_us,
             create_and_insert_store_elapsed_us,
-            number_unpackable_slots: 0,
+            count_unpackable_slots: 0,
         });
         write_ancient_accounts
             .shrinks_in_progress

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -299,7 +299,7 @@ impl AccountsDb {
             );
 
         let accounts_to_combine = self.calc_accounts_to_combine(&accounts_per_storage);
-        metrics.count_unpackable_slots += accounts_to_combine.number_unpackable_slots;
+        metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
 
         // pack the accounts with 1 ref
         let pack = PackedAncientStorage::pack(
@@ -386,7 +386,7 @@ impl AccountsDb {
             store_accounts_timing,
             rewrite_elapsed_us,
             create_and_insert_store_elapsed_us,
-            count_unpackable_slots: 0,
+            unpackable_slots_count: 0,
         });
         write_ancient_accounts
             .shrinks_in_progress
@@ -586,7 +586,7 @@ impl AccountsDb {
                 target_slots_sorted.push(info.slot);
             }
         }
-        let number_unpackable_slots = remove.len();
+        let unpackable_slots_count = remove.len();
         remove.into_iter().rev().for_each(|i| {
             accounts_to_combine.remove(i);
         });
@@ -594,7 +594,7 @@ impl AccountsDb {
             accounts_to_combine,
             accounts_keep_slots,
             target_slots_sorted,
-            number_unpackable_slots,
+            unpackable_slots_count,
         }
     }
 
@@ -723,7 +723,7 @@ struct AccountsToCombine<'a> {
     /// The rest will become dead slots with no accounts in them.
     target_slots_sorted: Vec<Slot>,
     /// when scanning, this many slots contained accounts that could not be packed because accounts with ref_count > 1 existed.
-    number_unpackable_slots: usize,
+    unpackable_slots_count: usize,
 }
 
 #[derive(Default)]
@@ -3141,7 +3141,7 @@ pub mod tests {
                 accounts_keep_slots: HashMap::default(),
                 accounts_to_combine: vec![shrink_collect],
                 target_slots_sorted: Vec::default(),
-                number_unpackable_slots: 0,
+                unpackable_slots_count: 0,
             };
             db.addref_accounts_failed_to_shrink_ancient(accounts_to_combine);
             db.accounts_index.scan(


### PR DESCRIPTION
#### Problem
When we are packing ancient append vecs, the current strategy is to not move accounts from a slot for all accounts with refcounts > 1. This is because we can't know easily what other slot(s) the older versions of the account are in. Thus, it isn't safe to move slots.

#### Summary of Changes
Add a metric to keep track of how many slots fit this criteria.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
