### PR TITLE
[zk-token-sdk] Add overflow checks on release build

### DIFF
--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -39,3 +39,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
#### Problem
In optimized release builds, overflow checks are disabled by default, which can lead to suppressed overflows and unexpected application behavior.

#### Summary of Changes
Add overflow checks on release build.

Note: Addresses an audit finding by Halborn: HAL-02.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
