### PR TITLE
zk-token-sdk: Fix incorrect mention of OsRng in docs

### DIFF
--- a/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
@@ -45,6 +45,8 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
     ///
     /// The function simply batches the input openings and invokes the standard grouped ciphertext
     /// validity proof constructor.
+    ///
+    /// This function is randomized. It uses `OsRng` internally to generate random scalars.
     pub fn new<T: Into<Scalar>>(
         (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
         (amount_lo, amount_hi): (T, T),
@@ -71,8 +73,6 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
     /// The function does *not* hash the public keys, commitment, or decryption handles into the
     /// transcript. For security, the caller (the main protocol) should hash these public
     /// components prior to invoking this constructor.
-    ///
-    /// This function is randomized. It uses `OsRng` internally to generate random scalars.
     pub fn verify(
         self,
         (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),


### PR DESCRIPTION
#### Problem

The documentation of BatchedGroupedCiphertext2HandlesValidityProof::verify mentions use of `OsRng`.

This function is used in Zero-Knowledge Token Proof Program instruction processing. Therefore use of OsRng would break consensus. 

#### Summary of Changes

It looks like the problematic comment was copy pasted from somewhere else as is not valid. Please double check that this is actually the case.

Removes the problematic comment. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
