### PR TITLE
Feature - Cooperative Program Loading

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -548,7 +548,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .clone(),
     );
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key, false, None));
+        loaded_programs.assign_program(key, bank.load_program(&key, false, None));
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -734,7 +734,7 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     transaction_accounts.push((*loader_id, processor_account));
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
     let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-    programs_loaded_for_tx_batch.replenish(
+    programs_loaded_for_tx_batch.assign_program(
         *loader_id,
         Arc::new(LoadedProgram::new_builtin(0, 0, builtin_function)),
     );
@@ -988,7 +988,7 @@ mod tests {
             .collect::<Vec<_>>();
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        programs_loaded_for_tx_batch.assign_program(
             callee_program_id,
             Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -1137,7 +1137,7 @@ mod tests {
         ];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        programs_loaded_for_tx_batch.assign_program(
             program_key,
             Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
         );

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -267,7 +267,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
         let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        programs_loaded_for_tx_batch.assign_program(
             mock_system_program_id,
             Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -490,7 +490,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
         let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        programs_loaded_for_tx_batch.assign_program(
             mock_program_id,
             Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -668,7 +668,7 @@ mod tests {
         )));
         let sysvar_cache = SysvarCache::default();
         let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        programs_loaded_for_tx_batch.assign_program(
             mock_program_id,
             Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
         );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -166,7 +166,7 @@ macro_rules! deploy_program {
         $drop
         load_program_metrics.program_id = $program_id.to_string();
         load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
-        $invoke_context.programs_modified_by_tx.replenish($program_id, Arc::new(executor));
+        $invoke_context.programs_modified_by_tx.assign_program($program_id, Arc::new(executor));
     }};
 }
 
@@ -1194,7 +1194,7 @@ fn process_loader_upgradeable_instruction(
                                 &log_collector,
                             )?;
                             let clock = invoke_context.get_sysvar_cache().get_clock()?;
-                            invoke_context.programs_modified_by_tx.replenish(
+                            invoke_context.programs_modified_by_tx.assign_program(
                                 program_key,
                                 Arc::new(LoadedProgram::new_tombstone(
                                     clock.slot,
@@ -1676,7 +1676,7 @@ pub mod test_utils {
                         .set_slot_for_tests(DELAY_VISIBILITY_SLOT_OFFSET);
                     invoke_context
                         .programs_modified_by_tx
-                        .replenish(*pubkey, Arc::new(loaded_program));
+                        .assign_program(*pubkey, Arc::new(loaded_program));
                 }
             }
         }
@@ -4051,7 +4051,7 @@ mod tests {
         };
         invoke_context
             .programs_modified_by_tx
-            .replenish(program_id, Arc::new(program));
+            .assign_program(program_id, Arc::new(program));
 
         assert_matches!(
             deploy_test_program(&mut invoke_context, program_id,),
@@ -4091,7 +4091,7 @@ mod tests {
         };
         invoke_context
             .programs_modified_by_tx
-            .replenish(program_id, Arc::new(program));
+            .assign_program(program_id, Arc::new(program));
 
         let program_id2 = Pubkey::new_unique();
         assert_matches!(

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -454,7 +454,7 @@ pub fn process_instruction_deploy(
     }
     invoke_context
         .programs_modified_by_tx
-        .replenish(*program.get_key(), Arc::new(executor));
+        .assign_program(*program.get_key(), Arc::new(executor));
     Ok(())
 }
 
@@ -672,7 +672,7 @@ mod tests {
                         invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context
                             .programs_modified_by_tx
-                            .replenish(*pubkey, Arc::new(loaded_program));
+                            .assign_program(*pubkey, Arc::new(loaded_program));
                     }
                 }
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1447,7 +1447,7 @@ impl Bank {
                     drop(loaded_programs_cache);
                     let recompiled = new.load_program(&key, false, Some(program_to_recompile));
                     let mut loaded_programs_cache = new.loaded_programs_cache.write().unwrap();
-                    loaded_programs_cache.replenish(key, recompiled);
+                    loaded_programs_cache.assign_program(key, recompiled);
                 }
             } else if new.epoch() != loaded_programs_cache.latest_root_epoch
                 || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
@@ -5047,9 +5047,9 @@ impl Bank {
         // Lock the global cache again to replenish the missing programs
         let mut loaded_programs_cache = self.loaded_programs_cache.write().unwrap();
         for (key, program) in missing_programs {
-            let (_was_occupied, entry) = loaded_programs_cache.replenish(key, program);
+            let entry = loaded_programs_cache.assign_program(key, program);
             // Use the returned entry as that might have been deduplicated globally
-            loaded_programs_for_txs.replenish(key, entry);
+            loaded_programs_for_txs.assign_program(key, entry);
         }
         loaded_programs_for_txs
     }
@@ -7752,7 +7752,7 @@ impl Bank {
         self.loaded_programs_cache
             .write()
             .unwrap()
-            .replenish(program_id, Arc::new(builtin));
+            .assign_program(program_id, Arc::new(builtin));
         debug!("Added program {} under {:?}", name, program_id);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7324,7 +7324,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
                 .set_slot_for_tests(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
             invoke_context
                 .programs_modified_by_tx
-                .replenish(program_keypair.pubkey(), loaded_program.clone());
+                .assign_program(program_keypair.pubkey(), loaded_program.clone());
         },
         |_invoke_context| {},
     );


### PR DESCRIPTION
#### Problem
Currently transaction batches race in parallel to load, verify and compile missing cache entries.
Instead they should be coordinating and split these tasks to distribute the workload across the threads and to avoid redundant work.

#### Summary of Changes
- Removes `LoadedPrograms::replenish()` and `LoadedProgramsForTxBatch::replenish()`.
- Adds `LoadedProgramType::Loading` and `LoadedProgram::new_loading()`.
- Adds `LoadedPrograms::get_cooperative_loading_task()` and `LoadedPrograms::submit_cooperative_loading_task()`.