### PR TITLE
[clap-v3-utils] Deprecate signer source validation

### DIFF
--- a/clap-v3-utils/src/fee_payer.rs
+++ b/clap-v3-utils/src/fee_payer.rs
@@ -11,6 +11,7 @@ pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
            is also passed. Defaults to the client keypair.",
 };
 
+#[allow(deprecated)]
 pub fn fee_payer_arg<'a>() -> Arg<'a> {
     Arg::new(FEE_PAYER_ARG.name)
         .long(FEE_PAYER_ARG.long)

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -18,7 +18,7 @@ use {
 // Sentinel value used to indicate to write to screen instead of file
 pub const STDOUT_OUTFILE_TOKEN: &str = "-";
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SignerSourceParserBuilder {
     allow_prompt: bool,
     allow_file_path: bool,
@@ -27,29 +27,16 @@ pub struct SignerSourceParserBuilder {
     allow_pubkey: bool,
     allow_legacy: bool,
 }
-impl Default for SignerSourceParserBuilder {
-    fn default() -> Self {
-        Self {
-            allow_prompt: true,
-            allow_file_path: true,
-            allow_usb: true,
-            allow_stdin: true,
-            allow_pubkey: true,
-            allow_legacy: true,
-        }
-    }
-}
 
 impl SignerSourceParserBuilder {
-    pub fn new() -> Self {
-        Self {
-            allow_prompt: false,
-            allow_file_path: false,
-            allow_usb: false,
-            allow_stdin: false,
-            allow_pubkey: false,
-            allow_legacy: true,
-        }
+    pub fn allow_all(mut self) -> Self {
+        self.allow_prompt = true;
+        self.allow_file_path = true;
+        self.allow_usb = true;
+        self.allow_stdin = true;
+        self.allow_pubkey = true;
+        self.allow_legacy = true;
+        self
     }
 
     pub fn allow_prompt(mut self) -> Self {
@@ -77,8 +64,8 @@ impl SignerSourceParserBuilder {
         self
     }
 
-    pub fn disallow_legacy(mut self) -> Self {
-        self.allow_legacy = false;
+    pub fn allow_legacy(mut self) -> Self {
+        self.allow_legacy = true;
         self
     }
 
@@ -397,7 +384,11 @@ mod tests {
             Arg::new("keypair")
                 .long("keypair")
                 .takes_value(true)
-                .value_parser(SignerSourceParserBuilder::new().allow_file_path().build()),
+                .value_parser(
+                    SignerSourceParserBuilder::default()
+                        .allow_file_path()
+                        .build(),
+                ),
         );
 
         // success case
@@ -441,9 +432,10 @@ mod tests {
                 .long("keypair")
                 .takes_value(true)
                 .value_parser(
-                    SignerSourceParserBuilder::new()
+                    SignerSourceParserBuilder::default()
                         .allow_file_path()
                         .allow_prompt()
+                        .allow_legacy()
                         .build(),
                 ),
         );
@@ -512,10 +504,9 @@ mod tests {
                 .long("keypair")
                 .takes_value(true)
                 .value_parser(
-                    SignerSourceParserBuilder::new()
+                    SignerSourceParserBuilder::default()
                         .allow_file_path()
                         .allow_prompt()
-                        .disallow_legacy()
                         .build(),
                 ),
         );
@@ -533,7 +524,12 @@ mod tests {
             Arg::new("keypair")
                 .long("keypair")
                 .takes_value(true)
-                .value_parser(SignerSourceParserBuilder::new().allow_prompt().build()),
+                .value_parser(
+                    SignerSourceParserBuilder::default()
+                        .allow_prompt()
+                        .allow_legacy()
+                        .build(),
+                ),
         );
 
         // success case
@@ -586,7 +582,7 @@ mod tests {
                 .long("signer")
                 .takes_value(true)
                 .value_parser(
-                    SignerSourceParserBuilder::new()
+                    SignerSourceParserBuilder::default()
                         .allow_pubkey()
                         .allow_file_path()
                         .build(),

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -419,7 +419,7 @@ mod tests {
             }
             if p == path_str));
 
-        // faile cases
+        // failure cases
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--keypair", "-"])
@@ -428,7 +428,7 @@ mod tests {
 
         let matches_error = command
             .clone()
-            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .try_get_matches_from(vec!["test", "--keypair", "usb://ledger"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }
@@ -493,7 +493,7 @@ mod tests {
             }
         );
 
-        // faile cases
+        // failure cases
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--keypair", "-"])
@@ -502,7 +502,7 @@ mod tests {
 
         let matches_error = command
             .clone()
-            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .try_get_matches_from(vec!["test", "--keypair", "usb://ledger"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
 
@@ -565,7 +565,7 @@ mod tests {
             }
         );
 
-        // faile cases
+        // failure cases
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--keypair", "-"])
@@ -574,7 +574,7 @@ mod tests {
 
         let matches_error = command
             .clone()
-            .try_get_matches_from(vec!["test", "--keypair", "usb::/ledger"])
+            .try_get_matches_from(vec!["test", "--keypair", "usb://ledger"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }
@@ -626,7 +626,7 @@ mod tests {
             }
             if p == path_str));
 
-        // faile cases
+        // failure cases
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--signer", "-"])
@@ -635,7 +635,7 @@ mod tests {
 
         let matches_error = command
             .clone()
-            .try_get_matches_from(vec!["test", "--signer", "usb::/ledger"])
+            .try_get_matches_from(vec!["test", "--signer", "usb://ledger"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -20,21 +20,21 @@ pub const STDOUT_OUTFILE_TOKEN: &str = "-";
 
 #[derive(Debug)]
 pub struct SignerSourceParserBuilder {
-    prompt: bool,
-    file_path: bool,
-    usb: bool,
-    stdin: bool,
-    pubkey: bool,
+    allow_prompt: bool,
+    allow_file_path: bool,
+    allow_usb: bool,
+    allow_stdin: bool,
+    allow_pubkey: bool,
     allow_legacy: bool,
 }
 impl Default for SignerSourceParserBuilder {
     fn default() -> Self {
         Self {
-            prompt: true,
-            file_path: true,
-            usb: true,
-            stdin: true,
-            pubkey: true,
+            allow_prompt: true,
+            allow_file_path: true,
+            allow_usb: true,
+            allow_stdin: true,
+            allow_pubkey: true,
             allow_legacy: true,
         }
     }
@@ -43,37 +43,37 @@ impl Default for SignerSourceParserBuilder {
 impl SignerSourceParserBuilder {
     pub fn new() -> Self {
         Self {
-            prompt: false,
-            file_path: false,
-            usb: false,
-            stdin: false,
-            pubkey: false,
+            allow_prompt: false,
+            allow_file_path: false,
+            allow_usb: false,
+            allow_stdin: false,
+            allow_pubkey: false,
             allow_legacy: true,
         }
     }
 
     pub fn allow_prompt(mut self) -> Self {
-        self.prompt = true;
+        self.allow_prompt = true;
         self
     }
 
     pub fn allow_file_path(mut self) -> Self {
-        self.file_path = true;
+        self.allow_file_path = true;
         self
     }
 
     pub fn allow_usb(mut self) -> Self {
-        self.usb = true;
+        self.allow_usb = true;
         self
     }
 
     pub fn allow_stdin(mut self) -> Self {
-        self.stdin = true;
+        self.allow_stdin = true;
         self
     }
 
     pub fn allow_pubkey(mut self) -> Self {
-        self.pubkey = true;
+        self.allow_pubkey = true;
         self
     }
 
@@ -90,11 +90,11 @@ impl SignerSourceParserBuilder {
                     return Err(SignerSourceError::UnsupportedSource);
                 }
                 match signer_source.kind {
-                    SignerSourceKind::Prompt if self.prompt => Ok(signer_source),
-                    SignerSourceKind::Filepath(_) if self.file_path => Ok(signer_source),
-                    SignerSourceKind::Usb(_) if self.usb => Ok(signer_source),
-                    SignerSourceKind::Stdin if self.stdin => Ok(signer_source),
-                    SignerSourceKind::Pubkey(_) if self.pubkey => Ok(signer_source),
+                    SignerSourceKind::Prompt if self.allow_prompt => Ok(signer_source),
+                    SignerSourceKind::Filepath(_) if self.allow_file_path => Ok(signer_source),
+                    SignerSourceKind::Usb(_) if self.allow_usb => Ok(signer_source),
+                    SignerSourceKind::Stdin if self.allow_stdin => Ok(signer_source),
+                    SignerSourceKind::Pubkey(_) if self.allow_pubkey => Ok(signer_source),
                     _ => Err(SignerSourceError::UnsupportedSource),
                 }
             },

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -60,7 +60,7 @@ where
 
 // Return an error if a pubkey cannot be parsed.
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `clap::value_parser!(Pubkey)` instead"
 )]
 pub fn is_pubkey(string: &str) -> Result<(), String> {
@@ -81,7 +81,7 @@ where
 
 // Return an error if a keypair file cannot be parsed.
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().allow_file_path().build()` instead"
 )]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
@@ -95,7 +95,7 @@ where
 
 // Return an error if a keypair file cannot be parsed
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().allow_file_path().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
@@ -112,7 +112,7 @@ where
 
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
@@ -132,7 +132,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
@@ -146,7 +146,7 @@ where
 // Return an error if string cannot be parsed as a pubkey string, or a valid Signer that can
 // produce a pubkey()
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
@@ -172,7 +172,7 @@ where
 // Clap validators can't check multiple fields at once, so the verification that a `--signer` is
 // also provided and correct happens in parsing, not in validation.
 #[deprecated(
-    since = "1.17.2",
+    since = "1.18.0",
     note = "please use `SignerSourceParserBuilder::default().build()` instead"
 )]
 #[allow(deprecated)]

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -82,7 +82,7 @@ where
 // Return an error if a keypair file cannot be parsed.
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().allow_file_path().build()` instead"
 )]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
 where
@@ -96,7 +96,7 @@ where
 // Return an error if a keypair file cannot be parsed
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().allow_file_path().allow_prompt().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().allow_file_path().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
@@ -113,7 +113,7 @@ where
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().allow_prompt().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
@@ -133,7 +133,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().allow_pubkey().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
@@ -147,7 +147,7 @@ where
 // produce a pubkey()
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().allow_pubkey().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
@@ -173,7 +173,7 @@ where
 // also provided and correct happens in parsing, not in validation.
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParserBuilder::new().build()` instead"
+    note = "please use `SignerSourceParserBuilder::default().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -90,6 +90,10 @@ where
 }
 
 // Return an error if a keypair file cannot be parsed
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_file_path().allow_prompt().build()` instead"
+)]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -107,6 +107,10 @@ where
 }
 
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_prompt().build()` instead"
+)]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
         return Ok(());

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -82,7 +82,7 @@ where
 // Return an error if a keypair file cannot be parsed.
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().allow_file_path().build()` instead"
 )]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
 where
@@ -133,7 +133,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
@@ -147,7 +147,7 @@ where
 // produce a pubkey()
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -59,6 +59,10 @@ where
 }
 
 // Return an error if a pubkey cannot be parsed.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `clap::value_parser!(Pubkey)` instead"
+)]
 pub fn is_pubkey(string: &str) -> Result<(), String> {
     is_parsable_generic::<Pubkey, _>(string)
 }

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -96,7 +96,7 @@ where
 // Return an error if a keypair file cannot be parsed
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_file_path().allow_prompt().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().allow_file_path().allow_prompt().build()` instead"
 )]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
@@ -113,7 +113,7 @@ where
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_prompt().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().allow_prompt().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
@@ -133,7 +133,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
@@ -147,7 +147,7 @@ where
 // produce a pubkey()
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_file_path().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().allow_pubkey().allow_file_path().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
@@ -173,7 +173,7 @@ where
 // also provided and correct happens in parsing, not in validation.
 #[deprecated(
     since = "1.17.2",
-    note = "please use `SignerSourceParseBuilder::new().build()` instead"
+    note = "please use `SignerSourceParserBuilder::new().build()` instead"
 )]
 #[allow(deprecated)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -60,7 +60,7 @@ where
 
 // Return an error if a pubkey cannot be parsed.
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `clap::value_parser!(Pubkey)` instead"
 )]
 pub fn is_pubkey(string: &str) -> Result<(), String> {
@@ -81,7 +81,7 @@ where
 
 // Return an error if a keypair file cannot be parsed.
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_file_path().build()` instead"
 )]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
@@ -95,7 +95,7 @@ where
 
 // Return an error if a keypair file cannot be parsed
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_file_path().allow_prompt().build()` instead"
 )]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
@@ -112,7 +112,7 @@ where
 
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_prompt().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
@@ -132,7 +132,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
@@ -145,7 +145,7 @@ where
 // Return an error if string cannot be parsed as a pubkey string, or a valid Signer that can
 // produce a pubkey()
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
@@ -170,7 +170,7 @@ where
 // Clap validators can't check multiple fields at once, so the verification that a `--signer` is
 // also provided and correct happens in parsing, not in validation.
 #[deprecated(
-    since = "1.17.0",
+    since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().build()` instead"
 )]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -127,6 +127,10 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 }
 
 // Return an error if string cannot be parsed as pubkey string or keypair file location
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -136,6 +140,10 @@ where
 
 // Return an error if string cannot be parsed as a pubkey string, or a valid Signer that can
 // produce a pubkey()
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
+)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -157,6 +165,10 @@ where
 // when paired with an offline `--signer` argument to provide a Presigner (pubkey + signature).
 // Clap validators can't check multiple fields at once, so the verification that a `--signer` is
 // also provided and correct happens in parsing, not in validation.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().build()` instead"
+)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -135,6 +135,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -148,6 +149,7 @@ where
     since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().allow_pubkey().allow_path().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -173,6 +175,7 @@ where
     since = "1.17.2",
     note = "please use `SignerSourceParseBuilder::new().build()` instead"
 )]
