### PR TITLE
feature flag cleanup: cap_bpf_program_instruction_accounts

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -573,7 +573,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true, // should_cap_ix_accounts
         true, // copy_account_data
     )
     .unwrap();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -122,7 +122,6 @@ pub fn builtin_process_instruction(
         invoke_context
             .transaction_context
             .get_current_instruction_context()?,
-        true, // should_cap_ix_accounts
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
     )?;
 

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -126,8 +126,7 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -138,8 +137,7 @@ fn bench_serialize_unaligned_copy_account_data(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -151,8 +149,7 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -164,8 +161,7 @@ fn bench_serialize_aligned_copy_account_data(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, true).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -176,8 +172,7 @@ fn bench_serialize_unaligned_max_accounts(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -189,7 +184,6 @@ fn bench_serialize_aligned_max_accounts(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ =
-            serialize_parameters(&transaction_context, instruction_context, true, false).unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -33,10 +33,10 @@ use {
         entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         feature_set::{
             bpf_account_data_direct_mapping, cap_accounts_data_allocations_per_transaction,
-            cap_bpf_program_instruction_accounts, delay_visibility_of_program_deployment,
-            enable_bpf_loader_extend_program_ix, enable_bpf_loader_set_authority_checked_ix,
-            enable_program_redeployment_cooldown, limit_max_instruction_trace_length,
-            native_programs_consume_cu, remove_bpf_loader_incorrect_program_id,
+            delay_visibility_of_program_deployment, enable_bpf_loader_extend_program_ix,
+            enable_bpf_loader_set_authority_checked_ix, enable_program_redeployment_cooldown,
+            limit_max_instruction_trace_length, native_programs_consume_cu,
+            remove_bpf_loader_incorrect_program_id,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -1543,9 +1543,6 @@ fn execute<'a, 'b: 'a>(
     let (parameter_bytes, regions, accounts_metadata) = serialization::serialize_parameters(
         invoke_context.transaction_context,
         instruction_context,
-        invoke_context
-            .feature_set
-            .is_active(&cap_bpf_program_instruction_accounts::ID),
         !direct_mapping,
     )?;
     serialize_time.stop();

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -190,7 +190,6 @@ impl Serializer {
 pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    should_cap_ix_accounts: bool,
     copy_account_data: bool,
 ) -> Result<
     (
@@ -201,7 +200,7 @@ pub fn serialize_parameters(
     InstructionError,
 > {
     let num_ix_accounts = instruction_context.get_number_of_instruction_accounts();
-    if should_cap_ix_accounts && num_ix_accounts > MAX_INSTRUCTION_ACCOUNTS as IndexOfAccount {
+    if num_ix_accounts > MAX_INSTRUCTION_ACCOUNTS as IndexOfAccount {
         return Err(InstructionError::MaxAccountsExceeded);
     }
 
@@ -641,7 +640,6 @@ mod tests {
         struct TestCase {
             num_ix_accounts: usize,
             append_dup_account: bool,
-            should_cap_ix_accounts: bool,
             expected_err: Option<InstructionError>,
             name: &'static str,
         }
@@ -650,55 +648,27 @@ mod tests {
             for TestCase {
                 num_ix_accounts,
                 append_dup_account,
-                should_cap_ix_accounts,
                 expected_err,
                 name,
             } in [
                 TestCase {
-                    name: "serialize max accounts without cap",
-                    num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
-                    should_cap_ix_accounts: false,
-                    append_dup_account: false,
-                    expected_err: None,
-                },
-                TestCase {
-                    name: "serialize max accounts and append dup without cap",
-                    num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
-                    should_cap_ix_accounts: false,
-                    append_dup_account: true,
-                    expected_err: None,
-                },
-                TestCase {
                     name: "serialize max accounts with cap",
                     num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
-                    should_cap_ix_accounts: true,
                     append_dup_account: false,
                     expected_err: None,
                 },
                 TestCase {
                     name: "serialize too many accounts with cap",
                     num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS) + 1,
-                    should_cap_ix_accounts: true,
                     append_dup_account: false,
                     expected_err: Some(InstructionError::MaxAccountsExceeded),
                 },
                 TestCase {
                     name: "serialize too many accounts and append dup with cap",
                     num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
-                    should_cap_ix_accounts: true,
                     append_dup_account: true,
                     expected_err: Some(InstructionError::MaxAccountsExceeded),
                 },
-                // This test case breaks parameter deserialization and can be cleaned up
-                // when should_cap_ix_accounts is enabled.
-                //
-                // TestCase {
-                //     name: "serialize too many accounts and append dup without cap",
-                //     num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS) + 1,
-                //     should_cap_ix_accounts: false,
-                //     append_dup_account: true,
-                //     expected_err: None,
-                // },
             ] {
                 let program_id = solana_sdk::pubkey::new_rand();
                 let mut transaction_accounts = vec![(
@@ -757,7 +727,6 @@ mod tests {
                 let serialization_result = serialize_parameters(
                     invoke_context.transaction_context,
                     instruction_context,
-                    should_cap_ix_accounts,
                     copy_account_data,
                 );
                 assert_eq!(
@@ -912,7 +881,6 @@ mod tests {
             let (mut serialized, regions, accounts_metadata) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                true,
                 copy_account_data,
             )
             .unwrap();
@@ -1004,7 +972,6 @@ mod tests {
             let (mut serialized, regions, account_lengths) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                true,
                 copy_account_data,
             )
             .unwrap();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -244,7 +244,6 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true,            // should_cap_ix_accounts
         !direct_mapping, // copy_account_data
     )
     .unwrap();
@@ -279,7 +278,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true,            // should_cap_ix_accounts
         !direct_mapping, // copy_account_data
     )
     .unwrap();


### PR DESCRIPTION
#### Problem
`cap_bpf_program_instruction_accounts` is now activated on all clusters and unused code paths can be cleaned up

#### Summary of Changes
Removed now unused parameter in `fn serialize_parameters`

Closes https://github.com/solana-labs/solana/issues/26628
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
