### PR TITLE
[zk-token-sdk] clean-up range-proof docs

### DIFF
--- a/zk-token-sdk/src/range_proof/generators.rs
+++ b/zk-token-sdk/src/range_proof/generators.rs
@@ -6,10 +6,7 @@ use {
     sha3::{Sha3XofReader, Shake256},
 };
 
-/// Generators for Pedersen vector commitments.
-///
-/// The code is copied from https://github.com/dalek-cryptography/bulletproofs for now...
-
+/// Generators for Pedersen vector commitments that are used for inner-product proofs.
 struct GeneratorsChain {
     reader: Sha3XofReader,
 }
@@ -79,14 +76,6 @@ impl BulletproofGens {
         gens.increase_capacity(gens_capacity);
         gens
     }
-
-    // pub fn new_aggregate(gens_capacities: Vec<usize>) -> Vec<BulletproofGens> {
-    //     let mut gens_vector = Vec::new();
-    //     for (capacity, i) in gens_capacities.iter().enumerate() {
-    //         gens_vector.push(BulletproofGens::new(capacity, &i.to_le_bytes()));
-    //     }
-    //     gens_vector
-    // }
 
     /// Increases the generators' capacity to the amount specified.
     /// If less than or equal to the current capacity, does nothing.

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -81,7 +81,6 @@ impl RangeProof {
         let nm: usize = bit_lengths.iter().sum();
         assert!(nm.is_power_of_two());
 
-        // TODO: double check Pedersen generators and range proof generators does not interfere
         let bp_gens = BulletproofGens::new(nm);
 
         // bit-decompose values and generate their Pedersen vector commitment

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -81,7 +81,6 @@ impl RangeProof {
         let nm: usize = bit_lengths.iter().sum();
         assert!(nm.is_power_of_two());
 
-        // TODO: precompute generators
         // TODO: double check Pedersen generators and range proof generators does not interfere
         let bp_gens = BulletproofGens::new(nm);
 

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -1,3 +1,15 @@
+//! The Bulletproofs range-proof implementation over Curve25519 Ristretto points.
+//!
+//! The implementation is based on the dalek-cryptography bulletproofs
+//! [implementation](https://github.com/dalek-cryptography/bulletproofs). Compared to the original
+//! implementation by dalek-cryptography:
+//! - This implementation focuses on the range proof implementation, while the dalek-cryptography
+//! crate additionally implements the general bulletproofs implementation for languages that can be
+//! represented by arithmetic circuits as well as MPC.
+//! - This implementation implements a non-interactive range proof aggregation that is specified in
+//! the original Bulletproofs [paper](https://eprint.iacr.org/2017/1066) (Section 4.3).
+//!
+
 #[cfg(not(target_os = "solana"))]
 use {
     crate::encryption::pedersen::{Pedersen, PedersenCommitment, PedersenOpening},


### PR DESCRIPTION
#### Problem
The range proof docs are really a mess with incomplete documentation and TODO's.

#### Summary of Changes
It is a little embarrassing, but these have to be addressed.

- [4a79a1f](https://github.com/solana-labs/solana/pull/33803/commits/4a79a1fde31fdc922bd7433f70a377f8ad8d2ae0): I added docs to cite dalek-cryptography implementation of bulletproofs and how our implementation differs.
- [4a79a1f](https://github.com/solana-labs/solana/pull/33803/commits/4a79a1fde31fdc922bd7433f70a377f8ad8d2ae0): Removed a TODO comment on pre-computing generators for efficiency. I initially considered pre-computing the generators that are needed for range proofs as a form of optimization. I tested how pre-computing the generators effect the proof generation and runtime when I was benching the zk-token-proof program for compute units and it turned out that the improvement in speed was quite small compared to the added complexity and binary. This todo was not removed...
- [6dba397](https://github.com/solana-labs/solana/pull/33803/commits/6dba397858934e4e8577abaee707424777897526): This TODO was a reminder to double check that the generators that are used in Pedersen commitments for encryption does not interfere with those that are used for range proof. Since there is a unique domain separation https://github.com/solana-labs/solana/blob/master/zk-token-sdk/src/range_proof/generators.rs#L21 in the way generators are generated for range proofs, the generators should not interfere and we can safely remove this TODO.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