+#[allow(deprecated)]
 pub fn is_valid_signer<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
@@ -185,6 +188,7 @@ where
     since = "1.17.0",
     note = "please use `clap::value_parser!(PubkeySignature)` instead"
 )]
+#[allow(deprecated)]
 pub fn is_pubkey_sig<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -76,6 +76,10 @@ where
 }
 
 // Return an error if a keypair file cannot be parsed.
+#[deprecated(
+    since = "1.17.0",
+    note = "please use `SignerSourceParseBuilder::new().allow_file_path().build()` instead"
+)]
 pub fn is_keypair<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -440,6 +440,8 @@ pub(crate) enum SignerSourceError {
     DerivationPathError(#[from] DerivationPathError),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error("unsupported source")]
+    UnsupportedSource,
 }
 
 pub(crate) fn parse_signer_source<S: AsRef<str>>(

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -371,7 +371,7 @@ impl DefaultSigner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct SignerSource {
     pub kind: SignerSourceKind,
     pub derivation_path: Option<DerivationPath>,
@@ -402,6 +402,7 @@ const SIGNER_SOURCE_USB: &str = "usb";
 const SIGNER_SOURCE_STDIN: &str = "stdin";
 const SIGNER_SOURCE_PUBKEY: &str = "pubkey";
 
+#[derive(Clone)]
 pub(crate) enum SignerSourceKind {
     Prompt,
     Filepath(String),

--- a/clap-v3-utils/src/nonce.rs
+++ b/clap-v3-utils/src/nonce.rs
@@ -18,6 +18,7 @@ pub const NONCE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     help: "Provide the nonce authority keypair to use when signing a nonced transaction",
 };
 
+#[allow(deprecated)]
 fn nonce_arg<'a>() -> Arg<'a> {
     Arg::new(NONCE_ARG.name)
         .long(NONCE_ARG.long)
@@ -27,6 +28,7 @@ fn nonce_arg<'a>() -> Arg<'a> {
         .help(NONCE_ARG.help)
 }
 
+#[allow(deprecated)]
 pub fn nonce_authority_arg<'a>() -> Arg<'a> {
     Arg::new(NONCE_AUTHORITY_ARG.name)
         .long(NONCE_AUTHORITY_ARG.long)

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::arithmetic_side_effects, deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::arithmetic_side_effects, deprecated)]
+#![allow(clippy::arithmetic_side_effects)]
+#![allow(deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -87,7 +87,7 @@ impl From<Infallible> for LocatorError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Locator {
     pub manufacturer: Manufacturer,
     pub pubkey: Option<Pubkey>,

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},


### PR DESCRIPTION
#### Problem
In clap-v3, the `Arg::validator` is deprecated and replaced with `Arg::value_parser`. The idea is that when we validate an argument input, we generally parse the input, so dividing validation and parsing in separate steps forces you to parse input twice.

A previous PR https://github.com/solana-labs/solana/pull/33276 deprecated most of the validation functions in clap-v3-utils and replaced them with parsing functions. This PR is a follow-up that deprecates validation functions related to the signer.

#### Summary of Changes
I thought a bit about implementing the clap parsers for `Signer`, `Pubkey`, and `Keypair`. I think the most idiomatic way of doing this is to expose the `SignerSource` as an intermediate type to do the parsing. I made some examples in the test.

- [43adf9c](https://github.com/solana-labs/solana/pull/33802/commits/43adf9cd68d33db59d200aa9aa5f48756af524d6): The most idiomatic way to define a parser for signer related arguments was to make `SignerSource` be an intermediate type and let applications call `matches.get_one::<SignerSource>(...)` to validate and parse the signer source. To define a parser for `SignerSource` (to call `clap::builder::ValueParser::from(...)` on the `SignerSource` type), the `SignerSource` has to implement `Clone`. I thought adding `Clone` to `SignerSource` was okay since sensitive information is not actually parsed with `SignerSource`, but later when we call `signer_from_path` or `keypair_from_path`. Please let me know otherwise.
- [c4156b6](https://github.com/solana-labs/solana/pull/33802/commits/c4156b6571962688187960a068be0c0fac4d1fd5): I thought this was an appropriate place to use a builder pattern to build a `SignerSource` parser, so I added it.
- [2138cf1](https://github.com/solana-labs/solana/pull/33802/commits/2138cf178a64f69d3b047e4dd5a75d3b09ae6bd4), [5be66fb](https://github.com/solana-labs/solana/pull/33802/commits/5be66fb10bab2be448b418cec5e30818bf1a4635), [2d88923](https://github.com/solana-labs/solana/pull/33802/commits/2d88923db8b052471eab2243727868cab5d62b0a), [50a71c2](https://github.com/solana-labs/solana/pull/33802/commits/50a71c2d7aa3205c1f30ff3e191183e32babc93a), [abe9723](https://github.com/solana-labs/solana/pull/33802/commits/abe97238d0c8cbad9c74e30335af641e59d44e23), [366f374](https://github.com/solana-labs/solana/pull/33802/commits/366f374aea6e2c1e4d9e074bc71954d32e442d1a): I deprecated validation functions related to keypairs and added tests to demonstrated alternative ways to validate and parse.
- [f02a35c](https://github.com/solana-labs/solana/pull/33802/commits/f02a35c3de380ae082f21f5f9af6c07c6815bc9a) - Added flags to allow deprecation temporarily for CI. Some of these will be removed in follow-up PRs.

This is a split PR from https://github.com/solana-labs/solana/pull/33478

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
