### PR TITLE
Make Blockstore populate TransactionStatusIndex entries

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2109,6 +2109,17 @@ impl Blockstore {
         if !self.is_primary_access() {
             return Ok(());
         }
+
+        // Initialize TransactionStatusIndexMeta if they are not present already
+        if self.transaction_status_index_cf.get(0)?.is_none() {
+            self.transaction_status_index_cf
+                .put(0, &TransactionStatusIndexMeta::default())?;
+        }
+        if self.transaction_status_index_cf.get(1)?.is_none() {
+            self.transaction_status_index_cf
+                .put(1, &TransactionStatusIndexMeta::default())?;
+        }
+
         // If present, delete dummy entries inserted by old software
         // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2163,7 +2163,7 @@ impl Blockstore {
                 highest_primary_index_slot = Some(meta.max_slot);
             }
         }
-        if highest_primary_index_slot.is_some() {
+        if highest_primary_index_slot.is_some_and(|slot| slot != 0) {
             self.set_highest_primary_index_slot(highest_primary_index_slot);
         } else {
             self.db.set_clean_slot_0(true);


### PR DESCRIPTION
#### Problem
    A previous change removed logic that populated the
    TransactionStatusIndex entries at each of the legacy primary index keys
    (0 and 1). While these entries will not be read or written in the
    future, these entries are necessary for backwards compatibility. Namely,
    branches <= v1.17 expect these entries to be present and .unwrap()'s
    could fail if they are not.
    
    So, add the initialization of these entries back into Blockstore logic.
    We can remove initialization of these entries once our stable and beta
    branches are both versions that do not expect these entries to be
    present (should be v1.18).

I encountered this issue originally by:
- Creating a `Blockstore` with master (which does not insert these entries) AND
- Attempting to open the `Blockstore` with `solana-ledger-tool` which opens in Secondary (read-only mode)