### PR TITLE
v1.16: Update SPL downstream CI to use 1.16 compatible branch

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -8,7 +8,7 @@ source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
 rm -rf spl
-git clone https://github.com/solana-labs/solana-program-library.git spl
+git clone https://github.com/solana-labs/solana-program-library.git spl -b v1.16
 
 # copy toolchain file to use solana's rust version
 cp "$SOLANA_DIR"/rust-toolchain.toml spl/


### PR DESCRIPTION
#### Problem

With https://github.com/solana-labs/solana-program-library/pull/5575, SPL is updating to 1.17. That means the monorepo's downstream job on v1.16 will fail.

#### Summary of Changes

When doing the downstream job, checkout the last commit to use v1.16: https://github.com/solana-labs/solana-program-library/tree/v1.16

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
