### PR TITLE
program::message::AccountKeys: `Clone`, `Default`, `Debug`, `Eq`

### DIFF
--- a/sdk/program/src/message/account_keys.rs
+++ b/sdk/program/src/message/account_keys.rs
@@ -4,11 +4,12 @@ use {
         message::{v0::LoadedAddresses, CompileError},
         pubkey::Pubkey,
     },
-    std::{collections::BTreeMap, ops::Index},
+    std::{collections::BTreeMap, iter::zip, ops::Index},
 };
 
 /// Collection of static and dynamically loaded keys used to load accounts
 /// during transaction processing.
+#[derive(Clone, Default, Debug, Eq)]
 pub struct AccountKeys<'a> {
     static_keys: &'a [Pubkey],
     dynamic_keys: Option<&'a LoadedAddresses>,
@@ -135,6 +136,12 @@ impl<'a> AccountKeys<'a> {
                 })
             })
             .collect()
+    }
+}
+
+impl PartialEq for AccountKeys<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        zip(self.iter(), other.iter()).all(|(a, b)| a == b)
     }
 }
 


### PR DESCRIPTION
It is a pretty standard set of traits to implement on most types. Both `Pubkey` and `LoadedAddresses` contained within the `AccountKeys` already implement them.  Doing the same for `AccountKeys` could simplify unit tests and/or some common value manipulation logic.