### PR TITLE
program error: add `ArithmeticOverflow`

### DIFF
--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -61,6 +61,8 @@ pub enum ProgramError {
     BuiltinProgramsMustConsumeComputeUnits,
     #[error("Invalid account owner")]
     InvalidAccountOwner,
+    #[error("Program arithmetic overflowed")]
+    ArithmeticOverflow,
 }
 
 pub trait PrintProgramError {
@@ -110,6 +112,7 @@ impl PrintProgramError for ProgramError {
                 msg!("Error: BuiltinProgramsMustConsumeComputeUnits")
             }
             Self::InvalidAccountOwner => msg!("Error: InvalidAccountOwner"),
+            Self::ArithmeticOverflow => msg!("Error: ArithmeticOverflow"),
         }
     }
 }
@@ -145,6 +148,7 @@ pub const INVALID_ACCOUNT_DATA_REALLOC: u64 = to_builtin!(20);
 pub const MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED: u64 = to_builtin!(21);
 pub const BUILTIN_PROGRAMS_MUST_CONSUME_COMPUTE_UNITS: u64 = to_builtin!(22);
 pub const INVALID_ACCOUNT_OWNER: u64 = to_builtin!(23);
+pub const ARITHMETIC_OVERFLOW: u64 = to_builtin!(24);
 // Warning: Any new program errors added here must also be:
 // - Added to the below conversions
 // - Added as an equivalent to InstructionError
@@ -182,6 +186,7 @@ impl From<ProgramError> for u64 {
                 BUILTIN_PROGRAMS_MUST_CONSUME_COMPUTE_UNITS
             }
             ProgramError::InvalidAccountOwner => INVALID_ACCOUNT_OWNER,
+            ProgramError::ArithmeticOverflow => ARITHMETIC_OVERFLOW,
             ProgramError::Custom(error) => {
                 if error == 0 {
                     CUSTOM_ZERO
@@ -221,6 +226,7 @@ impl From<u64> for ProgramError {
                 Self::BuiltinProgramsMustConsumeComputeUnits
             }
             INVALID_ACCOUNT_OWNER => Self::InvalidAccountOwner,
+            ARITHMETIC_OVERFLOW => Self::ArithmeticOverflow,
             _ => Self::Custom(error as u32),
         }
     }
@@ -260,6 +266,7 @@ impl TryFrom<InstructionError> for ProgramError {
                 Ok(Self::BuiltinProgramsMustConsumeComputeUnits)
             }
             Self::Error::InvalidAccountOwner => Ok(Self::InvalidAccountOwner),
+            Self::Error::ArithmeticOverflow => Ok(Self::ArithmeticOverflow),
             _ => Err(error),
         }
     }
@@ -297,6 +304,7 @@ where
                 Self::BuiltinProgramsMustConsumeComputeUnits
             }
             INVALID_ACCOUNT_OWNER => Self::InvalidAccountOwner,
+            ARITHMETIC_OVERFLOW => Self::ArithmeticOverflow,
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {


### PR DESCRIPTION
#### Problem

We often write error variants to handle arithmetic overflow in the Solana Program Library because the error `ArithmeticOverflow` from `solana_sdk::instruction::InstructionError` does not have a counterpart in `solana_program::program_error::ProgramError`.

#### Summary of Changes

Add the `ArithmeticOverflow` error variant to `solana_program::program_error::ProgramError`.

Note: Marked as draft until rebased onto #33766 
