### PR TITLE
Add serialize/deserialize to ElGamalPubkey and AeCiphertext

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -1,5 +1,10 @@
 //! Plain Old Data types for the AES128-GCM-SIV authenticated encryption scheme.
 
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
 #[cfg(not(target_os = "solana"))]
 use crate::{encryption::auth_encryption as decoded, errors::ProofError};
 use {
@@ -10,6 +15,8 @@ use {
 
 /// Byte length of an authenticated encryption ciphertext
 const AE_CIPHERTEXT_LEN: usize = 36;
+
+struct AeCiphertextVisitor;
 
 /// The `AeCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -37,6 +44,36 @@ impl fmt::Display for AeCiphertext {
 impl Default for AeCiphertext {
     fn default() -> Self {
         Self::zeroed()
+    }
+}
+
+impl<'de> Visitor<'de> for AeCiphertextVisitor {
+    type Value = AeCiphertext;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a byte array of length AE_CIPHERTEXT_LEN")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut arr = [0u8; AE_CIPHERTEXT_LEN];
+        for i in 0..AE_CIPHERTEXT_LEN {
+            arr[i] = seq
+                .next_element()?
+                .ok_or(de::Error::invalid_length(i, &self))?;
+        }
+        Ok(AeCiphertext(arr))
+    }
+}
+
+impl<'de> Deserialize<'de> for AeCiphertext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple(AE_CIPHERTEXT_LEN, AeCiphertextVisitor)
     }
 }
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -1,5 +1,10 @@
 //! Plain Old Data types for the ElGamal encryption scheme.
 
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{encryption::elgamal as decoded, errors::ProofError},
@@ -22,6 +27,8 @@ pub(crate) const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// Byte length of an ElGamal ciphertext
 const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
+
+struct ElGamalCiphertextVisitor;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
@@ -46,6 +53,36 @@ impl Default for ElGamalCiphertext {
     }
 }
 
+impl<'de> Visitor<'de> for ElGamalCiphertextVisitor {
+    type Value = ElGamalCiphertext;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a byte array of length ELGAMAL_CIPHERTEXT_LEN")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if v.len() == ELGAMAL_CIPHERTEXT_LEN {
+            let mut arr = [0u8; ELGAMAL_CIPHERTEXT_LEN];
+            arr.copy_from_slice(v);
+            Ok(ElGamalCiphertext(arr))
+        } else {
+            Err(E::invalid_length(v.len(), &self))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ElGamalCiphertext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(ElGamalCiphertextVisitor)
+    }
+}
+
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
     fn from(decoded_ciphertext: decoded::ElGamalCiphertext) -> Self {
@@ -63,7 +100,7 @@ impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
 }
 
 /// The `ElGamalPubkey` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct ElGamalPubkey(pub [u8; ELGAMAL_PUBKEY_LEN]);
 


### PR DESCRIPTION
#### Problem

Allow serialisation  derivatives for  `AeCiphertextVisitor ` ,  `ElGamalCiphertext ` and `ElGamalPubkey ` in order to support token-22 extensions serialisation. See https://github.com/solana-labs/solana-program-library/pull/5437 

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
