### PR TITLE
Uses AccountHash in tiered storage

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -126,11 +126,10 @@ impl<'storage> StoredAccountMeta<'storage> {
     }
 
     pub fn hash(&self) -> &'storage AccountHash {
-        let hash = match self {
-            Self::AppendVec(av) => av.hash(),
-            Self::Hot(hot) => hot.hash().unwrap_or(&DEFAULT_ACCOUNT_HASH.0),
-        };
-        bytemuck::cast_ref(hash)
+        match self {
+            Self::AppendVec(av) => bytemuck::cast_ref(av.hash()),
+            Self::Hot(hot) => hot.hash().unwrap_or(&DEFAULT_ACCOUNT_HASH),
+        }
     }
 
     pub fn stored_size(&self) -> usize {

--- a/accounts-db/src/tiered_storage/byte_block.rs
+++ b/accounts-db/src/tiered_storage/byte_block.rs
@@ -151,6 +151,7 @@ impl ByteBlockReader {
 mod tests {
     use {
         super::*,
+        crate::accounts_hash::AccountHash,
         solana_sdk::{hash::Hash, stake_history::Epoch},
     };
 
@@ -311,7 +312,7 @@ mod tests {
         // prepare a vector of optional fields that contains all combinations
         // of Some and None.
         for rent_epoch in [None, Some(test_epoch)] {
-            for account_hash in [None, Some(Hash::new_unique())] {
+            for account_hash in [None, Some(AccountHash(Hash::new_unique()))] {
                 some_count += rent_epoch.iter().count() + account_hash.iter().count();
 
                 opt_fields_vec.push(AccountMetaOptionalFields {
@@ -351,10 +352,10 @@ mod tests {
                 offset += std::mem::size_of::<Epoch>();
             }
             if let Some(expected_hash) = opt_fields.account_hash {
-                let hash = read_type::<Hash>(&decoded_buffer, offset).unwrap();
+                let hash = read_type::<AccountHash>(&decoded_buffer, offset).unwrap();
                 assert_eq!(hash, &expected_hash);
                 verified_count += 1;
-                offset += std::mem::size_of::<Hash>();
+                offset += std::mem::size_of::<AccountHash>();
             }
         }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -2,17 +2,22 @@
 //! The account meta and related structs for hot accounts.
 
 use {
-    crate::tiered_storage::{
-        byte_block,
-        footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat, TieredStorageFooter},
-        index::AccountIndexFormat,
-        meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-        mmap_utils::get_type,
-        TieredStorageFormat, TieredStorageResult,
+    crate::{
+        accounts_hash::AccountHash,
+        tiered_storage::{
+            byte_block,
+            footer::{
+                AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat, TieredStorageFooter,
+            },
+            index::AccountIndexFormat,
+            meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+            mmap_utils::get_type,
+            TieredStorageFormat, TieredStorageResult,
+        },
     },
     memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
-    solana_sdk::{hash::Hash, stake_history::Epoch},
+    solana_sdk::stake_history::Epoch,
     std::{fs::OpenOptions, option::Option, path::Path},
 };
 
@@ -152,13 +157,13 @@ impl TieredAccountMeta for HotAccountMeta {
 
     /// Returns the account hash by parsing the specified account block.  None
     /// will be returned if this account does not persist this optional field.
-    fn account_hash<'a>(&self, account_block: &'a [u8]) -> Option<&'a Hash> {
+    fn account_hash<'a>(&self, account_block: &'a [u8]) -> Option<&'a AccountHash> {
         self.flags()
             .has_account_hash()
             .then(|| {
                 let offset = self.optional_fields_offset(account_block)
                     + AccountMetaOptionalFields::account_hash_offset(self.flags());
-                byte_block::read_type::<Hash>(account_block, offset)
+                byte_block::read_type::<AccountHash>(account_block, offset)
             })
             .flatten()
     }
@@ -239,9 +244,9 @@ pub mod tests {
             index::AccountIndexFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
         },
-        ::solana_sdk::{hash::Hash, pubkey::Pubkey, stake_history::Epoch},
         memoffset::offset_of,
         rand::Rng,
+        solana_sdk::{hash::Hash, pubkey::Pubkey, stake_history::Epoch},
         tempfile::TempDir,
     };
 
@@ -304,7 +309,7 @@ pub mod tests {
 
         let optional_fields = AccountMetaOptionalFields {
             rent_epoch: Some(TEST_RENT_EPOCH),
-            account_hash: Some(Hash::new_unique()),
+            account_hash: Some(AccountHash(Hash::new_unique())),
         };
 
         let flags = AccountMetaFlags::new_from(&optional_fields);
@@ -331,7 +336,7 @@ pub mod tests {
 
         let optional_fields = AccountMetaOptionalFields {
             rent_epoch: Some(TEST_RENT_EPOCH),
-            account_hash: Some(Hash::new_unique()),
+            account_hash: Some(AccountHash(Hash::new_unique())),
         };
 
         let flags = AccountMetaFlags::new_from(&optional_fields);

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -1,11 +1,14 @@
 use {
-    crate::tiered_storage::{
-        footer::{AccountMetaFormat, TieredStorageFooter},
-        hot::HotStorageReader,
-        meta::TieredAccountMeta,
-        TieredStorageResult,
+    crate::{
+        accounts_hash::AccountHash,
+        tiered_storage::{
+            footer::{AccountMetaFormat, TieredStorageFooter},
+            hot::HotStorageReader,
+            meta::TieredAccountMeta,
+            TieredStorageResult,
+        },
     },
-    solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
+    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, stake_history::Epoch},
     std::path::Path,
 };
 
@@ -32,7 +35,7 @@ impl<'accounts_file, M: TieredAccountMeta> TieredReadableAccount<'accounts_file,
     }
 
     /// Returns the hash of this account.
-    pub fn hash(&self) -> Option<&'accounts_file Hash> {
+    pub fn hash(&self) -> Option<&'accounts_file AccountHash> {
         self.meta.account_hash(self.account_block)
     }
 


### PR DESCRIPTION
#### Problem

Next on the list of places we use a bare `Hash` to mean an account's hash is the tiered storage code. So use an `AccountHash` when we need the hash of an account.


#### Summary of Changes

Use `AccountHash` in tiered storage.