### PR TITLE
docs: move rpc info to rpc docs

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -430,18 +430,3 @@ which starts the solana validator process uses "exec" to do so (example: "exec
 solana-validator ..."); otherwise, when logrotate sends its signal to the
 validator, the enclosing script will die and take the validator process with
 it.
-
-### Account indexing
-
-As the number of populated accounts on the cluster grows, account-data RPC
-requests that scan the entire account set -- like
-[`getProgramAccounts`](../api/http#getprogramaccounts) and
-[SPL-token-specific requests](../api/http#gettokenaccountsbydelegate) --
-may perform poorly. If your validator needs to support any of these requests,
-you can use the `--account-index` parameter to activate one or more in-memory
-account indexes that significantly improve RPC performance by indexing accounts
-by the key field. Currently supports the following parameter values:
-
-- `program-id`: each account indexed by its owning program; used by [getProgramAccounts](../api/http#getprogramaccounts)
-- `spl-token-mint`: each SPL token account indexed by its token Mint; used by [getTokenAccountsByDelegate](../api/http#gettokenaccountsbydelegate), and [getTokenLargestAccounts](../api/http#gettokenlargestaccounts)
-- `spl-token-owner`: each SPL token account indexed by the token-owner address; used by [getTokenAccountsByOwner](../api/http#gettokenaccountsbyowner), and [getProgramAccounts](../api/http#getprogramaccounts) requests that include an spl-token-owner filter.

--- a/docs/src/validator/get-started/setup-an-rpc-node.md
+++ b/docs/src/validator/get-started/setup-an-rpc-node.md
@@ -68,3 +68,18 @@ The identities of the [known validators](../../running-validator/validator-start
 Additional examples of other Solana cluster specific validator commands can be found on the [Clusters](../../clusters.md) page.
 
 Keep in mind, you will still need to customize these commands to operate as an RPC node, as well other operator specific configuration settings.
+
+## Account indexing
+
+As the number of populated accounts on the cluster grows, account-data RPC
+requests that scan the entire account set -- like
+[`getProgramAccounts`](../../api/http#getprogramaccounts) and
+[SPL-token-specific requests](../../api/http#gettokenaccountsbydelegate) --
+may perform poorly. If your validator needs to support any of these requests,
+you can use the `--account-index` parameter to activate one or more in-memory
+account indexes that significantly improve RPC performance by indexing accounts
+by the key field. Currently supports the following parameter values:
+
+- `program-id`: each account indexed by its owning program; used by [getProgramAccounts](../../api/http#getprogramaccounts)
+- `spl-token-mint`: each SPL token account indexed by its token Mint; used by [getTokenAccountsByDelegate](../../api/http#gettokenaccountsbydelegate), and [getTokenLargestAccounts](../../api/http#gettokenlargestaccounts)
+- `spl-token-owner`: each SPL token account indexed by the token-owner address; used by [getTokenAccountsByOwner](../../api/http#gettokenaccountsbyowner), and [getProgramAccounts](../../api/http#getprogramaccounts) requests that include an spl-token-owner filter.


### PR DESCRIPTION
#### Problem

The startup docs for a validator talk about the `--account-index` flag, which should never be used on a validator.

#### Summary of Changes

Moved `--account-index` information to start an rpc docs