### PR TITLE
Fix typos in documentation for Secp256k1 native program

### DIFF
--- a/docs/src/developing/runtime-facilities/programs.md
+++ b/docs/src/developing/runtime-facilities/programs.md
@@ -127,13 +127,13 @@ a count of the following struct serialized in the instruction data:
 
 ```
 struct Secp256k1SignatureOffsets {
-    secp_signature_key_offset: u16,        // offset to [signature,recovery_id,etherum_address] of 64+1+20 bytes
-    secp_signature_instruction_index: u8,  // instruction index to find data
-    secp_pubkey_offset: u16,               // offset to [signature,recovery_id] of 64+1 bytes
-    secp_signature_instruction_index: u8,  // instruction index to find data
+    secp_signature_offset: u16,            // offset to [signature,recovery_id] of 64+1 bytes
+    secp_signature_instruction_index: u8,  // instruction index to find signature
+    secp_pubkey_offset: u16,               // offset to ethereum_address pubkey of 20 bytes
+    secp_pubkey_instruction_index: u8,     // instruction index to find pubkey
     secp_message_data_offset: u16,         // offset to start of message data
     secp_message_data_size: u16,           // size of message data
-    secp_message_instruction_index: u8,    // index of instruction data to get message data
+    secp_message_instruction_index: u8,    // instruction index to find message data
 }
 ```
 
@@ -146,7 +146,7 @@ process_instruction() {
       instructions = &transaction.message().instructions
       signature = instructions[secp_signature_instruction_index].data[secp_signature_offset..secp_signature_offset + 64]
       recovery_id = instructions[secp_signature_instruction_index].data[secp_signature_offset + 64]
-      ref_eth_pubkey = instructions[secp_pubkey_instruction_index].data[secp_pubkey_offset..secp_pubkey_offset + 32]
+      ref_eth_pubkey = instructions[secp_pubkey_instruction_index].data[secp_pubkey_offset..secp_pubkey_offset + 20]
       message_hash = keccak256(instructions[secp_message_instruction_index].data[secp_message_data_offset..secp_message_data_offset + secp_message_data_size])
       pubkey = ecrecover(signature, recovery_id, message_hash)
       eth_pubkey = keccak256(pubkey[1..])[12..]


### PR DESCRIPTION
#### Problem

There are typos in the native program documentation for Secp256k1 signature verification, please see screenshot

<img width="998" alt="Screenshot 2023-10-20 at 2 07 09 PM" src="https://github.com/solana-labs/solana/assets/1387955/64390a60-e012-47ec-9d46-18caa3f9854c">



#### Summary of Changes
Fix the doc typos, no code changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
