### PR TITLE
fix some ancient stats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2041,7 +2041,7 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) random_shrink: AtomicU64,
     pub(crate) slots_considered: AtomicU64,
     pub(crate) ancient_scanned: AtomicU64,
-    pub(crate) second_pass_one_ref: AtomicU64,
+    pub(crate) bytes_ancient_created: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -2072,7 +2072,7 @@ impl ShrinkStatsSub {
 #[derive(Debug, Default)]
 pub struct ShrinkStats {
     last_report: AtomicInterval,
-    num_slots_shrunk: AtomicUsize,
+    pub(crate) num_slots_shrunk: AtomicUsize,
     storage_read_elapsed: AtomicU64,
     index_read_elapsed: AtomicU64,
     create_and_insert_store_elapsed: AtomicU64,
@@ -2346,8 +2346,8 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "second_pass_one_ref",
-                self.second_pass_one_ref.swap(0, Ordering::Relaxed) as i64,
+                "bytes_ancient_created",
+                self.bytes_ancient_created.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
         );
@@ -4204,14 +4204,20 @@ impl AccountsDb {
             );
         }
 
-        Self::update_shrink_stats(&self.shrink_stats, stats_sub);
+        Self::update_shrink_stats(&self.shrink_stats, stats_sub, true);
         self.shrink_stats.report();
     }
 
-    pub(crate) fn update_shrink_stats(shrink_stats: &ShrinkStats, stats_sub: ShrinkStatsSub) {
-        shrink_stats
-            .num_slots_shrunk
-            .fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn update_shrink_stats(
+        shrink_stats: &ShrinkStats,
+        stats_sub: ShrinkStatsSub,
+        increment_count: bool,
+    ) {
+        if increment_count {
+            shrink_stats
+                .num_slots_shrunk
+                .fetch_add(1, Ordering::Relaxed);
+        }
         shrink_stats.create_and_insert_store_elapsed.fetch_add(
             stats_sub.create_and_insert_store_elapsed_us,
             Ordering::Relaxed,
@@ -4752,7 +4758,7 @@ impl AccountsDb {
         // we should not try to shrink any of the stores from this slot anymore. All shrinking for this slot is now handled by ancient append vec code.
         self.shrink_candidate_slots.lock().unwrap().remove(&slot);
 
-        Self::update_shrink_stats(&self.shrink_ancient_stats.shrink_stats, stats_sub);
+        Self::update_shrink_stats(&self.shrink_ancient_stats.shrink_stats, stats_sub, true);
     }
 
     /// each slot in 'dropped_roots' has been combined into an ancient append vec.


### PR DESCRIPTION
#### Problem
When we disable rewrites, we will accumulate old append vecs & slots. We use ancient append vec packing to combine those. Some stats could use some love.

#### Summary of Changes
add, remove, and update stats better for ancient packing.

Sample output:
```
num_slots_shrunk=3
bytes_ancient_created=3,584,440,968
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
