### PR TITLE
Use program cache fork graph in extract()

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -168,7 +168,7 @@ fn test_account_subscription() {
     // Transfer 100 lamports from alice to bob
     let tx = system_transaction::transfer(&alice, &bob.pubkey(), 100, blockhash);
     bank_forks
-        .write()
+        .read()
         .unwrap()
         .get(1)
         .unwrap()
@@ -373,7 +373,7 @@ fn test_program_subscription() {
     // Create new program account at bob's address
     let tx = system_transaction::create_account(&alice, &bob, blockhash, 100, 0, &program_id);
     bank_forks
-        .write()
+        .read()
         .unwrap()
         .get(1)
         .unwrap()

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -659,7 +659,7 @@ mod tests {
         current_slot: Slot,
     ) -> transaction::Result<()> {
         bank_forks
-            .write()
+            .read()
             .unwrap()
             .get(current_slot)
             .unwrap()
@@ -1166,7 +1166,7 @@ mod tests {
 
         let tx = system_transaction::transfer(&alice, &bob.pubkey(), 100, blockhash);
         bank_forks
-            .write()
+            .read()
             .unwrap()
             .get(1)
             .unwrap()
@@ -1221,7 +1221,7 @@ mod tests {
 
         let tx = system_transaction::transfer(&alice, &bob.pubkey(), 100, blockhash);
         bank_forks
-            .write()
+            .read()
             .unwrap()
             .get(1)
             .unwrap()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -110,7 +110,7 @@ use {
         invoke_context::BuiltinFunctionWithContext,
         loaded_programs::{
             LoadProgramMetrics, LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType,
-            LoadedPrograms, LoadedProgramsForTxBatch, WorkingSlot, DELAY_VISIBILITY_SLOT_OFFSET,
+            LoadedPrograms, LoadedProgramsForTxBatch, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         log_collector::LogCollector,
         message_processor::MessageProcessor,
@@ -927,20 +927,6 @@ pub struct CommitTransactionCounts {
     pub committed_non_vote_transactions_count: u64,
     pub committed_with_failure_result_count: u64,
     pub signature_count: u64,
-}
-
-impl WorkingSlot for Bank {
-    fn current_slot(&self) -> Slot {
-        self.slot
-    }
-
-    fn current_epoch(&self) -> Epoch {
-        self.epoch
-    }
-
-    fn is_ancestor(&self, other: Slot) -> bool {
-        self.ancestors.contains_key(&other)
-    }
 }
 
 #[derive(Debug, Default)]
@@ -5031,7 +5017,7 @@ impl Bank {
         } = {
             // Lock the global cache to figure out which programs need to be loaded
             let loaded_programs_cache = self.loaded_programs_cache.read().unwrap();
-            loaded_programs_cache.extract(self, programs_and_slots.into_iter())
+            loaded_programs_cache.extract(self.slot, programs_and_slots.into_iter())
         };
 
         // Load missing programs while global cache is unlocked


### PR DESCRIPTION
#### Problem
`WorkingSlot` trait could be replaced with the global instance of `ForkGrpah`.

#### Summary of Changes
Use  the global `ForkGraph` if it's available. Otherwise, use the provided `WorkingSlot`.
Updated unit tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
