### PR TITLE
use max-heap to collect shink candidates by byte savings

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4325,8 +4325,7 @@ impl AccountsDb {
 
         // create a max-heap to store the StorageUsageInfo by saved bytes
         let mut store_usage: std::collections::BinaryHeap<StoreUsageInfo> =
-            std::collections::BinaryHeap::new();
-        store_usage.reserve(shrink_slots.len());
+            std::collections::BinaryHeap::with_capacity(shrink_slots.len());
         let mut total_alive_bytes: u64 = 0;
         let mut total_bytes: u64 = 0;
         for slot in shrink_slots {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4315,7 +4315,7 @@ impl AccountsDb {
         }
         impl PartialOrd for StoreUsageInfo {
             fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                other.alive_ratio.partial_cmp(&self.alive_ratio)
+                Some(self.cmp(other))
             }
         }
         impl PartialEq for StoreUsageInfo {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4773,6 +4773,8 @@ impl AccountsDb {
         let shrink_candidates_slots =
             std::mem::take(&mut *self.shrink_candidate_slots.lock().unwrap());
 
+        let shrink_candidates_count = shrink_candidates_slots.len();
+
         let (shrink_slots, shrink_slots_next_batch) = {
             if let AccountShrinkThreshold::TotalSpace { shrink_ratio } = self.shrink_ratio {
                 let (shrink_slots, shrink_slots_next_batch) = self
@@ -4813,7 +4815,6 @@ impl AccountsDb {
 
         let mut measure_shrink_all_candidates = Measure::start("shrink_all_candidate_slots");
         let num_candidates = shrink_slots.len();
-        let shrink_candidates_count = shrink_slots.len();
         self.thread_pool_clean.install(|| {
             shrink_slots
                 .into_par_iter()
@@ -4845,6 +4846,7 @@ impl AccountsDb {
                 i64
             ),
             ("shrink_candidates_count", shrink_candidates_count, i64),
+            ("shrink_candidates_selected_count", num_candidates, i64),
             ("shrink_candidates_pending_count", pended_counts, i64),
         );
 


### PR DESCRIPTION
#### Problem

1. selecting storage to shink by alive ratio may not improve the alive ratio as much as by byte savings. 

For example, given two storages below:
Storage A: alive = 1, total = 2,    alive ratio = 0.5
Storage B: alive = 6, total = 10,  alive ratio = 0.6

If we select by ratio, then A will be chosen to shrink, which gives result ratio of 7/11 (0.63).
However, if we select by bytes savings, B will be chosen. This gives the result ratio of 7/8 (0.875).

2. When collecting candidate storages for shrinking, we don't need to sort all the
storages. We could just partially sort the storages before the cutoff (i.e. use a heap).


#### Summary of Changes

Use max-heap to store and partially sort and select candidate storage for shrinking by bye savings.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
