### PR TITLE
Custom debug impl for LoadedPrograms cache

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -443,7 +443,6 @@ impl Default for ProgramRuntimeEnvironments {
     }
 }
 
-#[derive(Debug)]
 pub struct LoadedPrograms<FG: ForkGraph> {
     /// A two level index:
     ///
@@ -457,6 +456,16 @@ pub struct LoadedPrograms<FG: ForkGraph> {
     pub environments: ProgramRuntimeEnvironments,
     pub stats: Stats,
     fork_graph: Option<Arc<RwLock<FG>>>,
+}
+
+impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoadedPrograms Cache\nroot slot {}\nroot epoch {}\n{:#?}\ncached entries {:#?}",
+            self.latest_root_slot, self.latest_root_epoch, self.stats, self.entries
+        )
+    }
 }
 
 impl<FG: ForkGraph> Default for LoadedPrograms<FG> {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -460,11 +460,12 @@ pub struct LoadedPrograms<FG: ForkGraph> {
 
 impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "LoadedPrograms Cache\nroot slot {}\nroot epoch {}\n{:#?}\ncached entries {:#?}",
-            self.latest_root_slot, self.latest_root_epoch, self.stats, self.entries
-        )
+        f.debug_struct("LoadedPrograms")
+            .field("root slot", &self.latest_root_slot)
+            .field("root epoch", &self.latest_root_epoch)
+            .field("stats", &self.stats)
+            .field("cache", &self.entries)
+            .finish()
     }
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -56,7 +56,6 @@ struct SetRootTimings {
     prune_remove_ms: i64,
 }
 
-#[derive(Debug)]
 pub struct BankForks {
     banks: HashMap<Slot, BankWithScheduler>,
     descendants: HashMap<Slot, HashSet<Slot>>,


### PR DESCRIPTION
#### Problem
`LoadedPrograms` currently clones `Debug` trait. But, not all information is useful for debugging. A custom impl will be more useful.

#### Summary of Changes
Implement debug for LoadedPrograms cache.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
