### PR TITLE
Cargo registry server updates to download crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,7 @@ version = "1.18.0"
 dependencies = [
  "clap 2.33.3",
  "flate2",
+ "hex",
  "hyper",
  "log",
  "rustc_version 0.4.0",

--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 clap = { workspace = true }
 flate2 = { workspace = true }
+hex = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/cargo-registry/src/main.rs
+++ b/cargo-registry/src/main.rs
@@ -91,12 +91,18 @@ impl CargoRegistryService {
             return response_builder::error_incorrect_length();
         }
 
-        let _package = Program::crate_name_to_program_id(crate_name)
+        let package = Program::crate_name_to_program_id(crate_name)
             .and_then(|id| UnpackedCrate::fetch(id, client).ok());
 
         // Return the package to the caller in the response
-
-        response_builder::error_not_implemented()
+        if let Some(package) = package {
+            response_builder::success_response_bytes(package.0)
+        } else {
+            response_builder::error_response(
+                hyper::StatusCode::BAD_REQUEST,
+                "Failed to find the package",
+            )
+        }
     }
 
     fn handle_yank_request(

--- a/cargo-registry/src/response_builder.rs
+++ b/cargo-registry/src/response_builder.rs
@@ -22,6 +22,13 @@ pub(crate) fn success_response_str(value: &str) -> hyper::Response<hyper::Body> 
         .unwrap()
 }
 
+pub(crate) fn success_response_bytes(bytes: hyper::body::Bytes) -> hyper::Response<hyper::Body> {
+    hyper::Response::builder()
+        .status(hyper::StatusCode::OK)
+        .body(hyper::Body::from(bytes))
+        .unwrap()
+}
+
 pub(crate) fn success_response() -> hyper::Response<hyper::Body> {
     success_response_str("")
 }


### PR DESCRIPTION
#### Problem
`cargo fetch` need fixes, as it currently doesn't return a crate package.

#### Summary of Changes
- Return the crate package as response to the download command
- Use base16 for program ID. Using base58 doesn't work as it is case sensitive, and fetch uses lower case for all the values
- Return just the crate file, and do not include meta data information.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
