### PR TITLE
Removes cap_accounts_data_allocations_per_transaction featurization

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -655,7 +655,6 @@ macro_rules! with_mock_invoke_context {
             compute_budget.max_invoke_stack_height,
             compute_budget.max_instruction_trace_length,
         );
-        $transaction_context.enable_cap_accounts_data_allocations_per_transaction();
         let mut sysvar_cache = SysvarCache::default();
         sysvar_cache.fill_missing_entries(|pubkey, callback| {
             for index in 0..$transaction_context.get_number_of_accounts() {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -32,19 +32,16 @@ use {
         clock::Slot,
         entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         feature_set::{
-            bpf_account_data_direct_mapping, cap_accounts_data_allocations_per_transaction,
-            delay_visibility_of_program_deployment, enable_bpf_loader_extend_program_ix,
-            enable_bpf_loader_set_authority_checked_ix, enable_program_redeployment_cooldown,
-            limit_max_instruction_trace_length, native_programs_consume_cu,
-            remove_bpf_loader_incorrect_program_id,
+            bpf_account_data_direct_mapping, delay_visibility_of_program_deployment,
+            enable_bpf_loader_extend_program_ix, enable_bpf_loader_set_authority_checked_ix,
+            enable_program_redeployment_cooldown, limit_max_instruction_trace_length,
+            native_programs_consume_cu, remove_bpf_loader_incorrect_program_id,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
         native_loader,
-        program_error::{
-            MAX_ACCOUNTS_DATA_ALLOCATIONS_EXCEEDED, MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED,
-        },
+        program_error::MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
         saturating_add_assign,
@@ -1595,17 +1592,11 @@ fn execute<'a, 'b: 'a>(
         }
         match result {
             ProgramResult::Ok(status) if status != SUCCESS => {
-                let error: InstructionError = if (status == MAX_ACCOUNTS_DATA_ALLOCATIONS_EXCEEDED
+                let error: InstructionError = if status == MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED
                     && !invoke_context
                         .feature_set
-                        .is_active(&cap_accounts_data_allocations_per_transaction::id()))
-                    || (status == MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED
-                        && !invoke_context
-                            .feature_set
-                            .is_active(&limit_max_instruction_trace_length::id()))
+                        .is_active(&limit_max_instruction_trace_length::id())
                 {
-                    // Until the cap_accounts_data_allocations_per_transaction feature is
-                    // enabled, map the `MAX_ACCOUNTS_DATA_ALLOCATIONS_EXCEEDED` error to `InvalidError`.
                     // Until the limit_max_instruction_trace_length feature is
                     // enabled, map the `MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED` error to `InvalidError`.
                     InstructionError::InvalidError

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4864,12 +4864,6 @@ impl Bank {
                 std::usize::MAX
             },
         );
-        if self
-            .feature_set
-            .is_active(&feature_set::cap_accounts_data_allocations_per_transaction::id())
-        {
-            transaction_context.enable_cap_accounts_data_allocations_per_transaction();
-        }
         #[cfg(debug_assertions)]
         transaction_context.set_signature(tx.signature());
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12171,8 +12171,7 @@ fn test_cap_accounts_data_allocations_per_transaction() {
             / MAX_PERMITTED_DATA_LENGTH as usize;
 
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.activate_feature(&feature_set::cap_accounts_data_allocations_per_transaction::id());
+    let bank = Bank::new_for_tests(&genesis_config);
 
     let mut instructions = Vec::new();
     let mut keypairs = vec![mint_keypair.insecure_clone()];


### PR DESCRIPTION
#### Problem

Now that the [`cap_accounts_data_allocations_per_transaction`](https://github.com/solana-labs/solana/issues/27375) feature-gate has been enabled on all clusters, its code can be removed.

#### Summary of Changes

Remove the code for the feature-gate.

Fixes #27375
Feature Gate Issue: #27375 