### PR TITLE
docs: fix typo in watchtower/README.md

### DIFF
--- a/watchtower/README.md
+++ b/watchtower/README.md
@@ -9,7 +9,7 @@ If you only care about the health of one specific validator, the
 notifications to issues only affecting that validator.
 
 If you do not want duplicate notifications, for example if you have elected to
-recieve notifications by SMS the
+receive notifications by SMS the
 `--no-duplicate-notifications` command-line argument will suppress identical
 failure notifications.
 


### PR DESCRIPTION
#### Summary of Changes
This pull request fixes typo `recieve -> receive` in the file watchtower/README.md